### PR TITLE
Fix incorrect number highlighting (when part of an identifier).

### DIFF
--- a/edgedb/lang/edgeql/pygments/__init__.py
+++ b/edgedb/lang/edgeql/pygments/__init__.py
@@ -70,16 +70,18 @@ class EdgeQLLexer(RegexLexer):
         ],
         'numbers': [
             (r'''(?x)
-                (?: \d+ (?:\.\d*)?
-                    |
-                    \. \d+
-                ) (?:[eE](?:[+\-])?[0-9]+)
+                (?<!\w)
+                    (?: \d+ (?:\.\d*)?
+                        |
+                        \. \d+
+                    ) (?:[eE](?:[+\-])?[0-9]+)
             ''', token.Number.Float),
             (r'''(?x)
-                (?: \d+\.(?!\.)\d*
-                    |
-                    \.\d+)
+                (?<!\w)
+                    (?: \d+\.(?!\.)\d*
+                        |
+                        \.\d+)
             ''', token.Number.Float),
-            (r'\d+', token.Number.Integer),
+            (r'(?<!\w)\d+', token.Number.Integer),
         ],
     }

--- a/edgedb/lang/graphql/pygments/__init__.py
+++ b/edgedb/lang/graphql/pygments/__init__.py
@@ -40,16 +40,18 @@ class GraphQLLexer(RegexLexer):
         ],
         'numbers': [
             (r'''(?x)
-                (?: \d+ (?:\.\d*)?
-                    |
-                    \. \d+
-                ) (?:[eE](?:[+\-])?[0-9]+)
+                (?<!\w)
+                    (?: \d+ (?:\.\d*)?
+                        |
+                        \. \d+
+                    ) (?:[eE](?:[+\-])?[0-9]+)
             ''', token.Number.Float),
             (r'''(?x)
-                (?: \d+\.(?!\.)\d*
-                    |
-                    \.\d+)
+                (?<!\w)
+                    (?: \d+\.(?!\.)\d*
+                        |
+                        \.\d+)
             ''', token.Number.Float),
-            (r'\d+', token.Number.Integer),
+            (r'(?<!\w)\d+', token.Number.Integer),
         ],
     }

--- a/edgedb/lang/schema/pygments/__init__.py
+++ b/edgedb/lang/schema/pygments/__init__.py
@@ -65,16 +65,18 @@ class EdgeSchemaLexer(lexer.RegexLexer):
 
         'numbers': [
             (r'''(?x)
-                (?: \d+ (?:\.\d*)?
-                    |
-                    \. \d+
-                ) (?:[eE](?:[+\-])?[0-9]+)
+                (?<!\w)
+                    (?: \d+ (?:\.\d*)?
+                        |
+                        \. \d+
+                    ) (?:[eE](?:[+\-])?[0-9]+)
             ''', token.Number.Float),
             (r'''(?x)
-                (?: \d+\.(?!\.)\d*
-                    |
-                    \.\d+)
+                (?<!\w)
+                    (?: \d+\.(?!\.)\d*
+                        |
+                        \.\d+)
             ''', token.Number.Float),
-            (r'\d+', token.Number.Integer),
+            (r'(?<!\w)\d+', token.Number.Integer),
         ],
     }


### PR DESCRIPTION
A minor tweak to the pygments lexer that stops highlighting numbers in identifiers.