### PR TITLE
edgeql: Add `MATCHES` operator.

### DIFF
--- a/edgedb/lang/edgeql/ast.py
+++ b/edgedb/lang/edgeql/ast.py
@@ -56,16 +56,14 @@ OR = ast.ops.OR
 NOT = ast.ops.NOT
 IN = ast.ops.IN
 NOT_IN = ast.ops.NOT_IN
-LIKE = EdgeQLMatchOperator('~~', strname='LIKE')
-NOT_LIKE = EdgeQLMatchOperator('!~~', strname='NOT LIKE')
-ILIKE = EdgeQLMatchOperator('~~*', strname='ILIKE')
-NOT_ILIKE = EdgeQLMatchOperator('!~~*', strname='NOT ILIKE')
 
-REMATCH = EdgeQLMatchOperator('~')
-REIMATCH = EdgeQLMatchOperator('~*')
+LIKE = EdgeQLMatchOperator('LIKE')
+NOT_LIKE = EdgeQLMatchOperator('NOT LIKE')
+ILIKE = EdgeQLMatchOperator('ILIKE')
+NOT_ILIKE = EdgeQLMatchOperator('NOT ILIKE')
 
-RENOMATCH = EdgeQLMatchOperator('!~')
-RENOIMATCH = EdgeQLMatchOperator('!~*')
+REMATCH = EdgeQLMatchOperator('MATCHES')
+NOT_REMATCH = EdgeQLMatchOperator('NOT MATCHES')
 
 IS_OF = EdgeQLOperator('IS OF')
 IS_NOT_OF = EdgeQLOperator('IS NOT OF')

--- a/edgedb/lang/edgeql/parser/grammar/expressions.py
+++ b/edgedb/lang/edgeql/parser/grammar/expressions.py
@@ -698,10 +698,6 @@ class Expr(Nonterm):
             op = ast.ops.LE
         elif op == '@@':
             op = qlast.SEARCH
-        elif op == '~':
-            op = qlast.REMATCH
-        elif op == '~*':
-            op = qlast.REIMATCH
         elif op == '?=':
             op = qlast.EQUIVALENT
         elif op == '?!=':
@@ -734,6 +730,14 @@ class Expr(Nonterm):
 
     def reduce_Expr_NOT_ILIKE_Expr(self, *kids):
         self.val = qlast.BinOp(left=kids[0].val, op=qlast.NOT_ILIKE,
+                               right=kids[3].val)
+
+    def reduce_Expr_MATCHES_Expr(self, *kids):
+        self.val = qlast.BinOp(left=kids[0].val, op=qlast.REMATCH,
+                               right=kids[2].val)
+
+    def reduce_Expr_NOT_MATCHES_Expr(self, *kids):
+        self.val = qlast.BinOp(left=kids[0].val, op=qlast.NOT_REMATCH,
                                right=kids[3].val)
 
     def reduce_Expr_IS_Expr(self, *kids):

--- a/edgedb/lang/edgeql/parser/grammar/keywords.py
+++ b/edgedb/lang/edgeql/parser/grammar/keywords.py
@@ -82,6 +82,7 @@ reserved_keywords = [
     "is",
     "like",
     "limit",
+    "matches",
     "module",
     "not",
     "offset",

--- a/edgedb/lang/edgeql/parser/grammar/lexer.py
+++ b/edgedb/lang/edgeql/parser/grammar/lexer.py
@@ -87,7 +87,7 @@ class EdgeQLLexer(lexer.Lexer):
         Rule(token='OP',
              next_state=STATE_KEEP,
              regexp=r'''
-                (?: >= | <= | != | ~\* | ~ | \?= | \?!=)
+                (?: >= | <= | != | \?= | \?!=)
              '''),
 
         # SQL ops

--- a/edgedb/lang/edgeql/parser/grammar/precedence.py
+++ b/edgedb/lang/edgeql/parser/grammar/precedence.py
@@ -46,7 +46,8 @@ class P_ANGBRACKET(Precedence, assoc='nonassoc',
     pass
 
 
-class P_LIKE_ILIKE(Precedence, assoc='nonassoc', tokens=('LIKE', 'ILIKE')):
+class P_MATCH(Precedence, assoc='nonassoc',
+              tokens=('LIKE', 'ILIKE', 'MATCHES')):
     pass
 
 
@@ -54,15 +55,11 @@ class P_IN(Precedence, assoc='nonassoc', tokens=('IN',)):
     pass
 
 
-class P_POSTFIXOP(Precedence, assoc='left'):
-    pass
-
-
 class P_IDENT(Precedence, assoc='nonassoc', tokens=('IDENT', 'PARTITION')):
     pass
 
 
-class P_OP(Precedence, assoc='left', tokens=('OPERATOR', 'OP')):
+class P_OP(Precedence, assoc='left', tokens=('OP',)):
     pass
 
 

--- a/edgedb/lang/edgeql/parser/grammar/tokens.py
+++ b/edgedb/lang/edgeql/parser/grammar/tokens.py
@@ -148,10 +148,6 @@ class T_IDENT(Token):
     pass
 
 
-class T_OPERATOR(Token):
-    pass
-
-
 class T_OP(Token):
     pass
 

--- a/edgedb/lang/edgeql/pygments/__init__.py
+++ b/edgedb/lang/edgeql/pygments/__init__.py
@@ -28,7 +28,7 @@ class EdgeQLLexer(RegexLexer):
         'keywords': [
             (r'''(?ix)
                 \b(?<![:\.])(
-                    abstract | action | after | array | as | asc |
+                    abstract | action | after | any | array | as | asc |
                     atom | attribute | before | by | concept |
                     constraint | database | desc | event | final |
                     first | for | from | index | inherit | inheriting |
@@ -36,13 +36,13 @@ class EdgeQLLexer(RegexLexer):
                     policy | property | required | rename | target |
                     then | to | transaction | tuple | value | view |
 
-                    aggregate | all | alter | and | any | commit |
-                    create | delete | distinct | drop | else | except |
-                    exists | filter | function | get | group | if |
-                    ilike | in | insert | intersect | is | like |
-                    limit | module | not | offset | or | order | over |
+                    aggregate | all | alter | and | commit | create |
+                    delete | distinct | drop | else | empty | exists |
+                    false | filter | function | get | group | if |
+                    ilike | in | insert | is | like | limit | matches |
+                    module | not | offset | or | order | over |
                     partition | returning | rollback | select | set |
-                    singleton | start | update | union | with
+                    singleton | start | true | update | union | with
                 )\b
             ''', token.Keyword.Reserved),
         ],

--- a/edgedb/lang/ir/ast.py
+++ b/edgedb/lang/ir/ast.py
@@ -19,6 +19,7 @@ from edgedb.lang.schema import pointers as s_pointers
 from edgedb.lang.schema import sources as s_sources
 
 from edgedb.lang.edgeql import ast as qlast
+from edgedb.lang.edgeql.ast import REMATCH, NOT_REMATCH  # NOQA
 
 
 class ASTError(EdgeDBError):

--- a/edgedb/lang/schema/_std.eql
+++ b/edgedb/lang/schema/_std.eql
@@ -175,7 +175,7 @@ CREATE CONSTRAINT std::minlength(std::any) INHERITING (std::min, std::length) {
 
 CREATE CONSTRAINT std::regexp(std::any) INHERITING std::constraint {
     SET errmessage := 'invalid {subject}';
-    SET expr := ((subject ~ $0));
+    SET expr := ((subject MATCHES $0));
 };
 
 CREATE CONSTRAINT std::maxlength(std::any) INHERITING (std::max, std::length) {

--- a/edgedb/server/pgsql/ast.py
+++ b/edgedb/server/pgsql/ast.py
@@ -581,8 +581,10 @@ LIKE = PgSQLComparisonOperator('~~')
 NOT_LIKE = PgSQLComparisonOperator('!~~')
 ILIKE = PgSQLComparisonOperator('~~*')
 NOT_ILIKE = PgSQLComparisonOperator('!~~*')
+
 SIMILAR_TO = PgSQLComparisonOperator('~')
 NOT_SIMILAR_TO = PgSQLComparisonOperator('!~')
+
 IS_DISTINCT = PgSQLComparisonOperator('IS DISTINCT')
 IS_NOT_DISTINCT = PgSQLComparisonOperator('IS NOT DISTINCT')
 IS_OF = PgSQLComparisonOperator('IS OF')

--- a/edgedb/server/pgsql/compiler/expr.py
+++ b/edgedb/server/pgsql/compiler/expr.py
@@ -361,6 +361,10 @@ def compile_BinOp(
                 )
 
             return result
+        elif expr.op == irast.REMATCH:
+            op = '~'
+        elif expr.op == irast.NOT_REMATCH:
+            op = '!~'
         else:
             op = expr.op
 

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -468,7 +468,7 @@ class TestIntrospection(tb.QueryTestCase):
             SELECT Class {
                 name
             }
-            FILTER Class.name ~ '^test::\w+$'
+            FILTER Class.name MATCHES '^test::\w+$'
             ORDER BY Class.name;
         """, [
             [

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -541,21 +541,21 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             SELECT
                 Text {body}
             FILTER
-                Text.body ~ 'ed'
+                Text.body MATCHES 'ed'
             ORDER BY Text.body;
 
             WITH MODULE test
             SELECT
                 Text {body}
             FILTER
-                Text.body ~ 'eD'
+                Text.body MATCHES 'eD'
             ORDER BY Text.body;
 
             WITH MODULE test
             SELECT
                 Text {body}
             FILTER
-                Text.body ~ 'ed([S\s]|$)'
+                Text.body MATCHES 'ed([S\s]|$)'
             ORDER BY Text.body;
         """, [
             [{'body': 'EdgeDB needs to happen soon.'},
@@ -573,21 +573,21 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             SELECT
                 Text {body}
             FILTER
-                Text.body ~* 'ed'
+                Text.body MATCHES '(?i)ed'
             ORDER BY Text.body;
 
             WITH MODULE test
             SELECT
                 Text {body}
             FILTER
-                Text.body ~* 'eD'
+                Text.body MATCHES '(?i)eD'
             ORDER BY Text.body;
 
             WITH MODULE test
             SELECT
                 Text {body}
             FILTER
-                Text.body ~* 'ed([S\s]|$)'
+                Text.body MATCHES '(?i)ed([S\s]|$)'
             ORDER BY Text.body;
         """, [
             [{'body': 'EdgeDB needs to happen soon.'},
@@ -601,6 +601,78 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'body': 'EdgeDB needs to happen soon.'},
              {'body': 'Fix regression introduced by lexer tweak.'},
              {'body': 'We need to be able to render data in tabular format.'}],
+        ])
+
+    async def test_edgeql_select_match09(self):
+        await self.assert_query_result(r"""
+            WITH MODULE test
+            SELECT
+                Text {body}
+            FILTER
+                Text.body NOT MATCHES 'ed'
+            ORDER BY Text.body;
+
+            WITH MODULE test
+            SELECT
+                Text {body}
+            FILTER
+                Text.body NOT MATCHES 'eD'
+            ORDER BY Text.body;
+
+            WITH MODULE test
+            SELECT
+                Text {body}
+            FILTER
+                Text.body NOT MATCHES 'ed([S\s]|$)'
+            ORDER BY Text.body;
+        """, [
+            [{'body': 'Initial public release of EdgeDB.'},
+             {'body': 'Minor lexer tweaks.'},
+             {'body': 'Rewriting everything.'}],
+            [{'body': 'Fix regression introduced by lexer tweak.'},
+             {'body': 'Minor lexer tweaks.'},
+             {'body': 'Rewriting everything.'},
+             {'body': 'We need to be able to render data in tabular format.'}],
+            [{'body': 'EdgeDB needs to happen soon.'},
+             {'body': 'Initial public release of EdgeDB.'},
+             {'body': 'Minor lexer tweaks.'},
+             {'body': 'Rewriting everything.'}],
+        ])
+
+    async def test_edgeql_select_match10(self):
+        await self.assert_query_result(r"""
+            WITH MODULE test
+            SELECT
+                Text {body}
+            FILTER
+                NOT Text.body MATCHES 'ed'
+            ORDER BY Text.body;
+
+            WITH MODULE test
+            SELECT
+                Text {body}
+            FILTER
+                NOT Text.body MATCHES 'eD'
+            ORDER BY Text.body;
+
+            WITH MODULE test
+            SELECT
+                Text {body}
+            FILTER
+                NOT Text.body MATCHES 'ed([S\s]|$)'
+            ORDER BY Text.body;
+        """, [
+            [{'body': 'Initial public release of EdgeDB.'},
+             {'body': 'Minor lexer tweaks.'},
+             {'body': 'Rewriting everything.'}],
+            [{'body': 'Fix regression introduced by lexer tweak.'},
+             {'body': 'Minor lexer tweaks.'},
+             {'body': 'Rewriting everything.'},
+             {'body': 'We need to be able to render data in tabular format.'}],
+            [{'body': 'EdgeDB needs to happen soon.'},
+             {'body': 'Initial public release of EdgeDB.'},
+             {'body': 'Minor lexer tweaks.'},
+             {'body': 'Rewriting everything.'}],
         ])
 
     async def test_edgeql_select_type01(self):

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -262,8 +262,8 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
     def test_edgeql_syntax_ops13(self):
         """
         SELECT (User.name @@ 'bob');
-        SELECT (User.name ~ '^[[:lower:]]+$');
-        SELECT (User.name ~* 'don');
+        SELECT (User.name MATCHES '^[[:lower:]]+$');
+        SELECT (User.name NOT MATCHES 'don');
         """
 
     def test_edgeql_syntax_ops14(self):
@@ -375,7 +375,7 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  'Unexpected token.*~', line=2, col=16)
+                  'Unknown token.*~', line=2, col=16)
     def test_edgeql_syntax_ops21(self):
         """
         SELECT ~1;


### PR DESCRIPTION
Add `MATCHES` and `NOT MATCHES` regular expression operators. For the
case-insensitive version the "(?i)" flag should be used in the regular
expression being matched.

This is a pull request for issue #3.