### PR TITLE
edgeql: Add empty tuple.

### DIFF
--- a/edgedb/lang/edgeql/parser/grammar/expressions.py
+++ b/edgedb/lang/edgeql/parser/grammar/expressions.py
@@ -774,6 +774,9 @@ class Tuple(Nonterm):
     def reduce_LPAREN_Expr_COMMA_OptExprList_RPAREN(self, *kids):
         self.val = qlast.Tuple(elements=[kids[1].val] + kids[3].val)
 
+    def reduce_LPAREN_RPAREN(self, *kids):
+        self.val = qlast.Tuple(elements=[])
+
 
 class NamedTuple(Nonterm):
     def reduce_LPAREN_NamedTupleElementList_RPAREN(self, *kids):

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -972,6 +972,13 @@ class TestExpressions(tb.QueryTestCase):
                 SELECT (a := 1, b := 'foo') != (b := 'foo', a := 1);
             """)
 
+    async def test_edgeql_expr_tuple09(self):
+        await self.assert_query_result(r"""
+            SELECT ();
+        """, [
+            [[]],
+        ])
+
     async def test_edgeql_expr_tuple_indirection01(self):
         await self.assert_query_result(r"""
             SELECT ('foo', 42).0;

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2029,6 +2029,11 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
         SELECT (name := 'foo', val := 42).val;
         """
 
+    def test_edgeql_syntax_tuple03(self):
+        """
+        SELECT ();
+        """
+
     # DDL
     #
 


### PR DESCRIPTION
Empty tuples are now supported by EdgeDB. Needed for #44 