### PR TITLE
Use new constraints syntax in eschema.

### DIFF
--- a/edgedb/lang/common/context.py
+++ b/edgedb/lang/common/context.py
@@ -209,7 +209,7 @@ def has_context(func):
     return wrapper
 
 
-def rebase_context(base, context):
+def rebase_context(base, context, *, offset_column=0):
     if not context:
         return
 
@@ -217,9 +217,9 @@ def rebase_context(base, context):
     context.buffer = base.buffer
 
     if context.start.line == 1:
-        context.start.column += base.start.column - 1
+        context.start.column += base.start.column - 1 + offset_column
     context.start.line += base.start.line - 1
-    context.start.pointer += base.start.pointer
+    context.start.pointer += base.start.pointer + offset_column
 
 
 class ContextVisitor(ast.NodeVisitor):

--- a/edgedb/lang/edgeql/codegen.py
+++ b/edgedb/lang/edgeql/codegen.py
@@ -486,7 +486,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         if isinstance(node.func, tuple):
             self.write('::'.join(node.func))
         else:
-            self.write(node.func)
+            self.write(ident_to_str(node.func))
 
         self.write('(')
 

--- a/edgedb/lang/edgeql/parser/grammar/ddl.py
+++ b/edgedb/lang/edgeql/parser/grammar/ddl.py
@@ -1406,6 +1406,11 @@ class FuncDeclArg(Nonterm):
             default=kids[5].val
         )
 
+    def reduce_OptVariadic_DOLLAR_Identifier_OptDefault(self, *kids):
+        raise EdgeQLSyntaxError(
+            f'missing type declaration for function parameter ${kids[2].val}',
+            context=kids[1].context)
+
 
 class FuncDeclArgList(ListNonterm, element=FuncDeclArg,
                       separator=tokens.T_COMMA):

--- a/edgedb/lang/schema/ast.py
+++ b/edgedb/lang/schema/ast.py
@@ -10,6 +10,7 @@ import typing
 
 from edgedb.lang.common import enum as s_enum
 from edgedb.lang.common import ast, parsing
+from edgedb.lang.edgeql import ast as qlast
 
 
 class Base(ast.AST):
@@ -147,7 +148,7 @@ class Attribute(Base):
 
 class Constraint(Base):
     name: ObjectName
-    args: object  # TODO: make it `qlast.Tuple`
+    args: qlast.Tuple  # TODO: replace with `List[qlast.Base]`
     abstract: bool = False
     attributes: typing.List[Attribute]
 

--- a/edgedb/lang/schema/codegen.py
+++ b/edgedb/lang/schema/codegen.py
@@ -193,7 +193,7 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
         if node.variadic:
             self.write('*')
         if node.name is not None:
-            self.write(ident_to_str(node.name), ': ')
+            self.write('$', ident_to_str(node.name), ': ')
         self.visit(node.type)
 
         if node.default:
@@ -246,8 +246,9 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
         self.write('constraint ')
         self.visit(node.name)
         if node.args:
+            assert isinstance(node.args, eqlast.Tuple)
             self.write('(')
-            self.visit_list(node.args, newlines=False)
+            self.visit_list(node.args.elements)
             self.write(')')
 
         if node.attributes:

--- a/tests/schemas/constraints.eschema
+++ b/tests/schemas/constraints.eschema
@@ -7,36 +7,36 @@
 
 
 atom constraint_length extends str:
-    constraint maxlength := 16
-    constraint maxlength := 10
-    constraint minlength := 5
-    constraint minlength := 8
+    constraint maxlength(16)
+    constraint maxlength(10)
+    constraint minlength(5)
+    constraint minlength(8)
 
 
 atom constraint_length_2 extends constraint_length:
-    constraint minlength := 9
+    constraint minlength(9)
 
 
 atom constraint_minmax extends str:
-    constraint min := "99900000"
-    constraint min := "99990000"
-    constraint max := "9999999989"
+    constraint min("99900000")
+    constraint min("99990000")
+    constraint max("9999999989")
 
 
 atom constraint_strvalue extends str:
     constraint expression:
         subject := (subject)[-1:] = '9'
 
-    constraint regexp := "^\d+$"
+    constraint regexp("^\d+$")
 
     constraint expression:
         subject := (subject)[0] = '9'
 
-    constraint regexp := "^\d+9{3,}.*$"
+    constraint regexp("^\d+9{3,}.*$")
 
 
 atom constraint_enum extends str:
-   constraint enum := ['foo', 'bar']
+   constraint enum(['foo', 'bar'])
 
 
 link translated_label:
@@ -67,7 +67,7 @@ concept Object:
     link c_length to constraint_length
     link c_length_2 to constraint_length_2
     link c_length_3 to constraint_length_2:
-        constraint minlength := 10
+        constraint minlength(10)
 
     link c_minmax to constraint_minmax
     link c_strvalue to constraint_strvalue

--- a/tests/schemas/constraints_migration/schema.eschema
+++ b/tests/schemas/constraints_migration/schema.eschema
@@ -7,36 +7,36 @@
 
 
 atom constraint_length extends str:
-    constraint maxlength := 16
-    constraint maxlength := 10
-    constraint minlength := 5
-    constraint minlength := 8
+    constraint maxlength(16)
+    constraint maxlength(10)
+    constraint minlength(5)
+    constraint minlength(8)
 
 
 atom constraint_length_2 extends constraint_length:
-    constraint minlength := 9
+    constraint minlength(9)
 
 
 atom constraint_minmax extends str:
-    constraint min := "99900000"
-    constraint min := "99990000"
-    constraint max := "9999999989"
+    constraint min("99900000")
+    constraint min("99990000")
+    constraint max("9999999989")
 
 
 atom constraint_strvalue extends str:
     constraint expression:
         subject := (subject)[-1:] = '9'
 
-    constraint regexp := "^\d+$"
+    constraint regexp("^\d+$")
 
     constraint expression:
         subject := (subject)[0] = '9'
 
-    constraint regexp := "^\d+9{3,}.*$"
+    constraint regexp("^\d+9{3,}.*$")
 
 
 atom constraint_enum extends str:
-   constraint enum := ['foo', 'bar']
+   constraint enum(['foo', 'bar'])
 
 
 link translated_label:
@@ -67,7 +67,7 @@ concept Object:
     link c_length to constraint_length
     link c_length_2 to constraint_length_2
     link c_length_3 to constraint_length_2:
-        constraint minlength := 10
+        constraint minlength(10)
 
     link c_minmax to constraint_minmax
     link c_strvalue to constraint_strvalue

--- a/tests/schemas/constraints_migration/updated_schema.eschema
+++ b/tests/schemas/constraints_migration/updated_schema.eschema
@@ -7,36 +7,36 @@
 
 
 atom constraint_length extends str:
-    constraint maxlength := 16
-    constraint maxlength := 10
-    constraint minlength := 5
-    constraint minlength := 8
+    constraint maxlength(16)
+    constraint maxlength(10)
+    constraint minlength(5)
+    constraint minlength(8)
 
 
 atom constraint_length_2 extends constraint_length:
-    constraint minlength := 9
+    constraint minlength(9)
 
 
 atom constraint_minmax extends str:
-    constraint min := "99900000"
-    constraint min := "99990000"
-    constraint max := "9999999989"
+    constraint min("99900000")
+    constraint min("99990000")
+    constraint max("9999999989")
 
 
 atom constraint_strvalue extends str:
     constraint expression:
         subject := (subject)[-1:] = '9'
 
-    constraint regexp := "^\d+$"
+    constraint regexp("^\d+$")
 
     constraint expression:
         subject := (subject)[0] = '9'
 
-    constraint regexp := "^\d+9{3,}.*$"
+    constraint regexp("^\d+9{3,}.*$")
 
 
 atom constraint_enum extends str:
-   constraint enum := ['foo', 'bar']
+   constraint enum(['foo', 'bar'])
 
 
 link translated_label:
@@ -73,7 +73,7 @@ concept Object:
     link c_length to constraint_length
     link c_length_2 to constraint_length_2
     link c_length_3 to constraint_length_2:
-        constraint minlength := 10
+        constraint minlength(10)
 
     link c_minmax to constraint_minmax
     link c_strvalue to constraint_strvalue

--- a/tests/schemas/issues.eschema
+++ b/tests/schemas/issues.eschema
@@ -2,7 +2,7 @@ abstract concept Text:
     # This is an abstract object containing text.
     required link body to str:
         # Maximum length of text is 10000 characters.
-        constraint maxlength := 10000
+        constraint maxlength(10000)
 
 
 abstract concept Named:

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2560,6 +2560,15 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
             FROM SQL FUNCTION 'strlen';
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'missing type declaration.*\$arg3', line=2, col=74)
+    def test_edgeql_syntax_ddl_function30(self):
+        """
+        CREATE FUNCTION std::foobar($arg1: str, $arg2: str = 'DEFAULT', *$arg3)
+            RETURNING std::int
+            FROM EdgeQL $$$$;
+        """
+
     def test_edgeql_syntax_ddl_linkproperty01(self):
         """
         CREATE LINK PROPERTY std::linkproperty {


### PR DESCRIPTION
Update eschema parser to use EdgeQL parser for function and constraint
declarations, and for constraint application.

Enhance EdgeQL parser with a better error message for a missing
parameter type declaration.

Fixes #11.