### PR TITLE
Refactor eschema/keywords

### DIFF
--- a/edgedb/lang/edgeql/__init__.py
+++ b/edgedb/lang/edgeql/__init__.py
@@ -11,4 +11,5 @@ from .codegen import generate_source  # NOQA
 from .errors import EdgeQLError, EdgeQLSyntaxError  # NOQA
 from .optimizer import optimize, deoptimize  # NOQA
 from .parser import parse, parse_fragment, parse_block  # NOQA
+from .parser.grammar import keywords  # NOQA
 from .rewriter import rewrite_refs  # NOQA

--- a/edgedb/lang/edgeql/parser/grammar/keywords.py
+++ b/edgedb/lang/edgeql/parser/grammar/keywords.py
@@ -12,7 +12,7 @@ import typing
 keyword_types = range(1, 4)
 UNRESERVED_KEYWORD, RESERVED_KEYWORD, TYPE_FUNC_NAME_KEYWORD = keyword_types
 
-unreserved_keywords = [
+unreserved_keywords = frozenset([
     "abstract",
     "action",
     "after",
@@ -53,11 +53,12 @@ unreserved_keywords = [
     "tuple",
     "value",
     "view",
-]
+])
+
 
 # NOTE: all operators are made into RESERVED keywords for reasons of style.
 #
-reserved_keywords = [
+reserved_keywords = frozenset([
     "aggregate",
     "all",
     "alter",
@@ -99,7 +100,19 @@ reserved_keywords = [
     "update",
     "union",
     "with",
-]
+])
+
+
+def _check_keywords():
+    duplicate_keywords = reserved_keywords & unreserved_keywords
+    if duplicate_keywords:
+        raise ValueError(
+            f'The following EdgeQL keywords are defined as *both* '
+            f'reserved and unreserved: {duplicate_keywords!r}')
+
+
+_check_keywords()
+
 
 edgeql_keywords = {k: (k.upper(), UNRESERVED_KEYWORD)
                    for k in unreserved_keywords}


### PR DESCRIPTION
1. Add a number of checks to ensure that eschema and EdgeQL
   keywords are in sync.

2. Clearly separate unreserved and reserved keywords from
   each other.