### PR TITLE
Use the same set of reserved keywords in both EdgeQL and eschema

### DIFF
--- a/edgedb/lang/schema/parser/grammar/keywords.py
+++ b/edgedb/lang/schema/parser/grammar/keywords.py
@@ -42,13 +42,11 @@ unreserved_keywords = frozenset([
 ])
 
 
-reserved_keywords = frozenset([
-    "aggregate",
-    "false",
-    "function",
-    "set",
-    "true",
-])
+# We use the same reserved keywords in both eschema and EdgeQL
+# to enforce consistency in naming.  E.g. if a concept name is a reserved
+# keyword in EdgeQL and needs to be quoted, the same should apply to
+# eschema.
+reserved_keywords = edgeql.keywords.reserved_keywords
 
 
 def _check_keywords():

--- a/edgedb/lang/schema/parser/grammar/lexer.py
+++ b/edgedb/lang/schema/parser/grammar/lexer.py
@@ -60,7 +60,7 @@ class EdgeSchemaLexer(lexer.Lexer):
 
     NL = 'NEWLINE'
     MULTILINE_TOKENS = frozenset(('STRING', 'RAWSTRING'))
-    RE_FLAGS = re.X | re.M
+    RE_FLAGS = re.X | re.M | re.I
 
     # Basic keywords
     keyword_rules = [Rule(token=tok[0],

--- a/tests/test_edgeql_utils.py
+++ b/tests/test_edgeql_utils.py
@@ -20,7 +20,7 @@ class TestEdgeQLUtils(tb.BaseSyntaxTest):
         abstract concept NamedObject:
             required link name to str
 
-        concept Group extending NamedObject:
+        concept UserGroup extending NamedObject:
             link settings to Setting:
                 mapping: 1*
 
@@ -32,7 +32,7 @@ class TestEdgeQLUtils(tb.BaseSyntaxTest):
 
         concept User extending NamedObject:
             required link active to bool
-            link groups to Group:
+            link groups to UserGroup:
                 mapping: **
             required link age to int
             required link score to float

--- a/tests/test_graphql_functional.py
+++ b/tests/test_graphql_functional.py
@@ -17,7 +17,7 @@ class TestGraphQLFunctional(tb.QueryTestCase):
             abstract concept NamedObject:
                 required link name to str
 
-            concept Group extending NamedObject:
+            concept UserGroup extending NamedObject:
                 link settings to Setting:
                     mapping: **
 
@@ -29,7 +29,7 @@ class TestGraphQLFunctional(tb.QueryTestCase):
 
             concept User extending NamedObject:
                 required link active to bool
-                link groups to Group:
+                link groups to UserGroup:
                     mapping: **
                 required link age to int
                 required link score to float
@@ -52,12 +52,12 @@ class TestGraphQLFunctional(tb.QueryTestCase):
         };
 
         WITH MODULE test
-        INSERT `Group` {
+        INSERT UserGroup {
             name := 'basic'
         };
 
         WITH MODULE test
-        INSERT `Group` {
+        INSERT UserGroup {
             name := 'upgraded'
         };
 
@@ -67,7 +67,7 @@ class TestGraphQLFunctional(tb.QueryTestCase):
             age := 25,
             active := True,
             score := 3.14,
-            groups := (SELECT `Group` FILTER `Group`.name = 'basic')
+            groups := (SELECT UserGroup FILTER UserGroup.name = 'basic')
         };
 
         WITH MODULE test
@@ -76,7 +76,7 @@ class TestGraphQLFunctional(tb.QueryTestCase):
             age := 26,
             active := True,
             score := 1.23,
-            groups := (SELECT `Group` FILTER `Group`.name = 'upgraded')
+            groups := (SELECT UserGroup FILTER UserGroup.name = 'upgraded')
         };
 
         WITH MODULE test

--- a/tests/test_graphql_mutation.py
+++ b/tests/test_graphql_mutation.py
@@ -17,7 +17,7 @@ class TestGraphQLMutation(tb.QueryTestCase):
             abstract concept NamedObject:
                 required link name to str
 
-            concept Group extending NamedObject:
+            concept UserGroup extending NamedObject:
                 link settings to Setting:
                     mapping: **
 
@@ -29,7 +29,7 @@ class TestGraphQLMutation(tb.QueryTestCase):
 
             concept User extending NamedObject:
                 required link active to bool
-                link groups to Group:
+                link groups to UserGroup:
                     mapping: **
                 required link age to int
                 required link score to float
@@ -54,12 +54,12 @@ class TestGraphQLMutation(tb.QueryTestCase):
             };
 
             WITH MODULE test
-            INSERT `Group` {
+            INSERT UserGroup {
                 name := 'basic'
             };
 
             WITH MODULE test
-            INSERT `Group` {
+            INSERT UserGroup {
                 name := 'upgraded'
             };
 
@@ -69,7 +69,7 @@ class TestGraphQLMutation(tb.QueryTestCase):
                 age := 25,
                 active := True,
                 score := 3.14,
-                groups := (SELECT `Group` FILTER `Group`.name = 'basic')
+                groups := (SELECT UserGroup FILTER UserGroup.name = 'basic')
             };
 
             WITH MODULE test
@@ -78,7 +78,7 @@ class TestGraphQLMutation(tb.QueryTestCase):
                 age := 26,
                 active := True,
                 score := 1.23,
-                groups := (SELECT `Group` FILTER `Group`.name = 'upgraded')
+                groups := (SELECT UserGroup FILTER UserGroup.name = 'upgraded')
             };
 
             WITH MODULE test
@@ -92,7 +92,7 @@ class TestGraphQLMutation(tb.QueryTestCase):
 
     TEARDOWN_METHOD = """
             DELETE test::Setting;
-            DELETE test::Group;
+            DELETE test::UserGroup;
             DELETE test::User;
     """
 
@@ -193,7 +193,7 @@ class TestGraphQLMutation(tb.QueryTestCase):
     async def test_graphql_mutation_insert01(self):
         result = await self.con.execute(r"""
             mutation @edgedb(module: "test") {
-                insert__Group(__data: {
+                insert__UserGroup(__data: {
                     name: "new"
                 }) {
                     id
@@ -213,7 +213,7 @@ class TestGraphQLMutation(tb.QueryTestCase):
     async def test_graphql_mutation_insert02(self):
         groups = await self.con.execute(r"""
             query @edgedb(module: "test") {
-                Group(name: "basic") {
+                UserGroup(name: "basic") {
                     id,
                 }
             }
@@ -412,7 +412,7 @@ class TestGraphQLMutation(tb.QueryTestCase):
     async def test_graphql_mutation_update02(self):
         groups = await self.con.execute(r"""
             query @edgedb(module: "test") {
-                Group(name: "basic") {
+                UserGroup(name: "basic") {
                     id,
                 }
             }

--- a/tests/test_graphql_translator.py
+++ b/tests/test_graphql_translator.py
@@ -88,7 +88,7 @@ class TestGraphQLTranslation(TranslatorTest):
         abstract concept NamedObject:
             required link name to str
 
-        concept Group extending NamedObject:
+        concept UserGroup extending NamedObject:
             link settings to Setting:
                 mapping: 1*
 
@@ -100,7 +100,7 @@ class TestGraphQLTranslation(TranslatorTest):
 
         concept User extending NamedObject:
             required link active to bool
-            link groups to Group:
+            link groups to UserGroup:
                 mapping: **
             required link age to int
             required link score to float
@@ -116,7 +116,7 @@ class TestGraphQLTranslation(TranslatorTest):
 
     SCHEMA_123LIB = r"""
         concept Foo:
-            link select to str
+            link `select` to str
             link after to str
     """
 
@@ -232,7 +232,7 @@ class TestGraphQLTranslation(TranslatorTest):
 
     def test_graphql_translation_fragment01(self):
         r"""
-        fragment groupFrag on Group @edgedb(module: "test") {
+        fragment groupFrag on UserGroup @edgedb(module: "test") {
             id
             name
         }
@@ -271,7 +271,7 @@ class TestGraphQLTranslation(TranslatorTest):
             }
         }
 
-        fragment groupFrag on Group @edgedb(module: "test") {
+        fragment groupFrag on UserGroup @edgedb(module: "test") {
             id
             name
         }
@@ -302,7 +302,7 @@ class TestGraphQLTranslation(TranslatorTest):
             }
         }
 
-        fragment groupFrag on Group @edgedb(module: "test") {
+        fragment groupFrag on UserGroup @edgedb(module: "test") {
             id
             name
         }
@@ -339,7 +339,7 @@ class TestGraphQLTranslation(TranslatorTest):
             }
         }
 
-        fragment groupFrag on Group @edgedb(module: "test") {
+        fragment groupFrag on UserGroup @edgedb(module: "test") {
             id
             name
         }
@@ -438,7 +438,7 @@ class TestGraphQLTranslation(TranslatorTest):
             }
         }
 
-        fragment groupFrag on Group @edgedb(module: "test") {
+        fragment groupFrag on UserGroup @edgedb(module: "test") {
             id
             name
         }
@@ -468,7 +468,7 @@ class TestGraphQLTranslation(TranslatorTest):
             }
         }
 
-        fragment groupFrag on Group @edgedb(module: "test") {
+        fragment groupFrag on UserGroup @edgedb(module: "test") {
             id
             name
         }
@@ -499,7 +499,7 @@ class TestGraphQLTranslation(TranslatorTest):
             }
         }
 
-        fragment groupFrag on Group @edgedb(module: "test") {
+        fragment groupFrag on UserGroup @edgedb(module: "test") {
             name
         }
 
@@ -533,7 +533,7 @@ class TestGraphQLTranslation(TranslatorTest):
             }
         }
 
-        fragment groupFrag on Group @edgedb(module: "test") {
+        fragment groupFrag on UserGroup @edgedb(module: "test") {
             name
         }
 
@@ -569,7 +569,7 @@ class TestGraphQLTranslation(TranslatorTest):
             }
         }
 
-        fragment groupFrag on Group @edgedb(module: "test") {
+        fragment groupFrag on UserGroup @edgedb(module: "test") {
             name
         }
 
@@ -604,7 +604,7 @@ class TestGraphQLTranslation(TranslatorTest):
             }
         }
 
-        fragment groupFrag on Group @edgedb(module: "test") {
+        fragment groupFrag on UserGroup @edgedb(module: "test") {
             name
         }
 
@@ -1387,7 +1387,7 @@ class TestGraphQLTranslation(TranslatorTest):
         r"""
         query @edgedb(module: "test") {
             # this is an ENUM that gets simply converted to a string in EdgeQL
-            Group(name: admin) {
+            UserGroup(name: admin) {
                 id,
                 name,
             }
@@ -1396,12 +1396,12 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT
-            (test::`Group`){
+            (test::UserGroup){
                 id,
                 name,
             }
         FILTER
-            ((test::`Group`).name = 'admin');
+            ((test::UserGroup).name = 'admin');
         """
 
     def test_graphql_translation_arg_type01(self):
@@ -1861,7 +1861,7 @@ class TestGraphQLTranslation(TranslatorTest):
         }
 
         query @edgedb(module: "test") {
-            Group {
+            UserGroup {
                 ... userFrag
             }
         }
@@ -1875,7 +1875,7 @@ class TestGraphQLTranslation(TranslatorTest):
             name,
         }
 
-        fragment groupFrag on Group @edgedb(module: "test") {
+        fragment groupFrag on UserGroup @edgedb(module: "test") {
             ... userFrag
         }
 
@@ -2043,7 +2043,7 @@ class TestGraphQLTranslation(TranslatorTest):
 
     def test_graphql_translation_import01(self):
         r"""
-        fragment groupFrag on Group @edgedb(module: "test") {
+        fragment groupFrag on UserGroup @edgedb(module: "test") {
             id
             name
         }
@@ -2074,7 +2074,7 @@ class TestGraphQLTranslation(TranslatorTest):
     @tb.must_fail(GraphQLValidationError, line=8, col=13)
     def test_graphql_translation_import02(self):
         r"""
-        fragment groupFrag on Group @edgedb(module: "test") {
+        fragment groupFrag on UserGroup @edgedb(module: "test") {
             id
             name
         }
@@ -2342,7 +2342,7 @@ class TestGraphQLTranslation(TranslatorTest):
     def test_graphql_translation_insert01(self):
         r"""
         mutation @edgedb(module: "test") {
-            insert__Group(__data: {
+            insert__UserGroup(__data: {
                 name: "new"
             }) {
                 id,
@@ -2354,7 +2354,7 @@ class TestGraphQLTranslation(TranslatorTest):
 
         SELECT (
             INSERT
-                test::`Group` {
+                test::UserGroup {
                     name := 'new'
                 }
         ) {

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -138,6 +138,15 @@ concept `Log-Entry` extending OwnedObject, Text:
     required link attachment to Post, File, User
         """
 
+    @tb.must_fail(error.SchemaSyntaxError,
+                  "Unexpected token.*COMMIT",
+                  line=2, col=9)
+    def test_eschema_syntax_concept11(self):
+        """
+concept Commit:
+    required link name to std::str
+        """
+
     def test_eschema_syntax_type01(self):
         """
 concept User:


### PR DESCRIPTION
1. This commit also makes eschema keywords case-insensitive.

2. The set of reserved keywords is now the same for both EdgeQL
   and eschema.

3. This change further enforces the same naming rules for both
   languages. If an identifier needs to be quoted in one, it will
   need to be quoted in the other.