### PR TITLE
graphql: Fix issues around string escape characters.

### DIFF
--- a/edgedb/lang/graphql/ast.py
+++ b/edgedb/lang/graphql/ast.py
@@ -37,19 +37,16 @@ class StringLiteral(Literal):
     def tosource(self):
         value = self.value
         # generic substitutions for '\b' and '\f'
-        #
         value = value.replace('\b', '\\b').replace('\f', '\\f')
         value = repr(value)
         # escape \b \f \u1234 and \/ correctly
-        #
         value = re.sub(r'\\\\([fb])', r'\\\1', value)
         value = re.sub(r'\\\\(u[0-9a-fA-F]{4})', r'\\\1', value)
-        value = value.replace('/', r'\/')
+        # no need to escape '/' as '\/' since it's legal unescaped
 
+        # need to change quotation style
         if value[0] == "'":
-            # need to change quotation style
-            #
-            value = value[1:-1].replace(R'\'', "'").replace('"', R'\"')
+            value = value[1:-1].replace(R"\'", "'").replace('"', R'\"')
             value = '"' + value + '"'
 
         return value

--- a/tests/test_graphql_syntax.py
+++ b/tests/test_graphql_syntax.py
@@ -124,6 +124,36 @@ class TestGraphQLParser(GraphQLSyntaxTest):
         ) }
         """
 
+    def test_graphql_syntax_string11(self):
+        r"""
+        { field(arg: "\\/ \\\/") }
+
+% OK %
+
+        { field(arg: "\\/ \\/") }
+        """
+
+    def test_graphql_syntax_string12(self):
+        r"""
+        { field(arg: "\\\\x") }
+        """
+
+    @tb.must_fail(InvalidStringTokenError, line=2, col=25)
+    def test_graphql_syntax_string13(self):
+        r"""
+        { field(arg: "\\\x") }
+        """
+
+    def test_graphql_syntax_string14(self):
+        r"""
+        { field(arg: "\\'") }
+        """
+
+    def test_graphql_syntax_string15(self):
+        r"""
+        { field(arg: "\\\n \\\\n") }
+        """
+
     def test_graphql_syntax_short01(self):
         """{id}"""
 
@@ -517,6 +547,7 @@ class TestGraphQLParser(GraphQLSyntaxTest):
         """
 
     def test_graphql_syntax_values04(self):
+        # graphql escapes: \", \\, \/, \b, \f, \n, \r, \t
         r"""
         {
             foo(id: 4) {
@@ -524,6 +555,15 @@ class TestGraphQLParser(GraphQLSyntaxTest):
                 bar(name: "\"something\"",
                     more: "",
                     description: "\\\/\b\f\n\r\t 'blah' спам")
+            }
+        }
+% OK %
+        {
+            foo(id: 4) {
+                id
+                bar(name: "\"something\"",
+                    more: "",
+                    description: "\\/\b\f\n\r\t 'blah' спам")
             }
         }
         """


### PR DESCRIPTION
GraphQL has different valid escape sequences than Python. Specifically,
the `\/` is not a valid escape in Python, but it is in GraphQL. All
other escape sequences in GraphQL are also valid in Python.

There were several subtle issues with escape sequences converted
incorrectly. Main issues were incorrect and overzealous
escaping/unescaping (e.g. `"\\'"` was incorrectly converted).