### PR TITLE
Implement support for computable pointers in the compiler.

### DIFF
--- a/edgedb/lang/common/ast/visitor.py
+++ b/edgedb/lang/common/ast/visitor.py
@@ -38,6 +38,8 @@ def find_children(node, test_func, *args, force_traversal=False,
                         if not field_spec.hidden and test_func(
                                 n, *args, **kwargs):
                             result.append(n)
+                            if terminate_early:
+                                return result
                     except SkipNode:
                         continue
 
@@ -45,12 +47,16 @@ def find_children(node, test_func, *args, force_traversal=False,
                         _n = _find_children(n, test_func)
                         if _n is not None:
                             result.extend(_n)
+                            if terminate_early:
+                                return result
 
             elif base.is_ast_node(value):
                 try:
                     if not field_spec.hidden and test_func(
                             value, *args, **kwargs):
                         result.append(value)
+                        if terminate_early:
+                            return result
                 except SkipNode:
                     continue
 
@@ -58,9 +64,18 @@ def find_children(node, test_func, *args, force_traversal=False,
                     _n = _find_children(value, test_func)
                     if _n is not None:
                         result.extend(_n)
+                        if terminate_early:
+                            return result
         return result
 
-    return _find_children(node, test_func)
+    nodes = _find_children(node, test_func)
+    if terminate_early:
+        if nodes:
+            return nodes[0]
+        else:
+            return None
+    else:
+        return nodes
 
 
 def find_parent(node, test_func):

--- a/edgedb/server/pgsql/delta.py
+++ b/edgedb/server/pgsql/delta.py
@@ -1898,14 +1898,13 @@ class PointerMetaCommand(MetaCommand, sd.ClassCommand,
         default = self.updates.get('default')
         default_value = None
 
-        if default:
-            if default is not None:
-                if isinstance(default, s_expr.ExpressionText):
-                    default_value = schemamech.ptr_default_to_col_default(
-                        schema, link, default)
-                else:
-                    default_value = common.quote_literal(
-                        str(default))
+        if default is not None and not link.is_pure_computable():
+            if isinstance(default, s_expr.ExpressionText):
+                default_value = schemamech.ptr_default_to_col_default(
+                    schema, link, default)
+            else:
+                default_value = common.quote_literal(
+                    str(default))
 
         return default_value
 

--- a/tests/schemas/cards.eschema
+++ b/tests/schemas/cards.eschema
@@ -16,6 +16,8 @@ concept User extending Named:
     link deck to Card:
         mapping := '**'
 
+    link deck_cost := sum(ALL self.deck.cost)
+
     link friends to User:
         mapping := '**'
 
@@ -23,3 +25,4 @@ concept User extending Named:
 concept Card extending Named:
     required link element to str
     required link cost to int
+    link owners := self.<deck[IS User]

--- a/tests/test_edgeql_views.py
+++ b/tests/test_edgeql_views.py
@@ -170,3 +170,45 @@ class TestEdgeQLViews(tb.QueryTestCase):
                 {'name': 'Sprite'},
             ],
         ])
+
+    async def test_edgeql_computable_link_01(self):
+        await self.assert_query_result(r'''
+            WITH MODULE test
+            SELECT Card {
+                owners: {
+                    name
+                } ORDER BY .name
+            }
+            FILTER .name = 'Djinn';
+        ''', [
+            [{
+                'owners': [
+                    {'name': 'Carol'},
+                    {'name': 'Dave'}
+                ]
+            }]
+        ])
+
+    async def test_edgeql_computable_link_02(self):
+        await self.assert_query_result(r'''
+            WITH MODULE test
+            SELECT User {
+                name,
+                deck_cost
+            }
+            ORDER BY User.name;
+        ''', [
+            [{
+                'name': 'Alice',
+                'deck_cost': 11
+            }, {
+                'name': 'Bob',
+                'deck_cost': 9
+            }, {
+                'name': 'Carol',
+                'deck_cost': 16
+            }, {
+                'name': 'Dave',
+                'deck_cost': 20
+            }]
+        ])


### PR DESCRIPTION
Computable pointers are pointers that have a default expression and are
declared as read-only.

This teaches the compiler to recognize such pointers and replace
references to them with the default expression.  Conceptually, this is
equivalent to references to a computable pointer defined in a view.

Fixes: #20.