### PR TITLE
Normalize treatment of scope in query-level views

### DIFF
--- a/edgedb/lang/edgeql/compiler/expr.py
+++ b/edgedb/lang/edgeql/compiler/expr.py
@@ -83,8 +83,7 @@ def compile_Parameter(
 @dispatch.compile.register(qlast.DetachedExpr)
 def compile_DetachedExpr(
         expr: qlast.DetachedExpr, *, ctx: context.ContextLevel):
-    with ctx.new() as subctx:
-        subctx.path_id_namespace = subctx.aliases.get('ns')
+    with ctx.detached() as subctx:
         return dispatch.compile(expr.expr, ctx=subctx)
 
 

--- a/edgedb/lang/ir/ast.py
+++ b/edgedb/lang/ir/ast.py
@@ -19,7 +19,7 @@ from edgedb.lang.schema import types as s_types
 from edgedb.lang.edgeql import ast as qlast
 
 from .pathid import PathId, ScopeBranchNode, ScopeFenceNode  # noqa
-from .pathid import InvalidScopeConfiguration  # noqa
+from .pathid import InvalidScopeConfiguration, WeakNamespace  # noqa
 
 
 EdgeDBMatchOperator = qlast.EdgeQLMatchOperator

--- a/edgedb/lang/ir/inference/cardinality.py
+++ b/edgedb/lang/ir/inference/cardinality.py
@@ -65,9 +65,11 @@ def __infer_typeref(ir, singletons, schema):
 
 @_infer_cardinality.register(irast.Set)
 def __infer_set(ir, singletons, schema):
-    if ir.path_id in singletons:
-        return ONE
-    elif ir.rptr is not None:
+    for path_id in ir.path_id.iter_weak_namespace_prefixes():
+        if path_id in singletons:
+            return ONE
+
+    if ir.rptr is not None:
         if ir.rptr.ptrcls.singular(ir.rptr.direction):
             return infer_cardinality(ir.rptr.source, singletons, schema)
         else:

--- a/edgedb/lang/ir/utils.py
+++ b/edgedb/lang/ir/utils.py
@@ -81,33 +81,6 @@ def is_aggregated_expr(ir):
     return bool(set(ast.find_children(ir, flt)))
 
 
-def extend_path(schema, source_set, ptr):
-    scls = source_set.scls
-
-    if isinstance(ptr, str):
-        ptrcls = scls.resolve_pointer(schema, ptr)
-    else:
-        ptrcls = ptr
-
-    path_id = source_set.path_id.extend(
-        ptrcls, s_pointers.PointerDirection.Outbound, ptrcls.target)
-
-    target_set = irast.Set()
-    target_set.scls = ptrcls.target
-    target_set.path_id = path_id
-
-    ptr = irast.Pointer(
-        source=source_set,
-        target=target_set,
-        ptrcls=ptrcls,
-        direction=s_pointers.PointerDirection.Outbound
-    )
-
-    target_set.rptr = ptr
-
-    return target_set
-
-
 def get_id_path_id(
         path_id: irast.PathId, *,
         schema: s_schema.Schema) -> irast.PathId:
@@ -118,13 +91,6 @@ def get_id_path_id(
         source.resolve_pointer(schema, 'std::id'),
         s_pointers.PointerDirection.Outbound,
         schema.get('std::uuid'))
-
-
-def get_id_path(ir_set: irast.Set, *, schema: s_schema.Schema) -> irast.Set:
-    if not isinstance(ir_set.scls, s_concepts.Concept):
-        return ir_set
-    else:
-        return extend_path(schema, ir_set, 'std::id')
 
 
 def get_subquery_shape(ir_expr):

--- a/edgedb/server/pgsql/ast.py
+++ b/edgedb/server/pgsql/ast.py
@@ -89,7 +89,8 @@ class EdgeQLPathInfo(Base):
 
     # Ignore the below fields in AST visitor/transformer.
     __ast_meta__ = {
-        'path_scope', 'path_outputs', 'path_id', 'is_distinct', 'value_scope'
+        'path_scope', 'path_outputs', 'path_id', 'is_distinct', 'value_scope',
+        'path_id_mask'
     }
 
     # The path id represented by the node.
@@ -106,6 +107,8 @@ class EdgeQLPathInfo(Base):
 
     # Map of res target names corresponding to paths.
     path_outputs: typing.Dict[irast.PathId, OutputVar]
+
+    path_id_mask: typing.Set[irast.PathId]
 
 
 class BaseRangeVar(Base):
@@ -297,11 +300,9 @@ class Query(BaseRelation, EdgeQLPathInfo):
 
     # Ignore the below fields in AST visitor/transformer.
     __ast_meta__ = {'ptr_join_map', 'path_rvar_map', 'path_namespace',
-                    'view_path_id_map', 'path_id_mask', 'argnames',
-                    'nullable'}
+                    'view_path_id_map', 'argnames', 'nullable'}
 
     view_path_id_map: typing.Dict[irast.PathId, irast.PathId]
-    path_id_mask: typing.Set[irast.PathId]
     # Map of RangeVars corresponding to pointer relations.
     ptr_join_map: dict
     # Map of RangeVars corresponding to paths.

--- a/edgedb/server/pgsql/compiler/pathctx.py
+++ b/edgedb/server/pgsql/compiler/pathctx.py
@@ -34,13 +34,6 @@ class PathAspect(s_enum.StrEnum):
     SERIALIZED = 'serialized'
 
 
-class ScopeMask:
-    pass
-
-
-scope_mask = ScopeMask()
-
-
 def map_path_id(
         path_id: irast.PathId,
         path_id_map: typing.Dict[irast.PathId, irast.PathId]) -> irast.PathId:

--- a/tests/test_edgeql_filter.py
+++ b/tests/test_edgeql_filter.py
@@ -344,6 +344,8 @@ class TestEdgeQLFilter(tb.QueryTestCase):
             [],
         ])
 
+    # XXX: this test is not longer correct with respect to inline aliases.
+    @unittest.expectedFailure
     async def test_edgeql_filter_flow03(self):
         await self.assert_query_result(r'''
             # base line for a cross product

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -33,7 +33,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
             [[a, b] for a in cards for b in cards],
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_for_cross_02(self):
         await self.assert_sorted_query_result(r'''
             WITH MODULE test
@@ -109,7 +108,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
             }
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_for_mix_02(self):
         await self.assert_sorted_query_result(r'''
             WITH MODULE test
@@ -158,7 +156,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ]
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_for_mix_04(self):
         await self.assert_query_result(r'''
             WITH MODULE test
@@ -185,7 +182,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
             }
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_for_filter_02(self):
         await self.assert_query_result(r'''
             WITH MODULE test
@@ -207,7 +203,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
             }
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_for_filter_03(self):
         await self.assert_query_result(r'''
             WITH MODULE test

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -54,16 +54,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         SELECT Card{name, cost}
 % OK %
         "FENCE": {
-            "(test::Card)",
-            "FENCE": {
-                "(test::Card).>(std::id)[IS std::uuid]"
-            },
-            "FENCE": {
-                "(test::Card).>(test::name)[IS std::str]"
-            },
-            "FENCE": {
-                "(test::Card).>(test::cost)[IS std::int]"
-            }
+            "(test::Card)"
         }
         """
 
@@ -82,18 +73,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::Card)",
             "(test::Card).<(test::deck)[IS test::User]",
             "FENCE": {
-                "(test::Card).>(std::id)[IS std::uuid]"
-            },
-            "FENCE": {
-                "(test::Card).>(test::owner)[IS test::User]",
-                "FENCE": {
-                    "(test::Card).>(test::owner)[IS test::User]\
-.>(std::id)[IS std::uuid]"
-                }
-            },
-            "FENCE": {
-                "(test::Card).<(test::deck)[IS test::User]\
-.>(std::id)[IS std::uuid]"
+                "(test::Card).>(test::owner)[IS test::User]"
             }
         }
         """
@@ -113,18 +93,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::Card).<(test::deck)[IS test::User]",
             "(test::Card)",
             "FENCE": {
-                "(test::Card).<(test::deck)[IS test::User]\
-.>(std::id)[IS std::uuid]"
-            },
-            "FENCE": {
-                "(test::Card).>(std::id)[IS std::uuid]"
-            },
-            "FENCE": {
-                "(test::Card).>(test::owner)[IS test::User]",
-                "FENCE": {
-                    "(test::Card).>(test::owner)[IS test::User]\
-.>(std::id)[IS std::uuid]"
-                }
+                "(test::Card).>(test::owner)[IS test::User]"
             }
         }
         """
@@ -146,18 +115,10 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::Card)",
             "(test::User)",
             "FENCE": {
-                "(test::Card).>(std::id)[IS std::uuid]"
-            },
-            "FENCE": {
-                "(_::__view__|U@@w~1)",
-                "(test::Card).>(test::users)[IS test::User]",
-                "FENCE": {
-                    "(test::Card).>(test::users)[IS test::User]\
-.>(std::id)[IS std::uuid]"
-                }
-            },
-            "FENCE": {
-                "(test::User).>(std::id)[IS std::uuid]"
+                "(_::__view__|U@@w~1)": {
+                    "(test::User)"
+                },
+                "(test::Card).>(test::users)[IS test::User]"
             }
         }
         """
@@ -187,10 +148,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User).>(test::deck)[IS test::Card]": {
                 "(test::User)"
-            },
-            "FENCE": {
-                "(test::User).>(test::deck)[IS test::Card]\
-.>(std::id)[IS std::uuid]"
             }
         }
         """
@@ -205,11 +162,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::User).>(test::friends)[IS test::User]",
             "(test::User).>(test::friends)[IS test::User]\
 @(test::nickname)[IS std::str]",
-            "(test::User)",
-            "FENCE": {
-                "(test::User).>(test::friends)[IS test::User]\
-.>(std::id)[IS std::uuid]"
-            }
+            "(test::User)"
         }
         """
 
@@ -229,10 +182,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                         }
                     }
                 }
-            },
-            "FENCE": {
-                "(__expr__::expr~3).>(test::friends)[IS test::User]\
-.>(std::id)[IS std::uuid]"
             }
         }
         """
@@ -264,22 +213,14 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(schema::Type)",
             "FENCE": {
-                "(schema::Type).>(std::id)[IS std::uuid]"
+                "(schema::Type).>(schema::element_type)[IS schema::Type]"
             },
             "FENCE": {
                 "(schema::Type).>(__type__::indirection)[IS schema::Array]\
 .>(schema::element_type)[IS schema::Type]": {
                     "(schema::Type).>(__type__::indirection)[IS schema::Array]"
                 },
-                "(schema::Type).>(schema::element_type)[IS schema::Type]",
-                "FENCE": {
-                    "(schema::Type).>(schema::element_type)[IS schema::Type]\
-.>(schema::name)[IS std::str]"
-                },
-                "FENCE": {
-                    "(schema::Type).>(schema::element_type)[IS schema::Type]\
-.>(std::id)[IS std::uuid]"
-                }
+                "(schema::Type).>(schema::element_type)[IS schema::Type]"
             }
         }
         """
@@ -300,9 +241,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             },
             "(__expr__::expr~3)",
             "FENCE": {
-                "(__expr__::expr~3).>(std::id)[IS std::uuid]"
-            },
-            "FENCE": {
                 "(__expr__::expr~3).>(schema::foo)[IS std::str]"
             }
         }
@@ -322,9 +260,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(test::User).>(std::id)[IS std::uuid]"
-            },
-            "FENCE": {
                 "FENCE": {
                     "(test::User).>(test::friends)[IS test::User]"
                 },
@@ -339,8 +274,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 .>(test::name)[IS std::str]": {
                         "(test::User).>(test::deck)[IS test::Card]"
                     }
-                },
-                "(test::User).>(test::friends)[IS std::str]"
+                }
             },
             "FENCE": {
                 "(test::User).>(test::name)[IS std::str]"
@@ -356,13 +290,10 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "(test::Card).>(test::owners)[IS test::User]": {
-                "(test::Card).<(test::deck)[IS test::User]": {
-                    "(test::Card)"
+                "(test::Card)",
+                "FENCE": {
+                    "(test::Card).<(test::deck)[IS test::User]"
                 }
-            },
-            "FENCE": {
-                "(test::Card).>(test::owners)[IS test::User]\
-.>(std::id)[IS std::uuid]"
             }
         }
         """
@@ -390,13 +321,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 }
             },
             "(__expr__::expr~3)",
-            "FENCE": {
-                "(__expr__::expr~3).>(std::id)[IS std::uuid]"
-            },
-            "(__expr__::expr~6)",
-            "FENCE": {
-                "(__expr__::expr~6).>(std::id)[IS std::uuid]"
-            }
+            "(__expr__::expr~6)"
         }
         """
 
@@ -426,9 +351,11 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                             "(test::User).>(test::name)[IS std::str]"
                         }
                     },
-                    "(test::Card)",
                     "FENCE": {
-                        "(_::__view__|U@@w~1).>(test::deck)[IS test::Card]"
+                        "(test::Card)",
+                        "FENCE": {
+                            "(_::__view__|U@@w~1).>(test::deck)[IS test::Card]"
+                        }
                     }
                 }
             }
@@ -447,10 +374,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::Card)",
             "FENCE": {
-                "(test::Card).>(std::id)[IS std::uuid]"
-            },
-            "FENCE": {
-                "(test::Card).>(test::name)[IS std::str]"
+                "FENCE": {
+                    "(test::Card).>(test::name)[IS std::str]"
+                }
             }
         }
         """
@@ -469,11 +395,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(test::User).>(std::id)[IS std::uuid]"
-            },
-            "FENCE": {
-                "(__expr__::expr~4).>(test::name)[IS std::str]": {
-                    "(__expr__::expr~4)": {
+                "(__expr__::expr~5).>(test::name)[IS std::str]": {
+                    "(__expr__::expr~5)": {
                         "FENCE": {
                             "FENCE": {
                                 "(test::User).>(test::friends)[IS test::User]",
@@ -501,24 +424,28 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(test::User).>(test::friends)[IS test::User]\
+            "(_::__view__|x@@w~1)": {
+                "(test::User).>(test::friends)[IS test::User]\
 .>(test::deck_cost)[IS std::int]": {
+                    "FENCE": {
+                        "FENCE": {
+                            "(test::User).>(test::friends)\
+[IS test::User].>(test::deck)[IS test::Card].>(test::cost)[IS std::int]": {
+                                "(test::User).>(test::friends)\
+[IS test::User].>(test::deck)[IS test::Card]"
+                            }
+                        }
+                    }
+                },
                 "FENCE": {
                     "(test::User).>(test::friends)[IS test::User]\
-.>(test::deck)[IS test::Card].>(test::cost)[IS std::int]": {
-                        "(test::User).>(test::friends)[IS test::User]\
 .>(test::deck)[IS test::Card]"
-                    }
+                },
+                "(test::User).>(test::friends)[IS test::User]": {
+                    "(test::User)",
+                    "(test::User)"
                 }
             },
-            "FENCE": {
-                "(test::User).>(test::friends)[IS test::User]\
-.>(test::deck)[IS test::Card]"
-            },
-            "(test::User).>(test::friends)[IS test::User]": {
-                "(test::User)"
-            },
-            "(_::__view__|x@@w~1)",
             "FENCE": {
                 "(_::__view__|x@@w~1).>(__tuple__::0)[IS std::float]"
             }
@@ -528,18 +455,17 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_scope_tree_20(self):
         """
         WITH
-            MODULE test,
-            A := Card
+            MODULE test
         SELECT
-            Card.name + <str>count(A.owners)
+            Card.name + <str>count(Card.owners)
 
 % OK %
         "FENCE": {
             "(test::Card).>(test::name)[IS std::str]",
             "FENCE": {
-                "(_::__view__|A@@w~1).>(test::owners)[IS test::User]": {
-                    "(_::__view__|A@@w~1).<(test::deck)[IS test::User]": {
-                        "(_::__view__|A@@w~1)"
+                "(test::Card).>(test::owners)[IS test::User]": {
+                    "FENCE": {
+                        "(test::Card).<(test::deck)[IS test::User]"
                     }
                 }
             },
@@ -578,24 +504,13 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(test::User).>(std::id)[IS std::uuid]"
-            },
-            "FENCE": {
-                "(test::User).>(test::name)[IS std::str]"
+                "(test::User).>(test::deck)[IS test::Card]"
             },
             "FENCE": {
                 "(test::User).>(test::deck)[IS test::Card]",
                 "FENCE": {
                     "(test::User).>(test::deck)[IS test::Card]\
 @(test::count)[IS std::int]"
-                },
-                "FENCE": {
-                    "(test::User).>(test::deck)[IS test::Card]\
-.>(std::id)[IS std::uuid]"
-                },
-                "FENCE": {
-                    "(test::User).>(test::deck)[IS test::Card]\
-.>(test::name)[IS std::str]"
                 }
             },
             "FENCE": {
@@ -603,6 +518,31 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 .>(test::cost)[IS std::int]",
                 "(test::User).>(test::deck)[IS test::Card]\
 @(test::count)[IS std::int]",
+                "(test::User).>(test::deck)[IS test::Card]": {
+                    "FENCE": {
+                        "(test::User).>(test::deck)[IS test::Card]"
+                    }
+                }
+            }
+        }
+        """
+
+    def test_edgeql_ir_scope_tree_23(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            name,
+            deck := (SELECT x := User.deck ORDER BY x.name)
+        }
+
+% OK %
+        "FENCE": {
+            "(test::User)",
+            "FENCE": {
+                "(_::__view__|x@@w~2)",
+                "FENCE": {
+                    "(_::__view__|x@@w~2).>(test::name)[IS std::str]"
+                },
                 "(test::User).>(test::deck)[IS test::Card]"
             }
         }

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -682,7 +682,7 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             {1, 2, 3, 4},
             {1, 2},
             {1, 2, 3},
-            {1, 2, 3, 4},
+            {1, 2, 3},
         ])
 
     async def test_edgeql_props_setops_02(self):

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -68,14 +68,14 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ORDER BY _.0 THEN _.1.name;
         ''', [
             [
-                [1, {'a': [1], 'name': 'Alice'}],
-                [1, {'a': [1], 'name': 'Bob'}],
-                [1, {'a': [1], 'name': 'Carol'}],
-                [1, {'a': [1], 'name': 'Dave'}],
-                [2, {'a': [2], 'name': 'Alice'}],
-                [2, {'a': [2], 'name': 'Bob'}],
-                [2, {'a': [2], 'name': 'Carol'}],
-                [2, {'a': [2], 'name': 'Dave'}],
+                [1, {'a': 1, 'name': 'Alice'}],
+                [1, {'a': 1, 'name': 'Bob'}],
+                [1, {'a': 1, 'name': 'Carol'}],
+                [1, {'a': 1, 'name': 'Dave'}],
+                [2, {'a': 2, 'name': 'Alice'}],
+                [2, {'a': 2, 'name': 'Bob'}],
+                [2, {'a': 2, 'name': 'Carol'}],
+                [2, {'a': 2, 'name': 'Dave'}],
             ]
         ])
 
@@ -227,6 +227,8 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         ])
 
+    # XXX: this test is not longer correct with respect to inline aliases.
+    @unittest.expectedFailure
     async def test_edgeql_scope_tuple_06(self):
         await self.assert_query_result(r'''
             # compare to test_edgeql_scope_filter_03 to see how it
@@ -297,6 +299,8 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         ])
 
+    # XXX: this test is not longer correct with respect to inline aliases.
+    @unittest.expectedFailure
     async def test_edgeql_scope_tuple_07(self):
         await self.assert_query_result(r'''
             # compare to test_edgeql_scope_filter_03 to see how it
@@ -613,7 +617,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_scope_filter_05(self):
         await self.assert_query_result(r'''
             # User.name is wrapped into a SELECT, so it's a SET OF
@@ -636,7 +639,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             {'Alice', 'Bob', 'Carol', 'Dave'}
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_scope_filter_07(self):
         await self.assert_query_result(r'''
             # User.name is a SET OF argument of ??, so it's unaffected
@@ -991,6 +993,8 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ['Bog monster4', 'Dragon2', 'Giant turtle4']
         ])
 
+    # TODO: this test is no longer correct
+    @unittest.expectedFailure
     async def test_edgeql_scope_nested_07(self):
         await self.assert_query_result(r'''
             # semantically same as control query Q2, with lots of
@@ -1012,6 +1016,8 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ['Bog monster4', 'Dragon2', 'Giant turtle4']
         ])
 
+    # TODO: this test is no longer correct
+    @unittest.expectedFailure
     async def test_edgeql_scope_nested_08(self):
         await self.assert_query_result(r'''
             # semantically same as control query Q2, with lots of
@@ -1043,6 +1049,8 @@ class TestEdgeQLScope(tb.QueryTestCase):
              'Golem3', 'Sprite2', 'Giant eagle2', 'Djinn2'}
         ])
 
+    # TODO: this test is no longer correct
+    @unittest.expectedFailure
     async def test_edgeql_scope_nested_10(self):
         await self.assert_query_result(r'''
             # semantically same as control query Q3, except that some
@@ -1063,6 +1071,8 @@ class TestEdgeQLScope(tb.QueryTestCase):
              'Golem3', 'Sprite2', 'Giant eagle2', 'Djinn2'},
         ])
 
+    # TODO: this test is no longer correct
+    @unittest.expectedFailure
     async def test_edgeql_scope_nested_11(self):
         await self.assert_query_result(r'''
             # semantically same as control query Q3, except that some
@@ -1089,11 +1099,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 U2 := User.name + DETACHED User.name
             SELECT U2 + U2;
 
-            WITH
-                MODULE test,
-                U2 := User.name + DETACHED User.name
-            SELECT User.name + DETACHED User.name + U2;
-
             # DETACHED is reused directly
             WITH MODULE test
             SELECT User.name + DETACHED User.name +
@@ -1103,10 +1108,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 (a + b
                     for a in names
                     for b in names)},
-            {a + b + a + c
-                for a in names
-                for b in names
-                for c in names},
             {a + b + a + c
                 for a in names
                 for b in names
@@ -1139,10 +1140,8 @@ class TestEdgeQLScope(tb.QueryTestCase):
             {f'{a} vs {b}' for a in names for b in names if a != b},
         ])
 
-    # @unittest.expectedFailure
-    async def _test_edgeql_scope_detached_03(self):
-        # XXX: this test causes the system to take way too long to
-        # compute the result
+    @unittest.expectedFailure
+    async def test_edgeql_scope_detached_03(self):
         names = {'Alice', 'Bob', 'Carol', 'Dave'}
 
         # No good narrative here, just a bigger cross-product


### PR DESCRIPTION
This makes all views (any query expression to the right of `:=`), to be
evaluated in a semi-detached scope, where only symbols in the outer
scope are taken into account.  The use of the symbol denoting _any_ view
is now indistinguishable from a reference to a schema-level set, and
symbols used in the view expression are guaranteed not to interfere:

    WITH U1 := User, U2 := User SELECT (U1, U2) -> cartesian product

The `DETACHED` operator makes the compiler completely ignores all current
scope. Only schema-level symbols are recognized in the `DETACHED`
expression, and it is equivalent to declaring a schema-level view.

Additionally, all implicit `SELECTs` are now treated like explicit
`SELECT` statements from the scope standpoint.