### PR TITLE
edgeql: Make `__type__` into a reserved keyword.

### DIFF
--- a/edgedb/lang/edgeql/parser/grammar/ddl.py
+++ b/edgedb/lang/edgeql/parser/grammar/ddl.py
@@ -145,6 +145,14 @@ class InnerDDLStmtBlock(ListNonterm, element=InnerDDLStmt):
     pass
 
 
+class LinkName(Nonterm):
+    def reduce_NodeName(self, *kids):
+        self.val = kids[0].val
+
+    def reduce_DUNDERTYPE(self, *kids):
+        self.val = qlast.ObjectRef(name=kids[0].val)
+
+
 class DDLAliasBlock(Nonterm):
     def reduce_OptAliasBlock(self, *kids):
         # the purpose of this production is to make sure that DDL
@@ -1029,7 +1037,7 @@ class CreateLinkStmt(Nonterm):
     def reduce_CreateLink(self, *kids):
         r"""%reduce \
             DDLAliasBlock \
-            CREATE LINK NodeName OptExtending \
+            CREATE LINK LinkName OptExtending \
             OptCreateLinkCommandsBlock \
         """
         self.val = qlast.CreateLink(
@@ -1067,10 +1075,10 @@ commands_block(
 
 
 class AlterLinkStmt(Nonterm):
-    def reduce_CreateLink(self, *kids):
+    def reduce_AlterLink(self, *kids):
         r"""%reduce \
             DDLAliasBlock \
-            ALTER LINK NodeName \
+            ALTER LINK LinkName \
             AlterLinkCommandsBlock \
         """
         self.val = qlast.AlterLink(
@@ -1098,7 +1106,7 @@ commands_block(
 class DropLinkStmt(Nonterm):
     def reduce_DropLink(self, *kids):
         r"""%reduce \
-            DDLAliasBlock DROP LINK NodeName OptDropLinkCommandsBlock \
+            DDLAliasBlock DROP LINK LinkName OptDropLinkCommandsBlock \
         """
         self.val = qlast.DropLink(
             aliases=kids[0].val.aliases,
@@ -1124,7 +1132,7 @@ commands_block(
 class CreateConcreteLinkStmt(Nonterm):
     def reduce_CreateRegularRequiredLink(self, *kids):
         r"""%reduce \
-            CREATE REQUIRED LINK NodeName \
+            CREATE REQUIRED LINK LinkName \
             TO TypeNameList OptCreateConcreteLinkCommandsBlock \
         """
         self.val = qlast.CreateConcreteLink(
@@ -1136,7 +1144,7 @@ class CreateConcreteLinkStmt(Nonterm):
 
     def reduce_CreateRegularLink(self, *kids):
         r"""%reduce \
-            CREATE LINK NodeName \
+            CREATE LINK LinkName \
             TO TypeNameList OptCreateConcreteLinkCommandsBlock \
         """
         self.val = qlast.CreateConcreteLink(
@@ -1176,7 +1184,7 @@ commands_block(
 class AlterConcreteLinkStmt(Nonterm):
     def reduce_AlterLink(self, *kids):
         r"""%reduce \
-            ALTER LINK NodeName AlterConcreteLinkCommandsBlock \
+            ALTER LINK LinkName AlterConcreteLinkCommandsBlock \
         """
         self.val = qlast.AlterConcreteLink(
             name=kids[2].val,
@@ -1195,7 +1203,7 @@ commands_block(
 class DropConcreteLinkStmt(Nonterm):
     def reduce_DropLink(self, *kids):
         r"""%reduce \
-            DROP LINK NodeName OptDropConcreteLinkCommandsBlock \
+            DROP LINK LinkName OptDropConcreteLinkCommandsBlock \
         """
         self.val = qlast.DropConcreteLink(
             name=kids[2].val,

--- a/edgedb/lang/edgeql/parser/grammar/expressions.py
+++ b/edgedb/lang/edgeql/parser/grammar/expressions.py
@@ -333,12 +333,13 @@ class ShapePath(Nonterm):
     # A form of Path appearing as an element in shapes.
     #
     # one-of:
+    #   __type__
     #   link
     #   @prop
     #   [IS ObjectType].link
     #   [IS Link]@prop - currently not supported
 
-    def reduce_ShortNodeName(self, *kids):
+    def reduce_PathStepName(self, *kids):
         from edgedb.lang.schema import pointers as s_pointers
 
         self.val = qlast.Path(
@@ -360,7 +361,7 @@ class ShapePath(Nonterm):
             ]
         )
 
-    def reduce_ShapePathPtr_DOT_ShortNodeName(self, *kids):
+    def reduce_ShapePathPtr_DOT_PathStepName(self, *kids):
         from edgedb.lang.schema import pointers as s_pointers
 
         self.val = qlast.Path(
@@ -958,7 +959,7 @@ class Path(Nonterm):
 
 
 class PathStep(Nonterm):
-    def reduce_DOT_ShortNodeName(self, *kids):
+    def reduce_DOT_PathStepName(self, *kids):
         from edgedb.lang.schema import pointers as s_pointers
 
         self.val = qlast.Ptr(
@@ -975,7 +976,7 @@ class PathStep(Nonterm):
             direction=s_pointers.PointerDirection.Outbound
         )
 
-    def reduce_DOTFW_ShortNodeName(self, *kids):
+    def reduce_DOTFW_PathStepName(self, *kids):
         from edgedb.lang.schema import pointers as s_pointers
 
         self.val = qlast.Ptr(
@@ -983,7 +984,7 @@ class PathStep(Nonterm):
             direction=s_pointers.PointerDirection.Outbound
         )
 
-    def reduce_DOTBW_ShortNodeName(self, *kids):
+    def reduce_DOTBW_PathStepName(self, *kids):
         from edgedb.lang.schema import pointers as s_pointers
 
         self.val = qlast.Ptr(
@@ -999,6 +1000,14 @@ class PathStep(Nonterm):
             direction=s_pointers.PointerDirection.Outbound,
             type='property'
         )
+
+
+class PathStepName(Nonterm):
+    def reduce_ShortNodeName(self, *kids):
+        self.val = kids[0].val
+
+    def reduce_DUNDERTYPE(self, *kids):
+        self.val = qlast.ObjectRef(name=kids[0].val)
 
 
 class LinkDirection(Nonterm):

--- a/edgedb/lang/edgeql/parser/grammar/keywords.py
+++ b/edgedb/lang/edgeql/parser/grammar/keywords.py
@@ -65,6 +65,7 @@ unreserved_keywords = frozenset([
 reserved_keywords = frozenset([
     "__self__",
     "__subject__",
+    "__type__",
     "aggregate",
     "all",
     "alter",

--- a/edgedb/lang/edgeql/parser/grammar/lexer.py
+++ b/edgedb/lang/edgeql/parser/grammar/lexer.py
@@ -121,10 +121,6 @@ class EdgeQLLexer(lexer.Lexer):
                 (?P=Q)      # match closing quote type with whatever is in Q
              '''),
 
-        Rule(token='IDENT',
-             next_state=STATE_KEEP,
-             regexp=r'__type__'),
-
         Rule(token='BADIDENT',
              next_state=STATE_KEEP,
              regexp=r'''

--- a/edgedb/lang/edgeql/quote.py
+++ b/edgedb/lang/edgeql/quote.py
@@ -37,8 +37,9 @@ def dollar_quote_literal(text):
 
 
 def disambiguate_identifier(text):
-    if (keywords.by_type[keywords.RESERVED_KEYWORD].get(text.lower()) or
-            not _re_ident.fullmatch(text)):
+    if (text.lower() != '__type__' and
+        (keywords.by_type[keywords.RESERVED_KEYWORD].get(text.lower()) or
+         not _re_ident.fullmatch(text))):
         return '`{}`'.format(text)
     else:
         return text

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1212,7 +1212,6 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
     def test_edgeql_syntax_path_20(self):
         # illegal semantically, but syntactically valid
         """
-        SELECT __type__;
         SELECT __subject__;
         SELECT __self__;
         """
@@ -1234,6 +1233,20 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
     def test_edgeql_syntax_path_22(self):
         """
         SELECT TUP.0.2e2;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, 'Unexpected token.*DUNDERTYPE',
+                  line=2, col=16)
+    def test_edgeql_syntax_path_23(self):
+        """
+        SELECT __type__;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, 'Unexpected token.*DUNDERTYPE',
+                  line=2, col=24)
+    def test_edgeql_syntax_path_24(self):
+        """
+        SELECT Foo.bar@__type__;
         """
 
     def test_edgeql_syntax_type_interpretation_01(self):
@@ -2718,6 +2731,14 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
     def test_edgeql_syntax_ddl_linkproperty_03(self):
         """
         CREATE LINK PROPERTY PROPERTY std::linkproperty {
+            SET title := 'Base link property';
+        };
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=30)
+    def test_edgeql_syntax_ddl_linkproperty_04(self):
+        """
+        CREATE LINK PROPERTY __type__ {
             SET title := 'Base link property';
         };
         """


### PR DESCRIPTION
Dunder identifiers are now fully forbidden. `__type__` is a special
keyword that can only appear in certain specific places:
- paths
- shapes
- CREATE/ALTER/DROP LINK commands