### PR TITLE
Turn object type scalar "links" into "properties"

### DIFF
--- a/edgedb/lang/common/exceptions/__init__.py
+++ b/edgedb/lang/common/exceptions/__init__.py
@@ -41,7 +41,7 @@ class ConstraintViolationError(IntegrityConstraintViolationError):
     code = '23514'
 
 
-class LinkMappingCardinalityViolationError(IntegrityConstraintViolationError):
+class PointerCardinalityViolationError(IntegrityConstraintViolationError):
     code = '23600'
 
 

--- a/edgedb/lang/edgeql/ast.py
+++ b/edgedb/lang/edgeql/ast.py
@@ -566,28 +566,28 @@ class DropScalarType(DropObject):
     pass
 
 
-class CreateLinkProperty(CreateExtendingObject):
+class CreateProperty(CreateExtendingObject):
     pass
 
 
-class AlterLinkProperty(AlterObject):
+class AlterProperty(AlterObject):
     pass
 
 
-class DropLinkProperty(DropObject):
+class DropProperty(DropObject):
     pass
 
 
-class CreateConcreteLinkProperty(CreateObject):
+class CreateConcreteProperty(CreateObject):
     is_required: bool = False
     target: Expr
 
 
-class AlterConcreteLinkProperty(AlterObject):
+class AlterConcreteProperty(AlterObject):
     pass
 
 
-class DropConcreteLinkProperty(AlterObject):
+class DropConcreteProperty(AlterObject):
     pass
 
 

--- a/edgedb/lang/edgeql/codegen.py
+++ b/edgedb/lang/edgeql/codegen.py
@@ -854,32 +854,32 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
     def visit_DropScalarType(self, node):
         self._visit_DropObject(node, 'SCALAR TYPE')
 
-    def visit_CreateLinkProperty(self, node):
-        self._visit_CreateObject(node, 'ABSTRACT LINK PROPERTY')
+    def visit_CreateProperty(self, node):
+        self._visit_CreateObject(node, 'ABSTRACT PROPERTY')
 
-    def visit_AlterLinkProperty(self, node):
-        self._visit_AlterObject(node, 'ABSTRACT LINK PROPERTY')
+    def visit_AlterProperty(self, node):
+        self._visit_AlterObject(node, 'ABSTRACT PROPERTY')
 
-    def visit_DropLinkProperty(self, node):
-        self._visit_DropObject(node, 'ABSTRACT LINK PROPERTY')
+    def visit_DropProperty(self, node):
+        self._visit_DropObject(node, 'ABSTRACT PROPERTY')
 
-    def visit_CreateConcreteLinkProperty(self, node):
+    def visit_CreateConcreteProperty(self, node):
         keywords = []
 
         if node.is_required:
             keywords.append('REQUIRED')
-        keywords.append('LINK PROPERTY')
+        keywords.append('PROPERTY')
 
         def after_name():
             self.write(' -> ')
             self.visit(node.target)
         self._visit_CreateObject(node, *keywords, after_name=after_name)
 
-    def visit_AlterConcreteLinkProperty(self, node):
-        self._visit_AlterObject(node, 'LINK PROPERTY', allow_short=False)
+    def visit_AlterConcreteProperty(self, node):
+        self._visit_AlterObject(node, 'PROPERTY', allow_short=False)
 
-    def visit_DropConcreteLinkProperty(self, node):
-        self._visit_DropObject(node, 'LINK PROPERTY')
+    def visit_DropConcreteProperty(self, node):
+        self._visit_DropObject(node, 'PROPERTY')
 
     def visit_CreateLink(self, node):
         after_name = lambda: self._ddl_visit_bases(node)

--- a/edgedb/lang/edgeql/compiler/context.py
+++ b/edgedb/lang/edgeql/compiler/context.py
@@ -293,14 +293,16 @@ class ContextLevel(compiler.ContextLevel):
 
             if mode in {ContextSwitchMode.NEWFENCE_TEMP,
                         ContextSwitchMode.NEWSCOPE_TEMP}:
-                self.path_scope = prevlevel.path_scope.copy()
+                if prevlevel.path_scope is None:
+                    prevlevel.path_scope = irast.new_scope_tree()
 
-            if mode in {ContextSwitchMode.NEWSCOPE,
-                        ContextSwitchMode.NEWSCOPE_TEMP}:
-                self.path_scope = prevlevel.path_scope.add_branch()
+                self.path_scope = prevlevel.path_scope.copy()
 
             if mode in {ContextSwitchMode.NEWFENCE,
                         ContextSwitchMode.NEWFENCE_TEMP}:
+                if prevlevel.path_scope is None:
+                    prevlevel.path_scope = irast.new_scope_tree()
+
                 self.path_scope = prevlevel.path_scope.attach_fence()
 
     def on_pop(self, prevlevel):

--- a/edgedb/lang/edgeql/compiler/setgen.py
+++ b/edgedb/lang/edgeql/compiler/setgen.py
@@ -18,7 +18,6 @@ from edgedb.lang.ir import utils as irutils
 from edgedb.lang.schema import objtypes as s_objtypes
 from edgedb.lang.schema import expr as s_expr
 from edgedb.lang.schema import links as s_links
-from edgedb.lang.schema import lproperties as s_linkprops
 from edgedb.lang.schema import name as s_name
 from edgedb.lang.schema import nodes as s_nodes
 from edgedb.lang.schema import pointers as s_pointers
@@ -352,7 +351,7 @@ def extend_path(
     if target is None:
         target = ptrcls.get_far_endpoint(direction)
 
-    if isinstance(ptrcls, s_linkprops.LinkProperty):
+    if ptrcls.is_link_property():
         path_id = source_set.path_id.ptr_path().extend(
             ptrcls, direction, target)
     elif direction != s_pointers.PointerDirection.Inbound:
@@ -442,9 +441,9 @@ def class_indirection_set(
     poly_set = new_set(scls=target_scls, ctx=ctx)
     rptr = source_set.rptr
     if rptr is not None and not rptr.ptrcls.singular(rptr.direction):
-        cardinality = s_links.LinkMapping.ManyToMany
+        cardinality = s_pointers.PointerCardinality.ManyToMany
     else:
-        cardinality = s_links.LinkMapping.ManyToOne
+        cardinality = s_pointers.PointerCardinality.ManyToOne
     poly_set.path_id = irutils.type_indirection_path_id(
         source_set.path_id, target_scls, optional=optional,
         cardinality=cardinality)
@@ -593,7 +592,7 @@ def computable_ptr_set(
     subctx.path_scope_map = ctx.path_scope_map
     subctx.scope_id_ctr = ctx.scope_id_ctr
 
-    if isinstance(ptrcls, s_linkprops.LinkProperty):
+    if ptrcls.is_link_property():
         source_path_id = rptr.source.path_id.ptr_path()
     else:
         source_path_id = rptr.target.path_id.src_path()

--- a/edgedb/lang/edgeql/errors.py
+++ b/edgedb/lang/edgeql/errors.py
@@ -18,6 +18,10 @@ class EdgeQLSyntaxError(ParserError, EdgeDBSyntaxError):
     code = '42602'
 
 
+class EdgeQLDefinitionError(EdgeDBSyntaxError):
+    code = '42603'
+
+
 class EdgeQLExpressionError(EdgeQLError):
     pass
 

--- a/edgedb/lang/edgeql/optimizer.py
+++ b/edgedb/lang/edgeql/optimizer.py
@@ -269,7 +269,7 @@ class EdgeQLOptimizer:
                 for t in expr.targets:
                     self._process_expr(context, t)
 
-            elif isinstance(expr, qlast.CreateConcreteLinkProperty):
+            elif isinstance(expr, qlast.CreateConcreteProperty):
                 self._process_expr(context, expr.target)
 
         elif isinstance(expr, (qlast.CreateLocalPolicy,

--- a/edgedb/lang/edgeql/parser/grammar/ddl.py
+++ b/edgedb/lang/edgeql/parser/grammar/ddl.py
@@ -113,13 +113,13 @@ class InnerDDLStmt(Nonterm):
     def reduce_DropLinkStmt(self, *kids):
         self.val = kids[0].val
 
-    def reduce_CreateLinkPropertyStmt(self, *kids):
+    def reduce_CreatePropertyStmt(self, *kids):
         self.val = kids[0].val
 
-    def reduce_AlterLinkPropertyStmt(self, *kids):
+    def reduce_AlterPropertyStmt(self, *kids):
         self.val = kids[0].val
 
-    def reduce_DropLinkPropertyStmt(self, *kids):
+    def reduce_DropPropertyStmt(self, *kids):
         self.val = kids[0].val
 
     def reduce_CreateEventStmt(self, *kids):
@@ -870,16 +870,16 @@ class AlterTargetStmt(Nonterm):
 
 
 #
-# CREATE LINK PROPERTY
+# CREATE PROPERTY
 #
-class CreateLinkPropertyStmt(Nonterm):
-    def reduce_CreateLinkProperty(self, *kids):
+class CreatePropertyStmt(Nonterm):
+    def reduce_CreateProperty(self, *kids):
         r"""%reduce \
             DDLAliasBlock \
-            CREATE ABSTRACT LINKPROPERTY NodeName OptExtending \
+            CREATE ABSTRACT PROPERTY NodeName OptExtending \
             OptCreateCommandsBlock \
         """
-        self.val = qlast.CreateLinkProperty(
+        self.val = qlast.CreateProperty(
             aliases=kids[0].val.aliases,
             cardinality=kids[0].val.cardinality,
             name=kids[4].val,
@@ -889,11 +889,11 @@ class CreateLinkPropertyStmt(Nonterm):
 
 
 #
-# ALTER LINK PROPERTY
+# ALTER PROPERTY
 #
 
 commands_block(
-    'AlterLinkProperty',
+    'AlterProperty',
     RenameStmt,
     SetFieldStmt,
     DropFieldStmt,
@@ -901,14 +901,14 @@ commands_block(
 )
 
 
-class AlterLinkPropertyStmt(Nonterm):
-    def reduce_AlterLinkProperty(self, *kids):
+class AlterPropertyStmt(Nonterm):
+    def reduce_AlterProperty(self, *kids):
         r"""%reduce \
             DDLAliasBlock \
-            ALTER ABSTRACT LINKPROPERTY NodeName \
-            AlterLinkPropertyCommandsBlock \
+            ALTER ABSTRACT PROPERTY NodeName \
+            AlterPropertyCommandsBlock \
         """
-        self.val = qlast.AlterLinkProperty(
+        self.val = qlast.AlterProperty(
             aliases=kids[0].val.aliases,
             cardinality=kids[0].val.cardinality,
             name=kids[4].val,
@@ -917,15 +917,15 @@ class AlterLinkPropertyStmt(Nonterm):
 
 
 #
-# DROP LINK PROPERTY
+# DROP PROPERTY
 #
-class DropLinkPropertyStmt(Nonterm):
-    def reduce_DropLinkProperty(self, *kids):
+class DropPropertyStmt(Nonterm):
+    def reduce_DropProperty(self, *kids):
         r"""%reduce \
             DDLAliasBlock \
-            DROP ABSTRACT LINKPROPERTY NodeName \
+            DROP ABSTRACT PROPERTY NodeName \
         """
-        self.val = qlast.DropLinkProperty(
+        self.val = qlast.DropProperty(
             aliases=kids[0].val.aliases,
             cardinality=kids[0].val.cardinality,
             name=kids[4].val
@@ -933,54 +933,54 @@ class DropLinkPropertyStmt(Nonterm):
 
 
 #
-# CREATE LINK ... { CREATE LINK PROPERTY
+# CREATE LINK ... { CREATE PROPERTY
 #
 
 commands_block(
-    'CreateConcreteLinkProperty',
+    'CreateConcreteProperty',
     SetFieldStmt,
     CreateConcreteConstraintStmt
 )
 
 
-class CreateConcreteLinkPropertyStmt(Nonterm):
-    def reduce_CreateRegularRequiredLinkProperty(self, *kids):
+class CreateConcretePropertyStmt(Nonterm):
+    def reduce_CreateRegularRequiredProperty(self, *kids):
         r"""%reduce \
-            CREATE REQUIRED LINKPROPERTY NodeName \
-            ARROW TypeName OptCreateConcreteLinkPropertyCommandsBlock \
+            CREATE REQUIRED PROPERTY NodeName \
+            ARROW TypeName OptCreateConcretePropertyCommandsBlock \
         """
-        self.val = qlast.CreateConcreteLinkProperty(
+        self.val = qlast.CreateConcreteProperty(
             name=kids[3].val,
             is_required=True,
             target=kids[5].val,
             commands=kids[6].val
         )
 
-    def reduce_CreateRegularLinkProperty(self, *kids):
+    def reduce_CreateRegularProperty(self, *kids):
         r"""%reduce \
-            CREATE LINKPROPERTY NodeName \
-            ARROW TypeName OptCreateConcreteLinkPropertyCommandsBlock \
+            CREATE PROPERTY NodeName \
+            ARROW TypeName OptCreateConcretePropertyCommandsBlock \
         """
-        self.val = qlast.CreateConcreteLinkProperty(
+        self.val = qlast.CreateConcreteProperty(
             name=kids[2].val,
             is_required=False,
             target=kids[4].val,
             commands=kids[5].val
         )
 
-    def reduce_CREATE_LINKPROPERTY_NodeName_AS_Expr(self, *kids):
-        self.val = qlast.CreateConcreteLinkProperty(
+    def reduce_CREATE_PROPERTY_NodeName_AS_Expr(self, *kids):
+        self.val = qlast.CreateConcreteProperty(
             name=kids[2].val,
             target=kids[4].val
         )
 
 
 #
-# ALTER LINK ... { ALTER LINK PROPERTY
+# ALTER LINK ... { ALTER PROPERTY
 #
 
 commands_block(
-    'AlterConcreteLinkProperty',
+    'AlterConcreteProperty',
     RenameStmt,
     SetFieldStmt,
     DropFieldStmt,
@@ -992,28 +992,28 @@ commands_block(
 )
 
 
-class AlterConcreteLinkPropertyStmt(Nonterm):
-    def reduce_AlterLinkProperty(self, *kids):
+class AlterConcretePropertyStmt(Nonterm):
+    def reduce_AlterProperty(self, *kids):
         r"""%reduce \
-            ALTER LINKPROPERTY NodeName \
-            AlterConcreteLinkPropertyCommandsBlock \
+            ALTER PROPERTY NodeName \
+            AlterConcretePropertyCommandsBlock \
         """
-        self.val = qlast.AlterConcreteLinkProperty(
+        self.val = qlast.AlterConcreteProperty(
             name=kids[2].val,
             commands=kids[3].val
         )
 
 
 #
-# ALTER LINK ... { DROP LINK PROPERTY
+# ALTER LINK ... { DROP PROPERTY
 #
 
-class DropConcreteLinkPropertyStmt(Nonterm):
-    def reduce_DropLinkProperty(self, *kids):
+class DropConcretePropertyStmt(Nonterm):
+    def reduce_DropProperty(self, *kids):
         r"""%reduce \
-            DROP LINKPROPERTY NodeName \
+            DROP PROPERTY NodeName \
         """
-        self.val = qlast.DropConcreteLinkProperty(
+        self.val = qlast.DropConcreteProperty(
             name=kids[2].val
         )
 
@@ -1026,7 +1026,7 @@ commands_block(
     'CreateLink',
     SetFieldStmt,
     CreateConcreteConstraintStmt,
-    CreateConcreteLinkPropertyStmt,
+    CreateConcretePropertyStmt,
     CreateIndexStmt,
     CreateLocalPolicyStmt
 )
@@ -1061,9 +1061,9 @@ commands_block(
     CreateConcreteConstraintStmt,
     AlterConcreteConstraintStmt,
     DropConcreteConstraintStmt,
-    CreateConcreteLinkPropertyStmt,
-    AlterConcreteLinkPropertyStmt,
-    DropConcreteLinkPropertyStmt,
+    CreateConcretePropertyStmt,
+    AlterConcretePropertyStmt,
+    DropConcretePropertyStmt,
     CreateIndexStmt,
     DropIndexStmt,
     CreateLocalPolicyStmt,
@@ -1096,7 +1096,7 @@ commands_block(
     'DropLink',
     DropConcreteConstraintStmt,
     DropConcreteConstraintStmt,
-    DropConcreteLinkPropertyStmt,
+    DropConcretePropertyStmt,
     DropIndexStmt,
     DropLocalPolicyStmt,
 )
@@ -1124,7 +1124,7 @@ commands_block(
     'CreateConcreteLink',
     SetFieldStmt,
     CreateConcreteConstraintStmt,
-    CreateConcreteLinkPropertyStmt,
+    CreateConcretePropertyStmt,
     CreateLocalPolicyStmt
 )
 
@@ -1154,7 +1154,7 @@ class CreateConcreteLinkStmt(Nonterm):
             commands=kids[5].val
         )
 
-    def reduce_CREATE_LINK_NodeName_AS_Expr(self, *kids):
+    def reduce_CREATE_LINK_NodeName_TURNSTILE_Expr(self, *kids):
         self.val = qlast.CreateConcreteLink(
             name=kids[2].val,
             targets=[kids[4].val]
@@ -1171,9 +1171,9 @@ commands_block(
     CreateConcreteConstraintStmt,
     AlterConcreteConstraintStmt,
     DropConcreteConstraintStmt,
-    CreateConcreteLinkPropertyStmt,
-    AlterConcreteLinkPropertyStmt,
-    DropConcreteLinkPropertyStmt,
+    CreateConcretePropertyStmt,
+    AlterConcretePropertyStmt,
+    DropConcretePropertyStmt,
     CreateLocalPolicyStmt,
     AlterLocalPolicyStmt,
     DropLocalPolicyStmt,
@@ -1195,7 +1195,7 @@ class AlterConcreteLinkStmt(Nonterm):
 commands_block(
     'DropConcreteLink',
     DropConcreteConstraintStmt,
-    DropConcreteLinkPropertyStmt,
+    DropConcretePropertyStmt,
     DropLocalPolicyStmt,
 )
 
@@ -1218,6 +1218,7 @@ class DropConcreteLinkStmt(Nonterm):
 commands_block(
     'CreateObjectType',
     SetFieldStmt,
+    CreateConcretePropertyStmt,
     CreateConcreteLinkStmt,
     CreateIndexStmt
 )
@@ -1263,6 +1264,9 @@ commands_block(
     SetFieldStmt,
     DropFieldStmt,
     AlterExtending,
+    CreateConcretePropertyStmt,
+    AlterConcretePropertyStmt,
+    DropConcretePropertyStmt,
     CreateConcreteLinkStmt,
     AlterConcreteLinkStmt,
     DropConcreteLinkStmt,
@@ -1292,6 +1296,7 @@ class AlterObjectTypeStmt(Nonterm):
 
 commands_block(
     'DropObjectType',
+    DropConcretePropertyStmt,
     DropConcreteLinkStmt,
     DropConcreteConstraintStmt,
     DropIndexStmt

--- a/edgedb/lang/edgeql/parser/grammar/lexer.py
+++ b/edgedb/lang/edgeql/parser/grammar/lexer.py
@@ -151,14 +151,6 @@ class EdgeQLLexer(lexer.Lexer):
             common_rules,
     }
 
-    MERGE_TOKENS = {('LINK', 'PROPERTY'), ('DISTINCT', 'UNION')}
-
-    def __init__(self):
-        super().__init__()
-        # add capacity to handle a few tokens composed of 2 elements
-        self._possible_long_token = {x[0] for x in self.MERGE_TOKENS}
-        self._long_token_match = {x[1]: x[0] for x in self.MERGE_TOKENS}
-
     def token_from_text(self, rule_token, txt):
         if rule_token == 'BADIDENT':
             self.handle_error(txt)
@@ -200,23 +192,6 @@ class EdgeQLLexer(lexer.Lexer):
             if tok_type in {'WS', 'NL', 'COMMENT'}:
                 # Strip out whitespace and comments
                 continue
-            elif tok_type in self._possible_long_token:
-                # Buffer in case this is LINK PROPERTY or UNION OF
-                if not buffer:
-                    buffer.append(tok)
-                else:
-                    yield from iter(buffer)
-                    buffer[:] = [tok]
-
-            elif tok_type in self._long_token_match:
-                prev_token = buffer[-1] if buffer else None
-                if (prev_token and
-                        prev_token.type == self._long_token_match[tok_type]):
-                    tok = prev_token._replace(
-                        value=prev_token.value + ' ' + tok.value,
-                        type=prev_token.type + tok_type)
-                    buffer.pop()
-                yield tok
             else:
                 if buffer:
                     yield from iter(buffer)

--- a/edgedb/lang/graphql/types.py
+++ b/edgedb/lang/graphql/types.py
@@ -66,7 +66,7 @@ class _GQLType:
             raise NotImplementedError
 
     def convert_edb_to_gql_type(self, base, name):
-        if isinstance(base, s_pointers.BasePointer):
+        if isinstance(base, s_pointers.Pointer):
             base = base.target
         return _GQLType(
             edb_base=base,

--- a/edgedb/lang/ir/ast.py
+++ b/edgedb/lang/ir/ast.py
@@ -92,6 +92,7 @@ class Statement(Base):
     expr: Set
     views: typing.Dict[sn.Name, s_types.Type]
     params: typing.Dict[str, s_types.Type]
+    cardinality: Cardinality
     scope_tree: ScopeTreeNode
     scope_map: typing.Dict[Set, str]
     source_map: typing.Dict[s_pointers.Pointer,

--- a/edgedb/lang/ir/pathid.py
+++ b/edgedb/lang/ir/pathid.py
@@ -8,7 +8,6 @@
 
 from edgedb.lang.schema import scalars as s_scalars
 from edgedb.lang.schema import objtypes as s_objtypes
-from edgedb.lang.schema import lproperties as s_lprops
 from edgedb.lang.schema import pointers as s_pointers
 from edgedb.lang.schema import types as s_types
 
@@ -189,7 +188,7 @@ class PathId:
         for i in range(1, len(path) - 1, 2):
             ptr = path[i][0]
             ptrdir = path[i][1]
-            is_lprop = isinstance(ptr, s_lprops.LinkProperty)
+            is_lprop = ptr.is_link_property()
 
             lexpr = f'{ptr.shortname.name}'
 
@@ -283,7 +282,7 @@ class PathId:
         if target is None:
             target = link.get_far_endpoint(direction)
 
-        is_linkprop = isinstance(link, s_lprops.LinkProperty)
+        is_linkprop = link.is_link_property()
         if is_linkprop and not self._is_ptr:
             raise ValueError('link property path extension on a non-link path')
 
@@ -320,7 +319,8 @@ class PathId:
         return self._is_ptr
 
     def is_linkprop_path(self):
-        return isinstance(self.rptr(), s_lprops.LinkProperty)
+        rptr = self.rptr()
+        return rptr is not None and rptr.is_link_property()
 
     def is_type_indirection_path(self):
         rptr = self.rptr()

--- a/edgedb/lang/ir/utils.py
+++ b/edgedb/lang/ir/utils.py
@@ -242,7 +242,7 @@ class TypeIndirectionLink(s_links.Link):
 
 
 def type_indirection_path_id(path_id, target_type, *, optional: bool,
-                             cardinality: s_links.LinkMapping):
+                             cardinality: s_pointers.PointerCardinality):
     return path_id.extend(
         TypeIndirectionLink(path_id[-1], target_type,
                             optional=optional, cardinality=cardinality),

--- a/edgedb/lang/schema/_graphql.eschema
+++ b/edgedb/lang/schema/_graphql.eschema
@@ -15,15 +15,15 @@ scalar type directiveLocation extending str:
                       'FRAGMENT_SPREAD', 'INLINE_FRAGMENT'])
 
 abstract type Nameable:
-    link name -> str
-    link description -> str
+    property name -> str
+    property description -> str
 
 abstract type Named extending Nameable:
-    required inherited link name -> str
+    required inherited property name -> str
 
 abstract type Deprecatable:
-    required link isDeprecated -> bool
-    link deprecationReason -> str
+    required property isDeprecated -> bool
+    property deprecationReason -> str
 
 abstract type Callable:
     link args -> InputValue:
@@ -35,17 +35,17 @@ abstract type Typed:
         cardinality := '*1'
 
 type _Type extending Nameable:
-    required link kind -> typeKind
+    required property kind -> typeKind
 
 type Field extending Named, Deprecatable, Callable
 
 type InputValue extending Named:
-    link defaultValue -> str
+    property defaultValue -> str
 
 type EnumValue extending Named, Deprecatable
 
 type Directive extending Named, Callable:
-    required link locations -> directiveLocation:
+    required property locations -> directiveLocation:
         cardinality := '1*'
 
 type Schema extending Named:

--- a/edgedb/lang/schema/_std.eql
+++ b/edgedb/lang/schema/_std.eql
@@ -299,17 +299,11 @@ CREATE EVENT std::cascade_copy EXTENDING std::cascade_base;
 
 CREATE EVENT std::target_deleted EXTENDING std::deleted;
 
-CREATE ABSTRACT LINK PROPERTY std::linkproperty {
-    SET title := 'Base link property';
-};
+CREATE ABSTRACT PROPERTY std::property;
 
-CREATE ABSTRACT LINK PROPERTY std::source {
-    SET title := 'Link source';
-};
+CREATE ABSTRACT PROPERTY std::source;
 
-CREATE ABSTRACT LINK PROPERTY std::target {
-    SET title := 'Link target';
-};
+CREATE ABSTRACT PROPERTY std::target;
 
 CREATE ABSTRACT LINK std::link {
     CREATE POLICY FOR std::cascade_session_detach TO std::cascade_loaded;
@@ -321,10 +315,10 @@ CREATE ABSTRACT LINK std::link {
     CREATE POLICY FOR std::cascade_copy TO std::ignore;
 };
 
-CREATE ABSTRACT LINK std::id EXTENDING std::link;
+CREATE ABSTRACT PROPERTY std::id EXTENDING std::property;
 
 CREATE TYPE std::Object {
-    CREATE REQUIRED LINK std::id -> std::uuid {
+    CREATE REQUIRED PROPERTY std::id -> std::uuid {
         SET default := (SELECT std::uuid_generate_v1mc());
         SET cardinality := '11';
         SET readonly := True;
@@ -339,8 +333,8 @@ CREATE MODULE schema;
 
 # Base type for all schema entities.
 CREATE ABSTRACT TYPE schema::Object {
-    CREATE REQUIRED LINK schema::name -> std::str;
-    CREATE LINK schema::description -> std::str;
+    CREATE REQUIRED PROPERTY schema::name -> std::str;
+    CREATE PROPERTY schema::description -> std::str;
 };
 
 
@@ -354,7 +348,7 @@ CREATE TYPE schema::Attribute EXTENDING schema::Object {
 
 
 CREATE ABSTRACT LINK schema::attributes {
-    CREATE LINK PROPERTY schema::value -> std::str;
+    CREATE PROPERTY schema::value -> std::str;
 };
 
 
@@ -385,7 +379,7 @@ CREATE ABSTRACT TYPE schema::ContainerType EXTENDING schema::Type;
 
 CREATE TYPE schema::Array EXTENDING schema::ContainerType {
     CREATE REQUIRED LINK schema::element_type -> schema::Type;
-    CREATE LINK schema::dimensions -> array<std::int>;
+    CREATE PROPERTY schema::dimensions -> array<std::int>;
 };
 
 
@@ -397,8 +391,8 @@ CREATE TYPE schema::Map EXTENDING schema::ContainerType {
 
 CREATE TYPE schema::TypeElement {
     CREATE REQUIRED LINK schema::type -> schema::Type;
-    CREATE REQUIRED LINK schema::num -> std::int;
-    CREATE LINK schema::name -> std::str;
+    CREATE REQUIRED PROPERTY schema::num -> std::int;
+    CREATE PROPERTY schema::name -> std::str;
 };
 
 
@@ -425,11 +419,11 @@ CREATE ABSTRACT TYPE schema::InheritingObject EXTENDING schema::Object {
         SET cardinality := '**';
     };
 
-    CREATE LINK schema::is_abstract -> std::bool {
+    CREATE PROPERTY schema::is_abstract -> std::bool {
         SET default := false;
     };
 
-    CREATE LINK schema::is_final -> std::bool {
+    CREATE PROPERTY schema::is_final -> std::bool {
         SET default := false;
     };
 };
@@ -437,23 +431,23 @@ CREATE ABSTRACT TYPE schema::InheritingObject EXTENDING schema::Object {
 
 CREATE TYPE schema::Parameter {
     CREATE REQUIRED LINK schema::type -> schema::Type;
-    CREATE REQUIRED LINK schema::kind -> std::str;
-    CREATE REQUIRED LINK schema::num -> std::int;
-    CREATE LINK schema::name -> std::str;
-    CREATE LINK schema::default -> std::str;
-    CREATE LINK schema::variadic -> std::bool;
+    CREATE REQUIRED PROPERTY schema::kind -> std::str;
+    CREATE REQUIRED PROPERTY schema::num -> std::int;
+    CREATE PROPERTY schema::name -> std::str;
+    CREATE PROPERTY schema::default -> std::str;
+    CREATE PROPERTY schema::variadic -> std::bool;
 };
 
 
 CREATE TYPE schema::Constraint EXTENDING schema::InheritingObject {
-    CREATE LINK schema::expr -> std::str;
-    CREATE LINK schema::subjectexpr -> std::str;
-    CREATE LINK schema::finalexpr -> std::str;
-    CREATE LINK schema::errmessage -> std::str;
+    CREATE PROPERTY schema::expr -> std::str;
+    CREATE PROPERTY schema::subjectexpr -> std::str;
+    CREATE PROPERTY schema::finalexpr -> std::str;
+    CREATE PROPERTY schema::errmessage -> std::str;
     CREATE LINK schema::params -> schema::Parameter {
         SET cardinality := '**';
     };
-    CREATE LINK schema::args -> map<std::str, std::str>;
+    CREATE PROPERTY schema::args -> map<std::str, std::str>;
 };
 
 
@@ -465,7 +459,7 @@ CREATE ABSTRACT TYPE schema::ConsistencySubject EXTENDING schema::Object {
 
 
 CREATE TYPE schema::SourceIndex EXTENDING schema::Object {
-    CREATE LINK schema::expr -> std::str;
+    CREATE PROPERTY schema::expr -> std::str;
 };
 
 
@@ -479,9 +473,16 @@ CREATE ABSTRACT TYPE schema::Source EXTENDING schema::Object {
 CREATE ABSTRACT TYPE schema::Pointer EXTENDING schema::Object;
 
 
+ALTER TYPE schema::Source {
+    CREATE LINK schema::pointers -> schema::Pointer {
+        SET cardinality := '1*';
+    };
+};
+
+
 CREATE TYPE schema::ScalarType EXTENDING
         (schema::InheritingObject, schema::ConsistencySubject, schema::Type) {
-    CREATE LINK schema::default -> std::str;
+    CREATE PROPERTY schema::default -> std::str;
 };
 
 
@@ -510,7 +511,7 @@ CREATE TYPE schema::DerivedLink EXTENDING
          schema::Source);
 
 
-CREATE TYPE schema::LinkProperty EXTENDING
+CREATE TYPE schema::Property EXTENDING
         (schema::InheritingObject, schema::ConsistencySubject, schema::Pointer);
 
 
@@ -521,16 +522,16 @@ ALTER TYPE schema::Pointer {
 
 
 ALTER TYPE schema::Link {
-    CREATE LINK schema::link_properties -> schema::LinkProperty {
-        SET cardinality := '1*';
-    };
+    CREATE LINK schema::properties := __self__.pointers;
 };
 
 
 ALTER TYPE schema::ObjectType {
-    CREATE LINK schema::links -> schema::Link {
-        SET cardinality := '1*';
-    };
+    CREATE LINK schema::links := (SELECT __self__.pointers FILTER
+                                  __self__.pointers IS schema::Link);
+
+    CREATE LINK schema::properties := (SELECT __self__.pointers FILTER
+                                       __self__.pointers IS schema::Property);
 };
 
 
@@ -539,6 +540,6 @@ CREATE TYPE schema::Function EXTENDING schema::Object {
         SET cardinality := '**';
     };
     CREATE LINK schema::returntype -> schema::Type;
-    CREATE LINK schema::aggregate -> std::bool;
-    CREATE LINK schema::set_returning -> std::bool;
+    CREATE PROPERTY schema::aggregate -> std::bool;
+    CREATE PROPERTY schema::set_returning -> std::bool;
 };

--- a/edgedb/lang/schema/ast.py
+++ b/edgedb/lang/schema/ast.py
@@ -37,6 +37,10 @@ class Attribute(Spec):
     value: qlast.Base
 
 
+class Policy(Spec):
+    __fields = ['event', 'action']  # TODO: type this
+
+
 class Constraint(Spec):
     args: typing.List[qlast.FuncArg]
     attributes: typing.List[Attribute]
@@ -53,6 +57,12 @@ class Pointer(Spec):
 
     attributes: typing.List[Attribute]
     constraints: typing.List[Constraint]
+    policies: typing.List[Policy]
+
+    required: bool = False
+
+    # Expression of a computable link
+    expr: qlast.Base = None
 
 
 class Index(Spec):
@@ -60,23 +70,17 @@ class Index(Spec):
     expression: qlast.Base
 
 
-class Policy(Spec):
-    __fields = ['event', 'action']  # TODO: type this
-
-
-class LinkProperty(Pointer):
-    # Expression of a computable link property
-    expr: qlast.Base = None
+class Property(Pointer):
+    pass
 
 
 class Link(Pointer):
-    required: bool = False
+    properties: typing.List[Property]
 
-    # Expression of a computable link
-    expr: qlast.Base = None
 
-    policies: typing.List[Policy]
-    properties: typing.List[LinkProperty]
+# # XXX: to be killed
+# class Property(Property):
+#     pass
 
 
 class Declaration(Base):
@@ -103,6 +107,7 @@ class ObjectTypeDeclaration(Declaration):
     abstract: bool = False
     final: bool = False
     links: typing.List[Link]
+    properties: typing.List[Property]
     indexes: typing.List[Index]
     constraints: typing.List[Constraint]
 
@@ -141,16 +146,19 @@ class FunctionDeclaration(Declaration):
     set_returning: str = ''
 
 
-class LinkDeclaration(Declaration):
+class BasePointerDeclaration(Declaration):
     abstract: bool = False
-    properties: typing.List[LinkProperty]
     indexes: typing.List[Index]
     constraints: typing.List[Constraint]
     policies: typing.List[Policy]
 
 
-class LinkPropertyDeclaration(Declaration):
-    policies: typing.List[Policy]
+class PropertyDeclaration(BasePointerDeclaration):
+    pass
+
+
+class LinkDeclaration(BasePointerDeclaration):
+    properties: typing.List[Property]
 
 
 class Import(Base):

--- a/edgedb/lang/schema/codegen.py
+++ b/edgedb/lang/schema/codegen.py
@@ -97,7 +97,6 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
             .replace('declaration', ' ') \
             .replace('objecttype', 'type') \
             .replace('scalartype', 'scalar type')
-        decl = decl.replace('linkproperty', 'link property')
         self.write(decl)
         self.write(ident_to_str(node.name))
         if after_name:
@@ -107,8 +106,7 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
         self._visit_specs(node)
 
     def _visit_Pointer(self, node):
-        decl = node.__class__.__name__.lower().replace('linkproperty',
-                                                       'link property')
+        decl = node.__class__.__name__.lower()
         self.write(decl, ' ')
         self.visit(node.name)
 
@@ -199,7 +197,7 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
             self.write('abstract ')
         self._visit_Declaration(node)
 
-    def visit_LinkPropertyDeclaration(self, node):
+    def visit_PropertyDeclaration(self, node):
         if node.abstract:
             self.write('abstract ')
         self._visit_Declaration(node)
@@ -259,7 +257,9 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
             self.write('required ')
         self._visit_Pointer(node)
 
-    def visit_LinkProperty(self, node):
+    def visit_Property(self, node):
+        if node.required:
+            self.write('required ')
         self._visit_Pointer(node)
 
     def visit_Policy(self, node):

--- a/edgedb/lang/schema/objtypes.py
+++ b/edgedb/lang/schema/objtypes.py
@@ -12,6 +12,7 @@ from . import constraints
 from . import delta as sd
 from . import inheriting
 from . import links
+from . import lproperties
 from . import name as sn
 from . import named
 from . import nodes
@@ -26,10 +27,6 @@ class SourceNode(sources.Source, nodes.Node):
 
 class ObjectType(SourceNode, constraints.ConsistencySubject):
     _type = 'ObjectType'
-
-    @classmethod
-    def get_pointer_class(cls):
-        return links.Link
 
     def materialize_policies(self, schema):
         bases = self.bases
@@ -129,6 +126,7 @@ class DerivedObjectType(SourceNode,
 class ObjectTypeCommandContext(sd.ObjectCommandContext,
                                constraints.ConsistencySubjectCommandContext,
                                links.LinkSourceCommandContext,
+                               lproperties.PropertySourceContext,
                                nodes.NodeCommandContext):
     pass
 

--- a/edgedb/lang/schema/parser/grammar/keywords.py
+++ b/edgedb/lang/schema/parser/grammar/keywords.py
@@ -34,6 +34,7 @@ unreserved_keywords = frozenset([
     "link",
     "of",
     "on",
+    "property",
     "required",
     "scalar",
     "type",
@@ -50,7 +51,6 @@ reserved_keywords = edgeql.keywords.reserved_keywords
 
 
 def _check_keywords():
-    # TODO: Fix linkproperty;
     ALLOWED_NEW_UNRESERVED = {'import'}
 
     invalid_unreserved_keywords = \

--- a/edgedb/lang/schema/parser/grammar/lexer.py
+++ b/edgedb/lang/schema/parser/grammar/lexer.py
@@ -116,11 +116,6 @@ class EdgeSchemaLexer(lexer.Lexer):
                      if tok[0] not in {'LINK', 'TO', 'EXTENDING', 'ATTRIBUTE'}]
 
     common_rules = keyword_rules + [
-        # "link property" needs to be parsed as a single token
-        Rule(token='LINKPROPERTY',
-             next_state=STATE_KEEP,
-             regexp=r'\bLINK\s+PROPERTY\b'),
-
         Rule(token='LINK',
              next_state=STATE_KEEP,
              regexp=r'\bLINK\b'),

--- a/edgedb/lang/schema/parser/grammar/tokens.py
+++ b/edgedb/lang/schema/parser/grammar/tokens.py
@@ -117,10 +117,6 @@ class T_ANYTHING(Token):
     pass
 
 
-class T_LINKPROPERTY(Token):
-    pass
-
-
 def _gen_keyword_tokens():
     # Define keyword tokens
 

--- a/edgedb/lang/schema/sources.py
+++ b/edgedb/lang/schema/sources.py
@@ -11,6 +11,7 @@ from edgedb.lang.common.persistent_hash import persistent_hash
 from . import error as schema_error
 from . import indexes
 from . import name as sn
+from . import pointers
 from . import referencing
 from . import utils
 
@@ -29,12 +30,8 @@ class Source(indexes.IndexableSubject):
                                    ordered=True,
                                    requires_explicit_inherit=True,
                                    backref='source',
-                                   ref_cls='get_pointer_class',
+                                   ref_cls=pointers.Pointer,
                                    compcoef=0.857)
-
-    @classmethod
-    def get_pointer_class(cls):
-        raise NotImplementedError
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -183,11 +180,8 @@ class Source(indexes.IndexableSubject):
         for ptr_name in ptr_names:
             base_ptr_class = schema.get(ptr_name, default=None)
             if base_ptr_class:
-                root_class = schema.get(
-                    self.get_pointer_class().get_default_base_name())
-                skip_scalar = base_ptr_class.name == root_class.name
                 ptrs = resolver.getptr_inherited_from(
-                    self, schema, base_ptr_class, skip_scalar)
+                    self, schema, base_ptr_class, False)
                 break
 
         return ptrs

--- a/edgedb/lang/schema/std.py
+++ b/edgedb/lang/schema/std.py
@@ -22,8 +22,12 @@ def load_std_schema():
     std_eql_f = os.path.join(os.path.dirname(__file__), '_std.eql')
     with open(std_eql_f) as f:
         std_eql = f.read()
-    std_d = s_ddl.delta_from_ddl(edgeql.parse_block(std_eql), schema=schema)
-    std_d.apply(schema)
+
+    statements = edgeql.parse_block(std_eql)
+
+    for statement in statements:
+        cmd = s_ddl.delta_from_ddl(statement, schema=schema)
+        cmd.apply(schema)
 
     return schema
 

--- a/edgedb/lang/schema/utils.py
+++ b/edgedb/lang/schema/utils.py
@@ -72,6 +72,11 @@ def typeref_to_ast(t: so.Object) -> ql_ast.TypeName:
     return result
 
 
+def reduce_to_typeref(t: s_types.Type) -> so.Object:
+    ref, _ = t._reduce_to_ref()
+    return ref
+
+
 def resolve_typeref(ref: so.Object, schema) -> so.Object:
     if isinstance(ref, s_types.Tuple):
         if any(isinstance(st, so.ObjectRef) for st in ref.get_subtypes()):

--- a/edgedb/server/pgsql/common.py
+++ b/edgedb/server/pgsql/common.py
@@ -12,6 +12,7 @@ from edgedb.lang.common import persistent_hash
 
 from edgedb.lang.schema import objtypes as s_objtypes
 from edgedb.lang.schema import links as s_links
+from edgedb.lang.schema import lproperties as s_props
 
 from edgedb.server.pgsql.parser import keywords as pg_keywords
 
@@ -108,12 +109,12 @@ def objtype_name_to_table_name(name, catenate=True, prefix='edgedb_'):
     return convert_name(name, 'data', catenate)
 
 
-def objtype_name_to_record_name(name, catenate=False, prefix='edgedb_'):
-    return convert_name(name, 'objtype_record', catenate)
-
-
 def link_name_to_table_name(name, catenate=True):
     return convert_name(name, 'link', catenate)
+
+
+def prop_name_to_table_name(name, catenate=True):
+    return convert_name(name, 'prop', catenate)
 
 
 def get_table_name(obj, catenate=True):
@@ -121,6 +122,8 @@ def get_table_name(obj, catenate=True):
         return objtype_name_to_table_name(obj.name, catenate)
     elif isinstance(obj, s_links.Link):
         return link_name_to_table_name(obj.name, catenate)
+    elif isinstance(obj, s_props.Property):
+        return prop_name_to_table_name(obj.name, catenate)
     else:
         raise ValueError(f'cannot determine table for {obj!r}')
 

--- a/edgedb/server/pgsql/compiler/astutils.py
+++ b/edgedb/server/pgsql/compiler/astutils.py
@@ -8,7 +8,6 @@
 
 from edgedb.lang.common import ast
 
-from edgedb.lang.schema import lproperties as s_lprops
 from edgedb.lang.schema import pointers as s_pointers
 
 from edgedb.server.pgsql import ast as pgast
@@ -26,7 +25,7 @@ def tuple_element_for_shape_el(shape_el, value):
     attr_name = s_pointers.PointerVector(
         name=ptrname.name, module=ptrname.module,
         direction=ptrdir, target=ptrcls.get_far_endpoint(ptrdir),
-        is_linkprop=isinstance(ptrcls, s_lprops.LinkProperty))
+        is_linkprop=ptrcls.is_link_property())
 
     return pgast.TupleElement(
         path_id=shape_el.path_id,

--- a/edgedb/server/pgsql/compiler/expr.py
+++ b/edgedb/server/pgsql/compiler/expr.py
@@ -16,7 +16,6 @@ from edgedb.lang.ir import utils as irutils
 
 from edgedb.lang.schema import scalars as s_scalars
 from edgedb.lang.schema import objtypes as s_objtypes
-from edgedb.lang.schema import lproperties as s_lprops
 from edgedb.lang.schema import objects as s_obj
 from edgedb.lang.schema import pointers as s_pointers
 from edgedb.lang.schema import types as s_types
@@ -694,7 +693,7 @@ def _compile_set_in_singleton_mode(
             ptrcls = node.rptr.ptrcls
             source = node.rptr.source
 
-            if not isinstance(ptrcls, s_lprops.LinkProperty):
+            if not ptrcls.is_link_property():
                 if source.rptr:
                     raise RuntimeError(
                         'unexpectedly long path in simple expr')

--- a/edgedb/server/pgsql/compiler/output.py
+++ b/edgedb/server/pgsql/compiler/output.py
@@ -7,8 +7,6 @@
 """Compilation helpers for output formatting and serialization."""
 
 
-from edgedb.lang.schema import lproperties as s_lprops
-
 from edgedb.server.pgsql import ast as pgast
 
 from . import context
@@ -30,7 +28,7 @@ def tuple_var_as_json_object(tvar, *, env):
                 name = element.path_id[-1].name.name
             else:
                 name = rptr.shortname.name
-                if isinstance(rptr, s_lprops.LinkProperty):
+                if rptr.is_link_property():
                     name = '@' + name
             keyvals.append(pgast.Constant(val=name))
             if isinstance(element.val, pgast.TupleVar):

--- a/edgedb/server/pgsql/compiler/pathctx.py
+++ b/edgedb/server/pgsql/compiler/pathctx.py
@@ -15,7 +15,6 @@ from edgedb.lang.common import enum as s_enum
 from edgedb.lang.ir import ast as irast
 from edgedb.lang.ir import utils as irutils
 
-from edgedb.lang.schema import lproperties as s_lprops
 from edgedb.lang.schema import pointers as s_pointers
 from edgedb.lang.schema import types as s_types
 
@@ -141,7 +140,7 @@ def get_path_var(
             # This is an scalar set derived from an expression.
             src_path_id = path_id
 
-    elif isinstance(ptrcls, s_lprops.LinkProperty):
+    elif ptrcls.is_link_property():
         if ptr_info.table_type != 'link' and not is_inbound:
             # This is a link prop that is stored in source rel,
             # step back to link source rvar.

--- a/edgedb/server/pgsql/compiler/relctx.py
+++ b/edgedb/server/pgsql/compiler/relctx.py
@@ -12,6 +12,7 @@ import typing
 from edgedb.lang.ir import ast as irast
 from edgedb.lang.ir import utils as irutils
 
+from edgedb.lang.schema import links as s_links
 from edgedb.lang.schema import objtypes as s_objtypes
 from edgedb.lang.schema import pointers as s_pointers
 
@@ -289,14 +290,24 @@ def _new_mapped_pointer_rvar(
     ptr_rvar = dbobj.range_for_pointer(ir_ptr, env=ctx.env)
     ptr_rvar.nullable = nullable
     # Set up references according to the link direction.
-    src_ptr_info = pg_types.get_pointer_storage_info(
-        ptrcls.getptr(ctx.env.schema, 'std::source'), resolve_type=False)
-    src_col = src_ptr_info.column_name
+    if isinstance(ptrcls, s_links.Link):
+        # XXX: fix this once Properties are Sources
+        src_ptr_info = pg_types.get_pointer_storage_info(
+            ptrcls.getptr(ctx.env.schema, 'std::source'), resolve_type=False)
+        src_col = src_ptr_info.column_name
+    else:
+        src_col = common.edgedb_name_to_pg_name('std::source')
+
     source_ref = dbobj.get_column(None, src_col)
 
-    tgt_ptr_info = pg_types.get_pointer_storage_info(
-        ptrcls.getptr(ctx.env.schema, 'std::target'), resolve_type=False)
-    tgt_col = tgt_ptr_info.column_name
+    if isinstance(ptrcls, s_links.Link):
+        # XXX: fix this once Properties are Sources
+        tgt_ptr_info = pg_types.get_pointer_storage_info(
+            ptrcls.getptr(ctx.env.schema, 'std::target'), resolve_type=False)
+        tgt_col = tgt_ptr_info.column_name
+    else:
+        tgt_col = common.edgedb_name_to_pg_name('std::target')
+
     target_ref = dbobj.get_column(None, tgt_col)
 
     if ir_ptr.direction == s_pointers.PointerDirection.Inbound:

--- a/edgedb/server/pgsql/compiler/relgen.py
+++ b/edgedb/server/pgsql/compiler/relgen.py
@@ -17,7 +17,6 @@ from edgedb.lang.ir import utils as irutils
 
 from edgedb.lang.schema import scalars as s_scalars
 from edgedb.lang.schema import objtypes as s_objtypes
-from edgedb.lang.schema import lproperties as s_lprops
 from edgedb.lang.schema import types as s_types
 
 from edgedb.server.pgsql import ast as pgast
@@ -549,7 +548,7 @@ def process_set_as_path(
         ptrcls, resolve_type=False, link_bias=False)
 
     # Path is a link property.
-    is_linkprop = isinstance(ptrcls, s_lprops.LinkProperty)
+    is_linkprop = ptrcls.is_link_property()
     # Path is a reference to a relationship stored in the source table.
     is_inline_ref = ptr_info.table_type == 'ObjectType'
     is_scalar_ref = not isinstance(ptrcls.target, s_objtypes.ObjectType)

--- a/edgedb/server/pgsql/datasources/schema/links.py
+++ b/edgedb/server/pgsql/datasources/schema/links.py
@@ -44,6 +44,7 @@ async def fetch_properties(
                 p.name                  AS name,
                 edgedb._resolve_type_name(p.bases)
                                         AS bases,
+                p.cardinality           AS cardinality,
                 p.title                 AS title,
                 p.description           AS description,
                 p.required              AS required,
@@ -55,7 +56,7 @@ async def fetch_properties(
                 edgedb._resolve_type(p.target)
                                         AS target
             FROM
-                edgedb.LinkProperty p
+                edgedb.Property p
             ORDER BY
                 p.id, p.target NULLS FIRST
     """)

--- a/edgedb/server/pgsql/deltadbops.py
+++ b/edgedb/server/pgsql/deltadbops.py
@@ -683,10 +683,10 @@ class MappingIndex(dbops.Index):
         ids = tuple(sorted(list(link_map[n] for n in self.link_names)))
         id_str = '_'.join(str(i) for i in ids)
 
-        name = '%s_%s_%s_link_mapping_idx' % (
+        name = '%s_%s_%s_cardinality_idx' % (
             self.name_prefix, id_str, self.cardinality)
         name = common.edgedb_name_to_pg_name(name)
-        predicate = 'link_type_id IN (%s)' % ', '.join(str(id) for id in ids)
+        predicate = 'ptr_item_id IN (%s)' % ', '.join(str(id) for id in ids)
 
         code = '''
             CREATE {unique} INDEX {name} ON {table}s ({cols}) {predicate}
@@ -699,9 +699,9 @@ class MappingIndex(dbops.Index):
         return code
 
     def __repr__(self):
-        name = '%s_%s_%s_link_mapping_idx' % (
+        name = '%s_%s_%s_cardinality_idx' % (
             self.name_prefix, '<HASH>', self.cardinality)
-        predicate = 'link_type_id IN (%s)' % ', '.join(
+        predicate = 'ptr_item_id IN (%s)' % ', '.join(
             str(n) for n in self.link_names)
 
         return \

--- a/edgedb/server/pgsql/schemamech.py
+++ b/edgedb/server/pgsql/schemamech.py
@@ -18,7 +18,6 @@ from edgedb.lang.schema import scalars as s_scalars
 from edgedb.lang.schema import objtypes as s_objtypes
 from edgedb.lang.schema import error as s_err
 from edgedb.lang.schema import links as s_links
-from edgedb.lang.schema import lproperties as s_lprops
 from edgedb.lang.schema import name as sn
 
 from edgedb.lang.common import ast
@@ -97,7 +96,7 @@ class ConstraintMech:
             rptr = ref.rptr
             if rptr is not None:
                 ptr = ref.rptr.ptrcls
-                if isinstance(ptr, s_lprops.LinkProperty):
+                if ptr.is_link_property():
                     src = ref.rptr.source.rptr.ptrcls
                     if src.is_derived:
                         # This specialized pointer was derived specifically
@@ -502,7 +501,7 @@ class TypeMech:
 
             if isinstance(scls, s_links.Link):
                 cols.extend([
-                    dbops.Column(name='link_type_id', type='uuid'),
+                    dbops.Column(name='ptr_item_id', type='uuid'),
                     dbops.Column(name='std::source', type='uuid'),
                     dbops.Column(name='std::target', type='uuid')
                 ])

--- a/tests/schemas/cards.eschema
+++ b/tests/schemas/cards.eschema
@@ -1,31 +1,31 @@
 abstract type Named:
-    required link name -> str:
+    required property name -> str:
         delegated constraint unique
 
 
 abstract link deck:
-    link property count -> int
+    property count -> int
 
 
 abstract link friends:
-    link property nickname -> str
+    property nickname -> str
     # how the friend responded to requests for a favor
-    #link property favor -> array<bool>
+    #property favor -> array<bool>
 
 
 type User extending Named:
     link deck -> Card:
         cardinality := '**'
 
-    link deck_cost := sum(__self__.deck.cost)
+    property deck_cost := sum(__self__.deck.cost)
 
     link friends -> User:
         cardinality := '**'
 
 
 type Card extending Named:
-    required link element -> str
-    required link cost -> int
+    required property element -> str
+    required property cost -> int
     link owners := __self__.<deck[IS User]
 
 

--- a/tests/schemas/constraints.eschema
+++ b/tests/schemas/constraints.eschema
@@ -40,12 +40,12 @@ scalar type constraint_enum extending str:
 abstract link translated_label:
     cardinality := '1*'
 
-    link property lang -> str
-    link property prop1 -> str
+    property lang -> str
+    property prop1 -> str
 
 
 abstract link link_with_unique_property:
-    link property unique_property -> str:
+    property unique_property -> str:
         constraint unique
 
 
@@ -53,56 +53,60 @@ abstract link link_with_unique_property_inherited extending link_with_unique_pro
 
 
 abstract link another_link_with_unique_property:
-    link property unique_property -> str:
+    property unique_property -> str:
         constraint unique
 
 
 abstract link another_link_with_unique_property_inherited extending another_link_with_unique_property
 
 
+type Label:
+    property text -> str
+
+
 type Object:
-    link name -> str
-    link c_length -> constraint_length
-    link c_length_2 -> constraint_length_2
-    link c_length_3 -> constraint_length_2:
+    property name -> str
+    property c_length -> constraint_length
+    property c_length_2 -> constraint_length_2
+    property c_length_3 -> constraint_length_2:
         constraint minlength(10)
 
-    link c_minmax -> constraint_minmax
-    link c_strvalue -> constraint_strvalue
-    link c_enum -> constraint_enum
+    property c_minmax -> constraint_minmax
+    property c_strvalue -> constraint_strvalue
+    property c_enum -> constraint_enum
 
 
 type UniqueName:
-    link name -> str:
+    property name -> str:
         constraint unique
 
-    link link_with_unique_property -> str
+    link link_with_unique_property -> Object
 
-    link link_with_unique_property_inherited -> str
+    link link_with_unique_property_inherited -> Object
 
-    link translated_label -> str:
+    link translated_label -> Label:
         constraint unique on (__subject__@source, __subject__@lang)
         constraint unique on (__subject__@prop1)
 
 
 type UniqueNameInherited extending UniqueName:
-    inherited link name -> str
+    inherited property name -> str
 
 
 type UniqueDescription:
-    link description -> str:
+    property description -> str:
         constraint unique
 
-    link another_link_with_unique_property -> str
+    link another_link_with_unique_property -> Object
 
-    link another_link_with_unique_property_inherited -> str
+    link another_link_with_unique_property_inherited -> Object
 
 
 type UniqueDescriptionInherited extending UniqueDescription
 
 
 type UniqueName_2:
-    link name -> str:
+    property name -> str:
         constraint unique
 
 
@@ -110,7 +114,7 @@ type UniqueName_2_Inherited extending UniqueName_2
 
 
 type UniqueName_3 extending UniqueName_2:
-    inherited link name -> str:
+    inherited property name -> str:
         constraint unique on (lower(__subject__))
 
 
@@ -118,34 +122,34 @@ type UniqueName_4 extending UniqueName_2_Inherited
 
 
 type MultiConstraint:
-    link name -> str:
+    property name -> str:
         constraint unique
         constraint unique on (lower(__subject__))
 
-    link m1 -> str
+    property m1 -> str
 
 
 type ParentUniqueName:
-    link name -> str:
+    property name -> str:
         constraint unique
 
 
 type ReceivingParent:
-    link name -> str
+    property name -> str
 
 
 type LosingParent extending ParentUniqueName:
-    inherited link name -> str
-    link lp -> str
+    inherited property name -> str
+    property lp -> str
 
 
 type AbstractConstraintParent:
-    link name -> str:
+    property name -> str:
         delegated constraint unique
 
 
 type AbstractConstraintParent2:
-    link name -> str:
+    property name -> str:
         delegated constraint unique on (lower(__subject__))
 
 
@@ -153,23 +157,23 @@ type AbstractConstraintPureChild extending AbstractConstraintParent
 
 
 type AbstractConstraintMixedChild extending AbstractConstraintParent:
-    inherited link name -> str:
+    inherited property name -> str:
         constraint unique on (lower(__subject__))
 
 
 type AbstractConstraintPropagated extending AbstractConstraintParent:
-    inherited link name -> str:
+    inherited property name -> str:
         delegated constraint unique on (lower(__subject__))
 
 
 type AbstractConstraintParent3:
-    link name -> str:
+    property name -> str:
         delegated constraint unique
         delegated constraint unique on (lower(__subject__))
 
 
 type AbstractConstraintMultipleParentsFlattening extending AbstractConstraintParent, AbstractConstraintParent2:
-    link flat -> str
+    property flat -> str
 
 
 type LosingAbstractConstraintParent extending AbstractConstraintParent
@@ -179,7 +183,7 @@ type LosingAbstractConstraintParent2 extending AbstractConstraintParent
 
 
 type BecomingAbstractConstraint:
-    link name -> str:
+    property name -> str:
         constraint unique
 
 
@@ -187,7 +191,7 @@ type BecomingAbstractConstraintChild extending BecomingAbstractConstraint
 
 
 type BecomingConcreteConstraint:
-    link name -> str:
+    property name -> str:
         delegated constraint unique
 
 
@@ -195,7 +199,7 @@ type BecomingConcreteConstraintChild extending BecomingConcreteConstraint
 
 
 type AbstractInheritingNonAbstract extending ParentUniqueName:
-    inherited link name -> str:
+    inherited property name -> str:
         delegated constraint unique
 
 

--- a/tests/schemas/constraints_migration/schema.eschema
+++ b/tests/schemas/constraints_migration/schema.eschema
@@ -40,12 +40,12 @@ scalar type constraint_enum extending str:
 abstract link translated_label:
     cardinality := '1*'
 
-    link property lang -> str
-    link property prop1 -> str
+    property lang -> str
+    property prop1 -> str
 
 
 abstract link link_with_unique_property:
-    link property unique_property -> str:
+    property unique_property -> str:
         constraint unique
 
 
@@ -53,56 +53,60 @@ abstract link link_with_unique_property_inherited extending link_with_unique_pro
 
 
 abstract link another_link_with_unique_property:
-    link property unique_property -> str:
+    property unique_property -> str:
         constraint unique
 
 
 abstract link another_link_with_unique_property_inherited extending another_link_with_unique_property
 
 
+type Label:
+    property text -> str
+
+
 type Object:
-    link name -> str
-    link c_length -> constraint_length
-    link c_length_2 -> constraint_length_2
-    link c_length_3 -> constraint_length_2:
+    property name -> str
+    property c_length -> constraint_length
+    property c_length_2 -> constraint_length_2
+    property c_length_3 -> constraint_length_2:
         constraint minlength(10)
 
-    link c_minmax -> constraint_minmax
-    link c_strvalue -> constraint_strvalue
-    link c_enum -> constraint_enum
+    property c_minmax -> constraint_minmax
+    property c_strvalue -> constraint_strvalue
+    property c_enum -> constraint_enum
 
 
 type UniqueName:
-    link name -> str:
+    property name -> str:
         constraint unique
 
-    link link_with_unique_property -> str
+    link link_with_unique_property -> Object
 
-    link link_with_unique_property_inherited -> str
+    link link_with_unique_property_inherited -> Object
 
-    link translated_label -> str:
+    link translated_label -> Label:
         constraint unique on (__subject__@source, __subject__@lang)
         constraint unique on (__subject__@prop1)
 
 
 type UniqueNameInherited extending UniqueName:
-    inherited link name -> str
+    inherited property name -> str
 
 
 type UniqueDescription:
-    link description -> str:
+    property description -> str:
         constraint unique
 
-    link another_link_with_unique_property -> str
+    link another_link_with_unique_property -> Object
 
-    link another_link_with_unique_property_inherited -> str
+    link another_link_with_unique_property_inherited -> Object
 
 
 type UniqueDescriptionInherited extending UniqueDescription
 
 
 type UniqueName_2:
-    link name -> str:
+    property name -> str:
         constraint unique
 
 
@@ -110,7 +114,7 @@ type UniqueName_2_Inherited extending UniqueName_2
 
 
 type UniqueName_3 extending UniqueName_2:
-    inherited link name -> str:
+    inherited property name -> str:
         constraint unique on (lower(__subject__))
 
 
@@ -118,34 +122,34 @@ type UniqueName_4 extending UniqueName_2_Inherited
 
 
 type MultiConstraint:
-    link name -> str:
+    property name -> str:
         constraint unique
         constraint unique on (lower(__subject__))
 
-    link m1 -> str
+    property m1 -> str
 
 
 type ParentUniqueName:
-    link name -> str:
+    property name -> str:
         constraint unique
 
 
 type ReceivingParent:
-    link name -> str
+    property name -> str
 
 
 type LosingParent extending ParentUniqueName:
-    inherited link name -> str
-    link lp -> str
+    inherited property name -> str
+    property lp -> str
 
 
 type AbstractConstraintParent:
-    link name -> str:
+    property name -> str:
         delegated constraint unique
 
 
 type AbstractConstraintParent2:
-    link name -> str:
+    property name -> str:
         delegated constraint unique on (lower(__subject__))
 
 
@@ -153,23 +157,23 @@ type AbstractConstraintPureChild extending AbstractConstraintParent
 
 
 type AbstractConstraintMixedChild extending AbstractConstraintParent:
-    inherited link name -> str:
+    inherited property name -> str:
         constraint unique on (lower(__subject__))
 
 
 type AbstractConstraintPropagated extending AbstractConstraintParent:
-    inherited link name -> str:
+    inherited property name -> str:
         delegated constraint unique
 
 
 type AbstractConstraintParent3:
-    link name -> str:
+    property name -> str:
         delegated constraint unique
         delegated constraint unique on (lower(__subject__))
 
 
 type AbstractConstraintMultipleParentsFlattening extending AbstractConstraintParent, AbstractConstraintParent2:
-    link flat -> str
+    property flat -> str
 
 
 type LosingAbstractConstraintParent extending AbstractConstraintParent
@@ -179,7 +183,7 @@ type LosingAbstractConstraintParent2 extending AbstractConstraintParent
 
 
 type BecomingAbstractConstraint:
-    link name -> str:
+    property name -> str:
         constraint unique
 
 
@@ -187,7 +191,7 @@ type BecomingAbstractConstraintChild extending BecomingAbstractConstraint
 
 
 type BecomingConcreteConstraint:
-    link name -> str:
+    property name -> str:
         delegated constraint unique
 
 
@@ -195,7 +199,7 @@ type BecomingConcreteConstraintChild extending BecomingConcreteConstraint
 
 
 type AbstractInheritingNonAbstract extending ParentUniqueName:
-    inherited link name -> str:
+    inherited property name -> str:
         delegated constraint unique
 
 

--- a/tests/schemas/constraints_migration/updated_schema.eschema
+++ b/tests/schemas/constraints_migration/updated_schema.eschema
@@ -40,15 +40,15 @@ scalar type constraint_enum extending str:
 abstract link translated_label:
     cardinality := '1*'
 
-    link property lang -> str
-    link property prop1 -> str
+    property lang -> str
+    property prop1 -> str
 
 
 abstract link link_with_unique_property:
-    link property unique_property -> str:
+    property unique_property -> str:
         constraint unique
 
-    link property unique_property2 -> str:
+    property unique_property2 -> str:
         constraint unique
 
 
@@ -56,67 +56,71 @@ abstract link link_with_unique_property_inherited extending link_with_unique_pro
 
 
 abstract link another_link_with_unique_property:
-    link property unique_property -> str
+    property unique_property -> str
 
 
 abstract link another_link_with_unique_property_inherited extending another_link_with_unique_property
 
 
+type Label:
+    property text -> str
+
+
 type Object:
-    link name -> str:
+    property name -> str:
         constraint unique
         constraint unique on (std::lower(__subject__))
 
-    link c_length -> constraint_length
-    link c_length_2 -> constraint_length_2
-    link c_length_3 -> constraint_length_2:
+    property c_length -> constraint_length
+    property c_length_2 -> constraint_length_2
+    property c_length_3 -> constraint_length_2:
         constraint minlength(10)
 
-    link c_minmax -> constraint_minmax
-    link c_strvalue -> constraint_strvalue
-    link c_enum -> constraint_enum
+    property c_minmax -> constraint_minmax
+    property c_strvalue -> constraint_strvalue
+    property c_enum -> constraint_enum
 
-    link translated_label -> str:
+    link translated_label -> Label:
         constraint unique on (__subject__@source, __subject__@lang)
         constraint unique on (__subject__@prop1)
 
 
 type UniqueName:
-    link name -> str:
+    property name -> str:
         constraint unique
 
-    link name2 -> str:
+    property name2 -> str:
         constraint unique
 
-    link link_with_unique_property -> str
+    link link_with_unique_property -> Object
 
-    link link_with_unique_property_inherited -> str
+    link link_with_unique_property_inherited -> Object
 
-    link translated_label -> str:
+    link translated_label -> Label:
         constraint unique on (__subject__@source, __subject__@lang)
         constraint unique on (__subject__@prop1)
 
 
 type UniqueNameInherited extending UniqueName:
-    inherited link name -> str
+    inherited property name -> str
 
 
 type UniqueNameGrandchild extending UniqueNameInherited
 
 
 type UniqueDescription:
-    link description -> str
+    property description -> str
 
-    link another_link_with_unique_property -> str
+    link another_link_with_unique_property -> Object
 
-    link another_link_with_unique_property_inherited -> str
+    link another_link_with_unique_property_inherited -> Object
 
 
 type UniqueDescriptionInherited extending UniqueDescription
 
 
 type UniqueName_2_Renamed:
-    link name -> str:
+    property name -> str:
         constraint unique
 
 
@@ -130,34 +134,34 @@ type UniqueName_4 extending UniqueName_2_Inherited
 
 
 type MultiConstraint_Renamed:
-    link name -> str:
+    property name -> str:
         constraint unique
         constraint unique on (lower(__subject__))
 
-    link m1 -> str
+    property m1 -> str
 
 
 type ParentUniqueName:
-    link name -> str:
+    property name -> str:
         constraint unique
 
 
 type ReceivingParent extending ParentUniqueName:
-    inherited link name -> str
+    inherited property name -> str
 
 
 type LosingParent:
-    link name -> str
-    link lp -> str
+    property name -> str
+    property lp -> str
 
 
 type AbstractConstraintParent:
-    link name -> str:
+    property name -> str:
         delegated constraint unique
 
 
 type AbstractConstraintParent2:
-    link name -> str:
+    property name -> str:
         delegated constraint unique on (lower(__subject__))
 
 
@@ -165,36 +169,36 @@ type AbstractConstraintPureChild extending AbstractConstraintParent
 
 
 type AbstractConstraintMixedChild extending AbstractConstraintParent:
-    inherited link name -> str:
+    inherited property name -> str:
         constraint unique on (lower(__subject__))
 
 
 type AbstractConstraintPropagated extending AbstractConstraintParent:
-    inherited link name -> str:
+    inherited property name -> str:
         delegated constraint unique
 
 
 type AbstractConstraintParent3:
-    link name -> str:
+    property name -> str:
         delegated constraint unique
         delegated constraint unique on (lower(__subject__))
 
 
 type AbstractConstraintMultipleParentsFlattening extending AbstractConstraintParent, AbstractConstraintParent2:
-    link flat -> str
+    property flat -> str
 
 
 type LosingAbstractConstraintParent:
-    link name -> str:
+    property name -> str:
         constraint unique
 
 
 type LosingAbstractConstraintParent2:
-    link name -> str
+    property name -> str
 
 
 type BecomingAbstractConstraint:
-    link name -> str:
+    property name -> str:
         delegated constraint unique
 
 
@@ -202,7 +206,7 @@ type BecomingAbstractConstraintChild extending BecomingAbstractConstraint
 
 
 type BecomingConcreteConstraint:
-    link name -> str:
+    property name -> str:
         constraint unique
 
 
@@ -210,7 +214,7 @@ type BecomingConcreteConstraintChild extending BecomingConcreteConstraint
 
 
 type AbstractInheritingNonAbstract:
-    link name -> str:
+    property name -> str:
         delegated constraint unique
 
 

--- a/tests/schemas/insert.eschema
+++ b/tests/schemas/insert.eschema
@@ -1,35 +1,31 @@
-abstract link l3:
-    link property comment -> str:
-        default := "N/A"
-
 abstract link subordinates:
-    link property comment -> str
+    property comment -> str
 
 type Subordinate:
-    required link name -> str
+    required property name -> str
 
 type InsertTest:
-    link name -> str
-    link l1 -> int
-    required link l2 -> int
-    link l3 -> str:
+    property name -> str
+    property l1 -> int
+    required property l2 -> int
+    property l3 -> str:
         default := "test"
     link subordinates -> Subordinate:
         cardinality := '1*'
 
 type Annotation:
-    required link name -> str
-    link note -> str
+    required property name -> str
+    property note -> str
     link subject -> Object
 
 type DefaultTest1:
-    link num -> int:
+    property num -> int:
         default := 42
-    link foo -> str
+    property foo -> str
 
 type DefaultTest2:
-    link foo -> str
-    required link num -> int:
+    property foo -> str
+    required property num -> int:
         # XXX: circumventing sequence deficiency
         default :=
             SELECT DefaultTest1.num + 1
@@ -37,34 +33,18 @@ type DefaultTest2:
             LIMIT 1
 
 type DefaultTest3:
-    required link foo -> float:
+    required property foo -> float:
         # non-deterministic dynamic value
         default := random()
 
 type DefaultTest4:
-    required link bar -> int:
+    required property bar -> int:
         # deterministic dynamic value
         default := (SELECT count(DefaultTest4))
 
-# links and types to test scalar links with link properties
-abstract link special:
-    link property lang -> str
-
-abstract link title:
-    link property lang -> str
-
-
-type Offer:
-    # title translated into multiple languages
-    required link title -> str:
-        cardinality := '1*'
-
-    # some king of special offer for a specific language
-    link special -> str
-
 # types to test some inheritance issues
 type InputValue:
-    link val -> str
+    property val -> str
 
 abstract type Callable:
     link args -> InputValue:

--- a/tests/schemas/inventory.eschema
+++ b/tests/schemas/inventory.eschema
@@ -1,17 +1,17 @@
 abstract type Named:
-    required link name -> str:
+    required property name -> str:
         delegated constraint unique
 
 type Item extending Named:
-    link tag_set1 -> str:
+    property tag_set1 -> str:
         cardinality := '1*'
 
     # for scalar links there should not be any practical difference
     # between a 1* and ** cardinality
     #
-    link tag_set2 -> str:
+    property tag_set2 -> str:
         cardinality := '**'
 
-    link tag_array -> array<str>
+    property tag_array -> array<str>
 
-    link components -> map<str, int>
+    property components -> map<str, int>

--- a/tests/schemas/issues.eschema
+++ b/tests/schemas/issues.eschema
@@ -1,23 +1,23 @@
 abstract type Text:
     # This is an abstract object containing text.
-    required link body -> str:
+    required property body -> str:
         # Maximum length of text is 10000 characters.
         constraint maxlength(10000)
 
 
 abstract type Named:
-    required link name -> str
+    required property name -> str
 
 
 # Dictionary is a NamedObject variant, that enforces
 # name uniqueness across all instances if its subclass.
 abstract type Dictionary extending Named:
-    required inherited link name -> str:
+    required inherited property name -> str:
         delegated constraint unique
 
 
 abstract link todo:
-    link property rank -> int:
+    property rank -> int:
         default := 42
 
 
@@ -42,7 +42,7 @@ type LogEntry extending Owned, Text:
     # LogEntry is an Owned and a Text, so it
     # will have all of their links and attributes,
     # in particular, owner and text links.
-    required link spent_time -> int
+    required property spent_time -> int
 
 
 # issue_num_t is defined as a concrete sequence type,
@@ -58,7 +58,7 @@ type Comment extending Text, Owned:
 
 
 type Issue extending Named, Owned, Text:
-    required link number -> issue_num_t:
+    required property number -> issue_num_t:
         readonly := true
         # The number values are automatically generated,
         # and are not supposed to be directly writable.
@@ -76,18 +76,18 @@ type Issue extending Named, Owned, Text:
         # many-to-many relation.  The default cardinality is
         # *1 -- many-to-one.
 
-    link time_estimate -> int
+    property time_estimate -> int
 
     link time_spent_log -> LogEntry:
         cardinality := '1*'
         # 1* -- one-to-many cardinality.
 
-    link start_date -> datetime:
+    property start_date -> datetime:
         default := SELECT current_datetime()
         # The default value of start_date will be a
         # result of the EdgeQL expression above.
 
-    link due_date -> datetime
+    property due_date -> datetime
 
     link related_to -> Issue:
         cardinality := '**'
@@ -96,15 +96,15 @@ type Issue extending Named, Owned, Text:
     link references -> File, URL, Publication:
         cardinality := '**'
 
-    link tags -> array<str>
+    property tags -> array<str>
 
 
 type File extending Named
 
 
 type URL extending Named:
-    required link address -> str
+    required property address -> str
 
 
 type Publication:
-    required link title -> str
+    required property title -> str

--- a/tests/schemas/links_1.eschema
+++ b/tests/schemas/links_1.eschema
@@ -7,11 +7,11 @@
 
 
 type Target0:
-    link name -> str
+    property name -> str
 
 
 type Target1 extending Target0:
-    inherited link name -> str
+    inherited property name -> str
 
 
 type ObjectType0:

--- a/tests/schemas/links_1_migrated.eschema
+++ b/tests/schemas/links_1_migrated.eschema
@@ -7,11 +7,11 @@
 
 
 type Target0:
-    link name -> str
+    property name -> str
 
 
 type Target1 extending Target0:
-    inherited link name -> str
+    inherited property name -> str
 
 
 type ObjectType0:

--- a/tests/schemas/updates.eschema
+++ b/tests/schemas/updates.eschema
@@ -1,23 +1,23 @@
 type Status:
-    required link name -> str:
+    required property name -> str:
         constraint unique
 
 type Tag:
-    required link name -> str:
+    required property name -> str:
         constraint unique
 
 abstract link annotated_status:
-    link property note -> str
+    property note -> str
 
 abstract link weighted_tags:
-    link property weight -> int
+    property weight -> int
 
 abstract link annotated_tests:
-    link property note -> str
+    property note -> str
 
 type UpdateTest:
-    required link name -> str
-    link comment -> str
+    required property name -> str
+    property comment -> str
 
     # for testing singleton links
     link status -> Status

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -547,12 +547,12 @@ class TestConstraintsDDL(tb.DDLTestCase):
         qry = """
             CREATE ABSTRACT LINK test::translated_label {
                 SET cardinality := '1*';
-                CREATE LINK PROPERTY test::lang -> std::str;
-                CREATE LINK PROPERTY test::prop1 -> std::str;
+                CREATE PROPERTY test::lang -> std::str;
+                CREATE PROPERTY test::prop1 -> std::str;
             };
 
             CREATE ABSTRACT LINK test::link_with_unique_property {
-                CREATE LINK PROPERTY test::unique_property -> std::str {
+                CREATE PROPERTY test::unique_property -> std::str {
                     CREATE CONSTRAINT std::unique;
                 };
             };
@@ -561,11 +561,11 @@ class TestConstraintsDDL(tb.DDLTestCase):
                 EXTENDING test::link_with_unique_property;
 
             CREATE TYPE test::UniqueName {
-                CREATE LINK test::name -> std::str {
+                CREATE PROPERTY test::name -> std::str {
                     CREATE CONSTRAINT std::unique;
                 };
 
-                CREATE LINK test::linu_with_unique_property -> std::str;
+                CREATE LINK test::link_with_unique_property -> std::Object;
             };
         """
 
@@ -588,7 +588,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         qry = """
             CREATE TYPE test::AbstractConstraintParent {
-                CREATE LINK test::name -> std::str {
+                CREATE PROPERTY test::name -> std::str {
                     CREATE DELEGATED CONSTRAINT std::unique;
                 };
             };
@@ -641,11 +641,11 @@ class TestConstraintsDDL(tb.DDLTestCase):
             };
 
             CREATE TYPE test::ConstraintOnTest1 {
-                CREATE LINK test::foo -> std::str {
+                CREATE PROPERTY test::foo -> std::str {
                     CREATE CONSTRAINT test::mymax1(3);
                 };
 
-                CREATE LINK test::bar -> std::str {
+                CREATE PROPERTY test::bar -> std::str {
                     CREATE CONSTRAINT test::mymax_ext1(3);
                 };
             };
@@ -714,11 +714,11 @@ class TestConstraintsDDL(tb.DDLTestCase):
             };
 
             CREATE TYPE test::ConstraintOnTest2 {
-                CREATE LINK test::foo -> std::str {
+                CREATE PROPERTY test::foo -> std::str {
                     CREATE CONSTRAINT test::mymax2(3) ON (len(__subject__));
                 };
 
-                CREATE LINK test::bar -> std::str {
+                CREATE PROPERTY test::bar -> std::str {
                     CREATE CONSTRAINT std::max(3) ON (len(__subject__)) {
                         SET errmessage :=
                       # XXX: once simple string concat is possible here
@@ -796,7 +796,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             };
 
             CREATE TYPE test::ConstraintOnTest3 {
-                CREATE LINK test::foo -> std::str {
+                CREATE PROPERTY test::foo -> std::str {
                     CREATE CONSTRAINT test::mymax3(3) ON (len(__subject__));
                 };
             };
@@ -850,7 +850,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     };
 
                     CREATE TYPE test::InvalidConstraintTest1 {
-                        CREATE LINK test::foo -> std::str {
+                        CREATE PROPERTY test::foo -> std::str {
                             CREATE CONSTRAINT test::len_fail(3) {
                                 SET subjectexpr := len(__subject__);
                             };
@@ -868,7 +868,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     };
 
                     CREATE TYPE test::InvalidConstraintTest1 {
-                        CREATE LINK test::foo -> std::str {
+                        CREATE PROPERTY test::foo -> std::str {
                             CREATE CONSTRAINT test::len_fail(3) {
                                 SET subject := len(__subject__);
                             };
@@ -895,7 +895,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     };
 
                     CREATE TYPE test::InvalidConstraintTest2 {
-                        CREATE LINK test::foo -> std::str {
+                        CREATE PROPERTY test::foo -> std::str {
                             CREATE CONSTRAINT test::max_int(3)
                                 ON (len(__subject__));
                         };
@@ -911,7 +911,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             };
 
             CREATE TYPE test::ConstraintAlterTest1 {
-                CREATE LINK test::value -> std::int {
+                CREATE PROPERTY test::value -> std::int {
                     CREATE CONSTRAINT std::max(3);
                 };
             };
@@ -945,7 +945,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     'subjectexpr is not a valid constraint attribute'):
                 await self.con.execute("""
                     ALTER TYPE test::ConstraintAlterTest1 {
-                        ALTER LINK test::value {
+                        ALTER PROPERTY test::value {
                             ALTER CONSTRAINT std::max {
                                 SET subjectexpr := len(__subject__);
                             };
@@ -959,7 +959,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     'subject is not a valid constraint attribute'):
                 await self.con.execute("""
                     ALTER TYPE test::ConstraintAlterTest1 {
-                        ALTER LINK test::value {
+                        ALTER PROPERTY test::value {
                             ALTER CONSTRAINT std::max {
                                 SET subject := len(__subject__);
                             };
@@ -978,7 +978,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             };
 
             CREATE TYPE test::ConstraintAlterTest2 {
-                CREATE LINK test::value -> std::int {
+                CREATE PROPERTY test::value -> std::int {
                     CREATE CONSTRAINT std::max(3) ON (__subject__ % 10);
                 };
             };
@@ -1012,7 +1012,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     'subjectexpr is not a valid constraint attribute'):
                 await self.con.execute("""
                     ALTER TYPE test::ConstraintAlterTest1 {
-                        ALTER LINK test::value {
+                        ALTER PROPERTY test::value {
                             ALTER CONSTRAINT std::max {
                                 DROP ATTRIBUTE subjectexpr;
                             };
@@ -1026,7 +1026,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     'subject is not a valid constraint attribute'):
                 await self.con.execute("""
                     ALTER TYPE test::ConstraintAlterTest1 {
-                        ALTER LINK test::value {
+                        ALTER PROPERTY test::value {
                             ALTER CONSTRAINT std::max {
                                 DROP ATTRIBUTE subject;
                             };

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -22,12 +22,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_02(self):
         await self.con.execute("""
             CREATE ABSTRACT LINK test::test_object_link {
-                CREATE LINK PROPERTY test::test_link_prop -> std::int;
+                CREATE PROPERTY test::test_link_prop -> std::int;
             };
 
             CREATE TYPE test::TestObjectType {
-                CREATE LINK test::test_object_link -> std::str {
-                    CREATE LINK PROPERTY test::test_link_prop -> std::int {
+                CREATE LINK test::test_object_link -> std::Object {
+                    CREATE PROPERTY test::test_link_prop -> std::int {
                         SET title := 'Test Property';
                     };
                 };
@@ -37,7 +37,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_03(self):
         await self.con.execute("""
             CREATE ABSTRACT LINK test::test_object_link_prop {
-                CREATE LINK PROPERTY test::link_prop1 -> std::str;
+                CREATE PROPERTY test::link_prop1 -> std::str;
             };
         """)
 
@@ -274,9 +274,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_11(self):
         await self.con.execute("""
             CREATE TYPE test::TestContainerLinkObjectType {
-                CREATE LINK test::test_array_link -> array<std::str>;
-                CREATE LINK test::test_array_link_2 -> array<std::str[10]>;
-                CREATE LINK test::test_map_link -> map<std::str, std::int>;
+                CREATE PROPERTY test::test_array_link -> array<std::str>;
+                CREATE PROPERTY test::test_array_link_2 -> array<std::str[10]>;
+                CREATE PROPERTY test::test_map_link -> map<std::str, std::int>;
             };
         """)
 
@@ -286,7 +286,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r'Unknown token.*__subject__'):
             await self.con.execute(r"""
                 CREATE TYPE test::TestBadContainerLinkObjectType {
-                    CREATE LINK test::foo -> std::str {
+                    CREATE PROPERTY test::foo -> std::str {
                         CREATE CONSTRAINT expression
                             ON (`__subject__` = 'foo');
                     };
@@ -299,7 +299,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 'reference to a non-existent schema class: self'):
             await self.con.execute(r"""
                 CREATE TYPE test::TestBadContainerLinkObjectType {
-                    CREATE LINK test::foo -> std::str {
+                    CREATE PROPERTY test::foo -> std::str {
                         CREATE CONSTRAINT expression ON (`self` = 'foo');
                     };
                 };
@@ -309,8 +309,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_14(self):
         await self.con.execute("""
             CREATE TYPE test::TestSelfLink1 {
-                CREATE LINK test::foo1 -> std::str;
-                CREATE LINK test::bar1 -> std::str {
+                CREATE PROPERTY test::foo1 -> std::str;
+                CREATE PROPERTY test::bar1 -> std::str {
                     SET default := __self__.foo1;
                 };
             };
@@ -335,8 +335,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_15(self):
         await self.con.execute(r"""
             CREATE TYPE test::TestSelfLink2 {
-                CREATE LINK test::foo2 -> std::str;
-                CREATE LINK test::bar2 -> std::str {
+                CREATE PROPERTY test::foo2 -> std::str;
+                CREATE PROPERTY test::bar2 -> std::str {
                     # NOTE: this is a set of all TestSelfLink2.foo2
                     SET default := test::TestSelfLink2.foo2;
                     SET cardinality := '1*';
@@ -370,8 +370,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(client_errors.EdgeQLError):
             await self.con.execute(r"""
                 CREATE TYPE test::TestSelfLink3 {
-                    CREATE LINK test::foo3 -> std::str;
-                    CREATE LINK test::bar3 -> std::str {
+                    CREATE PROPERTY test::foo3 -> std::str;
+                    CREATE PROPERTY test::bar3 -> std::str {
                         # NOTE: this is a set of all TestSelfLink2.foo3
                         SET default := test::TestSelfLink2.foo3;
                     };
@@ -382,7 +382,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_17(self):
         await self.con.execute("""
             CREATE TYPE test::TestSelfLink4 {
-                CREATE LINK test::__typename4 -> std::str {
+                CREATE PROPERTY test::__typename4 -> std::str {
                     SET default := __self__.__type__.name;
                 };
             };

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -16,10 +16,10 @@ class TestDelete(tb.QueryTestCase):
     SETUP = """
         CREATE MIGRATION test::d_delete01 TO eschema $$
             type DeleteTest:
-                link name -> str
+                property name -> str
 
             type DeleteTest2:
-                link name -> str
+                property name -> str
         $$;
 
         COMMIT MIGRATION test::d_delete01;

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -220,13 +220,13 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             SELECT
                 ObjectType {
                     l := array_agg(
-                        ObjectType.links.name
+                        ObjectType.properties.name
                         FILTER
-                            ObjectType.links.name IN {
+                            ObjectType.properties.name IN {
                                 'std::id',
                                 'schema::name'
                             }
-                        ORDER BY ObjectType.links.name ASC
+                        ORDER BY ObjectType.properties.name ASC
                     )
                 }
             FILTER
@@ -324,10 +324,10 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_re_match_02(self):
         await self.assert_query_result(r'''
             WITH MODULE schema
-            SELECT x := re_match(ObjectType.name, '(\w+)::(Link\w*)')
+            SELECT x := re_match(ObjectType.name, '(\w+)::(Link|Property)')
             ORDER BY x;
         ''', [
-            [['schema', 'Link'], ['schema', 'LinkProperty']],
+            [['schema', 'Link'], ['schema', 'Property']],
         ])
 
     async def test_edgeql_functions_re_match_all_01(self):

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -836,49 +836,6 @@ class TestInsert(tb.QueryTestCase):
             ]
         )
 
-    async def test_edgeql_insert_linkprops_01(self):
-        res = await self.con.execute(r'''
-            INSERT test::Offer {
-                title := (SELECT 'Super offer' {@lang := 'en-US'})
-            };
-
-            INSERT test::Offer {
-                title := (SELECT 'Sample' {@lang := 'en-CA'}),
-                special := (SELECT 'Unavailable, sorry.' {@lang := 'en-CA'})
-            };
-
-            WITH MODULE test
-            SELECT Offer {
-                title: {
-                    @target,
-                    @lang
-                } ORDER BY Offer.title@lang,
-                special: {
-                    @target,
-                    @lang
-                }
-            }
-            ORDER BY Offer.special;
-        ''')
-
-        self.assert_data_shape(
-            res[-1], [{
-                'title': [{
-                    '@target': 'Super offer',
-                    '@lang': 'en-US',
-                }],
-            }, {
-                'title': [{
-                    '@target': 'Sample',
-                    '@lang': 'en-CA',
-                }],
-                'special': {
-                    '@target': 'Unavailable, sorry.',
-                    '@lang': 'en-CA',
-                },
-            }]
-        )
-
     @unittest.expectedFailure
     async def test_edgeql_insert_polymorphic_01(self):
         res = await self.con.execute(r'''

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2717,34 +2717,33 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
             std::int FROM SQL FUNCTION 'aaa';
         """
 
-    def test_edgeql_syntax_ddl_linkproperty_01(self):
+    def test_edgeql_syntax_ddl_property_01(self):
         """
-        CREATE ABSTRACT LINK PROPERTY std::linkproperty {
-            SET title := 'Base link property';
+        CREATE ABSTRACT PROPERTY std::property {
+            SET title := 'Base property';
         };
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=30)
-    def test_edgeql_syntax_ddl_linkproperty_02(self):
+    def test_edgeql_syntax_ddl_property_02(self):
         """
-        CREATE ABSTRACT LINK LINK PROPERTY std::linkproperty {
-            SET title := 'Base link property';
+        CREATE ABSTRACT PROPERTY std::property {
+            SET title := 'Base property';
         };
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=48)
-    def test_edgeql_syntax_ddl_linkproperty_03(self):
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=43)
+    def test_edgeql_syntax_ddl_property_03(self):
         """
-        CREATE ABSTRACT LINK PROPERTY PROPERTY std::linkproperty {
-            SET title := 'Base link property';
+        CREATE ABSTRACT PROPERTY PROPERTY std::property {
+            SET title := 'Base property';
         };
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=39)
-    def test_edgeql_syntax_ddl_linkproperty_04(self):
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=34)
+    def test_edgeql_syntax_ddl_property_04(self):
         """
-        CREATE ABSTRACT LINK PROPERTY __type__ {
-            SET title := 'Base link property';
+        CREATE ABSTRACT PROPERTY __type__ {
+            SET title := 'Base property';
         };
         """
 

--- a/tests/test_edgeql_utils.py
+++ b/tests/test_edgeql_utils.py
@@ -18,24 +18,24 @@ from edgedb.lang import _testbase as tb
 class TestEdgeQLUtils(tb.BaseSyntaxTest):
     SCHEMA = r"""
         abstract type NamedObject:
-            required link name -> str
+            required property name -> str
 
         type UserGroup extending NamedObject:
             link settings -> Setting:
                 cardinality := '1*'
 
         type Setting extending NamedObject:
-            required link value -> str
+            required property value -> str
 
         type Profile extending NamedObject:
-            required link value -> str
+            required property value -> str
 
         type User extending NamedObject:
-            required link active -> bool
+            required property active -> bool
             link groups -> UserGroup:
                 cardinality := '**'
-            required link age -> int
-            required link score -> float
+            required property age -> int
+            required property score -> float
             link profile -> Profile:
                 cardinality := '*1'
     """

--- a/tests/test_graphql_functional.py
+++ b/tests/test_graphql_functional.py
@@ -15,24 +15,24 @@ class TestGraphQLFunctional(tb.QueryTestCase):
     SETUP = """
         CREATE MIGRATION test::d1 TO eschema $$
             abstract type NamedObject:
-                required link name -> str
+                required property name -> str
 
             type UserGroup extending NamedObject:
                 link settings -> Setting:
                     cardinality := '**'
 
             type Setting extending NamedObject:
-                required link value -> str
+                required property value -> str
 
             type Profile extending NamedObject:
-                required link value -> str
+                required property value -> str
 
             type User extending NamedObject:
-                required link active -> bool
+                required property active -> bool
                 link groups -> UserGroup:
                     cardinality := '**'
-                required link age -> int
-                required link score -> float
+                required property age -> int
+                required property score -> float
                 link profile -> Profile:
                     cardinality := '*1'
         $$;

--- a/tests/test_graphql_translator.py
+++ b/tests/test_graphql_translator.py
@@ -87,24 +87,24 @@ class TranslatorTest(tb.BaseSyntaxTest, metaclass=BaseSchemaTestMeta):
 class TestGraphQLTranslation(TranslatorTest):
     SCHEMA_TEST = r"""
         abstract type NamedObject:
-            required link name -> str
+            required property name -> str
 
         type UserGroup extending NamedObject:
             link settings -> Setting:
                 cardinality := '1*'
 
         type Setting extending NamedObject:
-            required link value -> str
+            required property value -> str
 
         type Profile extending NamedObject:
-            required link value -> str
+            required property value -> str
 
         type User extending NamedObject:
-            required link active -> bool
+            required property active -> bool
             link groups -> UserGroup:
                 cardinality := '**'
-            required link age -> int
-            required link score -> float
+            required property age -> int
+            required property score -> float
             link profile -> Profile:
                 cardinality := '*1'
     """
@@ -117,8 +117,8 @@ class TestGraphQLTranslation(TranslatorTest):
 
     SCHEMA_123LIB = r"""
         type Foo:
-            link `select` -> str
-            link after -> str
+            property `select` -> str
+            property after -> str
     """
 
     def test_graphql_translation_query_01(self):

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -19,8 +19,8 @@ class TestIndexes(tb.DDLTestCase):
             #
             CREATE MIGRATION test::d1 TO eschema $$
                 type Person:
-                    link first_name -> str
-                    link last_name -> str
+                    property first_name -> str
+                    property last_name -> str
 
                     index name_index on (__self__.first_name,
                                          __self__.last_name)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -14,25 +14,25 @@ class TestSchema(tb.BaseSchemaTest):
     def test_schema_inherited_01(self):
         """
             type UniqueName:
-                link name -> str:
+                property name -> str:
                     constraint unique
 
             type UniqueName_2 extending UniqueName:
-                inherited link name -> str:
+                inherited property name -> str:
                     constraint unique
         """
 
     @tb.must_fail(s_err.SchemaError,
                   'test::name must be declared using the `inherited` keyword',
-                  position=171)
+                  position=175)
     def test_schema_inherited_02(self):
         """
             type UniqueName:
-                link name -> str:
+                property name -> str:
                     constraint unique
 
             type UniqueName_2 extending UniqueName:
-                link name -> str:
+                property name -> str:
                     constraint unique
         """
 
@@ -42,5 +42,43 @@ class TestSchema(tb.BaseSchemaTest):
     def test_schema_inherited_03(self):
         """
             type UniqueName:
-                inherited link name -> str
+                inherited property name -> str
+        """
+
+    @tb.must_fail(s_err.SchemaError,
+                  'invalid link target, expected object type, got ScalarType',
+                  position=54)
+    def test_schema_bad_link_01(self):
+        """
+            type Object:
+                link foo -> str
+        """
+
+    @tb.must_fail(s_err.SchemaError,
+                  'invalid link target, expected object type, got ScalarType',
+                  position=51)
+    def test_schema_bad_link_02(self):
+        """
+            type Object:
+                link foo := 1 + 1
+        """
+
+    @tb.must_fail(s_err.SchemaError,
+                  'invalid property target, expected primitive type, '
+                  'got ObjectType',
+                  position=58)
+    def test_schema_bad_prop_01(self):
+        """
+            type Object:
+                property foo -> Object
+        """
+
+    @tb.must_fail(s_err.SchemaError,
+                  'invalid property target, expected primitive type, '
+                  'got ObjectType',
+                  position=55)
+    def test_schema_bad_prop_02(self):
+        """
+            type Object:
+                property foo := (SELECT Object)
         """

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -56,14 +56,14 @@ abstract type OwnedObject:
     def test_eschema_syntax_type_03(self):
         """
         abstract type Text:
-            required link body -> str:
+            required property body -> str:
                 constraint maxlength (10000)
         """
 
     def test_eschema_syntax_type_04(self):
         """
 type LogEntry extending OwnedObject, Text:
-    required link spent_time -> int
+    required property spent_time -> int
         """
 
     def test_eschema_syntax_type_05(self):
@@ -75,7 +75,7 @@ type LogEntry extending OwnedObject, Text:
     def test_eschema_syntax_type_06(self):
         """
 type LogEntry extending OwnedObject, Text:
-    link start_date -> datetime:
+    property start_date -> datetime:
        default :=
             SELECT datetime::current_datetime()
        title := 'Start Date'
@@ -95,30 +95,33 @@ type Issue extending `foo.bar`::NamedObject, OwnedObject, Text:
     link watchers -> User:
         cardinality := '**'
 
-    link time_estimate -> int
-
     link time_spent_log -> LogEntry:
         cardinality := '1*'
 
     link start_date := SELECT datetime::current_datetime()
 
-    link start_date -> datetime:
+    link related_to -> Issue:
+        cardinality := '**'
+
+    property time_estimate -> int
+
+    property start_date -> datetime:
        default :=
             SELECT datetime::current_datetime()
        title := 'Start Date'
 
-    link due_date -> datetime
-
-    link related_to -> Issue:
-        cardinality := '**'
+    property due_date -> datetime
         """
 
+    @tb.must_fail(error.SchemaSyntaxError,
+                  "illegal definition",
+                  line=4, col=9)
     def test_eschema_syntax_type_08(self):
         """
 type Foo:
-    link time_estimate -> int:
-       link property unit:
-           default := 'minute'
+    property time_estimate -> int:
+        property unit:
+            default := 'minute'
        """
 
     def test_eschema_syntax_type_09(self):
@@ -144,7 +147,7 @@ type `Log-Entry` extending OwnedObject, Text:
     def test_eschema_syntax_type_11(self):
         """
 type Commit:
-    required link name -> std::str
+    required property name -> std::str
         """
 
     def test_eschema_syntax_link_target_type_01(self):
@@ -181,7 +184,7 @@ type LogEntry extending OwnedObject, Text:
     def test_eschema_syntax_index_02(self):
         """
 abstract link foobar:
-    link property foo:
+    property foo:
         title := 'Sample property'
 
     index prop on (self@foo)
@@ -203,7 +206,7 @@ type LogEntry extending    OwnedObject,    Text:
             # irrelevant comment indent
         # irrelevant comment indent
 
-  link start_date -> datetime:
+  property start_date -> datetime:
 
 
                        default :=
@@ -221,7 +224,7 @@ type LogEntry extending    OwnedObject,    Text:
     def test_eschema_syntax_ws_02(self):
         """
         type LogEntry extending OwnedObject, Text:
-            link start_date -> datetime:
+            property start_date -> datetime:
                default :=
                     SELECT datetime::current_datetime()
                title := 'Start Date'
@@ -229,7 +232,7 @@ type LogEntry extending    OwnedObject,    Text:
 
     def test_eschema_syntax_ws_03(self):
         """     type LogEntry extending OwnedObject, Text:
-                    link start_date -> datetime:
+                    property start_date -> datetime:
                        default :=
                             SELECT datetime::current_datetime()
                        title := 'Start Date'
@@ -240,7 +243,7 @@ type LogEntry extending    OwnedObject,    Text:
         type LogEntry extending (
                 OwnedObject,
                 Text):
-            link start_date -> datetime:
+            property start_date -> datetime:
                default :=
                     SELECT datetime::current_datetime()
                title := 'Start Date'
@@ -248,7 +251,7 @@ type LogEntry extending    OwnedObject,    Text:
 % OK %
 
         type LogEntry extending OwnedObject, Text:
-            link start_date -> datetime:
+            property start_date -> datetime:
                default :=
                     SELECT datetime::current_datetime()
                title := 'Start Date'
@@ -259,7 +262,7 @@ type LogEntry extending    OwnedObject,    Text:
         type LogEntry extending (
                 OwnedObject,
                 Text):
-            link start_date -> datetime:
+            property start_date -> datetime:
                default :=
                     SELECT
                     datetime::current_datetime()
@@ -272,7 +275,7 @@ type LogEntry extending    OwnedObject,    Text:
     def test_eschema_syntax_ws_06(self):
         r"""
         type LogEntry extending OwnedObject, Text:
-            link start_date -> datetime:
+            property start_date -> datetime:
                default :=
                     SELECT \
                     datetime::current_datetime()
@@ -303,9 +306,9 @@ type LogEntry extending    OwnedObject,    Text:
         # that provides a name link.
 
             # A few more optional links:
-            link first_name -> str
-            link last_name -> str
-            link email -> str
+            property first_name -> str
+            property last_name -> str
+            property email -> str
         """
 
     def test_eschema_syntax_scalar_01(self):
@@ -503,38 +506,38 @@ type Foo:
     constraint maxlength(4)
         """
 
-    def test_eschema_syntax_linkproperty_01(self):
+    def test_eschema_syntax_property_01(self):
         """
-abstract link property foo:
+abstract property foo:
     title := 'Sample property'
         """
 
-    def test_eschema_syntax_linkproperty_02(self):
+    def test_eschema_syntax_property_02(self):
         """
-abstract link property bar extending foo
+abstract property bar extending foo
         """
 
-    def test_eschema_syntax_linkproperty_03(self):
+    def test_eschema_syntax_property_03(self):
         """
-abstract link property bar extending foo:
+abstract property bar extending foo:
     title := 'Another property'
         """
 
-    def test_eschema_syntax_linkproperty_04(self):
+    def test_eschema_syntax_property_04(self):
         """
-abstract link property foo:
+abstract property foo:
     title := 'Sample property'
 
-abstract link property bar extending foo:
+abstract property bar extending foo:
     title := 'Another property'
         """
 
     @tb.must_fail(error.SchemaSyntaxError,
-                  r"Unexpected token.*LINKPROPERTY",
+                  r"Unexpected token.*PROPERTY",
                   line=2, col=1)
-    def test_eschema_syntax_linkproperty_05(self):
+    def test_eschema_syntax_property_05(self):
         """
-link property foo
+property foo
         """
 
     def test_eschema_syntax_action_01(self):
@@ -572,14 +575,14 @@ abstract link coollink extending boringlink
     def test_eschema_syntax_link_03(self):
         """
 abstract link coollink:
-    link property foo -> int
+    property foo -> int
         """
 
     def test_eschema_syntax_link_04(self):
         """
 abstract link coollink:
-    link property foo -> int
-    link property bar -> int
+    property foo -> int
+    property bar -> int
 
     constraint expr:
         expr := self.foo = self.bar
@@ -587,21 +590,21 @@ abstract link coollink:
 
     def test_eschema_syntax_link_05(self):
         """
-abstract link property foo:
+abstract property foo:
     title := 'Sample property'
 
-abstract link property bar extending foo:
+abstract property bar extending foo:
     title := 'Another property'
 
 abstract link coollink:
-    link property foo -> int:
+    property foo -> int:
         default := 2
         constraint min(0)
         constraint max(123456)
         constraint expr on (__subject__ % 2 = 0):
             title := 'aaa'
 
-    link property bar -> int
+    property bar -> int
 
     constraint expr on (self.foo = self.bar)
 
@@ -616,37 +619,37 @@ event self_deleted:
         """
 
     @tb.must_fail(error.SchemaSyntaxError,
-                  r'Unexpected token.*LINKPROPERTY', line=3, col=22)
+                  r'Link properties cannot be "required".', line=3, col=13)
     def test_eschema_syntax_link_06(self):
         """
         abstract link coollink:
-            required link property foo -> int
+            required property foo -> int
         """
 
     def test_eschema_syntax_link_07(self):
         """
         abstract link time_estimate:
-           link property unit -> str:
+           property unit -> str:
                constraint my_constraint(0)
         """
 
     def test_eschema_syntax_link_08(self):
         """
         abstract link time_estimate:
-           link property unit -> str:
+           property unit -> str:
                constraint my_constraint(0, <str>(42^2))
         """
 
     def test_eschema_syntax_link_09(self):
         """
         abstract link time_estimate:
-           link property unit -> str:
+           property unit -> str:
                constraint my_constraint(')', `)`($$)$$))
 
 % OK %
 
         abstract link time_estimate:
-           link property unit -> str:
+           property unit -> str:
                constraint my_constraint(')', `)`(')'))
         """
 
@@ -677,7 +680,7 @@ type Foo:
         import foo
 
         type Bar extending foo::Foo:
-            link text -> str
+            property text -> str
         """
 
     def test_eschema_syntax_import_02(self):
@@ -685,7 +688,7 @@ type Foo:
         import mylib.util.foo
 
         type Bar extending `mylib.util.foo`::Foo:
-            link text -> str
+            property text -> str
         """
 
     def test_eschema_syntax_import_03(self):
@@ -693,7 +696,7 @@ type Foo:
         import foo as bar
 
         type Bar extending bar::Foo:
-            link text -> str
+            property text -> str
         """
 
     def test_eschema_syntax_import_04(self):
@@ -701,7 +704,7 @@ type Foo:
         import mylib.util.foo as bar
 
         type Bar extending bar::Foo:
-            link text -> str
+            property text -> str
         """
 
     def test_eschema_syntax_import_05(self):
@@ -713,7 +716,7 @@ type Foo:
     otherlib.ham as spam)
 
         type Bar extending foo::Foo, sfoo::Foo, bar::Bar, spam::Ham:
-            link text -> str
+            property text -> str
         """
 
     def test_eschema_syntax_import_06(self):
@@ -721,7 +724,7 @@ type Foo:
         import action.event.foo
 
         type Bar extending `action.event.foo`::Foo:
-            link text -> str
+            property text -> str
         """
 
     @tb.must_fail(error.SchemaSyntaxError,
@@ -731,7 +734,7 @@ type Foo:
         import mylib.util.foo
 
         type Bar extending mylib.util.foo::Foo:
-            link text -> str
+            property text -> str
         """
 
     @tb.must_fail(error.SchemaSyntaxError,
@@ -741,7 +744,7 @@ type Foo:
         import action.event.foo
 
         type Bar extending action.event.foo::Foo:
-            link text -> str
+            property text -> str
         """
 
     def test_eschema_syntax_function_01(self):

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -12,16 +12,8 @@ from edgedb.client import exceptions
 
 class TestTransactions(tb.QueryTestCase):
     SETUP = """
-        CREATE ABSTRACT LINK test::name {
-            SET cardinality := '11';
-            SET readonly := False;
-        };
-
         CREATE TYPE test::TransactionTest EXTENDING std::Object {
-            CREATE LINK test::name -> std::str {
-                SET cardinality := '11';
-                SET readonly := False;
-            };
+            CREATE PROPERTY test::name -> std::str;
         };
     """
 


### PR DESCRIPTION
Current lumping of all object type pointers into "links" is awkward,
because object and scalar links are actually two different things and
behave differently when queried.

Make the distinction explicit: pointers to objects are called "links",
and pointers to primitive types are "properties".  This also allows "link
properties" to simply become "properties".