### PR TITLE
Add EdgeQL parser support for the new SET command

### DIFF
--- a/edgedb/lang/edgeql/ast.py
+++ b/edgedb/lang/edgeql/ast.py
@@ -132,14 +132,16 @@ class SortExpr(Clause):
     nones_order: str
 
 
-# TODO: this needs clean-up and refactoring to account for different
-# uses of aliases
-class AliasedExpr(Clause):
+class BaseAlias(Clause):
+    pass
+
+
+class AliasedExpr(BaseAlias):
     expr: Expr
     alias: str
 
 
-class NamespaceAliasDecl(Clause):
+class NamespaceAliasDecl(BaseAlias):
     namespace: str
     alias: str
 
@@ -739,3 +741,7 @@ class AlterFunction(AlterObject):
 class DropFunction(DropObject):
     args: typing.List[FuncParam]
     aggregate: bool = False
+
+
+class SessionStateDecl(Expr):
+    items: typing.List[BaseAlias]

--- a/edgedb/lang/edgeql/codegen.py
+++ b/edgedb/lang/edgeql/codegen.py
@@ -1005,6 +1005,12 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self.write(' = ')
             self.visit(node.default)
 
+    def visit_SessionStateDecl(self, node):
+        self.write('SET')
+        self._block_ws(1)
+        self.visit_list(node.items)
+        self._block_ws(-1)
+
     @classmethod
     def to_source(
             cls, node, indent_with=' ' * 4, add_line_information=False,

--- a/edgedb/lang/edgeql/parser/grammar/block.py
+++ b/edgedb/lang/edgeql/parser/grammar/block.py
@@ -11,13 +11,20 @@ from .precedence import *  # NOQA
 from .tokens import *  # NOQA
 from .statements import *  # NOQA
 from .ddl import *  # NOQA
+from .session import *  # NOQA
 
 
 class SingleStatement(Nonterm):
     def reduce_Stmt(self, *kids):
+        # Expressions
         self.val = kids[0].val
 
     def reduce_DDLStmt(self, *kids):
+        # Data definition commands
+        self.val = kids[0].val
+
+    def reduce_SessionStmt(self, *kids):
+        # Session-local utility commands
         self.val = kids[0].val
 
 

--- a/edgedb/lang/edgeql/parser/grammar/precedence.py
+++ b/edgedb/lang/edgeql/parser/grammar/precedence.py
@@ -54,10 +54,6 @@ class P_IN(Precedence, assoc='nonassoc', tokens=('IN',)):
     pass
 
 
-class P_POSTFIXOP(Precedence, assoc='left'):
-    pass
-
-
 class P_IDENT(Precedence, assoc='nonassoc', tokens=('IDENT', 'PARTITION')):
     pass
 

--- a/edgedb/lang/edgeql/parser/grammar/session.py
+++ b/edgedb/lang/edgeql/parser/grammar/session.py
@@ -1,0 +1,37 @@
+##
+# Copyright (c) 2008-present MagicStack Inc.
+# All rights reserved.
+#
+# See LICENSE for details.
+##
+
+
+from edgedb.lang.common.parsing import ListNonterm
+from edgedb.lang.edgeql import ast as qlast
+
+from . import tokens
+from .expressions import Nonterm
+from .tokens import *  # NOQA
+from .expressions import *  # NOQA
+
+
+class SessionStmt(Nonterm):
+    def reduce_SetStmt(self, *kids):
+        self.val = kids[0].val
+
+
+class SetDecl(Nonterm):
+    def reduce_AliasDecl(self, *kids):
+        self.val = kids[0].val
+
+
+class SetDeclList(ListNonterm, element=SetDecl,
+                  separator=tokens.T_COMMA):
+    pass
+
+
+class SetStmt(Nonterm):
+    def reduce_SET_SetDeclList(self, *kids):
+        self.val = qlast.SessionStateDecl(
+            items=kids[1].val
+        )

--- a/edgedb/lang/edgeql/parser/grammar/statements.py
+++ b/edgedb/lang/edgeql/parser/grammar/statements.py
@@ -8,7 +8,6 @@
 
 from edgedb.lang.edgeql import ast as qlast
 
-from ...errors import EdgeQLSyntaxError
 from .expressions import Nonterm
 from .precedence import *  # NOQA
 from .tokens import *  # NOQA
@@ -25,7 +24,7 @@ class Stmt(Nonterm):
     def reduce_RollbackTransactionStmt(self, *kids):
         self.val = kids[0].val
 
-    def reduce_SetStmt(self, *kids):
+    def reduce_ExprStmt(self, *kids):
         self.val = kids[0].val
 
 
@@ -35,13 +34,7 @@ class StartTransactionStmt(Nonterm):
 
 
 class CommitTransactionStmt(Nonterm):
-    def reduce_DDLAliasBlock_COMMIT(self, *kids):
-        # NOTE: DDLAliasBlock is trying to avoid conflicts
-        with_block = kids[0].val
-        if with_block.aliases:
-            raise EdgeQLSyntaxError(
-                'WITH block not allowed for a transaction COMMIT',
-                context=kids[0].context)
+    def reduce_COMMIT(self, *kids):
         self.val = qlast.CommitTransaction()
 
 

--- a/edgedb/lang/edgeql/parser/grammar/tokens.py
+++ b/edgedb/lang/edgeql/parser/grammar/tokens.py
@@ -152,14 +152,6 @@ class T_OP(Token):
     pass
 
 
-class T_LINKPROPERTY(Token):
-    pass
-
-
-class T_DISTINCTUNION(Token):
-    pass
-
-
 def _gen_keyword_tokens():
     # Define keyword tokens
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1492,7 +1492,7 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
         } FILTER (foo = 'special');
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=9)
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=6, col=15)
     def test_edgeql_syntax_with_02(self):
         """
         WITH
@@ -2788,4 +2788,31 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
             CREATE LINK schema::attributes -> schema::Attribute {
                 SET cardinality := '**';
             };
+        """
+
+    def test_edgeql_syntax_set_command_01(self):
+        """
+        SET MODULE default;
+
+% OK %
+
+        SET MODULE default;
+        """
+
+    def test_edgeql_syntax_set_command_02(self):
+        """
+        SET foo := MODULE default;
+
+% OK %
+
+        SET foo := MODULE default;
+        """
+
+    def test_edgeql_syntax_set_command_03(self):
+        """
+        SET MODULE default, foo := (SELECT User);
+
+% OK %
+
+        SET MODULE default, foo := (SELECT User);
         """


### PR DESCRIPTION
`SET` should be viewed as a session-level `WITH` block.  It declares
module and expression aliases that are available for subsequent commands
as if they had an equivalent explicit `WITH` block.

Issue: #123.