### PR TITLE
Add limited support for the SET command and introduce default module

### DIFF
--- a/edgedb/lang/common/ast/base.py
+++ b/edgedb/lang/common/ast/base.py
@@ -318,6 +318,10 @@ def _is_typing(type_):
     return _is_union(type_) or isinstance(type_, typing.TypingMeta)
 
 
+def _is_optional(type_):
+    return _is_union(type_) and type(None) in type_.__args__
+
+
 def _check_annotation(f_type, f_fullname, f_default):
     if _is_typing(f_type):
         if _is_union(f_type):
@@ -395,7 +399,7 @@ def _check_mapping_type(type_, value, raise_error, instance_type):
     vtype = type_.__args__[1]
     for k, v in value.items():
         _check_type(ktype, k, raise_error)
-        if not k:
+        if not k and not _is_optional(ktype):
             raise RuntimeError('empty key in map')
         _check_type(vtype, v, raise_error)
 

--- a/edgedb/lang/edgeql/ast.py
+++ b/edgedb/lang/edgeql/ast.py
@@ -141,8 +141,8 @@ class AliasedExpr(BaseAlias):
     alias: str
 
 
-class NamespaceAliasDecl(BaseAlias):
-    namespace: str
+class ModuleAliasDecl(BaseAlias):
+    module: str
     alias: str
 
 
@@ -329,7 +329,7 @@ class GroupExpr(Expr):
 #
 
 class Statement(Expr):
-    aliases: typing.List[typing.Union[AliasedExpr, NamespaceAliasDecl]]
+    aliases: typing.List[typing.Union[AliasedExpr, ModuleAliasDecl]]
     cardinality: Cardinality = Cardinality.DEFAULT
 
 
@@ -447,7 +447,6 @@ class AlterTarget(DDL):
 
 
 class ObjectDDL(CompositeDDL):
-    namespaces: list  # XXX: is it even used?
     name: ObjectRef
     commands: typing.List[DDL]
 

--- a/edgedb/lang/edgeql/codegen.py
+++ b/edgedb/lang/edgeql/codegen.py
@@ -287,12 +287,12 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self.visit_list(node.elements, newlines=False)
         self.write(')')
 
-    def visit_NamespaceAliasDecl(self, node):
+    def visit_ModuleAliasDecl(self, node):
         if node.alias:
             self.write(ident_to_str(node.alias))
             self.write(' := ')
         self.write('MODULE ')
-        self.write(any_ident_to_str(node.namespace))
+        self.write(any_ident_to_str(node.module))
 
     def visit_SortExpr(self, node):
         self.visit(node.path)

--- a/edgedb/lang/edgeql/compiler/context.py
+++ b/edgedb/lang/edgeql/compiler/context.py
@@ -66,7 +66,7 @@ class ContextLevel(compiler.ContextLevel):
     to the compiler programmatically).
     """
 
-    namespaces: typing.Dict[str, str]
+    modaliases: typing.Dict[str, str]
     """A combined list of module name aliases declared in the WITH block,
     or passed to the compiler programmatically.
     """
@@ -163,7 +163,7 @@ class ContextLevel(compiler.ContextLevel):
             self.derived_target_module = None
             self.aliases = compiler.AliasGenerator()
             self.anchors = {}
-            self.namespaces = {}
+            self.modaliases = {}
             self.arguments = {}
             self.all_sets = []
             self.stmt_metadata = {}
@@ -224,7 +224,7 @@ class ContextLevel(compiler.ContextLevel):
 
             if mode == ContextSwitchMode.SUBQUERY:
                 self.anchors = prevlevel.anchors.copy()
-                self.namespaces = prevlevel.namespaces.copy()
+                self.modaliases = prevlevel.modaliases.copy()
                 self.aliased_views = prevlevel.aliased_views.new_child()
                 self.view_class_map = prevlevel.view_class_map.copy()
                 self.class_view_overrides = \
@@ -247,7 +247,7 @@ class ContextLevel(compiler.ContextLevel):
 
             elif mode == ContextSwitchMode.DETACHED:
                 self.anchors = prevlevel.anchors.copy()
-                self.namespaces = prevlevel.namespaces.copy()
+                self.modaliases = prevlevel.modaliases.copy()
                 self.aliased_views = collections.ChainMap()
                 self.view_class_map = {}
                 self.class_view_overrides = {}
@@ -272,7 +272,7 @@ class ContextLevel(compiler.ContextLevel):
                 self.toplevel_result_view_name = None
             else:
                 self.anchors = prevlevel.anchors
-                self.namespaces = prevlevel.namespaces
+                self.modaliases = prevlevel.modaliases
                 self.aliased_views = prevlevel.aliased_views
                 self.view_class_map = prevlevel.view_class_map
                 self.class_view_overrides = prevlevel.class_view_overrides

--- a/edgedb/lang/edgeql/compiler/func.py
+++ b/edgedb/lang/edgeql/compiler/func.py
@@ -40,7 +40,7 @@ def compile_FunctionCall(
             funcname = sn.Name(expr.func[1], expr.func[0])
 
         funcs = fctx.schema.get_functions(
-            funcname, module_aliases=fctx.namespaces)
+            funcname, module_aliases=fctx.modaliases)
 
         if funcs is None:
             raise errors.EdgeQLError(

--- a/edgedb/lang/edgeql/compiler/schemactx.py
+++ b/edgedb/lang/edgeql/compiler/schemactx.py
@@ -45,7 +45,7 @@ def get_schema_object(
             return result
 
     try:
-        scls = ctx.schema.get(name=name, module_aliases=ctx.namespaces)
+        scls = ctx.schema.get(name=name, module_aliases=ctx.modaliases)
     except s_err.SchemaError as e:
         raise qlerrors.EdgeQLError(e.args[0], context=srcctx)
 
@@ -59,7 +59,7 @@ def get_schema_object(
 def resolve_schema_name(
         name: str, module: str, *,
         ctx: context.ContextLevel) -> sn.Name:
-    schema_module = ctx.namespaces.get(module)
+    schema_module = ctx.modaliases.get(module)
     if schema_module is None:
         return None
     else:

--- a/edgedb/lang/edgeql/compiler/setgen.py
+++ b/edgedb/lang/edgeql/compiler/setgen.py
@@ -616,7 +616,7 @@ def computable_ptr_set(
 
         qlctx = None
     else:
-        subctx.namespaces = qlctx.namespaces.copy()
+        subctx.modaliases = qlctx.modaliases.copy()
         subctx.aliased_views = qlctx.aliased_views.new_child()
         if source_scls.is_view():
             subctx.aliased_views[self_.scls.name] = None

--- a/edgedb/lang/edgeql/compiler/stmtctx.py
+++ b/edgedb/lang/edgeql/compiler/stmtctx.py
@@ -32,7 +32,7 @@ def init_context(
         *,
         schema: s_schema.Schema,
         arg_types: typing.Optional[typing.Iterable[s_obj.Object]]=None,
-        modaliases: typing.Optional[typing.Iterable[str]]=None,
+        modaliases: typing.Optional[typing.Dict[str, str]]=None,
         anchors: typing.Optional[typing.Dict[str, s_obj.Object]]=None,
         security_context: typing.Optional[str]=None,
         derived_target_module: typing.Optional[str]=None,
@@ -43,7 +43,7 @@ def init_context(
     ctx.schema = schema.get_overlay(extra=ctx.view_nodes)
 
     if modaliases:
-        ctx.namespaces.update(modaliases)
+        ctx.modaliases.update(modaliases)
 
     if arg_types:
         ctx.arguments.update(arg_types)
@@ -59,10 +59,14 @@ def init_context(
 
 def fini_expression(
         ir: irast.Base, *,
-        ctx: context.ContextLevel) -> irast.Statement:
+        ctx: context.ContextLevel) -> irast.Command:
     for ir_set in ctx.all_sets:
         if ir_set.path_id.namespace:
             ir_set.path_id = ir_set.path_id.strip_weak_namespaces()
+
+    if isinstance(ir, irast.Command):
+        # IR is already a Command
+        return ir
 
     if ctx.path_scope is not None:
         # Simple expressions have no scope.

--- a/edgedb/lang/edgeql/parser/__init__.py
+++ b/edgedb/lang/edgeql/parser/__init__.py
@@ -22,15 +22,15 @@ def parse(expr, module_aliases=None):
         tree = qlast.SelectQuery(result=tree)
 
     if module_aliases:
-        nses = []
+        modaliases = []
         for alias, module in module_aliases.items():
-            decl = qlast.NamespaceAliasDecl(namespace=module, alias=alias)
-            nses.append(decl)
+            decl = qlast.ModuleAliasDecl(module=module, alias=alias)
+            modaliases.append(decl)
 
-        if tree.namespaces is None:
-            tree.namespaces = nses
+        if not tree.aliases:
+            tree.aliases = modaliases
         else:
-            tree.namespaces.extend(nses)
+            tree.aliases = modaliases + tree.aliases
 
     return tree
 

--- a/edgedb/lang/edgeql/parser/grammar/expressions.py
+++ b/edgedb/lang/edgeql/parser/grammar/expressions.py
@@ -223,13 +223,13 @@ class WithBlock(Nonterm):
 
 class AliasDecl(Nonterm):
     def reduce_MODULE_ModuleName(self, *kids):
-        self.val = qlast.NamespaceAliasDecl(
-            namespace='.'.join(kids[1].val))
+        self.val = qlast.ModuleAliasDecl(
+            module='.'.join(kids[1].val))
 
     def reduce_Identifier_TURNSTILE_MODULE_ModuleName(self, *kids):
-        self.val = qlast.NamespaceAliasDecl(
+        self.val = qlast.ModuleAliasDecl(
             alias=kids[0].val,
-            namespace='.'.join(kids[3].val))
+            module='.'.join(kids[3].val))
 
     def reduce_AliasedExpr(self, *kids):
         self.val = kids[0].val

--- a/edgedb/lang/ir/ast.py
+++ b/edgedb/lang/ir/ast.py
@@ -11,6 +11,7 @@ import typing
 from edgedb.lang.common.exceptions import EdgeDBError
 from edgedb.lang.common import ast, compiler, parsing
 
+from edgedb.lang.schema import modules as s_modules
 from edgedb.lang.schema import name as sn
 from edgedb.lang.schema import objects as so
 from edgedb.lang.schema import pointers as s_pointers
@@ -87,7 +88,11 @@ class Set(Base):
             f'<ir.Set \'{self.path_id or self.scls.name}\' at 0x{id(self):x}>'
 
 
-class Statement(Base):
+class Command(Base):
+    pass
+
+
+class Statement(Command):
 
     expr: Set
     views: typing.Dict[sn.Name, s_types.Type]
@@ -292,3 +297,8 @@ class UpdateStmt(MutatingStmt):
 class DeleteStmt(MutatingStmt):
 
     where: Base
+
+
+class SessionStateCmd(Command):
+
+    modaliases: typing.Dict[typing.Optional[str], s_modules.Module]

--- a/edgedb/server/executor.py
+++ b/edgedb/server/executor.py
@@ -7,6 +7,7 @@
 
 import asyncpg
 
+from edgedb.lang.ir import ast as irast
 from edgedb.lang.schema import delta as s_delta
 from edgedb.lang.schema import deltas as s_deltas
 from edgedb.lang.common import exceptions
@@ -60,6 +61,11 @@ async def execute_plan(plan, protocol):
                 raise _error from e
             else:
                 raise
+
+    elif isinstance(plan, irast.SessionStateCmd):
+        # SET command
+
+        await backend.exec_session_state_cmd(plan)
 
     else:
         raise exceptions.InternalError('unexpected plan: {!r}'.format(plan))

--- a/edgedb/server/pgsql/backend.py
+++ b/edgedb/server/pgsql/backend.py
@@ -279,9 +279,8 @@ class Backend(s_deltarepo.DeltaProvider):
         common.edgedb_name_to_pg_name('std::target'))
 
     def __init__(self, connection):
-        self.modules = None
-
         self.schema = None
+        self.modaliases = {None: 'default'}
 
         self._constr_mech = schemamech.ConstraintMech()
         self._type_mech = schemamech.TypeMech()
@@ -539,6 +538,10 @@ class Backend(s_deltarepo.DeltaProvider):
         self.table_id_to_class_name_cache.clear()
         self.classname_to_table_id_cache.clear()
         self.attribute_link_map_cache.clear()
+
+    async def exec_session_state_cmd(self, cmd):
+        for alias, module in cmd.modaliases.items():
+            self.modaliases[alias] = module.name
 
     async def get_objtype_map(self, force_reload=False):
         if not self.objtype_cache or force_reload:

--- a/edgedb/server/planner.py
+++ b/edgedb/server/planner.py
@@ -46,9 +46,19 @@ def plan_statement(stmt, backend, flags={}, *, timer):
         # BEGIN/COMMIT
         return TransactionStatement(stmt)
 
+    elif isinstance(stmt, qlast.SessionStateDecl):
+        # SET ...
+        with timer.timeit('compile_eql_to_ir'):
+            ir = ql_compiler.compile_ast_to_ir(
+                stmt, schema=backend.schema, modaliases=backend.modaliases)
+
+        return ir
+
     else:
         # Queries
         with timer.timeit('compile_eql_to_ir'):
-            ir = ql_compiler.compile_ast_to_ir(stmt, schema=backend.schema)
+            ir = ql_compiler.compile_ast_to_ir(
+                stmt, schema=backend.schema, modaliases=backend.modaliases)
+
         return backend.compile(ir, output_format=compiler.OutputFormat.JSON,
                                timer=timer)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,108 @@
+##
+# Copyright (c) 2016-present MagicStack Inc.
+# All rights reserved.
+#
+# See LICENSE for details.
+##
+
+
+from edgedb.client import exceptions as err
+from edgedb.server import _testbase as tb
+
+
+class TestSession(tb.QueryTestCase):
+    SETUP = """
+        CREATE MODULE foo;
+
+        CREATE MIGRATION default::m TO eschema $$
+            type User:
+                required property name -> str
+        $$;
+
+        COMMIT MIGRATION default::m;
+
+        WITH MODULE default INSERT User {name := 'user'};
+
+        CREATE MIGRATION foo::m TO eschema $$
+            type Entity:
+                required property name -> str
+        $$;
+
+        COMMIT MIGRATION foo::m;
+
+        WITH MODULE foo INSERT Entity {name := 'entity'};
+    """
+
+    async def test_session_default_module_01(self):
+        await self.assert_query_result("""
+            SELECT User {name};
+        """, [[{
+            'name': 'user'
+        }]])
+
+    async def test_session_set_command_01(self):
+        await self.assert_query_result("""
+            SET MODULE foo;
+
+            SELECT Entity {name};
+        """, [
+
+            None,
+
+            [{
+                'name': 'entity'
+            }]
+        ])
+
+    async def test_session_set_command_02(self):
+        with self.assertRaisesRegex(
+                err.EdgeQLError,
+                'reference to a non-existent schema class: User'):
+            await self.assert_query_result("""
+                SET MODULE foo;
+
+                SELECT User {name};
+            """, [
+
+                None,
+
+                [{
+                    'name': 'user'
+                }]
+            ])
+
+    async def test_session_set_command_03(self):
+        await self.assert_query_result("""
+            SET MODULE foo, bar := MODULE default;
+
+            SELECT (Entity.name, bar::User.name);
+        """, [
+
+            None,
+
+            [['entity', 'user']]
+        ])
+
+    async def test_session_set_command_04(self):
+        with self.assertRaisesRegex(
+                err.EdgeQLError,
+                'expression aliases in SET are not supported yet'):
+            await self.assert_query_result("""
+                SET foo := 1 + 1;
+            """, [
+                None,
+            ])
+
+    async def test_session_set_command_05(self):
+        # Check that local WITH overrides the session level setting.
+        await self.assert_query_result("""
+            SET MODULE default, bar := MODULE foo;
+
+            WITH MODULE foo, bar := MODULE default
+            SELECT (Entity.name, bar::User.name);
+        """, [
+
+            None,
+
+            [['entity', 'user']]
+        ])


### PR DESCRIPTION
It is now possible to use the new `SET` command to set up module aliases
at session level.  `SET MODULE default;` is issued automatically upon a
new connection.

Issue: #123
Fixes: #152