### PR TITLE
Improve friendliness of error messages generated by invalid references

### DIFF
--- a/edgedb/client/exceptions/_base.py
+++ b/edgedb/client/exceptions/_base.py
@@ -87,9 +87,9 @@ class EdgeDBError(Exception, EdgeDBMessage):
     def __str__(self):
         msg = self.message
         if self.detail:
-            msg += '\nDETAIL:  {}'.format(self.detail)
+            msg += '\nDetails: {}'.format(self.detail)
         if self.hint:
-            msg += '\nHINT:  {}'.format(self.hint)
+            msg += '\nHint: {}'.format(self.hint)
         if self.context:
             msg += '\n' + self.context
 

--- a/edgedb/lang/common/context.py
+++ b/edgedb/lang/common/context.py
@@ -31,7 +31,7 @@ class SourcePoint:
 
 
 class ParserContext(markup.MarkupExceptionContext):
-    title = 'Parser Context'
+    title = 'Source Context'
 
     def __init__(self, name, buffer, start, end, document=None, *,
                  filename=None):

--- a/edgedb/lang/common/levenshtein.py
+++ b/edgedb/lang/common/levenshtein.py
@@ -1,0 +1,28 @@
+##
+# Copyright (c) 2011-present MagicStack Inc.
+# All rights reserved.
+#
+# See LICENSE for details.
+##
+
+
+def distance(s, t):
+    """Calculates Levenshtein distance between s and t."""
+
+    m, n = len(s), len(t)
+
+    if m > n:
+        s, t = t, s
+        m, n = n, m
+
+    ri = list(range(m + 1))
+
+    for i in range(1, n + 1):
+        ri_1, ri = ri, [i] + [0] * m
+
+        for j in range(1, m + 1):
+            ri[j] = min(ri_1[j] + 1,
+                        ri[j - 1] + 1,
+                        ri_1[j - 1] + int(s[j - 1] != t[i - 1]))
+
+    return ri[m]

--- a/edgedb/lang/edgeql/compiler/expr.py
+++ b/edgedb/lang/edgeql/compiler/expr.py
@@ -409,7 +409,7 @@ def compile_TypeFilter(
             f'is not an object type',
             context=expr.expr.context)
 
-    typ = schemactx.get_schema_object(expr.type.maintype, ctx=ctx)
+    typ = schemactx.get_schema_type(expr.type.maintype, ctx=ctx)
     if not isinstance(typ, s_objtypes.ObjectType):
         raise errors.EdgeQLError(
             f'invalid type filter operand: {typ.name} is not an object type',
@@ -422,7 +422,7 @@ def compile_TypeFilter(
 def compile_Indirection(
         expr: qlast.Base, *, ctx: context.ContextLevel) -> irast.Base:
     node = dispatch.compile(expr.arg, ctx=ctx)
-    int_type = schemactx.get_schema_object('std::int64', ctx=ctx)
+    int_type = schemactx.get_schema_type('std::int64', ctx=ctx)
     for indirection_el in expr.indirection:
         if isinstance(indirection_el, qlast.Index):
             idx = dispatch.compile(indirection_el.index, ctx=ctx)

--- a/edgedb/lang/edgeql/compiler/typegen.py
+++ b/edgedb/lang/edgeql/compiler/typegen.py
@@ -100,7 +100,7 @@ def ql_typeref_to_ir_typeref(
             typ.subtypes.append(subtype)
     else:
         typ = irast.TypeRef(
-            maintype=schemactx.get_schema_object(maintype, ctx=ctx).name,
+            maintype=schemactx.get_schema_type(maintype, ctx=ctx).name,
             subtypes=[]
         )
 
@@ -133,4 +133,4 @@ def ql_typeref_to_type(
 
             return coll.from_subtypes(subtypes)
     else:
-        return schemactx.get_schema_object(ql_t.maintype, ctx=ctx)
+        return schemactx.get_schema_type(ql_t.maintype, ctx=ctx)

--- a/edgedb/lang/edgeql/compiler/viewgen.py
+++ b/edgedb/lang/edgeql/compiler/viewgen.py
@@ -167,7 +167,7 @@ def _normalize_view_ptr_expr(
             expr=qlast.Path(steps=[qlast.Source()]),
             type=qlast.TypeName(maintype=steps[0]))
         lexpr = steps[1]
-        ptrsource = schemactx.get_schema_object(steps[0], ctx=ctx)
+        ptrsource = schemactx.get_schema_type(steps[0], ctx=ctx)
     elif len(steps) == 1:
         lexpr = steps[0]
         is_linkprop = lexpr.type == 'property'
@@ -192,7 +192,7 @@ def _normalize_view_ptr_expr(
         # Expand to:
         #     INSERT Foo { bar := (INSERT Spam { name := 'name' }) }
         if lexpr.target is not None:
-            ptr_target = schemactx.get_schema_object(
+            ptr_target = schemactx.get_schema_type(
                 lexpr.target, ctx=ctx)
         else:
             ptr_target = None
@@ -213,7 +213,7 @@ def _normalize_view_ptr_expr(
 
     if compexpr is None:
         if lexpr.target is not None:
-            ptr_target = schemactx.get_schema_object(
+            ptr_target = schemactx.get_schema_type(
                 lexpr.target, ctx=ctx)
         else:
             ptr_target = None

--- a/edgedb/lang/schema/basetypes/base.py
+++ b/edgedb/lang/schema/basetypes/base.py
@@ -278,7 +278,7 @@ def classname_from_type(typ):
 
     if classname is None:
         raise s_err.SchemaError(
-            'could not find matching schema class for %r' % typ)
+            'could not find matching schema item for %r' % typ)
 
     if is_composite:
         result = (container_type, classname)
@@ -304,7 +304,7 @@ def normalize_type(type, schema):
     classname = classname_from_type(type)
     if classname is None:
         raise s_err.SchemaError(
-            'could not find matching schema class for %r' % type)
+            'could not find matching schema item for %r' % type)
 
     is_composite = isinstance(classname, tuple)
 

--- a/edgedb/lang/schema/error.py
+++ b/edgedb/lang/schema/error.py
@@ -22,7 +22,11 @@ class SchemaNameError(SchemaError):
     pass
 
 
-class NoObjectError(SchemaError):
+class SchemaModuleNotFoundError(SchemaError):
+    pass
+
+
+class ItemNotFoundError(SchemaError):
     pass
 
 

--- a/edgedb/lang/schema/modules.py
+++ b/edgedb/lang/schema/modules.py
@@ -16,7 +16,7 @@ from edgedb.lang.edgeql import ast as qlast
 
 from . import delta as sd
 from . import functions as fu
-from .error import SchemaError
+from . import error as s_err
 from . import name as sn
 from . import named
 from . import objects as so
@@ -46,7 +46,7 @@ class Module(named.NamedObject):
     def add(self, obj):
         if obj in self:
             err = '{!r} is already present in the schema'.format(obj.name)
-            raise SchemaError(err)
+            raise s_err.SchemaError(err)
 
         if isinstance(obj, fu.Function):
             if obj.shortname.name not in self.funcs_by_name:
@@ -71,7 +71,7 @@ class Module(named.NamedObject):
         existing = self.discard(obj)
         if existing is None:
             err = 'object {!r} is not present in the schema'.format(obj.name)
-            raise SchemaError(err)
+            raise s_err.ItemNotFoundError(err)
 
         return existing
 
@@ -92,7 +92,7 @@ class Module(named.NamedObject):
     def get_functions(self, name):
         return self.funcs_by_name.get(name)
 
-    def get(self, name, default=SchemaError, *,
+    def get(self, name, default=s_err.ItemNotFoundError, *,
             module_aliases=None, type=None,
             implicit_builtins=True):
 
@@ -103,7 +103,7 @@ class Module(named.NamedObject):
                 try:
                     scls = self.get(name, module_aliases=module_aliases,
                                     type=typ, default=None)
-                except SchemaError:
+                except s_err.SchemaError:
                     pass
                 else:
                     if scls is not None:
@@ -126,7 +126,7 @@ class Module(named.NamedObject):
                            issubclass(default, Exception)))
 
             if raise_:
-                msg = ('reference to non-existent schema class: '
+                msg = ('reference to non-existent schema item: '
                        '{}::{}'.format(self.name, name))
                 if fail_cause is not None:
                     raise default(msg) from fail_cause

--- a/edgedb/lang/schema/objects.py
+++ b/edgedb/lang/schema/objects.py
@@ -683,6 +683,10 @@ class NamedObject(Object):
         self._cached_shortname = (self.name, shortname)
         return shortname
 
+    @property
+    def displayname(self) -> str:
+        return str(self.shortname)
+
     def delta_properties(self, delta, other, reverse=False, context=None):
         old, new = (other, self) if not reverse else (self, other)
 

--- a/edgedb/lang/schema/pointers.py
+++ b/edgedb/lang/schema/pointers.py
@@ -90,6 +90,10 @@ class Pointer(constraints.ConsistencySubject,
     cardinality = so.Field(PointerCardinality, default=None,
                            compcoef=0.833, coerce=True)
 
+    @property
+    def displayname(self) -> str:
+        return self.shortname.name
+
     def material_type(self):
         if self.generic():
             raise ValueError(f'{self!r} is generic')

--- a/edgedb/lang/schema/schema.py
+++ b/edgedb/lang/schema/schema.py
@@ -11,7 +11,7 @@ import typing
 
 from edgedb.lang.common.persistent_hash import persistent_hash
 
-from .error import SchemaError
+from . import error as s_err
 from . import modules as s_modules
 from . import name as schema_name
 
@@ -102,7 +102,7 @@ class Schema(TypeContainer):
         try:
             module = self.modules[obj.name.module]
         except KeyError as e:
-            raise SchemaError(
+            raise s_err.SchemaModuleNotFoundError(
                 f'module {obj.name.module!r} is not in this schema') from e
 
         module.add(obj)
@@ -119,7 +119,7 @@ class Schema(TypeContainer):
         try:
             module = self.modules[obj.name.module]
         except KeyError as e:
-            raise SchemaError(
+            raise s_err.SchemaModuleNotFoundError(
                 f'module {obj.name.module} is not in this schema') from e
 
         return module.delete(obj)
@@ -194,7 +194,7 @@ class Schema(TypeContainer):
         if funcs is not _void:
             return funcs
 
-        raise SchemaError(
+        raise s_err.ItemNotFoundError(
             f'reference to a non-existent function: {name}')
 
     def get(self, name, default=_void, *, module_aliases=None, type=None):
@@ -212,7 +212,8 @@ class Schema(TypeContainer):
         if obj is not _void:
             return obj
 
-        raise SchemaError(f'reference to a non-existent schema class: {name}')
+        raise s_err.ItemNotFoundError(
+            f'reference to a non-existent schema item: {name}')
 
     def has_module(self, module):
         return module in self.modules

--- a/edgedb/lang/schema/types.py
+++ b/edgedb/lang/schema/types.py
@@ -24,7 +24,7 @@ class ViewType(enum.IntEnum):
 
 
 class Type(so.NamedObject, derivable.DerivableObjectBase):
-    """A schema class that is a valid *type*."""
+    """A schema item that is a valid *type*."""
 
     # For a type representing a view, this would contain the
     # view type.  Non-view types have None here.

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -297,7 +297,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_13(self):
         with self.assertRaisesRegex(
                 client_errors.EdgeQLError,
-                'reference to a non-existent schema class: self'):
+                'reference to a non-existent schema item: self'):
             await self.con.execute(r"""
                 CREATE TYPE test::TestBadContainerLinkObjectType {
                     CREATE PROPERTY test::foo -> std::str {

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -3989,8 +3989,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_partial_05(self):
         with self.assertRaisesRegex(exc.EdgeQLError,
-                                    '.*number.*does not '
-                                    'resolve to any known path'):
+                                    'invalid property reference on a '
+                                    'primitive type expression'):
             await self.con.execute('''
                 WITH MODULE test
                 SELECT Issue.number FILTER .number > '1';
@@ -4173,3 +4173,27 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [True],
             [True],
         ])
+
+    async def test_edgeql_select_bad_reference_01(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLError,
+                r'reference to a non-existent schema item: Usr.*',
+                position=57,
+                hint="did you mean one of these: User, URL?"):
+
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT Usr;
+            """)
+
+    async def test_edgeql_select_bad_reference_02(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLError,
+                r"test::User has no link or property 'nam'",
+                position=61,
+                hint="did you mean 'name'?"):
+
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT User.nam;
+            """)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -82,3 +82,13 @@ class TestSchema(tb.BaseSchemaTest):
             type Object:
                 property foo := (SELECT Object)
         """
+
+    @tb.must_fail(s_err.SchemaError,
+                  'reference to a non-existent schema item: int',
+                  position=58,
+                  hint='did you mean one of these: int16, int32, int64?')
+    def test_schema_bad_type_01(self):
+        """
+            type Object:
+                property foo -> int
+        """

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -57,7 +57,7 @@ class TestSession(tb.QueryTestCase):
     async def test_session_set_command_02(self):
         with self.assertRaisesRegex(
                 err.EdgeQLError,
-                'reference to a non-existent schema class: User'):
+                'reference to a non-existent schema item: User'):
             await self.assert_query_result("""
                 SET MODULE foo;
 


### PR DESCRIPTION
References to non-existent types and pointers will now produce a list of
similar-looking valid alternatives.  Additionally, invalid link and
property reference error has a cleaner message.