### PR TITLE
schema: Add support for backslash line continuation.

### DIFF
--- a/edgedb/lang/common/parsing.py
+++ b/edgedb/lang/common/parsing.py
@@ -301,7 +301,7 @@ class Parser:
     def get_debug(self):
         return False
 
-    def get_exception(self, native_err, context):
+    def get_exception(self, native_err, context, token=None):
         if not isinstance(native_err, ParserError):
             return ParserError(native_err.args[0], context=context)
         else:
@@ -372,7 +372,8 @@ class Parser:
             self.parser.eoi()
 
         except parsing.SyntaxError as e:
-            raise self.get_exception(e, context=self.context(tok)) from e
+            raise self.get_exception(
+                e, context=self.context(tok), token=tok) from e
 
         except ParserError as e:
             raise self.get_exception(e, context=e.context) from e

--- a/edgedb/lang/edgeql/parser/parser.py
+++ b/edgedb/lang/edgeql/parser/parser.py
@@ -16,7 +16,7 @@ class EdgeQLParserBase(parsing.Parser):
     def get_debug(self):
         return debug.flags.edgeql_parser
 
-    def get_exception(self, native_err, context):
+    def get_exception(self, native_err, context, token=None):
         if isinstance(native_err, EdgeQLSyntaxError):
             return native_err
         return EdgeQLSyntaxError(native_err.args[0], context=context)

--- a/edgedb/lang/graphql/parser/parser.py
+++ b/edgedb/lang/graphql/parser/parser.py
@@ -143,7 +143,7 @@ class GraphQLParser(parsing.Parser):
     def get_lexer(self):
         return lexer.GraphQLLexer()
 
-    def get_exception(self, native_err, context):
+    def get_exception(self, native_err, context, token=None):
         if isinstance(native_err, GraphQLParserError):
             return native_err
         return GraphQLParserError(native_err.args[0], context=context)

--- a/edgedb/lang/schema/parser/grammar/lexer.py
+++ b/edgedb/lang/schema/parser/grammar/lexer.py
@@ -113,10 +113,10 @@ class EdgeSchemaLexer(lexer.Lexer):
         next_state=STATE_KEEP,
         regexp=r'\\\n')
 
-    raw_line_cont_rule = Rule(
-        token='RAWSTRING',
+    bad_line_cont_rule = Rule(
+        token='BADLINECONT',
         next_state=STATE_KEEP,
-        regexp=r'\\.')
+        regexp=r'\\.+?$')
 
     # Basic keywords
     keyword_rules = [Rule(token=tok[0],
@@ -151,6 +151,7 @@ class EdgeSchemaLexer(lexer.Lexer):
              regexp=r'[^\S\n]+'),
 
         line_cont_rule,
+        bad_line_cont_rule,
 
         Rule(token='NEWLINE',
              next_state=STATE_KEEP,
@@ -218,7 +219,7 @@ class EdgeSchemaLexer(lexer.Lexer):
             string_rule,
             qident_rule,
             line_cont_rule,
-            raw_line_cont_rule,
+            bad_line_cont_rule,
 
             Rule(token='RAWSTRING',
                  next_state=STATE_KEEP,
@@ -226,7 +227,7 @@ class EdgeSchemaLexer(lexer.Lexer):
         ],
         STATE_RAW_ANGLE: [
             line_cont_rule,
-            raw_line_cont_rule,
+            bad_line_cont_rule,
 
             Rule(token='RAWSTRING',
                  next_state=push_state(STATE_RAW_ANGLE),
@@ -245,7 +246,7 @@ class EdgeSchemaLexer(lexer.Lexer):
         ],
         STATE_RAW_TYPE: [
             line_cont_rule,
-            raw_line_cont_rule,
+            bad_line_cont_rule,
 
             Rule(token='RAWSTRING',
                  next_state=STATE_WS_SENSITIVE,
@@ -295,7 +296,7 @@ class EdgeSchemaLexer(lexer.Lexer):
         ],
         STATE_ATTRIBUTE_RAW_TYPE: [
             line_cont_rule,
-            raw_line_cont_rule,
+            bad_line_cont_rule,
 
             Rule(token='RAWSTRING',
                  next_state=STATE_WS_SENSITIVE,

--- a/edgedb/lang/schema/parser/grammar/tokens.py
+++ b/edgedb/lang/schema/parser/grammar/tokens.py
@@ -43,6 +43,10 @@ class T_LINECONT(Token):
     pass
 
 
+class T_BADLINECONT(Token):
+    pass
+
+
 class T_NL(Token):
     pass
 

--- a/edgedb/lang/schema/parser/parser.py
+++ b/edgedb/lang/schema/parser/parser.py
@@ -12,9 +12,17 @@ from .grammar import lexer
 
 
 class EdgeSchemaParser(parsing.Parser):
-    def get_exception(self, native_err, context):
+    def get_exception(self, native_err, context, token=None):
         if isinstance(native_err, SchemaSyntaxError):
             return native_err
+
+        if token and token.type == 'BADLINECONT':
+            context.start.column += 1
+            return SchemaSyntaxError(
+                'Unexpected character after line continuation '
+                'character',
+                context=context)
+
         # if the error is about unexpected <$> token, convert the text to be
         # referencing <NL> token
         if native_err.args[0] == 'Unexpected token: <$>':

--- a/edgedb/server/pgsql/parser/parser.py
+++ b/edgedb/server/pgsql/parser/parser.py
@@ -29,5 +29,5 @@ class PgSQLParser(parsing.Parser):
     def get_debug(self):
         return debug.flags.pgsql_parser
 
-    def get_exception(self, native_err, context):
+    def get_exception(self, native_err, context, token=None):
         return PgSQLParserError(native_err.args[0], context=context)

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -1280,3 +1280,25 @@ attribute foo std::int64;
         abstract attribute \
         2 foobar std::str
         """
+
+    @tb.must_fail(error.SchemaSyntaxError,
+                  r"Unexpected character after line continuation character",
+                  line=2, col=24)
+    def test_eschema_syntax_eol_10(self):
+        # this is intended to test trailing whitespace after "\"
+        """
+        abstract type \\       \
+
+              OwnedObject:
+            required link owner -> User
+        """
+
+    @tb.must_fail(error.SchemaSyntaxError,
+                  r"Unexpected character after line continuation character",
+                  line=2, col=29)
+    def test_eschema_syntax_eol_11(self):
+        # this is intended to test trailing whitespace after "\"
+        """
+        abstract attribute \\   \
+        foobar std::str
+        """


### PR DESCRIPTION
This syntax is not supported after `:=` or `:>` where normal indentation
rules apply.

This is addressing #153 