### PR TITLE
graphql: Handle more of the scalars from std.

### DIFF
--- a/edgedb/lang/graphql/types.py
+++ b/edgedb/lang/graphql/types.py
@@ -36,10 +36,20 @@ from edgedb.lang.schema.scalars import ScalarType
 
 EDB_TO_GQL_SCALARS_MAP = {
     'str': GraphQLString,
+    'anyint': GraphQLInt,
+    'int16': GraphQLInt,
+    'int32': GraphQLInt,
     'int64': GraphQLInt,
+    'anyfloat': GraphQLFloat,
+    'float32': GraphQLFloat,
     'float64': GraphQLFloat,
+    'anyreal': GraphQLFloat,
+    'decimal': GraphQLFloat,
     'bool': GraphQLBoolean,
     'uuid': GraphQLID,
+    'datetime': GraphQLString,
+    'date': GraphQLString,
+    'time': GraphQLString,
 }
 
 

--- a/tests/test_graphql_functional.py
+++ b/tests/test_graphql_functional.py
@@ -174,6 +174,34 @@ class TestGraphQLFunctional(tb.QueryTestCase):
             }],
         }]])
 
+    async def test_graphql_functional_arguments_01(self):
+        result = await self.con.execute(r"""
+            query {
+                User {
+                    id
+                    name
+                    age
+                }
+            }
+        """, graphql=True)
+
+        alice = [res for res in result[0][0]['User']
+                 if res['name'] == 'Alice'][0]
+
+        result = await self.con.execute(f"""
+            query {{
+                User(id: "{alice['id']}") {{
+                    id
+                    name
+                    age
+                }}
+            }}
+        """, graphql=True)
+
+        self.assert_data_shape(result, [[{
+            'User': [alice]
+        }]])
+
     async def test_graphql_functional_fragment_02(self):
         result = await self.con.execute(r"""
             fragment userFrag on User {

--- a/tests/test_graphql_translator.py
+++ b/tests/test_graphql_translator.py
@@ -954,6 +954,28 @@ class TestGraphQLTranslation(TranslatorTest):
         };
         """
 
+    def test_graphql_translation_arguments_04(self):
+        r"""
+        query {
+            User(id: "8598d268-4efa-11e8-9955-8f9c15d57680") {
+                name,
+            }
+        }
+
+% OK %
+
+        SELECT graphql::Query {
+            User := (SELECT
+                test::User {
+                    name
+                } FILTER (
+                    <str>test::User.id =
+                        '8598d268-4efa-11e8-9955-8f9c15d57680'
+                )
+            )
+        };
+        """
+
     def test_graphql_translation_variables_01(self):
         r"""
         query($name: String) {
@@ -1279,7 +1301,7 @@ class TestGraphQLTranslation(TranslatorTest):
                     name,
                 }
             FILTER
-                (test::User.id = $val))
+                (<str>test::User.id = $val))
         };
         """
 
@@ -1299,7 +1321,7 @@ class TestGraphQLTranslation(TranslatorTest):
                     name,
                 }
             FILTER
-                (test::User.id = $val))
+                (<str>test::User.id = $val))
         };
         """
 


### PR DESCRIPTION
Include more of the std scalar types into the list of the types
reflected into GraphQL. Date & time related types are automatically cast
into a str when they need to be filtered. Similarly uuid is also made
into a str when it is used for filtering.