### PR TITLE
Add support for VARIADIC arguments in constraints

### DIFF
--- a/edgedb/lang/schema/_graphql.eschema
+++ b/edgedb/lang/schema/_graphql.eschema
@@ -7,12 +7,12 @@
 
 
 scalar type __TypeKind extending str:
-     constraint enum(['SCALAR', 'OBJECT', 'INTERFACE', 'UNION', 'ENUM',
-                      'INPUT_OBJECT', 'LIST', 'NON_NULL'])
+     constraint enum('SCALAR', 'OBJECT', 'INTERFACE', 'UNION', 'ENUM',
+                     'INPUT_OBJECT', 'LIST', 'NON_NULL')
 
 scalar type __DirectiveLocation extending str:
-     constraint enum(['QUERY', 'MUTATION', 'FIELD', 'FRAGMENT_DEFINITION',
-                      'FRAGMENT_SPREAD', 'INLINE_FRAGMENT'])
+     constraint enum('QUERY', 'MUTATION', 'FIELD', 'FRAGMENT_DEFINITION',
+                     'FRAGMENT_SPREAD', 'INLINE_FRAGMENT')
 
 abstract type Nameable:
     property name -> str

--- a/edgedb/lang/schema/_std.eql
+++ b/edgedb/lang/schema/_std.eql
@@ -187,7 +187,7 @@ CREATE ABSTRACT CONSTRAINT std::max(std::any)
     SET expr := __subject__ <= $0;
 };
 
-CREATE ABSTRACT CONSTRAINT std::enum(array<std::any>)
+CREATE ABSTRACT CONSTRAINT std::enum(VARIADIC std::any)
         EXTENDING std::constraint
 {
     SET errmessage := '{__subject__} must be one of: {$0}.';
@@ -436,7 +436,6 @@ CREATE TYPE schema::Parameter {
     CREATE REQUIRED PROPERTY schema::num -> std::int64;
     CREATE PROPERTY schema::name -> std::str;
     CREATE PROPERTY schema::default -> std::str;
-    CREATE PROPERTY schema::variadic -> std::bool;
 };
 
 

--- a/edgedb/server/pgsql/backend.py
+++ b/edgedb/server/pgsql/backend.py
@@ -811,7 +811,7 @@ class Backend(s_deltarepo.DeltaProvider):
                 subjectexpr=r['subjectexpr'],
                 localfinalexpr=r['localfinalexpr'], finalexpr=r['finalexpr'],
                 errmessage=r['errmessage'], paramtypes=paramtypes,
-                args=r['args'])
+                varparam=r['varparam'], args=r['args'])
 
             if subject:
                 subject.add_constraint(constraint)

--- a/edgedb/server/pgsql/datasources/schema/constraints.py
+++ b/edgedb/server/pgsql/datasources/schema/constraints.py
@@ -30,6 +30,7 @@ async def fetch(
                 a.errmessage            AS errmessage,
                 edgedb._resolve_type(a.paramtypes)
                                         AS paramtypes,
+                a.varparam              AS varparam,
                 a.args                  AS args,
                 edgedb._resolve_type_name(a.subject)
                                         AS subject

--- a/edgedb/server/pgsql/metaschema.py
+++ b/edgedb/server/pgsql/metaschema.py
@@ -955,7 +955,7 @@ def _generate_param_view(schema):
                  UNION ALL
                  SELECT
                     id, paramtypes, NULL as paramnames, NULL as paramdefaults,
-                    NULL as paramkinds, NULL as varparam
+                    NULL as paramkinds, varparam as varparam
                  FROM edgedb.Constraint
                 ) AS f,
                 LATERAL UNNEST((f.paramtypes).types)

--- a/tests/schemas/constraints.eschema
+++ b/tests/schemas/constraints.eschema
@@ -33,8 +33,18 @@ scalar type constraint_strvalue extending str:
     constraint regexp("^\d+9{3,}.*$")
 
 
+# A variant of enum that uses an array argument instead of
+# a variadic.
+abstract constraint my_enum(array<std::any>):
+    expr := array_contains($0, __subject__)
+
+
 scalar type constraint_enum extending str:
-   constraint enum(['foo', 'bar'])
+   constraint enum('foo', 'bar')
+
+
+scalar type constraint_my_enum extending str:
+   constraint my_enum(['foo', 'bar'])
 
 
 abstract link translated_label:
@@ -74,6 +84,7 @@ type Object:
     property c_minmax -> constraint_minmax
     property c_strvalue -> constraint_strvalue
     property c_enum -> constraint_enum
+    property c_my_enum -> constraint_my_enum
 
 
 type UniqueName:

--- a/tests/schemas/constraints_migration/schema.eschema
+++ b/tests/schemas/constraints_migration/schema.eschema
@@ -34,7 +34,7 @@ scalar type constraint_strvalue extending str:
 
 
 scalar type constraint_enum extending str:
-   constraint enum(['foo', 'bar'])
+   constraint enum('foo', 'bar')
 
 
 abstract link translated_label:

--- a/tests/schemas/constraints_migration/updated_schema.eschema
+++ b/tests/schemas/constraints_migration/updated_schema.eschema
@@ -34,7 +34,7 @@ scalar type constraint_strvalue extending str:
 
 
 scalar type constraint_enum extending str:
-   constraint enum(['foo', 'bar'])
+   constraint enum('foo', 'bar')
 
 
 abstract link translated_label:

--- a/tests/schemas/issues.eschema
+++ b/tests/schemas/issues.eschema
@@ -104,3 +104,7 @@ type URL extending Named:
 
 type Publication:
     required property title -> str
+
+
+abstract constraint my_enum(array<std::any>):
+    expr := array_contains($0, __subject__)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -98,7 +98,7 @@ class TestConstraintsSchema(tb.QueryTestCase):
 
         await self._run_link_tests(data, 'test::Object', 'c_strvalue')
 
-    async def test_constraints_scalar_enum(self):
+    async def test_constraints_scalar_enum_01(self):
         data = {
             ('foobar', 'must be one of:'),
             ('bar', 'good'),
@@ -106,6 +106,15 @@ class TestConstraintsSchema(tb.QueryTestCase):
         }
 
         await self._run_link_tests(data, 'test::Object', 'c_enum')
+
+    async def test_constraints_scalar_enum_02(self):
+        data = {
+            ('foobar', 'invalid'),
+            ('bar', 'good'),
+            ('foo', 'good'),
+        }
+
+        await self._run_link_tests(data, 'test::Object', 'c_my_enum')
 
     async def test_constraints_unique_simple(self):
         async with self._run_and_rollback():

--- a/tests/test_deltas.py
+++ b/tests/test_deltas.py
@@ -75,7 +75,7 @@ class TestDeltas(tb.DDLTestCase):
         # dropped.
         result = await self.con.execute("""
             CREATE SCALAR TYPE test::a1 EXTENDING std::str {
-                CREATE CONSTRAINT std::enum(['a', 'b']) {
+                CREATE CONSTRAINT std::enum('a', 'b') {
                     SET description := 'test_delta_drop_01_constraint';
                 };
             };

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -380,11 +380,11 @@ class TestIntrospection(tb.QueryTestCase):
                     }
                 }
             } FILTER
-                .name LIKE '%enum%' AND
+                .name LIKE '%my_enum%' AND
                 NOT EXISTS .<constraints;
         """, [
             [{
-                'name': 'std::enum',
+                'name': 'test::my_enum',
                 'params': [
                     {
                         'num': 1,
@@ -413,11 +413,11 @@ class TestIntrospection(tb.QueryTestCase):
                     }
                 }
             } FILTER
-                .name LIKE '%enum%' AND
+                .name LIKE '%my_enum%' AND
                 NOT EXISTS .<constraints;
         """, [
             [{
-                'name': 'std::enum',
+                'name': 'test::my_enum',
                 'params': [
                     {
                         'num': 1,
@@ -426,6 +426,35 @@ class TestIntrospection(tb.QueryTestCase):
                             'element_type': {
                                 'name': 'std::any'
                             }
+                        }
+                    }
+                ]
+            }]
+        ])
+
+    async def test_edgeql_introspection_constraint_03(self):
+        await self.assert_query_result(r"""
+            SELECT schema::Constraint {
+                name,
+                params: {
+                    num,
+                    kind,
+                    type: {
+                        name,
+                    }
+                }
+            } FILTER
+                .name LIKE '%std::enum%' AND
+                NOT EXISTS .<constraints;
+        """, [
+            [{
+                'name': 'std::enum',
+                'params': [
+                    {
+                        'num': 1,
+                        'kind': 'VARIADIC',
+                        'type': {
+                            'name': 'std::any',
                         }
                     }
                 ]
@@ -474,6 +503,7 @@ class TestIntrospection(tb.QueryTestCase):
                 {'name': 'test::due_date'},
                 {'name': 'test::issue'},
                 {'name': 'test::issue_num_t'},
+                {'name': 'test::my_enum'},
                 {'name': 'test::name'},
                 {'name': 'test::number'},
                 {'name': 'test::owner'},

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2454,7 +2454,7 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
 
     def test_edgeql_syntax_ddl_constraint_01(self):
         """
-        CREATE ABSTRACT CONSTRAINT std::enum(array<std::any>)
+        CREATE ABSTRACT CONSTRAINT std::enum(VARIADIC std::any)
             EXTENDING std::constraint
         {
             SET errmessage := '{subject} must be one of: {param}.';
@@ -2464,7 +2464,7 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
 
     def test_edgeql_syntax_ddl_constraint_02(self):
         """
-        CREATE ABSTRACT CONSTRAINT std::enum(array<std::any>) {
+        CREATE ABSTRACT CONSTRAINT std::enum(VARIADIC std::any) {
             SET errmessage := '{subject} must be one of: {param}.';
             SET expr := array_contains($param, __subject__);
         };
@@ -2496,7 +2496,7 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
     def test_edgeql_syntax_ddl_constraint_05(self):
         """
         CREATE SCALAR TYPE std::decimal_rounding_t EXTENDING std::str {
-            CREATE CONSTRAINT std::enum(['a', 'b']);
+            CREATE CONSTRAINT std::enum('a', 'b');
         };
         """
 


### PR DESCRIPTION
Constraints can now be declared with a VARIADIC argument.  `std::enum`
is changed to use `VARIADIC`.

Additionally, fix abstract constraint declarations in Schema, which
were completely broken.