### PR TITLE
Make dunder names reserved in schema as well as in edgeql.

### DIFF
--- a/edgedb/lang/edgeql/parser/grammar/lexer.py
+++ b/edgedb/lang/edgeql/parser/grammar/lexer.py
@@ -124,18 +124,14 @@ class EdgeQLLexer(lexer.Lexer):
         Rule(token='BADIDENT',
              next_state=STATE_KEEP,
              regexp=r'''
-                    __[A-Za-z\200-\377_0-9\$%]*__
+                    __[^\W\d]\w*__
+                    |
+                    `__.*?__`
                 '''),
-
-        Rule(token='BADIDENT',
-             next_state=STATE_KEEP,
-             regexp=r'`__.*?__`'),
 
         Rule(token='IDENT',
              next_state=STATE_KEEP,
-             regexp=r'''
-                    [A-Za-z\200-\377_%] [A-Za-z\200-\377_0-9\$%]*
-                '''),
+             regexp=r'[^\W\d]\w*'),
 
         Rule(token='QIDENT',
              next_state=STATE_KEEP,

--- a/edgedb/lang/edgeql/quote.py
+++ b/edgedb/lang/edgeql/quote.py
@@ -12,7 +12,7 @@ from .parser.grammar import keywords
 
 
 _re_ident = re.compile(r'''(?x)
-    [A-Za-z\200-\377_%][A-Za-z\200-\377_\d\$%]*  # alphanumeric identifier
+    [^\W\d]\w*  # alphanumeric identifier
     |
     ([1-9]\d* | 0)  # purely integer identifier
 ''')

--- a/edgedb/lang/schema/parser/grammar/lexer.py
+++ b/edgedb/lang/schema/parser/grammar/lexer.py
@@ -93,10 +93,7 @@ class EdgeSchemaLexer(lexer.Lexer):
     ident_rule = Rule(
         token='IDENT',
         next_state=STATE_KEEP,
-        regexp=r'''
-               (?:[^\W\d]|\$)
-               (?:\w|\$)*
-        ''')
+        regexp=r'[^\W\d]\w*')
 
     qident_rule = Rule(
         token='QIDENT',
@@ -198,6 +195,14 @@ class EdgeSchemaLexer(lexer.Lexer):
         Rule(token='DOT',
              next_state=STATE_KEEP,
              regexp=r'\.'),
+
+        Rule(token='BADIDENT',
+             next_state=STATE_KEEP,
+             regexp=r'''
+                    __[^\W\d]\w*__
+                    |
+                    `__.*?__`
+                '''),
 
         string_rule,
         ident_rule,
@@ -324,6 +329,9 @@ class EdgeSchemaLexer(lexer.Lexer):
     }
 
     def token_from_text(self, rule_token, txt):
+        if rule_token == 'BADIDENT':
+            self.handle_error(txt)
+
         tok = super().token_from_text(rule_token, txt)
 
         if rule_token == 'QIDENT':

--- a/edgedb/lang/schema/quote.py
+++ b/edgedb/lang/schema/quote.py
@@ -11,7 +11,7 @@ import re
 from .parser.grammar import keywords
 
 
-_re_ident = re.compile(r'(?:[^\W\d]|\$)(?:\w|\$)*')
+_re_ident = re.compile(r'[^\W\d]\w*')
 
 
 def quote_literal(text):

--- a/edgedb/server/pgsql/parser/lexer.py
+++ b/edgedb/server/pgsql/parser/lexer.py
@@ -20,8 +20,8 @@ re_self = r'[,()\[\].;:+\-*/%^<>=]'
 re_opchars = r"[~!@\#&|`?+\-*/%^<>=]"
 re_opchars_pgsql = r'[~!@\#&|`?]'
 re_opchars_sql = r'[+\-*/^%<>=]'
-re_ident_start = r"[A-Za-z\200-\377_%]"
-re_ident_cont = r"[A-Za-z\200-\377_0-9\$%]"
+re_ident_start = r"[A-Za-z\200-\377_]"
+re_ident_cont = r"[A-Za-z\200-\377_0-9\$]"
 
 clean_string = re.compile(r"'(?:\s|\n)+'")
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -565,6 +565,41 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
         SELECT (event::`@event`);
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=16)
+    def test_edgeql_syntax_name_16(self):
+        """
+        SELECT __Foo__;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=22)
+    def test_edgeql_syntax_name_17(self):
+        """
+        SELECT __Foo.__bar__;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=16)
+    def test_edgeql_syntax_name_18(self):
+        """
+        SELECT `__Foo__`;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=22)
+    def test_edgeql_syntax_name_19(self):
+        """
+        SELECT __Foo.`__bar__`;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=21)
+    def test_edgeql_syntax_name_20(self):
+        """
+        SELECT __Foo$;
+        """
+
+    def test_edgeql_syntax_name_21(self):
+        """
+        SELECT Пример;
+        """
+
     def test_edgeql_syntax_shape_01(self):
         """
         SELECT Foo {bar};

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -150,6 +150,40 @@ type Commit:
     required property name -> std::str
         """
 
+    @tb.must_fail(error.SchemaSyntaxError, line=2, col=14)
+    def test_eschema_syntax_type_12(self):
+        """
+        type __Foo__:
+            required property name -> std::str
+        """
+
+    @tb.must_fail(error.SchemaSyntaxError, line=2, col=14)
+    def test_eschema_syntax_type_13(self):
+        """
+        type `__Foo__`:
+            required property name -> std::str
+        """
+
+    @tb.must_fail(error.SchemaSyntaxError, line=3, col=31)
+    def test_eschema_syntax_type_14(self):
+        """
+        type __Foo:
+            required property __name__ -> std::str
+        """
+
+    @tb.must_fail(error.SchemaSyntaxError, line=3, col=31)
+    def test_eschema_syntax_type_15(self):
+        """
+        type `__Foo`:
+            required property `__name__` -> std::str
+        """
+
+    def test_eschema_syntax_type_16(self):
+        """
+        type Пример:
+            required property номер -> int16
+        """
+
     def test_eschema_syntax_link_target_type_01(self):
         """
 type User:


### PR DESCRIPTION
Adjust the schema lexer to match the dunder identifier restrictions of
EdgeQL.

Add several syntax tests for illegal dunder names.

Fixes: #97