### PR TITLE
Treat assignemnt cast different from other implicit casts.

### DIFF
--- a/edgedb/lang/edgeql/compiler/viewgen.py
+++ b/edgedb/lang/edgeql/compiler/viewgen.py
@@ -341,7 +341,7 @@ def _normalize_view_ptr_expr(
             msg = 'cannot determine expression result type'
             raise errors.EdgeQLError(msg, context=shape_el.context)
 
-        if is_mutation and not ptr_target.implicitly_castable_to(
+        if is_mutation and not ptr_target.assignment_castable_to(
                 base_ptrcls.target, schema=ctx.schema):
             # Validate that the insert/update expression is
             # of the correct class.

--- a/edgedb/lang/schema/scalars.py
+++ b/edgedb/lang/schema/scalars.py
@@ -86,6 +86,21 @@ class ScalarType(nodes.Node, constraints.ConsistencySubject,
         else:
             return value
 
+    def assignment_castable_to(self, other: s_types.Type, schema) -> bool:
+        if self.issubclass(other) or other.issubclass(self):
+            # ScalarType compatibility is symmetric, i.e. a superclass instance
+            # is compatible with subclasses, as they all share the same
+            # fundamental type.
+            return True
+
+        # In addition all numerical types are compatible for purposes
+        # of assignment.
+        real_t = schema.get('std::anyreal')
+        if self.issubclass(real_t) and other.issubclass(real_t):
+            return True
+
+        return False
+
     def implicitly_castable_to(self, other: s_types.Type, schema) -> bool:
         if self.issubclass(other) or other.issubclass(self):
             # ScalarType compatibility is symmetric, i.e. a superclass instance

--- a/edgedb/lang/schema/types.py
+++ b/edgedb/lang/schema/types.py
@@ -38,6 +38,9 @@ class Type(so.NamedObject, derivable.DerivableObjectBase):
     def is_view(self):
         return self.view_type is not None
 
+    def assignment_castable_to(self, other: 'Type', schema) -> bool:
+        return self.implicitly_castable_to(other, schema)
+
     def implicitly_castable_to(self, other: 'Type', schema) -> bool:
         return self.issubclass(other)
 


### PR DESCRIPTION
An assignemnt cast is less strict that generic implicit cast. Typically
we want to allow assigning any numeric type to any other numeric type
and rely on runtime errors if the values are incompatible.