### PR TITLE
Set prompt_toolkit version. (2.0.0 has breaking changes).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ RUNTIME_DEPS = [
     'click',
     'graphql-core',
     'Parsing',
-    'prompt-toolkit',
+    'prompt_toolkit>=1.0.15,<2.0.0',
     'pygments',
     'setproctitle',
 ]


### PR DESCRIPTION
I will probably release prompt_toolkit 2.0 this or next week, and it has breaking changes, so it'd be good to merge this. After the release we can still upgrade.