### PR TITLE
Add support for well-known type IDs

### DIFF
--- a/edb/api/__init__.py
+++ b/edb/api/__init__.py
@@ -1,0 +1,17 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/edb/api/types.txt
+++ b/edb/api/types.txt
@@ -1,0 +1,33 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+00000000-0000-0000-0000-000000000001 std::uuid
+00000000-0000-0000-0000-000000000002 std::str
+00000000-0000-0000-0000-000000000003 std::bytes
+00000000-0000-0000-0000-000000000004 std::int16
+00000000-0000-0000-0000-000000000005 std::int32
+00000000-0000-0000-0000-000000000006 std::int64
+00000000-0000-0000-0000-000000000007 std::float32
+00000000-0000-0000-0000-000000000008 std::float64
+00000000-0000-0000-0000-000000000009 std::decimal
+00000000-0000-0000-0000-00000000000A std::bool
+00000000-0000-0000-0000-00000000000B std::datetime
+00000000-0000-0000-0000-00000000000C std::date
+00000000-0000-0000-0000-00000000000D std::time
+00000000-0000-0000-0000-00000000000E std::timedelta
+00000000-0000-0000-0000-00000000000F std::json

--- a/edb/server/pgsql/metaschema.py
+++ b/edb/server/pgsql/metaschema.py
@@ -106,7 +106,7 @@ class ObjectTable(dbops.Table):
             name=('edgedb', 'class'),
             columns=[
                 dbops.Column(
-                    name='id', type='uuid', required=True, readonly=True,
+                    name='id', type='uuid', required=True,
                     default='edgedb.uuid_generate_v1mc()')
             ],
             constraints=[


### PR DESCRIPTION
Scalar types in `std` now have predetermined IDs.  This is useful for
binary driver implementations, as the codec mapping can be set up at
compile time.

We use the UUID variant 0 with sequential node id so that standard type
ids can be treated as simple integers starting from 1.