### PR TITLE
edgeql: Change syntax for empty tuple type.

### DIFF
--- a/edb/lang/edgeql/ast.py
+++ b/edb/lang/edgeql/ast.py
@@ -241,8 +241,8 @@ class _TypeName(Expr):
 class TypeName(_TypeName):
     name: str  # name is used for types in named tuples
     maintype: ObjectRef
-    subtypes: typing.Union[typing.List[_TypeName], None]
-    dimensions: typing.Union[typing.List[int], None]
+    subtypes: typing.Optional[typing.List[_TypeName]]
+    dimensions: typing.Optional[typing.List[int]]
 
 
 class FuncParam(Base):

--- a/edb/lang/edgeql/ast.py
+++ b/edb/lang/edgeql/ast.py
@@ -241,7 +241,7 @@ class _TypeName(Expr):
 class TypeName(_TypeName):
     name: str  # name is used for types in named tuples
     maintype: ObjectRef
-    subtypes: typing.List[_TypeName]
+    subtypes: typing.Union[typing.List[_TypeName], None]
     dimensions: typing.Union[typing.List[int], None]
 
 

--- a/edb/lang/edgeql/codegen.py
+++ b/edb/lang/edgeql/codegen.py
@@ -592,7 +592,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self.visit(node.maintype)
         else:
             self.visit(node.maintype)
-        if node.subtypes:
+        if node.subtypes is not None:
             self.write('<')
             self.visit_list(node.subtypes, newlines=False)
             if node.dimensions is not None:

--- a/edb/lang/edgeql/parser/grammar/expressions.py
+++ b/edb/lang/edgeql/parser/grammar/expressions.py
@@ -1045,7 +1045,7 @@ class NonArrayTypeName(Nonterm):
     def reduce_NodeName(self, *kids):
         maintype = kids[0].val
 
-        # maintype cannot be 'array'
+        # maintype cannot be a collection
         if maintype.module is None and maintype.name in {'array', 'tuple'}:
             raise EdgeQLSyntaxError(
                 f"Unexpected {maintype.name!r}",

--- a/edb/lang/edgeql/parser/grammar/expressions.py
+++ b/edb/lang/edgeql/parser/grammar/expressions.py
@@ -1046,12 +1046,18 @@ class NonArrayTypeName(Nonterm):
         maintype = kids[0].val
 
         # maintype cannot be 'array'
-        if maintype.module is None and maintype.name == 'array':
+        if maintype.module is None and maintype.name in {'array', 'tuple'}:
             raise EdgeQLSyntaxError(
                 f"Unexpected {maintype.name!r}",
                 context=kids[0].context)
 
         self.val = qlast.TypeName(maintype=maintype)
+
+    def reduce_TUPLE_LANGBRACKET_RANGBRACKET(self, *kids):
+        self.val = qlast.TypeName(
+            maintype=qlast.ObjectRef(name='tuple'),
+            subtypes=[],
+        )
 
     def reduce_TUPLE_LANGBRACKET_TypeNameList_RANGBRACKET(self, *kids):
         self.val = qlast.TypeName(

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1418,7 +1418,7 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
 
     def test_edgeql_syntax_cast_07(self):
         """
-        SELECT <tuple>$1;
+        SELECT <tuple<>>$1;
         SELECT <tuple<Foo, int, str>>$1;
         SELECT <tuple<obj: Foo, count: int, name: str>>$1;
         """
@@ -2348,7 +2348,7 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
     def test_edgeql_syntax_ddl_attribute_05(self):
         # test parsing of tuple types
         """
-        CREATE ABSTRACT ATTRIBUTE std::foo tuple;
+        CREATE ABSTRACT ATTRIBUTE std::foo tuple<>;
         CREATE ABSTRACT ATTRIBUTE std::foo tuple<float64>;
         CREATE ABSTRACT ATTRIBUTE std::foo tuple<int64, str>;
         CREATE ABSTRACT ATTRIBUTE std::foo tuple<array<int64>, str>;
@@ -2406,6 +2406,20 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
     def test_edgeql_syntax_ddl_attribute_14(self):
         """
         CREATE ABSTRACT ATTRIBUTE std::paramtypes;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Unexpected '>'", line=2, col=50)
+    def test_edgeql_syntax_ddl_attribute_15(self):
+        """
+        CREATE ABSTRACT ATTRIBUTE std::foo array<>;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Unexpected 'tuple'", line=2, col=44)
+    def test_edgeql_syntax_ddl_attribute_16(self):
+        """
+        CREATE ABSTRACT ATTRIBUTE std::foo tuple;
         """
 
     def test_edgeql_syntax_ddl_constraint_01(self):


### PR DESCRIPTION
Empty tuple type is now indicated by `tuple<>`, whereas `tuple` without
angle brackets is now syntactically invalid.