### PR TITLE
graphql: Use a `filter` argument for more flexible filtering.

### DIFF
--- a/edb/lang/edgeql/ast.py
+++ b/edb/lang/edgeql/ast.py
@@ -128,12 +128,20 @@ class Base(ast.AST):
 
 
 class Expr(Base):
-    '''Abstract parent for all query expressions.'''
+    """Abstract parent for all query expressions."""
     pass
 
 
+class SubExpr(Base):
+    """A subexpression (used for ahcnors)."""
+
+    expr: typing.Union[Expr, object]
+    anchors: typing.Dict[typing.Union[str, ast.MetaAST],
+                         typing.Union[Expr, object]]
+
+
 class Clause(Base):
-    '''Abstract parent for all query clauses.'''
+    """Abstract parent for all query clauses."""
     pass
 
 

--- a/edb/lang/edgeql/compiler/context.py
+++ b/edb/lang/edgeql/compiler/context.py
@@ -47,11 +47,15 @@ class ContextSwitchMode(enum.Enum):
 
 
 class ViewRPtr:
-    def __init__(self, source, ptrcls, *,
-                 rptr=None, is_insert=False, is_update=False):
+    def __init__(self, source, *, ptrcls=None, ptrcls_name=None,
+                 ptrcls_is_linkprop=None,
+                 derived_ptrcls=None, rptr=None, is_insert=False,
+                 is_update=False):
         self.source = source
         self.ptrcls = ptrcls
-        self.derived_ptrcls = None
+        self.ptrcls_name = ptrcls_name
+        self.ptrcls_is_linkprop = ptrcls_is_linkprop
+        self.derived_ptrcls = derived_ptrcls
         self.rptr = rptr
         self.is_insert = is_insert
         self.is_update = is_update

--- a/edb/lang/edgeql/compiler/decompiler.py
+++ b/edb/lang/edgeql/compiler/decompiler.py
@@ -142,11 +142,15 @@ class IRDecompiler(ast.visitor.NodeVisitor):
     def visit_BinOp(self, node):
         result = qlast.BinOp()
         result.left = self.visit(node.left)
+        result.right = self.visit(node.right)
+        result.op = node.op
+        return result
 
-        if isinstance(node.op, ast.ops.TypeCheckOperator):
-            # Trim the trailing __type__ added by the compiler
-            result.left.steps = result.left.steps[:-1]
-
+    def visit_TypeCheckOp(self, node):
+        result = qlast.BinOp()
+        result.left = self.visit(node.left)
+        # Trim the trailing __type__ added by the compiler
+        result.left.steps = result.left.steps[:-1]
         result.right = self.visit(node.right)
         result.op = node.op
         return result

--- a/edb/lang/edgeql/compiler/expr.py
+++ b/edb/lang/edgeql/compiler/expr.py
@@ -550,7 +550,7 @@ def try_fold_binop(
 
 
 def compile_type_check_op(
-        expr: qlast.BinOp, *, ctx: context.ContextLevel) -> irast.BinOp:
+        expr: qlast.BinOp, *, ctx: context.ContextLevel) -> irast.TypeCheckOp:
     # <Expr> IS <Type>
     left = dispatch.compile(expr.left, ctx=ctx)
     with ctx.new() as subctx:
@@ -567,7 +567,7 @@ def compile_type_check_op(
 
     right = typegen.process_type_ref_expr(right)
 
-    return irast.BinOp(left=left, right=right, op=expr.op)
+    return irast.TypeCheckOp(left=left, right=right, op=expr.op)
 
 
 def _compile_set_op(

--- a/edb/lang/edgeql/compiler/pathctx.py
+++ b/edb/lang/edgeql/compiler/pathctx.py
@@ -63,6 +63,8 @@ def assign_set_scope(
         if scope.unique_id is None:
             scope.unique_id = ctx.scope_id_ctr.nextval()
         ir_set.path_scope_id = scope.unique_id
+        if scope.find_child(ir_set.path_id):
+            raise RuntimeError('scoped set must not contain itself')
 
     return ir_set
 

--- a/edb/lang/edgeql/compiler/setgen.py
+++ b/edb/lang/edgeql/compiler/setgen.py
@@ -499,8 +499,12 @@ def class_indirection_set(
 
 
 def class_set(
-        scls: s_nodes.Node, *, ctx: context.ContextLevel) -> irast.Set:
-    path_id = pathctx.get_path_id(scls, ctx=ctx)
+        scls: s_nodes.Node, *,
+        path_id: typing.Optional[irast.PathId]=None,
+        ctx: context.ContextLevel) -> irast.Set:
+
+    if path_id is None:
+        path_id = pathctx.get_path_id(scls, ctx=ctx)
     return new_set(path_id=path_id, scls=scls, ctx=ctx)
 
 

--- a/edb/lang/edgeql/compiler/setgen.py
+++ b/edb/lang/edgeql/compiler/setgen.py
@@ -644,7 +644,7 @@ def computable_ptr_set(
     subctx.aliases = ctx.aliases
     subctx.stmt = ctx.stmt
     subctx.view_scls = ptrcls.target
-    subctx.view_rptr = context.ViewRPtr(source_scls, ptrcls, rptr=rptr)
+    subctx.view_rptr = context.ViewRPtr(source_scls, ptrcls=ptrcls, rptr=rptr)
     subctx.toplevel_stmt = ctx.toplevel_stmt
     subctx.path_scope = ctx.path_scope
     subctx.class_shapes = ctx.class_shapes.copy()

--- a/edb/lang/edgeql/compiler/setgen.py
+++ b/edb/lang/edgeql/compiler/setgen.py
@@ -110,12 +110,12 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
         if isinstance(step, qlast.Source):
             # 'self' can only appear as the starting path label
             # syntactically and is a known anchor
-            path_tip = anchors.get(step.__class__)
+            path_tip = anchors[step.__class__]
 
         elif isinstance(step, qlast.Subject):
             # '__subject__' can only appear as the starting path label
             # syntactically and is a known anchor
-            path_tip = anchors.get(step.__class__)
+            path_tip = anchors[step.__class__]
 
         elif isinstance(step, qlast.ObjectRef):
             if i > 0:

--- a/edb/lang/edgeql/compiler/stmt.py
+++ b/edb/lang/edgeql/compiler/stmt.py
@@ -259,7 +259,8 @@ def compile_InsertQuery(
             ctx=ictx)
 
         stmt.result = setgen.class_set(
-            stmt.subject.scls.material_type(), ctx=ctx)
+            stmt.subject.scls.material_type(),
+            path_id=stmt.subject.path_id, ctx=ctx)
 
         result = fini_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 
@@ -291,7 +292,8 @@ def compile_UpdateQuery(
             ctx=ictx)
 
         stmt.result = setgen.class_set(
-            stmt.subject.scls.material_type(), ctx=ctx)
+            stmt.subject.scls.material_type(),
+            path_id=stmt.subject.path_id, ctx=ctx)
 
         stmt.where = clauses.compile_where_clause(
             expr.where, ctx=ictx)
@@ -324,8 +326,8 @@ def compile_DeleteQuery(
             subject, shape=None, result_alias=expr.subject_alias, ctx=ictx)
 
         stmt.result = setgen.class_set(
-            stmt.subject.scls.material_type(), ctx=ctx)
-        stmt.result.path_id = stmt.subject.path_id
+            stmt.subject.scls.material_type(),
+            path_id=stmt.subject.path_id, ctx=ctx)
 
         result = fini_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 

--- a/edb/lang/edgeql/compiler/viewgen.py
+++ b/edb/lang/edgeql/compiler/viewgen.py
@@ -374,7 +374,7 @@ def _normalize_view_ptr_expr(
 
     if qlexpr is not None or ptr_target is not ptrcls.target:
         if not ptrcls_is_derived:
-            if ptrcls.is_link_property():
+            if is_linkprop:
                 rptrcls = view_rptr.derived_ptrcls
                 if rptrcls is None:
                     rptrcls = schemactx.derive_view(

--- a/edb/lang/graphql/ast.py
+++ b/edb/lang/graphql/ast.py
@@ -89,7 +89,7 @@ class ListLiteral(Literal):
         return [val.topython() for val in self.value]
 
 
-class ObjectLiteral(Literal):
+class InputObjectLiteral(Literal):
     def topython(self):
         return {field.name: field.value.topython() for field in self.value}
 

--- a/edb/lang/graphql/codegen.py
+++ b/edb/lang/graphql/codegen.py
@@ -162,7 +162,7 @@ class GraphQLSourceGenerator(codegen.SourceGenerator):
         self._visit_list(node.value, separator=', ')
         self.write(']')
 
-    def visit_ObjectLiteral(self, node):
+    def visit_InputObjectLiteral(self, node):
         if node.value:
             self.write('{')
             self.new_lines = 1

--- a/edb/lang/graphql/parser/grammar/document.py
+++ b/edb/lang/graphql/parser/grammar/document.py
@@ -33,7 +33,7 @@ def check_const(expr):
     elif isinstance(expr, gqlast.ListLiteral):
         for val in expr.value:
             check_const(val)
-    elif isinstance(expr, gqlast.ObjectLiteral):
+    elif isinstance(expr, gqlast.InputObjectLiteral):
         for field in expr.value:
             check_const(field.value)
 
@@ -118,10 +118,10 @@ class BaseValue(Nonterm):
         self.val = gqlast.ListLiteral(value=kids[1].val)
 
     def reduce_LCBRACKET_RCBRACKET(self, *kids):
-        self.val = gqlast.ObjectLiteral(value={})
+        self.val = gqlast.InputObjectLiteral(value={})
 
     def reduce_LCBRACKET_ObjectFieldList_RCBRACKET(self, *kids):
-        self.val = gqlast.ObjectLiteral(value=kids[1].val)
+        self.val = gqlast.InputObjectLiteral(value=kids[1].val)
 
 
 class Value(Nonterm):

--- a/edb/lang/graphql/types.py
+++ b/edb/lang/graphql/types.py
@@ -23,7 +23,9 @@ from graphql import (
     GraphQLSchema,
     GraphQLObjectType,
     GraphQLInterfaceType,
+    GraphQLInputObjectType,
     GraphQLField,
+    GraphQLInputObjectField,
     GraphQLArgument,
     GraphQLList,
     GraphQLNonNull,
@@ -33,7 +35,9 @@ from graphql import (
     GraphQLBoolean,
     GraphQLID,
 )
+import itertools
 
+from edb.lang.common import ast
 from edb.lang.edgeql import ast as qlast
 from edb.lang.edgeql import codegen
 from edb.lang.edgeql.parser import parse_fragment
@@ -42,6 +46,8 @@ from edb.lang.schema import pointers as s_pointers
 from edb.lang.schema import types as s_types
 from edb.lang.schema.objtypes import ObjectType
 from edb.lang.schema.scalars import ScalarType
+
+from .errors import GraphQLCoreError
 
 
 EDB_TO_GQL_SCALARS_MAP = {
@@ -63,6 +69,18 @@ EDB_TO_GQL_SCALARS_MAP = {
 }
 
 
+GQL_TO_OPS_MAP = {
+    'eq': ast.ops.EQ,
+    'neq': ast.ops.NE,
+    'gt': ast.ops.GT,
+    'gte': ast.ops.GE,
+    'lt': ast.ops.LT,
+    'lte': ast.ops.LE,
+    'like': qlast.LIKE,
+    'ilike': qlast.ILIKE,
+}
+
+
 class GQLCoreSchema:
     def __init__(self, edb_schema):
         '''Create a graphql schema based on edgedb schema.'''
@@ -78,7 +96,7 @@ class GQLCoreSchema:
 
         self._gql_interfaces = {}
         self._gql_objtypes = {}
-        self._gql_fields = {}
+        self._gql_inobjtypes = {}
 
         self._define_types()
 
@@ -87,11 +105,16 @@ class GQLCoreSchema:
             fields=self.get_fields('Query'),
         )
 
-        self._gql_schema = GraphQLSchema(
-            query=query,
-            types=[objt for name, objt in self._gql_objtypes.items()
-                   if name != 'Query'],
-        )
+        # get a sorted list of types relevant for the Schema
+        types = [
+            objt for name, objt in
+            itertools.chain(self._gql_objtypes.items(),
+                            self._gql_inobjtypes.items())
+            # the Query is included separately
+            if name != 'Query'
+        ]
+        types = sorted(types, key=lambda x: x.name)
+        self._gql_schema = GraphQLSchema(query=query, types=types)
 
     def get_short_name(self, name):
         return name.split('::', 1)[-1]
@@ -142,7 +165,9 @@ class GQLCoreSchema:
                     continue
                 fields[name.split('::', 1)[1]] = GraphQLField(
                     GraphQLList(GraphQLNonNull(gqltype)),
-                    args=self.get_args(name),
+                    args={
+                        'filter': GraphQLArgument(self._gql_inobjtypes[name]),
+                    },
                 )
         else:
             edb_type = self.edb_schema.get(typename)
@@ -153,20 +178,35 @@ class GQLCoreSchema:
                 ptr = edb_type.resolve_pointer(self.edb_schema, name)
                 target = self._get_target(ptr)
                 if target:
-                    args = (self.get_args(ptr.target.name)
-                            if isinstance(ptr.target, ObjectType) else None)
+                    args = None
+                    if isinstance(ptr.target, ObjectType):
+                        args = {
+                            'filter': GraphQLArgument(
+                                self._gql_inobjtypes[ptr.target.name]),
+                        }
                     fields[name.name] = GraphQLField(target, args=args)
 
         return fields
 
     @lru_cache(maxsize=None)
-    def get_args(self, typename):
-        args = OrderedDict()
+    def get_input_fields(self, typename):
+        selftype = self._gql_inobjtypes[typename]
+        fields = OrderedDict()
+        fields['and'] = GraphQLInputObjectField(
+            GraphQLList(GraphQLNonNull(selftype)))
+        fields['or'] = GraphQLInputObjectField(
+            GraphQLList(GraphQLNonNull(selftype)))
+        fields['not'] = GraphQLInputObjectField(selftype)
 
         edb_type = self.edb_schema.get(typename)
         for name in sorted(edb_type.pointers, key=lambda x: x.name):
             if name.name == '__type__':
                 continue
+            if name.name in fields:
+                raise GraphQLCoreError(
+                    f"{name.name!r} of {typename} clashes with special "
+                    "reserved fields required for GraphQL conversion"
+                )
 
             ptr = edb_type.resolve_pointer(self.edb_schema, name)
 
@@ -174,14 +214,35 @@ class GQLCoreSchema:
                 continue
 
             target = self._convert_edb_type(ptr.target)
-            if target:
-                args[name.name] = GraphQLArgument(target)
+            intype = self._gql_inobjtypes.get(f'Filter{target.name}')
+            if intype:
+                fields[name.name] = GraphQLInputObjectField(intype)
 
-        return args
+        return fields
+
+    def define_generic_input_types(self):
+        eq = ['eq', 'neq']
+        comp = eq + ['gte', 'gt', 'lte', 'lt']
+        string = comp + ['like', 'ilike']
+
+        self._make_generic_input_type(GraphQLBoolean, *eq)
+        self._make_generic_input_type(GraphQLID, *eq)
+        self._make_generic_input_type(GraphQLInt, *comp)
+        self._make_generic_input_type(GraphQLFloat, *comp)
+        self._make_generic_input_type(GraphQLString, *string)
+
+    def _make_generic_input_type(self, base, *ops):
+        name = f'Filter{base.name}'
+        self._gql_inobjtypes[name] = GraphQLInputObjectType(
+            name=name,
+            fields={op: GraphQLInputObjectField(base) for op in ops},
+        )
 
     def _define_types(self):
         interface_types = []
         obj_types = []
+
+        self.define_generic_input_types()
 
         for modname in self.modules:
             # get all descendants of this abstract type
@@ -196,12 +257,20 @@ class GQLCoreSchema:
 
         # interfaces
         for t in interface_types:
+            short_name = self.get_short_name(t.name)
             gqltype = GraphQLInterfaceType(
-                name=self.get_short_name(t.name),
+                name=short_name,
                 fields=partial(self.get_fields, t.name),
                 resolve_type=lambda obj, info: obj,
             )
             self._gql_interfaces[t.name] = gqltype
+
+            # input object types corresponding to this interface
+            gqlintype = GraphQLInputObjectType(
+                name='Filter' + short_name,
+                fields=partial(self.get_input_fields, t.name),
+            )
+            self._gql_inobjtypes[t.name] = gqlintype
 
         # object types
         for t in obj_types:
@@ -216,8 +285,9 @@ class GQLCoreSchema:
                         st.name in self._gql_interfaces):
                     interfaces.append(self._gql_interfaces[st.name])
 
+            short_name = self.get_short_name(t.name)
             gqltype = GraphQLObjectType(
-                name=self.get_short_name(t.name) + 'Type',
+                name=short_name + 'Type',
                 fields=partial(self.get_fields, t.name),
                 interfaces=interfaces,
             )

--- a/edb/lang/ir/ast.py
+++ b/edb/lang/ir/ast.py
@@ -99,6 +99,12 @@ class Set(Base):
             f'<ir.Set \'{self.path_id or self.scls.name}\' at 0x{id(self):x}>'
 
 
+class TypeRef(Base):
+
+    maintype: str
+    subtypes: typing.List[sn.Name]
+
+
 class Command(Base):
     pass
 
@@ -195,6 +201,13 @@ class EquivalenceOp(BaseBinOp):
     pass
 
 
+class TypeCheckOp(Expr):
+
+    left: Set
+    right: typing.Union[TypeRef, Array]
+    op: ast.ops.Operator
+
+
 class IfElseExpr(Expr):
 
     condition: Set
@@ -248,12 +261,6 @@ class SliceIndirection(Expr):
     start: Base
     stop: Base
     step: Base
-
-
-class TypeRef(Expr):
-
-    maintype: str
-    subtypes: typing.List[sn.Name]
 
 
 class TypeCast(Expr):

--- a/edb/lang/ir/inference/cardinality.py
+++ b/edb/lang/ir/inference/cardinality.py
@@ -141,6 +141,11 @@ def __infer_equivop(ir, singletons, schema):
     return _common_cardinality([ir.left, ir.right], singletons, schema)
 
 
+@_infer_cardinality.register(irast.TypeCheckOp)
+def __infer_typecheckop(ir, singletons, schema):
+    return infer_cardinality(ir.left, singletons, schema)
+
+
 @_infer_cardinality.register(irast.UnaryOp)
 def __infer_unaryop(ir, singletons, schema):
     return infer_cardinality(ir.expr, singletons, schema)

--- a/edb/lang/ir/inference/types.py
+++ b/edb/lang/ir/inference/types.py
@@ -235,7 +235,6 @@ def __infer_binop(ir, schema):
     left_type, right_type = _infer_binop_args(ir.left, ir.right, schema)
 
     if isinstance(ir.op, (ast.ops.ComparisonOperator,
-                          ast.ops.TypeCheckOperator,
                           ast.ops.MembershipOperator)):
         result = schema.get('std::bool')
     else:
@@ -266,6 +265,12 @@ def __infer_binop(ir, schema):
 
 @_infer_type.register(irast.EquivalenceOp)
 def __infer_equivop(ir, schema):
+    left_type, right_type = _infer_binop_args(ir.left, ir.right, schema)
+    return schema.get('std::bool')
+
+
+@_infer_type.register(irast.TypeCheckOp)
+def __infer_typecheckop(ir, schema):
     left_type, right_type = _infer_binop_args(ir.left, ir.right, schema)
     return schema.get('std::bool')
 

--- a/edb/lang/schema/_graphql.eql
+++ b/edb/lang/schema/_graphql.eql
@@ -24,6 +24,4 @@ CREATE FUNCTION graphql::short_name(std::str) -> std::str
 
 # create Query
 WITH MODULE graphql
-INSERT Query {
-    name := 'Query',
-};
+INSERT Query;

--- a/edb/lang/schema/_graphql.eql
+++ b/edb/lang/schema/_graphql.eql
@@ -19,7 +19,7 @@
 
 CREATE FUNCTION graphql::short_name(std::str) -> std::str
     FROM SQL $$
-        SELECT regexp_replace($1, '.+?::(.+$)', '\1');
+        SELECT regexp_replace($1, '.+?::(.+$)', '\1') || 'Type';
     $$;
 
 # create Query

--- a/edb/lang/schema/_graphql.eschema
+++ b/edb/lang/schema/_graphql.eschema
@@ -17,80 +17,14 @@
 #
 
 
-scalar type __TypeKind extending str:
-     constraint enum('SCALAR', 'OBJECT', 'INTERFACE', 'UNION', 'ENUM',
-                     'INPUT_OBJECT', 'LIST', 'NON_NULL')
+# these are just some placeholders for packaging GraphQL queries
 
-scalar type __DirectiveLocation extending str:
-     constraint enum('QUERY', 'MUTATION', 'FIELD', 'FRAGMENT_DEFINITION',
-                     'FRAGMENT_SPREAD', 'INLINE_FRAGMENT')
+type __Type
 
-abstract type Nameable:
-    property name -> str
-    property description -> str
+type __Schema
 
-abstract type Named extending Nameable:
-    required inherited property name -> str
-
-abstract type Deprecatable:
-    required property isDeprecated -> bool
-    property deprecationReason -> str
-
-abstract type Callable:
-    link args -> __InputValue:
-        cardinality := '1*'
-
-abstract type Typed:
-    # not required for the moment
-    link type -> __Type
-
-type __Type extending Nameable:
-    property __typename := '__Type'
-    required property kind -> __TypeKind
-    link fields -> __Field:
-        cardinality := '1*'
-    link interfaces -> __Type:
-        cardinality := '1*'
-    link possibleTypes -> __Type:
-        cardinality := '1*'
-    link enumValues -> __EnumValue:
-        cardinality := '1*'
-    link inputFields -> __InputValue:
-        cardinality := '1*'
-    link ofType -> __Type:
-        cardinality := '*1'
-
-type __Field extending Named, Deprecatable, Callable, Typed:
-    property __typename := '__Field'
-
-type __InputValue extending Named, Typed:
-    property __typename := '__InputValue'
-    property defaultValue -> str
-
-type __EnumValue extending Named, Deprecatable:
-    property __typename := '__EnumValue'
-
-type __Directive extending Named, Callable:
-    property __typename := '__Directive'
-    required property locations -> __DirectiveLocation:
-        cardinality := '1*'
-
-type __Schema extending Named:
-    property __typename := '__Schema'
-    # not required for the moment
-    link types -> __Type:
-        cardinality := '**'
-    required link queryType -> __Type
-    link mutationType -> __Type
-    required link directives -> __Directive:
-        cardinality := '1*'
-
-type Query extending Named:
+type Query:
     property __typename := 'Query'
-    link __schema -> __Schema:
-        cardinality := '11'
-    link __type -> __Type:
-        cardinality := '11'
 
-type Mutation extending Named:
+type Mutation:
     property __typename := 'Mutation'

--- a/edb/lang/schema/constraints.py
+++ b/edb/lang/schema/constraints.py
@@ -177,7 +177,7 @@ class Constraint(inheriting.InheritingObject):
         subject = constraint.subject
         subjectexpr = constraint.get_field_value('subjectexpr')
         if subjectexpr:
-            _, subject = cls._normalize_constraint_expr(
+            subject, _ = cls._normalize_constraint_expr(
                 schema, {}, subjectexpr, subject)
 
         expr = constraint.get_field_value('expr')
@@ -223,9 +223,22 @@ class Constraint(inheriting.InheritingObject):
             expr_context = \
                 constraint.get_attribute_source_context('expr')
 
+        if subject is not constraint.subject:
+            # subject has been redefined
+            subject_anchor = qlast.SubExpr(
+                expr=subject,
+                anchors={
+                    qlast.Subject: constraint.subject
+                }
+            )
+        else:
+            subject_anchor = subject
+
         expr_text = cls.normalize_constraint_expr(
-            schema, module_aliases, expr_ql, subject=subject,
-            constraint=constraint, enforce_boolean=True,
+            schema, module_aliases, expr_ql,
+            subject=subject_anchor,
+            constraint=constraint,
+            enforce_boolean=True,
             expr_context=expr_context)
 
         constraint.expr = expr_text

--- a/edb/lang/schema/derivable.py
+++ b/edb/lang/schema/derivable.py
@@ -72,6 +72,7 @@ class DerivableObjectBase:
 
         if mark_derived:
             derived.is_derived = True
+            derived.derived_from = self
 
         if add_to_schema:
             existing_derived = schema.get(derived.name, default=None)

--- a/edb/lang/schema/inheriting.py
+++ b/edb/lang/schema/inheriting.py
@@ -323,6 +323,8 @@ class InheritingObject(derivable.DerivableObject):
     is_abstract = so.Field(bool, default=False,
                            inheritable=False, compcoef=0.909)
     is_derived = so.Field(bool, False, compcoef=0.909)
+    derived_from = so.Field(so.NamedObject, None, compcoef=0.909,
+                            inheritable=False)
     is_final = so.Field(bool, default=False, compcoef=0.909)
     is_virtual = so.Field(bool, default=False, compcoef=0.5)
 
@@ -477,6 +479,12 @@ class InheritingObject(derivable.DerivableObject):
         super().finalize(schema, bases=bases, dctx=dctx)
         self.mro = compute_mro(self)[1:]
         self.acquire_ancestor_inheritance(schema, dctx=dctx)
+
+    def get_nearest_non_derived_parent(self):
+        obj = self
+        while obj.derived_from is not None:
+            obj = obj.derived_from
+        return obj
 
     @classmethod
     def get_root_classes(cls):

--- a/edb/lang/schema/nodes.py
+++ b/edb/lang/schema/nodes.py
@@ -107,6 +107,8 @@ class NodeCommand(named.NamedObjectCommand):
 
                 for vptr in view.own_pointers.values():
                     vschema.add(vptr)
+                    if not hasattr(vptr, 'own_pointers'):
+                        continue
                     for vlprop in vptr.own_pointers.values():
                         vschema.add(vlprop)
 

--- a/edb/lang/schema/utils.py
+++ b/edb/lang/schema/utils.py
@@ -250,7 +250,7 @@ def find_item_suggestions(
 
     suggestions = []
 
-    if collection:
+    if collection is not None:
         suggestions.extend(collection)
     else:
         if modname:

--- a/edb/server/pgsql/compiler/clauses.py
+++ b/edb/server/pgsql/compiler/clauses.py
@@ -107,7 +107,6 @@ def compile_filter_clause(
         if ctx1.stmt is ctx1.toplevel_stmt:
             ctx1.toplevel_clause = ctx1.clause
         ctx1.expr_exposed = False
-        ctx1.shape_format = context.ShapeFormat.SERIALIZED
 
         # In WHERE we compile ir.Set as a boolean disjunction:
         #    EXISTS(SELECT FROM SetRel WHERE SetRel.value)

--- a/edb/server/pgsql/compiler/clauses.py
+++ b/edb/server/pgsql/compiler/clauses.py
@@ -52,7 +52,7 @@ def compile_iterator_expr(
     with ctx.new() as subctx:
         subctx.rel = query
 
-        dispatch.compile(iterator_expr, ctx=subctx)
+        dispatch.visit(iterator_expr, ctx=subctx)
         iterator_rvar = relctx.get_path_rvar(
             query, iterator_expr.path_id, aspect='value', ctx=ctx)
         iterator_query = iterator_rvar.query
@@ -77,7 +77,7 @@ def compile_output(
         if newctx.expr_exposed is None:
             newctx.expr_exposed = True
 
-        dispatch.compile(ir_set, ctx=newctx)
+        dispatch.visit(ir_set, ctx=newctx)
 
         path_id = ir_set.path_id
 
@@ -111,7 +111,7 @@ def compile_filter_clause(
         # In WHERE we compile ir.Set as a boolean disjunction:
         #    EXISTS(SELECT FROM SetRel WHERE SetRel.value)
         with ctx1.subrel() as subctx:
-            dispatch.compile(ir_set, ctx=subctx)
+            dispatch.visit(ir_set, ctx=subctx)
             wrapper = subctx.rel
             wrapper.where_clause = pathctx.get_path_value_var(
                 wrapper, ir_set.path_id, env=subctx.env)

--- a/edb/server/pgsql/compiler/context.py
+++ b/edb/server/pgsql/compiler/context.py
@@ -56,10 +56,9 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.env = None
             self.argmap = collections.OrderedDict()
 
-            stmt = pgast.SelectStmt()
             self.toplevel_stmt = None
-            self.stmt = stmt
-            self.rel = stmt
+            self.stmt = None
+            self.rel = None
             self.rel_hierarchy = {}
             self.pending_query = None
 

--- a/edb/server/pgsql/compiler/context.py
+++ b/edb/server/pgsql/compiler/context.py
@@ -68,7 +68,6 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.volatility_ref = None
             self.group_by_rels = {}
 
-            self.shape_format = ShapeFormat.SERIALIZED
             self.disable_semi_join = set()
             self.unique_paths = set()
 
@@ -91,7 +90,6 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.volatility_ref = prevlevel.volatility_ref
             self.group_by_rels = prevlevel.group_by_rels
 
-            self.shape_format = prevlevel.shape_format
             self.disable_semi_join = prevlevel.disable_semi_join.copy()
             self.unique_paths = prevlevel.unique_paths.copy()
 

--- a/edb/server/pgsql/compiler/dbobj.py
+++ b/edb/server/pgsql/compiler/dbobj.py
@@ -262,7 +262,11 @@ def range_for_ptrcls(
 def range_for_pointer(
         pointer: s_links.Link, *,
         env: context.Environment) -> pgast.BaseRangeVar:
-    return range_for_ptrcls(pointer.ptrcls, pointer.direction, env=env)
+    ptrcls = pointer.ptrcls
+    if ptrcls.derived_from is not None:
+        ptrcls = ptrcls.get_nearest_non_derived_parent()
+
+    return range_for_ptrcls(ptrcls, pointer.direction, env=env)
 
 
 def range_from_queryset(

--- a/edb/server/pgsql/compiler/dispatch.py
+++ b/edb/server/pgsql/compiler/dispatch.py
@@ -28,6 +28,15 @@ from . import context
 
 @functools.singledispatch
 def compile(
-        ir: irast.Base, *, ctx: context.CompilerContextLevel) -> pgast.Base:
+        ir: irast.Base, *,
+        ctx: context.CompilerContextLevel) -> pgast.Base:
     raise NotImplementedError(
         f'no IR compiler handler for {ir.__class__}')
+
+
+@functools.singledispatch
+def visit(
+        ir: irast.Base, *,
+        ctx: context.CompilerContextLevel) -> None:
+    """A compilation version that does not pull the value eagerly."""
+    compile(ir, ctx=ctx)

--- a/edb/server/pgsql/compiler/dml.py
+++ b/edb/server/pgsql/compiler/dml.py
@@ -227,7 +227,7 @@ def get_dml_range(
             relctx.include_rvar(range_stmt, iterator_rvar,
                                 path_id=iterator_set.path_id, ctx=subctx)
 
-        dispatch.compile(target_ir_set, ctx=subctx)
+        dispatch.visit(target_ir_set, ctx=subctx)
 
         pathctx.get_path_identity_output(
             range_stmt, target_ir_set.path_id, env=subctx.env)
@@ -403,7 +403,7 @@ def process_insert_body(
                 pathctx.put_path_rvar_if_not_exists(
                     wrapper, rptr.source.path_id, insert_rvar,
                     aspect='value', env=scopectx.env)
-                dispatch.compile(shape_el, ctx=scopectx)
+                dispatch.visit(shape_el, ctx=scopectx)
                 tuple_el = astutils.tuple_element_for_shape_el(shape_el, None)
                 prop_elements.append(tuple_el)
 
@@ -432,7 +432,7 @@ def compile_insert_shape_element(
             insvalctx.volatility_ref = context.NO_VOLATILITY
 
         insvalctx.path_scope[ir_stmt.subject.path_id] = insert_stmt
-        dispatch.compile(shape_el, ctx=insvalctx)
+        dispatch.visit(shape_el, ctx=insvalctx)
 
     return insvalctx.rel
 
@@ -903,7 +903,7 @@ def process_link_values(
             input_rel_ctx.expr_exposed = False
             input_rel_ctx.volatility_ref = pathctx.get_path_identity_var(
                 row_query, ir_stmt.subject.path_id, env=input_rel_ctx.env)
-            dispatch.compile(ir_expr, ctx=input_rel_ctx)
+            dispatch.visit(ir_expr, ctx=input_rel_ctx)
             if ir_expr.shape:
                 shape_tuple = shapecomp.compile_shape(
                     ir_expr, ir_expr.shape, ctx=input_rel_ctx)

--- a/edb/server/pgsql/compiler/expr.py
+++ b/edb/server/pgsql/compiler/expr.py
@@ -77,7 +77,7 @@ def compile_Set(
         value = _compile_set(ir_set, ctx=ctx)
 
     if is_toplevel:
-        return output.top_output_as_value(value, env=ctx.env)
+        return output.top_output_as_value(ctx.rel, env=ctx.env)
     else:
         return output.output_as_value(value, env=ctx.env)
 
@@ -531,18 +531,14 @@ def _compile_set(
         ir_set: irast.Set, *,
         ctx: context.CompilerContextLevel) -> pgast.Base:
 
-    is_toplevel = ctx.toplevel_stmt is None
     relgen.get_set_rvar(ir_set, ctx=ctx)
 
     shape = _get_shape(ir_set, ctx=ctx)
     if shape:
         value = _compile_shape(ir_set, shape=shape, ctx=ctx)
     else:
-        if is_toplevel:
-            value = ctx.toplevel_stmt
-        else:
-            value = pathctx.get_path_var(
-                ctx.rel, ir_set.path_id, aspect='value', env=ctx.env)
+        value = pathctx.get_path_value_var(
+            ctx.rel, ir_set.path_id, env=ctx.env)
 
     return value
 

--- a/edb/server/pgsql/compiler/pathctx.py
+++ b/edb/server/pgsql/compiler/pathctx.py
@@ -188,6 +188,8 @@ def get_path_var(
         if alt_aspect is not None:
             rel_rvar = maybe_get_path_rvar(
                 rel, path_id, aspect=alt_aspect, env=env)
+    else:
+        alt_aspect = None
 
     if rel_rvar is None:
         if src_path_id.is_objtype_path():
@@ -218,6 +220,7 @@ def get_path_var(
         # check if there is a cached var with less specificity.
         var = rel.path_namespace.get((path_id, alt_aspect))
         if var is not None:
+            put_path_var(rel, path_id, var, aspect=aspect, env=env)
             return var
 
     if rel_rvar is None:
@@ -746,6 +749,7 @@ def get_path_output_or_null(
     if alt_aspect is not None:
         ref = maybe_get_path_output(rel, path_id, aspect=alt_aspect, env=env)
         if ref is not None:
+            rel.path_outputs[path_id, aspect] = ref
             return ref, False
 
     alias = env.aliases.get('null')

--- a/edb/server/pgsql/compiler/relctx.py
+++ b/edb/server/pgsql/compiler/relctx.py
@@ -292,9 +292,18 @@ def new_empty_rvar(
     null_ref = pgast.ColumnRef(name=[nullref_alias], nullable=True)
     pathctx.put_rvar_path_output(rvar, ir_set.path_id, aspect='value',
                                  var=null_ref, env=ctx.env)
+    pathctx.put_path_var(rvar, ir_set.path_id, aspect='value',
+                         var=null_ref, env=ctx.env)
     if ir_set.path_id.is_objtype_path():
         pathctx.put_rvar_path_output(rvar, ir_set.path_id, aspect='identity',
                                      var=null_ref, env=ctx.env)
+        pathctx.put_path_var(rvar, ir_set.path_id, aspect='identity',
+                             var=null_ref, env=ctx.env)
+
+        emptyrel = pgast.SelectStmt()
+        empty_rvar = dbobj.rvar_for_rel(emptyrel, env=ctx.env)
+        pathctx.put_path_rvar(nullrel, path_id=ir_set.path_id,
+                              rvar=empty_rvar, aspect='source', env=ctx.env)
     return rvar
 
 

--- a/edb/server/pgsql/compiler/relctx.py
+++ b/edb/server/pgsql/compiler/relctx.py
@@ -286,22 +286,21 @@ def new_empty_rvar(
         ],
         nullable=True
     )
+
+    emptyrel = pgast.SelectStmt()
+    empty_rvar = dbobj.rvar_for_rel(emptyrel, env=ctx.env)
+
     rvar = dbobj.rvar_for_rel(nullrel, env=ctx.env)
     rvar.path_scope.add(ir_set.path_id)
     rvar.value_scope.add(ir_set.path_id)
     null_ref = pgast.ColumnRef(name=[nullref_alias], nullable=True)
     pathctx.put_rvar_path_output(rvar, ir_set.path_id, aspect='value',
                                  var=null_ref, env=ctx.env)
-    pathctx.put_path_var(rvar, ir_set.path_id, aspect='value',
-                         var=null_ref, env=ctx.env)
+    pathctx.put_path_rvar(nullrel, ir_set.path_id, aspect='value',
+                          rvar=empty_rvar, env=ctx.env)
     if ir_set.path_id.is_objtype_path():
         pathctx.put_rvar_path_output(rvar, ir_set.path_id, aspect='identity',
                                      var=null_ref, env=ctx.env)
-        pathctx.put_path_var(rvar, ir_set.path_id, aspect='identity',
-                             var=null_ref, env=ctx.env)
-
-        emptyrel = pgast.SelectStmt()
-        empty_rvar = dbobj.rvar_for_rel(emptyrel, env=ctx.env)
         pathctx.put_path_rvar(nullrel, path_id=ir_set.path_id,
                               rvar=empty_rvar, aspect='source', env=ctx.env)
     return rvar

--- a/edb/server/pgsql/compiler/relctx.py
+++ b/edb/server/pgsql/compiler/relctx.py
@@ -551,17 +551,18 @@ def get_scope(
     if ir_set.path_scope_id is None:
         return None
     else:
-        return ctx.scope_tree.find_by_unique_id(ir_set.path_scope_id)
+        return ctx.scope_tree.root.find_by_unique_id(ir_set.path_scope_id)
 
 
 def update_scope(
         ir_set: irast.Set, stmt: pgast.Query, *,
         ctx: context.CompilerContextLevel) -> None:
 
-    scope_tree = ctx.scope_tree.root.find_by_unique_id(ir_set.path_scope_id)
+    scope_tree = get_scope(ir_set, ctx=ctx)
+    if scope_tree is None:
+        return
 
     ctx.scope_tree = scope_tree
-
     ctx.path_scope = ctx.path_scope.new_child()
     ctx.path_scope.update({p.path_id: stmt for p in scope_tree.path_children})
 

--- a/edb/server/pgsql/compiler/relgen.py
+++ b/edb/server/pgsql/compiler/relgen.py
@@ -1113,10 +1113,17 @@ def process_set_as_tuple(
                 ir_set.path_id, element.name,
                 ir_set.scls.element_types[element.name]
             )
+            stmt.view_path_id_map[path_id] = element.val.path_id
 
             dispatch.compile(element.val, ctx=subctx)
-            stmt.view_path_id_map[path_id] = element.val.path_id
             elements.append(pgast.TupleElement(path_id=path_id))
+
+            var = pathctx.maybe_get_path_var(
+                stmt, element.val.path_id,
+                aspect='serialized', env=subctx.env)
+            if var is not None:
+                pathctx.put_path_var(stmt, path_id, var,
+                                     aspect='serialized', env=subctx.env)
 
         set_expr = pgast.TupleVar(elements=elements, named=expr.named)
 

--- a/edb/server/pgsql/compiler/shapecomp.py
+++ b/edb/server/pgsql/compiler/shapecomp.py
@@ -1,0 +1,70 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+"""Compilation helpers for shapes."""
+
+import typing
+
+from edb.lang.ir import ast as irast
+from edb.lang.ir import utils as irutils
+
+from edb.lang.schema import objtypes as s_objtypes
+from edb.lang.schema import pointers as s_pointers
+
+from edb.server.pgsql import ast as pgast
+
+from . import astutils
+from . import context
+from . import dispatch
+from . import expr as expr_compiler  # NOQA
+from . import relgen
+
+
+def compile_shape(
+        ir_set: irast.Set, shape: typing.List[irast.Set], *,
+        ctx: context.CompilerContextLevel) -> pgast.TupleVar:
+    elements = []
+
+    with ctx.newscope() as shapectx:
+        shapectx.disable_semi_join.add(ir_set.path_id)
+        shapectx.unique_paths.add(ir_set.path_id)
+
+        for el in shape:
+            rptr = el.rptr
+            ptrcls = rptr.ptrcls
+            ptrdir = rptr.direction or s_pointers.PointerDirection.Outbound
+            is_singleton = ptrcls.singular(ptrdir)
+
+            if (irutils.is_subquery_set(el) or
+                    isinstance(el.scls, s_objtypes.ObjectType) or
+                    not is_singleton or
+                    not ptrcls.required):
+                wrapper = relgen.set_as_subquery(
+                    el, as_value=True, ctx=shapectx)
+                if not is_singleton:
+                    value = relgen.set_to_array(
+                        ir_set=el, query=wrapper, ctx=shapectx)
+                else:
+                    value = wrapper
+            else:
+                value = dispatch.compile(el, ctx=shapectx)
+
+            elements.append(astutils.tuple_element_for_shape_el(el, value))
+
+    return pgast.TupleVar(elements=elements, named=True)

--- a/edb/server/pgsql/compiler/stmt.py
+++ b/edb/server/pgsql/compiler/stmt.py
@@ -207,7 +207,7 @@ def compile_GroupStmt(
             pathctx.put_path_bond(gvquery, group_path_id)
 
             for group_set in stmt.groupby:
-                dispatch.compile(group_set, ctx=gvctx)
+                dispatch.visit(group_set, ctx=gvctx)
                 path_id = group_set.path_id
                 if path_id.is_objtype_path():
                     pathctx.put_path_bond(gvquery, path_id)

--- a/edb/server/pgsql/datasources/schema/links.py
+++ b/edb/server/pgsql/datasources/schema/links.py
@@ -31,6 +31,7 @@ async def fetch(
                 edgedb._resolve_type_name(l.spectargets) AS spectargets,
                 l.name AS name,
                 edgedb._resolve_type_name(l.bases) AS bases,
+                edgedb._resolve_type_name(l.derived_from) AS derived_from,
                 l.cardinality,
                 l.required,
                 l.computable,
@@ -38,6 +39,7 @@ async def fetch(
                 l.description,
                 l.is_abstract,
                 l.is_final,
+                l.is_derived,
                 l.readonly,
                 l.default
             FROM
@@ -55,6 +57,8 @@ async def fetch_properties(
                 p.name                  AS name,
                 edgedb._resolve_type_name(p.bases)
                                         AS bases,
+                edgedb._resolve_type_name(p.derived_from)
+                                        AS derived_from,
                 p.cardinality           AS cardinality,
                 p.title                 AS title,
                 p.description           AS description,
@@ -65,7 +69,11 @@ async def fetch_properties(
                 edgedb._resolve_type_name(p.source)
                                         AS source,
                 edgedb._resolve_type(p.target)
-                                        AS target
+                                        AS target,
+
+                p.is_abstract           AS is_abstract,
+                p.is_final              AS is_final,
+                p.is_derived            AS is_derived
             FROM
                 edgedb.Property p
             ORDER BY

--- a/edb/server/pgsql/intromech.py
+++ b/edb/server/pgsql/intromech.py
@@ -572,6 +572,11 @@ class IntrospectionMech:
             elif name != 'std::link':
                 bases = (sn.Name('std::link'), )
 
+            if r['derived_from']:
+                derived_from = schema.get(r['derived_from'])
+            else:
+                derived_from = None
+
             title = self.json_to_word_combination(r['title'])
             description = r['description']
 
@@ -599,6 +604,7 @@ class IntrospectionMech:
                 spectargets=spectargets, cardinality=cardinality,
                 required=required,
                 title=title, description=description,
+                derived_from=derived_from, is_derived=r['is_derived'],
                 is_abstract=r['is_abstract'], is_final=r['is_final'],
                 readonly=r['readonly'], computable=r['computable'],
                 default=default)
@@ -675,6 +681,11 @@ class IntrospectionMech:
             description = r['description']
             source = schema.get(r['source']) if r['source'] else None
 
+            if r['derived_from']:
+                derived_from = schema.get(r['derived_from'])
+            else:
+                derived_from = None
+
             default = self.unpack_default(r['default'])
 
             required = r['required']
@@ -690,7 +701,9 @@ class IntrospectionMech:
                 name=name, source=source, target=target, required=required,
                 title=title, description=description, readonly=r['readonly'],
                 computable=r['computable'], default=default,
-                cardinality=cardinality)
+                cardinality=cardinality, derived_from=derived_from,
+                is_derived=r['is_derived'], is_abstract=r['is_abstract'],
+                is_final=r['is_final'])
 
             if bases and bases[0] in {'std::target', 'std::source'}:
                 if bases[0] == 'std::target' and source is not None:

--- a/edb/server/pgsql/schemamech.py
+++ b/edb/server/pgsql/schemamech.py
@@ -169,12 +169,12 @@ class ConstraintMech:
             sql_expr = sql_tree
 
         if isinstance(tree, irast.Statement):
-            tree = tree.expr.expr
+            tree = tree.expr
 
-        if isinstance(tree, irast.SelectStmt):
-            is_multicol = isinstance(tree.result.expr, irast.Tuple)
-        else:
-            is_multicol = isinstance(tree.expr, irast.Tuple)
+        if isinstance(tree.expr, irast.SelectStmt):
+            tree = tree.expr.result
+
+        is_multicol = isinstance(tree.expr, irast.Tuple)
 
         # Determine if the sequence of references are all simple refs, not
         # expressions.  This influences the type of Postgres constraint used.

--- a/edb/server/protocol.py
+++ b/edb/server/protocol.py
@@ -237,14 +237,9 @@ class Protocol(asyncio.Protocol):
 
         if graphql:
             with timer.timeit('graphql_translation'):
-                modules = {
-                    m.name for m in
-                    self.backend.schema.get_modules()
-                } - {'schema', 'graphql'}
                 script = graphql_compiler.translate(
                     self.backend.schema, script,
-                    variables={},
-                    modules=modules) + ';'
+                    variables={}) + ';'
 
         with timer.timeit('parse_eql'):
             statements = edgeql.parse_block(script)

--- a/tests/schemas/cards_views_setup.eql
+++ b/tests/schemas/cards_views_setup.eql
@@ -81,6 +81,12 @@ CREATE VIEW test::DaveCard := (
 );
 
 
+CREATE VIEW test::AliasedFriends := (
+    WITH MODULE test
+    SELECT User { my_friends := User.friends, my_name := User.name }
+);
+
+
 CREATE VIEW test::expert_map := (
     SELECT {
         ('Alice', 'pro'),

--- a/tests/schemas/graphql.eschema
+++ b/tests/schemas/graphql.eschema
@@ -1,0 +1,49 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2018-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+abstract type NamedObject:
+    required property name -> str
+
+type UserGroup extending NamedObject:
+    link settings -> Setting:
+        cardinality := '1*'
+
+type Setting extending NamedObject:
+    required property value -> str
+
+type Profile extending NamedObject:
+    required property value -> str
+    property tags -> array<str>
+    property odd -> array<int64>:
+        cardinality := '1*'
+
+type User extending NamedObject:
+    required property active -> bool
+    link groups -> UserGroup:
+        cardinality := '**'
+    required property age -> int64
+    required property score -> float64
+    link profile -> Profile:
+        cardinality := '*1'
+
+type Person extending test::User
+
+type Foo:
+    property `select` -> str
+    property after -> str

--- a/tests/schemas/graphql_setup.eql
+++ b/tests/schemas/graphql_setup.eql
@@ -1,0 +1,74 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2018-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+WITH MODULE test
+INSERT Setting {
+    name := 'template',
+    value := 'blue'
+};
+
+WITH MODULE test
+INSERT Setting {
+    name := 'perks',
+    value := 'full'
+};
+
+WITH MODULE test
+INSERT UserGroup {
+    name := 'basic'
+};
+
+WITH MODULE test
+INSERT UserGroup {
+    name := 'upgraded'
+};
+
+WITH MODULE test
+INSERT User {
+    name := 'John',
+    age := 25,
+    active := True,
+    score := 3.14,
+    groups := (SELECT UserGroup FILTER UserGroup.name = 'basic')
+};
+
+WITH MODULE test
+INSERT User {
+    name := 'Jane',
+    age := 25,
+    active := True,
+    score := 1.23,
+    groups := (SELECT UserGroup FILTER UserGroup.name = 'upgraded')
+};
+
+WITH MODULE test
+INSERT User {
+    name := 'Alice',
+    age := 27,
+    active := True,
+    score := 5.0
+};
+
+WITH MODULE test
+INSERT Person {
+    name := 'Bob',
+    age := 21,
+    active := True,
+    score := 4.2
+};

--- a/tests/test_edgeql_coalesce.py
+++ b/tests/test_edgeql_coalesce.py
@@ -20,7 +20,6 @@
 import os.path
 import unittest
 
-from edb.client import exceptions as exc
 from edb.server import _testbase as tb
 
 
@@ -114,17 +113,17 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ],
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_coalesce_scalar_06(self):
-        with self.assertRaisesRegex(
-                exc.EdgeQLError, r'inconsistent path'):
-            await self.con.execute(r"""
-                WITH MODULE test
-                SELECT Issue.time_estimate ?? -1
-                # the FILTER is illegal because `Issue.time_estimate`
-                # is used only as an OPTIONAL argument in the outer scope
-                FILTER NOT EXISTS Issue.time_estimate;
-            """)
+        # The result is either an empty set if at least one
+        # estimate exists, or `-1` if no estimates exist.
+        # Our database contains one estimate.
+        await self.assert_query_result(r"""
+            WITH MODULE test
+            SELECT Issue.time_estimate ?? -1
+            FILTER NOT EXISTS Issue.time_estimate;
+        """, [
+            []
+        ])
 
     async def test_edgeql_coalesce_scalar_07(self):
         await self.assert_sorted_query_result(r'''

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -269,6 +269,16 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [['2', 'Open']]
         ])
 
+    async def test_edgeql_functions_array_agg_12(self):
+        await self.assert_query_result(r'''
+            WITH
+                MODULE test
+            SELECT
+                array_agg(User{name} ORDER BY User.name);
+        ''', [
+            [[{'name': 'Elvis'}, {'name': 'Yury'}]]
+        ])
+
     async def test_edgeql_functions_array_unpack_01(self):
         await self.assert_query_result(r'''
             SELECT [1, 2];

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -451,10 +451,12 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 .>(test::deck_cost)[IS std::int64]": {
                         "FENCE": {
                             "FENCE": {
-                                "ns~2@@(test::User).>(test::friends)\
-[IS test::User].>(test::deck)[IS test::Card].>(test::cost)[IS std::int64]": {
+                                "FENCE": {
                                     "ns~2@@(test::User).>(test::friends)\
+[IS test::User].>(test::deck)[IS test::Card].>(test::cost)[IS std::int64]": {
+                                        "ns~2@@(test::User).>(test::friends)\
 [IS test::User].>(test::deck)[IS test::Card]"
+                                    }
                                 }
                             }
                         }

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -798,6 +798,24 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             {2, 3},
         ])
 
+    async def test_edgeql_props_computable_01(self):
+        await self.assert_query_result(r'''
+            WITH MODULE test
+            SELECT User {
+                name,
+                my_deck := (SELECT Card { @foo := Card.name }
+                            FILTER .name = 'Djinn')
+            }
+            FILTER User.name = 'Alice';
+        ''', [
+            [{
+                'name': 'Alice',
+                'my_deck': {
+                    '@foo': 'Djinn'
+                }
+            }],
+        ])
+
     async def test_edgeql_props_agg_01(self):
         await self.assert_query_result(r'''
             WITH MODULE test

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -786,7 +786,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             [3, 'Alice'],
         ]])
 
-    @unittest.expectedFailure
     async def test_edgeql_props_setops_05(self):
         await self.assert_query_result(r'''
             WITH

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -91,7 +91,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_scope_tuple_03(self):
         # get the User names and ids
         res = await self.con.execute(r'''
@@ -103,7 +102,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ORDER BY User.name;
         ''')
 
-        # there's a bug that makes both User shapes the same one
         await self.assert_query_result(r'''
             WITH MODULE test
             SELECT _ := (User { name }, User { id })

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -115,7 +115,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_scope_tuple_04(self):
         await self.assert_query_result(r'''
             WITH MODULE test

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -172,7 +172,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_scope_tuple_05(self):
         await self.assert_query_result(r'''
             # Same as above, but with a computable instead of real "friends"

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -3616,7 +3616,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             {'t': [[1, 2], [3, 4]]},
         ]])
 
-    async def test_edgeql_select_struct_01(self):
+    async def test_edgeql_select_tuple_05(self):
         await self.assert_query_result(r"""
             WITH MODULE test
             SELECT (
@@ -3627,8 +3627,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'statuses': 2, 'issues': 4}],
         ])
 
-    async def test_edgeql_select_struct_02(self):
-        # Struct in a common set expr.
+    async def test_edgeql_select_tuple_06(self):
+        # Tuple in a common set expr.
         await self.assert_query_result(r"""
             WITH
                 MODULE test,
@@ -3642,8 +3642,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [6],
         ])
 
-    async def test_edgeql_select_struct_03(self):
-        # Object in a struct.
+    async def test_edgeql_select_tuple_07(self):
+        # Object in a tuple.
         await self.assert_query_result(r"""
             WITH
                 MODULE test,
@@ -3662,8 +3662,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ['2'],
         ])
 
-    async def test_edgeql_select_struct_04(self):
-        # Object in a struct returned directly.
+    async def test_edgeql_select_tuple_08(self):
+        # Object in a tuple returned directly.
         await self.assert_query_result(r"""
             WITH
                 MODULE test
@@ -3679,8 +3679,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             }],
         ])
 
-    async def test_edgeql_select_struct_05(self):
-        # Object in a struct referred to directly.
+    async def test_edgeql_select_tuple_09(self):
+        # Object in a tuple referred to directly.
         await self.assert_query_result(r"""
             WITH
                 MODULE test
@@ -3692,7 +3692,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ['Yury'],
         ])
 
-    async def test_edgeql_select_tuple_06(self):
+    async def test_edgeql_select_tuple_10(self):
         # Tuple comparison
         await self.assert_query_result(r"""
             WITH

--- a/tests/test_edgeql_views.py
+++ b/tests/test_edgeql_views.py
@@ -218,3 +218,30 @@ class TestEdgeQLViews(tb.QueryTestCase):
                 'deck_cost': 20
             }]
         ])
+
+    async def test_edgeql_computable_aliased_link_01(self):
+        await self.assert_query_result(r'''
+            WITH MODULE test
+            SELECT AliasedFriends {
+                my_name,
+                my_friends: {
+                    @nickname
+                } ORDER BY .name
+            }
+            FILTER .name = 'Alice';
+        ''', [
+            [{
+                'my_name': 'Alice',
+                'my_friends': [
+                    {
+                        '@nickname': 'Swampy'
+                    },
+                    {
+                        '@nickname': 'Firefighter'
+                    },
+                    {
+                        '@nickname': 'Grumpy'
+                    },
+                ]
+            }]
+        ])

--- a/tests/test_graphql_functional.py
+++ b/tests/test_graphql_functional.py
@@ -95,7 +95,7 @@ class TestGraphQLFunctional(tb.QueryTestCase):
     async def test_graphql_functional_query_03(self):
         result = await self.con.execute(r"""
             query {
-                User(name: "John") {
+                User(filter: {name: {eq: "John"}}) {
                     name
                     age
                     groups {
@@ -133,7 +133,7 @@ class TestGraphQLFunctional(tb.QueryTestCase):
 
         result = await self.con.execute(f"""
             query {{
-                User(id: "{alice['id']}") {{
+                User(filter: {{id: {{eq: "{alice['id']}"}}}}) {{
                     id
                     name
                     age
@@ -145,6 +145,180 @@ class TestGraphQLFunctional(tb.QueryTestCase):
             'User': [alice]
         }]])
 
+    async def test_graphql_functional_arguments_02(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    name: {eq: "Bob"},
+                    active: {eq: true},
+                    age: {eq: 21}
+                }) {
+                    name
+                    age
+                    groups {
+                        id
+                        name
+                    }
+                }
+            }
+        """, graphql=True)
+
+        self.assert_data_shape(result, [[{
+            'User': [{
+                'name': 'Bob',
+                'age': 21,
+                'groups': None,
+            }],
+        }]])
+
+    async def test_graphql_functional_arguments_03(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    and: [{name: {eq: "Bob"}}, {active: {eq: true}}],
+                    age: {eq: 21}
+                }) {
+                    name
+                    score
+                }
+            }
+        """, graphql=True)
+
+        self.assert_data_shape(result, [[{
+            'User': [{
+                'name': 'Bob',
+                'score': 4.2,
+            }],
+        }]])
+
+    async def test_graphql_functional_arguments_04(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    not: {name: {eq: "Bob"}},
+                    age: {eq: 21}
+                }) {
+                    name
+                    score
+                }
+            }
+        """, graphql=True)
+
+        self.assert_data_shape(result, [[{
+            'User': None,
+        }]])
+
+    async def test_graphql_functional_arguments_05(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    or: [
+                        {not: {name: {eq: "Bob"}}},
+                        {age: {eq: 20}}
+                    ]
+                }) {
+                    name
+                    score
+                }
+            }
+        """, graphql=True)
+
+        result[0][0]['User'].sort(key=lambda x: x['name'])
+        self.assert_data_shape(result, [[{
+            'User': [
+                {'name': 'Alice', 'score': 5},
+                {'name': 'Jane', 'score': 1.23},
+                {'name': 'John', 'score': 3.14},
+            ],
+        }]])
+
+    async def test_graphql_functional_arguments_06(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    or: [
+                        {name: {neq: "Bob"}},
+                        {age: {eq: 20}}
+                    ]
+                }) {
+                    name
+                    score
+                }
+            }
+        """, graphql=True)
+
+        result[0][0]['User'].sort(key=lambda x: x['name'])
+        self.assert_data_shape(result, [[{
+            'User': [
+                {'name': 'Alice', 'score': 5},
+                {'name': 'Jane', 'score': 1.23},
+                {'name': 'John', 'score': 3.14},
+            ],
+        }]])
+
+    async def test_graphql_functional_arguments_07(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    name: {ilike: "%o%"},
+                    age: {gt: 22}
+                }) {
+                    name
+                    age
+                }
+            }
+        """, graphql=True)
+
+        result[0][0]['User'].sort(key=lambda x: x['name'])
+        self.assert_data_shape(result, [[{
+            'User': [
+                {'name': 'John', 'age': 25},
+            ],
+        }]])
+
+    async def test_graphql_functional_arguments_08(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    name: {like: "J%"},
+                    score: {
+                        gte: 3
+                        lt: 4.5
+                    }
+                }) {
+                    name
+                    score
+                }
+            }
+        """, graphql=True)
+
+        result[0][0]['User'].sort(key=lambda x: x['name'])
+        self.assert_data_shape(result, [[{
+            'User': [
+                {'name': 'John', 'score': 3.14},
+            ],
+        }]])
+
+    async def test_graphql_functional_arguments_09(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    name: {ilike: "%e"},
+                    age: {lte: 25}
+                }) {
+                    name
+                    age
+                }
+            }
+        """, graphql=True)
+
+        result[0][0]['User'].sort(key=lambda x: x['name'])
+        self.assert_data_shape(result, [[{
+            'User': [
+                {'name': 'Jane', 'age': 25},
+            ],
+        }]])
+
     async def test_graphql_functional_fragment_02(self):
         result = await self.con.execute(r"""
             fragment userFrag on User {
@@ -153,7 +327,7 @@ class TestGraphQLFunctional(tb.QueryTestCase):
             }
 
             query {
-                NamedObject(name: "Alice") {
+                NamedObject(filter: {name: {eq: "Alice"}}) {
                     name
                     ... userFrag
                 }
@@ -187,27 +361,27 @@ class TestGraphQLFunctional(tb.QueryTestCase):
         self.assert_data_shape(result, [[{
             'User': [{
                 'name': 'Alice',
-                '__typename': 'User',
+                '__typename': 'UserType',
                 'groups': None
             }, {
                 'name': 'Bob',
-                '__typename': 'Person',
+                '__typename': 'PersonType',
                 'groups': None
             }, {
                 'name': 'Jane',
-                '__typename': 'User',
+                '__typename': 'UserType',
                 'groups': [{
                     'id': uuid.UUID,
                     'name': 'upgraded',
-                    '__typename': 'UserGroup',
+                    '__typename': 'UserGroupType',
                 }]
             }, {
                 'name': 'John',
-                '__typename': 'User',
+                '__typename': 'UserType',
                 'groups': [{
                     'id': uuid.UUID,
                     'name': 'basic',
-                    '__typename': 'UserGroup',
+                    '__typename': 'UserGroupType',
                 }]
             }],
         }]])


### PR DESCRIPTION
Rather than taking arguments corresponding to the individual fields, use
a single `filter` argument to specify the filtering conditions. This is
more generic and easier to add more functionality to in the future.

Notice that this is based on top of the "gql-types" branch, so you may want to review that one first..