### PR TITLE
graphql: Use a `filter` argument for more flexible filtering.

### DIFF
--- a/edb/lang/graphql/ast.py
+++ b/edb/lang/graphql/ast.py
@@ -89,7 +89,7 @@ class ListLiteral(Literal):
         return [val.topython() for val in self.value]
 
 
-class ObjectLiteral(Literal):
+class InputObjectLiteral(Literal):
     def topython(self):
         return {field.name: field.value.topython() for field in self.value}
 

--- a/edb/lang/graphql/codegen.py
+++ b/edb/lang/graphql/codegen.py
@@ -162,7 +162,7 @@ class GraphQLSourceGenerator(codegen.SourceGenerator):
         self._visit_list(node.value, separator=', ')
         self.write(']')
 
-    def visit_ObjectLiteral(self, node):
+    def visit_InputObjectLiteral(self, node):
         if node.value:
             self.write('{')
             self.new_lines = 1

--- a/edb/lang/graphql/parser/grammar/document.py
+++ b/edb/lang/graphql/parser/grammar/document.py
@@ -33,7 +33,7 @@ def check_const(expr):
     elif isinstance(expr, gqlast.ListLiteral):
         for val in expr.value:
             check_const(val)
-    elif isinstance(expr, gqlast.ObjectLiteral):
+    elif isinstance(expr, gqlast.InputObjectLiteral):
         for field in expr.value:
             check_const(field.value)
 
@@ -118,10 +118,10 @@ class BaseValue(Nonterm):
         self.val = gqlast.ListLiteral(value=kids[1].val)
 
     def reduce_LCBRACKET_RCBRACKET(self, *kids):
-        self.val = gqlast.ObjectLiteral(value={})
+        self.val = gqlast.InputObjectLiteral(value={})
 
     def reduce_LCBRACKET_ObjectFieldList_RCBRACKET(self, *kids):
-        self.val = gqlast.ObjectLiteral(value=kids[1].val)
+        self.val = gqlast.InputObjectLiteral(value=kids[1].val)
 
 
 class Value(Nonterm):

--- a/edb/lang/graphql/types.py
+++ b/edb/lang/graphql/types.py
@@ -23,7 +23,9 @@ from graphql import (
     GraphQLSchema,
     GraphQLObjectType,
     GraphQLInterfaceType,
+    GraphQLInputObjectType,
     GraphQLField,
+    GraphQLInputObjectField,
     GraphQLArgument,
     GraphQLList,
     GraphQLNonNull,
@@ -33,7 +35,9 @@ from graphql import (
     GraphQLBoolean,
     GraphQLID,
 )
+import itertools
 
+from edb.lang.common import ast
 from edb.lang.edgeql import ast as qlast
 from edb.lang.edgeql import codegen
 from edb.lang.edgeql.parser import parse_fragment
@@ -42,6 +46,8 @@ from edb.lang.schema import pointers as s_pointers
 from edb.lang.schema import types as s_types
 from edb.lang.schema.objtypes import ObjectType
 from edb.lang.schema.scalars import ScalarType
+
+from .errors import GraphQLCoreError
 
 
 EDB_TO_GQL_SCALARS_MAP = {
@@ -63,6 +69,18 @@ EDB_TO_GQL_SCALARS_MAP = {
 }
 
 
+GQL_TO_OPS_MAP = {
+    'eq': ast.ops.EQ,
+    'neq': ast.ops.NE,
+    'gt': ast.ops.GT,
+    'gte': ast.ops.GE,
+    'lt': ast.ops.LT,
+    'lte': ast.ops.LE,
+    'like': qlast.LIKE,
+    'ilike': qlast.ILIKE,
+}
+
+
 class GQLCoreSchema:
     def __init__(self, edb_schema):
         '''Create a graphql schema based on edgedb schema.'''
@@ -78,7 +96,7 @@ class GQLCoreSchema:
 
         self._gql_interfaces = {}
         self._gql_objtypes = {}
-        self._gql_fields = {}
+        self._gql_inobjtypes = {}
 
         self._define_types()
 
@@ -87,11 +105,16 @@ class GQLCoreSchema:
             fields=self.get_fields('Query'),
         )
 
-        self._gql_schema = GraphQLSchema(
-            query=query,
-            types=[objt for name, objt in self._gql_objtypes.items()
-                   if name != 'Query'],
-        )
+        # get a sorted list of types relevant for the Schema
+        types = [
+            objt for name, objt in
+            itertools.chain(self._gql_objtypes.items(),
+                            self._gql_inobjtypes.items())
+            # the Query is included separately
+            if name != 'Query'
+        ]
+        types = sorted(types, key=lambda x: x.name)
+        self._gql_schema = GraphQLSchema(query=query, types=types)
 
     def get_short_name(self, name):
         return name.split('::', 1)[-1]
@@ -142,7 +165,9 @@ class GQLCoreSchema:
                     continue
                 fields[name.split('::', 1)[1]] = GraphQLField(
                     GraphQLList(GraphQLNonNull(gqltype)),
-                    args=self.get_args(name),
+                    args={
+                        'filter': GraphQLArgument(self._gql_inobjtypes[name]),
+                    },
                 )
         else:
             edb_type = self.edb_schema.get(typename)
@@ -153,20 +178,35 @@ class GQLCoreSchema:
                 ptr = edb_type.resolve_pointer(self.edb_schema, name)
                 target = self._get_target(ptr)
                 if target:
-                    args = (self.get_args(ptr.target.name)
-                            if isinstance(ptr.target, ObjectType) else None)
+                    args = None
+                    if isinstance(ptr.target, ObjectType):
+                        args = {
+                            'filter': GraphQLArgument(
+                                self._gql_inobjtypes[ptr.target.name]),
+                        }
                     fields[name.name] = GraphQLField(target, args=args)
 
         return fields
 
     @lru_cache(maxsize=None)
-    def get_args(self, typename):
-        args = OrderedDict()
+    def get_input_fields(self, typename):
+        selftype = self._gql_inobjtypes[typename]
+        fields = OrderedDict()
+        fields['and'] = GraphQLInputObjectField(
+            GraphQLList(GraphQLNonNull(selftype)))
+        fields['or'] = GraphQLInputObjectField(
+            GraphQLList(GraphQLNonNull(selftype)))
+        fields['not'] = GraphQLInputObjectField(selftype)
 
         edb_type = self.edb_schema.get(typename)
         for name in sorted(edb_type.pointers, key=lambda x: x.name):
             if name.name == '__type__':
                 continue
+            if name.name in fields:
+                raise GraphQLCoreError(
+                    f"{name.name!r} of {typename} clashes with special "
+                    "reserved fields required for GraphQL conversion"
+                )
 
             ptr = edb_type.resolve_pointer(self.edb_schema, name)
 
@@ -174,14 +214,35 @@ class GQLCoreSchema:
                 continue
 
             target = self._convert_edb_type(ptr.target)
-            if target:
-                args[name.name] = GraphQLArgument(target)
+            intype = self._gql_inobjtypes.get(f'Filter{target.name}')
+            if intype:
+                fields[name.name] = GraphQLInputObjectField(intype)
 
-        return args
+        return fields
+
+    def define_generic_input_types(self):
+        eq = ['eq', 'neq']
+        comp = eq + ['gte', 'gt', 'lte', 'lt']
+        string = comp + ['like', 'ilike']
+
+        self._make_generic_input_type(GraphQLBoolean, eq)
+        self._make_generic_input_type(GraphQLID, eq)
+        self._make_generic_input_type(GraphQLInt, comp)
+        self._make_generic_input_type(GraphQLFloat, comp)
+        self._make_generic_input_type(GraphQLString, string)
+
+    def _make_generic_input_type(self, base, ops):
+        name = f'Filter{base.name}'
+        self._gql_inobjtypes[name] = GraphQLInputObjectType(
+            name=name,
+            fields={op: GraphQLInputObjectField(base) for op in ops},
+        )
 
     def _define_types(self):
         interface_types = []
         obj_types = []
+
+        self.define_generic_input_types()
 
         for modname in self.modules:
             # get all descendants of this abstract type
@@ -196,12 +257,20 @@ class GQLCoreSchema:
 
         # interfaces
         for t in interface_types:
+            short_name = self.get_short_name(t.name)
             gqltype = GraphQLInterfaceType(
-                name=self.get_short_name(t.name),
+                name=short_name,
                 fields=partial(self.get_fields, t.name),
                 resolve_type=lambda obj, info: obj,
             )
             self._gql_interfaces[t.name] = gqltype
+
+            # input object types corresponding to this interface
+            gqlintype = GraphQLInputObjectType(
+                name='Filter' + short_name,
+                fields=partial(self.get_input_fields, t.name),
+            )
+            self._gql_inobjtypes[t.name] = gqlintype
 
         # object types
         for t in obj_types:
@@ -216,8 +285,9 @@ class GQLCoreSchema:
                         st.name in self._gql_interfaces):
                     interfaces.append(self._gql_interfaces[st.name])
 
+            short_name = self.get_short_name(t.name)
             gqltype = GraphQLObjectType(
-                name=self.get_short_name(t.name) + 'Type',
+                name=short_name + 'Type',
                 fields=partial(self.get_fields, t.name),
                 interfaces=interfaces,
             )

--- a/edb/lang/schema/_graphql.eql
+++ b/edb/lang/schema/_graphql.eql
@@ -19,7 +19,7 @@
 
 CREATE FUNCTION graphql::short_name(std::str) -> std::str
     FROM EdgeQL $$
-        SELECT re_replace($0, '.+?::(.+$)', '\1')
+        SELECT re_replace($0, '.+?::(.+$)', '\1') + 'Type'
     $$;
 
 # create Query

--- a/tests/test_graphql_functional.py
+++ b/tests/test_graphql_functional.py
@@ -95,7 +95,7 @@ class TestGraphQLFunctional(tb.QueryTestCase):
     async def test_graphql_functional_query_03(self):
         result = await self.con.execute(r"""
             query {
-                User(name: "John") {
+                User(filter: {name: {eq: "John"}}) {
                     name
                     age
                     groups {
@@ -133,7 +133,7 @@ class TestGraphQLFunctional(tb.QueryTestCase):
 
         result = await self.con.execute(f"""
             query {{
-                User(id: "{alice['id']}") {{
+                User(filter: {{id: {{eq: "{alice['id']}"}}}}) {{
                     id
                     name
                     age
@@ -145,6 +145,180 @@ class TestGraphQLFunctional(tb.QueryTestCase):
             'User': [alice]
         }]])
 
+    async def test_graphql_functional_arguments_02(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    name: {eq: "Bob"},
+                    active: {eq: true},
+                    age: {eq: 21}
+                }) {
+                    name
+                    age
+                    groups {
+                        id
+                        name
+                    }
+                }
+            }
+        """, graphql=True)
+
+        self.assert_data_shape(result, [[{
+            'User': [{
+                'name': 'Bob',
+                'age': 21,
+                'groups': None,
+            }],
+        }]])
+
+    async def test_graphql_functional_arguments_03(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    and: [{name: {eq: "Bob"}}, {active: {eq: true}}],
+                    age: {eq: 21}
+                }) {
+                    name
+                    score
+                }
+            }
+        """, graphql=True)
+
+        self.assert_data_shape(result, [[{
+            'User': [{
+                'name': 'Bob',
+                'score': 4.2,
+            }],
+        }]])
+
+    async def test_graphql_functional_arguments_04(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    not: {name: {eq: "Bob"}},
+                    age: {eq: 21}
+                }) {
+                    name
+                    score
+                }
+            }
+        """, graphql=True)
+
+        self.assert_data_shape(result, [[{
+            'User': None,
+        }]])
+
+    async def test_graphql_functional_arguments_05(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    or: [
+                        {not: {name: {eq: "Bob"}}},
+                        {age: {eq: 20}}
+                    ]
+                }) {
+                    name
+                    score
+                }
+            }
+        """, graphql=True)
+
+        result[0][0]['User'].sort(key=lambda x: x['name'])
+        self.assert_data_shape(result, [[{
+            'User': [
+                {'name': 'Alice', 'score': 5},
+                {'name': 'Jane', 'score': 1.23},
+                {'name': 'John', 'score': 3.14},
+            ],
+        }]])
+
+    async def test_graphql_functional_arguments_06(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    or: [
+                        {name: {neq: "Bob"}},
+                        {age: {eq: 20}}
+                    ]
+                }) {
+                    name
+                    score
+                }
+            }
+        """, graphql=True)
+
+        result[0][0]['User'].sort(key=lambda x: x['name'])
+        self.assert_data_shape(result, [[{
+            'User': [
+                {'name': 'Alice', 'score': 5},
+                {'name': 'Jane', 'score': 1.23},
+                {'name': 'John', 'score': 3.14},
+            ],
+        }]])
+
+    async def test_graphql_functional_arguments_07(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    name: {ilike: "%o%"},
+                    age: {gt: 22}
+                }) {
+                    name
+                    age
+                }
+            }
+        """, graphql=True)
+
+        result[0][0]['User'].sort(key=lambda x: x['name'])
+        self.assert_data_shape(result, [[{
+            'User': [
+                {'name': 'John', 'age': 25},
+            ],
+        }]])
+
+    async def test_graphql_functional_arguments_08(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    name: {like: "J%"},
+                    score: {
+                        gte: 3
+                        lt: 4.5
+                    }
+                }) {
+                    name
+                    score
+                }
+            }
+        """, graphql=True)
+
+        result[0][0]['User'].sort(key=lambda x: x['name'])
+        self.assert_data_shape(result, [[{
+            'User': [
+                {'name': 'John', 'score': 3.14},
+            ],
+        }]])
+
+    async def test_graphql_functional_arguments_09(self):
+        result = await self.con.execute(r"""
+            query {
+                User(filter: {
+                    name: {ilike: "%e"},
+                    age: {lte: 25}
+                }) {
+                    name
+                    age
+                }
+            }
+        """, graphql=True)
+
+        result[0][0]['User'].sort(key=lambda x: x['name'])
+        self.assert_data_shape(result, [[{
+            'User': [
+                {'name': 'Jane', 'age': 25},
+            ],
+        }]])
+
     async def test_graphql_functional_fragment_02(self):
         result = await self.con.execute(r"""
             fragment userFrag on User {
@@ -153,7 +327,7 @@ class TestGraphQLFunctional(tb.QueryTestCase):
             }
 
             query {
-                NamedObject(name: "Alice") {
+                NamedObject(filter: {name: {eq: "Alice"}}) {
                     name
                     ... userFrag
                 }
@@ -187,27 +361,27 @@ class TestGraphQLFunctional(tb.QueryTestCase):
         self.assert_data_shape(result, [[{
             'User': [{
                 'name': 'Alice',
-                '__typename': 'User',
+                '__typename': 'UserType',
                 'groups': None
             }, {
                 'name': 'Bob',
-                '__typename': 'Person',
+                '__typename': 'PersonType',
                 'groups': None
             }, {
                 'name': 'Jane',
-                '__typename': 'User',
+                '__typename': 'UserType',
                 'groups': [{
                     'id': uuid.UUID,
                     'name': 'upgraded',
-                    '__typename': 'UserGroup',
+                    '__typename': 'UserGroupType',
                 }]
             }, {
                 'name': 'John',
-                '__typename': 'User',
+                '__typename': 'UserType',
                 'groups': [{
                     'id': uuid.UUID,
                     'name': 'basic',
-                    '__typename': 'UserGroup',
+                    '__typename': 'UserGroupType',
                 }]
             }],
         }]])


### PR DESCRIPTION
Rather than taking arguments corresponding to the individual fields, use
a single `filter` argument to specify the filtering conditions. This is
more generic and easier to add more functionality to in the future.