### PR TITLE
Strengthen nullability checks in the query compiler

### DIFF
--- a/edb/lang/ir/scopetree.py
+++ b/edb/lang/ir/scopetree.py
@@ -379,10 +379,12 @@ class ScopeTreeNode:
         if node is not None:
             node.optional = True
 
-    def is_optional(self, path_id):
+    def is_optional(self, path_id) -> bool:
         node = self.find_visible(path_id)
         if node is not None:
             return node.optional
+        else:
+            return False
 
     def remove(self):
         """Remove this node from the tree (subtree becomes independent)."""

--- a/edb/server/pgsql/codegen.py
+++ b/edb/server/pgsql/codegen.py
@@ -121,6 +121,20 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         self.new_lines = 1
         self.write(')')
 
+    def visit_NullRelation(self, node):
+        self.write('(SELECT ')
+        if node.target_list:
+            self.visit_list(node.target_list)
+        if node.where_clause:
+            self.indentation += 1
+            self.new_lines = 1
+            self.write('WHERE')
+            self.new_lines = 1
+            self.indentation += 1
+            self.visit(node.where_clause)
+            self.indentation -= 2
+        self.write(')')
+
     def visit_SelectStmt(self, node):
         if node.values:
             self._visit_values_expr(node)
@@ -390,7 +404,7 @@ class SQLSourceGenerator(codegen.SourceGenerator):
     def visit_RangeVar(self, node):
         rel = node.relation
 
-        if isinstance(rel, pgast.Relation):
+        if isinstance(rel, (pgast.Relation, pgast.NullRelation)):
             self.visit(rel)
         elif isinstance(rel, pgast.CommonTableExpr):
             self.write(common.quote_ident(rel.name))

--- a/edb/server/pgsql/compiler/dml.py
+++ b/edb/server/pgsql/compiler/dml.py
@@ -822,7 +822,7 @@ def process_linkprop_update(
     cond = astutils.new_binop(
         pathctx.get_rvar_path_identity_var(
             dml_cte_rvar, ir_stmt.subject.path_id, env=ctx.env),
-        dbobj.get_column(target_tab, 'std::source'),
+        dbobj.get_column(target_tab, 'std::source', nullable=False),
         ast.ops.EQ
     )
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -755,7 +755,6 @@ class TestExpressions(tb.QueryTestCase):
                 SELECT [1, 2] + [3, 4];
             ''')
 
-    @unittest.expectedFailure
     async def test_edgeql_expr_array_06(self):
         await self.assert_query_result('''
             SELECT [1, <int64>{}];
@@ -763,7 +762,6 @@ class TestExpressions(tb.QueryTestCase):
             [],
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_expr_array_07(self):
         await self.assert_query_result('''
             WITH
@@ -1168,7 +1166,6 @@ class TestExpressions(tb.QueryTestCase):
             [[1, ['a', 'b', [0.1, 0.2]], 2, 3]],
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_expr_tuple_14(self):
         await self.assert_query_result('''
             SELECT (1, <int64>{});
@@ -1176,7 +1173,6 @@ class TestExpressions(tb.QueryTestCase):
             [],
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_expr_tuple_15(self):
         await self.assert_query_result('''
             WITH

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -570,7 +570,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_scope_tuple_12(self):
         await self.assert_query_result(r'''
             # this is similar to test_edgeql_scope_tuple_04


### PR DESCRIPTION
This round of fixes addresses specifically the handling of empty set
literals and empty set expressions within tuples.

Fixes: #202.