### PR TITLE
Postpone expression cardinality analysis until scope tree is complete

### DIFF
--- a/edb/lang/edgeql/compiler/clauses.py
+++ b/edb/lang/edgeql/compiler/clauses.py
@@ -27,8 +27,8 @@ from edb.lang.ir import ast as irast
 
 from . import context
 from . import dispatch
-from . import pathctx
 from . import setgen
+from . import stmtctx
 
 
 def compile_where_clause(
@@ -68,7 +68,7 @@ def compile_orderby_clause(
                 ir_sortexpr = dispatch.compile(sortexpr.path, ctx=exprctx)
                 ir_sortexpr = setgen.scoped_set(ir_sortexpr, ctx=exprctx)
                 ir_sortexpr.context = sortexpr.context
-                pathctx.enforce_singleton(ir_sortexpr, ctx=exprctx)
+                stmtctx.enforce_singleton(ir_sortexpr, ctx=exprctx)
 
             result.append(
                 irast.SortExpr(
@@ -89,7 +89,7 @@ def compile_limit_offset_clause(
             int_t = ctx.schema.get('std::int64')
             ir_set = setgen.scoped_set(ir_expr, typehint=int_t, ctx=subctx)
             ir_set.context = expr.context
-            pathctx.enforce_singleton(ir_set, ctx=subctx)
+            stmtctx.enforce_singleton(ir_set, ctx=subctx)
     else:
         ir_set = None
 

--- a/edb/lang/edgeql/compiler/pathctx.py
+++ b/edb/lang/edgeql/compiler/pathctx.py
@@ -23,7 +23,6 @@
 import typing
 
 from edb.lang.ir import ast as irast
-from edb.lang.ir import inference as irinference
 
 from edb.lang.schema import objects as s_obj
 
@@ -88,17 +87,3 @@ def set_path_alias(
         path_id: irast.PathId, alias: irast.PathId, *,
         ctx: context.CompilerContext) -> None:
     ctx.path_scope.set_alias(path_id, alias)
-
-
-def infer_cardinality(
-        expr: irast.Base, *, ctx: context.ContextLevel) -> irast.Cardinality:
-    return irinference.infer_cardinality(expr, ctx.path_scope, ctx.schema)
-
-
-def enforce_singleton(expr: irast.Base, *, ctx: context.ContextLevel) -> None:
-    cardinality = infer_cardinality(expr, ctx=ctx)
-    if cardinality != irast.Cardinality.ONE:
-        raise errors.EdgeQLError(
-            'possibly more than one element returned by an expression '
-            'where only singletons are allowed',
-            context=expr.context)

--- a/edb/lang/ir/inference/cardinality.py
+++ b/edb/lang/ir/inference/cardinality.py
@@ -91,8 +91,14 @@ def __infer_typeref(ir, scope_tree, schema):
 @_infer_cardinality.register(irast.Set)
 def __infer_set(ir, scope_tree, schema):
     parent_fence = scope_tree.parent_fence
-    if parent_fence is not None and parent_fence.is_visible(ir.path_id):
-        return ONE
+    if parent_fence is not None:
+        if scope_tree.namespaces:
+            path_id = ir.path_id.strip_namespace(scope_tree.namespaces)
+        else:
+            path_id = ir.path_id
+
+        if parent_fence.is_visible(path_id):
+            return ONE
 
     if ir.rptr is not None:
         if ir.rptr.ptrcls.singular(ir.rptr.direction):

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -60,14 +60,14 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ORDER BY _.1 THEN _.0.name;
         ''', [
             [
-                [{'a': [1], 'name': 'Alice'}, 1],
-                [{'a': [1], 'name': 'Bob'}, 1],
-                [{'a': [1], 'name': 'Carol'}, 1],
-                [{'a': [1], 'name': 'Dave'}, 1],
-                [{'a': [2], 'name': 'Alice'}, 2],
-                [{'a': [2], 'name': 'Bob'}, 2],
-                [{'a': [2], 'name': 'Carol'}, 2],
-                [{'a': [2], 'name': 'Dave'}, 2],
+                [{'a': 1, 'name': 'Alice'}, 1],
+                [{'a': 1, 'name': 'Bob'}, 1],
+                [{'a': 1, 'name': 'Carol'}, 1],
+                [{'a': 1, 'name': 'Dave'}, 1],
+                [{'a': 2, 'name': 'Alice'}, 2],
+                [{'a': 2, 'name': 'Bob'}, 2],
+                [{'a': 2, 'name': 'Carol'}, 2],
+                [{'a': 2, 'name': 'Dave'}, 2],
             ]
         ])
 
@@ -191,7 +191,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 [
                     {
                         'name': 'Alice',
-                        'fr': [{'@nickname': 'Swampy'}],
+                        'fr': {'@nickname': 'Swampy'},
                     },
                     {
                         'name': 'Bob',
@@ -200,7 +200,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 [
                     {
                         'name': 'Alice',
-                        'fr': [{'@nickname': 'Firefighter'}],
+                        'fr': {'@nickname': 'Firefighter'},
                     },
                     {
                         'name': 'Carol',
@@ -209,7 +209,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 [
                     {
                         'name': 'Alice',
-                        'fr': [{'@nickname': 'Grumpy'}],
+                        'fr': {'@nickname': 'Grumpy'},
                     },
                     {
                         'name': 'Dave',
@@ -218,7 +218,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 [
                     {
                         'name': 'Dave',
-                        'fr': [{'@nickname': None}],
+                        'fr': {'@nickname': None},
                     },
                     {
                         'name': 'Bob',
@@ -243,9 +243,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 [
                     {
                         'name': 'Alice',
-                        'foo': [
-                            {'name': 'Alice'},
-                        ],
+                        'foo': {'name': 'Alice'},
                     },
                     {
                         'name': 'Alice',
@@ -254,9 +252,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 [
                     {
                         'name': 'Bob',
-                        'foo': [
-                            {'name': 'Alice'},
-                        ],
+                        'foo': {'name': 'Alice'},
                     },
                     {
                         'name': 'Alice',
@@ -265,9 +261,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 [
                     {
                         'name': 'Carol',
-                        'foo': [
-                            {'name': 'Alice'},
-                        ],
+                        'foo': {'name': 'Alice'},
                     },
                     {
                         'name': 'Alice',
@@ -276,9 +270,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 [
                     {
                         'name': 'Dave',
-                        'foo': [
-                            {'name': 'Alice'},
-                        ],
+                        'foo': {'name': 'Alice'},
                     },
                     {
                         'name': 'Alice',
@@ -320,7 +312,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_scope_tuple_08(self):
         await self.assert_query_result(r'''
             # compare to test_edgeql_scope_filter_03 to see how it
@@ -328,7 +319,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             WITH
                 MODULE test,
                 U2 := User
-            SELECT _ := (
+            SELECT (
                 User {
                     name,
                     friends_of_others := (
@@ -347,7 +338,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 }
             )
             FILTER U2.friends.name = 'Bob'
-            ORDER BY _.0.name THEN _.1;
+            ORDER BY User.name THEN U2.friends.name;
         ''', [
             [
                 [
@@ -371,9 +362,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 [
                     {
                         'name': 'Carol',
-                        'friends_of_others': [
-                            {'name': 'Bob'},
-                        ],
+                        'friends_of_others': {'name': 'Bob'},
                     },
                     {
                         'name': 'Bob',
@@ -445,9 +434,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 [
                     {
                         'name': 'Carol',
-                        'friends_of_others': [
-                            {'name': 'Bob'},
-                        ],
+                        'friends_of_others': {'name': 'Bob'},
                     },
                     {
                         'name': 'Bob',
@@ -502,7 +489,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             [2.25],
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_scope_tuple_11(self):
         await self.assert_query_result(r'''
             WITH MODULE test


### PR DESCRIPTION
Currently, cardinality inference is happening at the same time as the
expression is compiled.  This is problematic, since there are cases
where the scope tree can be modified by further processing of the
expression, which could affect the inference result.  The most common
such case is expressions in tuples.

To avoid possible inconsistencies, postpone the cardinality inference
until the very end of statement compilation when the scope tree is
complete and final.