### PR TITLE
Untangle handling of scope in views

### DIFF
--- a/edb/lang/edgeql/compiler/schemactx.py
+++ b/edb/lang/edgeql/compiler/schemactx.py
@@ -138,11 +138,6 @@ def derive_view(
             ctx.schema, source, target, *qualifiers, name=derived_name,
             mark_derived=True)
     else:
-        # If this is already a derived class, reuse its name,
-        # so that the correct storage relations are used in DML.
-        if derived_name is None:
-            derived_name = scls.name
-
         derived = scls.derive_copy(
             ctx.schema, source, target, *qualifiers, name=derived_name,
             attrs=dict(bases=[scls]), mark_derived=True)

--- a/edb/lang/ir/scopetree.py
+++ b/edb/lang/ir/scopetree.py
@@ -99,14 +99,17 @@ class ScopeTreeNode:
 
     @property
     def name(self):
+        return self._name(debug=False)
+
+    def _name(self, debug):
         if self.path_id is None:
             return f'FENCE' if self.fenced else f'BRANCH'
         else:
-            return f'{self.path_id}{" [OPT]" if self.optional else ""}'
+            pid = self.path_id.pformat_internal(debug=debug)
+            return f'{pid}{" [OPT]" if self.optional else ""}'
 
-    @property
-    def debugname(self):
-        parts = [f'{self.name}']
+    def debugname(self, fuller=False):
+        parts = [f'{self._name(debug=fuller)}']
         if self.unique_id:
             parts.append(f'uid:{self.unique_id}')
         if self.namespaces:
@@ -520,7 +523,7 @@ class ScopeTreeNode:
         else:
             return ''
 
-    def pdebugformat(self):
+    def pdebugformat(self, fuller=False):
         if self.children:
             child_formats = []
             for c in self.children:
@@ -530,9 +533,9 @@ class ScopeTreeNode:
 
             child_formats = sorted(child_formats)
             children = textwrap.indent(',\n'.join(child_formats), '    ')
-            return f'"{self.debugname}": {{\n{children}\n}}'
+            return f'"{self.debugname(fuller=fuller)}": {{\n{children}\n}}'
         else:
-            return f'"{self.debugname}"'
+            return f'"{self.debugname(fuller=fuller)}"'
 
     def _set_parent(self, parent):
         current_parent = self.parent

--- a/edb/server/pgsql/compiler/relctx.py
+++ b/edb/server/pgsql/compiler/relctx.py
@@ -554,9 +554,17 @@ def update_scope(
     ctx.path_scope = ctx.path_scope.new_child()
     ctx.path_scope.update({p.path_id: stmt for p in scope_tree.path_children})
 
+    if (isinstance(ir_set.expr, irast.Stmt) and
+            ir_set.expr.iterator_stmt is not None):
+        iter_path_id = ir_set.expr.iterator_stmt.path_id
+    else:
+        iter_path_id = None
+
     for child_path in scope_tree.get_all_paths():
         parent_scope = scope_tree.parent
-        if parent_scope is None or not parent_scope.is_visible(child_path):
+        if ((parent_scope is None or
+                not parent_scope.is_visible(child_path)) and
+                child_path != iter_path_id):
             stmt.path_id_mask.add(child_path)
 
 

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -239,3 +239,28 @@ class TestEdgeQLFor(tb.QueryTestCase):
                 'Sprite',
             }
         ])
+
+    async def test_edgeql_for_in_computable_01(self):
+        await self.assert_query_result(r'''
+            WITH MODULE test
+            SELECT User {
+                select_deck := (
+                    FOR letter IN {'I', 'B'}
+                    UNION _ := (
+                        SELECT User.deck {
+                            name,
+                            @letter := letter
+                        }
+                        FILTER User.deck.name[0] = letter
+                    )
+                    ORDER BY _.name
+                )
+            } FILTER .name = 'Alice';
+        ''', [[
+            {
+                'select_deck': [
+                    {'name': 'Bog monster', '@letter': 'B'},
+                    {'name': 'Imp', '@letter': 'I'},
+                ]
+            }
+        ]])

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -818,8 +818,7 @@ class TestInsert(tb.QueryTestCase):
             ]
         )
 
-    @unittest.expectedFailure
-    async def test_edgeql_insert_linkprops_01(self):
+    async def test_edgeql_insert_linkprops_with_for_01(self):
         await self.assert_query_result(r"""
             WITH MODULE test
             FOR i IN {'1', '2', '3'} UNION (
@@ -846,9 +845,9 @@ class TestInsert(tb.QueryTestCase):
                     name,
                     @comment,
                 } ORDER BY InsertTest.subordinates.name
-            };
+            } FILTER .l2 = 99;
         """, [
-            {3},
+            [{}, ...],
             {1},
             [{
                 'l2': 99,


### PR DESCRIPTION
This round fixes a number of long-standing warts in the handling of
complex scope scenarios in the presence of query iterator
(`FOR` statements), inline expression aliases (`SELECT foo := ...`)
and computables in general.

The main changes here are improving the consistency of scope namespace
handling, as well as explicit disambiguation of computable pointer
paths, so in `SELECT User { name := lower(User.name) }` the shape
element `User.name` and the `User.name` reference in the computable
expression have different path ids.

Inline expression aliases are no longer treated as equivalent to a
`WITH` clause view, because that breaks `FOR` statements
(the iterator alias follows the `WITH` clause logically, hence
the views there cannot refer to the iterator symbol).  The SQL compiler
has also been fixed to handle shaped computables containing a `FOR`
expression.

Finally, view types defined by nested shapes are no longer created
twice, which should improve compiler performance on queries with lots of
nested shapes.