### PR TITLE
Implement new syntax for function parameters

### DIFF
--- a/edb/lang/edgeql/ast.py
+++ b/edb/lang/edgeql/ast.py
@@ -117,8 +117,13 @@ AggNONE = SetModifier.NONE
 class SetQualifier(s_enum.StrEnum):
     SET_OF = 'SET OF'
     OPTIONAL = 'OPTIONAL'
-    VARIADIC = 'VARIADIC'
     DEFAULT = ''
+
+
+class ParameterKind(s_enum.StrEnum):
+    VARIADIC = 'VARIADIC'
+    NAMED_ONLY = 'NAMED ONLY'
+    POSITIONAL = 'POSITIONAL'
 
 
 class Cardinality(s_enum.StrEnum):
@@ -274,6 +279,7 @@ class FuncParam(Base):
     name: str
     type: TypeExpr
     qualifier: SetQualifier = SetQualifier.DEFAULT
+    kind: ParameterKind
     default: Expr  # noqa (pyflakes bug)
 
 

--- a/edb/lang/edgeql/parser/grammar/expressions.py
+++ b/edb/lang/edgeql/parser/grammar/expressions.py
@@ -832,7 +832,7 @@ class ArgConstant(Nonterm):
     def reduce_DOLLAR_ICONST(self, *kids):
         self.val = qlast.Parameter(name=str(kids[1].val))
 
-    def reduce_DOLLAR_Identifier(self, *kids):
+    def reduce_DOLLAR_AnyIdentifier(self, *kids):
         self.val = qlast.Parameter(name=kids[1].val)
 
 
@@ -996,8 +996,8 @@ class FuncArgExpr(Nonterm):
     def reduce_Expr(self, *kids):
         self.val = qlast.FuncArg(arg=kids[0].val)
 
-    def reduce_Identifier_TURNSTILE_Expr(self, *kids):
-        self.val = qlast.FuncArg(name=kids[0].val, arg=kids[2].val)
+    def reduce_DOLLAR_AnyIdentifier_TURNSTILE_Expr(self, *kids):
+        self.val = qlast.FuncArg(name=kids[1].val, arg=kids[3].val)
 
 
 class FuncArg(Nonterm):

--- a/edb/lang/edgeql/parser/grammar/keywords.py
+++ b/edb/lang/edgeql/parser/grammar/keywords.py
@@ -54,8 +54,10 @@ unreserved_keywords = frozenset([
     "last",
     "link",
     "migration",
+    "named",
     "of",
     "on",
+    "only",
     "policy",
     "property",
     "rename",
@@ -70,6 +72,7 @@ unreserved_keywords = frozenset([
     "type",
     "using",
     "value",
+    "variadic",
     "view",
 ])
 
@@ -126,7 +129,6 @@ reserved_keywords = frozenset([
     "typeof",
     "update",
     "union",
-    "variadic",
     "with",
 ])
 

--- a/edb/lang/edgeql/quote.py
+++ b/edb/lang/edgeql/quote.py
@@ -47,10 +47,11 @@ def dollar_quote_literal(text):
     return quote + text + quote
 
 
-def disambiguate_identifier(text):
+def disambiguate_identifier(text, *, allow_reserved=False):
+    reserved = keywords.by_type[keywords.RESERVED_KEYWORD]
     if (text.lower() != '__type__' and
-        (keywords.by_type[keywords.RESERVED_KEYWORD].get(text.lower()) or
-         not _re_ident.fullmatch(text))):
+            ((not allow_reserved and reserved.get(text.lower())) or
+                not _re_ident.fullmatch(text))):
         return '`{}`'.format(text)
     else:
         return text

--- a/edb/lang/schema/_graphql.eql
+++ b/edb/lang/schema/_graphql.eql
@@ -17,9 +17,9 @@
 #
 
 
-CREATE FUNCTION graphql::short_name(std::str) -> std::str
+CREATE FUNCTION graphql::short_name($name: std::str) -> std::str
     FROM EdgeQL $$
-        SELECT re_replace($0, '.+?::(.+$)', '\1') + 'Type'
+        SELECT re_replace($name, '.+?::(.+$)', '\1') + 'Type'
     $$;
 
 # create Query

--- a/edb/lang/schema/_std.eql
+++ b/edb/lang/schema/_std.eql
@@ -94,38 +94,39 @@ CREATE ABSTRACT ATTRIBUTE stdattrs::from_function std::str;
 CREATE ABSTRACT ATTRIBUTE stdattrs::initial_value std::str;
 CREATE ABSTRACT ATTRIBUTE stdattrs::varparam std::int64;
 
-CREATE FUNCTION std::lower(std::str) -> std::str
+CREATE FUNCTION std::lower($str: std::str) -> std::str
     FROM SQL FUNCTION 'lower';
 
-CREATE FUNCTION std::sum(SET OF std::int64) -> std::int64 {
+CREATE FUNCTION std::sum($set: SET OF std::int64) -> std::int64 {
     INITIAL VALUE 0;
     FROM SQL FUNCTION 'sum';
 };
 
-CREATE FUNCTION std::sum(SET OF std::float64) -> std::float64 {
+CREATE FUNCTION std::sum($set: SET OF std::float64) -> std::float64 {
     INITIAL VALUE 0;
     FROM SQL FUNCTION 'sum';
 };
 
-CREATE FUNCTION std::count(SET OF std::any) -> std::int64 {
+CREATE FUNCTION std::count($set: SET OF std::any) -> std::int64 {
     INITIAL VALUE 0;
     FROM SQL FUNCTION 'count';
 };
 
-CREATE FUNCTION std::array_agg(SET OF std::any) -> array<std::any> {
+CREATE FUNCTION std::array_agg($set: SET OF std::any) -> array<std::any> {
     INITIAL VALUE [];
     FROM SQL FUNCTION 'array_agg';
 };
 
-CREATE FUNCTION std::is_distinct(SET OF std::any) -> std::bool {
+CREATE FUNCTION std::is_distinct($set: SET OF std::any) -> std::bool {
     INITIAL VALUE True;
     FROM SQL FUNCTION '--system--';
 };
 
-CREATE FUNCTION std::array_unpack(array<std::any>) -> SET OF std::any
+CREATE FUNCTION std::array_unpack($array: array<std::any>) -> SET OF std::any
     FROM SQL FUNCTION '--system--';
 
-CREATE FUNCTION std::array_contains(array<std::any>, std::any) -> std::bool
+CREATE FUNCTION std::array_contains($array: array<std::any>,
+                                    $what: std::any) -> std::bool
     FROM SQL $$
         SELECT
             CASE
@@ -134,13 +135,13 @@ CREATE FUNCTION std::array_contains(array<std::any>, std::any) -> std::bool
             END;
     $$;
 
-CREATE FUNCTION std::array_enumerate(array<std::any>) ->
+CREATE FUNCTION std::array_enumerate($array: array<std::any>) ->
         SET OF tuple<std::any, std::int64>
     FROM SQL FUNCTION '--system--';
 
 # TODO: this function will later also take a
 #       NAMED ONLY $default: any = <any>{}
-CREATE FUNCTION std::array_get(array<std::any>, std::int64)
+CREATE FUNCTION std::array_get($array: array<std::any>, $index: std::int64)
         -> OPTIONAL std::any
     FROM SQL $$
         SELECT $1[(
@@ -152,13 +153,13 @@ CREATE FUNCTION std::array_get(array<std::any>, std::int64)
         )]
     $$;
 
-CREATE FUNCTION std::len(std::str) -> std::int64
+CREATE FUNCTION std::len($str: std::str) -> std::int64
     FROM SQL FUNCTION 'char_length';
 
-CREATE FUNCTION std::len(std::bytes) -> std::int64
+CREATE FUNCTION std::len($bytes: std::bytes) -> std::int64
     FROM SQL FUNCTION 'length';
 
-CREATE FUNCTION std::len(array<std::any>) -> std::int64
+CREATE FUNCTION std::len($array: array<std::any>) -> std::int64
     FROM SQL $$
         SELECT array_length($1, 1)::bigint
     $$;
@@ -166,22 +167,27 @@ CREATE FUNCTION std::len(array<std::any>) -> std::int64
 CREATE FUNCTION std::random() -> std::float64
     FROM SQL FUNCTION 'random';
 
-CREATE FUNCTION std::re_match(std::str, std::str) -> array<std::str>
+CREATE FUNCTION std::re_match($str: std::str,
+                              $pattern: std::str) -> array<std::str>
     FROM SQL $$
         SELECT regexp_matches($1, $2);
     $$;
 
-CREATE FUNCTION std::re_match_all(std::str, std::str) -> SET OF array<std::str>
+CREATE FUNCTION std::re_match_all($str: std::str,
+                                  $pattern: std::str) -> SET OF array<std::str>
     FROM SQL $$
         SELECT regexp_matches($1, $2, 'g');
     $$;
 
-CREATE FUNCTION std::re_test(std::str, std::str) -> std::bool
+CREATE FUNCTION std::re_test($str: std::str, $pattern: std::str) -> std::bool
     FROM SQL $$
         SELECT $1 ~ $2;
     $$;
 
-CREATE FUNCTION std::re_replace(std::str, std::str, std::str, std::str = '')
+CREATE FUNCTION std::re_replace($str: std::str,
+                                $pattern: std::str,
+                                $sub: std::str,
+                                $flags: std::str = '')
         -> std::str
     FROM SQL $$
         SELECT regexp_replace($1, $2, $3, $4);
@@ -210,28 +216,28 @@ CREATE ABSTRACT CONSTRAINT std::expression
     SET expr := __subject__;
 };
 
-CREATE ABSTRACT CONSTRAINT std::max(std::any)
+CREATE ABSTRACT CONSTRAINT std::max($max: std::any)
         EXTENDING std::constraint
 {
-    SET errmessage := 'Maximum allowed value for {__subject__} is {$0}.';
-    SET expr := __subject__ <= $0;
+    SET errmessage := 'Maximum allowed value for {__subject__} is {$max}.';
+    SET expr := __subject__ <= $max;
 };
 
-CREATE ABSTRACT CONSTRAINT std::enum(VARIADIC std::any)
+CREATE ABSTRACT CONSTRAINT std::enum(VARIADIC $vals: std::any)
         EXTENDING std::constraint
 {
-    SET errmessage := '{__subject__} must be one of: {$0}.';
-    SET expr := array_contains($0, __subject__);
+    SET errmessage := '{__subject__} must be one of: {$vals}.';
+    SET expr := array_contains($vals, __subject__);
 };
 
-CREATE ABSTRACT CONSTRAINT std::min(std::any)
+CREATE ABSTRACT CONSTRAINT std::min($min: std::any)
         EXTENDING std::constraint
 {
-    SET errmessage := 'Minimum allowed value for {__subject__} is {$0}.';
-    SET expr := __subject__ >= $0;
+    SET errmessage := 'Minimum allowed value for {__subject__} is {$min}.';
+    SET expr := __subject__ >= $min;
 };
 
-CREATE ABSTRACT CONSTRAINT std::minexclusive(std::any)
+CREATE ABSTRACT CONSTRAINT std::minexclusive($min: std::any)
         EXTENDING std::min
 {
     SET errmessage := '{__subject__} must be greater than {$0}.';
@@ -244,29 +250,29 @@ CREATE ABSTRACT CONSTRAINT std::length ON (len(<std::str>__subject__))
     SET errmessage := 'invalid {__subject__}';
 };
 
-CREATE ABSTRACT CONSTRAINT std::minlength(std::int64)
+CREATE ABSTRACT CONSTRAINT std::minlength($min: std::int64)
         EXTENDING (std::min, std::length)
 {
-    SET errmessage := '{__subject__} must be no shorter than {$0} characters.';
+    SET errmessage := '{__subject__} must be no shorter than {$min} characters.';
 };
 
-CREATE ABSTRACT CONSTRAINT std::regexp(std::any)
+CREATE ABSTRACT CONSTRAINT std::regexp($pattern: std::any)
         EXTENDING std::constraint
 {
     SET errmessage := 'invalid {__subject__}';
-    SET expr := re_test(__subject__, $0);
+    SET expr := re_test(__subject__, $pattern);
 };
 
-CREATE ABSTRACT CONSTRAINT std::maxlength(std::int64)
+CREATE ABSTRACT CONSTRAINT std::maxlength($max: std::int64)
         EXTENDING (std::max, std::length)
 {
-    SET errmessage := '{__subject__} must be no longer than {$0} characters.';
+    SET errmessage := '{__subject__} must be no longer than {$max} characters.';
 };
 
-CREATE ABSTRACT CONSTRAINT std::maxexclusive(std::any)
+CREATE ABSTRACT CONSTRAINT std::maxexclusive($max: std::any)
         EXTENDING std::max
 {
-    SET errmessage := '{__subject__} must be less than {$0}.';
+    SET errmessage := '{__subject__} must be less than {$max}.';
 };
 
 CREATE ABSTRACT CONSTRAINT std::unique

--- a/edb/lang/schema/declarative.py
+++ b/edb/lang/schema/declarative.py
@@ -336,15 +336,10 @@ class DeclarationLoader:
 
             paramnames, paramdefaults, paramtypes, paramkinds, variadic = \
                 s_func.parameters_from_ast(decl, self._mod_aliases,
-                                           self._schema)
+                                           self._schema,
+                                           allow_named=False)
 
-            for pname, pdefault, ptype in zip(paramnames, paramdefaults,
-                                              paramtypes):
-                if pname is not None:
-                    raise s_err.SchemaDefinitionError(
-                        'constraints do not support named parameters',
-                        context=decl.context)
-
+            for pdefault, ptype in zip(paramdefaults, paramtypes):
                 if pdefault is not None:
                     raise s_err.SchemaDefinitionError(
                         'constraints do not support parameters '
@@ -355,6 +350,7 @@ class DeclarationLoader:
                     raise s_err.SchemaDefinitionError(
                         'untyped parameter', context=decl.context)
 
+            constraint.paramnames = paramnames
             constraint.paramtypes = paramtypes
             constraint.varparam = variadic
 

--- a/edb/lang/schema/functions.py
+++ b/edb/lang/schema/functions.py
@@ -229,7 +229,7 @@ class DeleteFunction(named.DeleteNamedObject, FunctionCommand):
         return cls._get_function_fullname(name, paramtypes)
 
 
-def parameters_from_ast(astnode, modaliases, schema):
+def parameters_from_ast(astnode, modaliases, schema, *, allow_named=True):
     paramdefaults = []
     paramnames = []
     paramtypes = []
@@ -247,7 +247,12 @@ def parameters_from_ast(astnode, modaliases, schema):
         paramtypes.append(utils.ast_to_typeref(
             arg.type, modaliases=modaliases, schema=schema))
 
-        if arg.qualifier == qlast.SetQualifier.VARIADIC:
+        if arg.kind is qlast.ParameterKind.VARIADIC:
             variadic = argi
+
+        if arg.kind is qlast.ParameterKind.NAMED_ONLY and not allow_named:
+            raise ql_errors.EdgeQLError(
+                'named only parameters are not allowed in this context',
+                context=astnode.context)
 
     return paramnames, paramdefaults, paramtypes, paramkinds, variadic

--- a/edb/server/pgsql/datasources/schema/constraints.py
+++ b/edb/server/pgsql/datasources/schema/constraints.py
@@ -39,6 +39,7 @@ async def fetch(
                 a.localfinalexpr        AS localfinalexpr,
                 a.finalexpr             AS finalexpr,
                 a.errmessage            AS errmessage,
+                a.paramnames,
                 edgedb._resolve_type(a.paramtypes)
                                         AS paramtypes,
                 a.varparam              AS varparam,

--- a/edb/server/pgsql/intromech.py
+++ b/edb/server/pgsql/intromech.py
@@ -386,13 +386,16 @@ class IntrospectionMech:
                     s[1] for s in self.unpack_typedesc_nodes(
                         r['paramtypes']['types'], schema)]
 
+            paramnames = r['paramnames'] if r['paramnames'] else []
+
             constraint = s_constr.Constraint(
                 name=name, subject=subject, title=title,
                 description=description, is_abstract=r['is_abstract'],
                 is_final=r['is_final'], expr=r['expr'],
                 subjectexpr=r['subjectexpr'],
                 localfinalexpr=r['localfinalexpr'], finalexpr=r['finalexpr'],
-                errmessage=r['errmessage'], paramtypes=paramtypes,
+                errmessage=r['errmessage'],
+                paramtypes=paramtypes, paramnames=paramnames,
                 varparam=r['varparam'], args=r['args'])
 
             if subject:

--- a/tests/schemas/constraints.eschema
+++ b/tests/schemas/constraints.eschema
@@ -46,8 +46,8 @@ scalar type constraint_strvalue extending str:
 
 # A variant of enum that uses an array argument instead of
 # a variadic.
-abstract constraint my_enum(array<std::any>):
-    expr := array_contains($0, __subject__)
+abstract constraint my_enum($enum: array<std::any>):
+    expr := array_contains($enum, __subject__)
 
 
 scalar type constraint_enum extending str:

--- a/tests/schemas/issues.eschema
+++ b/tests/schemas/issues.eschema
@@ -125,5 +125,5 @@ type Publication:
     required property title -> str
 
 
-abstract constraint my_enum(array<std::any>):
-    expr := array_contains($0, __subject__)
+abstract constraint my_enum($enum: array<std::any>):
+    expr := array_contains($enum, __subject__)

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -426,7 +426,8 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             SET MODULE test;
 
             SELECT array_get(array_agg(Issue.number ORDER BY Issue.number), 2);
-            SELECT array_get(array_agg(Issue.number ORDER BY Issue.number), -2);
+            SELECT array_get(array_agg(
+                Issue.number ORDER BY Issue.number), -2);
             SELECT array_get(array_agg(Issue.number), 20);
             SELECT array_get(array_agg(Issue.number), -20);
         ''', [

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1751,7 +1751,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_func_05(self):
         await self.con.execute(r'''
-            CREATE FUNCTION test::concat1(VARIADIC std::any) -> std::str
+            CREATE FUNCTION test::concat1(VARIADIC $s: std::any) -> std::str
                 FROM SQL FUNCTION 'concat';
         ''')
 
@@ -1788,12 +1788,12 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         ])
 
         await self.con.execute(r'''
-            DROP FUNCTION test::concat1(VARIADIC std::any);
+            DROP FUNCTION test::concat1(VARIADIC $s: std::any);
         ''')
 
     async def test_edgeql_select_func_06(self):
         await self.con.execute(r'''
-            CREATE FUNCTION test::concat2(VARIADIC std::str) -> std::str
+            CREATE FUNCTION test::concat2(VARIADIC $s: std::str) -> std::str
                 FROM SQL FUNCTION 'concat';
         ''')
 
@@ -1803,7 +1803,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_func_07(self):
         await self.con.execute(r'''
-            CREATE FUNCTION test::concat3($sep: std::str, VARIADIC std::str)
+            CREATE FUNCTION test::concat3($sep: std::str,
+                                          VARIADIC $s: std::str)
                     -> std::str
                 FROM SQL FUNCTION 'concat_ws';
         ''')
@@ -1831,7 +1832,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 },
                 {
                     'num': 1,
-                    'name': None,
+                    'name': 's',
                     'kind': 'VARIADIC',
                     'type': {
                         'name': 'std::str'
@@ -1857,7 +1858,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         ])
 
         await self.con.execute(r'''
-            DROP FUNCTION test::concat3($sep: std::str, VARIADIC std::str);
+            DROP FUNCTION test::concat3($sep: std::str, VARIADIC $s: std::str);
         ''')
 
     async def test_edgeql_select_func_08(self):
@@ -1879,9 +1880,9 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_func_09(self):
         await self.con.execute('''
-            CREATE FUNCTION test::my_edgeql_func1(std::str) -> std::str
+            CREATE FUNCTION test::my_edgeql_func1($s: std::str) -> std::str
                 FROM EdgeQL $$
-                    SELECT 'str=' + $0
+                    SELECT 'str=' + $s
                 $$;
         ''')
 
@@ -1892,7 +1893,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         ])
 
         await self.con.execute('''
-            DROP FUNCTION test::my_edgeql_func1(std::str);
+            DROP FUNCTION test::my_edgeql_func1($s: std::str);
         ''')
 
     async def test_edgeql_select_exists_01(self):

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -844,7 +844,7 @@ type Foo:
         """
         # the line continuation is just to allow long single line
         function myfunc($arg1: str, $arg2: str = 'DEFAULT',
-                        $arg3: variadic std::int64) -> \
+                        variadic $arg3: std::int64) -> \
                         set of int:
             volatile := true
             description :>
@@ -854,7 +854,7 @@ type Foo:
 
 % OK %
         function myfunc($arg1: str, $arg2: str = 'DEFAULT',
-                        $arg3: variadic std::int64) -> \
+                        variadic $arg3: std::int64) -> \
                         set of int:
             volatile := true
             description :=
@@ -867,7 +867,9 @@ type Foo:
         """
         function myfunc($arg1: str,
                         $arg2: str = 'DEFAULT',
-                        $arg3: variadic std::int64) -> set of int:
+                        variadic $arg3: std::int64,
+                        named only $arg4: std::int64,
+                        named only $arg5: std::int64) -> set of int:
             from edgeql :=
                 SELECT blarg
         """
@@ -1015,7 +1017,7 @@ type Foo:
     def test_eschema_syntax_aggregate_04(self):
         """
         aggregate myfunc($arg1: str, $arg2: str = 'DEFAULT',
-                         $arg3: variadic std::int64) -> int64:
+                         variadic $arg3: std::int64) -> int64:
             initial value := 42
             volatile := true
             description := 'myfunc sample'
@@ -1032,12 +1034,13 @@ type Foo:
             from sql function: length
         """
 
-    @tb.must_fail(error.SchemaSyntaxError, r"Unexpected '\)'",
-                  line=3, col=41)
+    @tb.must_fail(error.SchemaSyntaxError,
+                  r"missing type declaration for.*parameter \$arg3",
+                  line=3, col=35)
     def test_eschema_syntax_aggregate_06(self):
         """
         aggregate myfunc($arg1: str, $arg2: str = 'DEFAULT',
-                         $arg3: variadic) -> int64:
+                         variadic $arg3) -> int64:
             initial value := 42
         """
 


### PR DESCRIPTION
Paremeter kind and parameter type are now different things.
The following parameter kinds are supported right now:

 * regular positional parameters
 * VARIADIC
 * NAMED ONLY

The syntax for declaring functions & constraints not longer
allows to specify unnamed parameters -- names are required.

Old syntax:

    CREATE FUNCTION foo(int64)
    CREATE FUNCTION foo(VARIADIC SET OF str)
    CREATE FUNCTION foo($a: VARIADIC SET OF str)

New syntax:

    CREATE FUNCTION foo($p: int64)
    CREATE FUNCTION foo(VARIADIC $name: SET OF str)
    CREATE FUNCTION foo(VARIADIC $a: SET OF str)

Syntax for declaring named-only parameters (not yet supported by the
compiler):

    CREATE FUNCTION foo($pos1: int64, $pos2: str,
                        NAMED ONLY $n1: str, NAMED ONLY $n2: int64)

Named-only parameters will only be supported by functions (not
constraints).