### PR TITLE
Refactor schema::Function and schema::Parameter

### DIFF
--- a/edb/lang/edgeql/ast.py
+++ b/edb/lang/edgeql/ast.py
@@ -114,10 +114,18 @@ AggDISTINCT = SetModifier.DISTINCT
 AggNONE = SetModifier.NONE
 
 
-class SetQualifier(s_enum.StrEnum):
+class TypeModifier(s_enum.StrEnum):
     SET_OF = 'SET OF'
     OPTIONAL = 'OPTIONAL'
-    DEFAULT = ''
+    SINGLETON = 'SINGLETON'
+
+    def to_edgeql(self):
+        if self is TypeModifier.SET_OF:
+            return 'SET OF'
+        elif self is TypeModifier.OPTIONAL:
+            return 'OPTIONAL'
+        else:
+            return ''
 
 
 class ParameterKind(s_enum.StrEnum):
@@ -278,7 +286,7 @@ class TypeOp(TypeExpr):
 class FuncParam(Base):
     name: str
     type: TypeExpr
-    qualifier: SetQualifier = SetQualifier.DEFAULT
+    typemod: TypeModifier = TypeModifier.SINGLETON
     kind: ParameterKind
     default: Expr  # noqa (pyflakes bug)
 
@@ -804,7 +812,7 @@ class CreateFunction(CreateObject):
     aggregate: bool = False
     initial_value: Expr
     code: FunctionCode
-    set_returning: SetQualifier = SetQualifier.DEFAULT
+    returning_typemod: TypeModifier = TypeModifier.SINGLETON
 
 
 class AlterFunction(AlterObject):

--- a/edb/lang/edgeql/codegen.py
+++ b/edb/lang/edgeql/codegen.py
@@ -1012,8 +1012,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self.visit_list(node.args, newlines=False)
             self.write(')')
             self.write(' -> ')
-            if node.set_returning:
-                self.write(node.set_returning.upper(), ' ')
+            self.write(node.returning_typemod.to_edgeql(), ' ')
             self.visit(node.returning)
 
             if node.commands or node.initial_value:
@@ -1059,8 +1058,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         if node.name is not None:
             self.write(param_to_str(node.name), ': ')
 
-        if node.qualifier:
-            self.write(node.qualifier.upper(), ' ')
+        self.write(node.typemod.to_edgeql(), ' ')
 
         self.visit(node.type)
 

--- a/edb/lang/edgeql/compiler/viewgen.py
+++ b/edb/lang/edgeql/compiler/viewgen.py
@@ -663,7 +663,7 @@ def _compile_view_shapes_in_fcall(
     preserves_type = (
         any(irutils.is_polymorphic_type(p)
             for p in funcobj.paramtypes) and
-        irutils.is_polymorphic_type(funcobj.returntype)
+        irutils.is_polymorphic_type(funcobj.return_type)
     )
 
     if preserves_type:

--- a/edb/lang/edgeql/parser/grammar/ddl.py
+++ b/edb/lang/edgeql/parser/grammar/ddl.py
@@ -1525,7 +1525,7 @@ class FuncDeclArg(Nonterm):
         self.val = qlast.FuncParam(
             kind=kids[0].val,
             name=kids[2].val,
-            qualifier=kids[4].val,
+            typemod=kids[4].val,
             type=kids[5].val,
             default=kids[6].val
         )
@@ -1687,13 +1687,13 @@ commands_block(
 
 class OptTypeQualifier(Nonterm):
     def reduce_SET_OF(self, *kids):
-        self.val = qlast.SetQualifier.SET_OF
+        self.val = qlast.TypeModifier.SET_OF
 
     def reduce_OPTIONAL(self, *kids):
-        self.val = qlast.SetQualifier.OPTIONAL
+        self.val = qlast.TypeModifier.OPTIONAL
 
     def reduce_empty(self):
-        self.val = qlast.SetQualifier.DEFAULT
+        self.val = qlast.TypeModifier.SINGLETON
 
 
 class CreateFunctionStmt(Nonterm, _ProcessFunctionBlockMixin):
@@ -1706,7 +1706,7 @@ class CreateFunctionStmt(Nonterm, _ProcessFunctionBlockMixin):
             name=kids[2].val,
             args=kids[3].val,
             returning=kids[6].val,
-            set_returning=kids[5].val,
+            returning_typemod=kids[5].val,
             **self._process_function_body(kids[7])
         )
 

--- a/edb/lang/edgeql/utils.py
+++ b/edb/lang/edgeql/utils.py
@@ -53,17 +53,19 @@ def inline_parameters(ql_expr: qlast.Base, args: typing.Dict[str, qlast.Base]):
 
 def index_parameters(ql_args: typing.List[qlast.Base], *,
                      paramnames: typing.List[str],
-                     varparam: typing.Optional[int]=None):
+                     paramkinds: typing.List[qlast.ParameterKind]):
     result = {}
     varargs = None
 
-    for (i, e), n in itertools.zip_longest(enumerate(ql_args),
-                                           paramnames,
-                                           fillvalue=None):
+    for (i, e), n, k in itertools.zip_longest(enumerate(ql_args),
+                                              paramnames,
+                                              paramkinds,
+                                              fillvalue=None):
         if isinstance(e, qlast.SelectQuery):
             e = e.result
 
-        if varparam is not None and i == varparam:
+        if k is qlast.ParameterKind.VARIADIC:
+            assert varargs is None
             varargs = []
             result[n] = qlast.Array(elements=varargs)
 

--- a/edb/lang/ir/ast.py
+++ b/edb/lang/ir/ast.py
@@ -42,7 +42,8 @@ EdgeDBMatchOperator = qlast.EdgeQLMatchOperator
 EquivalenceOperator = qlast.EquivalenceOperator
 SetOperator = qlast.SetOperator
 SetModifier = qlast.SetModifier
-SetQualifier = qlast.SetQualifier
+TypeModifier = qlast.TypeModifier
+ParameterKind = qlast.ParameterKind
 Cardinality = qlast.Cardinality
 
 UNION = qlast.UNION

--- a/edb/lang/ir/inference/cardinality.py
+++ b/edb/lang/ir/inference/cardinality.py
@@ -115,7 +115,7 @@ def __infer_set(ir, scope_tree, schema):
 
 @_infer_cardinality.register(irast.FunctionCall)
 def __infer_func_call(ir, scope_tree, schema):
-    if ir.func.set_returning:
+    if ir.func.return_typemod is qlast.TypeModifier.SET_OF:
         return MANY
     else:
         return ONE

--- a/edb/lang/ir/inference/types.py
+++ b/edb/lang/ir/inference/types.py
@@ -115,7 +115,7 @@ def __infer_set(ir, schema):
 
 @_infer_type.register(irast.FunctionCall)
 def __infer_func_call(ir, schema):
-    rtype = ir.func.returntype
+    rtype = ir.func.return_type
 
     if is_polymorphic_type(rtype):
         # Polymorphic function, determine the result type from

--- a/edb/lang/schema/_std.eql
+++ b/edb/lang/schema/_std.eql
@@ -87,12 +87,11 @@ CREATE ABSTRACT ATTRIBUTE stdattrs::default std::str;
 CREATE ABSTRACT ATTRIBUTE stdattrs::expression std::str;
 CREATE ABSTRACT ATTRIBUTE stdattrs::cardinality std::str;
 CREATE ABSTRACT ATTRIBUTE stdattrs::aggregate std::bool;
-CREATE ABSTRACT ATTRIBUTE stdattrs::set_returning std::bool;
 CREATE ABSTRACT ATTRIBUTE stdattrs::language std::str;
 CREATE ABSTRACT ATTRIBUTE stdattrs::code std::str;
 CREATE ABSTRACT ATTRIBUTE stdattrs::from_function std::str;
 CREATE ABSTRACT ATTRIBUTE stdattrs::initial_value std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::varparam std::int64;
+CREATE ABSTRACT ATTRIBUTE stdattrs::return_typemod std::str;
 
 CREATE FUNCTION std::lower($str: std::str) -> std::str
     FROM SQL FUNCTION 'lower';
@@ -465,6 +464,7 @@ CREATE ABSTRACT TYPE schema::InheritingObject EXTENDING schema::Object {
 
 CREATE TYPE schema::Parameter {
     CREATE REQUIRED LINK schema::type -> schema::Type;
+    CREATE REQUIRED PROPERTY schema::typemod -> std::str;
     CREATE REQUIRED PROPERTY schema::kind -> std::str;
     CREATE REQUIRED PROPERTY schema::num -> std::int64;
     CREATE PROPERTY schema::name -> std::str;
@@ -582,7 +582,7 @@ CREATE TYPE schema::Function EXTENDING schema::Object {
     CREATE LINK schema::params -> schema::Parameter {
         SET cardinality := '**';
     };
-    CREATE LINK schema::returntype -> schema::Type;
+    CREATE LINK schema::return_type -> schema::Type;
+    CREATE PROPERTY schema::return_typemod -> std::str;
     CREATE PROPERTY schema::aggregate -> std::bool;
-    CREATE PROPERTY schema::set_returning -> std::bool;
 };

--- a/edb/lang/schema/ast.py
+++ b/edb/lang/schema/ast.py
@@ -159,7 +159,7 @@ class FunctionDeclaration(Declaration):
     aggregate: bool = False
     initial_value: qlast.Base
     code: FunctionCode
-    set_returning: str = ''
+    returning_typemod: qlast.TypeModifier
 
 
 class BasePointerDeclaration(Declaration):

--- a/edb/lang/schema/codegen.py
+++ b/edb/lang/schema/codegen.py
@@ -229,8 +229,7 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
         self.write('(')
         self.visit_list(node.args, newlines=False)
         self.write(') -> ')
-        if node.set_returning:
-            self.write(node.set_returning, ' ')
+        self.write(node.returning_typemod.to_edgeql(), ' ')
         self.visit(node.returning)
         self.write(':')
         self.new_lines = 1

--- a/edb/lang/schema/declarative.py
+++ b/edb/lang/schema/declarative.py
@@ -334,12 +334,11 @@ class DeclarationLoader:
                 constraint.subjectexpr = s_expr.ExpressionText(
                     qlcodegen.generate_source(subjexpr))
 
-            paramnames, paramdefaults, paramtypes, paramkinds, variadic = \
-                s_func.parameters_from_ast(decl, self._mod_aliases,
-                                           self._schema,
-                                           allow_named=False)
+            pi = s_func.parameters_from_ast(decl, self._mod_aliases,
+                                            self._schema,
+                                            allow_named=False)
 
-            for pdefault, ptype in zip(paramdefaults, paramtypes):
+            for pdefault, ptype in zip(pi.paramdefaults, pi.paramtypes):
                 if pdefault is not None:
                     raise s_err.SchemaDefinitionError(
                         'constraints do not support parameters '
@@ -350,9 +349,9 @@ class DeclarationLoader:
                     raise s_err.SchemaDefinitionError(
                         'untyped parameter', context=decl.context)
 
-            constraint.paramnames = paramnames
-            constraint.paramtypes = paramtypes
-            constraint.varparam = variadic
+            constraint.paramnames = pi.paramnames
+            constraint.paramtypes = pi.paramtypes
+            constraint.paramkinds = pi.paramkinds
 
     def _init_scalars(self, scalars):
         for scalar, scalardecl in scalars.items():

--- a/edb/lang/schema/parser/grammar/declarations.py
+++ b/edb/lang/schema/parser/grammar/declarations.py
@@ -166,7 +166,7 @@ class RowRawString(Nonterm):
                 f'Could not parse EdgeQL parameters declaration {expr!r}',
                 context=context) from None
 
-        return (eql.set_returning, eql.returning)
+        return (eql.returning_typemod, eql.returning)
 
 
 class RowRawStr(Nonterm):
@@ -648,12 +648,12 @@ class FunctionDeclCore(Nonterm):
                 raise SchemaSyntaxError(
                     'illegal definition', context=spec.context)
 
-        set_returning, returning = kids[3].parse_as_function_type()
+        returning_typemod, returning = kids[3].parse_as_function_type()
 
         self.val = esast.FunctionDeclaration(
             name=kids[0].val,
             args=kids[1].val,
-            set_returning=set_returning,
+            returning_typemod=returning_typemod,
             returning=returning,
             attributes=attributes,
             initial_value=init_val,

--- a/edb/server/pgsql/compiler/expr.py
+++ b/edb/server/pgsql/compiler/expr.py
@@ -522,7 +522,7 @@ def compile_FunctionCall(
         raise RuntimeError(
             'aggregate functions are not supported in simple expressions')
 
-    if funcobj.set_returning:
+    if funcobj.return_typemod is irast.TypeModifier.SET_OF:
         raise RuntimeError(
             'set returning functions are not supported in simple expressions')
 

--- a/edb/server/pgsql/compiler/relgen.py
+++ b/edb/server/pgsql/compiler/relgen.py
@@ -251,8 +251,8 @@ def _get_set_rvar(
         rvars = process_set_as_tuple_indirection(ir_set, stmt, ctx=ctx)
 
     elif isinstance(ir_set.expr, irast.FunctionCall):
-        if any(k == irast.SetQualifier.SET_OF
-               for k in ir_set.expr.func.paramkinds):
+        if any(k == irast.TypeModifier.SET_OF
+               for k in ir_set.expr.func.paramtypemods):
             # Call to an aggregate function.
             rvars = process_set_as_agg_expr(ir_set, stmt, ctx=ctx)
         else:
@@ -1263,10 +1263,10 @@ def process_set_as_func_expr(
         set_expr = pgast.FuncCall(
             name=name, args=args, with_ordinality=with_ordinality)
 
-    if funcobj.set_returning:
-        rtype = funcobj.returntype
+    if funcobj.return_typemod is irast.TypeModifier.SET_OF:
+        rtype = funcobj.return_type
 
-        if isinstance(funcobj.returntype, s_types.Tuple):
+        if isinstance(funcobj.return_type, s_types.Tuple):
             colnames = [name for name in rtype.element_types]
         else:
             colnames = [ctx.env.aliases.get('v')]
@@ -1356,7 +1356,7 @@ def process_set_as_agg_expr(
             serialization_safe = (
                 any(irutils.is_polymorphic_type(p)
                     for p in funcobj.paramtypes) and
-                irutils.is_polymorphic_type(funcobj.returntype)
+                irutils.is_polymorphic_type(funcobj.return_type)
             )
 
             if not serialization_safe:

--- a/edb/server/pgsql/datasources/schema/constraints.py
+++ b/edb/server/pgsql/datasources/schema/constraints.py
@@ -40,9 +40,9 @@ async def fetch(
                 a.finalexpr             AS finalexpr,
                 a.errmessage            AS errmessage,
                 a.paramnames,
+                a.paramkinds,
                 edgedb._resolve_type(a.paramtypes)
                                         AS paramtypes,
-                a.varparam              AS varparam,
                 a.args                  AS args,
                 edgedb._resolve_type_name(a.subject)
                                         AS subject

--- a/edb/server/pgsql/datasources/schema/functions.py
+++ b/edb/server/pgsql/datasources/schema/functions.py
@@ -31,16 +31,16 @@ async def fetch(
                 f.description AS description,
                 edgedb._resolve_type(f.paramtypes) AS paramtypes,
                 f.paramnames,
-                f.varparam,
-                f.paramdefaults,
                 f.paramkinds,
+                f.paramdefaults,
+                f.paramtypemods,
                 f.aggregate,
-                f.set_returning,
+                f.return_typemod,
                 f.language,
                 f.code,
                 f.from_function,
                 f.initial_value,
-                edgedb._resolve_type(f.returntype) AS returntype
+                edgedb._resolve_type(f.return_type) AS return_type
             FROM
                 edgedb.function f
             ORDER BY

--- a/edb/server/pgsql/intromech.py
+++ b/edb/server/pgsql/intromech.py
@@ -336,18 +336,18 @@ class IntrospectionMech:
                 'title': self.json_to_word_combination(row['title']),
                 'description': row['description'],
                 'aggregate': row['aggregate'],
-                'set_returning': row['set_returning'],
-                'varparam': row['varparam'],
+                'return_typemod': row['return_typemod'],
                 'from_function': row['from_function'],
                 'code': row['code'],
                 'initial_value': row['initial_value'],
                 'paramtypes': paramtypes,
                 'paramnames': row['paramnames'] if row['paramnames'] else [],
+                'paramkinds': row['paramkinds'] if row['paramkinds'] else [],
                 'paramdefaults':
                     row['paramdefaults'] if row['paramdefaults'] else [],
-                'paramkinds':
-                    row['paramkinds'] if row['paramkinds'] else [],
-                'returntype': self.unpack_typeref(row['returntype'], schema)
+                'paramtypemods':
+                    row['paramtypemods'] if row['paramtypemods'] else [],
+                'return_type': self.unpack_typeref(row['return_type'], schema)
             }
 
             func = s_funcs.Function(**func_data)
@@ -387,6 +387,7 @@ class IntrospectionMech:
                         r['paramtypes']['types'], schema)]
 
             paramnames = r['paramnames'] if r['paramnames'] else []
+            paramkinds = r['paramkinds'] if r['paramkinds'] else []
 
             constraint = s_constr.Constraint(
                 name=name, subject=subject, title=title,
@@ -396,7 +397,8 @@ class IntrospectionMech:
                 localfinalexpr=r['localfinalexpr'], finalexpr=r['finalexpr'],
                 errmessage=r['errmessage'],
                 paramtypes=paramtypes, paramnames=paramnames,
-                varparam=r['varparam'], args=r['args'])
+                paramkinds=paramkinds,
+                args=r['args'])
 
             if subject:
                 subject.add_constraint(constraint)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -675,6 +675,52 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         await self.con.execute(qry)
 
+        await self.assert_query_result(r'''
+            SELECT schema::Constraint {
+                name,
+                is_abstract,
+                params: {
+                    num,
+                    name,
+                    kind,
+                    type: {
+                        name
+                    },
+                    typemod,
+                    @value
+                } ORDER BY schema::Constraint.params.num ASC
+            } FILTER .name = 'test::mymax_ext1' ORDER BY .is_abstract;
+        ''', [[
+            {
+                "name": 'test::mymax_ext1',
+                "params": [
+                    {
+                        "num": 0,
+                        "kind": 'POSITIONAL',
+                        "name": 'max',
+                        "type": {"name": 'std::int64'},
+                        "@value": '3',
+                        "typemod": None
+                    }
+                ],
+                "is_abstract": False
+            },
+            {
+                "name": 'test::mymax_ext1',
+                "params": [
+                    {
+                        "num": 0,
+                        "kind": 'POSITIONAL',
+                        "name": 'max',
+                        "type": {"name": 'std::int64'},
+                        "@value": None,
+                        "typemod": None
+                    }
+                ],
+                "is_abstract": False
+            }
+        ]])
+
         # making sure the constraint was applied successfully
         async with self._run_and_rollback():
             with self.assertRaisesRegex(

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1803,7 +1803,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_func_07(self):
         await self.con.execute(r'''
-            CREATE FUNCTION test::concat3($sep: std::str,
+            CREATE FUNCTION test::concat3($sep: OPTIONAL std::str,
                                           VARIADIC $s: std::str)
                     -> std::str
                 FROM SQL FUNCTION 'concat_ws';
@@ -1817,28 +1817,41 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                     kind,
                     type: {
                         name
-                    }
-                } ORDER BY schema::Function.params.num ASC
+                    },
+                    typemod
+                } ORDER BY .num ASC,
+                return_type: {
+                    name
+                },
+                return_typemod
             } FILTER schema::Function.name = 'test::concat3';
         ''', [
-            [{'params': [
-                {
-                    'num': 0,
-                    'name': 'sep',
-                    'kind': '',
-                    'type': {
-                        'name': 'std::str'
+            [{
+                'params': [
+                    {
+                        'num': 0,
+                        'name': 'sep',
+                        'kind': 'POSITIONAL',
+                        'type': {
+                            'name': 'std::str'
+                        },
+                        'typemod': 'OPTIONAL'
+                    },
+                    {
+                        'num': 1,
+                        'name': 's',
+                        'kind': 'VARIADIC',
+                        'type': {
+                            'name': 'std::str'
+                        },
+                        'typemod': 'SINGLETON'
                     }
+                ],
+                'return_type': {
+                    'name': 'std::str'
                 },
-                {
-                    'num': 1,
-                    'name': 's',
-                    'kind': 'VARIADIC',
-                    'type': {
-                        'name': 'std::str'
-                    }
-                }
-            ]}]
+                'return_typemod': 'SINGLETON'
+            }]
         ])
 
         with self.assertRaisesRegex(exc.EdgeQLError,


### PR DESCRIPTION
1. Rename vague "set qualifier" to "type modifier" and use
   it consistently for parameter & return types.

2. Drop Function.varparam.

3. Rename Function.returntype to Function.return_type.

4. Add Function.paramkinds, Function.return_typemod.

5. Drop Function.set_returning.

6. Add 'typemod' property to schema::Parameter.

This PR makes it possible to add a schema.FunctionParameter object
to simplify working with functions in compilers as well as paves the
way to implementing named arguments.