### PR TITLE
Make `assert_sorted_query_result` a bit safer.

### DIFF
--- a/edb/server/_testbase.py
+++ b/edb/server/_testbase.py
@@ -384,7 +384,9 @@ class BaseQueryTestCase(DatabaseTestCase):
         res = await self.con.execute(query)
         # sort the query result by using the supplied key
         for r in res:
-            r.sort(key=key)
+            # don't bother sorting empty things
+            if r:
+                r.sort(key=key)
         self.assert_data_shape(res, result)
         return res
 


### PR DESCRIPTION
It's useful to set up a module for a bunch of `SELECT` queries as a
separate `SET MODULE test;` statement. This produces a `None` in the
results that doesn't really need to be sorted.