### PR TITLE
Add support for casting objects and tuples to std::json

### DIFF
--- a/edb/lang/edgeql/compiler/func.py
+++ b/edb/lang/edgeql/compiler/func.py
@@ -76,7 +76,8 @@ def compile_FunctionCall(
 
         fixup_param_scope(funcobj, args, kwargs, ctx=fctx)
 
-        node = irast.FunctionCall(func=funcobj, args=args, kwargs=kwargs)
+        node = irast.FunctionCall(func=funcobj, args=args, kwargs=kwargs,
+                                  context=expr.context)
 
         if funcobj.initial_value is not None:
             rtype = irutils.infer_type(node, fctx.schema)

--- a/edb/lang/edgeql/compiler/setgen.py
+++ b/edb/lang/edgeql/compiler/setgen.py
@@ -563,6 +563,7 @@ def new_expression_set(
         path_id=path_id,
         scls=result_type,
         expr=ir_expr,
+        context=ir_expr.context,
         ctx=ctx
     )
 

--- a/edb/lang/edgeql/compiler/viewgen.py
+++ b/edb/lang/edgeql/compiler/viewgen.py
@@ -685,3 +685,13 @@ def _compile_view_shapes_in_tuple(
         ctx: context.ContextLevel) -> None:
     for element in expr.elements:
         compile_view_shapes(element.val, ctx=ctx)
+
+
+@compile_view_shapes.register(irast.Array)
+def _compile_view_shapes_in_array(
+        expr: irast.Array, *,
+        rptr: typing.Optional[irast.Pointer]=None,
+        parent_view_type: typing.Optional[s_types.ViewType]=None,
+        ctx: context.ContextLevel) -> None:
+    for element in expr.elements:
+        compile_view_shapes(element, ctx=ctx)

--- a/edb/lang/ir/utils.py
+++ b/edb/lang/ir/utils.py
@@ -17,6 +17,9 @@
 #
 
 
+import json
+import typing
+
 from edb.lang.common import ast
 
 from edb.lang.schema import objtypes as s_objtypes
@@ -25,6 +28,7 @@ from edb.lang.schema import name as s_name
 from edb.lang.schema import pointers as s_pointers
 from edb.lang.schema import schema as s_schema
 from edb.lang.schema import sources as s_sources  # NOQA
+from edb.lang.schema import types as s_types  # NOQA
 
 from . import ast as irast
 from .inference import amend_empty_set_type  # NOQA
@@ -260,3 +264,17 @@ def type_indirection_path_id(path_id, target_type, *, optional: bool,
         s_pointers.PointerDirection.Outbound,
         target_type
     )
+
+
+def get_source_context_as_json(expr: irast.Base) -> typing.Optional[str]:
+    if expr.context:
+        details = json.dumps({
+            'line': expr.context.start.line,
+            'column': expr.context.start.column,
+            'name': expr.context.name,
+        })
+
+    else:
+        details = None
+
+    return details

--- a/edb/server/pgsql/ast.py
+++ b/edb/server/pgsql/ast.py
@@ -509,6 +509,12 @@ class FuncCall(BaseExpr):
         return nullable
 
 
+class NamedFuncArg(Base):
+
+    name: str
+    val: Base
+
+
 class Indices(Base):
     """Array subscript or slice bounds."""
 

--- a/edb/server/pgsql/codegen.py
+++ b/edb/server/pgsql/codegen.py
@@ -570,6 +570,10 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         if node.with_ordinality:
             self.write(' WITH ORDINALITY')
 
+    def visit_NamedFuncArg(self, node):
+        self.write(common.quote_ident(node.name), ' => ')
+        self.visit(node.val)
+
     def visit_SubLink(self, node):
         if node.type == pgast.SubLinkType.EXISTS:
             self.write('EXISTS')

--- a/edb/server/pgsql/compiler/pathctx.py
+++ b/edb/server/pgsql/compiler/pathctx.py
@@ -255,8 +255,8 @@ def get_path_var(
 
     if isinstance(var, pgast.TupleVar):
         for element in var.elements:
-            put_path_var(rel, element.path_id, element.val,
-                         aspect=aspect, env=env)
+            put_path_var_if_not_exists(rel, element.path_id, element.val,
+                                       aspect=aspect, env=env)
 
     return var
 

--- a/edb/server/pgsql/metaschema.py
+++ b/edb/server/pgsql/metaschema.py
@@ -153,7 +153,10 @@ class RaiseExceptionFunction(dbops.Function):
 class RaiseSpecificExceptionFunction(dbops.Function):
     text = '''
     BEGIN
-        RAISE EXCEPTION USING ERRCODE = exc, MESSAGE = msg, DETAIL = det;
+        RAISE EXCEPTION USING
+            ERRCODE = exc,
+            MESSAGE = msg,
+            DETAIL = COALESCE(det, '');
         RETURN rtype;
     END;
     '''
@@ -229,7 +232,7 @@ class AssertJSONTypeFunction(dbops.Function):
 
     def __init__(self):
         super().__init__(
-            name=('edgedb', '_assert_jsonb_type'),
+            name=('edgedb', 'jsonb_assert_type'),
             args=[('val', ('jsonb',)), ('typenames', ('text[]',)),
                   ('msg', ('text',), 'NULL'), ('det', ('text',), "''")],
             returns=('jsonb',),

--- a/tests/schemas/json_setup.eql
+++ b/tests/schemas/json_setup.eql
@@ -21,41 +21,41 @@ SET MODULE test;
 
 INSERT JSONTest {
     number := 0,
-    j_string := <json>'"the"',
-    j_number := <json>'2',
-    j_boolean := <json>'true',
-    j_array := <json>'[1, 1, 1]',
-    j_object := <json>'{
+    j_string := <json>'the',
+    j_number := <json>2,
+    j_boolean := <json>true,
+    j_array := str_to_json('[1, 1, 1]'),
+    j_object := str_to_json('{
         "a": 1,
         "b": 2
-    }',
-    data := <json>'null',
+    }'),
+    data := str_to_json('null'),
 };
 
 INSERT JSONTest {
     number := 1,
-    j_string := <json>'"quick"',
-    j_number := <json>'2.7',
-    j_boolean := <json>'false',
-    j_array := <json>'[]',
-    j_object := <json>'{
+    j_string := <json>'quick',
+    j_number := <json>2.7,
+    j_boolean := <json>false,
+    j_array := str_to_json('[]'),
+    j_object := str_to_json('{
         "b": 1,
         "c": 2
-    }',
-    data := <json>'{}',
+    }'),
+    data := str_to_json('{}'),
 };
 
 INSERT JSONTest {
     number := 2,
-    j_string := <json>'"brown"',
-    j_number := <json>'2.71',
-    j_boolean := <json>'true',
-    j_array := <json>'[2, "q", [3], {}, null]',
+    j_string := <json>'brown',
+    j_number := <json>2.71,
+    j_boolean := <json>true,
+    j_array := str_to_json('[2, "q", [3], {}, null]'),
 };
 
 INSERT JSONTest {
     number := 3,
-    data := <json>'[
+    data := str_to_json('[
         1.61,
         null,
         "Fraka",
@@ -70,5 +70,5 @@ INSERT JSONTest {
         },
         75,
         true
-    ]',
+    ]'),
 };


### PR DESCRIPTION
`<json>Object` now always returns a `std::json` value containing
the output representation of the object. That is, the result is
the same as the output of `SELECT Object` in JSON mode, including
the type shape.

Now, casting a non-named tuple to `std::json` returns a JSON array,
and casting a named tuple to `std::json` returns a JSON object.

Casting non-scalar JSON values to scalars is now an error, as well as
casting a non-matching JSON scalar value.

Issue: #251.