### PR TITLE
Add support for `on target delete` clause for links

### DIFF
--- a/edb/lang/edgeql/ast.py
+++ b/edb/lang/edgeql/ast.py
@@ -349,7 +349,7 @@ class Set(Expr):
     elements: typing.List[Expr]
 
 
-# Expressions used only in statemets
+# Expressions used only in statements
 #
 
 class ByExprBase(Base):

--- a/edb/lang/schema/_std.eql
+++ b/edb/lang/schema/_std.eql
@@ -18,8 +18,6 @@
 
 
 CREATE MODULE std;
-CREATE MODULE stdattrs;  # standard schema attributes need to be in a separate
-                         # module to avoid name conflicts.
 
 CREATE ABSTRACT SCALAR TYPE std::any;
 
@@ -63,35 +61,6 @@ CREATE ABSTRACT ATTRIBUTE std::pattern std::str;
 
 CREATE ABSTRACT SCALAR TYPE std::sequence EXTENDING std::int64;
 
-CREATE ABSTRACT ATTRIBUTE stdattrs::precision array<std::int16>;
-
-CREATE ABSTRACT ATTRIBUTE stdattrs::name std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::is_abstract std::bool;
-CREATE ABSTRACT ATTRIBUTE stdattrs::is_final std::bool;
-CREATE ABSTRACT ATTRIBUTE stdattrs::is_derived std::bool;
-CREATE ABSTRACT ATTRIBUTE stdattrs::is_virtual std::bool;
-CREATE ABSTRACT ATTRIBUTE stdattrs::view_type std::int64;
-CREATE ABSTRACT ATTRIBUTE stdattrs::title std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::description std::str;
-
-CREATE ABSTRACT ATTRIBUTE stdattrs::expr std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::subjectexpr std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::finalexpr std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::errmessage std::str;
-
-CREATE ABSTRACT ATTRIBUTE stdattrs::value std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::required std::bool;
-CREATE ABSTRACT ATTRIBUTE stdattrs::readonly std::bool;
-CREATE ABSTRACT ATTRIBUTE stdattrs::computable std::bool;
-CREATE ABSTRACT ATTRIBUTE stdattrs::default std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::expression std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::cardinality std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::aggregate std::bool;
-CREATE ABSTRACT ATTRIBUTE stdattrs::language std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::code std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::from_function std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::initial_value std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::return_typemod std::str;
 
 CREATE FUNCTION std::lower($str: std::str) -> std::str
     FROM SQL FUNCTION 'lower';
@@ -322,59 +291,7 @@ CREATE ABSTRACT CONSTRAINT std::unique
     SET expr := std::is_distinct(__subject__);
 };
 
-CREATE ACTION std::restrict {
-    SET title := 'Abort the event if a pointer exists';
-};
-
-CREATE ACTION std::cascade {
-    SET title := 'Cascade the event through the pointer';
-};
-
-CREATE ACTION std::delete_pointer {
-    SET title := 'Delete pointer';
-};
-
-CREATE ACTION std::ignore {
-    SET title := 'Ignore the event';
-};
-
-CREATE ACTION std::delete_source {
-    SET title := 'Delete pointer target';
-};
-
-CREATE ACTION std::delete_orphan_target {
-    SET title := 'Delete target if no instances of the inbound pointer to it exist';
-};
-
-CREATE ACTION std::cascade_loaded {
-    SET title := 'Cascade the event through the pointer if target is loaded to the local session';
-};
-
-CREATE ACTION std::delete_target {
-    SET title := 'Delete pointer target';
-};
-
 CREATE EVENT std::event;
-
-CREATE EVENT std::cascade_base EXTENDING std::event;
-
-CREATE EVENT std::cascade_session_detach EXTENDING std::cascade_base;
-
-CREATE EVENT std::cascade_serialize EXTENDING std::cascade_base;
-
-CREATE EVENT std::internal EXTENDING std::event;
-
-CREATE EVENT std::deleted EXTENDING std::internal;
-
-CREATE EVENT std::source_deleted EXTENDING std::deleted;
-
-CREATE EVENT std::self_deleted EXTENDING std::deleted;
-
-CREATE EVENT std::cascade_session_attach EXTENDING std::cascade_base;
-
-CREATE EVENT std::cascade_copy EXTENDING std::cascade_base;
-
-CREATE EVENT std::target_deleted EXTENDING std::deleted;
 
 CREATE ABSTRACT PROPERTY std::property;
 
@@ -382,15 +299,7 @@ CREATE ABSTRACT PROPERTY std::source;
 
 CREATE ABSTRACT PROPERTY std::target;
 
-CREATE ABSTRACT LINK std::link {
-    CREATE POLICY FOR std::cascade_session_detach TO std::cascade_loaded;
-    CREATE POLICY FOR std::cascade_serialize TO std::cascade_loaded;
-    CREATE POLICY FOR std::source_deleted TO std::restrict;
-    CREATE POLICY FOR std::self_deleted TO std::ignore;
-    CREATE POLICY FOR std::cascade_session_attach TO std::cascade_loaded;
-    CREATE POLICY FOR std::target_deleted TO std::restrict;
-    CREATE POLICY FOR std::cascade_copy TO std::ignore;
-};
+CREATE ABSTRACT LINK std::link;
 
 CREATE ABSTRACT PROPERTY std::id EXTENDING std::property;
 
@@ -406,6 +315,46 @@ CREATE ABSTRACT TYPE std::Object {
 # INTROSPECTION SCHEMA
 
 CREATE MODULE schema;
+
+CREATE MODULE stdattrs;  # standard schema attributes need to be in a separate
+                         # module to avoid name conflicts.
+
+# Standard schema item attributes.
+CREATE ABSTRACT ATTRIBUTE stdattrs::name std::str;
+CREATE ABSTRACT ATTRIBUTE stdattrs::is_abstract std::bool;
+CREATE ABSTRACT ATTRIBUTE stdattrs::is_final std::bool;
+CREATE ABSTRACT ATTRIBUTE stdattrs::is_derived std::bool;
+CREATE ABSTRACT ATTRIBUTE stdattrs::is_virtual std::bool;
+CREATE ABSTRACT ATTRIBUTE stdattrs::view_type std::int64;
+CREATE ABSTRACT ATTRIBUTE stdattrs::title std::str;
+CREATE ABSTRACT ATTRIBUTE stdattrs::description std::str;
+
+CREATE ABSTRACT ATTRIBUTE stdattrs::expr std::str;
+CREATE ABSTRACT ATTRIBUTE stdattrs::subjectexpr std::str;
+CREATE ABSTRACT ATTRIBUTE stdattrs::finalexpr std::str;
+CREATE ABSTRACT ATTRIBUTE stdattrs::errmessage std::str;
+
+CREATE ABSTRACT ATTRIBUTE stdattrs::value std::str;
+CREATE ABSTRACT ATTRIBUTE stdattrs::required std::bool;
+CREATE ABSTRACT ATTRIBUTE stdattrs::readonly std::bool;
+CREATE ABSTRACT ATTRIBUTE stdattrs::computable std::bool;
+CREATE ABSTRACT ATTRIBUTE stdattrs::default std::str;
+CREATE ABSTRACT ATTRIBUTE stdattrs::expression std::str;
+CREATE ABSTRACT ATTRIBUTE stdattrs::cardinality std::str;
+CREATE ABSTRACT ATTRIBUTE stdattrs::aggregate std::bool;
+CREATE ABSTRACT ATTRIBUTE stdattrs::language std::str;
+CREATE ABSTRACT ATTRIBUTE stdattrs::code std::str;
+CREATE ABSTRACT ATTRIBUTE stdattrs::from_function std::str;
+CREATE ABSTRACT ATTRIBUTE stdattrs::initial_value std::str;
+CREATE ABSTRACT ATTRIBUTE stdattrs::return_typemod std::str;
+
+CREATE SCALAR TYPE schema::target_delete_action_t EXTENDING std::str {
+    CREATE CONSTRAINT std::enum ('RESTRICT', 'DELETE SOURCE', 'SET EMPTY',
+                                 'SET DEFAULT', 'DEFERRED RESTRICT');
+};
+
+CREATE ABSTRACT ATTRIBUTE stdattrs::on_target_delete
+    schema::target_delete_action_t;
 
 
 # Base type for all schema entities.
@@ -607,6 +556,8 @@ ALTER TYPE schema::Pointer {
 
 ALTER TYPE schema::Link {
     CREATE LINK schema::properties := __source__.pointers;
+    CREATE PROPERTY schema::on_target_delete ->
+        schema::target_delete_action_t;
 };
 
 

--- a/edb/lang/schema/ast.py
+++ b/edb/lang/schema/ast.py
@@ -35,10 +35,7 @@ class Base(ast.AST):
 
     def __repr__(self):
         ar = self._extra_repr()
-        return '<{}.{} at {:#x}{}>'.format(self.__class__.ns,
-                                           self.__class__.__name__,
-                                           id(self),
-                                           ar)
+        return f'<{self.__class__.__name__} at {id(self):#x}{ar}>'
 
 
 class Spec(Base):
@@ -93,7 +90,7 @@ class Property(Pointer):
 
 class Link(Pointer):
     properties: typing.List[Property]
-    on_delete: OnTargetDelete
+    on_target_delete: OnTargetDelete
 
 
 # # XXX: to be killed

--- a/edb/lang/schema/codegen.py
+++ b/edb/lang/schema/codegen.py
@@ -56,7 +56,7 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
         if (getattr(node, 'attributes', None) or
                 getattr(node, 'constraints', None) or
                 getattr(node, 'links', None) or
-                getattr(node, 'on_delete', None) or
+                getattr(node, 'on_target_delete', None) or
                 getattr(node, 'properties', None)):
             self.write(':')
             self.new_lines = 1
@@ -73,8 +73,8 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
                 self._visit_list(node.policies)
             if getattr(node, 'indexes', None):
                 self._visit_list(node.indexes)
-            if getattr(node, 'on_delete', None):
-                self.visit(node.on_delete)
+            if getattr(node, 'on_target_delete', None):
+                self.visit(node.on_target_delete)
 
             self.indentation -= 1
         self.new_lines = 2

--- a/edb/lang/schema/derivable.py
+++ b/edb/lang/schema/derivable.py
@@ -62,13 +62,15 @@ class DerivableObjectBase:
 
     def finalize_derived(self, schema, derived, *, merge_bases=None,
                          replace_original=None, add_to_schema=False,
-                         mark_derived=False, attrs=None, dctx=None, **kwargs):
+                         mark_derived=False, apply_defaults=True,
+                         attrs=None, dctx=None, **kwargs):
 
         if merge_bases:
             derived.acquire_ancestor_inheritance(
                 schema, bases=merge_bases)
 
-        derived.finalize(schema, bases=merge_bases)
+        derived.finalize(schema, bases=merge_bases,
+                         apply_defaults=apply_defaults)
 
         if mark_derived:
             derived.is_derived = True
@@ -105,7 +107,7 @@ class DerivableObjectBase:
     def derive(self, schema, source, *qualifiers, merge_bases=None,
                replace_original=None, add_to_schema=False,
                mark_derived=False, attrs=None, dctx=None,
-               name=None, **kwargs):
+               name=None, apply_defaults=True, **kwargs):
         if not self.generic():
             raise TypeError(
                 'cannot derive from specialized {} {!r}'.format(
@@ -120,7 +122,7 @@ class DerivableObjectBase:
         self.finalize_derived(
             schema, derived, merge_bases=merge_bases,
             add_to_schema=add_to_schema, mark_derived=mark_derived,
-            dctx=dctx)
+            apply_defaults=apply_defaults, dctx=dctx)
 
         return derived
 

--- a/edb/lang/schema/expr.py
+++ b/edb/lang/schema/expr.py
@@ -27,14 +27,17 @@ class ExpressionText(str):
 
 class ExpressionList(typed.TypedList, type=literal.Literal):
     @classmethod
-    def merge_values(cls, ours, theirs, schema):
-        if not ours:
+    def merge_values(cls, target, sources, field_name, *, schema):
+        result = getattr(target, field_name)
+        for source in sources:
+            theirs = getattr(source, field_name)
             if theirs:
-                ours = theirs[:]
-        elif theirs and isinstance(ours[-1], ExpressionText):
-            ours.extend(theirs)
+                if result is None:
+                    result = theirs[:]
+                else:
+                    result.extend(theirs)
 
-        return ours
+        return result
 
 
 class ExpressionDict(typed.TypedDict, keytype=str, valuetype=literal.Literal):

--- a/edb/lang/schema/inheriting.py
+++ b/edb/lang/schema/inheriting.py
@@ -326,9 +326,10 @@ class InheritingObject(derivable.DerivableObject):
     is_final = so.Field(bool, default=False, compcoef=0.909)
     is_virtual = so.Field(bool, default=False, compcoef=0.5)
 
-    def merge(self, obj, *, schema, dctx=None):
-        super().merge(obj, schema=schema, dctx=dctx)
-        schema.drop_inheritance_cache(obj)
+    def merge(self, *objs, schema, dctx=None):
+        super().merge(*objs, schema=schema, dctx=dctx)
+        for obj in objs:
+            schema.drop_inheritance_cache(obj)
 
     def delta(self, other, reverse=False, *, context):
         old, new = (other, self) if not reverse else (self, other)
@@ -465,16 +466,16 @@ class InheritingObject(derivable.DerivableObject):
         if bases is None:
             bases = self.bases
 
-        for base in bases:
-            self.merge(base, schema=schema, dctx=dctx)
+        self.merge(*bases, schema=schema, dctx=dctx)
 
     def update_descendants(self, schema, dctx=None):
         for child in self.children(schema):
             child.acquire_ancestor_inheritance(schema, dctx=dctx)
             child.update_descendants(schema, dctx=dctx)
 
-    def finalize(self, schema, bases=None, *, dctx=None):
-        super().finalize(schema, bases=bases, dctx=dctx)
+    def finalize(self, schema, bases=None, *, apply_defaults=True, dctx=None):
+        super().finalize(schema, bases=bases, apply_defaults=apply_defaults,
+                         dctx=dctx)
         self.mro = compute_mro(self)[1:]
         self.acquire_ancestor_inheritance(schema, dctx=dctx)
 

--- a/edb/lang/schema/lproperties.py
+++ b/edb/lang/schema/lproperties.py
@@ -98,20 +98,22 @@ class Property(pointers.Pointer):
         result.default = self.default
         return result
 
-    def finalize(self, schema, bases=None, *, dctx=None):
-        super().finalize(schema, bases=bases, dctx=dctx)
+    def finalize(self, schema, bases=None, *, apply_defaults=True, dctx=None):
+        super().finalize(schema, bases=bases, apply_defaults=apply_defaults,
+                         dctx=dctx)
 
-        if not self.generic() and self.cardinality is None:
-            self.cardinality = pointers.PointerCardinality.OneToOne
+        if not self.generic() and apply_defaults:
+            if self.cardinality is None:
+                self.cardinality = pointers.PointerCardinality.OneToOne
 
-            if dctx is not None:
-                from . import delta as sd
+                if dctx is not None:
+                    from . import delta as sd
 
-                dctx.current().op.add(sd.AlterObjectProperty(
-                    property='cardinality',
-                    new_value=self.cardinality,
-                    source='default'
-                ))
+                    dctx.current().op.add(sd.AlterObjectProperty(
+                        property='cardinality',
+                        new_value=self.cardinality,
+                        source='default'
+                    ))
 
     @classmethod
     def get_root_classes(cls):

--- a/edb/lang/schema/parser/grammar/declarations.py
+++ b/edb/lang/schema/parser/grammar/declarations.py
@@ -919,7 +919,7 @@ class Link(Nonterm):
             constraints=constraints,
             policies=policies,
             properties=properties,
-            on_delete=on_delete)
+            on_target_delete=on_delete)
 
     def reduce_LINK_Spec(self, *kids):
         self.val = self._process_pointerspec(kids[1].val)

--- a/edb/lang/schema/pointers.py
+++ b/edb/lang/schema/pointers.py
@@ -17,6 +17,8 @@
 #
 
 
+import functools
+
 from edb.lang import edgeql
 from edb.lang.edgeql import ast as qlast
 from edb.lang.common import enum
@@ -73,15 +75,11 @@ class PointerCardinality(enum.StrEnum):
         return self.__class__(min(self[0], other[0]) + min(self[1], other[1]))
 
     @classmethod
-    def merge_values(cls, ours, theirs, schema):
-        if ours and theirs and ours != theirs:
-            result = ours & theirs
-        elif not ours and theirs:
-            result = theirs
-        else:
-            result = ours
-
-        return result
+    def merge_values(cls, target, sources, field_name, *, schema):
+        def f(values):
+            return functools.reduce(lambda a, b: a & b, values)
+        return utils.merge_reduce(target, sources, field_name,
+                                  schema=schema, f=f)
 
 
 class Pointer(constraints.ConsistencySubject,

--- a/edb/lang/schema/referencing.py
+++ b/edb/lang/schema/referencing.py
@@ -457,17 +457,18 @@ class ReferencingObject(inheriting.InheritingObject,
 
         return similarity
 
-    def merge(self, obj, *, schema, dctx=None):
-        super().merge(obj, schema=schema, dctx=None)
+    def merge(self, *objs, schema, dctx=None):
+        super().merge(*objs, schema=schema, dctx=None)
 
-        for refdict in self.__class__.get_refdicts():
-            # Merge Object references in each registered collection.
-            #
-            this_coll = getattr(self, refdict.attr)
-            other_coll = getattr(obj, refdict.attr)
+        for obj in objs:
+            for refdict in self.__class__.get_refdicts():
+                # Merge Object references in each registered collection.
+                #
+                this_coll = getattr(self, refdict.attr)
+                other_coll = getattr(obj, refdict.attr)
 
-            this_coll.update({k: v for k, v in other_coll.items()
-                              if k not in this_coll})
+                this_coll.update({k: v for k, v in other_coll.items()
+                                 if k not in this_coll})
 
     def delta(self, other, reverse=False, context=None):
         old, new = (other, self) if not reverse else (self, other)
@@ -626,8 +627,9 @@ class ReferencingObject(inheriting.InheritingObject,
 
             setattr(self, attr, attrs)
 
-    def finalize(self, schema, bases=None, *, dctx=None):
-        super().finalize(schema, bases=bases, dctx=dctx)
+    def finalize(self, schema, bases=None, *, apply_defaults=True, dctx=None):
+        super().finalize(schema, bases=bases, apply_defaults=apply_defaults,
+                         dctx=dctx)
 
         if bases is None:
             bases = self.bases

--- a/edb/lang/schema/utils.py
+++ b/edb/lang/schema/utils.py
@@ -239,22 +239,28 @@ def get_full_inheritance_map(schema, classes):
     return result
 
 
-def merge_sticky_bool(ours, theirs, schema):
-    if ours is not None and theirs is not None:
-        result = max(ours, theirs)
+def merge_reduce(target, sources, field_name, *, schema, f):
+    values = []
+    ours = getattr(target, field_name)
+    if ours is not None:
+        values.append(ours)
+    for source in sources:
+        theirs = getattr(source, field_name)
+        if theirs is not None:
+            values.append(theirs)
+
+    if values:
+        return f(values)
     else:
-        result = theirs if theirs is not None else ours
-
-    return result
+        return None
 
 
-def merge_weak_bool(ours, theirs, schema):
-    if ours is not None and theirs is not None:
-        result = min(ours, theirs)
-    else:
-        result = theirs if theirs is not None else ours
+def merge_sticky_bool(target, sources, field_name, *, schema):
+    return merge_reduce(target, sources, field_name, schema=schema, f=max)
 
-    return result
+
+def merge_weak_bool(target, sources, field_name, *, schema):
+    return merge_reduce(target, sources, field_name, schema=schema, f=min)
 
 
 def find_item_suggestions(

--- a/edb/server/pgsql/errormech.py
+++ b/edb/server/pgsql/errormech.py
@@ -33,7 +33,9 @@ class ErrorMech:
             ('cardinality', re.compile(r'^.*".*_cardinality_idx".*$')),
             ('link_target', re.compile(r'^.*link target constraint$')),
             ('constraint', re.compile(r'^.*;schemaconstr(?:#\d+)?".*$')),
-            ('id', re.compile(r'^.*"(?:\w+)_data_pkey".*$')), ))
+            ('id', re.compile(r'^.*"(?:\w+)_data_pkey".*$')),
+            ('link_target_del', re.compile(r'^.*link target policy$')),
+        ))
     }
 
     @classmethod
@@ -116,6 +118,10 @@ class ErrorMech:
 
                 return edgedb_error.InvalidPointerTargetError(msg)
 
+            elif error_type == 'link_target_del':
+                return edgedb_error.ConstraintViolationError(
+                    err.message, detail=err.detail)
+
             elif error_type == 'constraint':
                 constraint_name = \
                     await constr_mech.constraint_name_from_pg_name(
@@ -133,5 +139,6 @@ class ErrorMech:
                 msg = 'unique link constraint violation'
                 errcls = edgedb_error.UniqueConstraintViolationError
                 return errcls(msg=msg)
+
         else:
             return edgedb_error.EdgeDBBackendError(err.message)

--- a/edb/server/pgsql/metaschema.py
+++ b/edb/server/pgsql/metaschema.py
@@ -781,6 +781,7 @@ class TriggerDescType(dbops.CompositeType):
             dbops.Column(name='proc', type='text[]'),
             dbops.Column(name='is_constraint', type='bool'),
             dbops.Column(name='granularity', type='text'),
+            dbops.Column(name='deferred', type='bool'),
             dbops.Column(name='timing', type='text'),
             dbops.Column(name='events', type='text[]'),
             dbops.Column(name='definition', type='text'),
@@ -800,6 +801,7 @@ class IntrospectTriggersFunction(dbops.Function):
             trg_proc,
             trg_constraint,
             trg_granularity,
+            trg_deferred,
             trg_timing,
             trg_events,
             trg_definition,
@@ -832,6 +834,8 @@ class IntrospectTriggersFunction(dbops.Function):
                         WHEN (t.tgtype & (1 << 0)) != 0 THEN 'row'
                         ELSE 'statement'
                     END)                                    AS trg_granularity,
+
+                    t.tginitdeferred                        AS trg_deferred,
 
                     (CASE
                         WHEN (t.tgtype & (1 << 1)) != 0 THEN 'before'

--- a/edb/server/protocol.py
+++ b/edb/server/protocol.py
@@ -89,7 +89,6 @@ class Protocol(asyncio.Protocol):
         self._loop = loop
         self.pgconn = None
         self.state = ConnectionState.NOT_CONNECTED
-        self.transactions = []
         self.buffer = bytearray()
 
     def connection_made(self, transport):

--- a/tests/schemas/link_tgt_del.eschema
+++ b/tests/schemas/link_tgt_del.eschema
@@ -1,0 +1,44 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-2016 MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+abstract type Named:
+    required property name -> str
+
+
+type Target1 extending Named
+type Target1Child extending Target1
+
+
+type Source1 extending Named:
+    link tgt1_restrict -> Target1:
+        on target delete restrict
+
+    link tgt1_set_empty -> Target1:
+        on target delete set empty
+
+    link tgt1_del_source -> Target1:
+        on target delete delete source
+
+    link tgt1_deferred_restrict -> Target1:
+        on target delete deferred restrict
+
+
+type Source2 extending Named:
+    link src1_del_source -> Source1:
+        on target delete delete source

--- a/tests/test_deltas.py
+++ b/tests/test_deltas.py
@@ -314,6 +314,7 @@ ALTER TYPE test::NamedObject {
     CREATE REQUIRED LINK test::related -> test::NamedObject {
         SET cardinality := '*1';
         SET is_virtual := False;
+        SET on_target_delete := 'RESTRICT';
         SET readonly := False;
     };
     ALTER LINK test::related {

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -197,6 +197,8 @@ class TestIntrospection(tb.QueryTestCase):
                         {'name': 'stdattrs::is_final', '@value': 'false'},
                         {'name': 'stdattrs::is_virtual', '@value': 'false'},
                         {'name': 'stdattrs::name', '@value': 'test::todo'},
+                        {'name': 'stdattrs::on_target_delete',
+                         '@value': 'RESTRICT'},
                         {'name': 'stdattrs::readonly', '@value': 'false'},
                         {'name': 'stdattrs::required', '@value': 'false'},
                     ]

--- a/tests/test_link_target_delete.py
+++ b/tests/test_link_target_delete.py
@@ -1,0 +1,277 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import pathlib
+
+from edb.client import exceptions
+
+from edb.lang import _testbase as tb
+from edb.lang.schema import error as s_err
+from edb.lang.schema import links as s_links
+
+from edb.server import _testbase as stb
+
+
+class TestLinkTargetDeleteSchema(tb.BaseSchemaTest):
+    def test_schema_on_target_delete_01(self):
+        schema = self.load_schema("""
+            type Object:
+                link foo -> Object:
+                    on target delete set empty
+
+                link bar -> Object
+        """)
+
+        obj = schema.get('test::Object')
+
+        self.assertEqual(obj.getptr(schema, 'foo').on_target_delete,
+                         s_links.LinkTargetDeleteAction.SET_EMPTY)
+
+        self.assertEqual(obj.getptr(schema, 'bar').on_target_delete,
+                         s_links.LinkTargetDeleteAction.RESTRICT)
+
+    def test_schema_on_target_delete_02(self):
+        schema = self.load_schema("""
+            type Object:
+                link foo -> Object:
+                    on target delete set empty
+
+            type Object2 extending Object:
+                inherited link foo -> Object:
+                    title := "Foo"
+
+            type Object3 extending Object:
+                inherited link foo -> Object:
+                    on target delete restrict
+        """)
+
+        obj2 = schema.get('test::Object2')
+        self.assertEqual(obj2.getptr(schema, 'foo').on_target_delete,
+                         s_links.LinkTargetDeleteAction.SET_EMPTY)
+
+        obj3 = schema.get('test::Object3')
+        self.assertEqual(obj3.getptr(schema, 'foo').on_target_delete,
+                         s_links.LinkTargetDeleteAction.RESTRICT)
+
+    @tb.must_fail(s_err.SchemaError,
+                  "cannot implicitly resolve the `on target delete` action "
+                  "for 'test::C.foo'")
+    def test_schema_on_target_delete_03(self):
+        """
+            type A:
+                link foo -> Object:
+                    on target delete restrict
+
+            type B:
+                link foo -> Object:
+                    on target delete set empty
+
+            type C extending A, B
+        """
+
+
+class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
+    SCHEMA = pathlib.Path(__file__).parent / 'schemas' / 'link_tgt_del.eschema'
+    ISOLATED_METHODS = False
+
+    async def test_link_on_target_delete_restrict_01(self):
+        async with self._run_and_rollback():
+            await self.con.execute("""
+                INSERT test::Target1 {
+                    name := 'Target1.1'
+                };
+
+                INSERT test::Source1 {
+                    name := 'Source1.1',
+                    tgt1_restrict := (
+                        SELECT test::Target1
+                        FILTER .name = 'Target1.1'
+                    )
+                };
+            """)
+
+            with self.assertRaisesRegex(
+                    exceptions.ConstraintViolationError,
+                    'deletion of test::Target1 .* is prohibited by link'):
+                await self.con.execute("""
+                    DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                """)
+
+    async def test_link_on_target_delete_restrict_02(self):
+        async with self._run_and_rollback():
+            await self.con.execute("""
+                INSERT test::Target1Child {
+                    name := 'Target1Child.1'
+                };
+
+                INSERT test::Source1 {
+                    name := 'Source1.1',
+                    tgt1_restrict := (
+                        SELECT test::Target1
+                        FILTER .name = 'Target1Child.1'
+                    )
+                };
+            """)
+
+            with self.assertRaisesRegex(
+                    exceptions.ConstraintViolationError,
+                    'deletion of test::Target1 .* is prohibited by link'):
+                await self.con.execute("""
+                    DELETE (SELECT test::Target1Child
+                            FILTER .name = 'Target1Child.1');
+                """)
+
+    async def test_link_on_target_delete_deferred_restrict_01(self):
+            exception_is_deferred = False
+
+            with self.assertRaisesRegex(
+                    exceptions.ConstraintViolationError,
+                    'deletion of test::Target1 .* is prohibited by link'):
+
+                async with self.con.transaction():
+                    await self.con.execute("""
+                        INSERT test::Target1 {
+                            name := 'Target1.1'
+                        };
+
+                        INSERT test::Source1 {
+                            name := 'Source1.1',
+                            tgt1_deferred_restrict := (
+                                SELECT test::Target1
+                                FILTER .name = 'Target1.1'
+                            )
+                        };
+                    """)
+
+                    await self.con.execute("""
+                        DELETE (SELECT test::Target1
+                                FILTER .name = 'Target1.1');
+                    """)
+
+                    exception_is_deferred = True
+
+            self.assertTrue(exception_is_deferred)
+
+    async def test_link_on_target_delete_set_empty_01(self):
+        async with self._run_and_rollback():
+            await self.con.execute("""
+                INSERT test::Target1 {
+                    name := 'Target1.1'
+                };
+
+                INSERT test::Source1 {
+                    name := 'Source1.1',
+                    tgt1_set_empty := (
+                        SELECT test::Target1
+                        FILTER .name = 'Target1.1'
+                    )
+                };
+            """)
+
+            await self.assert_query_result(r'''
+                WITH MODULE test
+                SELECT
+                    Source1 {
+                        tgt1_set_empty: {
+                            name
+                        }
+                    };
+            ''', [
+                [{
+                    'tgt1_set_empty': {'name': 'Target1.1'},
+                }]
+            ])
+
+            await self.con.execute("""
+                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+            """)
+
+            await self.assert_query_result(r'''
+                WITH MODULE test
+                SELECT
+                    Source1 {
+                        tgt1_set_empty: {
+                            name
+                        }
+                    };
+            ''', [
+                [{
+                    'tgt1_set_empty': None,
+                }]
+            ])
+
+    async def test_link_on_target_delete_delete_source_01(self):
+        async with self._run_and_rollback():
+            await self.con.execute("""
+                INSERT test::Target1 {
+                    name := 'Target1.1'
+                };
+
+                INSERT test::Source1 {
+                    name := 'Source1.1',
+                    tgt1_del_source := (
+                        SELECT test::Target1
+                        FILTER .name = 'Target1.1'
+                    )
+                };
+
+                INSERT test::Source2 {
+                    name := 'Source2.1',
+                    src1_del_source := (
+                        SELECT test::Source1
+                        FILTER .name = 'Source1.1'
+                    )
+                };
+            """)
+
+            await self.assert_query_result(r'''
+                WITH MODULE test
+                SELECT
+                    Source2 {
+                        src1_del_source: {
+                            name,
+                            tgt1_del_source: {
+                                name
+                            }
+                        }
+                    }
+                FILTER
+                    .name = 'Source2.1';
+            ''', [
+                [{
+                    'src1_del_source': {
+                        'name': 'Source1.1',
+                        'tgt1_del_source': {'name': 'Target1.1'},
+                    }
+                }]
+            ])
+
+            await self.con.execute("""
+                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+            """)
+
+            await self.assert_query_result(r'''
+                WITH MODULE test
+                SELECT
+                    Source2
+                FILTER
+                    .name = 'Source2.1';
+            ''', [
+                []
+            ])


### PR DESCRIPTION
The new `on target delete` clause of concrete links is a mechanism
to specify what happens when a target object of a link instance
is deleted.

Currently implemented modes are:

* `RESTRICT` -- produce an error indicating that deletion cannot be
  done due to an existing link. This is the default.
* `DEFERRED RESTRICT` -- same as the above, but the check is postponed
  until the end of the current transaction, if there is no transaction,
  equivalent to `RESTRICT`.
* `SET EMPTY` -- remove the link, can only be used with links that are
  not required.
* `DELETE SOURCE` -- remove the link and the source of the link
  (cascaded deletion).