### PR TITLE
Interpret numeric literals the way PostgreSQL does (almost)

### DIFF
--- a/edb/lang/edgeql/ast.py
+++ b/edb/lang/edgeql/ast.py
@@ -17,6 +17,7 @@
 #
 
 
+import decimal
 import typing
 
 from edb.lang.common import enum as s_enum
@@ -231,7 +232,7 @@ class FunctionCall(Expr):
 
 
 class Constant(Expr):
-    value: typing.Union[int, str, float, bool, bytes]
+    value: typing.Union[int, str, float, bool, bytes, decimal.Decimal]
 
 
 class Parameter(Expr):

--- a/edb/lang/edgeql/compiler/setgen.py
+++ b/edb/lang/edgeql/compiler/setgen.py
@@ -609,7 +609,8 @@ def ensure_set(
             typehint is not None):
         irutils.amend_empty_set_type(expr, typehint, schema=ctx.schema)
 
-    if typehint is not None and not expr.scls.issubclass(typehint):
+    if (typehint is not None and
+            not expr.scls.implicitly_castable_to(typehint, ctx.schema)):
         raise errors.EdgeQLError(
             f'expecting expression of type {typehint.name}, '
             f'got {expr.scls.name}',

--- a/edb/lang/edgeql/parser/grammar/expressions.py
+++ b/edb/lang/edgeql/parser/grammar/expressions.py
@@ -19,6 +19,8 @@
 
 import ast as pyast
 import collections
+import decimal
+import numbers
 import re
 
 from edb.lang.common import ast
@@ -621,7 +623,12 @@ class Expr(Nonterm):
 
     @parsing.precedence(precedence.P_UMINUS)
     def reduce_MINUS_Expr(self, *kids):
-        self.val = qlast.UnaryOp(op=ast.ops.UMINUS, operand=kids[1].val)
+        operand = kids[1].val
+        if (isinstance(operand, qlast.Constant) and
+                isinstance(operand.value, numbers.Number)):
+            self.val = qlast.Constant(value=-operand.value)
+        else:
+            self.val = qlast.UnaryOp(op=ast.ops.UMINUS, operand=kids[1].val)
 
     def reduce_Expr_PLUS_Expr(self, *kids):
         self.val = qlast.BinOp(left=kids[0].val, op=ast.ops.ADD,
@@ -848,7 +855,7 @@ class BaseNumberConstant(Nonterm):
         self.val = qlast.Constant(value=int(kids[0].val))
 
     def reduce_FCONST(self, *kids):
-        self.val = qlast.Constant(value=float(kids[0].val))
+        self.val = qlast.Constant(value=decimal.Decimal(kids[0].val))
 
 
 class BaseStringConstant(Nonterm):

--- a/edb/lang/schema/functions.py
+++ b/edb/lang/schema/functions.py
@@ -326,7 +326,7 @@ class CreateFunction(named.CreateNamedObject, FunctionCommand):
 
             if check_default_type:
                 default_type = irutils.infer_type(default, schema)
-                if not default_type.issubclass(p.type):
+                if not default_type.assignment_castable_to(p.type, schema):
                     raise ql_errors.EdgeQLError(
                         f'invalid declaration of parameter ${p.name} of '
                         f'function "{name}()": unexpected type of the default '

--- a/edb/lang/schema/types.py
+++ b/edb/lang/schema/types.py
@@ -245,6 +245,13 @@ class Array(Collection):
         return self.element_type.implicitly_castable_to(
             other.element_type, schema)
 
+    def assignment_castable_to(self, other: Type, schema) -> bool:
+        if not isinstance(other, Array):
+            return False
+
+        return self.element_type.assignment_castable_to(
+            other.element_type, schema)
+
     def find_common_implicitly_castable_type(
             self, other: Type, schema) -> typing.Optional[Type]:
 
@@ -345,6 +352,19 @@ class Tuple(Collection):
 
         for st, ot in zip(self.element_types, other.element_types):
             if not st.implicitly_castable_to(ot, schema):
+                return False
+
+        return True
+
+    def assignment_castable_to(self, other: Type, schema) -> bool:
+        if not isinstance(other, Tuple):
+            return False
+
+        if len(self.element_types) != len(other.element_types):
+            return False
+
+        for st, ot in zip(self.element_types, other.element_types):
+            if not st.assignment_castable_to(ot, schema):
                 return False
 
         return True

--- a/edb/server/pgsql/codegen.py
+++ b/edb/server/pgsql/codegen.py
@@ -622,7 +622,10 @@ class SQLSourceGenerator(codegen.SourceGenerator):
                     'unexpected NULLS order: {}'.format(node.nulls))
 
     def visit_TypeCast(self, node):
+        # '::' has very high precedence, so parenthesize the expression.
+        self.write('(')
         self.visit(node.arg)
+        self.write(')')
         self.write('::')
         self.visit(node.type_name)
 

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -384,16 +384,16 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             {'std::float64'},
 
             {'std::float64'},
-            {'std::decimal'},
+            {'std::float64'},
             {'std::decimal'},
 
             {'std::decimal'},
             {'std::float64'},
-            {'std::float64'},
+            {'std::decimal'},
 
             {'std::float64'},
             {'std::float32'},
-            {'std::float64'},
+            {'std::decimal'},
         ])
 
     async def test_edgeql_calls_11(self):

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -440,10 +440,8 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
     async def test_edgeql_functions_array_get_03(self):
         with self.assertRaisesRegex(
-                # FIXME: a different error should be used here, this
-                # one leaks Postgres types
-                exc.UnknownEdgeDBError,
-                r'integer out of range'):
+                exc.EdgeQLError,
+                r'could not find a function variant array_get'):
 
             await self.con.execute(r'''
                 SELECT array_get([1, 2, 3], 2^40);

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -132,7 +132,7 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
 
         SELECT 354.32;
         SELECT 35400000000000.32;
-        SELECT 3.54e+19;
+        SELECT 35400000000000000000.32;
         SELECT 3.5432e+20;
         SELECT 3.5432e+20;
         SELECT 3.5432e-20;


### PR DESCRIPTION
Numeric literals are now interpreted almost like they do in
PostgreSQL:

  - numerics without a decimal point that fit into 64 bits are
    interpreted as `std::int64`,
  - all other numeric literals are interpreted as `std::decimal`