### PR TITLE
Add support for raw string literals; tweak lexer/ast.

### DIFF
--- a/edb/lang/edgeql/ast.py
+++ b/edb/lang/edgeql/ast.py
@@ -24,6 +24,7 @@ from edb.lang.common import enum as s_enum
 from edb.lang.common import ast, parsing
 
 from . import functypes as ft
+from . import quote
 
 
 # Operators
@@ -233,6 +234,25 @@ class FunctionCall(Expr):
 
 class Constant(Expr):
     value: typing.Union[int, str, float, bool, bytes, decimal.Decimal]
+
+
+class StringConstant(Constant):
+    quote: str
+
+    @classmethod
+    def from_pystr(cls, s: str):
+        s = s.replace('\\', '\\\\')
+        value = quote.quote_literal(s)
+        return cls(value=value[1:-1], quote="'")
+
+
+class RawStringConstant(Constant):
+    quote: str
+
+    @classmethod
+    def from_pystr(cls, s: str):
+        value = quote.quote_literal(s)
+        return cls(value=value[1:-1], quote="'")
 
 
 class Parameter(Expr):

--- a/edb/lang/edgeql/codegen.py
+++ b/edb/lang/edgeql/codegen.py
@@ -505,6 +505,15 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
     def visit_Parameter(self, node):
         self.write(param_to_str(node.name))
 
+    def visit_StringConstant(self, node):
+        self.write(node.quote, node.value, node.quote)
+
+    def visit_RawStringConstant(self, node):
+        if node.quote.startswith('$'):
+            self.write(node.quote, node.value, node.quote)
+        else:
+            self.write('r', node.quote, node.value, node.quote)
+
     def visit_Constant(self, node):
         if isinstance(node.value, str):
             self.write(edgeql_quote.quote_literal(node.value))

--- a/edb/lang/edgeql/compiler/decompiler.py
+++ b/edb/lang/edgeql/compiler/decompiler.py
@@ -175,6 +175,12 @@ class IRDecompiler(ast.visitor.NodeVisitor):
     def visit_Constant(self, node):
         return qlast.Constant(value=node.value)
 
+    def visit_StringConstant(self, node):
+        return qlast.StringConstant.from_pystr(node.value)
+
+    def visit_RawStringConstant(self, node):
+        return qlast.RawStringConstant.from_pystr(node.value)
+
     def visit_Array(self, node):
         return qlast.Array(elements=[
             self.visit(e) for e in node.elements

--- a/edb/lang/edgeql/compiler/expr.py
+++ b/edb/lang/edgeql/compiler/expr.py
@@ -161,11 +161,20 @@ def compile_Set(
 def compile_Constant(
         expr: qlast.Base, *, ctx: context.ContextLevel) -> irast.Base:
 
+    node_cls = irast.Constant
+
     if expr.value is None:
         ct = None
     else:
-        if isinstance(expr.value, str):
+        if isinstance(expr, qlast.StringConstant):
             std_type = 'std::str'
+            node_cls = irast.StringConstant
+        elif isinstance(expr, qlast.RawStringConstant):
+            std_type = 'std::str'
+            node_cls = irast.RawStringConstant
+        elif isinstance(expr.value, str):
+            std_type = 'std::str'
+            node_cls = irast.StringConstant
         elif isinstance(expr.value, decimal.Decimal):
             std_type = 'std::decimal'
         elif isinstance(expr.value, float):
@@ -187,7 +196,7 @@ def compile_Constant(
         ct = ctx.schema.get(std_type)
 
     return setgen.generated_set(
-        irast.Constant(value=expr.value, type=ct), ctx=ctx)
+        node_cls(value=expr.value, type=ct), ctx=ctx)
 
 
 @dispatch.compile.register(qlast.EmptyCollection)

--- a/edb/lang/edgeql/parser/grammar/lexer.py
+++ b/edb/lang/edgeql/parser/grammar/lexer.py
@@ -43,7 +43,7 @@ class EdgeQLLexer(lexer.Lexer):
     MERGE_TOKENS = {('NAMED', 'ONLY')}
 
     NL = 'NL'
-    MULTILINE_TOKENS = frozenset(('SCONST', 'BCONST'))
+    MULTILINE_TOKENS = frozenset(('SCONST', 'BCONST', 'RSCONST'))
     RE_FLAGS = re.X | re.M | re.I
 
     # Basic keywords
@@ -122,31 +122,50 @@ class EdgeQLLexer(lexer.Lexer):
                     b
                 )
                 (?P<BQ>
-                    (
-                        ' | "
-                    )
+                    ' | "
                 )
                 (?:
                     (
-                        (\\\\ | \\['"] | \n | .)*?
+                        \\\\ | \\['"] | \n | .
                         # we'll validate escape codes in the parser
                     )*?
                 )
                 (?P=BQ)
              '''),
 
+        Rule(token='RSCONST',
+             next_state=STATE_KEEP,
+             regexp=rf'''
+                (?:
+                    r
+                )?
+                (?P<RQ>
+                    (?:
+                        (?<=r) (?: ' | ")
+                    ) | (?:
+                        (?<!r) (?: {re_dquote})
+                    )
+                )
+                (?:
+                    (
+                        \n | .
+                        # we'll validate escape codes in the parser
+                    )*?
+                )
+                (?P=RQ)
+             '''),
+
         Rule(token='SCONST',
              next_state=STATE_KEEP,
              regexp=rf'''
                 (?P<Q>
-                    (
-                        ' | " |
-                        {re_dquote}
-                    )
+                    ' | "
                 )
                 (?:
-                    (\\\\ | \\['"] | \n | .)*?
-                    # we'll validate escapes codes in the parser
+                    (
+                        \\\\ | \\['"] | \n | .
+                        # we'll validate escape codes in the parser
+                    )*?
                 )
                 (?P=Q)
              '''),

--- a/edb/lang/edgeql/parser/grammar/tokens.py
+++ b/edb/lang/edgeql/parser/grammar/tokens.py
@@ -177,6 +177,10 @@ class T_SCONST(Token):
     pass
 
 
+class T_RSCONST(Token):
+    pass
+
+
 class T_IDENT(Token):
     pass
 

--- a/edb/lang/graphql/translator.py
+++ b/edb/lang/graphql/translator.py
@@ -119,8 +119,8 @@ class GraphQLTranslator(ast.NodeVisitor):
             if (isinstance(el.compexpr, qlast.FunctionCall) and
                     el.compexpr.func == 'str_to_json'):
                 name = el.expr.steps[0].ptr.name
-                el.compexpr.args[0].arg.value = json.dumps(
-                    gqlresult.data[name], indent=4).replace('\\', '\\\\')
+                el.compexpr.args[0].arg = qlast.StringConstant.from_pystr(
+                    json.dumps(gqlresult.data[name], indent=4))
 
         return translated
 

--- a/edb/lang/ir/ast.py
+++ b/edb/lang/ir/ast.py
@@ -146,6 +146,14 @@ class Constant(Expr):
         super().__init__(*args, type=type, **kwargs)
 
 
+class StringConstant(Constant):
+    pass
+
+
+class RawStringConstant(Constant):
+    pass
+
+
 class Parameter(Base):
 
     name: str

--- a/edb/lang/schema/_graphql.eql
+++ b/edb/lang/schema/_graphql.eql
@@ -19,7 +19,7 @@
 
 CREATE FUNCTION graphql::short_name(name: std::str) -> std::str
     FROM EdgeQL $$
-        SELECT re_replace(name, '.+?::(.+$)', '\\1') + 'Type'
+        SELECT re_replace(name, '.+?::(.+$)', r'\1') + 'Type'
     $$;
 
 # create Query

--- a/edb/server/pgsql/ast.py
+++ b/edb/server/pgsql/ast.py
@@ -440,6 +440,12 @@ class Constant(BaseExpr):
     val: object
 
 
+class EscapedStringConstant(Constant):
+    """An "E"-prefixed string."""
+
+    val: str
+
+
 class LiteralExpr(BaseExpr):
     """A literal expression."""
 

--- a/edb/server/pgsql/codegen.py
+++ b/edb/server/pgsql/codegen.py
@@ -517,10 +517,14 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         elif isinstance(node.val, bytes):
             b = binascii.b2a_hex(node.val).decode('ascii')
             self.write(f"'\\x{b}'::bytea")
-        elif isinstance(node.val, str):
-            self.write(common.quote_e_literal(node.val))
         else:
             self.write(common.quote_literal(str(node.val)))
+
+    def visit_EscapedStringConstant(self, node):
+        if node.val is None:
+            self.write('NULL')
+        else:
+            self.write(common.quote_e_literal(node.val))
 
     def visit_ParamRef(self, node):
         self.write('$', str(node.number))

--- a/edb/server/pgsql/compiler/expr.py
+++ b/edb/server/pgsql/compiler/expr.py
@@ -131,7 +131,12 @@ def compile_Parameter(
 @dispatch.compile.register(irast.Constant)
 def compile_Constant(
         expr: irast.Base, *, ctx: context.CompilerContextLevel) -> pgast.Base:
-    result = pgast.Constant(val=expr.value)
+
+    if isinstance(expr, irast.StringConstant):
+        result = pgast.EscapedStringConstant(val=expr.value)
+    else:
+        result = pgast.Constant(val=expr.value)
+
     result = typecomp.cast(
         result, source_type=expr.type, target_type=expr.type,
         ir_expr=expr, force=True, env=ctx.env)

--- a/tests/schemas/constraints.eschema
+++ b/tests/schemas/constraints.eschema
@@ -37,11 +37,11 @@ scalar type constraint_minmax extending str:
 scalar type constraint_strvalue extending str:
     constraint expression on (__subject__[-1:] = '9')
 
-    constraint regexp("^\\d+$")
+    constraint regexp(r"^\d+$")
 
     constraint expression on (__subject__[0] = '9')
 
-    constraint regexp("^\\d+9{3,}.*$")
+    constraint regexp(r"^\d+9{3,}.*$")
 
 
 # A variant of enum that uses an array argument instead of

--- a/tests/schemas/constraints_migration/schema.eschema
+++ b/tests/schemas/constraints_migration/schema.eschema
@@ -37,11 +37,11 @@ scalar type constraint_minmax extending str:
 scalar type constraint_strvalue extending str:
     constraint expression on (__subject__[-1:] = '9')
 
-    constraint regexp("^\\d+$")
+    constraint regexp(r"^\d+$")
 
     constraint expression on (__subject__[0] = '9')
 
-    constraint regexp("^\\d+9{3,}.*$")
+    constraint regexp(r"^\d+9{3,}.*$")
 
 
 scalar type constraint_enum extending str:

--- a/tests/schemas/constraints_migration/updated_schema.eschema
+++ b/tests/schemas/constraints_migration/updated_schema.eschema
@@ -37,11 +37,11 @@ scalar type constraint_minmax extending str:
 scalar type constraint_strvalue extending str:
     constraint expression on (__subject__[-1:] = '9')
 
-    constraint regexp("^\\d+$")
+    constraint regexp(r"^\d+$")
 
     constraint expression on (__subject__[0] = '9')
 
-    constraint regexp("^\\d+9{3,}.*$")
+    constraint regexp(r"^\d+9{3,}.*$")
 
 
 scalar type constraint_enum extending str:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -83,12 +83,12 @@ class TestConstraintsSchema(tb.QueryTestCase):
     async def test_constraints_scalar_minmax(self):
         data = {
             # max-value is "9999999989"
-            (10 ** 9 - 1, "Maximum allowed value for .* is '9999999989'."),
+            (10 ** 9 - 1, 'Maximum allowed value for .* is "9999999989".'),
             (10 ** 9 - 11, 'good'),
 
             # min-value is "99990000"
             (10 ** 8 - 10 ** 4 - 1,
-             "Minimum allowed value for .* is '99990000'."),
+             'Minimum allowed value for .* is "99990000".'),
             (10 ** 8 - 21, 'good'),
         }
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -1141,10 +1141,26 @@ class TestExpressions(tb.QueryTestCase):
             SELECT ':\x62:\u2665:\U000025C6:☎️:';
             SELECT '\'"\\\'\""\\x\\u';
             SELECT "'\"\\\'\"\\x\\u";
+
+            SELECT 'aa\
+            bb \
+            aa';
+
+            SELECT r'\n';
+
+            SELECT r'aa\
+            bb \
+            aa';
         """, [
             [':b:♥:◆:☎️:'],
             ['\'"\\\'\""\\x\\u'],
             ['\'"\\\'"\\x\\u'],
+
+            ['aa            bb             aa'],
+
+            ['\\n'],
+
+            ['aa\\\n            bb \\\n            aa'],
         ])
 
     async def test_edgeql_expr_tuple_01(self):

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -100,15 +100,19 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
         """
         SELECT 'a1';
         SELECT "a1";
+        SELECT r'a1';
+        SELECT r"a1";
         SELECT $$a1$$;
         SELECT $qwe$a1$qwe$;
 
 % OK %
 
         SELECT 'a1';
-        SELECT 'a1';
-        SELECT 'a1';
-        SELECT 'a1';
+        SELECT "a1";
+        SELECT r'a1';
+        SELECT r"a1";
+        SELECT $$a1$$;
+        SELECT $qwe$a1$qwe$;
         """
 
     def test_edgeql_syntax_constants_03(self):
@@ -214,7 +218,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"invalid str literal: invalid escape sequence '\\c'",
+                  r"invalid string literal: invalid escape sequence '\\c'",
                   line=2, col=16)
     def test_edgeql_syntax_constants_15(self):
         """
@@ -222,7 +226,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"invalid str literal: invalid escape sequence '\\x0z'",
+                  r"invalid string literal: invalid escape sequence '\\x0z'",
                   line=2, col=16)
     def test_edgeql_syntax_constants_16(self):
         r"""
@@ -244,7 +248,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"invalid str literal: invalid escape sequence '\\u0zaa'",
+                  r"invalid string literal: invalid escape sequence '\\u0zaa'",
                   line=2, col=16)
     def test_edgeql_syntax_constants_19(self):
         r"""
@@ -261,7 +265,7 @@ aa';
 
     def test_edgeql_syntax_constants_21(self):
         r"""
-        select '\'"\\\'\""\\x\\u';
+        SELECT '\'"\\\'\""\\x\\u';
         """
 
     def test_edgeql_syntax_constants_22(self):
@@ -329,6 +333,78 @@ aa';
     def test_edgeql_syntax_constants_30(self):
         r"""
         SELECT 'aaa\x0';
+        """
+
+    def test_edgeql_syntax_constants_31(self):
+        r"""
+        SELECT 'aa\
+        bb \
+        aa';
+% OK %
+        SELECT 'aa bb aa';
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"invalid string literal",
+                  line=2, col=16)
+    def test_edgeql_syntax_constants_32(self):
+        r"""
+        SELECT 'aa\
+        bb \
+        aa\';
+% OK %
+        SELECT 'aabb aa';
+        """
+
+    def test_edgeql_syntax_constants_33(self):
+        r"""
+        SELECT r'aaa\x0';
+        """
+
+    def test_edgeql_syntax_constants_34(self):
+        r"""
+        SELECT r'\';
+        """
+
+    def test_edgeql_syntax_constants_35(self):
+        r"""
+        SELECT r"\n\w\d";
+        """
+
+    def test_edgeql_syntax_constants_36(self):
+        r"""
+        SELECT $aa$\n\w\d$aa$;
+        """
+
+    def test_edgeql_syntax_constants_37(self):
+        r"""
+        SELECT "'''";
+        """
+
+    def test_edgeql_syntax_constants_38(self):
+        r"""
+        SELECT "\n";
+        """
+
+    def test_edgeql_syntax_constants_39(self):
+        r"""
+        SELECT "\x1F\x01\x00\x6e";
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"invalid escape sequence '\\x8F'",
+                  line=2, col=16)
+    def test_edgeql_syntax_constants_40(self):
+        r"""
+        SELECT "\x1F\x01\x8F\x6e";
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"invalid string literal: invalid escape sequence '\\\('",
+                  line=2, col=16)
+    def test_edgeql_syntax_constants_41(self):
+        """
+        SELECT 'aaa \(aaa) bbb';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError, line=1, col=12)

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -715,7 +715,7 @@ event self_deleted:
 
         abstract link time_estimate:
            property unit -> str:
-               constraint my_constraint(')', `)`(')'))
+               constraint my_constraint(')', `)`($$)$$))
         """
 
     def test_eschema_syntax_link_10(self):
@@ -825,7 +825,7 @@ type Foo:
 
         function some_func(foo: std::int64 = 42) -> std::str:
             from sql :=
-                'SELECT \'life\';'
+                "SELECT 'life';"
         """
 
     def test_eschema_syntax_function_03(self):
@@ -904,7 +904,7 @@ type Foo:
 
 % OK %
 
-        function some_func(foo: str = ')') -> std::str:
+        function some_func(foo: str = $$)$$) -> std::str:
             from edgeql function: some_other_func
         """
 
@@ -915,7 +915,7 @@ type Foo:
 
 % OK %
 
-        function some_func(foo: str = ')') -> std::str:
+        function some_func(foo: str = $a1$)$a1$) -> std::str:
             from edgeql function: some_other_func
         """
 


### PR DESCRIPTION
1. Add raw strings.

* `$$ ... $$` strings are now raw strings.

* New syntax: `r'...'` and `r"..."` -- raw string literals.

Raw strings do not process any escapes, meaning that `\` symbol
acts just as any other one.

2. Tweak string literals.

Regular strings no longer accept \xhh codes over 0x7F.  This is
modeled after Rust strings [1], quoting:

"Higher values are not permitted because it is ambiguous whether
they mean Unicode code points or byte values."

3. New AST nodes.

EdgeQL and IR implementations got two new nodes: `StringConstant` and
`RawStringConstant`.  SQL has also a new node: `EscapedStringConstant`
(compiles to an `E'...'` string).

[1] https://doc.rust-lang.org/reference/tokens.html#character-escapes