### PR TITLE
edgeql: Add more `on target delete` tests.

### DIFF
--- a/tests/schemas/link_tgt_del.eschema
+++ b/tests/schemas/link_tgt_del.eschema
@@ -38,7 +38,18 @@ type Source1 extending Named:
     link tgt1_deferred_restrict -> Target1:
         on target delete deferred restrict
 
+    link tgt1_m2m_restrict -> Target1:
+        on target delete restrict
+        cardinality := '**'
+
+    link tgt1_m2m_del_source -> Target1:
+        on target delete delete source
+        cardinality := '**'
+
 
 type Source2 extending Named:
     link src1_del_source -> Source1:
         on target delete delete source
+
+
+type Source3 extending Source1

--- a/tests/test_link_target_delete.py
+++ b/tests/test_link_target_delete.py
@@ -204,7 +204,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
         self.assertTrue(success)
 
-    @unittest.expectedFailure
     async def test_link_on_target_delete_restrict_06(self):
         success = False
 
@@ -232,7 +231,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
         self.assertTrue(success)
 
-    @unittest.expectedFailure
     async def test_link_on_target_delete_restrict_07(self):
         success = False
 
@@ -350,9 +348,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
         self.assertTrue(success)
 
-    # XXX: the failure happens during clean-up and should disappear
-    # once the tests "delete_restrict" 06-08 pass
-    @unittest.expectedFailure
     async def test_link_on_target_delete_deferred_restrict_04(self):
         async with self.con.transaction():
             await self.con.execute(r"""


### PR DESCRIPTION
Deletion doesn't work even when it's done source first, target next.

Because of that some cleanup code fails to run. That triggers errors in other tests. Please run the tests one-by-one.