### PR TITLE
Stop interpreting literals into Python values in constants

### DIFF
--- a/edb/lang/edgeql/codegen.py
+++ b/edb/lang/edgeql/codegen.py
@@ -20,7 +20,7 @@
 import re
 
 from edb.lang.common.exceptions import EdgeDBError
-from edb.lang.common.ast import codegen, AST, base
+from edb.lang.common.ast import codegen, base
 
 from . import ast as edgeql_ast
 from . import quote as edgeql_quote
@@ -514,13 +514,17 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         else:
             self.write('r', node.quote, node.value, node.quote)
 
-    def visit_Constant(self, node):
-        if isinstance(node.value, str):
-            self.write(edgeql_quote.quote_literal(node.value))
-        elif isinstance(node.value, AST):
-            self.visit(node.value)
-        else:
-            self.write(str(node.value))
+    def visit_IntegerConstant(self, node):
+        self.write(node.value)
+
+    def visit_FloatConstant(self, node):
+        self.write(node.value)
+
+    def visit_BooleanConstant(self, node):
+        self.write(node.value)
+
+    def visit_BytesConstant(self, node):
+        self.write('b', node.quote, node.value, node.quote)
 
     def visit_FunctionCall(self, node):
         if isinstance(node.func, tuple):

--- a/edb/lang/edgeql/compiler/__init__.py
+++ b/edb/lang/edgeql/compiler/__init__.py
@@ -24,6 +24,8 @@ from edb.lang.edgeql import parser
 from edb.lang.common import debug
 from edb.lang.common import markup  # NOQA
 
+from edb.lang.ir import staeval as ireval
+
 from .decompiler import decompile_ir  # NOQA
 from . import dispatch
 from . import stmtctx
@@ -116,3 +118,8 @@ def compile_ast_to_ir(tree,
         debug.dump(ir_expr)
 
     return ir_expr
+
+
+def evaluate_ast_to_python_val(tree, schema, *, modaliases=None) -> object:
+    ir = compile_ast_fragment_to_ir(tree, schema, modaliases=modaliases)
+    return ireval.evaluate_to_python_val(ir, schema=schema)

--- a/edb/lang/edgeql/compiler/decompiler.py
+++ b/edb/lang/edgeql/compiler/decompiler.py
@@ -172,14 +172,23 @@ class IRDecompiler(ast.visitor.NodeVisitor):
     def visit_Parameter(self, node):
         return qlast.Parameter(name=node.name)
 
-    def visit_Constant(self, node):
-        return qlast.Constant(value=node.value)
-
     def visit_StringConstant(self, node):
-        return qlast.StringConstant.from_pystr(node.value)
+        return qlast.StringConstant.from_python(node.value)
 
     def visit_RawStringConstant(self, node):
-        return qlast.RawStringConstant.from_pystr(node.value)
+        return qlast.RawStringConstant.from_python(node.value)
+
+    def visit_BytesConstant(self, node):
+        return qlast.BytesConstant(value=node.value)
+
+    def visit_BooleanConstant(self, node):
+        return qlast.BooleanConstant(value=node.value)
+
+    def visit_FloatConstant(self, node):
+        return qlast.FloatConstant(value=node.value)
+
+    def visit_IntegerConstant(self, node):
+        return qlast.IntegerConstant(value=node.value)
 
     def visit_Array(self, node):
         return qlast.Array(elements=[
@@ -306,7 +315,7 @@ class IRDecompiler(ast.visitor.NodeVisitor):
     def _is_none(self, expr):
         return (
             expr is None or (
-                isinstance(expr, (irast.Constant, qlast.Constant)) and
+                isinstance(expr, (irast.BaseConstant, qlast.BaseConstant)) and
                 expr.value is None
             )
         )

--- a/edb/lang/edgeql/compiler/setgen.py
+++ b/edb/lang/edgeql/compiler/setgen.py
@@ -663,7 +663,7 @@ def computable_ptr_set(
         if isinstance(ptrcls.default, s_expr.ExpressionText):
             qlexpr = astutils.ensure_qlstmt(qlparser.parse(ptrcls.default))
         else:
-            qlexpr = qlast.Constant(value=ptrcls.default)
+            qlexpr = qlast.BaseConstant.from_python(ptrcls.default)
 
         qlctx = None
         inner_source_path_id = None

--- a/edb/lang/edgeql/lexutils.py
+++ b/edb/lang/edgeql/lexutils.py
@@ -1,0 +1,57 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Support utilities for lexical processing of literals."""
+
+
+import re
+
+
+def unescape_string(st):
+
+    str_re = re.compile(r'''
+        (?P<slash> \\\\) |
+        (?P<dq> \\") |
+        (?P<sq> \\') |
+        (?:\\x(?P<x>[0-7][0-9a-fA-F])) |
+        (?:\\u(?P<u>[0-9a-fA-F]{4})) |
+        (?:\\U(?P<U>[0-9a-fA-F]{8})) |
+        (?P<n>\\n) |
+        (?P<t>\\t) |
+        (?P<r>\\r)
+    ''', re.X)
+
+    subs = {
+        'slash': '\\',
+        'dq': '"',
+        'sq': "'",
+        't': '\t',
+        'n': '\n',
+        'r': '\r',
+    }
+
+    def cb(m):
+        g = m.lastgroup
+        try:
+            return subs[g]
+        except KeyError:
+            pass
+
+        return chr(int(m.group(g), 16))
+
+    return str_re.sub(cb, st)

--- a/edb/lang/edgeql/parser/grammar/ddl.py
+++ b/edb/lang/edgeql/parser/grammar/ddl.py
@@ -296,7 +296,7 @@ class SetFieldStmt(Nonterm):
         # if the expression is trivial (a literal or variable), it
         # should be treated as an eager expression
         eager = isinstance(kids[3].val,
-                           (qlast.Constant, qlast.Tuple))
+                           (qlast.BaseConstant, qlast.Tuple))
         self.val = qlast.CreateAttributeValue(
             name=kids[1].val,
             value=kids[3].val,
@@ -1679,7 +1679,7 @@ class InitialValue(Nonterm):
 
         # make sure that the initial value is a literal for now
         #
-        if not isinstance(val, (qlast.Constant, qlast.EmptyCollection,
+        if not isinstance(val, (qlast.BaseConstant, qlast.EmptyCollection,
                                 qlast.Array)):
             raise EdgeQLSyntaxError("initial value must be a literal",
                                     context=val.context)

--- a/edb/lang/graphql/translator.py
+++ b/edb/lang/graphql/translator.py
@@ -119,7 +119,7 @@ class GraphQLTranslator(ast.NodeVisitor):
             if (isinstance(el.compexpr, qlast.FunctionCall) and
                     el.compexpr.func == 'str_to_json'):
                 name = el.expr.steps[0].ptr.name
-                el.compexpr.args[0].arg = qlast.StringConstant.from_pystr(
+                el.compexpr.args[0].arg = qlast.StringConstant.from_python(
                     json.dumps(gqlresult.data[name], indent=4))
 
         return translated
@@ -531,9 +531,9 @@ class GraphQLTranslator(ast.NodeVisitor):
 
         # convert integers into qlast literals
         if offset is not None and not isinstance(offset, qlast.Base):
-            offset = qlast.Constant(value=max(0, offset))
+            offset = qlast.BaseConstant.from_python(max(0, offset))
         if limit is not None:
-            limit = qlast.Constant(value=max(0, limit))
+            limit = qlast.BaseConstant.from_python(max(0, limit))
 
         return where, orderby, offset, limit
 
@@ -673,7 +673,7 @@ class GraphQLTranslator(ast.NodeVisitor):
         return qlast.Parameter(name=node.value[1:])
 
     def visit_Literal(self, node):
-        return qlast.Constant(value=node.value)
+        return qlast.BaseConstant.from_python(node.value)
 
     def _visit_list_of_inputs(self, inputs, op):
         result = [self.visit(node) for node in inputs]

--- a/edb/lang/ir/ast.py
+++ b/edb/lang/ir/ast.py
@@ -135,22 +135,40 @@ class EmptySet(Set):
     pass
 
 
-class Constant(Expr):
+class BaseConstant(Expr):
 
-    value: object
+    value: str
     type: s_types.Type
 
     def __init__(self, *args, type, **kwargs):
-        if type is None:
-            raise ValueError('type argument must not be None')
         super().__init__(*args, type=type, **kwargs)
+        if self.type is None:
+            raise ValueError('cannot create irast.Constant without a type')
+        if self.value is None:
+            raise ValueError('cannot create irast.Constant without a value')
 
 
-class StringConstant(Constant):
+class StringConstant(BaseConstant):
     pass
 
 
-class RawStringConstant(Constant):
+class RawStringConstant(BaseConstant):
+    pass
+
+
+class IntegerConstant(BaseConstant):
+    pass
+
+
+class FloatConstant(BaseConstant):
+    pass
+
+
+class BooleanConstant(BaseConstant):
+    pass
+
+
+class BytesConstant(BaseConstant):
     pass
 
 

--- a/edb/lang/ir/inference/cardinality.py
+++ b/edb/lang/ir/inference/cardinality.py
@@ -122,7 +122,7 @@ def __infer_func_call(ir, scope_tree, schema):
         return ONE
 
 
-@_infer_cardinality.register(irast.Constant)
+@_infer_cardinality.register(irast.BaseConstant)
 @_infer_cardinality.register(irast.Parameter)
 def __infer_const_or_param(ir, scope_tree, schema):
     return ONE
@@ -284,8 +284,8 @@ def __infer_select_stmt(ir, scope_tree, schema):
         return ir.cardinality
     else:
         if (ir.limit is not None and
-                isinstance(ir.limit.expr, irast.Constant) and
-                ir.limit.expr.value == 1):
+                isinstance(ir.limit.expr, irast.IntegerConstant) and
+                ir.limit.expr.value == '1'):
             # Explicit LIMIT 1 clause.
             stmt_card = ONE
         else:

--- a/edb/lang/ir/inference/types.py
+++ b/edb/lang/ir/inference/types.py
@@ -172,7 +172,7 @@ def __infer_func_call(ir, schema):
         return rtype
 
 
-@_infer_type.register(irast.Constant)
+@_infer_type.register(irast.BaseConstant)
 @_infer_type.register(irast.Parameter)
 def __infer_const_or_param(ir, schema):
     return ir.type
@@ -366,13 +366,14 @@ def __infer_slice(ir, schema):
             context=ir.start.context)
 
     for index in [ir.start, ir.stop]:
-        index_type = infer_type(index, schema)
+        if index is not None:
+            index_type = infer_type(index, schema)
 
-        if not index_type.implicitly_castable_to(int_t, schema):
-            raise ql_errors.EdgeQLError(
-                f'cannot index {base_name} by {index_type.name}, '
-                f'{int_t.name} was expected',
-                context=index.context)
+            if not index_type.implicitly_castable_to(int_t, schema):
+                raise ql_errors.EdgeQLError(
+                    f'cannot index {base_name} by {index_type.name}, '
+                    f'{int_t.name} was expected',
+                    context=index.context)
 
     return node_type
 

--- a/edb/lang/ir/staeval.py
+++ b/edb/lang/ir/staeval.py
@@ -1,0 +1,263 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+"""Static evaluation of EdgeQL IR."""
+
+
+import decimal
+import functools
+
+from edb.lang.common import ast
+from edb.lang.edgeql import errors
+from edb.lang.edgeql import lexutils as ql_lexutils
+
+from edb.lang.ir import ast as irast
+from edb.lang.ir import utils as irutils
+
+from edb.lang.schema import schema as s_schema
+from edb.lang.schema import scalars as s_scalars
+
+
+class StaticEvaluationError(errors.EdgeQLError):
+    pass
+
+
+class UnsupportedExpressionError(errors.EdgeQLError):
+    pass
+
+
+def evaluate_to_python_val(
+        ir: irast.Base,
+        schema: s_schema.Schema) -> object:
+    const = evaluate(ir, schema=schema)
+    return const_to_python(const, schema=schema)
+
+
+@functools.singledispatch
+def evaluate(ir: irast.Base, schema: s_schema.Schema) -> irast.BaseConstant:
+    raise UnsupportedExpressionError(
+        f'no static IR evaluation handler for {ir.__class__}')
+
+
+@evaluate.register(irast.Set)
+def evaluate_Set(
+        ir_set: irast.Set,
+        schema: s_schema.Schema) -> irast.BaseConstant:
+    if ir_set.expr is not None:
+        return evaluate(ir_set.expr, schema=schema)
+    else:
+        raise UnsupportedExpressionError(
+            'expression is not constant', context=ir_set.context)
+
+
+@evaluate.register(irast.BaseConstant)
+def evaluate_BaseConstant(
+        ir_const: irast.BaseConstant,
+        schema: s_schema.Schema) -> irast.BaseConstant:
+    return ir_const
+
+
+@evaluate.register(irast.BinOp)
+def evaluate_BinOp(
+        binop: irast.BinOp,
+        schema: s_schema.Schema) -> irast.BaseConstant:
+
+    real_t = schema.get('std::anyreal')
+
+    result_type = irutils.infer_type(binop, schema)
+    folded = None
+    op = binop.op
+
+    # Left and right nodes are constants.
+    if isinstance(op, ast.ops.ComparisonOperator):
+        folded = evaluate_comparison_binop(binop, schema=schema)
+
+    elif result_type.issubclass(real_t):
+        folded = evaluate_arithmetic_binop(binop, schema=schema)
+
+    else:
+        raise UnsupportedExpressionError(
+            'expression is not constant', context=binop.context)
+
+    return folded
+
+
+@evaluate.register(irast.UnaryOp)
+def evaluate_UnaryOp(
+        unop: irast.UnaryOp,
+        schema: s_schema.Schema) -> irast.BaseConstant:
+
+    real_t = schema.get('std::anyreal')
+    int_t = schema.get('std::anyint')
+
+    result_type = unop.expr.scls
+
+    if (result_type.issubclass(real_t) and
+            unop.op in (ast.ops.UMINUS, ast.ops.UPLUS)):
+
+        if unop.op == ast.ops.UMINUS:
+            op_val = -evaluate_to_python_val(unop.expr, schema=schema)
+
+            if result_type.issubclass(int_t):
+                return irast.IntegerConstant(
+                    value=str(op_val), type=result_type)
+            else:
+                return irast.FloatConstant(
+                    value=str(op_val), type=result_type)
+        else:
+            return evaluate(unop.expr, schema=schema)
+
+    raise UnsupportedExpressionError(
+        f'unexpected unary operation: {unop.op} {result_type.displayname}',
+        context=unop.context)
+
+
+def evaluate_comparison_binop(
+        binop: irast.BinOp,
+        schema: s_schema.Schema) -> irast.BooleanConstant:
+
+    op = binop.op
+    left = evaluate(binop.left, schema=schema)
+    left_val = const_to_python(left, schema=schema)
+    right = evaluate(binop.right, schema=schema)
+    right_val = const_to_python(right, schema=schema)
+
+    if op == ast.ops.EQ:
+        value = left_val == right_val
+    elif op == ast.ops.NE:
+        value = left_val != right_val
+    elif op == ast.ops.GT:
+        value = left_val > right_val
+    elif op == ast.ops.GE:
+        value = left_val >= right_val
+    elif op == ast.ops.LT:
+        value = left_val < right_val
+    elif op == ast.ops.LE:
+        value = left_val <= right_val
+    else:
+        raise UnsupportedExpressionError(
+            f'unexpected operator: {op}',
+            context=binop.context)
+
+    return irast.BooleanConstant(
+        value='true' if value else 'false',
+        type=schema.get('std::bool')
+    )
+
+
+def evaluate_arithmetic_binop(
+        binop: irast.BinOp,
+        schema: s_schema.Schema) -> irast.BaseConstant:
+
+    op = binop.op
+    left = evaluate(binop.left, schema=schema)
+    left_val = const_to_python(left, schema=schema)
+    right = evaluate(binop.right, schema=schema)
+    right_val = const_to_python(right, schema=schema)
+
+    real_t = schema.get('std::anyreal')
+    int_t = schema.get('std::anyint')
+
+    left_type = irutils.infer_type(left, schema)
+    right_type = irutils.infer_type(right, schema)
+
+    if not left_type.issubclass(real_t) or not right_type.issubclass(real_t):
+        return
+
+    result_type = s_scalars.get_op_type(
+        op, left_type, right_type, schema=schema)
+
+    if op == ast.ops.ADD:
+        value = left_val + right_val
+    elif op == ast.ops.SUB:
+        value = left_val - right_val
+    elif op == ast.ops.MUL:
+        value = left_val * right_val
+    elif op == ast.ops.DIV:
+        if left_type.issubclass(int_t) and right_type.issubclass(int_t):
+            value = left_val // right_val
+        else:
+            value = left_val / right_val
+    elif op == ast.ops.POW:
+        value = left_val ** right_val
+    elif op == ast.ops.MOD:
+        value = left_val % right_val
+    else:
+        raise UnsupportedExpressionError(
+            f'unexpected operator: {op}',
+            context=binop.context)
+
+    if result_type.issubclass(int_t):
+        return irast.IntegerConstant(value=str(value), type=result_type)
+    else:
+        return irast.FloatConstant(value=str(value), type=result_type)
+
+
+@functools.singledispatch
+def const_to_python(
+        ir: irast.BaseConstant,
+        schema: s_schema.Schema) -> object:
+    raise NotImplementedError(
+        f'cannot convert {ir.__class__} to a Python value')
+
+
+@const_to_python.register(irast.IntegerConstant)
+def int_const_to_python(
+        ir: irast.IntegerConstant,
+        schema: s_schema.Schema) -> object:
+
+    if ir.type.name == 'std::decimal':
+        return decimal.Decimal(ir.value)
+    else:
+        return int(ir.value)
+
+
+@const_to_python.register(irast.FloatConstant)
+def float_const_to_python(
+        ir: irast.FloatConstant,
+        schema: s_schema.Schema) -> object:
+
+    if ir.type.name == 'std::decimal':
+        return decimal.Decimal(ir.value)
+    else:
+        return float(ir.value)
+
+
+@const_to_python.register(irast.StringConstant)
+def str_const_to_python(
+        ir: irast.StringConstant,
+        schema: s_schema.Schema) -> str:
+
+    return ql_lexutils.unescape_string(ir.value)
+
+
+@const_to_python.register(irast.RawStringConstant)
+def raw_str_const_to_python(
+        ir: irast.RawStringConstant,
+        schema: s_schema.Schema) -> str:
+
+    return ir.value
+
+
+@const_to_python.register(irast.BooleanConstant)
+def bool_const_to_python(
+        ir: irast.BooleanConstant,
+        schema: s_schema.Schema) -> bool:
+
+    return ir.value == 'true'

--- a/edb/lang/schema/codegen.py
+++ b/edb/lang/schema/codegen.py
@@ -154,7 +154,7 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
     def _visit_assignment(self, node):
         self.write(' := ')
 
-        if (isinstance(node, eqlast.Constant) and
+        if (isinstance(node, eqlast.BaseConstant) and
                 (not isinstance(node.value, str) or
                  '\n' not in node.value)):
             self._visit_edgeql(node, ident=False)

--- a/edb/lang/schema/declarative.py
+++ b/edb/lang/schema/declarative.py
@@ -282,7 +282,7 @@ class DeclarationLoader:
         return typ
 
     def _get_literal_value(self, node):
-        if not isinstance(node, edgeql.ast.Constant):
+        if not isinstance(node, edgeql.ast.BaseConstant):
             raise TypeError('Literal expected '
                             '(got type {!r})'.format(type(node).__name__))
 
@@ -473,9 +473,6 @@ class DeclarationLoader:
 
     def _parse_ptr_default(self, expr, source, ptr):
         """Set the default value for a pointer."""
-        if not isinstance(expr, edgeql.ast.SelectQuery):
-            expr = edgeql.ast.Constant(value=self._get_literal_value(expr))
-
         ptr.default = s_expr.ExpressionText(qlcodegen.generate_source(expr))
 
     def _parse_attribute_values(self, subject, subjdecl):
@@ -743,8 +740,7 @@ class DeclarationLoader:
                         self._normalize_ptr_default(
                             attr.value, objtype, spec_link, ptrdecl)
                     else:
-                        expr = edgeql.ast.Constant(
-                            value=self._get_literal_value(attr.value))
+                        expr = attr.value
                         _, _, spec_link.default = edgeql.utils.normalize_tree(
                             expr, self._schema)
 

--- a/edb/lang/schema/links.py
+++ b/edb/lang/schema/links.py
@@ -507,7 +507,7 @@ class CreateLink(LinkCommand, referencing.CreateReferencedInheritingObject):
             pass
         elif op.property == 'search':
             if op.new_value:
-                v = qlast.Constant(value=str(op.new_value.weight))
+                v = qlast.BaseConstant.from_python(str(op.new_value.weight))
                 self._set_attribute_ast(context, node, 'search_weight', v)
         elif op.property == 'target' and objtype:
             if not node.target:
@@ -669,7 +669,7 @@ class AlterLink(LinkCommand, named.AlterNamedObject):
             pass
         elif op.property == 'search':
             if op.new_value:
-                v = qlast.Constant(value=str(op.new_value.weight))
+                v = qlast.BaseConstant.from_python(str(op.new_value.weight))
                 self._set_attribute_ast(context, node, 'search_weight', v)
             else:
                 self._drop_attribute_ast(context, node, 'search_weight')

--- a/edb/lang/schema/parser/grammar/declarations.py
+++ b/edb/lang/schema/parser/grammar/declarations.py
@@ -69,7 +69,7 @@ def parse_edgeql(expr: str, ctx, *, offset_column=0, indent=0):
 def parse_edgeql_constant(expr: str, ctx, *, indent=0):
     node = parse_edgeql(expr, ctx, indent=indent)
     if (isinstance(node, qlast.SelectQuery) and
-            isinstance(node.result, qlast.Constant)):
+            isinstance(node.result, qlast.BaseConstant)):
         node = node.result
     return node
 
@@ -1073,7 +1073,7 @@ class Value(Nonterm):
     def reduce_COLONGT_NL_INDENT_RawString_NL_DEDENT(self, *kids):
         text = kids[3].val.value
         text = textwrap.dedent(text).strip()
-        self.val = qlast.Constant(value=text)
+        self.val = qlast.BaseConstant.from_python(text)
 
     def reduce_AssignmentBlob(self, *kids):
         self.val = kids[0].val

--- a/edb/lang/schema/pointers.py
+++ b/edb/lang/schema/pointers.py
@@ -372,38 +372,13 @@ class PointerCommand(constraints.ConsistencySubjectCommand,
     @classmethod
     def _parse_default(cls, cmd):
         return
-        for sub in cmd(sd.AlterObjectProperty):
-            if sub.property == 'default':
-                if isinstance(sub.new_value, sexpr.ExpressionText):
-                    expr = edgeql.parse(sub.new_value)
-
-                    if expr.op == qlast.UNION:
-                        candidates = []
-                        cls._extract_union_operands(expr, candidates)
-                        deflt = []
-
-                        for candidate in candidates:
-                            cexpr = candidate.result
-                            if isinstance(cexpr, qlast.Constant):
-                                deflt.append(cexpr.value)
-                            else:
-                                text = edgeql.generate_source(candidate,
-                                                              pretty=False)
-                                deflt.append(sexpr.ExpressionText(text))
-                    else:
-                        deflt = [sub.new_value]
-
-                else:
-                    deflt = [sub.new_value]
-
-                sub.new_value = deflt
 
     def _encode_default(self, context, node, op):
         if op.new_value:
             expr = op.new_value
             if not isinstance(expr, sexpr.ExpressionText):
                 expr_t = qlast.SelectQuery(
-                    result=qlast.Constant(value=expr)
+                    result=qlast.BaseConstant.from_python(expr)
                 )
                 expr = edgeql.generate_source(expr_t, pretty=False)
 

--- a/edb/server/pgsql/ast.py
+++ b/edb/server/pgsql/ast.py
@@ -433,15 +433,42 @@ class Expr(BaseExpr):
     rexpr: Base
 
 
-class Constant(BaseExpr):
-    """A literal constant."""
+class BaseConstant(BaseExpr):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if not isinstance(self, NullConstant) and self.val is None:
+            raise ValueError('cannot create a pgast.Constant without a value')
+
+
+class StringConstant(BaseConstant):
+    """A literal string constant."""
 
     # Constant value
-    val: object
+    val: str
 
 
-class EscapedStringConstant(Constant):
+class NullConstant(BaseConstant):
+    """A NULL constant."""
+
+
+class EscapedStringConstant(BaseConstant):
     """An "E"-prefixed string."""
+
+    val: str
+
+
+class ByteaConstant(BaseConstant):
+    """An bytea string."""
+
+    val: str
+
+
+class NumericConstant(BaseConstant):
+
+    val: str
+
+
+class BooleanConstant(BaseConstant):
 
     val: str
 

--- a/edb/server/pgsql/compiler/astutils.py
+++ b/edb/server/pgsql/compiler/astutils.py
@@ -50,7 +50,7 @@ def tuple_element_for_shape_el(shape_el, value):
 def is_null_const(expr):
     if isinstance(expr, pgast.TypeCast):
         expr = expr.arg
-    return isinstance(expr, pgast.Constant) and expr.val is None
+    return isinstance(expr, pgast.NullConstant)
 
 
 def is_set_op_query(query):

--- a/edb/server/pgsql/compiler/dml.py
+++ b/edb/server/pgsql/compiler/dml.py
@@ -313,7 +313,8 @@ def process_insert_body(
                 where_clause=astutils.new_binop(
                     op=ast.ops.EQ,
                     lexpr=pgast.ColumnRef(name=['name']),
-                    rexpr=pgast.Constant(val=ir_stmt.subject.scls.shortname)
+                    rexpr=pgast.StringConstant(
+                        val=ir_stmt.subject.scls.shortname)
                 )
             )
         )
@@ -630,7 +631,7 @@ def process_link_update(
             ],
             where_clause=astutils.new_binop(
                 lexpr=pgast.ColumnRef(name=[ltab_alias, 'name']),
-                rexpr=pgast.Constant(val=mptrcls.name),
+                rexpr=pgast.StringConstant(val=mptrcls.name),
                 op=ast.ops.EQ
             )
         ),

--- a/edb/server/pgsql/compiler/output.py
+++ b/edb/server/pgsql/compiler/output.py
@@ -51,7 +51,7 @@ def tuple_var_as_json_object(tvar, *, path_id, env):
                 name = rptr.shortname.name
                 if rptr.is_link_property():
                     name = '@' + name
-            keyvals.append(pgast.Constant(val=name))
+            keyvals.append(pgast.StringConstant(val=name))
             if isinstance(element.val, pgast.TupleVar):
                 val = serialize_expr(
                     element.val, path_id=element.path_id, env=env)
@@ -212,7 +212,7 @@ def top_output_as_value(
         new_val = pgast.CoalesceExpr(
             args=[
                 new_val,
-                pgast.Constant(val='[]')
+                pgast.StringConstant(val='[]')
             ]
         )
 

--- a/edb/server/pgsql/compiler/pathctx.py
+++ b/edb/server/pgsql/compiler/pathctx.py
@@ -597,7 +597,7 @@ def _get_rel_path_output(
         else:
             name = env.aliases.get('v')
 
-        val = typecomp.cast(pgast.Constant(val=None, nullable=True),
+        val = typecomp.cast(pgast.NullConstant(nullable=True),
                             source_type=target,
                             target_type=target,
                             force=True, env=env)
@@ -805,7 +805,7 @@ def get_path_output_or_null(
     alias = env.aliases.get('null')
     restarget = pgast.ResTarget(
         name=alias,
-        val=pgast.Constant(val=None))
+        val=pgast.NullConstant())
 
     if hasattr(rel, 'returning_list'):
         rel.returning_list.append(restarget)

--- a/edb/server/pgsql/compiler/relctx.py
+++ b/edb/server/pgsql/compiler/relctx.py
@@ -435,7 +435,8 @@ def new_static_class_rvar(
         lateral: bool=True,
         ctx: context.CompilerContextLevel) -> pgast.BaseRangeVar:
     set_rvar = new_root_rvar(ir_set, ctx=ctx)
-    clsname = pgast.Constant(val=ir_set.rptr.source.scls.material_type().name)
+    clsname = pgast.StringConstant(
+        val=ir_set.rptr.source.scls.material_type().name)
     nameref = dbobj.get_column(
         set_rvar, common.edgedb_name_to_pg_name('schema::name'),
         nullable=False)

--- a/edb/server/pgsql/compiler/relgen.py
+++ b/edb/server/pgsql/compiler/relgen.py
@@ -168,7 +168,7 @@ def get_set_rvar(
                                           rvars=rvars, ctx=subctx)
         elif not is_optional and is_empty_set:
             null_query = rvars.main.rvar.query
-            null_query.where_clause = pgast.Constant(val=False)
+            null_query.where_clause = pgast.BooleanConstant(val='FALSE')
 
         for set_rvar in rvars.new:
             # overwrite_path_rvar is needed because we want
@@ -429,11 +429,11 @@ def prepare_optional_rel(
 
                 scope_rel.target_list.insert(
                     0,
-                    pgast.ResTarget(val=pgast.Constant(val=1),
+                    pgast.ResTarget(val=pgast.NumericConstant(val='1'),
                                     name=marker))
                 emptyrel.target_list.insert(
                     0,
-                    pgast.ResTarget(val=pgast.Constant(val=2),
+                    pgast.ResTarget(val=pgast.NumericConstant(val='2'),
                                     name=marker))
 
                 unionqry = unionctx.rel
@@ -860,10 +860,10 @@ def process_set_as_membership_expr(
             pathctx.get_path_value_output(
                 wrapper, ir_set.path_id, env=ctx.env)
 
-            coalesce_val = expr.op == ast.ops.NOT_IN
+            coalesce_val = 'TRUE' if expr.op == ast.ops.NOT_IN else 'FALSE'
             with subctx.subrel() as subsubctx:
                 coalesce = pgast.CoalesceExpr(
-                    args=[wrapper, pgast.Constant(val=coalesce_val)])
+                    args=[wrapper, pgast.BooleanConstant(val=coalesce_val)])
 
                 wrapper = subsubctx.rel
                 pathctx.put_path_value_var(
@@ -1072,11 +1072,11 @@ def process_set_as_coalesce(
 
                     larg.target_list.insert(
                         0,
-                        pgast.ResTarget(val=pgast.Constant(val=1),
+                        pgast.ResTarget(val=pgast.NumericConstant(val='1'),
                                         name=marker))
                     rarg.target_list.insert(
                         0,
-                        pgast.ResTarget(val=pgast.Constant(val=2),
+                        pgast.ResTarget(val=pgast.NumericConstant(val='2'),
                                         name=marker))
 
                     unionqry = sub2ctx.rel
@@ -1214,13 +1214,13 @@ def process_set_as_tuple_indirection(
                 stmt, path_id=tuple_set.path_id, env=subctx.env)
 
             type_sentinel = typecomp.cast(
-                pgast.Constant(val=None),
+                pgast.NullConstant(),
                 source_type=ir_set.scls, target_type=ir_set.scls, force=True,
                 env=subctx.env)
 
             tuple_atts = list(tuple_set.scls.element_types.keys())
-            att_idx = pgast.Constant(
-                val=tuple_atts.index(ir_set.expr.name) + 1
+            att_idx = pgast.NumericConstant(
+                val=str(tuple_atts.index(ir_set.expr.name) + 1)
             )
 
             set_expr = pgast.FuncCall(
@@ -1387,7 +1387,7 @@ def process_set_as_func_expr(
                     kind=pgast.ExprKind.OP,
                     name='-',
                     lexpr=set_expr.elements[1].val,
-                    rexpr=pgast.Constant(val=1))
+                    rexpr=pgast.NumericConstant(val='1'))
 
             for element in set_expr.elements:
                 pathctx.put_path_value_var(

--- a/edb/server/pgsql/compiler/typecomp.py
+++ b/edb/server/pgsql/compiler/typecomp.py
@@ -127,7 +127,7 @@ def cast(
                                 node
                             ]),
                         type_name=pgast.TypeName(name=('text',))),
-                    pgast.Constant(val='"')
+                    pgast.StringConstant(val='"')
                 ])
 
         elif source_type.issubclass(bool_t) and target_type.issubclass(int_t):
@@ -154,7 +154,7 @@ def cast(
             # to SQL: (INT != 0)
             return astutils.new_binop(
                 node,
-                pgast.Constant(val=0),
+                pgast.NumericConstant(val='0'),
                 op=ast.ops.NE)
 
         elif source_type.issubclass(json_t):
@@ -183,20 +183,22 @@ def cast(
             if expected_json_type is not None:
                 if ir_expr is not None:
                     srcctx = irutils.get_source_context_as_json(ir_expr)
+                    details = pgast.StringConstant(val=srcctx)
                 else:
                     srcctx = None
+                    details = pgast.NullConstant()
 
                 node = pgast.FuncCall(
                     name=('edgedb', 'jsonb_assert_type'),
                     args=[
                         node,
                         pgast.ArrayExpr(elements=[
-                            pgast.Constant(val=expected_json_type),
-                            pgast.Constant(val='null'),
+                            pgast.StringConstant(val=expected_json_type),
+                            pgast.StringConstant(val='null'),
                         ]),
                         pgast.NamedFuncArg(
                             name='det',
-                            val=pgast.Constant(val=srcctx)
+                            val=details,
                         )
                     ]
                 )
@@ -207,7 +209,7 @@ def cast(
                         name=('array_to_json',),
                         args=[pgast.ArrayExpr(elements=[node])]
                     ),
-                    rexpr=pgast.Constant(val=0),
+                    rexpr=pgast.NumericConstant(val='0'),
                     op='->>'
                 ),
                 type_name=pgast.TypeName(

--- a/edb/server/pgsql/parser/pgsql.py
+++ b/edb/server/pgsql/parser/pgsql.py
@@ -709,7 +709,7 @@ class BitWithoutLength(Nonterm):
             self.val = pgast.TypeName(name=('varbit',))
         else:
             self.val = pgast.TypeName(name=('bit',))
-            self.val.typmods = [pgast.Constant(val=1)]
+            self.val.typmods = [pgast.NumericConstant(val='1')]
 
 
 class Character(Nonterm):
@@ -1268,7 +1268,7 @@ class a_expr(Nonterm):
 
     def reduce_a_expr_IS_TRUE_P(self, *kids):
         "%reduce a_expr IS TRUE_P"
-        right = pgast.Constant(val=True)
+        right = pgast.BooleanConstant(val='TRUE')
         self.val = pgast.Expr(
             name=ast.ops.IS,
             lexpr=kids[0].val,
@@ -1277,7 +1277,7 @@ class a_expr(Nonterm):
 
     def reduce_a_expr_IS_NOT_TRUE_P(self, *kids):
         "%reduce a_expr IS NOT TRUE_P"
-        right = pgast.Constant(val=True)
+        right = pgast.BooleanConstant(val='TRUE')
         self.val = pgast.Expr(
             name=ast.ops.IS_NOT,
             lexpr=kids[0].val,
@@ -1286,7 +1286,7 @@ class a_expr(Nonterm):
 
     def reduce_a_expr_IS_FALSE_P(self, *kids):
         "%reduce a_expr IS FALSE_P"
-        right = pgast.Constant(val=False)
+        right = pgast.BooleanConstant(val='FALSE')
         self.val = pgast.Expr(
             name=ast.ops.IS,
             lexpr=kids[0].val,
@@ -1295,7 +1295,7 @@ class a_expr(Nonterm):
 
     def reduce_a_expr_IS_NOT_FALSE_P(self, *kids):
         "%reduce a_expr IS NOT FALSE_P"
-        right = pgast.Constant(val=False)
+        right = pgast.BooleanConstant(val='FALSE')
         self.val = pgast.Expr(
             name=ast.ops.IS_NOT,
             lexpr=kids[0].val,
@@ -1683,41 +1683,41 @@ class AexprConst(Nonterm):
 
     def reduce_ICONST(self, *kids):
         "%reduce ICONST"
-        self.val = pgast.Constant(val=kids[0].val)
+        self.val = pgast.NumericConstant(val=kids[0].val)
 
     def reduce_FCONST(self, *kids):
         "%reduce FCONST"
-        self.val = pgast.Constant(val=kids[0].val)
+        self.val = pgast.NumericConstant(val=kids[0].val)
 
     def reduce_SCONST(self, *kids):
         "%reduce SCONST"
-        self.val = pgast.Constant(val=kids[0].val)
+        self.val = pgast.StringConstant(val=kids[0].val)
 
     def reduce_BCONST(self, *kids):
         "%reduce BCONST"
-        self.val = pgast.Constant(val=kids[0].val)
+        self.val = pgast.StringConstant(val=kids[0].val)
 
     def reduce_XCONST(self, *kids):
         "%reduce XCONST"
-        self.val = pgast.Constant(val=kids[0].val)
+        self.val = pgast.StringConstant(val=kids[0].val)
 
     def reduce_type_const(self, *kids):
         "%reduce func_name SCONST"
         self.val = pgast.TypeCast(
-            arg=pgast.Constant(val=kids[1].val),
+            arg=pgast.StringConstant(val=kids[1].val),
             type_name=pgast.TypeName(name=(kids[0].val,)))
 
     def reduce_type_mods_const(self, *kids):
         "%reduce func_name LPAREN func_arg_list RPAREN SCONST"
         self.val = pgast.TypeCast(
-            art=pgast.Constant(val=kids[4].val),
+            art=pgast.StringConstant(val=kids[4].val),
             type_name=pgast.TypeName(
                 name=(kids[0].val,), typmods=kids[2].val))
 
     def reduce_ConstTypename_const(self, *kids):
         "%reduce ConstTypename SCONST"
         self.val = pgast.TypeCast(
-            arg=pgast.Constant(val=kids[1].val),
+            arg=pgast.StringConstant(val=kids[1].val),
             type_name=kids[0].val)
 
     def reduce_ConstInterval_SCONST_opt_interval(self, *kids):
@@ -1725,7 +1725,7 @@ class AexprConst(Nonterm):
         typ = kids[0].val
         typ.typmods = kids[2].val
         self.val = pgast.TypeCast(
-            argr=pgast.Constant(val=kids[1].val),
+            argr=pgast.StringConstant(val=kids[1].val),
             type_name=typ)
 
     def reduce_ConstInterval_ICONST_SCONST_opt_interval(self, *kids):
@@ -1743,20 +1743,20 @@ class AexprConst(Nonterm):
             typ.typmods = [{'precision': kids[2].val}]
 
         self.val = pgast.TypeCast(
-            expr=pgast.Constant(val=kids[4].val),
+            expr=pgast.StringConstant(val=kids[4].val),
             type_name=typ)
 
     def reduce_TRUE_P(self, *kids):
         "%reduce TRUE_P"
-        self.val = pgast.Constant(val=True)
+        self.val = pgast.BooleanConstant(val='TRUE')
 
     def reduce_FALSE_P(self, *kids):
         "%reduce FALSE_P"
-        self.val = pgast.Constant(val=False)
+        self.val = pgast.BooleanConstant(val='FALSE')
 
     def reduce_NULL_P(self, *kids):
         "%reduce NULL_P"
-        self.val = pgast.Constant(val=None)
+        self.val = pgast.NullConstant()
 
 
 class ColId(Nonterm):

--- a/tests/test_deltas.py
+++ b/tests/test_deltas.py
@@ -286,52 +286,52 @@ class TestDeltaDDLGeneration(tb.DDLTestCase):
             result[1],
             '''\
 CREATE ABSTRACT PROPERTY test::lang {
-    SET is_virtual := False;
-    SET readonly := False;
+    SET is_virtual := false;
+    SET readonly := false;
 };
 CREATE ABSTRACT PROPERTY test::name {
-    SET is_virtual := False;
-    SET readonly := False;
+    SET is_virtual := false;
+    SET readonly := false;
 };
 CREATE ABSTRACT LINK test::related EXTENDING std::link {
-    SET is_virtual := False;
-    SET readonly := False;
+    SET is_virtual := false;
+    SET readonly := false;
 };
 ALTER ABSTRACT LINK test::related CREATE PROPERTY test::lang -> std::str {
     SET cardinality := '11';
-    SET is_virtual := False;
-    SET readonly := False;
+    SET is_virtual := false;
+    SET readonly := false;
 };
 CREATE TYPE test::NamedObject EXTENDING std::Object {
-    SET is_virtual := False;
+    SET is_virtual := false;
 };
 ALTER TYPE test::NamedObject {
     CREATE REQUIRED PROPERTY test::name -> std::str {
         SET cardinality := '11';
-        SET is_virtual := False;
-        SET readonly := False;
+        SET is_virtual := false;
+        SET readonly := false;
     };
     CREATE REQUIRED LINK test::related -> test::NamedObject {
         SET cardinality := '*1';
-        SET is_virtual := False;
+        SET is_virtual := false;
         SET on_target_delete := 'RESTRICT';
-        SET readonly := False;
+        SET readonly := false;
     };
     ALTER LINK test::related {
         CREATE PROPERTY std::source -> test::NamedObject {
             SET cardinality := '11';
-            SET is_virtual := False;
-            SET readonly := False;
+            SET is_virtual := false;
+            SET readonly := false;
         };
         CREATE PROPERTY std::target -> test::NamedObject {
             SET cardinality := '11';
-            SET is_virtual := False;
-            SET readonly := False;
+            SET is_virtual := false;
+            SET readonly := false;
         };
         CREATE PROPERTY test::lang -> std::str {
             SET cardinality := '11';
-            SET is_virtual := False;
-            SET readonly := False;
+            SET is_virtual := false;
+            SET readonly := false;
         };
     };
 };
@@ -354,17 +354,17 @@ ALTER TYPE test::NamedObject {
             result[1],
             '''\
 CREATE ABSTRACT PROPERTY test::a {
-    SET is_virtual := False;
-    SET readonly := False;
+    SET is_virtual := false;
+    SET readonly := false;
 };
 CREATE TYPE test::NamedObject EXTENDING std::Object {
-    SET is_virtual := False;
+    SET is_virtual := false;
 };
 ALTER TYPE test::NamedObject CREATE REQUIRED PROPERTY \
 test::a -> array<std::int64> {
     SET cardinality := '11';
-    SET is_virtual := False;
-    SET readonly := False;
+    SET is_virtual := false;
+    SET readonly := false;
 };
             '''
         )
@@ -385,30 +385,30 @@ test::a -> array<std::int64> {
             result[1],
             '''\
             CREATE ABSTRACT PROPERTY test::bar {
-                SET is_virtual := False;
-                SET readonly := False;
+                SET is_virtual := false;
+                SET readonly := false;
             };
             CREATE ABSTRACT PROPERTY test::__typename {
-                SET is_virtual := False;
-                SET readonly := False;
+                SET is_virtual := false;
+                SET readonly := false;
             };
             CREATE ABSTRACT TYPE test::Foo EXTENDING std::Object {
-                SET is_virtual := False;
+                SET is_virtual := false;
             };
             ALTER TYPE test::Foo {
                 CREATE PROPERTY test::bar -> std::str {
                     SET cardinality := '11';
-                    SET is_virtual := False;
-                    SET readonly := False;
+                    SET is_virtual := false;
+                    SET readonly := false;
                 };
                 CREATE PROPERTY test::__typename -> std::str {
                     SET cardinality := '*1';
-                    SET computable := True;
+                    SET computable := true;
                     SET default := SELECT
                         'foo'
                     ;
-                    SET is_virtual := False;
-                    SET readonly := False;
+                    SET is_virtual := false;
+                    SET readonly := false;
                 };
             };
             '''
@@ -430,30 +430,30 @@ test::a -> array<std::int64> {
             result[1],
             '''\
             CREATE ABSTRACT PROPERTY test::bar {
-                SET is_virtual := False;
-                SET readonly := False;
+                SET is_virtual := false;
+                SET readonly := false;
             };
             CREATE ABSTRACT PROPERTY test::__typename {
-                SET is_virtual := False;
-                SET readonly := False;
+                SET is_virtual := false;
+                SET readonly := false;
             };
             CREATE ABSTRACT TYPE test::Foo EXTENDING std::Object {
-                SET is_virtual := False;
+                SET is_virtual := false;
             };
             ALTER TYPE test::Foo {
                 CREATE PROPERTY test::bar -> std::str {
                     SET cardinality := '11';
-                    SET is_virtual := False;
-                    SET readonly := False;
+                    SET is_virtual := false;
+                    SET readonly := false;
                 };
                 CREATE PROPERTY test::__typename -> std::str {
                     SET cardinality := '*1';
-                    SET computable := True;
+                    SET computable := true;
                     SET default := SELECT
                         __source__.__type__[IS schema::Type].name
                     ;
-                    SET is_virtual := False;
-                    SET readonly := False;
+                    SET is_virtual := false;
+                    SET readonly := false;
                 };
             };
             '''

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -137,10 +137,10 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
         SELECT 354.32;
         SELECT 35400000000000.32;
         SELECT 35400000000000000000.32;
-        SELECT 3.5432e+20;
+        SELECT 3.5432e20;
         SELECT 3.5432e+20;
         SELECT 3.5432e-20;
-        SELECT 3.5432e-18;
+        SELECT 354.32e-20;
         """
 
     def test_edgeql_syntax_constants_05(self):
@@ -184,7 +184,7 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
         r"""
         SELECT b'1\t\n1' + b"2\x00";
 % OK %
-        SELECT (b'1\t\n1' + b'2\x00');
+        SELECT (b'1\t\n1' + b"2\x00");
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -216,7 +216,8 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
         SELECT b'aa
 aa';
 % OK %
-        SELECT b'aa\naa';
+        SELECT b'aa
+aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,


### PR DESCRIPTION
Currently, the "value" field in various `Constant` AST nodes is a Python
value, which is obtained by interpreting the corresponding EdgeQL
literal.  When rendered back into code, the Python value is then
converted back into an EdgeQL or SQL value.  This approach is inconvenient
and is potentially lossy, so stop doing it and store the actual literal
value as a string, converting to Python only when necessary for
interpretation (such as constant folding).