### PR TITLE
schema: Add support for spaces + tabs indents.

### DIFF
--- a/edb/lang/common/parsing.py
+++ b/edb/lang/common/parsing.py
@@ -382,7 +382,7 @@ class Parser:
         except ParserError as e:
             raise self.get_exception(e, context=e.context) from e
 
-        except lexer.UnknownTokenError as e:
+        except lexer.LexError as e:
             raise self.get_exception(e, context=self.context(None)) from e
 
         return self.parser.start[0].val

--- a/edb/lang/graphql/parser/errors.py
+++ b/edb/lang/graphql/parser/errors.py
@@ -17,7 +17,6 @@
 #
 
 
-from edb.lang.common.lexer import LexError
 from edb.lang.common.parsing import ParserError
 from edb.lang.graphql.errors import GraphQLError
 
@@ -40,8 +39,4 @@ class GraphQLUniquenessError(GraphQLParserError):
 
 
 class InvalidStringTokenError(GraphQLParserError):
-    pass
-
-
-class UnterminatedStringError(LexError):
     pass

--- a/edb/lang/graphql/parser/grammar/lexer.py
+++ b/edb/lang/graphql/parser/grammar/lexer.py
@@ -20,11 +20,14 @@
 import re
 
 from edb.lang.common import lexer
-from edb.lang.graphql.parser.errors import UnterminatedStringError
 from .keywords import graphql_keywords
 
 
-__all__ = ('GraphQLLexer')
+__all__ = ('GraphQLLexer', 'UnterminatedStringError')
+
+
+class UnterminatedStringError(lexer.LexError):
+    pass
 
 
 STATE_KEEP = 0

--- a/edb/lang/graphql/parser/parser.py
+++ b/edb/lang/graphql/parser/parser.py
@@ -157,6 +157,10 @@ class GraphQLParser(parsing.Parser):
     def get_exception(self, native_err, context, token=None):
         if isinstance(native_err, GraphQLParserError):
             return native_err
+        elif isinstance(native_err, lexer.UnterminatedStringError):
+            # update the context
+            context.start.line = native_err.line
+            context.start.column = native_err.col
         return GraphQLParserError(native_err.args[0], context=context)
 
     def process_lex_token(self, mod, tok):

--- a/tests/test_graphql_syntax.py
+++ b/tests/test_graphql_syntax.py
@@ -24,7 +24,6 @@ from edb.lang.graphql import generate_source as gql_to_source
 from edb.lang.graphql.parser import parser as gql_parser
 from edb.lang.graphql.parser.errors import (GraphQLParserError,
                                             GraphQLUniquenessError,
-                                            UnterminatedStringError,
                                             InvalidStringTokenError)
 
 
@@ -58,11 +57,11 @@ class TestGraphQLParser(GraphQLSyntaxTest):
     def test_graphql_syntax_empty05(self):
         """\r\n;"""
 
-    @tb.must_fail(UnterminatedStringError, line=1, col=2)
+    @tb.must_fail(GraphQLParserError, line=1, col=2)
     def test_graphql_syntax_empty06(self):
         '''"'''
 
-    @tb.must_fail(UnterminatedStringError, line=2, col=10)
+    @tb.must_fail(GraphQLParserError, line=2, col=10)
     def test_graphql_syntax_empty07(self):
         """
         "
@@ -121,13 +120,13 @@ class TestGraphQLParser(GraphQLSyntaxTest):
         { field(arg:"\uFEFF\n") };
         """
 
-    @tb.must_fail(UnterminatedStringError, line=2, col=29)
+    @tb.must_fail(GraphQLParserError, line=2, col=29)
     def test_graphql_syntax_string09(self):
         """
         { field(arg:"foo') }
         """
 
-    @tb.must_fail(UnterminatedStringError, line=3, col=23)
+    @tb.must_fail(GraphQLParserError, line=3, col=23)
     def test_graphql_syntax_string10(self):
         r"""
         { field(

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -55,6 +55,99 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
 
         """
 
+    def test_eschema_syntax_tabs_01(self):
+        """
+\tabstract type Foo:
+\t\trequired property foo -> str
+
+\tabstract type Bar:
+\t\trequired property bar -> str
+        """
+
+    def test_eschema_syntax_tabs_02(self):
+        """
+\t  abstract type Foo:
+\t      required property foo -> str
+
+\t  abstract type Bar:
+\t      required property bar -> str
+        """
+
+    @tb.must_fail(error.SchemaSyntaxError,
+                  "Tabs used after spaces", line=2)
+    def test_eschema_syntax_tabs_03(self):
+        """
+        \tabstract type Foo:
+        \t\trequired property foo -> str
+
+        \tabstract type Bar:
+        \t\trequired property bar -> str
+        """
+
+    @tb.must_fail(error.SchemaSyntaxError,
+                  "Inconsistent indentation", line=3)
+    def test_eschema_syntax_tabs_04(self):
+        """
+\t\t    abstract type Foo:
+\t\t\t    required property foo -> str
+
+\t\t    abstract type Bar:
+\t\t\t    required property bar -> str
+        """
+
+    @tb.must_fail(error.SchemaSyntaxError,
+                  "Inconsistent indentation", line=5)
+    def test_eschema_syntax_tabs_05(self):
+        """
+\t\t  abstract type Foo:
+\t\t      required property foo -> str
+
+\t      abstract type Bar:
+\t          required property bar -> str
+        """
+
+    @tb.must_fail(error.SchemaSyntaxError,
+                  "Unexpected indentation level decrease", line=6)
+    def test_eschema_syntax_tabs_06(self):
+        """
+\t\tabstract type Foo:
+\t\t\t\trequired property foo -> str
+
+\t\tabstract type Bar:
+\trequired property foo -> str
+        """
+
+    def test_eschema_syntax_tabs_07(self):
+        """
+type LogEntry extending OwnedObject, Text:
+\tproperty start_date -> datetime:
+\t\tdefault :=
+\t\t\tSELECT datetime::current_datetime()
+\t\ttitle := 'Start Date'
+        """
+
+    def test_eschema_syntax_tabs_08(self):
+        """
+type LogEntry extending OwnedObject, Text:
+\tproperty start_date -> datetime:
+\t\tdefault :=
+\t\t\tSELECT
+\t\t\t      datetime::current_datetime()
+\t\ttitle := 'Start Date'
+        """
+
+    @tb.must_fail(error.SchemaSyntaxError,
+                  "Inconsistent indentation", line=6)
+    def test_eschema_syntax_tabs_09(self):
+        """
+type LogEntry extending OwnedObject, Text:
+\tproperty start_date -> datetime:
+\t\tdefault :=
+\t\t\tSELECT
+\t\t         datetime::current_datetime()
+\t\ttitle := 'Start Date'
+        """
+
     def test_eschema_syntax_type_01(self):
         """type User extending builtins::NamedObject"""
 
@@ -125,8 +218,7 @@ type Issue extending `foo.bar`::NamedObject, OwnedObject, Text:
         """
 
     @tb.must_fail(error.SchemaSyntaxError,
-                  "illegal definition",
-                  line=4, col=9)
+                  "illegal definition", line=4, col=9)
     def test_eschema_syntax_type_08(self):
         """
 type Foo:
@@ -377,6 +469,29 @@ type LogEntry extending    OwnedObject,    Text:
             property first_name -> str
             property last_name -> str
             property email -> str
+        """
+
+    def test_eschema_syntax_ws_10(self):
+        """
+                # this comment must not affect indentation
+
+abstract link friends:
+    property nickname -> str
+    # this comment must not affect indentation
+
+type Foo:
+    required property foo -> str
+    # this comment must not affect indentation
+type Bar:
+    required property bar -> str
+  # this comment must not affect indentation
+
+type Baz:
+    required property baz -> str
+        # this comment must not affect indentation
+
+type Boo:
+    required property boo -> str
         """
 
     def test_eschema_syntax_scalar_01(self):
@@ -1317,4 +1432,13 @@ attribute foo std::int64;
         """
         abstract attribute \\   \
         foobar std::str
+        """
+
+    @tb.must_fail(error.SchemaSyntaxError,
+                  "Illegal line continuation", line=3)
+    def test_eschema_syntax_eol_12(self):
+        r"""
+        abstract type Foo:
+        \
+        required link owner -> User
         """


### PR DESCRIPTION
Indentation must be consistent, so if a mix of tabs and spaces is used,
tabs must come first and shallow indentation must be an exact prefix of
deeper indentation.

It is illegal to use a tab after a space in indentation.

It is illegal to use a line continuation immediately after indentation.
Some other content must appear first on that line.

Whitespace is still ignored in parentheses or in the middle of a line
even if it is extended via line continuation.