### PR TITLE
Revert decimal literals back to std::float64

### DIFF
--- a/edb/lang/edgeql/compiler/expr.py
+++ b/edb/lang/edgeql/compiler/expr.py
@@ -185,7 +185,7 @@ def compile_BaseConstant(
     elif isinstance(expr, qlast.FloatConstant):
         if expr.is_negative:
             value = f'-{value}'
-        std_type = 'std::decimal'
+        std_type = 'std::float64'
         node_cls = irast.FloatConstant
     elif isinstance(expr, qlast.BooleanConstant):
         std_type = 'std::bool'

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -337,7 +337,6 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             SELECT sum({<float32>1, 2, 3});
 
             SELECT sum({<float32>1, <int32>2, 3});
-            SELECT sum({<float32>1, <int32>2, <decimal>3});
             SELECT sum({<int16>1, <int32>2, <decimal>3});
 
             SELECT sum({1.1, 2.2, 3});
@@ -346,7 +345,6 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             {6},
             {6},
 
-            {6},
             {6},
             {6},
 
@@ -360,7 +358,6 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             SELECT sum({<float32>1, 2, 3}).__type__.name;
 
             SELECT sum({<float32>1, <int32>2, 3}).__type__.name;
-            SELECT sum({<float32>1, <int32>2, <decimal>3}).__type__.name;
             SELECT sum({<int16>1, <int32>2, <decimal>3}).__type__.name;
 
             SELECT sum({<int16>1, 2, <decimal>3}).__type__.name;
@@ -376,16 +373,15 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             {'std::float64'},
 
             {'std::float64'},
-            {'std::float64'},
             {'std::decimal'},
 
             {'std::decimal'},
             {'std::float64'},
-            {'std::decimal'},
+            {'std::float64'},
 
             {'std::float64'},
             {'std::float32'},
-            {'std::decimal'},
+            {'std::float64'},
         ])
 
     async def test_edgeql_calls_11(self):

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -117,7 +117,7 @@ class TestExpressions(tb.QueryTestCase):
             SELECT (-9223372036854775809).__type__.name;
         """, [
             {'std::int64'},
-            {'std::decimal'},
+            {'std::float64'},
             {'std::int64'},
             {'std::int64'},
             {'std::decimal'},
@@ -631,6 +631,7 @@ class TestExpressions(tb.QueryTestCase):
             SELECT {1, <float32>2.1}.__type__.name;
             SELECT {1, 2.1}.__type__.name;
             SELECT (-2.1).__type__.name;
+            SELECT {1, <decimal>2.1}.__type__.name;
         """, [
             ['std::int64'],
             ['std::int64'],
@@ -641,7 +642,8 @@ class TestExpressions(tb.QueryTestCase):
             ['std::float64'],
             ['std::float64'],
             ['std::float64'],
-            ['std::decimal'],
+            ['std::float64'],
+            ['std::float64'],
             ['std::decimal'],
         ])
 
@@ -744,6 +746,13 @@ class TestExpressions(tb.QueryTestCase):
             [[1.5, 1]],
         ])
 
+    async def test_edgeql_expr_implicit_cast_08(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLError, 'could not determine expression type'):
+            await self.query(r'''
+                SELECT {1.0, <decimal>2.0};
+            ''')
+
     async def test_edgeql_expr_type_01(self):
         await self.assert_query_result(r"""
             SELECT 'foo'.__type__.name;
@@ -755,7 +764,7 @@ class TestExpressions(tb.QueryTestCase):
         await self.assert_query_result(r"""
             SELECT (1.0 + 2).__type__.name;
         """, [
-            ['std::decimal'],
+            ['std::float64'],
         ])
 
     async def test_edgeql_expr_set_01(self):
@@ -985,7 +994,7 @@ class TestExpressions(tb.QueryTestCase):
 
     async def test_edgeql_expr_array_17(self):
         with self.assertRaisesRegex(
-                exc.EdgeQLError, r'cannot index array by.*decimal'):
+                exc.EdgeQLError, r'cannot index array by.*float'):
 
             await self.con.execute("""
                 SELECT [1, 2][1.0];
@@ -993,7 +1002,7 @@ class TestExpressions(tb.QueryTestCase):
 
     async def test_edgeql_expr_array_18(self):
         with self.assertRaisesRegex(
-                exc.EdgeQLError, r'cannot slice array by.*decimal'):
+                exc.EdgeQLError, r'cannot slice array by.*float'):
 
             await self.con.execute("""
                 SELECT [1, 2][1.0:3];
@@ -1114,7 +1123,7 @@ class TestExpressions(tb.QueryTestCase):
 
     async def test_edgeql_expr_string_05(self):
         with self.assertRaisesRegex(
-                exc.EdgeQLError, r'cannot index string by.*decimal'):
+                exc.EdgeQLError, r'cannot index string by.*float'):
 
             await self.con.execute("""
                 SELECT '123'[-1.0];
@@ -1122,7 +1131,7 @@ class TestExpressions(tb.QueryTestCase):
 
     async def test_edgeql_expr_string_06(self):
         with self.assertRaisesRegex(
-                exc.EdgeQLError, r'cannot slice string by.*decimal'):
+                exc.EdgeQLError, r'cannot slice string by.*float'):
 
             await self.con.execute("""
                 SELECT '123'[1.0:];


### PR DESCRIPTION
In e793fd37 I changed the interpretation of numerics with a decimal
point to `std::decimal`.  The motivation behind that change was to
adhere to the behavior of PostgreSQL (and the SQL standard
intepretation).  However, it quickly became apparent that this approach,
despite its acceptance in the SQL world, has significant practical
disadvantages.

First and foremost, literals-as-decimals practically requires that
decimals are implicitly castable to floats, otherwise any expression
involving literals and float properties becomes a quagmire of casts.
But casting decimals to floats implicitly loses precision and can be
surprising in other contexts.

Secondly, the vast majority of contemporary programming languages
interpret decimal literals as 64-bit floats.  Many languages have no
built-in concept of arbitrary-precision decimals, which forces a
compromise between an implicit loss of precision or decimal-as-text
representation, both of which are less than ideal.

Thirdly, exact-precision floating point numbers aren't exactly a
necessity in most applications.  Scientific calculations are inherently
performed with errors and tolerances in mind, and majorly prefer the
performance/precision ratio of IEEE floats to that of numerics.
Diligent financial applications tend to avoid fixed- and floating-point
arithmetic as much as possible and compute amounts as integers instead.

For these reasons, numeric literals with a decimal point are now
interpreted as `std::float64`.  Additionally, implicit casts between the
floats and `std::decimal` have been removed, although the assignment cast
is still present.