### PR TITLE
Prohibit views and abstract types in `INSERT`

### DIFF
--- a/edb/lang/edgeql/compiler/stmt.py
+++ b/edb/lang/edgeql/compiler/stmt.py
@@ -256,6 +256,15 @@ def compile_InsertQuery(
         init_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 
         subject = dispatch.compile(expr.subject, ctx=ictx)
+        if subject.scls.is_abstract:
+            raise errors.EdgeQLError(
+                f'cannot insert: {subject.scls.displayname} is abstract',
+                context=expr.subject.context)
+
+        if subject.scls.is_view():
+            raise errors.EdgeQLError(
+                f'cannot insert: {subject.scls.displayname} is a view',
+                context=expr.subject.context)
 
         stmt.subject = compile_query_subject(
             subject,

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -945,3 +945,25 @@ class TestInsert(tb.QueryTestCase):
                     subordinates := <Object>{}
                 };
                 """)
+
+    async def test_edgeql_insert_abstract(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLError,
+                r"cannot insert: std::Object is abstract",
+                position=7):
+            await self.query("""\
+                INSERT Object;
+            """)
+
+    async def test_edgeql_insert_view(self):
+        await self.con.execute('''
+            CREATE VIEW test::Foo := (SELECT test::InsertTest);
+        ''')
+
+        with self.assertRaisesRegex(
+                exc.EdgeQLError,
+                r"cannot insert: test::Foo is a view",
+                position=7):
+            await self.query("""\
+                INSERT test::Foo;
+            """)


### PR DESCRIPTION
`INSERT <AbstractType>` and `INSERT <ViewType>` now raise a clear error.

Closes: #256