### PR TITLE
Cleanup function call compilation in EdgeQL compiler

### DIFF
--- a/edb/lang/edgeql/ast.py
+++ b/edb/lang/edgeql/ast.py
@@ -864,7 +864,6 @@ class FunctionCode(Clause):
 class CreateFunction(CreateObject):
     args: typing.List[FuncParam]
     returning: TypeExpr
-    aggregate: bool = False
     initial_value: Expr
     code: FunctionCode
     returning_typemod: ft.TypeModifier = ft.TypeModifier.SINGLETON
@@ -876,7 +875,6 @@ class AlterFunction(AlterObject):
 
 class DropFunction(DropObject):
     args: typing.List[FuncParam]
-    aggregate: bool = False
 
 
 class SessionStateDecl(Expr):

--- a/edb/lang/edgeql/codegen.py
+++ b/edb/lang/edgeql/codegen.py
@@ -1048,7 +1048,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                     self.write(';')
 
             if node.code.from_name:
-                self.write(f' FROM {node.code.language} {typ} ')
+                self.write(f' FROM {node.code.language} FUNCTION ')
                 self.write(f'{node.code.from_name!r}')
             else:
                 self.write(f' FROM {node.code.language} ')
@@ -1060,7 +1060,6 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 self._block_ws(-1)
                 self.write('}')
 
-        typ = 'AGGREGATE' if node.aggregate else 'FUNCTION'
         self._visit_CreateObject(node, 'FUNCTION', after_name=after_name,
                                  render_commands=False)
 

--- a/edb/lang/edgeql/compiler/context.py
+++ b/edb/lang/edgeql/compiler/context.py
@@ -174,9 +174,6 @@ class ContextLevel(compiler.ContextLevel):
     scope_id_ctr: compiler.Counter
     """Path scope id counter."""
 
-    in_aggregate: bool
-    """True if the current location is inside an aggregate function call."""
-
     view_rptr: ViewRPtr
     """Pointer information for the top-level view of the substatement."""
 
@@ -233,7 +230,6 @@ class ContextLevel(compiler.ContextLevel):
             self.path_scope_is_temp = False
             self.path_scope_map = {}
             self.scope_id_ctr = compiler.Counter()
-            self.in_aggregate = False
             self.view_scls = None
             self.expr_exposed = False
 
@@ -294,7 +290,6 @@ class ContextLevel(compiler.ContextLevel):
                 self.view_scls = None
                 self.clause = None
                 self.stmt = None
-                self.in_aggregate = False
 
                 self.partial_path_prefix = None
 
@@ -319,7 +314,6 @@ class ContextLevel(compiler.ContextLevel):
                 self.view_scls = None
                 self.clause = None
                 self.stmt = None
-                self.in_aggregate = False
 
                 self.partial_path_prefix = None
 
@@ -333,8 +327,6 @@ class ContextLevel(compiler.ContextLevel):
 
                 self.clause = prevlevel.clause
                 self.stmt = prevlevel.stmt
-
-                self.in_aggregate = prevlevel.in_aggregate
 
                 self.partial_path_prefix = prevlevel.partial_path_prefix
 

--- a/edb/lang/edgeql/compiler/decompiler.py
+++ b/edb/lang/edgeql/compiler/decompiler.py
@@ -220,7 +220,6 @@ class IRDecompiler(ast.visitor.NodeVisitor):
         else:
             args = node.args
 
-        # FIXME: hack to reconstruct args for a trivial aggregate function
         args = [qlast.FuncArg(arg=arg) for arg in self.visit(args)]
         if node.agg_filter or node.agg_sort:
             args[0].sort = node.agg_sort
@@ -228,7 +227,7 @@ class IRDecompiler(ast.visitor.NodeVisitor):
                               if node.agg_filter is not None else None)
 
         result = qlast.FunctionCall(
-            func=(node.func.shortname.module, node.func.shortname.name),
+            func=(node.func_shortname.module, node.func_shortname.name),
             args=args,
         )
 

--- a/edb/lang/edgeql/compiler/viewgen.py
+++ b/edb/lang/edgeql/compiler/viewgen.py
@@ -658,14 +658,8 @@ def _compile_view_shapes_in_fcall(
         rptr: typing.Optional[irast.Pointer]=None,
         parent_view_type: typing.Optional[s_types.ViewType]=None,
         ctx: context.ContextLevel) -> None:
-    funcobj = expr.func
 
-    preserves_type = (
-        any(p.type.is_polymorphic() for p in funcobj.params) and
-        funcobj.return_type.is_polymorphic()
-    )
-
-    if preserves_type:
+    if expr.func_polymorphic:
         for arg in expr.args:
             arg_scope = pathctx.get_set_scope(arg, ctx=ctx)
             if arg_scope is not None:

--- a/edb/lang/edgeql/parser/grammar/keywords.py
+++ b/edb/lang/edgeql/parser/grammar/keywords.py
@@ -30,7 +30,6 @@ unreserved_keywords = frozenset([
     "abstract",
     "action",
     "after",
-    "aggregate",
     "as",
     "asc",
     "attribute",

--- a/edb/lang/ir/ast.py
+++ b/edb/lang/ir/ast.py
@@ -29,6 +29,7 @@ from edb.lang.schema import pointers as s_pointers
 from edb.lang.schema import types as s_types
 
 from edb.lang.edgeql import ast as qlast
+from edb.lang.edgeql import functypes as ft
 
 from .pathid import PathId, WeakNamespace  # noqa
 from .scopetree import InvalidScopeConfiguration, ScopeTreeNode  # noqa
@@ -266,17 +267,44 @@ class SortExpr(Base):
 
 class FunctionCall(Expr):
 
-    func: so.Object
+    # Bound function has polymorphic parameters and
+    # a polymorphic return type.
+    func_polymorphic: bool
+
+    # Bound function's name.
+    func_shortname: sn.Name
+
+    # If the bound function is a "FROM SQL" function, this
+    # attribute will be set to the name of the SQL function.
+    func_sql_function: typing.Optional[str]
+
+    # Bound arguments.
     args: typing.List[Base]
-    kwargs: dict
+
+    # Typemods of parameters.  This list corresponds to ".args"
+    # (so `zip(args, params_typemods)` is valid.)
+    params_typemods: typing.List[ft.TypeModifier]
+
+    # True if the bound function has a variadic parameter and
+    # there are no arguments that are bound to it.
+    has_empty_variadic: bool = False
+    # Set to the type of the variadic parameter of the bound function
+    # (or None, if the function has no variadic parameters.)
+    variadic_param_type: typing.Optional[s_types.Type]
+
+    # Return type and typemod.  In bodies of polymorphic functions
+    # the return type can be polymorphic; in queries the return
+    # type will be a concrete schema type.
+    type: s_types.Type
+    typemod: ft.TypeModifier
+
     agg_sort: typing.List[SortExpr]
     agg_filter: Base
     agg_set_modifier: qlast.SetModifier
+
     partition: typing.List[Base]
     window: bool
     initial_value: Base
-    type: s_types.Type
-    has_empty_variadic: bool = False
 
 
 class TupleIndirection(Expr):

--- a/edb/lang/ir/astexpr.py
+++ b/edb/lang/ir/astexpr.py
@@ -31,7 +31,7 @@ class DistinctConjunctionExpr:
         if self.pattern is None:
             # Basic std::is_distinct(blah) expression
             pure_distinct_expr = irastmatch.FunctionCall(
-                func=astmatch.Object(shortname='std::is_distinct'),
+                func_shortname='std::is_distinct',
                 args=[astmatch.group('expr', irastmatch.Base())],
             )
 

--- a/edb/lang/ir/inference/cardinality.py
+++ b/edb/lang/ir/inference/cardinality.py
@@ -116,7 +116,7 @@ def __infer_set(ir, scope_tree, schema):
 
 @_infer_cardinality.register(irast.FunctionCall)
 def __infer_func_call(ir, scope_tree, schema):
-    if ir.func.return_typemod is ql_ft.TypeModifier.SET_OF:
+    if ir.typemod is ql_ft.TypeModifier.SET_OF:
         return MANY
     else:
         return ONE

--- a/edb/lang/ir/utils.py
+++ b/edb/lang/ir/utils.py
@@ -81,17 +81,6 @@ def is_set_membership_expr(ir):
     )
 
 
-def is_aggregated_expr(ir):
-    def flt(n):
-        if isinstance(n, irast.FunctionCall):
-            return n.func.aggregate
-        elif isinstance(n, irast.Stmt):
-            # Make sure we don't dip into subqueries
-            raise ast.SkipNode()
-
-    return bool(set(ast.find_children(ir, flt)))
-
-
 def get_id_path_id(
         path_id: irast.PathId, *,
         schema: s_schema.Schema) -> irast.PathId:

--- a/edb/lang/schema/_std.eql
+++ b/edb/lang/schema/_std.eql
@@ -351,7 +351,6 @@ CREATE ABSTRACT ATTRIBUTE stdattrs::computable std::bool;
 CREATE ABSTRACT ATTRIBUTE stdattrs::default std::str;
 CREATE ABSTRACT ATTRIBUTE stdattrs::expression std::str;
 CREATE ABSTRACT ATTRIBUTE stdattrs::cardinality std::str;
-CREATE ABSTRACT ATTRIBUTE stdattrs::aggregate std::bool;
 CREATE ABSTRACT ATTRIBUTE stdattrs::language std::str;
 CREATE ABSTRACT ATTRIBUTE stdattrs::code std::str;
 CREATE ABSTRACT ATTRIBUTE stdattrs::from_function std::str;
@@ -587,5 +586,4 @@ CREATE TYPE schema::Function EXTENDING schema::Object {
     };
     CREATE LINK schema::return_type -> schema::Type;
     CREATE PROPERTY schema::return_typemod -> std::str;
-    CREATE PROPERTY schema::aggregate -> std::bool;
 };

--- a/edb/lang/schema/ast.py
+++ b/edb/lang/schema/ast.py
@@ -155,7 +155,6 @@ class FunctionCode(Base):
 class FunctionDeclaration(Declaration):
     args: list
     returning: qlast.TypeName
-    aggregate: bool = False
     initial_value: qlast.Base
     code: FunctionCode
     returning_typemod: qlft.TypeModifier

--- a/edb/lang/schema/codegen.py
+++ b/edb/lang/schema/codegen.py
@@ -220,10 +220,7 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
         self._visit_Declaration(node)
 
     def visit_FunctionDeclaration(self, node):
-        if node.aggregate:
-            self.write('aggregate ')
-        else:
-            self.write('function ')
+        self.write('function ')
 
         self.write(node.name)
         self.write('(')

--- a/edb/lang/schema/functions.py
+++ b/edb/lang/schema/functions.py
@@ -256,7 +256,6 @@ class Function(so.NamedObject):
                       coerce=True, compcoef=0.4)
 
     return_type = so.Field(so.Object, compcoef=0.2)
-    aggregate = so.Field(bool, default=False, compcoef=0.4)
 
     code = so.Field(str, default=None, compcoef=0.4)
     language = so.Field(qlast.Language, default=None, compcoef=0.4,
@@ -461,11 +460,6 @@ class CreateFunction(named.CreateNamedObject, FunctionCommand):
             property='return_type',
             new_value=utils.ast_to_typeref(
                 astnode.returning, modaliases=modaliases, schema=schema)
-        ))
-
-        cmd.add(sd.AlterObjectProperty(
-            property='aggregate',
-            new_value=astnode.aggregate
         ))
 
         cmd.add(sd.AlterObjectProperty(

--- a/edb/server/pgsql/common.py
+++ b/edb/server/pgsql/common.py
@@ -26,6 +26,7 @@ from edb.lang.common import persistent_hash
 from edb.lang.schema import objtypes as s_objtypes
 from edb.lang.schema import links as s_links
 from edb.lang.schema import lproperties as s_props
+from edb.lang.schema import name as s_name
 
 from edb.server.pgsql.parser import keywords as pg_keywords
 
@@ -141,6 +142,13 @@ def link_name_to_table_name(name, catenate=True):
 
 def prop_name_to_table_name(name, catenate=True):
     return convert_name(name, 'prop', catenate)
+
+
+def schema_name_to_pg_name(name: s_name.Name):
+    return (
+        edgedb_module_name_to_schema_name(name.module),
+        edgedb_name_to_pg_name(name.name)
+    )
 
 
 def get_table_name(obj, catenate=True):

--- a/edb/server/pgsql/datasources/schema/functions.py
+++ b/edb/server/pgsql/datasources/schema/functions.py
@@ -29,7 +29,6 @@ async def fetch(
                 f.name AS name,
                 f.title AS title,
                 f.description AS description,
-                f.aggregate,
                 f.return_typemod,
                 f.language,
                 f.code,

--- a/edb/server/pgsql/intromech.py
+++ b/edb/server/pgsql/intromech.py
@@ -345,7 +345,6 @@ class IntrospectionMech:
                 'name': name,
                 'title': self.json_to_word_combination(row['title']),
                 'description': row['description'],
-                'aggregate': row['aggregate'],
                 'language': row['language'],
                 'params': self._decode_func_params(row, schema),
                 'return_typemod': row['return_typemod'],

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -399,9 +399,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [100, 101],
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_functions_array_enumerate_02(self):
-        # Fix type inference for functions.
         await self.assert_query_result(r'''
             SELECT array_enumerate([10,20]).0 + 100;
         ''', [


### PR DESCRIPTION
* irast.FunctionCall no longer has 'func' attribute; new attributes
  were added to provide info about the call: 'func_shortname',
  'func_polymorphic', 'sql_function', 'params_types',
  'params_typemods', 'variadic_type'.

* Drop schema.Function.aggregate and related code in codegens
  and compilers.