### PR TITLE
Allow indexing named tuples by position; fix named tuples serialization

### DIFF
--- a/edb/lang/edgeql/compiler/setgen.py
+++ b/edb/lang/edgeql/compiler/setgen.py
@@ -461,17 +461,14 @@ def tuple_indirection_set(
     else:
         el_name = ptr_name[1]
 
-    if el_name in source.element_types:
-        path_id = irutils.tuple_indirection_path_id(
-            path_tip.path_id, el_name,
-            source.element_types[el_name])
-        expr = irast.TupleIndirection(
-            expr=path_tip, name=el_name, path_id=path_id,
-            context=source_context)
-    else:
-        raise errors.EdgeQLReferenceError(
-            f'{el_name} is not a member of a tuple',
-            context=source_context)
+    el_norm_name = source.normalize_index(el_name)
+    el_type = source.get_subtype(el_name)
+
+    path_id = irutils.tuple_indirection_path_id(
+        path_tip.path_id, el_norm_name, el_type)
+    expr = irast.TupleIndirection(
+        expr=path_tip, name=el_norm_name, path_id=path_id,
+        context=source_context)
 
     return generated_set(expr, ctx=ctx)
 

--- a/edb/lang/ir/inference/types.py
+++ b/edb/lang/ir/inference/types.py
@@ -39,8 +39,7 @@ from edb.lang.ir import ast as irast
 def amend_empty_set_type(es: irast.EmptySet, t: s_obj.Object, schema) -> None:
     alias = es.path_id.target.name.name
     scls_name = s_name.Name(module='__expr__', name=alias)
-    scls = t.__class__(name=scls_name, bases=[t])
-    scls.acquire_ancestor_inheritance(schema)
+    scls = t.derive_subtype(schema, name=scls_name)
     es.path_id = irast.PathId(scls)
     es.scls = t
 
@@ -441,7 +440,7 @@ def __infer_struct(ir, schema):
 @_infer_type.register(irast.TupleIndirection)
 def __infer_struct_indirection(ir, schema):
     struct_type = infer_type(ir.expr, schema)
-    result = struct_type.element_types.get(ir.name)
+    result = struct_type.get_subtype(ir.name)
     if result is None:
         raise ql_errors.EdgeQLError('could not determine struct element type',
                                     context=ir.context)

--- a/edb/lang/schema/_std.eql
+++ b/edb/lang/schema/_std.eql
@@ -115,7 +115,7 @@ CREATE FUNCTION std::array_contains(array: array<any>,
     $$;
 
 CREATE FUNCTION std::array_enumerate(array: array<any>) ->
-        SET OF tuple<any, std::int64>
+        SET OF tuple<element:any, index:std::int64>
     FROM SQL FUNCTION '--system--';
 
 CREATE FUNCTION std::array_get(array: array<any>,

--- a/edb/lang/schema/nodes.py
+++ b/edb/lang/schema/nodes.py
@@ -35,6 +35,11 @@ class Node(inheriting.InheritingObject, s_types.Type):
             t = t.bases[0]
         return t
 
+    def derive_subtype(self, schema, *, name: str) -> s_types.Type:
+        st = type(self)(name=name, bases=[self])
+        st.acquire_ancestor_inheritance(schema)
+        return st
+
     def peel_view(self):
         if self.is_view():
             return self.bases[0]

--- a/edb/lang/schema/objtypes.py
+++ b/edb/lang/schema/objtypes.py
@@ -39,6 +39,9 @@ class SourceNode(sources.Source, nodes.Node):
 class ObjectType(SourceNode, constraints.ConsistencySubject):
     _type = 'ObjectType'
 
+    def is_object_type(self):
+        return True
+
     def materialize_policies(self, schema):
         bases = self.bases
 

--- a/edb/server/pgsql/compiler/relgen.py
+++ b/edb/server/pgsql/compiler/relgen.py
@@ -1163,7 +1163,7 @@ def process_set_as_tuple(
         for element in expr.elements:
             path_id = irutils.tuple_indirection_path_id(
                 ir_set.path_id, element.name,
-                ir_set.scls.element_types[element.name]
+                ir_set.scls.get_subtype(element.name)
             )
             stmt.view_path_id_map[path_id] = element.val.path_id
 
@@ -1218,10 +1218,8 @@ def process_set_as_tuple_indirection(
                 source_type=ir_set.scls, target_type=ir_set.scls, force=True,
                 env=subctx.env)
 
-            tuple_atts = list(tuple_set.scls.element_types.keys())
-            att_idx = pgast.NumericConstant(
-                val=str(tuple_atts.index(ir_set.expr.name) + 1)
-            )
+            index = tuple_set.scls.index_of(ir_set.expr.name)
+            att_idx = pgast.NumericConstant(val=str(index + 1))
 
             set_expr = pgast.FuncCall(
                 name=('edgedb', 'row_getattr_by_num'),
@@ -1373,7 +1371,7 @@ def process_set_as_func_expr(
                 elements=[
                     pgast.TupleElement(
                         path_id=irutils.tuple_indirection_path_id(
-                            ir_set.path_id, n, rtype.element_types[n],
+                            ir_set.path_id, n, rtype.get_subtype(n),
                         ),
                         name=n,
                         val=dbobj.get_column(

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -393,17 +393,41 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             SELECT [10, 20];
             SELECT array_enumerate([10,20]);
             SELECT array_enumerate([10,20]).1 + 100;
+            SELECT array_enumerate([10,20]).index + 100;
         ''', [
             [[10, 20]],
-            [[10, 0], [20, 1]],
+            [{"element": 10, "index": 0}, {"element": 20, "index": 1}],
+            [100, 101],
             [100, 101],
         ])
 
     async def test_edgeql_functions_array_enumerate_02(self):
         await self.assert_query_result(r'''
             SELECT array_enumerate([10,20]).0 + 100;
+            SELECT array_enumerate([10,20]).element + 1000;
         ''', [
             [110, 120],
+            [1010, 1020],
+        ])
+
+    @unittest.expectedFailure
+    async def test_edgeql_functions_array_enumerate_03(self):
+        await self.assert_query_result(r'''
+            SELECT array_enumerate([(x:=1)]).0;
+            SELECT array_enumerate([(x:=1)]).0.x;
+
+            SELECT array_enumerate([(x:=(a:=2))]).0;
+            SELECT array_enumerate([(x:=(a:=2))]).0.x;
+
+            SELECT array_enumerate([(x:=(a:=2))]).0.x.a;
+        ''', [
+            [{"x": 1}],
+            [1],
+
+            [{"x": {"a": 2}}],
+            [{"a": 2}],
+
+            [2],
         ])
 
     async def test_edgeql_functions_array_get_01(self):
@@ -471,6 +495,27 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [2],
             [4200],
             [4200],
+        ])
+
+    async def test_edgeql_functions_array_get_06(self):
+        await self.assert_query_result(r'''
+            SELECT array_get([(20,), (30,)], 0);
+            SELECT array_get([(a:=20), (a:=30)], 1);
+
+            SELECT array_get([(20,), (30,)], 0).0;
+            SELECT array_get([(a:=20), (a:=30)], 1).0;
+
+            SELECT array_get([(a:=20, b:=1), (a:=30, b:=2)], 0).a;
+            SELECT array_get([(a:=20, b:=1), (a:=30, b:=2)], 1).b;
+        ''', [
+            [[20]],
+            [{'a': 30}],  # XXX
+
+            [20],
+            [30],
+
+            [20],
+            [2],
         ])
 
     async def test_edgeql_functions_re_match_01(self):


### PR DESCRIPTION
Named tuples can now be indexed by position.  The below two queries are
equivalent:

    db> SELECT (a:=1).a;
    db> SELECT (a:=1).0;

Named tuples will now be correctly serialized to JSON in more cases,
for example:

    db> SELECT [(a:=1)][0];
    {"a": 1}

Serialization of nested named tuples is still broken in some cases
though:

    db> SELECT [(a:=(x:=1))][0];
    {"a": {"f1": 1}}