### PR TITLE
eschema: Remove `:>` syntax.

### DIFF
--- a/edb/lang/schema/parser/grammar/declarations.py
+++ b/edb/lang/schema/parser/grammar/declarations.py
@@ -1061,11 +1061,6 @@ class Attributes(ListNonterm, element=Attribute):
 
 
 class Value(Nonterm):
-    def reduce_COLONGT_NL_INDENT_RawString_NL_DEDENT(self, *kids):
-        text = kids[3].val.value
-        text = textwrap.dedent(text).strip()
-        self.val = qlast.BaseConstant.from_python(text)
-
     def reduce_AssignmentBlob(self, *kids):
         self.val = kids[0].val
 

--- a/edb/lang/schema/parser/grammar/tokens.py
+++ b/edb/lang/schema/parser/grammar/tokens.py
@@ -94,10 +94,6 @@ class T_ASSIGN(Token):
     pass
 
 
-class T_COLONGT(Token):
-    pass
-
-
 class T_ARROW(Token):
     pass
 
@@ -125,10 +121,6 @@ class T_INDENT(Token):
 
 
 class T_DEDENT(Token):
-    pass
-
-
-class T_ANYTHING(Token):
     pass
 
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -277,24 +277,21 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"Unexpected '''",
-                  line=2, col=20)
+                  r"Unterminated string ';", line=2, col=20)
     def test_edgeql_syntax_constants_23(self):
         r"""
         SELECT '\\'';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"Unexpected '\"'",
-                  line=2, col=20)
+                  r'Unterminated string ";', line=2, col=20)
     def test_edgeql_syntax_constants_24(self):
         r"""
         SELECT "\\"";
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"Unexpected '''",
-                  line=2, col=21)
+                  r"Unterminated string ';", line=2, col=21)
     def test_edgeql_syntax_constants_25(self):
         r"""
         SELECT b'\\'';

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -316,6 +316,61 @@ type Commit:
                 on target delete delete source
         """
 
+    @tb.must_fail(error.SchemaSyntaxError,
+                  "Unexpected end of line", line=4, col=38)
+    def test_eschema_syntax_type_19(self):
+        # testing bugs due to incorrect indentation
+        """
+        type Foo:
+            property foo -> str:
+                default := some_func(
+    1, 2, 3)
+        """
+
+    @tb.must_fail(error.SchemaSyntaxError,
+                  "Unterminated string '", line=4, col=38)
+    def test_eschema_syntax_type_20(self):
+        # testing bugs due to incorrect indentation
+        """
+        type Foo:
+            property foo -> str:
+                default := some_func('
+                1, 2, 3')
+        """
+
+    @tb.must_fail(error.SchemaSyntaxError,
+                  r"Unterminated string \$\$some_func\(", line=5, col=21)
+    def test_eschema_syntax_type_21(self):
+        # testing bugs due to incorrect indentation
+        """
+        type Foo:
+            property foo -> str:
+                default :=
+                    $$some_func(
+    1, 2, 3)$$
+        """
+
+    def test_eschema_syntax_type_22(self):
+        """
+        type Foo:
+            property foo -> str:
+                # if it's defined on the same line as :=
+                # the definition must be a one-liner
+                default := some_func(1, 2, 3)
+
+            property bar -> str:
+                # multi-line definition with correct indentation
+                default :=
+                    some_func('
+                    1, 2, 3')
+
+            property baz -> str:
+                # multi-line definition with correct indentation
+                default :=
+                    $$some_func(
+                    1, 2, 3)$$
+        """
+
     def test_eschema_syntax_link_target_type_01(self):
         """
 type User:
@@ -946,13 +1001,10 @@ type Foo:
     def test_eschema_syntax_function_03(self):
         r"""
         function some_func(foo: std::int64 = 42) -> std::str:
-            from edgeql :>
+            from edgeql:=
+                $$
                 SELECT 'life';
-
-% OK %
-        function some_func(foo: std::int64 = 42) -> std::str:
-            from edgeql :=
-                'SELECT \'life\';'
+                $$
         """
 
     def test_eschema_syntax_function_04(self):
@@ -962,20 +1014,10 @@ type Foo:
                         variadic arg3: std::int64) -> \
                         set of int:
             volatile := true
-            description :>
-                myfunc sample
-            from sql :>
-                SELECT blarg;
-
-% OK %
-        function myfunc(arg1: str, arg2: str = 'DEFAULT',
-                        variadic arg3: std::int64) -> \
-                        set of int:
-            volatile := true
             description :=
                 'myfunc sample'
             from sql :=
-                'SELECT blarg;'
+                $$SELECT blarg;$$
         """
 
     def test_eschema_syntax_function_05(self):


### PR DESCRIPTION
The `:>` syntax is too obscure. Using `:=` with an explicit string is
better.