### PR TITLE
Upgrade flake8 and fix the newly found issues

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E402,E731,D100,D101,D102,D103,D104,D105
+ignore = E402,E731,D100,D101,D102,D103,D104,D105,W504,E252
 exclude = .git,__pycache__,build,dist,.eggs
 

--- a/edb/lang/common/ast/base.py
+++ b/edb/lang/common/ast/base.py
@@ -424,7 +424,7 @@ def _check_type(type_, value, raise_error):
         for t in typing_inspect.get_args(type_, evaluate=True):
             try:
                 _check_type(t, value, raise_error)
-            except TypeError as e:
+            except TypeError:
                 pass
             else:
                 break

--- a/edb/lang/common/term.py
+++ b/edb/lang/common/term.py
@@ -403,7 +403,7 @@ class AbstractStyle:
         self.reverse = reverse
 
     def _filter_color(self, color):
-        raise NotImplemented()
+        raise NotImplementedError
 
     def _get_color(self):
         return self._rcolor_table[self._color]

--- a/edb/lang/edgeql/ast.py
+++ b/edb/lang/edgeql/ast.py
@@ -349,7 +349,7 @@ class FuncParam(Base):
     type: TypeExpr
     typemod: ft.TypeModifier = ft.TypeModifier.SINGLETON
     kind: ft.ParameterKind
-    default: Expr  # noqa (pyflakes bug)
+    default: Expr
 
 
 class IsOp(Expr):
@@ -387,8 +387,8 @@ class Introspect(Expr):
 
 class IfElse(Expr):
     condition: Expr
-    if_expr: Expr  # noqa (pyflakes bug)
-    else_expr: Expr  # noqa (pyflakes bug)
+    if_expr: Expr
+    else_expr: Expr
 
 
 class Coalesce(Expr):

--- a/edb/lang/edgeql/compiler/context.py
+++ b/edb/lang/edgeql/compiler/context.py
@@ -111,18 +111,18 @@ class ContextLevel(compiler.ContextLevel):
     aliased_views: typing.Dict[str, s_nodes.Node]
     """A dictionary of views aliased in a statement body."""
 
-    schema_view_cache: typing.Dict[s_nodes.Node, s_nodes.Node]  # noqa
+    schema_view_cache: typing.Dict[s_nodes.Node, s_nodes.Node]
     """Type cache used by schema-level views."""
 
     expr_view_cache: typing.Dict[typing.Tuple[qlast.Base, str],
-                                 irast.Set]  # noqa
+                                 irast.Set]
     """Type cache used by expression-level views."""
 
     shape_type_cache: typing.Dict[typing.Tuple[qlast.ShapeElement, ...],
                                   s_nodes.Node]
     """Type cache for shape expressions."""
 
-    class_view_overrides: typing.Dict[s_name.SchemaName, s_nodes.Node]  # noqa
+    class_view_overrides: typing.Dict[s_name.SchemaName, s_nodes.Node]
     """Object mapping used by implicit view override in SELECT."""
 
     clause: str
@@ -149,8 +149,8 @@ class ContextLevel(compiler.ContextLevel):
     view_map: typing.Dict[irast.PathId, irast.Set]
     """Set translation map.  Used for views."""
 
-    class_shapes: typing.Dict[s_types.Type,                     # noqa
-                              typing.List[s_pointers.Pointer]]  # noqa
+    class_shapes: typing.Dict[s_types.Type,
+                              typing.List[s_pointers.Pointer]]
     """Object output or modification shapes."""
 
     completion_work: typing.List[typing.Callable]

--- a/edb/lang/edgeql/compiler/stmt.py
+++ b/edb/lang/edgeql/compiler/stmt.py
@@ -379,7 +379,7 @@ def compile_SessionStateDecl(
                     testmode_ir, schema=ctx.schema)
             except ireval.StaticEvaluationError as e:
                 raise errors.EdgeQLError('invalid SET expression',
-                                         context=item.context)
+                                         context=item.context) from e
             else:
                 if not isinstance(testmode, bool):
                     raise errors.EdgeQLError(

--- a/edb/lang/edgeql/parser/grammar/ddl.py
+++ b/edb/lang/edgeql/parser/grammar/ddl.py
@@ -1665,7 +1665,7 @@ class CreateFunctionArgs(Nonterm):
 def _parse_language(node):
     try:
         return qlast.Language(node.val.upper())
-    except ValueError as ex:
+    except ValueError:
         raise EdgeQLSyntaxError(
             f'{node.val} is not a valid language',
             context=node.context) from None

--- a/edb/lang/graphql/ast.py
+++ b/edb/lang/graphql/ast.py
@@ -106,7 +106,7 @@ class Variable(Base):
 
 
 class Document(Base):
-    definitions: list  # noqa (pyflakes bug)
+    definitions: list
 
 
 class Definition(Base):

--- a/edb/lang/ir/ast.py
+++ b/edb/lang/ir/ast.py
@@ -246,11 +246,11 @@ class TypeCheckOp(Expr):
 class IfElseExpr(Expr):
 
     condition: Set
-    if_expr: Set  # noqa (pyflakes bug)
-    else_expr: Set  # noqa (pyflakes bug)
+    if_expr: Set
+    else_expr: Set
 
-    if_expr_card: Cardinality  # noqa
-    else_expr_card: Cardinality  # noqa
+    if_expr_card: Cardinality
+    else_expr_card: Cardinality
 
 
 class Coalesce(Base):

--- a/edb/lang/schema/objtypes.py
+++ b/edb/lang/schema/objtypes.py
@@ -116,7 +116,7 @@ class ObjectType(SourceNode, constraints.ConsistencySubject):
                     yield link_name, link_set
                     break
 
-    def implicitly_castable_to(self, other: 'Type', schema) -> bool:
+    def implicitly_castable_to(self, other: s_types.Type, schema) -> bool:
         return self.issubclass(other)
 
     @classmethod

--- a/edb/lang/schema/parser/grammar/declarations.py
+++ b/edb/lang/schema/parser/grammar/declarations.py
@@ -77,7 +77,7 @@ def parse_edgeql_constant(expr: str, ctx, *, indent=0):
 def _parse_language(node):
     try:
         return esast.Language(node.val.upper())
-    except ValueError as ex:
+    except ValueError:
         raise SchemaSyntaxError(
             f'{node.val} is not a valid language',
             context=node.context) from None

--- a/edb/lang/schema/pseudo.py
+++ b/edb/lang/schema/pseudo.py
@@ -43,15 +43,15 @@ class Any(PseudoType):
     def is_polymorphic(self):
         return True
 
-    def _resolve_polymorphic(self, concrete_type: 'Type'):
+    def _resolve_polymorphic(self, concrete_type: s_types.Type):
         if isinstance(concrete_type, s_scalars.ScalarType):
             return concrete_type.get_topmost_concrete_base()
         return concrete_type
 
-    def _to_nonpolymorphic(self, concrete_type: 'Type'):
+    def _to_nonpolymorphic(self, concrete_type: s_types.Type):
         return concrete_type
 
-    def _test_polymorphic(self, other: 'Type'):
+    def _test_polymorphic(self, other: s_types.Type):
         return other.is_any()
 
     def find_common_implicitly_castable_type(

--- a/edb/lang/schema/scalars.py
+++ b/edb/lang/schema/scalars.py
@@ -86,20 +86,20 @@ class ScalarType(nodes.Node, constraints.ConsistencySubject,
     def is_polymorphic(self):
         return bool(self.is_abstract and self.name.module == 'std')
 
-    def _resolve_polymorphic(self, concrete_type: 'Type'):
+    def _resolve_polymorphic(self, concrete_type: s_types.Type):
         if (self.is_polymorphic() and
                 concrete_type.is_scalar() and
                 not concrete_type.is_polymorphic()):
             return concrete_type
 
-    def _to_nonpolymorphic(self, concrete_type: 'Type'):
+    def _to_nonpolymorphic(self, concrete_type: s_types.Type):
         if (not concrete_type.is_polymorphic() and
                 concrete_type.issubclass(self)):
             return concrete_type
         raise TypeError(
             f'cannot interpret {concrete_type.name} as {self.name}')
 
-    def _test_polymorphic(self, other: 'Type'):
+    def _test_polymorphic(self, other: s_types.Type):
         if other.is_any():
             return True
         else:

--- a/edb/repl/__init__.py
+++ b/edb/repl/__init__.py
@@ -110,7 +110,7 @@ class InputBuffer(pt_buffer.Buffer):
             lexer.setinputstr(text)
             try:
                 toks = list(lexer.lex())
-            except core_lexer.UnknownTokenError as ex:
+            except core_lexer.UnknownTokenError:
                 return True
 
             if toks[-1].type == ';':
@@ -149,7 +149,7 @@ class Cli:
         pt_token.Token.Timing.Value: '#888',
     })
 
-    exit_commands = {'exit', 'quit', '\q', ':q'}
+    exit_commands = {'exit', 'quit', R'\q', ':q'}
 
     def _command(prefix, title, desc, *, _all_commands={}):
         def wrap(func):
@@ -278,7 +278,7 @@ class Cli:
             print('Could not establish connection', file=sys.stderr)
             exit(1)
 
-    @_command('c', '\c DBNAME', 'connect to database DBNAME')
+    @_command('c', R'\c DBNAME', 'connect to database DBNAME')
     def command_connect(self, args):
         new_db = args.strip()
         new_args = {**self.conn_args,
@@ -288,7 +288,7 @@ class Cli:
         self.ensure_connection(new_args)
         self.conn_args = new_args
 
-    @_command('l', '\l', 'list databases')
+    @_command('l', R'\l', 'list databases')
     def command_list_dbs(self, args):
         result = self.run_coroutine(
             self.connection.list_dbs())
@@ -297,7 +297,7 @@ class Cli:
         for dbn in result:
             print(f'  {dbn}')
 
-    @_command('psql', '\psql', 'open psql to the current postgres process')
+    @_command('psql', R'\psql', 'open psql to the current postgres process')
     def command_psql(self, args):
         result = self.run_coroutine(
             self.connection.get_pgcon())
@@ -344,7 +344,7 @@ class Cli:
                 if command in self.exit_commands:
                     raise EOFError
 
-                if command == '\?':
+                if command == R'\?':
                     for title, desc, _ in self.commands.values():
                         print(f'  {title:<20} {desc}')
                     continue
@@ -357,7 +357,7 @@ class Cli:
                         self.commands[prefix][2](self, args)
                     else:
                         print(f'No command {command} is found.')
-                        print('Try \? to see the list of supported commands.')
+                        print(R'Try \? to see the list of supported commands.')
                     continue
 
                 self.ensure_connection(self.conn_args)

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -193,7 +193,7 @@ def run_server(args):
         else:
             _run_server(cluster, args)
 
-    except BaseException as e:
+    except BaseException:
         if pg_cluster_init_by_us and not _server_initialized:
             logger.warning('server bootstrap did not complete successfully, '
                            'removing the data directory')

--- a/edb/server/pgsql/ast.py
+++ b/edb/server/pgsql/ast.py
@@ -521,7 +521,7 @@ class FuncCall(BaseExpr):
     # OVER clause, if any
     over: Base
     # WITH ORDINALITY
-    with_ordinality: bool = False  # noqa (pyflakes bug)
+    with_ordinality: bool = False
 
     def __init__(self, *, nullable: typing.Optional[bool]=None,
                  null_safe: bool=False, **kwargs) -> None:
@@ -647,7 +647,7 @@ class ColumnDef(Base):
     # type of column
     typename: TypeName
     # default value, if any
-    default_expr: Base  # noqa (pyflakes bug)
+    default_expr: Base
     # COLLATE clause, if any
     coll_clause: Base
 
@@ -755,7 +755,7 @@ class CaseExpr(BaseExpr):
     # List of WHEN clauses
     args: typing.List[CaseWhen]
     # ELSE clause
-    defresult: Base  # noqa (pyflakes bug)
+    defresult: Base
 
 
 class PgSQLOperator(ast.ops.Operator):

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ RUNTIME_DEPS = [
 
 EXTRA_DEPS = {
     'test': [
-        'flake8~=3.5.0',
-        'pycodestyle~=2.3.1',
+        'flake8~=3.6.0',
+        'pycodestyle~=2.4.0',
     ]
 }
 

--- a/tests/common/test_ast.py
+++ b/tests/common/test_ast.py
@@ -170,7 +170,7 @@ class ASTBaseTests(unittest.TestCase):
         with self.assertRaisesRegex(
                 RuntimeError, r'unable to resolve type annotations'):
             class Node2(ast.AST):
-                field: 'abc'
+                field: 'abc'  # noqa
 
         with self.assertRaisesRegex(RuntimeError,
                                     r"Mapping.*is not supported"):

--- a/tests/test_deltas.py
+++ b/tests/test_deltas.py
@@ -221,8 +221,8 @@ class TestDeltaLinkInheritance(tb.DDLTestCase):
 
         with self.assertRaisesRegex(
                 exceptions.InvalidPointerTargetError,
-                "invalid target for link '\(test::ObjectType01\)\.target': "
-                "'test::Target0' \(expecting 'test::Target1'\)"):
+                r"invalid target for link '\(test::ObjectType01\)\.target': "
+                r"'test::Target0' \(expecting 'test::Target1'\)"):
             # Target0 is not allowed to be targeted by ObjectType01, since
             # ObjectType01 inherits from ObjectType1 which requires more
             # specific Target1.

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -191,7 +191,7 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
                   r"invalid bytes literal: invalid escape sequence '\\c'",
                   line=2, col=16)
     def test_edgeql_syntax_constants_11(self):
-        """
+        R"""
         SELECT b'aaa\cbbb';
         """
 
@@ -224,7 +224,7 @@ aa';
                   r"invalid string literal: invalid escape sequence '\\c'",
                   line=2, col=16)
     def test_edgeql_syntax_constants_15(self):
-        """
+        r"""
         SELECT 'aaa\cbbb';
         """
 
@@ -406,7 +406,7 @@ aa';
                   r"invalid string literal: invalid escape sequence '\\\('",
                   line=2, col=16)
     def test_edgeql_syntax_constants_41(self):
-        """
+        r"""
         SELECT 'aaa \(aaa) bbb';
         """
 
@@ -625,7 +625,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected '\*'", line=2, col=16)
+                  r"Unexpected '\*'", line=2, col=16)
     def test_edgeql_syntax_ops_20(self):
         """
         SELECT *1;
@@ -985,7 +985,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected '\.'", line=3, col=21)
+                  r"Unexpected '\.'", line=3, col=21)
     def test_edgeql_syntax_shape_11(self):
         """
         SELECT Foo {
@@ -1023,14 +1023,14 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected '\('", line=2, col=21)
+                  r"Unexpected '\('", line=2, col=21)
     def test_edgeql_syntax_shape_15(self):
         """
         SELECT Foo {(bar)};
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected '\('", line=2, col=30)
+                  r"Unexpected '\('", line=2, col=30)
     def test_edgeql_syntax_shape_16(self):
         """
         SELECT Foo {[IS Bar].(bar)};
@@ -1114,7 +1114,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected '\*'", line=4, col=24)
+                  r"Unexpected '\*'", line=4, col=24)
     def test_edgeql_syntax_shape_26(self):
         """
         SELECT Issue{
@@ -1124,7 +1124,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected '\*'", line=4, col=24)
+                  r"Unexpected '\*'", line=4, col=24)
     def test_edgeql_syntax_shape_27(self):
         """
         SELECT Issue{
@@ -1134,7 +1134,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected '\*'", line=4, col=24)
+                  r"Unexpected '\*'", line=4, col=24)
     def test_edgeql_syntax_shape_28(self):
         """
         SELECT Issue{
@@ -1144,7 +1144,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected '\*'", line=4, col=24)
+                  r"Unexpected '\*'", line=4, col=24)
     def test_edgeql_syntax_shape_29(self):
         """
         SELECT Issue{
@@ -1348,14 +1348,14 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected '\)'", line=2, col=28)
+                  r"Unexpected '\)'", line=2, col=28)
     def test_edgeql_syntax_struct_12(self):
         """
         SELECT (a := 1, foo);
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected '\.'", line=2, col=28)
+                  r"Unexpected '\.'", line=2, col=28)
     def test_edgeql_syntax_struct_13(self):
         """
         SELECT (a := 1, foo.bar);
@@ -1676,7 +1676,7 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected '\{'", line=3, col=19)
+                  r"Unexpected '\{'", line=3, col=19)
     def test_edgeql_syntax_cast_03(self):
         """
         SELECT


### PR DESCRIPTION
The new pycodestyle version introduces the new W504 (break after a
binary operator), and E252 (missing whitespace around equal sign in type
annotated function arguments).  Both are reversals of an earlier policy
and, as such, generate an enormous number of errors in the current code,
so I chose to silence instead of fixing them for now.