### PR TITLE
Turn function/operator/constraint parameters into full schema items

### DIFF
--- a/edb/lang/edgeql/ast.py
+++ b/edb/lang/edgeql/ast.py
@@ -775,8 +775,11 @@ class DropConcreteLink(DropObject):
     pass
 
 
-class CreateConstraint(CreateExtendingObject):
-    args: typing.List[FuncParam]
+class CallableObject(ObjectDDL):
+    params: typing.List[FuncParam]
+
+
+class CreateConstraint(CreateExtendingObject, CallableObject):
     subject: typing.Optional[Expr]
 
 
@@ -789,7 +792,7 @@ class DropConstraint(DropObject):
 
 
 class CreateConcreteConstraint(CreateObject):
-    args: typing.List[Base]
+    args: typing.List[FuncArg]
     is_abstract: bool = False
     subject: typing.Optional[Expr]
 
@@ -834,8 +837,7 @@ class FunctionCode(Clause):
     from_name: str
 
 
-class CreateFunction(CreateObject):
-    args: typing.List[FuncParam]
+class CreateFunction(CreateObject, CallableObject):
     returning: TypeExpr
     code: FunctionCode
     returning_typemod: ft.TypeModifier = ft.TypeModifier.SINGLETON
@@ -845,8 +847,8 @@ class AlterFunction(AlterObject):
     value: Base
 
 
-class DropFunction(DropObject):
-    args: typing.List[FuncParam]
+class DropFunction(DropObject, CallableObject):
+    pass
 
 
 class OperatorCode(Clause):
@@ -854,9 +856,8 @@ class OperatorCode(Clause):
     from_name: str
 
 
-class OperatorCommand(ObjectDDL):
+class OperatorCommand(CallableObject):
     kind: ft.OperatorKind
-    args: typing.List[FuncParam]
 
 
 class CreateOperator(CreateObject, OperatorCommand):

--- a/edb/lang/edgeql/codegen.py
+++ b/edb/lang/edgeql/codegen.py
@@ -864,9 +864,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_CreateConstraint(self, node):
         def after_name():
-            if node.args:
+            if node.params:
                 self.write('(')
-                self.visit_list(node.args, newlines=False)
+                self.visit_list(node.params, newlines=False)
                 self.write(')')
             if node.subject:
                 self.write(' ON (')
@@ -1025,7 +1025,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
     def visit_CreateFunction(self, node):
         def after_name():
             self.write('(')
-            self.visit_list(node.args, newlines=False)
+            self.visit_list(node.params, newlines=False)
             self.write(')')
             self.write(' -> ')
             self.write(node.returning_typemod.to_edgeql(), ' ')

--- a/edb/lang/edgeql/compiler/__init__.py
+++ b/edb/lang/edgeql/compiler/__init__.py
@@ -155,14 +155,14 @@ def compile_func_to_ir(func, schema, *,
         name='__defaults_mask__', type=schema.get('std::bytes'))
 
     for pi, p in enumerate(func.params.as_pg_params().params):
-        anchors[p.name] = irast.Parameter(name=p.name, type=p.type)
+        anchors[p.shortname] = irast.Parameter(name=p.shortname, type=p.type)
 
         if p.default is None:
             continue
 
         tree.aliases.append(
             qlast.AliasedExpr(
-                alias=p.name,
+                alias=p.shortname,
                 expr=qlast.IfElse(
                     condition=qlast.BinOp(
                         left=qlast.FunctionCall(
@@ -178,7 +178,8 @@ def compile_func_to_ir(func, schema, *,
                             ]),
                         right=qlast.IntegerConstant(value='0'),
                         op=qlast.EQ),
-                    if_expr=qlast.Path(steps=[qlast.ObjectRef(name=p.name)]),
+                    if_expr=qlast.Path(
+                        steps=[qlast.ObjectRef(name=p.shortname)]),
                     else_expr=qlast._Optional(expr=p.get_ql_default()))))
 
     ir = compile_ast_to_ir(

--- a/edb/lang/edgeql/compiler/func.py
+++ b/edb/lang/edgeql/compiler/func.py
@@ -261,10 +261,10 @@ def try_bind_func_args(
 
         pi += 1
 
-        if param.name in kwargs:
+        if param.shortname in kwargs:
             matched_kwargs += 1
 
-            arg_type, arg_val = kwargs[param.name]
+            arg_type, arg_val = kwargs[param.shortname]
             if not _check_type(arg_val, arg_type, param.type):
                 return _NO_MATCH
 
@@ -352,7 +352,7 @@ def try_bind_func_args(
                 if val is not None:
                     continue
 
-                null_args.add(param.name)
+                null_args.add(param.shortname)
 
                 defaults_mask |= 1 << i
 
@@ -368,7 +368,7 @@ def try_bind_func_args(
                         if resolved_poly_base_type is None:
                             raise errors.EdgeQLError(
                                 f'could not resolve "anytype" type for the '
-                                f'${param.name} parameter')
+                                f'${param.shortname} parameter')
                         else:
                             default_type = resolved_poly_base_type
                     else:
@@ -381,7 +381,7 @@ def try_bind_func_args(
                     default = irutils.new_empty_set(
                         ctx.schema,
                         scls=default_type,
-                        alias=param.name)
+                        alias=param.shortname)
                 else:
                     default = param.get_ir_default(schema=ctx.schema)
 
@@ -505,7 +505,7 @@ def finalize_args(bound_call: BoundCall, *,
                 arg_scope.collapse()
                 pathctx.assign_set_scope(arg, None, ctx=ctx)
             if (param_mod is _OPTIONAL or
-                    param.name in bound_call.null_args):
+                    param.shortname in bound_call.null_args):
                 pathctx.register_set_in_scope(arg, ctx=ctx)
                 pathctx.mark_path_as_optional(arg.path_id, ctx=ctx)
 

--- a/edb/lang/edgeql/optimizer.py
+++ b/edb/lang/edgeql/optimizer.py
@@ -277,7 +277,7 @@ class EdgeQLOptimizer:
                 self._process_expr(context, expr.target)
 
             elif isinstance(expr, qlast.OperatorCommand):
-                for arg in expr.args:
+                for arg in expr.params:
                     self._process_expr(context, arg)
 
                 if isinstance(expr, qlast.CreateOperator):

--- a/edb/lang/edgeql/parser/grammar/ddl.py
+++ b/edb/lang/edgeql/parser/grammar/ddl.py
@@ -635,7 +635,7 @@ class CreateConstraintStmt(Nonterm):
                     OptOnExpr OptExtending OptCreateCommandsBlock"""
         self.val = qlast.CreateConstraint(
             name=kids[3].val,
-            args=kids[4].val,
+            params=kids[4].val,
             subject=kids[5].val,
             bases=kids[6].val,
             commands=kids[7].val,
@@ -1672,7 +1672,7 @@ class CreateFunctionStmt(Nonterm, _ProcessFunctionBlockMixin):
         """
         self.val = qlast.CreateFunction(
             name=kids[2].val,
-            args=kids[3].val,
+            params=kids[3].val,
             returning=kids[6].val,
             returning_typemod=kids[5].val,
             **self._process_function_body(kids[7])
@@ -1684,7 +1684,7 @@ class DropFunctionStmt(Nonterm):
         r"""%reduce DROP FUNCTION NodeName CreateFunctionArgs"""
         self.val = qlast.DropFunction(
             name=kids[2].val,
-            args=kids[3].val)
+            params=kids[3].val)
 
 
 class FunctionType(Nonterm):
@@ -1740,7 +1740,7 @@ class CreateOperatorStmt(Nonterm):
         self.val = qlast.CreateOperator(
             kind=ft.OperatorKind(kids[1].val),
             name=kids[3].val,
-            args=kids[4].val,
+            params=kids[4].val,
             returning_typemod=kids[6].val,
             returning=kids[7].val,
             **self._process_operator_body(kids[8])
@@ -1795,7 +1795,7 @@ class AlterOperatorStmt(Nonterm):
         self.val = qlast.AlterOperator(
             kind=ft.OperatorKind(kids[1].val),
             name=kids[3].val,
-            args=kids[4].val,
+            params=kids[4].val,
             commands=kids[5].val
         )
 
@@ -1812,5 +1812,5 @@ class DropOperatorStmt(Nonterm):
         self.val = qlast.DropOperator(
             kind=ft.OperatorKind(kids[1].val),
             name=kids[3].val,
-            args=kids[4].val,
+            params=kids[4].val,
         )

--- a/edb/lang/edgeql/utils.py
+++ b/edb/lang/edgeql/utils.py
@@ -71,15 +71,15 @@ def index_parameters(ql_args: typing.List[qlast.Base], *,
         if isinstance(e, qlast.SelectQuery):
             e = e.result
 
-        if parameters.variadic and parameters.variadic.pos == i:
+        if parameters.variadic and parameters.variadic.num == i:
             assert varargs is None
             varargs = []
-            result[p.name] = qlast.Array(elements=varargs)
+            result[p.shortname] = qlast.Array(elements=varargs)
 
         if varargs is not None:
             varargs.append(e)
         else:
-            result[p.name] = e
+            result[p.shortname] = e
 
     return result
 

--- a/edb/lang/schema/ast.py
+++ b/edb/lang/schema/ast.py
@@ -89,11 +89,6 @@ class Link(Pointer):
     on_target_delete: OnTargetDelete
 
 
-# # XXX: to be killed
-# class Property(Property):
-#     pass
-
-
 class Declaration(Base):
     name: str
     extends: typing.List[qlast.TypeName]
@@ -121,7 +116,7 @@ class ObjectTypeDeclaration(Declaration):
 
 class ConstraintDeclaration(Declaration):
     abstract: bool = False
-    args: typing.List[qlast.Base]
+    params: typing.List[qlast.FuncParam]
     subject: typing.Optional[qlast.Expr]
 
 
@@ -141,7 +136,7 @@ class FunctionCode(Base):
 
 
 class FunctionDeclaration(Declaration):
-    args: list
+    params: list
     returning: qlast.TypeName
     code: FunctionCode
     returning_typemod: qlft.TypeModifier

--- a/edb/lang/schema/codegen.py
+++ b/edb/lang/schema/codegen.py
@@ -200,9 +200,9 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
 
     def visit_ConstraintDeclaration(self, node):
         def after_name(node):
-            if node.args:
+            if node.params:
                 self.write('(')
-                self.visit_list(node.args, newlines=False)
+                self.visit_list(node.params, newlines=False)
                 self.write(')')
             if node.subject:
                 self.write(' on ')
@@ -231,7 +231,7 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
 
         self.write(node.name)
         self.write('(')
-        self.visit_list(node.args, newlines=False)
+        self.visit_list(node.params, newlines=False)
         self.write(') -> ')
         self.write(node.returning_typemod.to_edgeql(), ' ')
         self.visit(node.returning)

--- a/edb/lang/schema/declarative.py
+++ b/edb/lang/schema/declarative.py
@@ -30,6 +30,7 @@ from edb.lang import edgeql
 from edb.lang.edgeql import ast as qlast
 from edb.lang.edgeql import codegen as qlcodegen
 from edb.lang.edgeql import compiler as qlcompiler
+from edb.lang.edgeql import functypes as ft
 from edb.lang.edgeql import utils as qlutils
 
 from edb.lang.ir import ast as ir_ast
@@ -112,6 +113,10 @@ class DeclarationLoader:
                 objcls_kw['is_abstract'] = decl.delegated
             if hasattr(decl, 'final'):
                 objcls_kw['final'] = decl.final
+
+            if objcls is s_constr.Constraint:
+                objcls_kw['return_type'] = self._schema.get('std::bool')
+                objcls_kw['return_typemod'] = ft.TypeModifier.SINGLETON
 
             obj = objcls(name=name,
                          sourcectx=decl.context,
@@ -342,7 +347,7 @@ class DeclarationLoader:
 
             params = s_func.FuncParameterList.from_ast(
                 decl, self._mod_aliases, self._schema,
-                allow_named=False)
+                allow_named=False, func_fqname=constraint.name)
 
             for param in params:
                 if param.default is not None:

--- a/edb/lang/schema/delta.py
+++ b/edb/lang/schema/delta.py
@@ -609,13 +609,16 @@ class CreateObject(ObjectCommand):
     _delta_action = 'create'
 
     def _create_begin(self, schema, context):
-        props = self.get_struct_properties(schema)
+        schema, props = self._make_constructor_args(schema, context)
 
         metaclass = self.get_schema_metaclass()
         self.scls = metaclass(
             **props, _setdefaults_=False, _relaxrequired_=True)
 
         return schema
+
+    def _make_constructor_args(self, schema, context):
+        return schema, self.get_struct_properties(schema)
 
     def _create_innards(self, schema, context):
         return schema

--- a/edb/lang/schema/named.py
+++ b/edb/lang/schema/named.py
@@ -204,14 +204,6 @@ class CreateNamedObject(CreateOrAlterNamedObject, sd.CreateObject):
         else:
             super()._apply_field_ast(schema, context, node, op)
 
-    def apply(self, schema, context):
-        metaclass = self.get_schema_metaclass()
-        if schema.get(self.classname, default=None, type=metaclass):
-            raise ValueError(f'{self.classname!r} already exists in schema')
-
-        # apply will add to the schema
-        return sd.CreateObject.apply(self, schema, context)
-
     def __repr__(self):
         return '<%s.%s "%s">' % (self.__class__.__module__,
                                  self.__class__.__name__,

--- a/edb/lang/schema/named.py
+++ b/edb/lang/schema/named.py
@@ -152,7 +152,7 @@ class NamedObjectCommand(sd.ObjectCommand):
             if subnode is not None:
                 node.commands.append(subnode)
 
-    def _add_to_schema(self, schema):
+    def _add_to_schema(self, schema, context):
         metaclass = self.get_schema_metaclass()
         if schema.get(self.classname, default=None, type=metaclass):
             raise ValueError(f'{self.classname!r} already exists in schema')
@@ -161,7 +161,7 @@ class NamedObjectCommand(sd.ObjectCommand):
 
     def _create_begin(self, schema, context):
         schema = super()._create_begin(schema, context)
-        return self._add_to_schema(schema)
+        return self._add_to_schema(schema, context)
 
 
 class CreateOrAlterNamedObject(NamedObjectCommand):

--- a/edb/lang/schema/parser/grammar/declarations.py
+++ b/edb/lang/schema/parser/grammar/declarations.py
@@ -421,14 +421,14 @@ class ConstraintCallableAndExtends(Nonterm):
             self, *kids):
         self.val = esast.ConstraintDeclaration(
             name=kids[0].val,
-            args=kids[1].val,
+            params=kids[1].val,
             subject=kids[2].val,
             extends=kids[3].val)
 
     def reduce_Identifier_OptFunctionParameters_OptOnExpr(self, *kids):
         self.val = esast.ConstraintDeclaration(
             name=kids[0].val,
-            args=kids[1].val,
+            params=kids[1].val,
             subject=kids[2].val)
 
 
@@ -573,7 +573,7 @@ class FunctionDeclCore(Nonterm):
 
         self.val = esast.FunctionDeclaration(
             name=kids[0].val,
-            args=kids[1].val,
+            params=kids[1].val,
             returning_typemod=returning_typemod,
             returning=returning,
             attributes=attributes,
@@ -655,7 +655,7 @@ class ParenRawString(Nonterm):
                 f'Could not parse EdgeQL parameters declaration {expr!r}',
                 context=context) from None
 
-        return eql.args
+        return eql.params
 
     def parse_as_expr(self):
         expr = self.val.value

--- a/edb/lang/schema/referencing.py
+++ b/edb/lang/schema/referencing.py
@@ -441,8 +441,6 @@ class ReferencingObject(inheriting.InheritingObject,
     def delta(cls, old, new, *, context=None, old_schema, new_schema):
         context = context or so.ComparisonContext()
 
-        cls = type(new if new is not None else old)
-
         with context(old, new):
             delta = super().delta(old, new, context=context,
                                   old_schema=old_schema, new_schema=new_schema)

--- a/edb/lang/schema/types.py
+++ b/edb/lang/schema/types.py
@@ -278,7 +278,8 @@ class Collection(Type):
         strefs = []
 
         for st in self.get_subtypes():
-            strefs.append(so.ObjectRef(classname=st.name))
+            st_ref, _ = st._reduce_to_ref(schema)
+            strefs.append(st_ref)
 
         return (
             self.__class__.from_subtypes(strefs),

--- a/edb/lib/schema.eql
+++ b/edb/lib/schema.eql
@@ -171,19 +171,32 @@ CREATE TYPE schema::Parameter {
 };
 
 
-CREATE ABSTRACT LINK schema::params {
+CREATE ABSTRACT LINK schema::args {
     CREATE PROPERTY schema::value -> std::str;
 };
 
 
-CREATE TYPE schema::Constraint EXTENDING schema::InheritingObject {
+CREATE ABSTRACT TYPE schema::CallableObject extending schema::Object {
+
+    CREATE MULTI LINK schema::params -> schema::Parameter {
+        CREATE CONSTRAINT std::exclusive;
+    };
+
+    CREATE LINK schema::return_type -> schema::Type;
+    CREATE PROPERTY schema::return_typemod -> std::str;
+};
+
+
+CREATE TYPE schema::Constraint EXTENDING
+        (schema::CallableObject, schema::InheritingObject)
+{
+    CREATE MULTI LINK schema::args -> schema::Parameter {
+        CREATE CONSTRAINT std::exclusive;
+    };
     CREATE PROPERTY schema::expr -> std::str;
     CREATE PROPERTY schema::subjectexpr -> std::str;
     CREATE PROPERTY schema::finalexpr -> std::str;
     CREATE PROPERTY schema::errmessage -> std::str;
-    CREATE MULTI LINK schema::params -> schema::Parameter {
-        CREATE CONSTRAINT std::exclusive;
-    };
 };
 
 
@@ -277,21 +290,10 @@ ALTER TYPE schema::ObjectType {
 };
 
 
-CREATE TYPE schema::Function EXTENDING schema::Object {
-    CREATE MULTI LINK schema::params -> schema::Parameter {
-        CREATE CONSTRAINT std::exclusive;
-    };
-    CREATE LINK schema::return_type -> schema::Type;
-    CREATE PROPERTY schema::return_typemod -> std::str;
-};
+CREATE TYPE schema::Function EXTENDING schema::CallableObject;
 
 
-CREATE TYPE schema::Operator EXTENDING schema::Object {
-    CREATE MULTI LINK schema::params -> schema::Parameter {
-        CREATE CONSTRAINT std::exclusive;
-    };
-    CREATE LINK schema::return_type -> schema::Type;
-    CREATE LINK schema::commutator -> schema::Operator;
-    CREATE PROPERTY schema::return_typemod -> std::str;
+CREATE TYPE schema::Operator EXTENDING schema::CallableObject {
     CREATE PROPERTY schema::operator_kind -> schema::operator_kind_t;
+    CREATE LINK schema::commutator -> schema::Operator;
 };

--- a/edb/server/pgsql/datasources/schema/constraints.py
+++ b/edb/server/pgsql/datasources/schema/constraints.py
@@ -42,19 +42,11 @@ async def fetch(
                 a.args                  AS args,
                 edgedb._resolve_type_name(a.subject)
                                         AS subject,
-
-                (SELECT array_agg(
-                    (p.pos,
-                     p.name,
-                     p.default,
-                     edgedb._resolve_type(p.type),
-                     p.typemod,
-                     p.kind))
-
-                    FROM
-                        unnest(a.params) AS p
-                )                       AS params
-
+                edgedb._resolve_type_name(a.params)
+                                        AS params,
+                edgedb._resolve_type(a.return_type)
+                                        AS return_type,
+                a.return_typemod        AS return_typemod
 
             FROM
                 edgedb.constraint a

--- a/edb/server/pgsql/datasources/schema/functions.py
+++ b/edb/server/pgsql/datasources/schema/functions.py
@@ -35,21 +35,29 @@ async def fetch(
                 f.from_function,
                 f.initial_value,
                 edgedb._resolve_type(f.return_type) AS return_type,
-
-                (SELECT array_agg(
-                    (p.pos,
-                     p.name,
-                     p.default,
-                     edgedb._resolve_type(p.type),
-                     p.typemod,
-                     p.kind))
-
-                    FROM
-                        unnest(f.params) AS p
-                )                       AS params
+                edgedb._resolve_type_name(f.params) AS params
 
             FROM
                 edgedb.function f
             ORDER BY
                 f.id
+    """)
+
+
+async def fetch_params(
+        conn: asyncpg.connection.Connection) -> typing.List[asyncpg.Record]:
+    return await conn.fetch("""
+        SELECT
+                p.id,
+                p.name,
+                p.num,
+                p.default,
+                edgedb._resolve_type(p.type) AS type,
+                p.typemod,
+                p.kind
+
+            FROM
+                edgedb.Parameter p
+            ORDER BY
+                p.id
     """)

--- a/edb/server/pgsql/datasources/schema/operators.py
+++ b/edb/server/pgsql/datasources/schema/operators.py
@@ -35,18 +35,7 @@ async def fetch(
                 o.operator_kind,
                 edgedb._resolve_type(o.return_type) AS return_type,
                 edgedb._resolve_type_name(o.commutator) AS commutator,
-
-                (SELECT array_agg(
-                    (p.pos,
-                     p.name,
-                     p.default,
-                     edgedb._resolve_type(p.type),
-                     p.typemod,
-                     p.kind))
-
-                    FROM
-                        unnest(o.params) AS p
-                ) AS params
+                edgedb._resolve_type_name(o.params) AS params
 
             FROM
                 edgedb.operator o

--- a/edb/server/pgsql/types.py
+++ b/edb/server/pgsql/types.py
@@ -210,8 +210,9 @@ class PointerStorageInfo:
                 'schema::element_type',
                 'schema::element_types',
                 'schema::key_type',
-                'schema::type'
-            }
+            } or
+            (pointer.shortname == 'schema::type' and
+                pointer.source.shortname != 'schema::Parameter')
         )
 
     @classmethod

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -700,7 +700,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             SELECT schema::Constraint {
                 name,
                 is_abstract,
-                params: {
+                args: {
                     num,
                     name,
                     kind,
@@ -709,12 +709,12 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     },
                     typemod,
                     @value
-                } ORDER BY schema::Constraint.params.num ASC
+                } ORDER BY schema::Constraint.args.num ASC
             } FILTER .name = 'test::mymax_ext1' ORDER BY .is_abstract;
         ''', [[
             {
                 "name": 'test::mymax_ext1',
-                "params": [
+                "args": [
                     {
                         "num": 0,
                         "kind": 'POSITIONAL',
@@ -728,7 +728,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             },
             {
                 "name": 'test::mymax_ext1',
-                "params": [
+                "args": [
                     {
                         "num": 0,
                         "kind": 'POSITIONAL',

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1059,7 +1059,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         name
                     },
                     typemod
-                },
+                } ORDER BY .name,
                 operator_kind,
                 return_typemod
             }

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -473,7 +473,7 @@ class TestIntrospection(tb.QueryTestCase):
                 subject: {
                     name
                 },
-                params: {
+                args: {
                     num,
                     @value
                 } ORDER BY .num
@@ -484,7 +484,7 @@ class TestIntrospection(tb.QueryTestCase):
                 'subject': {
                     'name': 'test::body'
                 },
-                'params': [{
+                'args': [{
                     'num': 0,
                     '@value': '10000'
                 }]
@@ -506,50 +506,22 @@ class TestIntrospection(tb.QueryTestCase):
     async def test_edgeql_introspection_meta_02(self):
         await self.assert_query_result(r"""
             WITH MODULE schema
-            SELECT Object {
+            SELECT InheritingObject {
                 name
             }
-            FILTER re_test(r'^test::\w+$', Object.name) AND
-                Object.name NOT LIKE '%:Virtual_%'
-            ORDER BY Object.name;
+            FILTER
+                re_test(r'^test::\w+$', InheritingObject.name)
+                AND InheritingObject.name NOT LIKE '%:Virtual_%'
+                AND InheritingObject.is_abstract
+            ORDER BY InheritingObject.name;
         """, [
             [
-                {'name': 'test::Comment'},
                 {'name': 'test::Dictionary'},
-                {'name': 'test::File'},
-                {'name': 'test::Issue'},
-                {'name': 'test::LogEntry'},
                 {'name': 'test::Named'},
                 {'name': 'test::Owned'},
-                {'name': 'test::Priority'},
-                {'name': 'test::Publication'},
-                {'name': 'test::Status'},
                 {'name': 'test::Text'},
-                {'name': 'test::URL'},
-                {'name': 'test::User'},
-                {'name': 'test::address'},
-                {'name': 'test::body'},
-                {'name': 'test::due_date'},
-                {'name': 'test::issue'},
-                {'name': 'test::issue_num_t'},
                 {'name': 'test::my_enum'},
-                {'name': 'test::name'},
-                {'name': 'test::number'},
-                {'name': 'test::owner'},
-                {'name': 'test::parent'},
-                {'name': 'test::priority'},
-                {'name': 'test::rank'},
-                {'name': 'test::references'},
-                {'name': 'test::related_to'},
-                {'name': 'test::spent_time'},
-                {'name': 'test::start_date'},
-                {'name': 'test::status'},
-                {'name': 'test::tags'},
-                {'name': 'test::time_estimate'},
-                {'name': 'test::time_spent_log'},
-                {'name': 'test::title'},
                 {'name': 'test::todo'},
-                {'name': 'test::watchers'},
             ]
         ])
 

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -799,11 +799,11 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         await self.assert_query_result("""
             WITH MODULE schema
             SELECT
-                Object {
+                ScalarType {
                     name
                 }
             FILTER
-                json_to_str(<json>(Object {name})) LIKE '%std::json%';
+                json_to_str(<json>(ScalarType {name})) LIKE '%std::json%';
         """, [
             [{
                 'name': 'std::json',


### PR DESCRIPTION
Parameter is now a proper schema item as opposed to a weird ad-hoc struct. 
This removes a bunch of specialization for the handling of parameters in
functions, constraints, and operators.