### PR TITLE
edgeql: Add constructor functions for multiple data types.

### DIFF
--- a/edb/lang/graphql/translator.py
+++ b/edb/lang/graphql/translator.py
@@ -118,7 +118,7 @@ class GraphQLTranslator(ast.NodeVisitor):
         for el in eql[0].result.elements:
             # swap in the json bits
             if (isinstance(el.compexpr, qlast.FunctionCall) and
-                    el.compexpr.func == 'str_to_json'):
+                    el.compexpr.func == 'to_json'):
                 name = el.expr.steps[0].ptr.name
                 el.compexpr.args[0].arg = qlast.StringConstant.from_python(
                     json.dumps(gqlresult.data[name], indent=4))

--- a/edb/lang/graphql/types.py
+++ b/edb/lang/graphql/types.py
@@ -572,7 +572,7 @@ class GQLBaseType(metaclass=GQLTypeMeta):
         '''
 
         if self.dummy:
-            return parse_fragment(f'''str_to_json("xxx")'''), None, None
+            return parse_fragment(f'''to_json("xxx")'''), None, None
 
         eql = parse_fragment(f'''
             SELECT {self.edb_base_name} {{

--- a/edb/lib/std/20-genericfuncs.eql
+++ b/edb/lib/std/20-genericfuncs.eql
@@ -44,7 +44,7 @@ CREATE FUNCTION
 std::len(array: array<anytype>) -> std::int64
 {
     FROM SQL $$
-    SELECT COALESCE(array_length("array", 1), 0)::bigint
+    SELECT cardinality("array")::bigint
     $$;
 };
 

--- a/edb/lib/std/30-datetimefuncs.eql
+++ b/edb/lib/std/30-datetimefuncs.eql
@@ -84,3 +84,21 @@ std::timedelta_get(dt: std::timedelta, el: std::str) -> std::float64
     SELECT date_part("el", dt)
     $$;
 };
+
+
+CREATE FUNCTION
+std::datetime_trunc(dt: std::datetime, unit: std::str) -> std::datetime
+{
+    FROM SQL $$
+    SELECT date_trunc(unit, dt)
+    $$;
+};
+
+
+CREATE FUNCTION
+std::timedelta_trunc(dt: std::timedelta, unit: std::str) -> std::timedelta
+{
+    FROM SQL $$
+    SELECT date_trunc(unit, dt)
+    $$;
+};

--- a/edb/lib/std/30-jsonfuncs.eql
+++ b/edb/lib/std/30-jsonfuncs.eql
@@ -54,21 +54,3 @@ std::json_get(
     )
     $$;
 };
-
-
-CREATE FUNCTION
-std::json_to_str(json: std::json) -> std::str
-{
-    FROM SQL $$
-    SELECT "json"::text
-    $$;
-};
-
-
-CREATE FUNCTION
-std::str_to_json(str: std::str) -> std::json
-{
-    FROM SQL $$
-    SELECT "str"::jsonb
-    $$;
-};

--- a/edb/lib/std/70-converters.eql
+++ b/edb/lib/std/70-converters.eql
@@ -1,0 +1,420 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2018-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+## Function that construct various scalars from strings or other types.
+
+
+# std::to_str
+# --------
+
+# Normalize [naive] datetime to text conversion to have
+# the same format as one would get by serializing to JSON.
+# Otherwise Postgres doesn't follow the ISO8601 standard
+# and uses ' ' instead of 'T' as a separator between date
+# and time.
+#
+# EdgeQL: <text><datetime>'2010-10-10';
+# To SQL: trim(to_json('2010-01-01'::timestamptz)::text, '"')
+CREATE FUNCTION
+std::to_str(dt: std::datetime, fmt: OPTIONAL str={}) -> std::str
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            trim(to_json(dt)::text, '"')
+        ELSE
+            to_char(dt, fmt)
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_str(dt: std::naive_datetime, fmt: OPTIONAL str={}) -> std::str
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            trim(to_json(dt)::text, '"')
+        ELSE
+            to_char(dt, fmt)
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_str(d: std::naive_date, fmt: OPTIONAL str={}) -> std::str
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            d::text
+        ELSE
+            to_char(d, fmt)
+        END
+    )
+    $$;
+};
+
+
+# Currently naive time is formatted by composing it with the naive
+# current local date. This at least guarantees that the time
+# formatting is accessible and consistent with full datetime
+# formatting, but it exposes current date as well if it is included in
+# the format.
+# FIXME: date formatting should not have any special effect.
+CREATE FUNCTION
+std::to_str(nt: std::naive_time, fmt: OPTIONAL str={}) -> std::str
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            nt::text
+        ELSE
+            to_char(date_trunc('day', localtimestamp) + nt, fmt)
+        END
+    )
+    $$;
+};
+
+
+# FIXME: There's no good safe default for all possible timedeltas and some
+# timedeltas cannot be formatted without non-trivial conversions (e.g.
+# 7,000 days).
+
+
+CREATE FUNCTION
+std::to_str(i: std::int64, fmt: OPTIONAL str={}) -> std::str
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            i::text
+        ELSE
+            to_char(i, fmt)
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_str(f: std::float64, fmt: OPTIONAL str={}) -> std::str
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            f::text
+        ELSE
+            to_char(f, fmt)
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_str(d: std::decimal, fmt: OPTIONAL str={}) -> std::str
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            d::text
+        ELSE
+            to_char(d, fmt)
+        END
+    )
+    $$;
+};
+
+
+
+
+# JSON can be prettified by specifying 'pretty' as the format, any
+# other value will result in an exception.
+CREATE FUNCTION
+std::to_str(json: std::json, fmt: OPTIONAL str={}) -> std::str
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            "json"::text
+        WHEN fmt = 'pretty' THEN
+            jsonb_pretty("json")
+        ELSE
+            edgedb._raise_specific_exception(
+                'invalid_parameter_value',
+                'format ''' || fmt || ''' is invalid for JSON',
+                NULL,
+                NULL::text
+            )
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_json(str: std::str) -> std::json
+{
+    FROM SQL $$
+    SELECT "str"::jsonb
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_datetime(s: std::str, fmt: OPTIONAL str={}) -> std::datetime
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            s::timestamptz
+        ELSE
+            to_timestamp(s, fmt)
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_datetime(year: std::int64, month: std::int64, day: std::int64,
+                 hour: std::int64, min: std::int64, sec: std::float64)
+    -> std::datetime
+{
+    FROM SQL $$
+    SELECT make_timestamptz(
+        year::int, month::int, day::int,
+        hour::int, min::int, sec
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_datetime(year: std::int64, month: std::int64, day: std::int64,
+                 hour: std::int64, min: std::int64, sec: std::float64,
+                 timezone: std::str)
+    -> std::datetime
+{
+    FROM SQL $$
+    SELECT make_timestamptz(
+        year::int, month::int, day::int,
+        hour::int, min::int, sec, timezone
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_naive_datetime(s: std::str, fmt: OPTIONAL str={})
+    -> std::naive_datetime
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            s::timestamp
+        ELSE
+            to_timestamp(s, fmt)::timestamp
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_naive_datetime(year: std::int64, month: std::int64, day: std::int64,
+                       hour: std::int64, min: std::int64, sec: std::float64)
+    -> std::naive_datetime
+{
+    FROM SQL $$
+    SELECT make_timestamp(
+        year::int, month::int, day::int,
+        hour::int, min::int, sec
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_naive_date(s: std::str, fmt: OPTIONAL str={}) -> std::naive_date
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            s::date
+        ELSE
+            to_date(s, fmt)
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_naive_date(year: std::int64, month: std::int64, day: std::int64)
+    -> std::naive_date
+{
+    FROM SQL $$
+    SELECT make_date(year::int, month::int, day::int)
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_naive_time(s: std::str, fmt: OPTIONAL str={}) -> std::naive_time
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            s::time
+        ELSE
+            to_timestamp(s, fmt)::time
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_naive_time(hour: std::int64, min: std::int64, sec: std::float64)
+    -> std::naive_time
+{
+    FROM SQL $$
+    SELECT make_time(hour::int, min::int, sec)
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_timedelta(
+        NAMED ONLY years: std::int64=0,
+        NAMED ONLY months: std::int64=0,
+        NAMED ONLY weeks: std::int64=0,
+        NAMED ONLY days: std::int64=0,
+        NAMED ONLY hours: std::int64=0,
+        NAMED ONLY mins: std::int64=0,
+        NAMED ONLY secs: std::float64=0
+    ) -> std::timedelta
+{
+    FROM SQL $$
+    SELECT make_interval(
+        years::int,
+        months::int,
+        weeks::int,
+        days::int,
+        hours::int,
+        mins::int,
+        secs
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_decimal(s: std::str, fmt: OPTIONAL str={}) -> std::decimal
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            s::numeric
+        ELSE
+            to_number(s, fmt)
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_int64(s: std::str, fmt: OPTIONAL str={}) -> std::int64
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            s::bigint
+        ELSE
+            to_number(s, fmt)::bigint
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_int32(s: std::str, fmt: OPTIONAL str={}) -> std::int32
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            s::int
+        ELSE
+            to_number(s, fmt)::int
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_int16(s: std::str, fmt: OPTIONAL str={}) -> std::int16
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            s::smallint
+        ELSE
+            to_number(s, fmt)::smallint
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_float64(s: std::str, fmt: OPTIONAL str={}) -> std::float64
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            s::float8
+        ELSE
+            to_number(s, fmt)::float8
+        END
+    )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_float32(s: std::str, fmt: OPTIONAL str={}) -> std::float32
+{
+    FROM SQL $$
+    SELECT (
+        CASE WHEN fmt IS NULL THEN
+            s::float4
+        ELSE
+            to_number(s, fmt)::float4
+        END
+    )
+    $$;
+};

--- a/edb/server/pgsql/compiler/typecomp.py
+++ b/edb/server/pgsql/compiler/typecomp.py
@@ -50,6 +50,7 @@ def cast(
     json_t = schema.get('std::json')
     str_t = schema.get('std::str')
     datetime_t = schema.get('std::datetime')
+    naive_datetime_t = schema.get('std::naive_datetime')
     bool_t = schema.get('std::bool')
     real_t = schema.get('std::anyreal')
     bytes_t = schema.get('std::bytes')
@@ -125,10 +126,14 @@ def cast(
 
     else:
         # `target_type` is not a collection.
-        if (source_type.issubclass(env.schema, datetime_t) and
+        if (source_type.issubclass(env.schema,
+                                   (datetime_t, naive_datetime_t)) and
                 target_type.issubclass(env.schema, str_t)):
-            # Normalize datetime to text conversion to have the same
-            # format as one would get by serializing to JSON.
+            # Normalize [naive] datetime to text conversion to have
+            # the same format as one would get by serializing to JSON.
+            # Otherwise Postgres doesn't follow the ISO8601 standard
+            # and uses ' ' instead of 'T' as a separator between date
+            # and time.
             #
             # EdgeQL: <text><datetime>'2010-10-10';
             # To SQL: trim(to_json('2010-01-01'::timestamptz)::text, '"')

--- a/tests/schemas/json_setup.eql
+++ b/tests/schemas/json_setup.eql
@@ -24,12 +24,12 @@ INSERT JSONTest {
     j_string := <json>'the',
     j_number := <json>2,
     j_boolean := <json>true,
-    j_array := str_to_json('[1, 1, 1]'),
-    j_object := str_to_json('{
+    j_array := to_json('[1, 1, 1]'),
+    j_object := to_json('{
         "a": 1,
         "b": 2
     }'),
-    data := str_to_json('null'),
+    data := to_json('null'),
     edb_string := 'jumps'
 };
 
@@ -38,12 +38,12 @@ INSERT JSONTest {
     j_string := <json>'quick',
     j_number := <json>2.7,
     j_boolean := <json>false,
-    j_array := str_to_json('[]'),
-    j_object := str_to_json('{
+    j_array := to_json('[]'),
+    j_object := to_json('{
         "b": 1,
         "c": 2
     }'),
-    data := str_to_json('{}'),
+    data := to_json('{}'),
     edb_string := 'over'
 };
 
@@ -52,12 +52,12 @@ INSERT JSONTest {
     j_string := <json>'brown',
     j_number := <json>2.71,
     j_boolean := <json>true,
-    j_array := str_to_json('[2, "q", [3], {}, null]'),
+    j_array := to_json('[2, "q", [3], {}, null]'),
 };
 
 INSERT JSONTest {
     number := 3,
-    data := str_to_json('[
+    data := to_json('[
         1.61,
         null,
         "Fraka",

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -826,7 +826,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
         try:
             await self.assert_query_result(r'''
                 SELECT test::call23('abcde', 2);
-                SELECT test::call23(str_to_json('[{"a":"b"}]'), 0);
+                SELECT test::call23(to_json('[{"a":"b"}]'), 0);
                 SELECT test::call23('abcde', <int32>2);
             ''', [
                 ['c'],

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -34,18 +34,18 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_cast_01(self):
         await self.assert_query_result("""
-            SELECT str_to_json('"qwerty"');
-            SELECT str_to_json('1');
-            SELECT str_to_json('2.3e-2');
+            SELECT to_json('"qwerty"');
+            SELECT to_json('1');
+            SELECT to_json('2.3e-2');
 
-            SELECT str_to_json('true');
-            SELECT str_to_json('false');
-            SELECT str_to_json('null');
+            SELECT to_json('true');
+            SELECT to_json('false');
+            SELECT to_json('null');
 
-            SELECT str_to_json('[2, "a", 3.456]');
-            SELECT str_to_json('[2, "a", 3.456, [["b", 1]]]');
+            SELECT to_json('[2, "a", 3.456]');
+            SELECT to_json('[2, "a", 3.456, [["b", 1]]]');
 
-            SELECT str_to_json('{
+            SELECT to_json('{
                 "a": 1,
                 "b": 2.87,
                 "c": [2, "a", 3.456],
@@ -87,14 +87,14 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_cast_02(self):
         await self.assert_query_result("""
-            SELECT <str>str_to_json('"qwerty"');
-            SELECT <int64>str_to_json('1');
-            SELECT <float64>str_to_json('2.3e-2');
+            SELECT <str>to_json('"qwerty"');
+            SELECT <int64>to_json('1');
+            SELECT <float64>to_json('2.3e-2');
 
-            SELECT <bool>str_to_json('true');
-            SELECT <bool>str_to_json('false');
+            SELECT <bool>to_json('true');
+            SELECT <bool>to_json('false');
 
-            SELECT <array<int64>>str_to_json('[2, 3, 5]');
+            SELECT <array<int64>>to_json('[2, 3, 5]');
         """, [
             ['qwerty'],
             [1],
@@ -108,10 +108,10 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_cast_03(self):
         await self.assert_query_result("""
-            SELECT <str>str_to_json('null');
-            SELECT <int64>str_to_json('null');
-            SELECT <float64>str_to_json('null');
-            SELECT <bool>str_to_json('null');
+            SELECT <str>to_json('null');
+            SELECT <int64>to_json('null');
+            SELECT <float64>to_json('null');
+            SELECT <bool>to_json('null');
         """, [
             [],
             [],
@@ -121,10 +121,10 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_cast_04(self):
         await self.assert_query_result("""
-            SELECT <str>str_to_json('null') ?= <str>{};
-            SELECT <int64>str_to_json('null') ?= <int64>{};
-            SELECT <float64>str_to_json('null') ?= <float64>{};
-            SELECT <bool>str_to_json('null') ?= <bool>{};
+            SELECT <str>to_json('null') ?= <str>{};
+            SELECT <int64>to_json('null') ?= <int64>{};
+            SELECT <float64>to_json('null') ?= <float64>{};
+            SELECT <bool>to_json('null') ?= <bool>{};
         """, [
             [True],
             [True],
@@ -135,9 +135,9 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_cast_05(self):
         await self.assert_query_result("""
             SELECT <json>{} ?= (
-                SELECT x := str_to_json('1') FILTER x = str_to_json('2')
+                SELECT x := to_json('1') FILTER x = to_json('2')
             );
-            SELECT <json>{} ?= str_to_json('null');
+            SELECT <json>{} ?= to_json('null');
         """, [
             [True],
             [False],
@@ -155,12 +155,12 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_01(self):
         await self.assert_query_result("""
-            SELECT (str_to_json('[1, "a", 3]'))[0] = str_to_json('1');
-            SELECT (str_to_json('[1, "a", 3]'))[1] = str_to_json('"a"');
-            SELECT (str_to_json('[1, "a", 3]'))[2] = str_to_json('3');
+            SELECT (to_json('[1, "a", 3]'))[0] = to_json('1');
+            SELECT (to_json('[1, "a", 3]'))[1] = to_json('"a"');
+            SELECT (to_json('[1, "a", 3]'))[2] = to_json('3');
 
-            SELECT (str_to_json('[1, "a", 3]'))[<int16>0] = str_to_json('1');
-            SELECT (str_to_json('[1, "a", 3]'))[<int32>0] = str_to_json('1');
+            SELECT (to_json('[1, "a", 3]'))[<int16>0] = to_json('1');
+            SELECT (to_json('[1, "a", 3]'))[<int32>0] = to_json('1');
         """, [
             [True],
             [True],
@@ -172,11 +172,11 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_02(self):
         await self.assert_query_result("""
-            SELECT (str_to_json('{"a": 1, "b": null}'))["a"] =
-                str_to_json('1');
+            SELECT (to_json('{"a": 1, "b": null}'))["a"] =
+                to_json('1');
 
-            SELECT (str_to_json('{"a": 1, "b": null}'))["b"] =
-                str_to_json('null');
+            SELECT (to_json('{"a": 1, "b": null}'))["b"] =
+                to_json('null');
         """, [
             [True],
             [True],
@@ -184,7 +184,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_03(self):
         await self.assert_query_result("""
-            SELECT (<str>(str_to_json('["qwerty"]'))[0])[1];
+            SELECT (<str>(to_json('["qwerty"]'))[0])[1];
         """, [
             ['w'],
         ])
@@ -195,7 +195,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 exc.UnknownEdgeDBError,
                 r'json index 10 is out of bounds'):
             await self.con.execute(r"""
-                SELECT (str_to_json('[1, "a", 3]'))[10];
+                SELECT (to_json('[1, "a", 3]'))[10];
             """)
 
     async def test_edgeql_json_accessor_05(self):
@@ -204,7 +204,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 exc.UnknownEdgeDBError,
                 r'json index -10 is out of bounds'):
             await self.con.execute(r"""
-                SELECT (str_to_json('[1, "a", 3]'))[-10];
+                SELECT (to_json('[1, "a", 3]'))[-10];
             """)
 
     async def test_edgeql_json_accessor_06(self):
@@ -214,7 +214,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 exc.UnknownEdgeDBError,
                 r'cannot index json array by text'):
             await self.con.execute(r"""
-                SELECT (str_to_json('[1, "a", 3]'))['1'];
+                SELECT (to_json('[1, "a", 3]'))['1'];
             """)
 
     async def test_edgeql_json_accessor_07(self):
@@ -223,7 +223,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 exc.UnknownEdgeDBError,
                 r"json index 'c' is out of bounds"):
             await self.con.execute(r"""
-                SELECT (str_to_json('{"a": 1, "b": null}'))["c"];
+                SELECT (to_json('{"a": 1, "b": null}'))["c"];
             """)
 
     async def test_edgeql_json_accessor_08(self):
@@ -233,7 +233,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 exc.UnknownEdgeDBError,
                 r'cannot index json object by integer'):
             await self.con.execute(r"""
-                SELECT (str_to_json('{"a": 1, "b": null}'))[0];
+                SELECT (to_json('{"a": 1, "b": null}'))[0];
             """)
 
     async def test_edgeql_json_accessor_09(self):
@@ -243,7 +243,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 exc.UnknownEdgeDBError,
                 r'cannot index json null'):
             await self.con.execute(r"""
-                SELECT (str_to_json('null'))[0];
+                SELECT (to_json('null'))[0];
             """)
 
     async def test_edgeql_json_accessor_10(self):
@@ -253,7 +253,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 exc.UnknownEdgeDBError,
                 r'cannot index json boolean'):
             await self.con.execute(r"""
-                SELECT (str_to_json('true'))[0];
+                SELECT (to_json('true'))[0];
             """)
 
     async def test_edgeql_json_accessor_11(self):
@@ -263,7 +263,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 exc.UnknownEdgeDBError,
                 r'cannot index json number'):
             await self.con.execute(r"""
-                SELECT (str_to_json('123'))[0];
+                SELECT (to_json('123'))[0];
             """)
 
     async def test_edgeql_json_accessor_12(self):
@@ -272,7 +272,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 exc.UnknownEdgeDBError,
                 r'cannot index json string'):
             await self.con.execute(r"""
-                SELECT (str_to_json('"qwerty"'))[0];
+                SELECT (to_json('"qwerty"'))[0];
             """)
 
     async def test_edgeql_json_accessor_13(self):
@@ -412,7 +412,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             WITH MODULE test
             SELECT (
                 SELECT JSONTest FILTER .number = 0
-            ).data ?= str_to_json('null');
+            ).data ?= to_json('null');
 
             WITH MODULE test
             SELECT (
@@ -422,7 +422,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             WITH MODULE test
             SELECT (
                 SELECT JSONTest FILTER .number = 2
-            ).data ?= str_to_json('null');
+            ).data ?= to_json('null');
         ''', [
             {False},
             {True},
@@ -432,15 +432,15 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_typeof_01(self):
         await self.assert_query_result(r"""
-            SELECT json_typeof(str_to_json('2'));
-            SELECT json_typeof(str_to_json('"foo"'));
-            SELECT json_typeof(str_to_json('true'));
-            SELECT json_typeof(str_to_json('false'));
-            SELECT json_typeof(str_to_json('null'));
-            SELECT json_typeof(str_to_json('[]'));
-            SELECT json_typeof(str_to_json('[2]'));
-            SELECT json_typeof(str_to_json('{}'));
-            SELECT json_typeof(str_to_json('{"a": 2}'));
+            SELECT json_typeof(to_json('2'));
+            SELECT json_typeof(to_json('"foo"'));
+            SELECT json_typeof(to_json('true'));
+            SELECT json_typeof(to_json('false'));
+            SELECT json_typeof(to_json('null'));
+            SELECT json_typeof(to_json('[]'));
+            SELECT json_typeof(to_json('[2]'));
+            SELECT json_typeof(to_json('{}'));
+            SELECT json_typeof(to_json('{"a": 2}'));
             SELECT json_typeof(<json>{});
         """, [
             ['number'],
@@ -476,7 +476,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_array_unpack_01(self):
         await self.assert_query_result("""
-            SELECT json_array_unpack(str_to_json('[1, "a", null]'));
+            SELECT json_array_unpack(to_json('[1, "a", null]'));
         """, [
             [1, 'a', None],  # None is legitimate JSON null
         ])
@@ -488,7 +488,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 exc.UnknownEdgeDBError,
                 r'operator does not exist: jsonb = bigint'):
             await self.con.execute(r'''
-                SELECT json_array_unpack(str_to_json('[2,3,4]')) IN
+                SELECT json_array_unpack(to_json('[2,3,4]')) IN
                     {2, 3, 4};
             ''')
 
@@ -499,15 +499,15 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 exc.UnknownEdgeDBError,
                 r'operator does not exist: jsonb = text'):
             await self.con.execute(r'''
-                SELECT json_array_unpack(str_to_json('[2,3,4]')) IN
+                SELECT json_array_unpack(to_json('[2,3,4]')) IN
                     {'2', '3', '4'};
             ''')
 
     async def test_edgeql_json_array_unpack_04(self):
         await self.assert_query_result(r'''
-            SELECT json_array_unpack(str_to_json('[2,3,4]')) IN
+            SELECT json_array_unpack(to_json('[2,3,4]')) IN
                 <json>{2, 3, 4};
-            SELECT json_array_unpack(str_to_json('[2,3,4]')) NOT IN
+            SELECT json_array_unpack(to_json('[2,3,4]')) NOT IN
                 <json>{2, 3, 4};
         ''', [
             [True, True, True],
@@ -533,7 +533,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 MODULE test,
                 JT0 := (SELECT JSONTest FILTER .number = 0)
             # unpacking [1, 1, 1]
-            SELECT json_array_unpack(JT0.j_array) = str_to_json('1');
+            SELECT json_array_unpack(JT0.j_array) = to_json('1');
         ''', [
             [True, True, True],
         ])
@@ -565,7 +565,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_object_unpack_01(self):
         await self.assert_sorted_query_result(r'''
-            SELECT json_object_unpack(str_to_json('{
+            SELECT json_object_unpack(to_json('{
                 "q": 1,
                 "w": [2, null, 3],
                 "e": null
@@ -586,7 +586,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
             WITH MODULE test
             SELECT json_object_unpack(JSONTest.j_object) =
-                ('c', str_to_json('1'));
+                ('c', to_json('1'));
 
             WITH MODULE test
             SELECT json_object_unpack(JSONTest.j_object).0 IN {'a', 'b', 'c'};
@@ -745,7 +745,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
             SELECT json_get(
                 JSONTest.data, '4', 'b', 'bar', '2', 'bogus',
-                default := str_to_json('null')
+                default := to_json('null')
             ) ?? <json>'oups';
 
             SELECT json_get(
@@ -777,7 +777,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         res = await self.query("""
             WITH MODULE schema
             SELECT
-                json_to_str(<json>(
+                to_str(<json>(
                     SELECT Object {
                         name,
                         foo := 'bar',
@@ -803,7 +803,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                     name
                 }
             FILTER
-                json_to_str(<json>(ScalarType {name})) LIKE '%std::json%';
+                to_str(<json>(ScalarType {name})) LIKE '%std::json%';
         """, [
             [{
                 'name': 'std::json',
@@ -817,7 +817,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             SELECT
                 True
             FILTER
-                json_to_str(
+                to_str(
                     (
                         <tuple<json>>(
                             (
@@ -842,7 +842,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             SELECT
                 True
             FILTER
-                json_to_str(<json>[(
+                to_str(<json>[(
                     SELECT Object {
                         name,
                         foo := 'bar',
@@ -928,7 +928,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         res = await self.query("""
             WITH MODULE schema
             SELECT
-                json_to_str(<json>(
+                to_str(<json>(
                     1,
                     (SELECT Object {
                             name,
@@ -949,7 +949,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_cast_tuple_to_json_02(self):
         res = await self.query("""
             SELECT
-                json_to_str(<json>(
+                to_str(<json>(
                     foo := 1,
                     bar := [1, 2, 3]
                 ));
@@ -965,12 +965,12 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_slice_01(self):
         await self.assert_query_result(r'''
-            SELECT str_to_json('[1, "a", 3, null]')[:1];
-            SELECT str_to_json('[1, "a", 3, null]')[:-1];
-            SELECT str_to_json('[1, "a", 3, null]')[1:-1];
-            SELECT str_to_json('[1, "a", 3, null]')[-1:1];
-            SELECT str_to_json('[1, "a", 3, null]')[-100:100];
-            SELECT str_to_json('[1, "a", 3, null]')[100:-100];
+            SELECT to_json('[1, "a", 3, null]')[:1];
+            SELECT to_json('[1, "a", 3, null]')[:-1];
+            SELECT to_json('[1, "a", 3, null]')[1:-1];
+            SELECT to_json('[1, "a", 3, null]')[-1:1];
+            SELECT to_json('[1, "a", 3, null]')[-100:100];
+            SELECT to_json('[1, "a", 3, null]')[100:-100];
         ''', [
             [[1]],
             [[1, 'a', 3]],
@@ -1016,7 +1016,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 exc.EdgeQLError, r'cannot slice json array by.*str'):
 
             await self.con.execute(r"""
-                SELECT str_to_json('[1, "a", 3, null]')[:'1'];
+                SELECT to_json('[1, "a", 3, null]')[:'1'];
             """)
 
     async def test_edgeql_json_bytes_cast_01(self):
@@ -1165,3 +1165,53 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 ],
             }],
         ])
+
+    async def test_edgeql_json_str_function_01(self):
+        await self.assert_query_result(r'''
+            SELECT to_str(<json>[1, 2, 3, 4]);
+            SELECT to_str(<json>[1, 2, 3, 4], 'pretty');
+        ''', [
+            {'[1, 2, 3, 4]'},
+            {'[\n    1,\n    2,\n    3,\n    4\n]'},
+        ])
+
+    async def test_edgeql_json_str_function_02(self):
+        with self.assertRaisesRegex(
+                exc.UnknownEdgeDBError,
+                r"format 'foo' is invalid for JSON"):
+            async with self.con.transaction():
+                await self.con.execute(r'''
+                    SELECT to_str(<json>[1, 2, 3, 4], 'foo');
+                ''')
+
+        with self.assertRaisesRegex(
+                exc.UnknownEdgeDBError,
+                r"format '' is invalid for JSON"):
+            async with self.con.transaction():
+                await self.con.execute(r'''
+                    SELECT to_str(<json>[1, 2, 3, 4], '');
+                ''')
+
+        with self.assertRaisesRegex(
+                exc.UnknownEdgeDBError,
+                r"format 'PRETTY' is invalid for JSON"):
+            async with self.con.transaction():
+                await self.con.execute(r'''
+                    SELECT to_str(<json>[1, 2, 3, 4], 'PRETTY');
+                ''')
+
+        with self.assertRaisesRegex(
+                exc.UnknownEdgeDBError,
+                r"format 'Pretty' is invalid for JSON"):
+            async with self.con.transaction():
+                await self.con.execute(r'''
+                    SELECT to_str(<json>[1, 2, 3, 4], 'Pretty');
+                ''')
+
+        with self.assertRaisesRegex(
+                exc.UnknownEdgeDBError,
+                r"format 'p' is invalid for JSON"):
+            async with self.con.transaction():
+                await self.con.execute(r'''
+                    SELECT to_str(<json>[1, 2, 3, 4], 'p');
+                ''')

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -4351,7 +4351,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                     number,
                     time_estimate
                 } FILTER Issue.number = '1'
-            ) = str_to_json('{"number": "1", "time_estimate": 3000}');
+            ) = to_json('{"number": "1", "time_estimate": 3000}');
 
             WITH MODULE test
             SELECT (
@@ -4359,7 +4359,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                     number,
                     time_estimate
                 } FILTER Issue.number = '2'
-            ) = str_to_json('{"number": "2", "time_estimate": null}');
+            ) = to_json('{"number": "2", "time_estimate": null}');
         ''', [
             [True],
             [True],

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -273,7 +273,7 @@ aa';
 
     def test_edgeql_syntax_constants_22(self):
         r"""
-        SELECT str_to_json('{"defaultValue": "\\"SMALLEST\\""}');
+        SELECT to_json('{"defaultValue": "\\"SMALLEST\\""}');
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,

--- a/tests/test_graphql_translator.py
+++ b/tests/test_graphql_translator.py
@@ -2558,7 +2558,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __schema := str_to_json('{
+            __schema := to_json('{
                 "__typename": "__Schema"
             }')
         };
@@ -2578,7 +2578,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __schema := str_to_json('{
+            __schema := to_json('{
                 "__typename": "__Schema"
             }')
         };
@@ -2621,7 +2621,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __schema := str_to_json('{
+            __schema := to_json('{
                 "directives": [
                     {
                         "name": "include",
@@ -2723,7 +2723,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __schema := str_to_json('{
+            __schema := to_json('{
                 "mutationType": null
             }')
         };
@@ -2759,7 +2759,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __schema := str_to_json('{
+            __schema := to_json('{
                 "queryType": {
                     "kind": "OBJECT",
                     "name": "Query",
@@ -2788,7 +2788,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __schema := str_to_json('{
+            __schema := to_json('{
                 "types": [
                     {"kind": "OBJECT", "name": "Query"},
                     {"kind": "INPUT_OBJECT", "name": "FilterFoo"},
@@ -2861,7 +2861,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            Foo := str_to_json('{
+            Foo := to_json('{
                 "types": [
                     {"kind": "OBJECT", "name": "Query"},
                     {"kind": "INPUT_OBJECT", "name": "FilterFoo"},
@@ -2939,7 +2939,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __schema := str_to_json('{
+            __schema := to_json('{
                 "directives": [
                     {
                         "name": "include",
@@ -2997,7 +2997,7 @@ class TestGraphQLTranslation(TranslatorTest):
                     }
                 }
             ),
-            __schema := str_to_json('{
+            __schema := to_json('{
                 "types": [
                     {"kind": "OBJECT", "name": "Query"},
                     {"kind": "INPUT_OBJECT", "name": "FilterFoo"},
@@ -3069,7 +3069,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __type := str_to_json('{
+            __type := to_json('{
                 "__typename": "__Type",
                 "name": "User",
                 "kind": "INTERFACE"
@@ -3107,7 +3107,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __type := str_to_json('{
+            __type := to_json('{
                 "__typename": "__Type",
                 "kind": "OBJECT"
                 "name": "UserType",
@@ -3161,7 +3161,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __type := str_to_json('{
+            __type := to_json('{
                 "__typename": "__Type",
                 "kind": "INTERFACE"
                 "name": "User",
@@ -3230,7 +3230,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __type := str_to_json('{
+            __type := to_json('{
                 "__typename": "__Type",
                 "name": "UserGroup",
                 "kind": "INTERFACE",
@@ -3341,7 +3341,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __type := str_to_json('{
+            __type := to_json('{
                 "__typename": "__Type",
                 "name": "UserGroupType",
                 "kind": "OBJECT",
@@ -3458,7 +3458,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __type := str_to_json('{
+            __type := to_json('{
                 "__typename": "__Type",
                 "name": "ProfileType",
                 "kind": "OBJECT",
@@ -3654,7 +3654,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __type := str_to_json('{
+            __type := to_json('{
                 "__typename": "__Type",
                 "kind": "INTERFACE",
                 "name": "NamedObject",
@@ -4318,7 +4318,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __type := str_to_json('{
+            __type := to_json('{
                 "__typename": "__Type",
                 "name": "UserGroupType",
                 "kind": "OBJECT",
@@ -4484,7 +4484,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __type := str_to_json('{
+            __type := to_json('{
                 "__typename": "__Type",
                 "name": "FilterUser",
                 "kind": "INPUT_OBJECT",
@@ -4606,7 +4606,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __type := str_to_json('{
+            __type := to_json('{
                 "__typename": "__Type",
                 "name": "OrderUser",
                 "kind": "INPUT_OBJECT",
@@ -4689,7 +4689,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            __type := str_to_json('{
+            __type := to_json('{
                 "__typename": "__Type",
                 "name": "Ordering",
                 "kind": "INPUT_OBJECT",
@@ -4745,7 +4745,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            directionEnum := str_to_json('{
+            directionEnum := to_json('{
                 "__typename": "__Type",
                 "name": "directionEnum",
                 "kind": "ENUM",
@@ -4754,7 +4754,7 @@ class TestGraphQLTranslation(TranslatorTest):
                     {"name": "DESC"}
                 ]
             }'),
-            nullsOrderingEnum := str_to_json('{
+            nullsOrderingEnum := to_json('{
                 "__typename": "__Type",
                 "name": "nullsOrderingEnum",
                 "kind": "ENUM",


### PR DESCRIPTION
The `str` function is meant to be like a parametrized cast. When called
without the format parameter it is equivalent to casting via `<str>`.

`str` usage with `json` scalars is not equivalent to casting, it is
producing a string representation of JSON. The inverse function `json`
is therefore parsing a string, not casting either:
- `str_to_json` becomes `json`
- `json_to_str` becomes `str`

Add various date and time constructor functions.

Add `bool` function that converts values of other types to a boolean based
on how "truthy" the values are. E.g. `0`, `''` and `[]` are converted to
`False` and `23`, `'q'`, and `[1, 2]` are converted to `True`.