### PR TITLE
Fix schema.Pointer to use SchemaFields; fix props parser in eschema

### DIFF
--- a/edb/lang/edgeql/compiler/stmt.py
+++ b/edb/lang/edgeql/compiler/stmt.py
@@ -529,7 +529,7 @@ def compile_result_clause(
             # or UPDATE, there's no need to explicitly specify the
             # empty set type and it can be assumed to match the pointer
             # target type.
-            target_t = view_rptr.ptrcls.target
+            target_t = view_rptr.ptrcls.get_target(ctx.schema)
 
             if astutils.is_ql_empty_set(result_expr):
                 expr = irutils.new_empty_set(
@@ -584,7 +584,7 @@ def compile_query_subject(
         matching_type = (
             expr.rptr is not None and
             view_rptr.ptrcls_is_linkprop ==
-            expr.rptr.ptrcls.is_link_property())
+            expr.rptr.ptrcls.is_link_property(ctx.schema))
         if matching_type:
             # We are inside an expression that defines a link alias in
             # the parent shape, ie. Spam { alias := Foo.bar }, so

--- a/edb/lang/edgeql/utils.py
+++ b/edb/lang/edgeql/utils.py
@@ -93,7 +93,8 @@ def normalize_tree(expr, schema, *, modaliases=None, anchors=None,
         expr, schema,
         modaliases=modaliases, anchors=anchors)
 
-    edgeql_tree = compiler.decompile_ir(ir, inline_anchors=inline_anchors)
+    edgeql_tree = compiler.decompile_ir(
+        ir, inline_anchors=inline_anchors, schema=schema)
 
     source = codegen.generate_source(edgeql_tree, pretty=False)
 

--- a/edb/lang/ir/utils.py
+++ b/edb/lang/ir/utils.py
@@ -25,6 +25,7 @@ from edb.lang.common import ast
 from edb.lang.schema import objtypes as s_objtypes
 from edb.lang.schema import links as s_links
 from edb.lang.schema import name as s_name
+from edb.lang.schema import objects as so
 from edb.lang.schema import pointers as s_pointers
 from edb.lang.schema import pseudo as s_pseudo
 from edb.lang.schema import schema as s_schema
@@ -230,26 +231,19 @@ def tuple_indirection_path_id(tuple_path_id, element_name, element_type, *,
 class TypeIndirectionLink(s_links.Link):
     """A Link subclass that can be used in type indirection path ids."""
 
+    optional = so.SchemaField(
+        bool, compcoef=0.909, ephemeral=True, introspectable=False)
+
     def __init__(self, source, target, *, optional, cardinality):
         name = 'optindirection' if optional else 'indirection'
         super().__init__(
             name=s_name.Name(module='__type__', name=name),
             source=source,
             target=target,
-            direction=s_pointers.PointerDirection.Outbound
+            direction=s_pointers.PointerDirection.Outbound,
+            cardinality=cardinality,
+            optional=optional,
         )
-        self.optional = optional
-        self.cardinality = cardinality
-
-    def __hash__(self):
-        return hash((self.__class__, self.name, self.source, self.target))
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return False
-
-        return (self.name == other.name and self.source == other.source and
-                self.target == other.target)
 
     def generic(self, schema):
         # Make PathId happy.

--- a/edb/lang/schema/database.py
+++ b/edb/lang/schema/database.py
@@ -85,17 +85,19 @@ class AlterDatabase(DatabaseCommand):
                     schema, _ = op.apply(schema, context)
 
             for link in schema.get_objects(type='link'):
-                if link.target and not isinstance(link.target,
-                                                  so.Object):
-                    link.target = schema.get(link.target)
+                link_target = link.get_target(schema)
+                if link_target and not isinstance(link_target, so.Object):
+                    schema = link.set_field_value(
+                        schema, 'target', schema.get(link_target))
 
                 schema = link.acquire_ancestor_inheritance(schema)
                 schema = link.finalize(schema)
 
             for link in schema.get_objects(type='computable'):
-                if link.target and not isinstance(link.target,
-                                                  so.Object):
-                    link.target = schema.get(link.target)
+                link_target = link.get_target(schema)
+                if link_target and not isinstance(link_target, so.Object):
+                    schema = link.set_field_value(
+                        schema, 'target', link_target)
 
             for objtype in schema.get_objects(type='ObjectType'):
                 schema = objtype.acquire_ancestor_inheritance(schema)

--- a/edb/lang/schema/links.py
+++ b/edb/lang/schema/links.py
@@ -54,11 +54,15 @@ def merge_actions(target: so.Object, sources: typing.List[so.Object],
                     current = theirs
                     current_from = source
                 elif current != theirs:
-                    tgt_repr = (f'{target.source.displayname}.'
+                    target_source = target.get_source(schema)
+                    current_from_source = current_from.get_source(schema)
+                    source_source = source.get_source(schema)
+
+                    tgt_repr = (f'{target_source.displayname}.'
                                 f'{target.displayname}')
-                    cf_repr = (f'{current_from.source.displayname}.'
+                    cf_repr = (f'{current_from_source.displayname}.'
                                f'{current_from.displayname}')
-                    other_repr = (f'{source.source.displayname}.'
+                    other_repr = (f'{source_source.displayname}.'
                                   f'{source.displayname}')
 
                     raise s_err.SchemaError(
@@ -94,8 +98,12 @@ class Link(sources.Source, pointers.Pointer):
         if not pointers.has(schema, src_n):
             source_pbase = schema.get(src_n)
             schema, source_p = source_pbase.derive(
-                schema, self, self.source, mark_derived=mark_derived,
-                add_to_schema=add_to_schema, dctx=dctx)
+                schema,
+                self,
+                self.get_source(schema),
+                mark_derived=mark_derived,
+                add_to_schema=add_to_schema,
+                dctx=dctx)
 
             schema = self.add_pointer(schema, source_p)
 
@@ -103,8 +111,12 @@ class Link(sources.Source, pointers.Pointer):
         if not pointers.has(schema, tgt_n):
             target_pbase = schema.get(tgt_n)
             schema, target_p = target_pbase.derive(
-                schema, self, self.target, mark_derived=mark_derived,
-                add_to_schema=add_to_schema, dctx=dctx)
+                schema,
+                self,
+                self.get_target(schema),
+                mark_derived=mark_derived,
+                add_to_schema=add_to_schema,
+                dctx=dctx)
 
             schema = self.add_pointer(schema, target_p)
 
@@ -124,7 +136,7 @@ class Link(sources.Source, pointers.Pointer):
 
         return schema, ptr
 
-    def is_link_property(self):
+    def is_link_property(self, schema):
         return False
 
     def scalar(self):

--- a/edb/lang/schema/objects.py
+++ b/edb/lang/schema/objects.py
@@ -140,13 +140,13 @@ class Field(struct.ProtoField):  # derived from ProtoField for validation
     __slots__ = ('name', 'type', 'default', 'coerce', 'formatters',
                  'frozen',
                  'compcoef', 'inheritable', 'hashable', 'simpledelta',
-                 'merge_fn', 'ephemeral', 'introspectable')
+                 'merge_fn', 'ephemeral', 'introspectable', 'public')
 
     def __init__(self, type, default=NoDefault, *, coerce=False,
                  str_formatter=str, repr_formatter=repr, frozen=False,
                  compcoef=None, inheritable=True, hashable=True,
                  simpledelta=True, merge_fn=None, ephemeral=False,
-                 introspectable=True, **kwargs):
+                 introspectable=True, public=False, **kwargs):
         """Schema item core attribute definition.
 
         """
@@ -157,6 +157,7 @@ class Field(struct.ProtoField):  # derived from ProtoField for validation
         self.default = default
         self.coerce = coerce
         self.frozen = frozen
+        self.public = public
 
         if coerce and len(type) > 1:
             raise ValueError(
@@ -1000,8 +1001,8 @@ class Object(metaclass=ObjectMeta):
 
 class NamedObject(Object):
     name = Field(sn.Name, inheritable=False, compcoef=0.670)
-    title = Field(str, default=None, compcoef=0.909, coerce=True)
-    description = Field(str, default=None, compcoef=0.909)
+    title = Field(str, default=None, compcoef=0.909, coerce=True, public=True)
+    description = Field(str, default=None, compcoef=0.909, public=True)
 
     @classmethod
     def mangle_name(cls, name) -> str:

--- a/edb/lang/schema/objtypes.py
+++ b/edb/lang/schema/objtypes.py
@@ -49,8 +49,8 @@ class ObjectType(SourceNode, constraints.ConsistencySubject):
 
             for link in schema.get_objects(type='link'):
                 if (link.shortname.name == name and
-                        link.target is not None and
-                        source.issubclass(schema, link.target)):
+                        link.get_target(schema) is not None and
+                        source.issubclass(schema, link.get_target(schema))):
                     ptrs.add(link)
 
             return ptrs
@@ -61,8 +61,8 @@ class ObjectType(SourceNode, constraints.ConsistencySubject):
 
             for link in schema.get_objects(type='link'):
                 if (link.shortname == name and
-                        link.target is not None and
-                        source.issubclass(schema, link.target)):
+                        link.get_target(schema) is not None and
+                        source.issubclass(schema, link.get_target(schema))):
                     ptrs.add(link)
 
             return ptrs
@@ -80,9 +80,9 @@ class ObjectType(SourceNode, constraints.ConsistencySubject):
             result = set()
             for link in schema.get_objects(type='link'):
                 if link.issubclass(schema, base_ptr_class) \
-                        and link.target is not None \
+                        and link.get_target(schema) is not None \
                         and (not skip_scalar or not link.scalar()) \
-                        and source.issubclass(schema, link.target):
+                        and source.issubclass(schema, link.get_target(schema)):
                     result.add(link)
             return result
 

--- a/edb/lang/schema/scalars.py
+++ b/edb/lang/schema/scalars.py
@@ -40,8 +40,9 @@ class ScalarType(nodes.Node, constraints.ConsistencySubject,
                  attributes.AttributeSubject):
     _type = 'ScalarType'
 
-    default = so.Field(expr.ExpressionText, default=None,
-                       coerce=True, compcoef=0.909)
+    default = so.SchemaField(
+        expr.ExpressionText, default=None,
+        coerce=True, compcoef=0.909)
 
     def _get_deps(self, schema):
         deps = super()._get_deps(schema)

--- a/edb/server/pgsql/backend.py
+++ b/edb/server/pgsql/backend.py
@@ -278,7 +278,7 @@ class Backend:
 
             for ptr in view_shapes[t]:
                 subdesc = self._describe_type(
-                    schema, ptr.target, view_shapes, _tuples)
+                    schema, ptr.get_target(schema), view_shapes, _tuples)
                 subdesc.cardinality = (
                     '1' if ptr.singular(self.schema) else '*'
                 )
@@ -290,7 +290,7 @@ class Backend:
                 # There are link properties in the mix
                 for ptr in view_shapes[t_rptr]:
                     subdesc = self._describe_type(
-                        schema, ptr.target, view_shapes, _tuples)
+                        schema, ptr.get_target(schema), view_shapes, _tuples)
                     subdesc.cardinality = (
                         '1' if ptr.singular(self.schema) else '*'
                     )

--- a/edb/server/pgsql/compiler/astutils.py
+++ b/edb/server/pgsql/compiler/astutils.py
@@ -26,7 +26,7 @@ from edb.lang.schema import pointers as s_pointers
 from edb.server.pgsql import ast as pgast
 
 
-def tuple_element_for_shape_el(shape_el, value):
+def tuple_element_for_shape_el(shape_el, value, *, ctx):
     if shape_el.path_id.is_type_indirection_path():
         rptr = shape_el.rptr.source.rptr
     else:
@@ -36,9 +36,11 @@ def tuple_element_for_shape_el(shape_el, value):
     ptrname = ptrcls.shortname
 
     attr_name = s_pointers.PointerVector(
-        name=ptrname.name, module=ptrname.module,
-        direction=ptrdir, target=ptrcls.get_far_endpoint(ptrdir),
-        is_linkprop=ptrcls.is_link_property())
+        name=ptrname.name,
+        module=ptrname.module,
+        direction=ptrdir,
+        target=ptrcls.get_far_endpoint(ctx.env.schema, ptrdir),
+        is_linkprop=ptrcls.is_link_property(ctx.env.schema))
 
     return pgast.TupleElement(
         path_id=shape_el.path_id,

--- a/edb/server/pgsql/compiler/dbobj.py
+++ b/edb/server/pgsql/compiler/dbobj.py
@@ -189,7 +189,7 @@ def range_for_ptrcls(
     `ptrcls` taking source inheritance into account.
     """
     linkname = ptrcls.shortname
-    endpoint = ptrcls.source
+    endpoint = ptrcls.get_source(env.schema)
 
     tgt_col = pgtypes.get_pointer_storage_info(
         ptrcls, resolve_type=False, link_bias=True).column_name

--- a/edb/server/pgsql/compiler/expr.py
+++ b/edb/server/pgsql/compiler/expr.py
@@ -626,7 +626,7 @@ def _compile_set_in_singleton_mode(
             ptrcls = node.rptr.ptrcls
             source = node.rptr.source
 
-            if not ptrcls.is_link_property():
+            if not ptrcls.is_link_property(ctx.env.schema):
                 if source.rptr:
                     raise RuntimeError(
                         'unexpectedly long path in simple expr')

--- a/edb/server/pgsql/compiler/output.py
+++ b/edb/server/pgsql/compiler/output.py
@@ -79,7 +79,7 @@ def tuple_var_as_json_object(tvar, *, path_id, env):
                 name = element.path_id.target_name.name
             else:
                 name = rptr.shortname.name
-                if rptr.is_link_property():
+                if rptr.is_link_property(env.schema):
                     name = '@' + name
             keyvals.append(pgast.StringConstant(val=name))
             if isinstance(element.val, pgast.TupleVar):

--- a/edb/server/pgsql/compiler/pathctx.py
+++ b/edb/server/pgsql/compiler/pathctx.py
@@ -172,7 +172,7 @@ def get_path_var(
             # This is an scalar set derived from an expression.
             src_path_id = path_id
 
-    elif ptrcls.is_link_property():
+    elif ptrcls.is_link_property(env.schema):
         if ptr_info.table_type != 'link' and not is_inbound:
             # This is a link prop that is stored in source rel,
             # step back to link source rvar.
@@ -588,7 +588,7 @@ def _get_rel_path_output(
 
     if isinstance(rel, pgast.NullRelation):
         if ptrcls is not None:
-            target = ptrcls.target
+            target = ptrcls.get_target(env.schema)
         else:
             target = path_id.target
 
@@ -612,8 +612,9 @@ def _get_rel_path_output(
         ptr_info = pg_types.get_pointer_storage_info(
             ptrcls, resolve_type=False, link_bias=False)
 
-        result = pgast.ColumnRef(name=[ptr_info.column_name],
-                                 nullable=not ptrcls.required)
+        result = pgast.ColumnRef(
+            name=[ptr_info.column_name],
+            nullable=not ptrcls.get_required(env.schema))
     rel.path_outputs[path_id, aspect] = result
     return result
 

--- a/edb/server/pgsql/compiler/relctx.py
+++ b/edb/server/pgsql/compiler/relctx.py
@@ -300,8 +300,9 @@ def new_root_rvar(
 
         if ptr_info.table_type == 'ObjectType':
             # Inline link
-            rref = dbobj.get_column(None, ptr_info.column_name,
-                                    nullable=not ptrcls.required)
+            rref = dbobj.get_column(
+                None, ptr_info.column_name,
+                nullable=not ptrcls.get_required(ctx.env.schema))
             pathctx.put_rvar_path_bond(
                 set_rvar, ir_set.path_id.src_path())
             pathctx.put_rvar_path_output(
@@ -390,7 +391,9 @@ def _new_mapped_pointer_rvar(
     else:
         tgt_col = common.edgedb_name_to_pg_name('std::target')
 
-    target_ref = dbobj.get_column(None, tgt_col, nullable=not ptrcls.required)
+    target_ref = dbobj.get_column(
+        None, tgt_col,
+        nullable=not ptrcls.get_required(ctx.env.schema))
 
     if ir_ptr.direction == s_pointers.PointerDirection.Inbound:
         near_ref = target_ref

--- a/edb/server/pgsql/compiler/relgen.py
+++ b/edb/server/pgsql/compiler/relgen.py
@@ -641,10 +641,11 @@ def process_set_as_path(
         ptrcls, resolve_type=False, link_bias=False)
 
     # Path is a link property.
-    is_linkprop = ptrcls.is_link_property()
+    is_linkprop = ptrcls.is_link_property(ctx.env.schema)
     # Path is a reference to a relationship stored in the source table.
     is_inline_ref = ptr_info.table_type == 'ObjectType'
-    is_scalar_ref = not isinstance(ptrcls.target, s_objtypes.ObjectType)
+    is_scalar_ref = not isinstance(ptrcls.get_target(ctx.env.schema),
+                                   s_objtypes.ObjectType)
     is_inline_scalar_ref = is_inline_ref and is_scalar_ref
     source_is_visible = ctx.scope_tree.is_visible(ir_source.path_id)
     semi_join = (

--- a/edb/server/pgsql/compiler/shapecomp.py
+++ b/edb/server/pgsql/compiler/shapecomp.py
@@ -72,7 +72,7 @@ def compile_shape(
             if (irutils.is_subquery_set(el) or
                     isinstance(el.scls, s_objtypes.ObjectType) or
                     not is_singleton or
-                    not ptrcls.required):
+                    not ptrcls.get_required(ctx.env.schema)):
                 wrapper = relgen.set_as_subquery(
                     el, as_value=True, ctx=shapectx)
                 if not is_singleton:
@@ -83,6 +83,7 @@ def compile_shape(
             else:
                 value = dispatch.compile(el, ctx=shapectx)
 
-            elements.append(astutils.tuple_element_for_shape_el(el, value))
+            elements.append(
+                astutils.tuple_element_for_shape_el(el, value, ctx=shapectx))
 
     return pgast.TupleVar(elements=elements, named=True)

--- a/edb/server/pgsql/metaschema.py
+++ b/edb/server/pgsql/metaschema.py
@@ -2025,7 +2025,7 @@ async def generate_views(conn, schema):
         cols = []
 
         for pn, ptr in schema_cls.get_pointers(schema).items(schema):
-            if ptr.is_pure_computable():
+            if ptr.is_pure_computable(schema):
                 continue
 
             field = mcls.get_field(pn.name)

--- a/edb/server/pgsql/schemamech.py
+++ b/edb/server/pgsql/schemamech.py
@@ -108,7 +108,7 @@ class ConstraintMech:
             rptr = ref.rptr
             if rptr is not None:
                 ptr = ref.rptr.ptrcls
-                if ptr.is_link_property():
+                if ptr.is_link_property(schema):
                     src = ref.rptr.source.rptr.ptrcls
                     if src.is_derived:
                         # This specialized pointer was derived specifically

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -115,8 +115,9 @@ class TestSchema(tb.BaseSchemaTest):
         """)
 
         obj = schema.get('test::Object')
-        self.assertEqual(obj.getptr(schema, 'foo_plus_bar').cardinality,
-                         s_pointers.Cardinality.ONE)
+        self.assertEqual(
+            obj.getptr(schema, 'foo_plus_bar').get_cardinality(schema),
+            s_pointers.Cardinality.ONE)
 
     def test_schema_computable_cardinality_inference_02(self):
         schema = self.load_schema("""
@@ -127,5 +128,6 @@ class TestSchema(tb.BaseSchemaTest):
         """)
 
         obj = schema.get('test::Object')
-        self.assertEqual(obj.getptr(schema, 'foo_plus_bar').cardinality,
-                         s_pointers.Cardinality.MANY)
+        self.assertEqual(
+            obj.getptr(schema, 'foo_plus_bar').get_cardinality(schema),
+            s_pointers.Cardinality.MANY)


### PR DESCRIPTION
* All fields in schema.Pointer are SchemaFields now

* The new 'public' field attribute tells if the field is settable
  via eschame attribute syntax.