### PR TITLE
Refactor compilation of function parameters

### DIFF
--- a/edb/lang/edgeql/compiler/__init__.py
+++ b/edb/lang/edgeql/compiler/__init__.py
@@ -26,6 +26,8 @@ from edb.lang.edgeql import parser as ql_parser
 from edb.lang.common import debug
 from edb.lang.common import markup  # NOQA
 
+from edb.lang.schema import functions as s_func
+
 from edb.lang.edgeql import ast as qlast
 from edb.lang.ir import ast as irast
 from edb.lang.ir import staeval as ireval
@@ -155,7 +157,8 @@ def compile_func_to_ir(func, schema, *,
         name='__defaults_mask__', type=schema.get('std::bytes'))
 
     func_params = func.get_params(schema)
-    for pi, p in enumerate(func_params.as_pg_params(schema).params):
+    pg_params = s_func.PgParams.from_params(schema, func_params)
+    for pi, p in enumerate(pg_params.params):
         anchors[p.shortname] = irast.Parameter(
             name=p.shortname, type=p.get_type(schema))
 

--- a/edb/lang/edgeql/compiler/func.py
+++ b/edb/lang/edgeql/compiler/func.py
@@ -248,7 +248,7 @@ def try_bind_func_args(
             # being called with some arguments.
             return _NO_MATCH
 
-    pg_params = func_params.as_pg_params(schema)
+    pg_params = s_func.PgParams.from_params(schema, func_params)
     named_only = func_params.find_named_only(schema)
 
     if no_args_call and pg_params.has_param_wo_default:

--- a/edb/lang/schema/constraints.py
+++ b/edb/lang/schema/constraints.py
@@ -448,9 +448,15 @@ class CreateConstraint(ConstraintCommand,
         elif isinstance(astnode, qlast.CreateConstraint):
             params = s_func.FuncParameterList.from_ast(
                 schema, astnode, context.modaliases,
-                allow_named=False, func_fqname=cmd.classname)
+                func_fqname=cmd.classname)
 
             for param in params:
+                if param.get_kind(schema) is ft.ParameterKind.NAMED_ONLY:
+                    raise ql_errors.EdgeQLError(
+                        'named only parameters are not allowed '
+                        'in this context',
+                        context=astnode.context)
+
                 if param.get_default(schema) is not None:
                     raise ql_errors.EdgeQLError(
                         'constraints do not support parameters '

--- a/edb/lang/schema/declarative.py
+++ b/edb/lang/schema/declarative.py
@@ -346,9 +346,15 @@ class DeclarationLoader:
 
             params = s_func.FuncParameterList.from_ast(
                 self._schema, decl, self._mod_aliases,
-                allow_named=False, func_fqname=constraint.name)
+                func_fqname=constraint.name)
 
             for param in params:
+                if param.get_kind(self._schema) is ft.ParameterKind.NAMED_ONLY:
+                    raise s_err.SchemaDefinitionError(
+                        'named only parameters are not allowed '
+                        'in this context',
+                        context=decl.context)
+
                 if param.get_default(self._schema) is not None:
                     raise s_err.SchemaDefinitionError(
                         'constraints do not support parameters '

--- a/edb/server/pgsql/delta.py
+++ b/edb/server/pgsql/delta.py
@@ -390,7 +390,7 @@ class FunctionCommand:
 
     def compile_args(self, func: s_funcs.Function, schema):
         func_params = func.get_params(schema)
-        pg_params = func_params.as_pg_params(schema)
+        pg_params = s_funcs.PgParams.from_params(schema, func_params)
         has_inlined_defaults = func.has_inlined_defaults(schema)
 
         args = []


### PR DESCRIPTION
Now, the compilation of parameter declarations in function-like objects
does not create parameter schema items unnecessarily.