### PR TITLE
schema: Reimplement ObjectMapping as ObjectIndex

### DIFF
--- a/edb/lang/graphql/types.py
+++ b/edb/lang/graphql/types.py
@@ -186,7 +186,7 @@ class GQLCoreSchema:
         else:
             edb_type = self.edb_schema.get(typename)
             pointers = edb_type.get_pointers(self.edb_schema)
-            for name in sorted(pointers.names(self.edb_schema),
+            for name in sorted(pointers.shortnames(self.edb_schema),
                                key=lambda x: x.name):
                 if name.name == '__type__':
                     continue
@@ -215,9 +215,10 @@ class GQLCoreSchema:
         fields['not'] = GraphQLInputObjectField(selftype)
 
         edb_type = self.edb_schema.get(typename)
-        for name in sorted(
-                edb_type.get_pointers(self.edb_schema).names(self.edb_schema),
-                key=lambda x: x.name):
+        pointers = edb_type.get_pointers(self.edb_schema)
+        names = sorted(pointers.shortnames(self.edb_schema),
+                       key=lambda x: x.name)
+        for name in names:
             if name.name == '__type__':
                 continue
             if name.name in fields:
@@ -289,9 +290,11 @@ class GQLCoreSchema:
         fields = OrderedDict()
 
         edb_type = self.edb_schema.get(typename)
-        for name in sorted(
-                edb_type.get_pointers(self.edb_schema).names(self.edb_schema),
-                key=lambda x: x.name):
+        pointers = edb_type.get_pointers(self.edb_schema)
+        names = sorted(pointers.shortnames(self.edb_schema),
+                       key=lambda x: x.name)
+
+        for name in names:
             if name.name == '__type__':
                 continue
 

--- a/edb/lang/schema/attributes.py
+++ b/edb/lang/schema/attributes.py
@@ -61,14 +61,14 @@ class AttributeSubject(referencing.ReferencingObject):
         ref_cls=AttributeValue)
 
     attributes = so.SchemaField(
-        so.ObjectMapping,
+        so.ObjectIndexByShortname,
         inheritable=False, ephemeral=True, coerce=True,
-        default=so.ObjectMapping, hashable=False)
+        default=so.ObjectIndexByShortname, hashable=False)
 
     own_attributes = so.SchemaField(
-        so.ObjectMapping, compcoef=0.909,
+        so.ObjectIndexByShortname, compcoef=0.909,
         inheritable=False, ephemeral=True, coerce=True,
-        default=so.ObjectMapping)
+        default=so.ObjectIndexByShortname)
 
     def add_attribute(self, schema, attribute, replace=False):
         schema = self.add_classref(

--- a/edb/lang/schema/constraints.py
+++ b/edb/lang/schema/constraints.py
@@ -311,15 +311,15 @@ class ConsistencySubject(referencing.ReferencingObject):
         ref_cls=Constraint)
 
     constraints = so.SchemaField(
-        so.ObjectMapping,
+        so.ObjectIndexByShortname,
         inheritable=False, ephemeral=True, coerce=True,
-        default=so.ObjectMapping, hashable=False)
+        default=so.ObjectIndexByShortname, hashable=False)
 
     own_constraints = so.SchemaField(
-        so.ObjectMapping, compcoef=0.887,
+        so.ObjectIndexByShortname, compcoef=0.887,
         inheritable=False, ephemeral=True,
         coerce=True,
-        default=so.ObjectMapping)
+        default=so.ObjectIndexByShortname)
 
     @classmethod
     def inherit_pure(cls, schema, item, source, *, dctx=None):
@@ -342,7 +342,7 @@ class ConsistencySubject(referencing.ReferencingObject):
         if attr == 'constraints':
             # Make sure abstract constraints from parents are mixed in
             # properly.
-            constraints = set(self.get_constraints(schema).names(schema))
+            constraints = set(self.get_constraints(schema).shortnames(schema))
             inherited = itertools.chain.from_iterable(
                 b.get_constraints(schema).objects(schema)
                 for b in bases)

--- a/edb/lang/schema/declarative.py
+++ b/edb/lang/schema/declarative.py
@@ -54,7 +54,6 @@ from . import links as s_links
 from . import lproperties as s_props
 from . import modules as s_mod
 from . import name as s_name
-from . import named as s_named
 from . import objects as s_obj
 from . import pseudo as s_pseudo
 from . import scalars as s_scalars
@@ -331,7 +330,7 @@ class DeclarationLoader:
                     default_base_name, module_aliases=self._mod_aliases)
                 bases.append(default_base)
 
-        return s_named.NamedObjectList.create(self._schema, bases)
+        return s_obj.ObjectList.create(self._schema, bases)
 
     def _init_constraints(self, constraints):
         for constraint, decl in constraints.items():

--- a/edb/lang/schema/deltas.py
+++ b/edb/lang/schema/deltas.py
@@ -30,8 +30,8 @@ from . import objects as so
 
 class Delta(named.NamedObject):
     parents = so.SchemaField(
-        named.NamedObjectList,
-        default=named.NamedObjectList, coerce=True, inheritable=False)
+        so.ObjectList,
+        default=so.ObjectList, coerce=True, inheritable=False)
 
     target = so.SchemaField(
         s_ast.Schema,

--- a/edb/lang/schema/indexes.py
+++ b/edb/lang/schema/indexes.py
@@ -53,14 +53,14 @@ class IndexableSubject(referencing.ReferencingObject):
         ref_cls=SourceIndex)
 
     indexes = so.SchemaField(
-        so.ObjectMapping,
+        so.ObjectIndexByShortname,
         inheritable=False, ephemeral=True, coerce=True,
-        default=so.ObjectMapping, hashable=False)
+        default=so.ObjectIndexByShortname, hashable=False)
 
     own_indexes = so.SchemaField(
-        so.ObjectMapping, compcoef=0.909,
+        so.ObjectIndexByShortname, compcoef=0.909,
         inheritable=False, ephemeral=True, coerce=True,
-        default=so.ObjectMapping)
+        default=so.ObjectIndexByShortname)
 
     def add_index(self, schema, index):
         return self.add_classref(schema, 'indexes', index)

--- a/edb/lang/schema/inheriting.py
+++ b/edb/lang/schema/inheriting.py
@@ -121,7 +121,7 @@ class CreateInheritingObject(named.CreateNamedObject, InheritingObjectCommand):
 
         modaliases = context.modaliases
 
-        bases = named.NamedObjectList.create(
+        bases = so.ObjectList.create(
             schema,
             [utils.ast_to_typeref(b, modaliases=modaliases, schema=schema)
              for b in getattr(astnode, 'bases', None) or []]
@@ -133,7 +133,7 @@ class CreateInheritingObject(named.CreateNamedObject, InheritingObjectCommand):
 
             if default_base is not None and classname != default_base:
                 default_base = schema.get(default_base)
-                bases = named.NamedObjectList.create(
+                bases = so.ObjectList.create(
                     schema,
                     [utils.reduce_to_typeref(schema, default_base)])
 
@@ -319,13 +319,13 @@ def create_virtual_parent(schema, children, *,
 
 class InheritingObject(derivable.DerivableObject):
     bases = so.SchemaField(
-        named.NamedObjectList,
-        default=named.NamedObjectList,
+        so.ObjectList,
+        default=so.ObjectList,
         coerce=True, inheritable=False, compcoef=0.714,
         debug_getter=True)
 
     mro = so.SchemaField(
-        named.NamedObjectList,
+        so.ObjectList,
         coerce=True, default=None, hashable=False,
         debug_getter=True)
 
@@ -425,7 +425,7 @@ class InheritingObject(derivable.DerivableObject):
         return schema, derived
 
     def get_base_names(self, schema):
-        return self.get_bases(schema).get_names(schema)
+        return self.get_bases(schema).names(schema)
 
     def get_topmost_concrete_base(self, schema):
         # Get the topmost non-abstract base.

--- a/edb/lang/schema/links.py
+++ b/edb/lang/schema/links.py
@@ -83,8 +83,8 @@ class Link(sources.Source, pointers.Pointer):
     schema_class_displayname = 'link'
 
     spectargets = so.SchemaField(
-        named.NamedObjectSet,
-        default=named.NamedObjectSet,
+        so.ObjectSet,
+        default=so.ObjectSet,
         coerce=True)
 
     on_target_delete = so.SchemaField(
@@ -249,7 +249,7 @@ class CreateLink(LinkCommand, referencing.CreateReferencedInheritingObject):
                 cmd.add(
                     sd.AlterObjectProperty(
                         property='spectargets',
-                        new_value=named.NamedObjectList([
+                        new_value=so.ObjectList([
                             utils.ast_to_typeref(
                                 t, modaliases=context.modaliases,
                                 schema=schema)
@@ -274,7 +274,7 @@ class CreateLink(LinkCommand, referencing.CreateReferencedInheritingObject):
                 create_virt_parent.update((
                     sd.AlterObjectProperty(
                         property='bases',
-                        new_value=named.NamedObjectList([
+                        new_value=so.ObjectList([
                             so.ObjectRef(name=sn.Name(
                                 module='std', name='Object'
                             ))
@@ -510,7 +510,7 @@ class AlterTarget(sd.Command):
             alter_ptr_ctx.op.add(
                 sd.AlterObjectProperty(
                     property='spectargets',
-                    new_value=named.NamedObjectList([
+                    new_value=so.ObjectList([
                         so.ObjectRef(
                             name=sn.Name(
                                 module=t.module,

--- a/edb/lang/schema/named.py
+++ b/edb/lang/schema/named.py
@@ -20,7 +20,6 @@
 import base64
 
 from edb.lang.common import struct
-from edb.lang.common.persistent_hash import persistent_hash
 
 from edb.lang.edgeql import ast as qlast
 
@@ -32,44 +31,6 @@ from . import error as s_err
 
 
 NamedObject = so.NamedObject
-
-
-class NamedObjectList(so.ObjectList, type=NamedObject):
-    def get_names(self, schema):
-        return tuple(ref.name for ref in self.objects(schema))
-
-    def persistent_hash(self, *, schema):
-        return persistent_hash(self.get_names(schema), schema=schema)
-
-    @classmethod
-    def compare_values(cls, ours, theirs, *,
-                       our_schema, their_schema, context, compcoef):
-        our_names = ours.get_names(our_schema) if ours else tuple()
-        their_names = theirs.get_names(their_schema) if theirs else tuple()
-
-        if frozenset(our_names) != frozenset(their_names):
-            return compcoef
-        else:
-            return 1.0
-
-
-class NamedObjectSet(so.ObjectSet, type=NamedObject):
-    def get_names(self, schema):
-        return frozenset(ref.name for ref in self.objects(schema))
-
-    def persistent_hash(self, *, schema):
-        return persistent_hash(self.get_names(schema), schema=schema)
-
-    @classmethod
-    def compare_values(cls, ours, theirs, *,
-                       our_schema, their_schema, context, compcoef):
-        our_names = ours.get_names(our_schema) if ours else frozenset()
-        their_names = theirs.get_names(their_schema) if theirs else frozenset()
-
-        if our_names != their_names:
-            return compcoef
-        else:
-            return 1.0
 
 
 class NamedObjectCommand(sd.ObjectCommand):
@@ -179,7 +140,7 @@ class CreateNamedObject(CreateOrAlterNamedObject, sd.CreateObject):
             pass
         elif op.property == 'bases':
             if not isinstance(op.new_value, so.ObjectList):
-                bases = NamedObjectList.create(schema, op.new_value)
+                bases = so.ObjectList.create(schema, op.new_value)
             else:
                 bases = op.new_value
 

--- a/edb/lang/schema/sources.py
+++ b/edb/lang/schema/sources.py
@@ -46,14 +46,14 @@ class Source(indexes.IndexableSubject):
         ref_cls=pointers.Pointer)
 
     pointers = so.SchemaField(
-        so.ObjectMapping,
+        so.ObjectIndexByShortname,
         inheritable=False, ephemeral=True, coerce=True,
-        default=so.ObjectMapping, hashable=False)
+        default=so.ObjectIndexByShortname, hashable=False)
 
     own_pointers = so.SchemaField(
-        so.ObjectMapping, compcoef=0.857,
+        so.ObjectIndexByShortname, compcoef=0.857,
         inheritable=False, ephemeral=True, coerce=True,
-        default=so.ObjectMapping)
+        default=so.ObjectIndexByShortname)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/edb/server/pgsql/delta.py
+++ b/edb/server/pgsql/delta.py
@@ -168,7 +168,7 @@ class NamedObjectMetaCommand(
             recvalue = dbops.Query(
                 f'edgedb._resolve_type_id(ARRAY[{name_array}]::text[])')
 
-        elif isinstance(value, s_obj.ObjectMapping):
+        elif isinstance(value, s_obj.ObjectIndexBase):
             result = s_types.Tuple.from_subtypes(
                 schema,
                 dict(value.items(schema)),
@@ -1331,8 +1331,8 @@ class CompositeObjectMetaCommand(NamedObjectMetaCommand):
 
                 orig_ptrs = orig_source.get_pointers(schema)
                 dropped_ptrs = (
-                    set(orig_ptrs.names(schema)) -
-                    set(ptrs.names(schema))
+                    set(orig_ptrs.shortnames(schema)) -
+                    set(ptrs.shortnames(schema))
                 )
 
                 if dropped_ptrs:


### PR DESCRIPTION
Currently, `ObjectMapping` stores a key-value dictionary internally.
The key is actually not arbitrary, and is the shortname of the value.
Since names are transient properties, the mapping should not store them
and should refer to the referenced object every time a key is requested.
The new implementation is called an `ObjectIndex`, and there are two
variants: `ObjectIndexByShortname`, which implements the behavior of the
former `ObjectMapping`, and `ObjectIndexByFullname`, which is the same,
but uses the fullname of the referenced object as a key.

This also greatly reduces code duplication between various
`ObjectCollection` subclasses, since the core methods and the underlying
storage are essentially the same.