### PR TITLE
schema: Fix `std` module resolution.

### DIFF
--- a/edb/lang/schema/schema.py
+++ b/edb/lang/schema/schema.py
@@ -218,8 +218,8 @@ class Schema(TypeContainer):
                 return result
 
         if implicit_builtins:
-            std = self.modules['std']
-            result = getter([std], nqname)
+            std = self._resolve_module('std')
+            result = getter(std, nqname)
             if result is not None:
                 return result
 


### PR DESCRIPTION
Resolve implicit builtin `std` the same way as when it is explicitly
specified.

(The fix was originally done by Elvis in my working branch)