### PR TITLE
Stop merging constraints by name

### DIFF
--- a/edb/lang/schema/attributes.py
+++ b/edb/lang/schema/attributes.py
@@ -76,7 +76,8 @@ class AttributeSubject(referencing.ReferencingObject):
         return schema
 
     def del_attribute(self, schema, attribute_name):
-        return self.del_classref(schema, 'attributes', attribute_name)
+        shortname = Attribute.shortname_from_fullname(attribute_name)
+        return self.del_classref(schema, 'attributes', shortname)
 
 
 class AttributeCommandContext(sd.ObjectCommandContext):

--- a/edb/lang/schema/delta.py
+++ b/edb/lang/schema/delta.py
@@ -247,6 +247,14 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
         else:
             return None
 
+    def set_attribute_value(self, attr_name, value):
+        for op in self.get_subcommands(type=AlterObjectProperty):
+            if op.property == attr_name:
+                op.new_value = value
+                break
+        else:
+            self.add(AlterObjectProperty(property=attr_name, new_value=value))
+
     def discard_attribute(self, attr_name):
         for op in self.get_subcommands(type=AlterObjectProperty):
             if op.property == attr_name:

--- a/edb/lang/schema/objects.py
+++ b/edb/lang/schema/objects.py
@@ -1321,6 +1321,10 @@ class ObjectIndexBase(ObjectCollection, container=tuple):
         cls._key = key
 
     @classmethod
+    def get_key_for(cls, schema, obj):
+        return cls._key(schema, obj)
+
+    @classmethod
     def create(cls, schema, data: typing.Iterable[NamedObject]):
         coll = super().create(schema, data)
         coll._check_duplicates(schema)

--- a/edb/lang/schema/pointers.py
+++ b/edb/lang/schema/pointers.py
@@ -346,11 +346,18 @@ class Pointer(constraints.ConsistencySubject, PointerLike):
     def generic(self, schema):
         return self.get_source(schema) is None
 
-    def is_exclusive(self, schema):
+    def is_exclusive(self, schema) -> bool:
         if self.generic(schema):
             raise ValueError(f'{self!r} is generic')
 
-        return self.get_constraints(schema).has(schema, 'std::exclusive')
+        exclusive = schema.get('std::exclusive')
+
+        for constr in self.get_constraints(schema).objects(schema):
+            if (constr.issubclass(schema, exclusive) and
+                    not constr.get_subjectexpr(schema)):
+                return True
+
+        return False
 
     def singular(self, schema, direction=PointerDirection.Outbound):
         # Determine the cardinality of a given endpoint set.

--- a/edb/server/pgsql/datasources/schema/constraints.py
+++ b/edb/server/pgsql/datasources/schema/constraints.py
@@ -38,7 +38,6 @@ async def fetch(
                                         AS bases,
                 a.expr                  AS expr,
                 a.subjectexpr           AS subjectexpr,
-                a.localfinalexpr        AS localfinalexpr,
                 a.finalexpr             AS finalexpr,
                 a.errmessage            AS errmessage,
                 a.args                  AS args,

--- a/edb/server/pgsql/delta.py
+++ b/edb/server/pgsql/delta.py
@@ -695,7 +695,7 @@ class RenameConstraint(
     def apply(self, schema, context):
         constr_ctx = context.get(s_constr.ConstraintCommandContext)
         assert constr_ctx
-        orig_constraint = constr_ctx.scls
+        orig_constraint = constr_ctx.original_class
         schemac_to_backendc = \
             schemamech.ConstraintMech.schema_constraint_to_backend_constraint
         orig_bconstr = schemac_to_backendc(

--- a/edb/server/pgsql/deltadbops.py
+++ b/edb/server/pgsql/deltadbops.py
@@ -524,11 +524,11 @@ class AlterTableInheritableConstraintBase(
 
     def alter_constraint(self, old_constraint, new_constraint):
         if old_constraint.is_abstract and not new_constraint.is_abstract:
-            # No longer abstract, create db structures
+            # No longer delegated, create db structures
             self.create_constraint(new_constraint)
 
         elif not old_constraint.is_abstract and new_constraint.is_abstract:
-            # Now abstract, drop db structures
+            # Now delegated, drop db structures
             self.drop_constraint(new_constraint)
 
         else:

--- a/edb/server/pgsql/intromech.py
+++ b/edb/server/pgsql/intromech.py
@@ -430,7 +430,7 @@ class IntrospectionMech:
             description = r['description']
             subject = schema.get(r['subject']) if r['subject'] else None
 
-            basemap[name] = bases
+            basemap[name] = r['bases'] or []
 
             if not r['subject']:
                 schema, params = self._decode_func_params(schema, r, param_map)
@@ -447,7 +447,7 @@ class IntrospectionMech:
                 description=description, is_abstract=r['is_abstract'],
                 is_final=r['is_final'], expr=r['expr'],
                 subjectexpr=r['subjectexpr'],
-                localfinalexpr=r['localfinalexpr'], finalexpr=r['finalexpr'],
+                finalexpr=r['finalexpr'],
                 errmessage=r['errmessage'],
                 args=r['args'],
                 return_type=self.unpack_typeref(r['return_type'], schema),

--- a/tests/schemas/constraints.eschema
+++ b/tests/schemas/constraints.eschema
@@ -183,7 +183,7 @@ type AbstractConstraintMixedChild extending AbstractConstraintParent:
 
 type AbstractConstraintPropagated extending AbstractConstraintParent:
     inherited property name -> str:
-        delegated constraint exclusive on (lower(__subject__))
+        delegated constraint exclusive
 
 
 type AbstractConstraintParent3:


### PR DESCRIPTION
Currently, if several constraints of the same abstract name are declared
on a schema item, these constraints are merged into a single constraint,
where individual constraint expressions are AND-ed.  This approach has
been dicated historically by `ReferencingObject` logic, since
`ObjectMapping` used shortnames as keys.  The downside of this merging is
that it is destructive, i.e. there is no record of the constraint
components that were actually declared on the schema item.  Now that the
`ObjectIndex` has a fullname variant, we can stop merging the
constraints and generate the concrete name from the constraint
expression to disambiguate constraints derived from the same abstract
constraint.