### PR TITLE
Make schema fully immutable

### DIFF
--- a/edb/lang/edgeql/compiler/func.py
+++ b/edb/lang/edgeql/compiler/func.py
@@ -96,7 +96,7 @@ def compile_FunctionCall(
         fatal_array_check = len(funcs) == 1
         matched_call = _NO_MATCH
 
-        for func in funcs:
+        for func in sorted(funcs, key=lambda f: f.get_name(schema)):
             call = try_bind_func_args(
                 args, kwargs, funcname, func,
                 fatal_array_check=fatal_array_check,

--- a/edb/lang/edgeql/compiler/schemactx.py
+++ b/edb/lang/edgeql/compiler/schemactx.py
@@ -191,7 +191,7 @@ def derive_view_name(
     if ctx.derived_target_module:
         derived_name_module = ctx.derived_target_module
     else:
-        derived_name_module = '__view__'
+        derived_name_module = '__derived__'
 
     derived_sname = stype.get_specialized_name(
         derived_name_base, *derived_name_quals)

--- a/edb/lang/edgeql/compiler/stmtctx.py
+++ b/edb/lang/edgeql/compiler/stmtctx.py
@@ -30,6 +30,7 @@ from edb.lang.edgeql import errors
 from edb.lang.ir import ast as irast
 
 from edb.lang.schema import functions as s_func
+from edb.lang.schema import modules as s_mod
 from edb.lang.schema import name as s_name
 from edb.lang.schema import objects as s_obj
 from edb.lang.schema import pointers as s_pointers
@@ -61,8 +62,9 @@ def init_context(
         context.ContextLevel:
     stack = context.CompilerContext()
     ctx = stack.current
+    schema, _ = s_mod.Module.create_in_schema(schema, name='__derived__')
     ctx.env = context.Environment(
-        schema=schema.get_overlay(extra=ctx.view_nodes),
+        schema=schema,
         path_scope=irast.new_scope_tree())
 
     if singletons:
@@ -282,10 +284,10 @@ def declare_view(
             if isinstance(alias, s_name.SchemaName):
                 basename = alias
             else:
-                basename = s_name.SchemaName(module='__view__', name=alias)
+                basename = s_name.SchemaName(module='__derived__', name=alias)
 
             view_name = s_name.SchemaName(
-                module=ctx.derived_target_module or '_',
+                module=ctx.derived_target_module or '__derived__',
                 name=s_obj.NamedObject.get_specialized_name(
                     basename,
                     ctx.aliases.get('w')

--- a/edb/lang/schema/ddl.py
+++ b/edb/lang/schema/ddl.py
@@ -61,7 +61,7 @@ def compile_migration(cmd, target_schema, current_schema):
     if not declarations:
         return cmd
 
-    s_decl.load_module_declarations(target_schema, [
+    target_schema = s_decl.load_module_declarations(target_schema, [
         (cmd.classname.module, declarations)
     ])
 

--- a/edb/lang/schema/delta.py
+++ b/edb/lang/schema/delta.py
@@ -53,10 +53,11 @@ def delta_schemas(schema1, schema2):
     global_dels = []
 
     for type in s_ordering.get_global_dep_order():
-        o1 = schema1.get_objects(type=type)
-        new = ordered.OrderedIndex(o1, key=lambda o: o.get_name(schema1))
-        o2 = schema2.get_objects(type=type)
-        old = ordered.OrderedIndex(o2, key=lambda o: o.get_name(schema2))
+        new = s_ordering.sort_objects(
+            schema1, schema1.get_objects(type=type))
+
+        old = s_ordering.sort_objects(
+            schema2, schema2.get_objects(type=type))
 
         if issubclass(type, derivable.DerivableObject):
             new = filter(lambda i: i.generic(schema1), new)
@@ -102,16 +103,14 @@ def delta_module(schema1, schema2, modname):
         result.add(create)
 
     for type in s_ordering.get_global_dep_order():
-        new = ordered.OrderedIndex(
-            schema1.get_objects(modules=[modname], type=type),
-            key=lambda o: o.get_name(schema1))
+        new = s_ordering.sort_objects(
+            schema1, schema1.get_objects(modules=[modname], type=type))
 
         if module2 is not None:
-            old = ordered.OrderedIndex(
-                schema2.get_objects(modules=[modname], type=type),
-                key=lambda o: o.get_name(schema2))
+            old = s_ordering.sort_objects(
+                schema2, schema2.get_objects(modules=[modname], type=type))
         else:
-            old = ordered.OrderedIndex(key=lambda o: o.get_name(schema2))
+            old = set()
 
         if issubclass(type, derivable.DerivableObject):
             new = filter(lambda i: i.generic(schema1), new)
@@ -579,10 +578,6 @@ class ObjectCommandContext(CommandContextToken):
         super().__init__(op)
         self.scls = scls
         self.original_schema = schema
-        if scls is not None:
-            _, self.original_class = scls.temp_copy(schema)
-        else:
-            self.original_class = None
 
 
 class CreateObject(ObjectCommand):

--- a/edb/lang/schema/inheriting.py
+++ b/edb/lang/schema/inheriting.py
@@ -139,12 +139,6 @@ class CreateInheritingObject(named.CreateNamedObject, InheritingObjectCommand):
 
         return bases
 
-    def _create_finalize(self, schema, context):
-        schema = super()._create_finalize(schema, context)
-        for base in self.scls.get_bases(schema).objects(schema):
-            schema = schema.drop_inheritance_cache(base)
-        return schema
-
 
 class AlterInheritingObject(named.AlterNamedObject, InheritingObjectCommand):
     def _alter_begin(self, schema, context, scls):
@@ -159,12 +153,7 @@ class AlterInheritingObject(named.AlterNamedObject, InheritingObjectCommand):
 
 
 class DeleteInheritingObject(named.DeleteNamedObject, InheritingObjectCommand):
-    def _delete_finalize(self, schema, context, scls):
-        bases = scls.get_bases(schema).objects(schema)
-        schema = super()._delete_finalize(schema, context, scls)
-        for base in bases:
-            schema = schema.drop_inheritance_cache(base)
-        return schema
+    pass
 
 
 class RebaseNamedObject(named.NamedObjectCommand):
@@ -356,12 +345,6 @@ class InheritingObject(derivable.DerivableObject):
     is_virtual = so.SchemaField(
         bool,
         default=False, compcoef=0.5)
-
-    def merge(self, *objs, schema, dctx=None):
-        schema = super().merge(*objs, schema=schema, dctx=dctx)
-        for obj in objs:
-            schema = schema.drop_inheritance_cache(obj)
-        return schema
 
     @classmethod
     def delta(cls, old, new, *, context, old_schema, new_schema):

--- a/edb/lang/schema/named.py
+++ b/edb/lang/schema/named.py
@@ -183,9 +183,6 @@ class RenameNamedObject(NamedObjectCommand):
                                          self.classname, self.new_name)
 
     def _rename_begin(self, schema, context, scls):
-        schema = schema.drop_inheritance_cache(scls)
-        schema = schema.drop_inheritance_cache_for_child(scls)
-
         self.old_name = self.classname
         schema = scls.set_field_value(schema, 'name', self.new_name)
 
@@ -411,10 +408,7 @@ class AlterNamedObject(CreateOrAlterNamedObject, sd.AlterObject):
         scls = schema.get(self.classname, type=metaclass)
         self.scls = scls
 
-        with self.new_context(schema, context) as ctx:
-            ctx.original_schema = schema
-            _, ctx.original_class = scls.temp_copy(schema)
-
+        with self.new_context(schema, context):
             schema = self._alter_begin(schema, context, scls)
             schema = self._alter_innards(schema, context, scls)
             schema = self._alter_finalize(schema, context, scls)
@@ -437,11 +431,8 @@ class DeleteNamedObject(NamedObjectCommand, sd.DeleteObject):
         metaclass = self.get_schema_metaclass()
         scls = schema.get(self.classname, type=metaclass)
         self.scls = scls
-        self.old_class = scls
 
-        with self.new_context(schema, context) as ctx:
-            ctx.original_class = scls
-
+        with self.new_context(schema, context):
             schema = self._delete_begin(schema, context, scls)
             schema = self._delete_innards(schema, context, scls)
             schema = self._delete_finalize(schema, context, scls)

--- a/edb/lang/schema/objects.py
+++ b/edb/lang/schema/objects.py
@@ -363,8 +363,7 @@ class Object(metaclass=ObjectMeta):
         return obj
 
     @classmethod
-    def _create_in_schema(cls, schema, *, id=None,
-                          _nameless=False, **data) -> 'Object':
+    def _create_in_schema(cls, schema, *, id=None, **data) -> 'Object':
         if not cls.is_schema_object:
             raise TypeError(f'{cls.__name__} type cannot be created in schema')
 
@@ -387,7 +386,7 @@ class Object(metaclass=ObjectMeta):
 
         id = cls._prepare_id(id, data)
         scls = cls._create_from_id(id)
-        schema = schema._add(id, scls, obj_data, _nameless=_nameless)
+        schema = schema._add(id, scls, obj_data)
 
         return schema, scls
 
@@ -575,7 +574,7 @@ class Object(metaclass=ObjectMeta):
 
         return schema
 
-    def copy_with(self, schema, updates: dict, *, _nameless=False):
+    def copy_with(self, schema, updates: dict):
         fields = type(self)._fields
 
         if updates.keys() - fields.keys():
@@ -597,11 +596,7 @@ class Object(metaclass=ObjectMeta):
                     continue
                 new[field_name] = val
 
-        return type(self).create_in_schema(schema, **new, _nameless=_nameless)
-
-    def temp_copy(self, schema):
-        new_id = uuidgen.uuid1mc()
-        return self.copy_with(schema, updates={'id': new_id}, _nameless=True)
+        return type(self).create_in_schema(schema, **new)
 
     def is_type(self):
         return False
@@ -1077,11 +1072,11 @@ class NamedObject(Object):
         str, default=None, compcoef=0.909, public=True)
 
     @classmethod
-    def create_in_schema(cls, schema, *, _nameless=False, **kwargs):
+    def create_in_schema(cls, schema, **kwargs):
         name = kwargs.get('name')
         if not name:
             raise RuntimeError(f'cannot create {cls} without a name')
-        return cls._create_in_schema(schema, _nameless=_nameless, **kwargs)
+        return cls._create_in_schema(schema, **kwargs)
 
     @classmethod
     def mangle_name(cls, name) -> str:

--- a/edb/lang/schema/referencing.py
+++ b/edb/lang/schema/referencing.py
@@ -351,7 +351,7 @@ class CreateReferencedInheritingObject(inheriting.CreateInheritingObject):
 class ReferencingObject(inheriting.InheritingObject,
                         metaclass=ReferencingObjectMeta):
 
-    def copy_with(self, schema, updates, *, _nameless=False):
+    def copy_with(self, schema, updates):
         for refdict in self.__class__.get_refdicts():
             attr = refdict.attr
             local_attr = refdict.local_attr
@@ -378,9 +378,7 @@ class ReferencingObject(inheriting.InheritingObject,
             else:
                 updates[local_attr] = local_coll
 
-        schema, result = super().copy_with(
-            schema, updates, _nameless=_nameless)
-        return schema, result
+        return super().copy_with(schema, updates)
 
     def merge(self, *objs, schema, dctx=None):
         schema = super().merge(*objs, schema=schema, dctx=None)
@@ -667,7 +665,7 @@ class ReferencingObject(inheriting.InheritingObject,
                 # decision to the referenced class here.
                 schema, merged = classrefcls.inherit_pure(
                     schema, item, source=self, dctx=dctx)
-                pure_inheritance = merged is item
+                pure_inheritance = merged == item
 
             else:
                 # Not inherited

--- a/edb/lang/schema/std.py
+++ b/edb/lang/schema/std.py
@@ -82,7 +82,7 @@ def load_std_schema(
         schema = s_schema.Schema()
 
     for modname in STD_MODULES:
-        load_std_module(schema, modname)
+        schema = load_std_module(schema, modname)
 
     return schema
 

--- a/edb/server/pgsql/compiler/context.py
+++ b/edb/server/pgsql/compiler/context.py
@@ -144,6 +144,6 @@ class Environment:
         self.root_rels = set()
         self.rel_overlays = collections.defaultdict(list)
         self.output_format = output_format
-        self.schema = schema.get_overlay()
+        self.schema = schema
         self.tuple_formats = {}
         self.use_named_params = use_named_params

--- a/edb/server/pgsql/intromech.py
+++ b/edb/server/pgsql/intromech.py
@@ -115,7 +115,6 @@ class IntrospectionMech:
 
     async def _init_introspection_cache(self):
         await self._type_mech.init_cache(self.connection)
-        await self._constr_mech.init_cache(self.connection)
         self.domain_to_scalar_map = await self._init_scalar_map_cache()
         # ObjectType map needed early for type filtering operations
         # in schema queries
@@ -722,9 +721,9 @@ class IntrospectionMech:
                 g[link.get_name(schema)]['merge'].extend(
                     b.get_name(schema) for b in link_bases)
 
-        topological.normalize(g, merger=s_links.Link.merge, schema=schema)
+        links = topological.sort(g)
 
-        for link in schema.get_objects(type=s_links.Link):
+        for link in links:
             schema = link.finalize(schema)
 
         return schema
@@ -816,10 +815,9 @@ class IntrospectionMech:
                 g[prop.get_name(schema)]['merge'].extend(
                     b.get_name(schema) for b in prop_bases)
 
-        topological.normalize(
-            g, merger=s_props.Property.merge, schema=schema)
+        props = topological.sort(g)
 
-        for prop in schema.get_objects(type=s_props.Property):
+        for prop in props:
             schema = prop.finalize(schema)
 
         return schema
@@ -972,10 +970,8 @@ class IntrospectionMech:
                 g[objtype.get_name(schema)]["merge"].extend(
                     b.get_name(schema) for b in objtype_bases)
 
-        topological.normalize(
-            g, merger=s_objtypes.ObjectType.merge, schema=schema)
-
-        for objtype in schema.get_objects(type=s_objtypes.BaseObjectType):
+        objtypes = topological.sort(g)
+        for objtype in objtypes:
             schema = objtype.finalize(schema)
 
         return schema

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ RUNTIME_DEPS = [
     'asyncpg',
     'click',
     'graphql-core',
+    'immutables>=0.7',
     'Parsing',
     'prompt_toolkit>=1.0.15,<2.0.0',
     'pygments',

--- a/tests/test_deltas.py
+++ b/tests/test_deltas.py
@@ -343,8 +343,8 @@ test::a -> array<std::int64>;
         self._assert_result(
             result[1],
             '''\
-            CREATE ABSTRACT PROPERTY test::bar;
             CREATE ABSTRACT PROPERTY test::__typename;
+            CREATE ABSTRACT PROPERTY test::bar;
             CREATE ABSTRACT TYPE test::Foo EXTENDING std::Object;
             ALTER TYPE test::Foo {
                 CREATE SINGLE PROPERTY test::bar -> std::str;
@@ -373,8 +373,8 @@ test::a -> array<std::int64>;
         self._assert_result(
             result[1],
             '''\
-            CREATE ABSTRACT PROPERTY test::bar;
             CREATE ABSTRACT PROPERTY test::__typename;
+            CREATE ABSTRACT PROPERTY test::bar;
             CREATE ABSTRACT TYPE test::Foo EXTENDING std::Object;
             ALTER TYPE test::Foo {
                 CREATE SINGLE PROPERTY test::bar -> std::str;

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -126,7 +126,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::Card)",
             "(test::User)",
             "FENCE": {
-                "(_::__view__|U@@w~1)": {
+                "(__derived__::__derived__|U@@w~1)": {
                     "FENCE": {
                         "(test::User)"
                     }
@@ -338,7 +338,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         """
 
     def test_edgeql_ir_scope_tree_16(self):
-        # Apparent misplaced "(_::__view__|U@@w~1)" in the FILTER
+        # Apparent misplaced "(__derived__::__derived__|U@@w~1)" in the FILTER
         # fence is due to a view_map replacement artifact.
         """
         WITH MODULE test,
@@ -356,10 +356,11 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(_::__view__|U@@w~1).>(test::cards)[IS test::Card]\
+            "(__derived__::__derived__|U@@w~1).>(test::cards)[IS test::Card]\
 .>(test::foo)[IS std::float64]": {
-                "(_::__view__|U@@w~1).>(test::cards)[IS test::Card]": {
-                    "(_::__view__|U@@w~1)": {
+                "(__derived__::__derived__|U@@w~1)\
+.>(test::cards)[IS test::Card]": {
+                    "(__derived__::__derived__|U@@w~1)": {
                         "FENCE": {
                             "(test::User)",
                             "FENCE": {
@@ -370,7 +371,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                     "FENCE": {
                         "(test::Card)",
                         "FENCE": {
-                            "(_::__view__|U@@w~1)\
+                            "(__derived__::__derived__|U@@w~1)\
 .>(test::deck)[IS test::Card]"
                         }
                     }
@@ -441,7 +442,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(_::__view__|x@@w~1)": {
+            "(__derived__::__derived__|x@@w~1)": {
                 "FENCE": {
                     "(test::User).>(test::friends)[IS test::User]": {
                         "(test::User)"
@@ -467,7 +468,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 }
             },
             "FENCE": {
-                "(_::__view__|x@@w~1).>(__tuple__::0)[IS std::decimal]"
+                "(__derived__::__derived__|x@@w~1)\
+.>(__tuple__::0)[IS std::decimal]"
             }
         }
         """
@@ -568,14 +570,15 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(_::__view__|x@@w~1)": {
+                "(__derived__::__derived__|x@@w~1)": {
                     "FENCE": {
                         "(test::User).>(test::deck)[IS test::Card]"
                     }
                 },
                 "(test::User).>(test::deck)[IS test::Card]",
                 "FENCE": {
-                    "(_::__view__|x@@w~1).>(test::name)[IS std::str]"
+                    "(__derived__::__derived__|x@@w~1)\
+.>(test::name)[IS std::str]"
                 }
             }
         }
@@ -590,9 +593,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(_::__view__|_@@w~2)": {
+            "(__derived__::__derived__|_@@w~2)": {
                 "FENCE": {
-                    "(_::__view__|A@@w~1)",
+                    "(__derived__::__derived__|A@@w~1)",
                     "(test::User)"
                 }
             }
@@ -619,7 +622,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(_::__view__|letter@@w~1)",
+                "(__derived__::__derived__|letter@@w~1)",
                 "(test::User).>(test::select_deck)[IS test::Card]",
                 "FENCE": {
                     "(test::User).>(test::deck)[IS test::Card]",
@@ -655,7 +658,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(_::__view__|foo@@w~2)": {
+                "(__derived__::__derived__|foo@@w~2)": {
                     "FENCE": {
                         "(test::User).>(test::deck)[IS test::Card]",
                         "FENCE": {
@@ -664,7 +667,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                         }
                     }
                 },
-                "(_::__view__|letter@@w~1)",
+                "(__derived__::__derived__|letter@@w~1)",
                 "(test::User).>(test::select_deck)[IS test::Card]"
             },
             "FENCE": {

--- a/tests/test_edgeql_utils.py
+++ b/tests/test_edgeql_utils.py
@@ -53,7 +53,7 @@ class TestEdgeQLUtils(tb.BaseSyntaxTest):
     def setUpClass(cls):
         super().setUpClass()
         cls.schema = s_std.load_std_schema()
-        s_decl.parse_module_declarations(
+        cls.schema = s_decl.parse_module_declarations(
             cls.schema, [('test', cls.SCHEMA)])
 
     def _assert_normalize_expr(self, text, expected,

--- a/tests/test_graphql_translator.py
+++ b/tests/test_graphql_translator.py
@@ -85,7 +85,7 @@ class TranslatorTest(tb.BaseSyntaxTest, metaclass=BaseSchemaTestMeta):
         super().setUpClass()
         cls.schema = s_std.load_std_schema()
         cls.schema = s_std.load_graphql_schema(cls.schema)
-        s_decl.parse_module_declarations(cls.schema, cls._decls)
+        cls.schema = s_decl.parse_module_declarations(cls.schema, cls._decls)
 
     def run_test(self, *, source, spec, expected=None):
         debug = bool(os.environ.get('DEBUG_GRAPHQL'))


### PR DESCRIPTION
This is the culmination of the schema immutability effort.  Data for
schema item fields, as well as all schema indexes are now using
`immutable.Map`, and every schema mutation now returns a schema copy.

This change allows us to do things like durable schema snapshots in
transactions, as well as free schema copies.

Co-authored-by: Yury Selivanov (@1st1)