### PR TITLE
schema: Prohibit reading and writing field data to non-existent items

### DIFF
--- a/edb/lang/edgeql/compiler/schemactx.py
+++ b/edb/lang/edgeql/compiler/schemactx.py
@@ -134,6 +134,21 @@ def derive_view(
             stype=stype, derived_name_quals=derived_name_quals,
             derived_name_base=derived_name_base, ctx=ctx)
 
+    if isinstance(stype, s_types.Type):
+        if is_insert:
+            vtype = s_types.ViewType.Insert
+        elif is_update:
+            vtype = s_types.ViewType.Update
+        else:
+            vtype = s_types.ViewType.Select
+
+        if attrs is None:
+            attrs = {}
+        else:
+            attrs = dict(attrs)
+
+        attrs['view_type'] = vtype
+
     if isinstance(stype, s_types.Collection):
         ctx.env.schema, derived = stype.derive_subtype(
             ctx.env.schema, name=derived_name)
@@ -159,16 +174,6 @@ def derive_view(
                     computable_data = ctx.source_map.get(src_ptr)
                     if computable_data is not None:
                         ctx.source_map[ptr] = computable_data
-
-    if isinstance(derived, s_types.Type):
-        if is_insert:
-            vtype = s_types.ViewType.Insert
-        elif is_update:
-            vtype = s_types.ViewType.Update
-        else:
-            vtype = s_types.ViewType.Select
-        ctx.env.schema = derived.set_field_value(
-            ctx.env.schema, 'view_type', vtype)
 
     if isinstance(derived, s_types.Type):
         ctx.view_nodes[derived.get_name(ctx.env.schema)] = derived

--- a/edb/lang/edgeql/compiler/viewgen.py
+++ b/edb/lang/edgeql/compiler/viewgen.py
@@ -626,11 +626,6 @@ def _compile_view_shapes_in_set(
         parent_view_type: typing.Optional[s_types.ViewType]=None,
         ctx: context.ContextLevel) -> None:
 
-    stype = ir_set.stype
-
-    is_mutation = stype.get_view_type(ctx.env.schema) in (
-        s_types.ViewType.Update, s_types.ViewType.Insert)
-
     shape_ptrs = _get_shape_configuration(
         ir_set, rptr=rptr, parent_view_type=parent_view_type, ctx=ctx)
 
@@ -649,6 +644,11 @@ def _compile_view_shapes_in_set(
                 pathctx.register_set_in_scope(ir_set, ctx=scopectx)
         else:
             pathctx.register_set_in_scope(ir_set, ctx=ctx)
+
+        stype = ir_set.stype
+
+        is_mutation = stype.get_view_type(ctx.env.schema) in (
+            s_types.ViewType.Update, s_types.ViewType.Insert)
 
         for path_tip, ptr in shape_ptrs:
             element = setgen.extend_path(

--- a/edb/lang/schema/nodes.py
+++ b/edb/lang/schema/nodes.py
@@ -40,10 +40,12 @@ class Node(inheriting.InheritingObject, s_types.Type):
 
     def derive_subtype(
             self, schema, *,
-            name: str) -> typing.Tuple[s_schema.Schema, s_types.Type]:
+            name: str,
+            attrs: typing.Optional[typing.Mapping]=None
+    ) -> typing.Tuple[s_schema.Schema, s_types.Type]:
 
         return type(self).create_in_schema_with_inheritance(
-            schema, name=name, bases=[self])
+            schema, name=name, bases=[self], **attrs)
 
     def peel_view(self, schema):
         if self.is_view(schema):
@@ -118,7 +120,7 @@ class NodeCommand(named.NamedObjectCommand):
             derived_delta.update(adds_mods)
             derived_delta.update(dels)
 
-            if ir.stype.is_view(schema):
+            if ir.stype.is_view(ir.schema):
                 for op in list(derived_delta.get_subcommands()):
                     if op.classname == cmd.classname:
                         for subop in op.get_subcommands():

--- a/edb/lang/schema/pseudo.py
+++ b/edb/lang/schema/pseudo.py
@@ -44,6 +44,12 @@ class Any(PseudoType):
     def get_name(self, schema):
         return self.name
 
+    def get__virtual_children(self, schema):
+        return None
+
+    def get_bases(self, schema):
+        return so.ObjectList.create_empty()
+
     def is_any(self):
         return True
 

--- a/edb/lang/schema/referencing.py
+++ b/edb/lang/schema/referencing.py
@@ -627,6 +627,7 @@ class ReferencingObject(inheriting.InheritingObject,
 
         for classref_key in classref_keys:
             local = local_classrefs.get(schema, classref_key, None)
+            local_schema = schema
 
             inherited = []
             for b in bases:
@@ -671,28 +672,28 @@ class ReferencingObject(inheriting.InheritingObject,
 
             if (local is not None and local is not merged and
                     requires_explicit_inherit and
-                    not local.get_declared_inherited(schema) and
+                    not local.get_declared_inherited(local_schema) and
                     dctx is not None and dctx.declarative):
                 # locally defined references *must* use
                 # the `inherited` keyword if ancestors have
                 # a reference under the same name.
                 raise s_err.SchemaDefinitionError(
                     f'{self.get_shortname(schema)}: '
-                    f'{local.get_shortname(schema)} must be '
+                    f'{local.get_shortname(local_schema)} must be '
                     f'declared using the `inherited` keyword because '
                     f'it is defined in the following ancestor(s): '
                     f'{", ".join(a.get_shortname(schema) for a in ancestry)}',
-                    context=local.get_sourcectx(schema)
+                    context=local.get_sourcectx(local_schema)
                 )
 
             if (merged is local and local is not None and
-                    local.get_declared_inherited(schema)):
+                    local.get_declared_inherited(local_schema)):
                 raise s_err.SchemaDefinitionError(
                     f'{self.get_shortname(schema)}: '
-                    f'{local.get_shortname(schema)} cannot '
+                    f'{local.get_shortname(local_schema)} cannot '
                     f'be declared `inherited` as there are no ancestors '
                     f'defining it.',
-                    context=local.get_sourcectx(schema)
+                    context=local.get_sourcectx(local_schema)
                 )
 
             if merged is not local:
@@ -700,7 +701,7 @@ class ReferencingObject(inheriting.InheritingObject,
                     if dctx is not None:
                         delta = merged.delta(local, merged,
                                              context=None,
-                                             old_schema=schema,
+                                             old_schema=local_schema,
                                              new_schema=schema)
                         if delta.has_subcommands():
                             dctx.current().op.add(delta)

--- a/edb/lang/schema/schema.py
+++ b/edb/lang/schema/schema.py
@@ -106,7 +106,9 @@ class Schema:
         try:
             d = self._id_to_data[obj_id]
         except KeyError:
-            return None
+            err = (f'cannot get {field!r} value: item {str(obj_id)!r} '
+                   f'is not present in the schema {self!r}')
+            raise s_err.SchemaError(err) from None
 
         return d.get(field)
 
@@ -114,7 +116,9 @@ class Schema:
         try:
             data = self._id_to_data[obj_id]
         except KeyError:
-            data = immu.Map()
+            err = (f'cannot set {field!r} value: item {str(obj_id)!r} '
+                   f'is not present in the schema {self!r}')
+            raise s_err.SchemaError(err) from None
 
         name_to_id = None
         if field == 'name':

--- a/edb/server/pgsql/backend.py
+++ b/edb/server/pgsql/backend.py
@@ -286,7 +286,7 @@ class Backend:
                 subdesc = self._describe_type(
                     schema, ptr.get_target(schema), view_shapes, _tuples)
                 subdesc.cardinality = (
-                    '1' if ptr.singular(self.schema) else '*'
+                    '1' if ptr.singular(schema) else '*'
                 )
                 subtypes.append(subdesc)
                 element_names.append(ptr.get_shortname(schema).name)
@@ -298,7 +298,7 @@ class Backend:
                     subdesc = self._describe_type(
                         schema, ptr.get_target(schema), view_shapes, _tuples)
                     subdesc.cardinality = (
-                        '1' if ptr.singular(self.schema) else '*'
+                        '1' if ptr.singular(schema) else '*'
                     )
                     subtypes.append(subdesc)
                     element_names.append(ptr.get_shortname(schema).name)

--- a/edb/server/pgsql/delta.py
+++ b/edb/server/pgsql/delta.py
@@ -495,17 +495,18 @@ class DeleteFunction(
         FunctionCommand, DeleteNamedObject, adapts=s_funcs.DeleteFunction):
 
     def apply(self, schema, context):
+        orig_schema = schema
         schema, func = super().apply(schema, context)
 
-        if func.get_code(schema):
+        if func.get_code(orig_schema):
             # An EdgeQL or a SQL function
             # (not just an alias to a SQL function).
 
-            variadic = func.get_params(schema).find_variadic(schema)
+            variadic = func.get_params(orig_schema).find_variadic(orig_schema)
             self.pgops.add(
                 dbops.DropFunction(
-                    name=self.get_pgname(func, schema),
-                    args=self.compile_args(func, schema),
+                    name=self.get_pgname(func, orig_schema),
+                    args=self.compile_args(func, orig_schema),
                     has_variadic=variadic is not None,
                 )
             )
@@ -1029,7 +1030,7 @@ class DeleteScalarType(ScalarTypeMetaCommand,
                 table=table, condition=[(
                     'name', str(self.classname))]))
 
-        if self.is_sequence(schema, scalar):
+        if self.is_sequence(orig_schema, scalar):
             seq_name = common.get_backend_name(
                 orig_schema, scalar, catenate=False, aspect='sequence')
             self.pgops.add(dbops.DropSequence(name=seq_name))


### PR DESCRIPTION
If an item does not exist in the schema, all get- and set- operations on
its fields must fail.