### PR TITLE
Minimize the number of SQL statements in std bootstrap and cache them

### DIFF
--- a/edb/lang/common/devmode.py
+++ b/edb/lang/common/devmode.py
@@ -1,0 +1,101 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2011-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import hashlib
+import logging
+import os
+import pathlib
+import pickle
+import tempfile
+import typing
+
+
+logger = logging.getLogger('edb.devmode.cache')
+
+
+def enable_dev_mode():
+    os.environ['__EDGEDB_DEVMODE'] = '1'
+
+
+def is_in_dev_mode() -> bool:
+    devmode = os.environ.get('__EDGEDB_DEVMODE', '0')
+    return devmode.lower() not in ('0', '', 'false')
+
+
+def get_dev_mode_cache_dir() -> os.PathLike:
+    if is_in_dev_mode():
+        root = pathlib.Path(__file__).parent.parent.parent.parent
+        cache_dir = (root / 'build' / 'cache')
+        cache_dir.mkdir(exist_ok=True)
+        return cache_dir
+    else:
+        raise RuntimeError('server is not running in dev mode')
+
+
+def read_dev_mode_cache(cache_key, path):
+    full_path = get_dev_mode_cache_dir() / path
+
+    if full_path.exists():
+        with open(full_path, 'rb') as f:
+            src_hash = f.read(16)
+            if src_hash == cache_key:
+                try:
+                    return pickle.load(f)
+                except Exception:
+                    logging.exception(f'could not unpickle {path}')
+
+
+def write_dev_mode_cache(obj, cache_key, path):
+    full_path = get_dev_mode_cache_dir() / path
+
+    try:
+        with tempfile.NamedTemporaryFile(
+                mode='wb', dir=full_path.parent, delete=False) as f:
+            f.write(cache_key)
+            pickle.dump(obj, file=f, protocol=pickle.HIGHEST_PROTOCOL)
+    except Exception:
+        try:
+            os.unlink(f.name)
+        except OSError:
+            pass
+        finally:
+            raise
+    else:
+        os.rename(f.name, full_path)
+
+
+def hash_dirs(dirs: typing.Tuple[str, str]) -> bytes:
+    def hash_dir(dirname, ext, paths):
+        with os.scandir(dirname) as it:
+            for entry in it:
+                if entry.is_file() and entry.name.endswith(ext):
+                    paths.append(entry.path)
+                elif entry.is_dir():
+                    hash_dir(entry.path, ext, paths)
+
+    paths = []
+    for dirname, ext in dirs:
+        hash_dir(dirname, ext, paths)
+
+    h = hashlib.md5()
+    for path in sorted(paths):
+        with open(path, 'rb') as f:
+            h.update(f.read())
+
+    return h.digest()

--- a/edb/lib/.gitignore
+++ b/edb/lib/.gitignore
@@ -1,1 +1,0 @@
-.schema.pickle

--- a/edb/repl/__init__.py
+++ b/edb/repl/__init__.py
@@ -42,6 +42,7 @@ from prompt_toolkit.layout import lexers as pt_lexers
 
 from edb import client
 from edb.lang.common import datetime
+from edb.lang.common import devmode
 from edb.lang.common import lexer as core_lexer
 from edb.lang.common import markup
 from edb.lang.common.markup.renderers import terminal as markup_term
@@ -504,5 +505,5 @@ def main():
 
 
 def main_dev():
-    edgedb_cluster.enable_dev_mode()
+    devmode.enable_dev_mode()
     main()

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -31,6 +31,7 @@ import sys
 import click
 from asyncpg import cluster as pg_cluster
 
+from edb.lang.common import devmode
 from edb.lang.common import exceptions
 
 from . import cluster as edgedb_cluster
@@ -126,7 +127,7 @@ def _run_server(cluster, args):
 
 
 def run_server(args):
-    if edgedb_cluster.is_in_dev_mode():
+    if devmode.is_in_dev_mode():
         logger.info('EdgeDB server starting in DEV mode.')
     else:
         logger.info('EdgeDB server starting.')
@@ -135,7 +136,7 @@ def run_server(args):
     pg_cluster_started_by_us = False
 
     try:
-        if args['data_dir']:
+        if not args['postgres']:
             server_settings = {
                 'log_connections': 'yes',
                 'log_statement': 'all',
@@ -187,6 +188,7 @@ def run_server(args):
 
         else:
             cluster = pg_cluster.RunningCluster(dsn=args['postgres'])
+            cluster._data_dir = args['data_dir']
 
         if args['bootstrap']:
             _init_cluster(cluster, args)
@@ -272,5 +274,5 @@ def main(**kwargs):
 
 
 def main_dev():
-    edgedb_cluster.enable_dev_mode()
+    devmode.enable_dev_mode()
     main()

--- a/edb/server/protocol.py
+++ b/edb/server/protocol.py
@@ -275,7 +275,8 @@ class Protocol(asyncio.Protocol):
             self.send_error(e)
             return
 
-        fut = self._loop.create_task(backend.open_database(self.pgconn))
+        fut = self._loop.create_task(backend.open_database(
+            self.pgconn, self._pg_cluster.get_data_dir()))
 
         fut.add_done_callback(self._on_edge_connect)
 

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -19,9 +19,9 @@
 
 import click
 
-from edb.server import cluster
+from edb.lang.common import devmode
 
 
 @click.group()
 def edbcommands():
-    cluster.enable_dev_mode()
+    devmode.enable_dev_mode()


### PR DESCRIPTION
Bundling the entire std bootstrap sequence into a single script block
allows for somewhat faster execution and makes it easier to cache the
script.  Additionally, the std schema pickle is now cached in the data
directory.