### PR TITLE
Restrict usage of abstract scalars and anytype.

### DIFF
--- a/edb/lang/edgeql/compiler/inference/types.py
+++ b/edb/lang/edgeql/compiler/inference/types.py
@@ -298,7 +298,16 @@ def __infer_typeref(ir, env):
 
 @_infer_type.register(irast.TypeCast)
 def __infer_typecast(ir, env):
-    return infer_type(ir.type, env)
+    stype = infer_type(ir.type, env)
+
+    # is_polymorphic is synonymous to get_is_abstract for scalars
+    if stype.is_polymorphic(env.schema):
+        raise ql_errors.EdgeQLError(
+            f'cannot cast into an abstract scalar '
+            f'{stype.get_displayname(env.schema)}',
+            context=ir.context)
+
+    return stype
 
 
 @_infer_type.register(irast.Stmt)

--- a/edb/lang/edgeql/compiler/schemactx.py
+++ b/edb/lang/edgeql/compiler/schemactx.py
@@ -29,6 +29,7 @@ from edb.lang.schema import name as sn
 from edb.lang.schema import nodes as s_nodes
 from edb.lang.schema import objects as s_obj
 from edb.lang.schema import pointers as s_pointers
+from edb.lang.schema import pseudo as s_pseudo
 from edb.lang.schema import sources as s_sources
 from edb.lang.schema import types as s_types
 from edb.lang.schema import utils as s_utils
@@ -51,6 +52,8 @@ def get_schema_object(
             srcctx = name.context
         module = name.module
         name = name.name
+    elif isinstance(name, qlast.AnyType):
+        return s_pseudo.Any.create()
 
     if module:
         name = sn.Name(name=name, module=module)

--- a/edb/lang/edgeql/compiler/typegen.py
+++ b/edb/lang/edgeql/compiler/typegen.py
@@ -106,6 +106,12 @@ def _ql_typeref_to_ir_typeref(
             typ.subtypes.append(subtype)
     else:
         styp = schemactx.get_schema_type(maintype, ctx=ctx)
+
+        if styp.contains_any():
+            raise errors.EdgeQLSyntaxError(
+                f"Unexpected 'anytype'",
+                context=maintype.context)
+
         typ = irast.TypeRef(
             maintype=styp.get_name(ctx.env.schema),
             subtypes=[]

--- a/edb/lang/edgeql/parser/grammar/expressions.py
+++ b/edb/lang/edgeql/parser/grammar/expressions.py
@@ -1264,7 +1264,7 @@ class TypeExpr(Nonterm):
         self.val = kids[0].val
 
     def reduce_TYPEOF_Expr(self, *kids):
-        self.val = qlast.TypeOf(expr=kids[0].val)
+        self.val = qlast.TypeOf(expr=kids[1].val)
 
     def reduce_LPAREN_FullTypeExpr_RPAREN(self, *kids):
         self.val = kids[1].val

--- a/edb/lang/schema/pseudo.py
+++ b/edb/lang/schema/pseudo.py
@@ -50,6 +50,9 @@ class Any(PseudoType):
     def get_bases(self, schema):
         return so.ObjectList.create_empty()
 
+    def get_is_abstract(self, schema):
+        return True
+
     def is_any(self):
         return True
 

--- a/edb/lang/schema/scalars.py
+++ b/edb/lang/schema/scalars.py
@@ -82,8 +82,7 @@ class ScalarType(nodes.Node, constraints.ConsistencySubject,
         return True
 
     def is_polymorphic(self, schema):
-        return bool(self.get_is_abstract(schema) and
-                    self.get_name(schema).module == 'std')
+        return self.get_is_abstract(schema)
 
     def _resolve_polymorphic(self, schema, concrete_type: s_types.Type):
         if (self.is_polymorphic(schema) and

--- a/edb/lang/schema/types.py
+++ b/edb/lang/schema/types.py
@@ -80,6 +80,9 @@ class Type(so.NamedObject, derivable.DerivableObjectBase):
     def is_any(self):
         return False
 
+    def contains_any(self):
+        return self.is_any()
+
     def is_scalar(self):
         return False
 
@@ -210,6 +213,9 @@ class Collection(Type):
     def is_polymorphic(self, schema):
         return any(st.is_polymorphic(schema)
                    for st in self.get_subtypes())
+
+    def contains_any(self):
+        return any(st.contains_any() for st in self.get_subtypes())
 
     @property
     def is_virtual(self):

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -1027,13 +1027,14 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 );
             ''')
 
+    @unittest.expectedFailure
     async def test_edgeql_calls_29(self):
         await self.con.execute('''
             CREATE FUNCTION test::call29(
                 a: anyint
             ) -> anyint
                 FROM EdgeQL $$
-                    SELECT a + <anyint>1
+                    SELECT a + 1
                 $$;
         ''')
 

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -1,0 +1,82 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2018-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import unittest  # NOQA
+
+from edb.client import exceptions as exc
+from edb.server import _testbase as tb
+
+
+class TestEdgeQLCasts(tb.QueryTestCase):
+    # casting into an abstract scalar should be illegal
+    async def test_edgeql_casts_illegal_01(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLSyntaxError, r"Unexpected 'anytype'"):
+            await self.con.execute("""
+                SELECT <anytype>123;
+            """)
+
+    async def test_edgeql_casts_illegal_02(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLError, r'cannot cast.*abstract'):
+            await self.con.execute("""
+                SELECT <anyscalar>123;
+            """)
+
+    async def test_edgeql_casts_illegal_03(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLError, r'cannot cast.*abstract'):
+            await self.con.execute("""
+                SELECT <anyreal>123;
+            """)
+
+    async def test_edgeql_casts_illegal_04(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLError, r'cannot cast.*abstract'):
+            await self.con.execute("""
+                SELECT <anyint>123;
+            """)
+
+    async def test_edgeql_casts_illegal_05(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLError, r'cannot cast.*abstract'):
+            await self.con.execute("""
+                SELECT <anyfloat>123;
+            """)
+
+    async def test_edgeql_casts_illegal_06(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLError, r'cannot cast.*abstract'):
+            await self.con.execute("""
+                SELECT <sequence>123;
+            """)
+
+    async def test_edgeql_casts_illegal_07(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLSyntaxError, r"Unexpected 'anytype'"):
+            await self.con.execute("""
+                SELECT <array<anytype>>[123];
+            """)
+
+    async def test_edgeql_casts_illegal_08(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLSyntaxError, r"Unexpected 'anytype'"):
+            await self.con.execute("""
+                SELECT <tuple<int64, anytype>>(123, 123);
+            """)

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -4438,3 +4438,194 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         ''', [
             [True],
         ])
+
+    async def test_edgeql_select_is_01(self):
+        await self.assert_query_result(r'''
+            SELECT 5 IS int64;
+            SELECT 5 IS anyint;
+            SELECT 5 IS anyreal;
+            SELECT 5 IS anyscalar;
+            SELECT 5 IS int16;
+            SELECT 5 IS float64;
+            SELECT 5 IS anyfloat;
+            SELECT 5 IS str;
+            SELECT 5 IS Object;
+        ''', [
+            [True],
+            [True],
+            [True],
+            [True],
+            [False],
+            [False],
+            [False],
+            [False],
+            [False],
+        ])
+
+    async def test_edgeql_select_is_02(self):
+        await self.assert_query_result(r'''
+            SELECT 5.5 IS int64;
+            SELECT 5.5 IS anyint;
+            SELECT 5.5 IS anyreal;
+            SELECT 5.5 IS anyscalar;
+            SELECT 5.5 IS int16;
+            SELECT 5.5 IS float64;
+            SELECT 5.5 IS anyfloat;
+            SELECT 5.5 IS str;
+            SELECT 5.5 IS Object;
+        ''', [
+            [False],
+            [False],
+            [True],
+            [True],
+            [False],
+            [True],
+            [True],
+            [False],
+            [False],
+        ])
+
+    async def test_edgeql_select_is_03(self):
+        await self.assert_query_result(r'''
+            SET MODULE test;
+
+            SELECT Issue.time_estimate IS int64 LIMIT 1;
+            SELECT Issue.time_estimate IS anyint LIMIT 1;
+            SELECT Issue.time_estimate IS anyreal LIMIT 1;
+            SELECT Issue.time_estimate IS anyscalar LIMIT 1;
+            SELECT Issue.time_estimate IS int16 LIMIT 1;
+            SELECT Issue.time_estimate IS float64 LIMIT 1;
+            SELECT Issue.time_estimate IS anyfloat LIMIT 1;
+            SELECT Issue.time_estimate IS str LIMIT 1;
+            SELECT Issue.time_estimate IS Object LIMIT 1;
+        ''', [
+            None,
+            [True],
+            [True],
+            [True],
+            [True],
+            [False],
+            [False],
+            [False],
+            [False],
+            [False],
+        ])
+
+    async def test_edgeql_select_is_04(self):
+        await self.assert_query_result(r'''
+            SET MODULE test;
+
+            SELECT Issue.number IS int64 LIMIT 1;
+            SELECT Issue.number IS anyint LIMIT 1;
+            SELECT Issue.number IS anyreal LIMIT 1;
+            SELECT Issue.number IS anyscalar LIMIT 1;
+            SELECT Issue.number IS int16 LIMIT 1;
+            SELECT Issue.number IS float64 LIMIT 1;
+            SELECT Issue.number IS anyfloat LIMIT 1;
+            SELECT Issue.number IS str LIMIT 1;
+            SELECT Issue.number IS Object LIMIT 1;
+        ''', [
+            None,
+            [False],
+            [False],
+            [False],
+            [True],
+            [False],
+            [False],
+            [False],
+            [True],
+            [False],
+        ])
+
+    async def test_edgeql_select_is_05(self):
+        await self.assert_query_result(r'''
+            SET MODULE test;
+
+            SELECT Issue.status IS int64 LIMIT 1;
+            SELECT Issue.status IS anyint LIMIT 1;
+            SELECT Issue.status IS anyreal LIMIT 1;
+            SELECT Issue.status IS anyscalar LIMIT 1;
+            SELECT Issue.status IS int16 LIMIT 1;
+            SELECT Issue.status IS float64 LIMIT 1;
+            SELECT Issue.status IS anyfloat LIMIT 1;
+            SELECT Issue.status IS str LIMIT 1;
+            SELECT Issue.status IS Object LIMIT 1;
+        ''', [
+            None,
+            [False],
+            [False],
+            [False],
+            [False],
+            [False],
+            [False],
+            [False],
+            [False],
+            [True],
+        ])
+
+    async def test_edgeql_select_is_06(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLSyntaxError, r"Unexpected 'anytype'"):
+            await self.con.execute(r'''
+                SELECT 5 IS anytype;
+            ''')
+
+    async def test_edgeql_select_is_07(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLSyntaxError, r"Unexpected 'anytype'"):
+            await self.con.execute(r'''
+                SELECT 5.5 IS anytype;
+            ''')
+
+    async def test_edgeql_select_is_08(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLSyntaxError, r"Unexpected 'anytype'"):
+            await self.con.execute(r'''
+                SELECT '5.5' IS anytype;
+            ''')
+
+    async def test_edgeql_select_is_09(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLSyntaxError, r"Unexpected 'anytype'"):
+            await self.con.execute(r'''
+                SELECT test::Issue.time_estimate IS anytype LIMIT 1;
+            ''')
+
+    async def test_edgeql_select_is_10(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLSyntaxError, r"Unexpected 'anytype'"):
+            await self.con.execute(r'''
+                SELECT test::Issue.number IS anytype LIMIT 1;
+            ''')
+
+    async def test_edgeql_select_is_11(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLSyntaxError, r"Unexpected 'anytype'"):
+            await self.con.execute(r'''
+                SELECT test::Issue.status IS anytype LIMIT 1;
+            ''')
+
+    async def test_edgeql_select_is_12(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLSyntaxError, r"Unexpected 'anytype'"):
+            await self.con.execute(r'''
+                SELECT [5] IS (array<anytype>);
+            ''')
+
+    async def test_edgeql_select_is_13(self):
+        with self.assertRaisesRegex(
+                exc.EdgeQLSyntaxError, r"Unexpected 'anytype'"):
+            await self.con.execute(r'''
+                SELECT (5, 'hello') IS (tuple<anytype, str>);
+            ''')
+
+    # FIXME: IS doesn't work for arrays and tuples
+    @unittest.expectedFailure
+    async def test_edgeql_select_is_14(self):
+        await self.assert_query_result(r'''
+            SELECT [5] IS (array<int64>);
+            SELECT (5, 'hello') IS (tuple<int64, str>);
+        ''', [
+            [True],
+            [True],
+        ])


### PR DESCRIPTION
Casting into an abstract scalar or anytype is now forbidden.

Technically anytype is a valid type that is the supertype for both
anyscalar and Object. It is legal to use it in any place where a type is
expected. However, in most places that would create an illegal
expression, such as an illegal cast to an abstract scalar (via either
<anytype> or [IS anytype]). It is also illegal to use anytype in
EXTENDING clause (it creates ambiguity w.r.t. how the list of base types
is linearized). It is legal when anytype appears in function
signature definitions or as the type expression in IS operator.

Anytype cannot be a link or property target for the same reason as
anyscalar: the current implementation in unable to support this kind of
polymorphism (unlike object polymorphism).

Anytype is also special in the fact that it doesn't have a corresponding
entry in the schema module (no Type object).