### PR TITLE
Add schema.abc module with most of schema abstract base types

### DIFF
--- a/edb/lang/edgeql/compiler/expr.py
+++ b/edb/lang/edgeql/compiler/expr.py
@@ -29,9 +29,9 @@ from edb.lang.ir import ast as irast
 from edb.lang.ir import staeval as ireval
 from edb.lang.ir import utils as irutils
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import objtypes as s_objtypes
 from edb.lang.schema import pointers as s_pointers
-from edb.lang.schema import types as s_types
 from edb.lang.schema import utils as s_utils
 
 from edb.lang.edgeql import ast as qlast
@@ -334,7 +334,7 @@ def compile_Array(
     elements = [dispatch.compile(e, ctx=ctx) for e in expr.elements]
     # check that none of the elements are themselves arrays
     for el, expr_el in zip(elements, expr.elements):
-        if isinstance(inference.infer_type(el, ctx.env), s_types.Array):
+        if isinstance(inference.infer_type(el, ctx.env), s_abc.Array):
             raise errors.EdgeQLError(
                 f'nested arrays are not supported',
                 context=expr_el.context)
@@ -507,7 +507,7 @@ def _cast_expr(
     new_typeref = typegen.ql_typeref_to_ir_typeref(ql_type, ctx=ctx)
     json_t = ctx.env.schema.get('std::json')
 
-    if isinstance(orig_type, s_types.Tuple):
+    if isinstance(orig_type, s_abc.Tuple):
         if new_type.issubclass(ctx.env.schema, json_t):
             # Casting to std::json involves casting each tuple
             # element and also keeping the cast around the whole tuple.
@@ -544,7 +544,7 @@ def _cast_expr(
         else:
             # For tuple-to-tuple casts we generate a new tuple
             # to simplify things on sqlgen side.
-            if not isinstance(new_type, s_types.Tuple):
+            if not isinstance(new_type, s_abc.Tuple):
                 raise errors.EdgeQLError(
                     f'cannot cast tuple to '
                     f'{new_type.get_name(ctx.env.schema)}',
@@ -592,7 +592,7 @@ def _cast_expr(
             isinstance(ir_expr.expr, irast.Array)):
         if new_type.issubclass(ctx.env.schema, json_t):
             el_type = ql_type
-        elif not isinstance(new_type, s_types.Array):
+        elif not isinstance(new_type, s_abc.Array):
             raise errors.EdgeQLError(
                 f'cannot cast array to {new_type.get_name(ctx.env.schema)}',
                 context=source_context)
@@ -710,7 +710,7 @@ def compile_set_op(
     left_type = inference.infer_type(left, ctx.env)
     right_type = inference.infer_type(right, ctx.env)
 
-    if left_type != right_type and isinstance(left_type, s_types.Collection):
+    if left_type != right_type and isinstance(left_type, s_abc.Collection):
         common_type = left_type.find_common_implicitly_castable_type(
             right_type, ctx.env.schema)
 

--- a/edb/lang/edgeql/compiler/inference/types.py
+++ b/edb/lang/edgeql/compiler/inference/types.py
@@ -22,6 +22,7 @@ import typing
 
 from edb.lang.common import ast
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import inheriting as s_inh
 from edb.lang.schema import name as s_name
 from edb.lang.schema import objects as s_obj
@@ -64,7 +65,7 @@ def _infer_common_type(irs: typing.List[irast.Base], env):
             continue
 
         t = infer_type(arg, env)
-        if isinstance(t, s_types.Collection):
+        if isinstance(t, s_abc.Collection):
             seen_coll = True
         elif isinstance(t, s_scalars.ScalarType):
             seen_scalar = True
@@ -157,7 +158,7 @@ def __infer_setop(ir, env):
 
     assert ir.op == qlast.UNION
 
-    if isinstance(left_type, (s_scalars.ScalarType, s_types.Collection)):
+    if isinstance(left_type, (s_scalars.ScalarType, s_abc.Collection)):
         result = left_type.find_common_implicitly_castable_type(
             right_type, env.schema)
 
@@ -338,7 +339,7 @@ def __infer_slice(ir, env):
         base_name = 'json array'
     elif node_type.issubclass(env.schema, bytes_t):
         base_name = 'bytes'
-    elif isinstance(node_type, s_types.Array):
+    elif isinstance(node_type, s_abc.Array):
         base_name = 'array'
     elif node_type.is_any():
         base_name = 'anytype'
@@ -407,7 +408,7 @@ def __infer_index(ir, env):
 
         result = json_t
 
-    elif isinstance(node_type, s_types.Array):
+    elif isinstance(node_type, s_abc.Array):
 
         if not index_type.implicitly_castable_to(int_t, env.schema):
             raise ql_errors.EdgeQLError(

--- a/edb/lang/edgeql/compiler/schemactx.py
+++ b/edb/lang/edgeql/compiler/schemactx.py
@@ -24,6 +24,7 @@ import typing
 
 from edb.lang.common import parsing
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import error as s_err
 from edb.lang.schema import name as sn
 from edb.lang.schema import nodes as s_nodes
@@ -137,7 +138,7 @@ def derive_view(
             stype=stype, derived_name_quals=derived_name_quals,
             derived_name_base=derived_name_base, ctx=ctx)
 
-    if isinstance(stype, s_types.Type):
+    if isinstance(stype, s_abc.Type):
         if is_insert:
             vtype = s_types.ViewType.Insert
         elif is_update:
@@ -152,7 +153,7 @@ def derive_view(
 
         attrs['view_type'] = vtype
 
-    if isinstance(stype, s_types.Collection):
+    if isinstance(stype, s_abc.Collection):
         ctx.env.schema, derived = stype.derive_subtype(
             ctx.env.schema, name=derived_name)
     else:
@@ -177,7 +178,7 @@ def derive_view(
                     if computable_data is not None:
                         ctx.source_map[ptr] = computable_data
 
-    if isinstance(derived, s_types.Type):
+    if isinstance(derived, s_abc.Type):
         ctx.view_nodes[derived.get_name(ctx.env.schema)] = derived
 
     return derived

--- a/edb/lang/edgeql/compiler/setgen.py
+++ b/edb/lang/edgeql/compiler/setgen.py
@@ -29,6 +29,7 @@ from edb.lang.common import parsing
 from edb.lang.ir import ast as irast
 from edb.lang.ir import utils as irutils
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import expr as s_expr
 from edb.lang.schema import links as s_links
 from edb.lang.schema import name as s_name
@@ -184,7 +185,7 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
                 source = path_tip.stype
 
             with ctx.newscope(fenced=True, temporary=True) as subctx:
-                if isinstance(source, s_types.Tuple):
+                if isinstance(source, s_abc.Tuple):
                     path_tip = tuple_indirection_set(
                         path_tip, source=source, ptr_name=ptr_name,
                         source_context=step.context, ctx=subctx)

--- a/edb/lang/edgeql/compiler/stmtctx.py
+++ b/edb/lang/edgeql/compiler/stmtctx.py
@@ -29,6 +29,7 @@ from edb.lang.edgeql import errors
 
 from edb.lang.ir import ast as irast
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import functions as s_func
 from edb.lang.schema import modules as s_mod
 from edb.lang.schema import name as s_name
@@ -163,7 +164,7 @@ def compile_anchor(
 
     show_as_anchor = True
 
-    if isinstance(anchor, s_types.Type):
+    if isinstance(anchor, s_abc.Type):
         step = setgen.class_set(anchor, ctx=ctx)
 
     elif (isinstance(anchor, s_pointers.Pointer) and

--- a/edb/lang/edgeql/compiler/typegen.py
+++ b/edb/lang/edgeql/compiler/typegen.py
@@ -25,6 +25,7 @@ import typing
 
 from edb.lang.ir import ast as irast
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import objects as s_obj
 from edb.lang.schema import types as s_types
 
@@ -37,7 +38,7 @@ from . import schemactx
 
 def type_to_ql_typeref(t: s_obj.Object, *,
                        ctx: context.ContextLevel) -> qlast.TypeName:
-    if not isinstance(t, s_types.Collection):
+    if not isinstance(t, s_abc.Collection):
         result = qlast.TypeName(
             maintype=qlast.ObjectRef(
                 module=t.get_name(ctx.env.schema).module,
@@ -127,7 +128,7 @@ def ql_typeref_to_type(
         coll = s_types.Collection.get_class(
             ql_t.maintype.name)
 
-        if issubclass(coll, s_types.Tuple):
+        if issubclass(coll, s_abc.Tuple):
             subtypes = collections.OrderedDict()
             named = False
             for si, st in enumerate(ql_t.subtypes):

--- a/edb/lang/graphql/types.py
+++ b/edb/lang/graphql/types.py
@@ -44,9 +44,9 @@ from edb.lang.edgeql import ast as qlast
 from edb.lang.edgeql import codegen
 from edb.lang.edgeql.parser import parse_fragment
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import modules as s_mod
 from edb.lang.schema import pointers as s_pointers
-from edb.lang.schema import types as s_types
 from edb.lang.schema import objtypes as s_objtypes
 from edb.lang.schema import scalars as s_scalars
 
@@ -131,7 +131,7 @@ class GQLCoreSchema:
 
         # only arrays can be validly wrapped, other containers don't
         # produce a valid graphql type
-        if isinstance(edb_target, s_types.Array):
+        if isinstance(edb_target, s_abc.Array):
             el_type = self._convert_edb_type(edb_target.element_type)
             if el_type:
                 target = GraphQLList(GraphQLNonNull(el_type))

--- a/edb/lang/ir/pathid.py
+++ b/edb/lang/ir/pathid.py
@@ -16,11 +16,11 @@
 # limitations under the License.
 #
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import name as sn
 from edb.lang.schema import objtypes as s_objtypes
 from edb.lang.schema import pointers as s_pointers
 from edb.lang.schema import scalars as s_scalars
-from edb.lang.schema import types as s_types
 
 
 class PathId:
@@ -53,7 +53,7 @@ class PathId:
     @classmethod
     def from_type(cls, schema, initializer, *, namespace=None, typename=None):
         pid = cls()
-        if not isinstance(initializer, s_types.Type):
+        if not isinstance(initializer, s_abc.Type):
             raise ValueError(
                 f'invalid PathId: bad source: {initializer!r}')
         pid._path = (initializer,)

--- a/edb/lang/schema/abc.py
+++ b/edb/lang/schema/abc.py
@@ -1,0 +1,69 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+class Object:
+    pass
+
+
+class Database(Object):
+    pass
+
+
+class Delta(Object):
+    pass
+
+
+class Constraint(Object):
+    pass
+
+
+class Function(Object):
+    pass
+
+
+class Operator(Object):
+    pass
+
+
+class Parameter(Object):
+    pass
+
+
+class Type(Object):
+    pass
+
+
+class ScalarType(Type):
+    pass
+
+
+class ObjectType(Type):
+    pass
+
+
+class Collection(Type):
+    pass
+
+
+class Tuple(Collection):
+    pass
+
+
+class Array(Collection):
+    pass

--- a/edb/lang/schema/attributes.py
+++ b/edb/lang/schema/attributes.py
@@ -20,6 +20,7 @@
 
 from edb.lang.edgeql import ast as qlast
 
+from . import abc as s_abc
 from . import delta as sd
 from . import inheriting
 from . import name as sn
@@ -32,7 +33,9 @@ from . import utils
 
 class Attribute(inheriting.InheritingObject):
 
-    type = so.SchemaField(s_types.Type, compcoef=0.909)
+    type = so.SchemaField(
+        s_types.Type,
+        compcoef=0.909)
 
 
 class AttributeValue(inheriting.InheritingObject):
@@ -108,7 +111,7 @@ class CreateAttribute(AttributeCommand, named.CreateNamedObject):
     def _apply_field_ast(self, schema, context, node, op):
         if op.property == 'type':
             tp = op.new_value
-            if isinstance(tp, s_types.Collection):
+            if isinstance(tp, s_abc.Collection):
                 maintype = tp.schema_name
                 stt = tp.get_subtypes()
 

--- a/edb/lang/schema/constraints.py
+++ b/edb/lang/schema/constraints.py
@@ -24,6 +24,7 @@ from edb.lang.edgeql import ast as qlast
 from edb.lang.edgeql import errors as ql_errors
 from edb.lang.edgeql import functypes as ft
 
+from . import abc as s_abc
 from . import delta as sd
 from . import error as s_errors
 from . import expr as s_expr
@@ -37,7 +38,8 @@ from . import referencing
 from . import utils
 
 
-class Constraint(inheriting.InheritingObject, s_func.CallableObject):
+class Constraint(inheriting.InheritingObject, s_func.CallableObject,
+                 s_abc.Constraint):
 
     expr = so.SchemaField(
         s_expr.ExpressionText, default=None, compcoef=0.909,

--- a/edb/lang/schema/database.py
+++ b/edb/lang/schema/database.py
@@ -20,13 +20,14 @@
 from edb.lang.common import struct
 from edb.lang.edgeql import ast as qlast
 
+from . import abc as s_abc
 from . import delta as sd
 from . import modules
 from . import named
 from . import objects as so
 
 
-class Database(named.NamedObject):
+class Database(named.NamedObject, s_abc.Database):
     # Override 'name' to str type, since databases don't have
     # fully-qualified names.
     name = so.SchemaField(str)

--- a/edb/lang/schema/declarative.py
+++ b/edb/lang/schema/declarative.py
@@ -34,6 +34,7 @@ from edb.lang.edgeql.parser.grammar import lexutils as ql_lexutils
 from . import ast as s_ast
 from . import parser as s_parser
 
+from . import abc as s_abc
 from . import attributes as s_attrs
 from . import delta as s_delta
 from . import objtypes as s_objtypes
@@ -339,7 +340,7 @@ class DeclarationLoader:
                              for p in constraint_params.objects(self._schema)])
 
         for dep in list(deps):
-            if isinstance(dep, s_types.Collection):
+            if isinstance(dep, s_abc.Collection):
                 deps.update(dep.get_subtypes())
                 deps.discard(dep)
 
@@ -744,7 +745,7 @@ class DeclarationLoader:
                         f'is declared as "single"',
                         context=expr.context)
 
-        if (not isinstance(expr_type, s_types.Type) or
+        if (not isinstance(expr_type, s_abc.Type) or
                 (ptr.get_target(self._schema) is not None and
                  not expr_type.issubclass(
                     self._schema, ptr.get_target(self._schema)))):

--- a/edb/lang/schema/delta.py
+++ b/edb/lang/schema/delta.py
@@ -32,7 +32,7 @@ from . import utils
 
 
 def delta_schemas(schema1, schema2):
-    from . import modules, objects as so, database
+    from . import modules, database
     from . import derivable
 
     result = database.AlterDatabase()
@@ -82,7 +82,7 @@ def delta_schemas(schema1, schema2):
 
 
 def delta_module(schema1, schema2, modname):
-    from . import objects as so, database
+    from . import database
     from . import derivable
 
     result = database.AlterDatabase()

--- a/edb/lang/schema/deltas.py
+++ b/edb/lang/schema/deltas.py
@@ -22,13 +22,14 @@
 
 from edb.lang.edgeql import ast as qlast
 
+from . import abc as s_abc
 from . import ast as s_ast
 from . import delta as sd
 from . import named
 from . import objects as so
 
 
-class Delta(named.NamedObject):
+class Delta(named.NamedObject, s_abc.Delta):
     parents = so.SchemaField(
         so.ObjectList,
         default=so.ObjectList, coerce=True, inheritable=False)

--- a/edb/lang/schema/derivable.py
+++ b/edb/lang/schema/derivable.py
@@ -19,11 +19,12 @@
 
 from edb.lang.common import uuidgen
 
+from . import abc as s_abc
 from . import name as sn
 from . import objects as so
 
 
-class DerivableObjectBase:
+class DerivableObjectBase(s_abc.Object):
     # Override name field comparison coefficient on the
     # presumption that the derived names may be different,
     # but base names may be equal.

--- a/edb/lang/schema/functions.py
+++ b/edb/lang/schema/functions.py
@@ -25,6 +25,7 @@ from edb.lang.edgeql import errors as ql_errors
 from edb.lang.edgeql import codegen
 from edb.lang.edgeql import functypes as ft
 
+from . import abc as s_abc
 from . import delta as sd
 from . import expr
 from . import name as sn
@@ -170,7 +171,7 @@ class ParameterDesc(typing.NamedTuple):
         return cmd
 
 
-class Parameter(named.NamedObject):
+class Parameter(named.NamedObject, s_abc.Parameter):
 
     num = so.SchemaField(
         int, compcoef=0.4)
@@ -457,7 +458,7 @@ class CallableCommand(named.NamedObjectCommand):
         quals = []
         for param in pgp.params:
             pt = param.get_type(schema)
-            if isinstance(pt, s_types.Collection):
+            if isinstance(pt, s_abc.Collection):
                 quals.append(pt.schema_name)
                 for st in pt.get_subtypes():
                     quals.append(st.get_name(schema))
@@ -528,7 +529,7 @@ class DeleteCallableObject(named.DeleteNamedObject):
         return cmd
 
 
-class Function(CallableObject):
+class Function(CallableObject, s_abc.Function):
 
     code = so.SchemaField(
         str, default=None, compcoef=0.4)

--- a/edb/lang/schema/inheriting.py
+++ b/edb/lang/schema/inheriting.py
@@ -20,6 +20,7 @@
 from edb.lang.common import struct
 from edb.lang.edgeql import ast as qlast
 
+from . import abc as s_abc
 from . import delta as sd
 from . import derivable
 from . import error as s_err
@@ -252,7 +253,7 @@ def compute_mro(schema, obj):
 
 def create_virtual_parent(schema, children, *,
                           module_name=None, minimize_by=None):
-    from . import scalars as s_scalars, objtypes as s_objtypes, sources
+    from . import objtypes as s_objtypes, sources
 
     if len(children) == 1:
         return schema, next(iter(children))
@@ -290,7 +291,7 @@ def create_virtual_parent(schema, children, *,
     seen_objtypes = False
 
     for target in children:
-        if isinstance(target, s_scalars.ScalarType):
+        if isinstance(target, s_abc.ScalarType):
             if seen_objtypes:
                 raise s_err.SchemaError(
                     'cannot mix scalars and objects in link target list')

--- a/edb/lang/schema/objects.py
+++ b/edb/lang/schema/objects.py
@@ -32,6 +32,7 @@ from edb.lang.common import topological
 from edb.lang.common import typed
 from edb.lang.common import uuidgen
 
+from . import abc as s_abc
 from . import error as s_err
 from . import name as sn
 
@@ -282,7 +283,11 @@ class ObjectMeta(type):
                         self._get_schema_field_value(schema, _fn)
                 )
 
-        cls = super().__new__(mcls, name, bases, clsdict)
+        try:
+            cls = super().__new__(mcls, name, bases, clsdict)
+        except TypeError as ex:
+            raise TypeError(
+                f'Object metaclass has failed to create class {name}: {ex}')
 
         for parent in reversed(cls.__mro__):
             if parent is cls:
@@ -331,7 +336,7 @@ class FieldValueNotFoundError(Exception):
     pass
 
 
-class Object(metaclass=ObjectMeta):
+class Object(s_abc.Object, metaclass=ObjectMeta):
     """Base schema item class."""
 
     id = Field(

--- a/edb/lang/schema/objtypes.py
+++ b/edb/lang/schema/objtypes.py
@@ -19,6 +19,7 @@
 
 from edb.lang.edgeql import ast as qlast
 
+from . import abc as s_abc
 from . import constraints
 from . import delta as sd
 from . import inheriting
@@ -36,7 +37,8 @@ class BaseObjectType(sources.Source, nodes.Node):
     pass
 
 
-class ObjectType(BaseObjectType, constraints.ConsistencySubject):
+class ObjectType(BaseObjectType, constraints.ConsistencySubject,
+                 s_abc.ObjectType):
 
     def is_object_type(self):
         return True

--- a/edb/lang/schema/operators.py
+++ b/edb/lang/schema/operators.py
@@ -23,6 +23,7 @@ from edb.lang.edgeql import ast as qlast
 from edb.lang.edgeql import errors as ql_errors
 from edb.lang.edgeql import functypes as ft
 
+from . import abc as s_abc
 from . import delta as sd
 from . import functions as s_func
 from . import name as sn
@@ -31,7 +32,7 @@ from . import objects as so
 from . import utils
 
 
-class Operator(s_func.CallableObject):
+class Operator(s_func.CallableObject, s_abc.Operator):
 
     operator_kind = so.SchemaField(
         ft.OperatorKind, coerce=True, compcoef=0.4)

--- a/edb/lang/schema/pointers.py
+++ b/edb/lang/schema/pointers.py
@@ -23,6 +23,7 @@ from edb.lang import edgeql
 from edb.lang.edgeql import ast as qlast
 from edb.lang.common import enum
 
+from . import abc as s_abc
 from . import constraints
 from . import delta as sd
 from . import error as schema_error
@@ -183,7 +184,7 @@ class Pointer(constraints.ConsistencySubject, PointerLike):
 
     @classmethod
     def merge_targets(cls, schema, ptr, t1, t2):
-        from . import scalars as s_scalars, objtypes as s_objtypes
+        from . import objtypes as s_objtypes
 
         # When two pointers are merged, check target compatibility
         # and return a target that satisfies both specified targets.
@@ -191,8 +192,8 @@ class Pointer(constraints.ConsistencySubject, PointerLike):
 
         source = ptr.get_source(schema)
 
-        if (isinstance(t1, s_scalars.ScalarType) !=
-                isinstance(t2, s_scalars.ScalarType)):
+        if (isinstance(t1, s_abc.ScalarType) !=
+                isinstance(t2, s_abc.ScalarType)):
             # Targets are not of the same node type
 
             pn = ptr.get_shortname(schema)
@@ -210,7 +211,7 @@ class Pointer(constraints.ConsistencySubject, PointerLike):
                 f'could not merge "{pn}" pointer: invalid ' +
                 'target type mix', details=detail)
 
-        elif isinstance(t1, s_scalars.ScalarType):
+        elif isinstance(t1, s_abc.ScalarType):
             # Targets are both scalars
             if t1 != t2:
                 pn = ptr.get_shortname(schema)

--- a/edb/lang/schema/scalars.py
+++ b/edb/lang/schema/scalars.py
@@ -23,6 +23,7 @@ import typing
 from edb.lang.common import ast
 from edb.lang.edgeql import ast as qlast
 
+from . import abc as s_abc
 from . import attributes
 from . import constraints
 from . import delta as sd
@@ -37,7 +38,7 @@ from . import types as s_types
 
 
 class ScalarType(nodes.Node, constraints.ConsistencySubject,
-                 attributes.AttributeSubject):
+                 attributes.AttributeSubject, s_abc.ScalarType):
 
     default = so.SchemaField(
         expr.ExpressionText, default=None,
@@ -67,7 +68,7 @@ class ScalarType(nodes.Node, constraints.ConsistencySubject,
                 ptypes = [p.get_type(schema) for p in c_params]
                 if ptypes:
                     for ptype in ptypes:
-                        if isinstance(ptype, s_types.Collection):
+                        if isinstance(ptype, s_abc.Collection):
                             subtypes = ptype.get_subtypes()
                         else:
                             subtypes = [ptype]

--- a/edb/lang/schema/types.py
+++ b/edb/lang/schema/types.py
@@ -25,6 +25,7 @@ import uuid
 
 from edb.lang.common import typed
 
+from . import abc as s_abc
 from . import derivable
 from . import error as s_err
 from . import expr as s_expr
@@ -41,7 +42,7 @@ class ViewType(enum.IntEnum):
     Update = enum.auto()
 
 
-class Type(so.NamedObject, derivable.DerivableObjectBase):
+class Type(so.NamedObject, derivable.DerivableObjectBase, s_abc.Type):
     """A schema item that is a valid *type*."""
 
     # For a type representing a view, this would contain the
@@ -180,7 +181,7 @@ class Type(so.NamedObject, derivable.DerivableObjectBase):
     __str__ = __repr__
 
 
-class Collection(Type):
+class Collection(Type, s_abc.Collection):
 
     name = so.Field(
         s_name.SchemaName,
@@ -282,7 +283,6 @@ class Collection(Type):
         return ()
 
     def get_subtype(self, schema, typeref):
-        from . import scalars as s_scalars
         from . import types as s_types
 
         if isinstance(typeref, so.ObjectRef):
@@ -290,7 +290,7 @@ class Collection(Type):
         else:
             eltype = typeref
 
-        if isinstance(eltype, s_scalars.ScalarType):
+        if isinstance(eltype, s_abc.ScalarType):
             eltype = eltype.get_topmost_concrete_base(schema)
             eltype = s_types.BaseTypeMeta.get_implementation(eltype.name)
 
@@ -339,7 +339,7 @@ class Dimensions(typed.FrozenTypedList, type=int):
     pass
 
 
-class Array(Collection):
+class Array(Collection, s_abc.Array):
     schema_name = 'array'
     element_type = so.Field(so.Object)
     dimensions = so.Field(Dimensions, coerce=True)
@@ -478,7 +478,7 @@ class Array(Collection):
         )
 
 
-class Tuple(Collection):
+class Tuple(Collection, s_abc.Tuple):
     schema_name = 'tuple'
 
     named = so.Field(bool)

--- a/edb/lang/schema/utils.py
+++ b/edb/lang/schema/utils.py
@@ -24,6 +24,7 @@ import typing
 from edb.lang.common import levenshtein
 from edb.lang.edgeql import ast as ql_ast
 
+from . import abc as s_abc
 from . import error as s_err
 from . import name as sn
 from . import objects as so
@@ -61,7 +62,7 @@ def ast_to_typeref(
     if node.subtypes is not None:
         coll = s_types.Collection.get_class(node.maintype.name)
 
-        if issubclass(coll, s_types.Tuple):
+        if issubclass(coll, s_abc.Tuple):
             subtypes = collections.OrderedDict()
             # tuple declaration must either be named or unnamed, but not both
             named = None
@@ -114,7 +115,7 @@ def ast_to_typeref(
 
 
 def typeref_to_ast(schema, t: so.Object) -> ql_ast.TypeName:
-    if not isinstance(t, s_types.Collection):
+    if not isinstance(t, s_abc.Collection):
         result = ql_ast.TypeName(
             maintype=ql_ast.ObjectRef(
                 module=t.get_name(schema).module,

--- a/edb/server/pgsql/backend.py
+++ b/edb/server/pgsql/backend.py
@@ -33,12 +33,12 @@ from edb.lang import edgeql
 
 from edb.lang.schema import delta as sd
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import database as s_db
 from edb.lang.schema import ddl as s_ddl
 from edb.lang.schema import deltas as s_deltas
 from edb.lang.schema import schema as s_schema
 from edb.lang.schema import std as s_std
-from edb.lang.schema import types as s_types
 
 from edb.server import query as backend_query
 from edb.server.pgsql import dbops
@@ -360,11 +360,11 @@ class Backend:
         mt = t.material_type(schema)
         is_tuple = False
 
-        if isinstance(t, s_types.Collection):
+        if isinstance(t, s_abc.Collection):
             subtypes = [self._describe_type(schema, st, view_shapes, _tuples)
                         for st in t.get_subtypes()]
 
-            if isinstance(t, s_types.Tuple) and t.named:
+            if isinstance(t, s_abc.Tuple) and t.named:
                 element_names = list(t.element_types.keys())
             else:
                 element_names = None

--- a/edb/server/pgsql/compiler/expr.py
+++ b/edb/server/pgsql/compiler/expr.py
@@ -28,9 +28,9 @@ from edb.lang.edgeql import functypes as ql_ft
 from edb.lang.ir import ast as irast
 from edb.lang.ir import utils as irutils
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import scalars as s_scalars
 from edb.lang.schema import objects as s_obj
-from edb.lang.schema import types as s_types
 
 from edb.server.pgsql import ast as pgast
 from edb.server.pgsql import common
@@ -332,13 +332,13 @@ def compile_BinOp(
                 op == ast.ops.ADD):
             op = '||'
 
-    if isinstance(left_type, s_types.Tuple):
+    if isinstance(left_type, s_abc.Tuple):
         left = _tuple_to_row_expr(expr.left, ctx=newctx)
         left_count = len(left.args)
     else:
         left_count = 0
 
-    if isinstance(right_type, s_types.Tuple):
+    if isinstance(right_type, s_abc.Tuple):
         right = _tuple_to_row_expr(expr.right, ctx=newctx)
         right_count = len(right.args)
     else:

--- a/edb/server/pgsql/compiler/pathctx.py
+++ b/edb/server/pgsql/compiler/pathctx.py
@@ -28,8 +28,8 @@ from edb.lang.common import enum as s_enum
 from edb.lang.ir import ast as irast
 from edb.lang.ir import utils as irutils
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import pointers as s_pointers
-from edb.lang.schema import types as s_types
 
 from edb.server.pgsql import ast as pgast
 from edb.server.pgsql import types as pg_types
@@ -398,7 +398,7 @@ def get_path_output_alias(
     if rptr is not None:
         ptrname = rptr.get_shortname(env.schema)
         alias_base = ptrname.name
-    elif isinstance(path_id.target, s_types.Collection):
+    elif isinstance(path_id.target, s_abc.Collection):
         alias_base = path_id.target.schema_name
     else:
         _, _, alias_base = path_id.target_name.rpartition('::')

--- a/edb/server/pgsql/compiler/relgen.py
+++ b/edb/server/pgsql/compiler/relgen.py
@@ -30,9 +30,9 @@ from edb.lang.edgeql import functypes as ql_ft
 from edb.lang.ir import ast as irast
 from edb.lang.ir import utils as irutils
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import scalars as s_scalars
 from edb.lang.schema import objtypes as s_objtypes
-from edb.lang.schema import types as s_types
 
 from edb.server.pgsql import ast as pgast
 from edb.server.pgsql import common
@@ -538,7 +538,7 @@ def get_set_rel_alias(ir_set: irast.Set, *,
             ir_set.rptr.ptrcls.get_shortname(ctx.env.schema).name
         )
     else:
-        if isinstance(ir_set.stype, s_types.Collection):
+        if isinstance(ir_set.stype, s_abc.Collection):
             alias_hint = ir_set.stype.schema_name
         else:
             _, _, dname = ir_set.path_id.target_name.rpartition('::')
@@ -1261,7 +1261,7 @@ def process_set_as_type_cast(
 
             if (is_json_cast and
                     isinstance(inner_set.stype,
-                               (s_objtypes.ObjectType, s_types.Collection))):
+                               (s_abc.ObjectType, s_abc.Collection))):
                 subctx.expr_exposed = True
                 subctx.output_format = context.OutputFormat.JSON
                 implicit_cast = True
@@ -1274,7 +1274,7 @@ def process_set_as_type_cast(
                     stmt, inner_set.path_id, env=subctx.env)
 
                 if serialized is not None:
-                    if isinstance(inner_set.stype, s_types.Collection):
+                    if isinstance(inner_set.stype, s_abc.Collection):
                         serialized = output.serialize_expr_to_json(
                             serialized, path_id=inner_set.path_id,
                             env=subctx.env)
@@ -1360,7 +1360,7 @@ def process_set_as_func_expr(
     if expr.typemod is ql_ft.TypeModifier.SET_OF:
         rtype = expr.stype
 
-        if isinstance(rtype, s_types.Tuple):
+        if isinstance(rtype, s_abc.Tuple):
             colnames = list(rtype.element_types.keys())
         else:
             colnames = [ctx.env.aliases.get('v')]

--- a/edb/server/pgsql/intromech.py
+++ b/edb/server/pgsql/intromech.py
@@ -26,6 +26,7 @@ from edb.lang.common import topological
 
 from edb.lang import schema as so
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import attributes as s_attrs
 from edb.lang.schema import scalars as s_scalars
 from edb.lang.schema import objtypes as s_objtypes
@@ -418,7 +419,7 @@ class IntrospectionMech:
                 typemods = None
 
             named = all(s[0] is not None for s in subtypes)
-            if issubclass(coll_type, s_types.Tuple) and named:
+            if issubclass(coll_type, s_abc.Tuple) and named:
                 st = collections.OrderedDict(subtypes)
                 typemods = {'named': named}
             else:

--- a/edb/server/pgsql/metaschema.py
+++ b/edb/server/pgsql/metaschema.py
@@ -26,6 +26,7 @@ from edb.lang.common import adapter, debug, typed
 from edb.lang.common import context as parser_context
 from edb.lang.common import exceptions
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import attributes as s_attrs
 from edb.lang.schema import constraints as s_constraints
 from edb.lang.schema import database as s_db
@@ -36,7 +37,6 @@ from edb.lang.schema import named as s_named
 from edb.lang.schema import objects as s_obj
 from edb.lang.schema import pseudo as s_pseudo
 from edb.lang.schema import referencing as s_ref
-from edb.lang.schema import types as s_types
 
 from . import common
 from . import dbops
@@ -1447,7 +1447,7 @@ def get_interesting_metaclasses():
 
     metaclasses = [
         mcls for mcls in metaclasses
-        if (not issubclass(mcls, (s_obj.ObjectRef, s_types.Collection)) and
+        if (not issubclass(mcls, (s_obj.ObjectRef, s_abc.Collection)) and
             not isinstance(mcls, adapter.Adapter) and
             not issubclass(mcls, (s_db.Database)))
     ]

--- a/edb/server/pgsql/types.py
+++ b/edb/server/pgsql/types.py
@@ -24,13 +24,13 @@ import uuid
 
 from edb.lang.ir import utils as irutils
 
+from edb.lang.schema import abc as s_abc
 from edb.lang.schema import scalars as s_scalars
 from edb.lang.schema import objtypes as s_objtypes
 from edb.lang.schema import name as sn
 from edb.lang.schema import named as s_named
 from edb.lang.schema import objects as s_obj
 from edb.lang.schema import schema as s_schema
-from edb.lang.schema import types as s_types
 
 from . import common
 from .common import quote_literal as ql
@@ -143,10 +143,10 @@ def pg_type_from_object(
     if isinstance(obj, s_scalars.ScalarType):
         return pg_type_from_scalar(schema, obj, topbase=topbase)
 
-    elif isinstance(obj, s_types.Tuple):
+    elif isinstance(obj, s_abc.Tuple):
         return ('record',)
 
-    elif isinstance(obj, s_types.Array):
+    elif isinstance(obj, s_abc.Array):
         if obj.is_polymorphic(schema):
             return ('anyarray',)
         else:
@@ -377,7 +377,7 @@ class TypeDesc:
         )
 
     @classmethod
-    def from_type(cls, schema, type: s_types.Type) -> 'TypeDesc':
+    def from_type(cls, schema, type: s_abc.Type) -> 'TypeDesc':
         nodes = []
         cls._get_typedesc(schema, [(None, type)], nodes)
         return cls(nodes)
@@ -393,15 +393,15 @@ class TypeDesc:
             indexes.append(len(typedesc) - 1)
 
         for i, (tn, t) in enumerate(types):
-            if isinstance(t, s_types.Collection):
-                if isinstance(t, s_types.Tuple) and t.named:
+            if isinstance(t, s_abc.Collection):
+                if isinstance(t, s_abc.Tuple) and t.named:
                     stypes = list(t.element_types.items())
                 else:
                     stypes = [(None, st) for st in t.get_subtypes()]
 
                 subtypes = cls._get_typedesc(
                     schema, stypes, typedesc, is_root=False)
-                if isinstance(t, s_types.Array):
+                if isinstance(t, s_abc.Array):
                     dimensions = t.dimensions
                 else:
                     dimensions = []


### PR DESCRIPTION
This simplifies isinstance() checks and allows to avoid circular
dependancies between schema modules in many cases.