### PR TITLE
Drop schema.NamedObject.

### DIFF
--- a/edb/lang/schema/attributes.py
+++ b/edb/lang/schema/attributes.py
@@ -38,7 +38,7 @@ class Attribute(inheriting.InheritingObject):
 class AttributeValue(inheriting.InheritingObject):
 
     subject = so.SchemaField(
-        named.NamedObject, compcoef=1.0, default=None, inheritable=False)
+        so.Object, compcoef=1.0, default=None, inheritable=False)
 
     attribute = so.SchemaField(
         Attribute, compcoef=0.429)

--- a/edb/lang/schema/database.py
+++ b/edb/lang/schema/database.py
@@ -22,11 +22,10 @@ from edb.lang.edgeql import ast as qlast
 
 from . import delta as sd
 from . import modules
-from . import named
 from . import objects as so
 
 
-class Database(named.NamedObject):
+class Database(so.Object):
     # Override 'name' to str type, since databases don't have
     # fully-qualified names.
     name = so.SchemaField(str)

--- a/edb/lang/schema/deltas.py
+++ b/edb/lang/schema/deltas.py
@@ -28,7 +28,7 @@ from . import named
 from . import objects as so
 
 
-class Delta(named.NamedObject):
+class Delta(so.Object):
     parents = so.SchemaField(
         so.ObjectList,
         default=so.ObjectList, coerce=True, inheritable=False)

--- a/edb/lang/schema/derivable.py
+++ b/edb/lang/schema/derivable.py
@@ -134,7 +134,7 @@ class DerivableObjectBase:
         return schema, derived
 
 
-class DerivableObject(so.NamedObject, DerivableObjectBase):
+class DerivableObject(so.Object, DerivableObjectBase):
 
     # Indicates that the object has been declared as
     # explicitly inherited.

--- a/edb/lang/schema/functions.py
+++ b/edb/lang/schema/functions.py
@@ -170,7 +170,7 @@ class ParameterDesc(typing.NamedTuple):
         return cmd
 
 
-class Parameter(named.NamedObject):
+class Parameter(so.Object):
 
     num = so.SchemaField(
         int, compcoef=0.4)
@@ -368,7 +368,7 @@ class FuncParameterList(so.ObjectList, type=Parameter):
         return schema, cls.create(schema, params)
 
 
-class CallableObject(so.NamedObject):
+class CallableObject(so.Object):
 
     params = so.SchemaField(
         FuncParameterList,

--- a/edb/lang/schema/indexes.py
+++ b/edb/lang/schema/indexes.py
@@ -32,7 +32,7 @@ from . import utils as s_utils
 
 class SourceIndex(inheriting.InheritingObject):
 
-    subject = so.SchemaField(so.NamedObject)
+    subject = so.SchemaField(so.Object)
 
     expr = so.SchemaField(
         s_expr.ExpressionText, coerce=True, compcoef=0.909)

--- a/edb/lang/schema/inheriting.py
+++ b/edb/lang/schema/inheriting.py
@@ -351,7 +351,7 @@ class InheritingObject(derivable.DerivableObject):
         default=False, compcoef=0.909)
 
     derived_from = so.SchemaField(
-        so.NamedObject,
+        so.Object,
         default=None, compcoef=0.909, inheritable=False)
 
     is_final = so.SchemaField(

--- a/edb/lang/schema/modules.py
+++ b/edb/lang/schema/modules.py
@@ -26,7 +26,7 @@ from . import named
 from . import objects as so
 
 
-class Module(named.NamedObject):
+class Module(so.Object):
     # Override 'name' to str type, since modules don't have
     # fully-qualified names.
     name = so.SchemaField(str)

--- a/edb/lang/schema/named.py
+++ b/edb/lang/schema/named.py
@@ -30,9 +30,6 @@ from . import name as sn
 from . import error as s_err
 
 
-NamedObject = so.NamedObject
-
-
 class NamedObjectCommand(sd.ObjectCommand):
     classname = struct.Field(sn.Name)
 

--- a/edb/lang/schema/referencing.py
+++ b/edb/lang/schema/referencing.py
@@ -444,7 +444,7 @@ class ReferencingObject(inheriting.InheritingObject,
 
         if not result or farthest:
             bases = (c for c in self.compute_mro(schema)[1:]
-                     if isinstance(c, named.NamedObject))
+                     if isinstance(c, so.Object))
 
             for c in bases:
                 if c.get_field_value(schema, local_attr).has(schema, name):

--- a/edb/lang/schema/types.py
+++ b/edb/lang/schema/types.py
@@ -41,7 +41,7 @@ class ViewType(enum.IntEnum):
     Update = enum.auto()
 
 
-class Type(so.NamedObject, derivable.DerivableObjectBase):
+class Type(so.Object, derivable.DerivableObjectBase):
     """A schema item that is a valid *type*."""
 
     # For a type representing a view, this would contain the

--- a/edb/server/pgsql/dbops/tables.py
+++ b/edb/server/pgsql/dbops/tables.py
@@ -64,6 +64,9 @@ class Table(composites.CompositeDBObject):
         self.columns = \
             collections.OrderedDict((c.name, c) for c in self.iter_columns())
 
+    def add_constraint(self, const):
+        self.constraints.add(const)
+
     def get_column(self, name):
         return self.columns.get(name)
 

--- a/edb/server/pgsql/delta.py
+++ b/edb/server/pgsql/delta.py
@@ -145,12 +145,11 @@ class NamedObjectMetaCommand(
     def _get_name(self, schema, value):
         if isinstance(value, s_obj.ObjectRef):
             name = value.get_name(schema)
-        elif isinstance(value, s_named.NamedObject):
+        elif isinstance(value, s_obj.Object):
             name = value.get_name(schema)
         else:
             raise ValueError(
-                'expecting a ObjectRef or a '
-                'NamedObject, got {!r}'.format(value))
+                f'expecting a ObjectRef or an Object, got {value!r}')
 
         return name
 

--- a/edb/server/pgsql/types.py
+++ b/edb/server/pgsql/types.py
@@ -27,7 +27,6 @@ from edb.lang.ir import utils as irutils
 from edb.lang.schema import scalars as s_scalars
 from edb.lang.schema import objtypes as s_objtypes
 from edb.lang.schema import name as sn
-from edb.lang.schema import named as s_named
 from edb.lang.schema import objects as s_obj
 from edb.lang.schema import schema as s_schema
 from edb.lang.schema import types as s_types
@@ -427,11 +426,10 @@ class TypeDesc:
     def _get_name(cls, schema, value):
         if isinstance(value, s_obj.ObjectRef):
             name = value.classname
-        elif isinstance(value, s_named.NamedObject):
+        elif isinstance(value, s_obj.Object):
             name = value.get_name(schema)
         else:
             raise ValueError(
-                'expecting a ObjectRef or a '
-                'NamedObject, got {!r}'.format(value))
+                f'expecting a ObjectRef or an Object, got {value!r}')
 
         return name


### PR DESCRIPTION
All EdgeDB schema objects have a 'name' field now, so having
both NamedObject and Object is pointless.