### PR TITLE
Fix type casts for named tuples

### DIFF
--- a/edb/lang/edgeql/compiler/typegen.py
+++ b/edb/lang/edgeql/compiler/typegen.py
@@ -37,16 +37,30 @@ from . import schemactx
 
 
 def type_to_ql_typeref(t: s_obj.Object, *,
+                       _name=None,
                        ctx: context.ContextLevel) -> qlast.TypeName:
     if not isinstance(t, s_abc.Collection):
         result = qlast.TypeName(
+            name=_name,
             maintype=qlast.ObjectRef(
                 module=t.get_name(ctx.env.schema).module,
                 name=t.get_name(ctx.env.schema).name
             )
         )
+    elif isinstance(t, s_abc.Tuple) and t.named:
+        result = qlast.TypeName(
+            name=_name,
+            maintype=qlast.ObjectRef(
+                name=t.schema_name
+            ),
+            subtypes=[
+                type_to_ql_typeref(st, _name=sn, ctx=ctx)
+                for sn, st in t.element_types.items()
+            ]
+        )
     else:
         result = qlast.TypeName(
+            name=_name,
             maintype=qlast.ObjectRef(
                 name=t.schema_name
             ),

--- a/edb/lang/schema/types.py
+++ b/edb/lang/schema/types.py
@@ -500,11 +500,11 @@ class Tuple(Collection, s_abc.Tuple):
 
         if name is None:
             if named:
-                st_names = ','.join(st.get_name(schema)
-                                    for st in element_types.values())
-            else:
                 st_names = ','.join(f'{sn}:={st.get_name(schema)}'
                                     for sn, st in element_types.items())
+            else:
+                st_names = ','.join(st.get_name(schema)
+                                    for st in element_types.values())
             name = s_name.SchemaName(
                 module='std',
                 name=f'tuple<{st_names}>')
@@ -594,7 +594,7 @@ class Tuple(Collection, s_abc.Tuple):
             named = typemods.get('named', False)
 
         if not isinstance(subtypes, collections.abc.Mapping):
-            types = collections.OrderedDict()
+            types = {}
             for i, t in enumerate(subtypes):
                 types[str(i)] = t
         else:

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -717,26 +717,35 @@ class TestExpressions(tb.QueryTestCase):
             [[1, 2], [3, 4.5]],
         ])
 
-    @unittest.expectedFailure
     async def test_edgeql_expr_implicit_cast_06(self):
         await self.assert_query_result(r"""
             SELECT {(1, 2.0), (3, 4.5)};
             SELECT {(1, 2), (3, 4.5)};
+            SELECT {(3, 4.5), (1, 2.0)};
 
             SELECT {(x := 1, y := 2.0), (x := 3, y := 4.5)};
             SELECT {(x := 1, y := 2), (x := 3, y := 4.5)};
+            SELECT {(x := 3, y := 4.5), (x := 1, y := 2)};
 
             SELECT {(x := 1, y := 2), (a := 3, b := 4.5)};
+            SELECT {(a := 3, b := 4.5), (x := 1, y := 2)};
+
             SELECT {(1, 2), (a := 3, b := 4.5)};
+            SELECT {(a := 3, b := 4.5), (1, 2)};
         """, [
             [[1, 2], [3, 4.5]],
             [[1, 2], [3, 4.5]],
+            [[3, 4.5], [1, 2]],
 
             [{"x": 1, "y": 2}, {"x": 3, "y": 4.5}],
             [{"x": 1, "y": 2}, {"x": 3, "y": 4.5}],
+            [{"x": 3, "y": 4.5}, {"x": 1, "y": 2}],
 
             [[1, 2], [3, 4.5]],
+            [[3, 4.5], [1, 2]],
+
             [[1, 2], [3, 4.5]],
+            [[3, 4.5], [1, 2]],
         ])
 
     async def test_edgeql_expr_implicit_cast_07(self):


### PR DESCRIPTION
* Fix routine for transforming schema type to qlast type
  to preserve named tuple's element names

* Fix schema.Tuple.name to correctly reflect whether the tuple
  is named or not