### PR TITLE
Implement array, string and byte concatenation via the `++` operator

### DIFF
--- a/edb/lang/edgeql/parser/grammar/expressions.py
+++ b/edb/lang/edgeql/parser/grammar/expressions.py
@@ -680,6 +680,10 @@ class Expr(Nonterm):
         self.val = qlast.BinOp(left=kids[0].val, op=kids[1].val,
                                right=kids[2].val)
 
+    def reduce_Expr_DOUBLEPLUS_Expr(self, *kids):
+        self.val = qlast.BinOp(left=kids[0].val, op=kids[1].val,
+                               right=kids[2].val)
+
     def reduce_Expr_MINUS_Expr(self, *kids):
         self.val = qlast.BinOp(left=kids[0].val, op=kids[1].val,
                                right=kids[2].val)

--- a/edb/lang/edgeql/parser/grammar/lexer.py
+++ b/edb/lang/edgeql/parser/grammar/lexer.py
@@ -94,13 +94,16 @@ class EdgeQLLexer(lexer.Lexer):
              next_state=STATE_KEEP,
              regexp=r'//'),
 
+        Rule(token='++',
+             next_state=STATE_KEEP,
+             regexp=r'\+\+'),
+
         Rule(token='OP',
              next_state=STATE_KEEP,
              regexp=r'''
                 (?: >= | <= | != | \?= | \?!=)
              '''),
 
-        # SQL ops
         Rule(token='self',
              next_state=STATE_KEEP,
              regexp=r'[,()\[\].@;:+\-*/%^<>=&|]'),

--- a/edb/lang/edgeql/parser/grammar/precedence.py
+++ b/edb/lang/edgeql/parser/grammar/precedence.py
@@ -77,7 +77,8 @@ class P_IS(Precedence, assoc='nonassoc', tokens=('IS',)):
     pass
 
 
-class P_ADD_OP(Precedence, assoc='left', tokens=('PLUS', 'MINUS')):
+class P_ADD_OP(Precedence, assoc='left',
+               tokens=('PLUS', 'MINUS', 'DOUBLEPLUS')):
     pass
 
 

--- a/edb/lang/edgeql/parser/grammar/tokens.py
+++ b/edb/lang/edgeql/parser/grammar/tokens.py
@@ -101,6 +101,10 @@ class T_PLUS(Token, lextoken='+'):
     pass
 
 
+class T_DOUBLEPLUS(Token, lextoken='++'):
+    pass
+
+
 class T_MINUS(Token, lextoken='-'):
     pass
 

--- a/edb/lang/ir/staeval.py
+++ b/edb/lang/ir/staeval.py
@@ -95,6 +95,9 @@ op_table = {
     ('INFIX', 'std::>='): lambda a, b: a >= b,
     ('INFIX', 'std::<'): lambda a, b: a < b,
     ('INFIX', 'std::<='): lambda a, b: a <= b,
+
+    # Concatenation
+    ('INFIX', 'std::++'): lambda a, b: a + b,
 }
 
 
@@ -126,8 +129,8 @@ def evaluate_OperatorCall(
 def const_to_python(
         ir: irast.BaseConstant,
         schema: s_schema.Schema) -> object:
-    raise NotImplementedError(
-        f'cannot convert {ir.__class__} to a Python value')
+    raise UnsupportedExpressionError(
+        f'cannot convert {ir!r} to Python value')
 
 
 @const_to_python.register(irast.IntegerConstant)

--- a/edb/lib/std/20-genericfuncs.eql
+++ b/edb/lib/std/20-genericfuncs.eql
@@ -126,25 +126,3 @@ std::`!=` (l: anytuple, r: anytuple) -> std::bool
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL anytuple, r: OPTIONAL anytuple) -> std::bool
     FROM SQL EXPRESSION;
-
-
-CREATE INFIX OPERATOR
-std::`=` (l: array<anytype>, r: array<anytype>) -> std::bool
-    FROM SQL OPERATOR '=';
-
-
-CREATE INFIX OPERATOR
-std::`?=` (l: OPTIONAL array<anytype>,
-           r: OPTIONAL array<anytype>) -> std::bool
-    FROM SQL EXPRESSION;
-
-
-CREATE INFIX OPERATOR
-std::`!=` (l: array<anytype>, r: array<anytype>) -> std::bool
-    FROM SQL OPERATOR '<>';
-
-
-CREATE INFIX OPERATOR
-std::`?!=` (l: OPTIONAL array<anytype>,
-            r: OPTIONAL array<anytype>) -> std::bool
-    FROM SQL EXPRESSION;

--- a/edb/lib/std/30-arrayfuncs.eql
+++ b/edb/lib/std/30-arrayfuncs.eql
@@ -74,3 +74,34 @@ std::array_get(
     )
     $$;
 };
+
+
+## Array operators
+
+
+CREATE INFIX OPERATOR
+std::`=` (l: array<anytype>, r: array<anytype>) -> std::bool
+    FROM SQL OPERATOR '=';
+
+
+CREATE INFIX OPERATOR
+std::`?=` (l: OPTIONAL array<anytype>,
+           r: OPTIONAL array<anytype>) -> std::bool
+    FROM SQL EXPRESSION;
+
+
+CREATE INFIX OPERATOR
+std::`!=` (l: array<anytype>, r: array<anytype>) -> std::bool
+    FROM SQL OPERATOR '<>';
+
+
+CREATE INFIX OPERATOR
+std::`?!=` (l: OPTIONAL array<anytype>,
+            r: OPTIONAL array<anytype>) -> std::bool
+    FROM SQL EXPRESSION;
+
+
+# Concatenation
+CREATE INFIX OPERATOR
+std::`++` (l: array<anytype>, r: array<anytype>) -> array<anytype>
+    FROM SQL OPERATOR '||';

--- a/edb/lib/std/30-bytesfuncs.eql
+++ b/edb/lib/std/30-bytesfuncs.eql
@@ -54,5 +54,5 @@ std::`?!=` (l: OPTIONAL std::bytes, r: OPTIONAL std::bytes) -> std::bool
 
 
 CREATE INFIX OPERATOR
-std::`+` (l: std::bytes, r: std::bytes) -> std::bytes
+std::`++` (l: std::bytes, r: std::bytes) -> std::bytes
     FROM SQL OPERATOR r'||';

--- a/edb/lib/std/30-strfuncs.eql
+++ b/edb/lib/std/30-strfuncs.eql
@@ -47,8 +47,9 @@ std::`?!=` (l: OPTIONAL std::str, r: OPTIONAL std::str) -> std::bool
     FROM SQL EXPRESSION;
 
 
+# Concatenation.
 CREATE INFIX OPERATOR
-std::`+` (l: std::str, r: std::str) -> std::str
+std::`++` (l: std::str, r: std::str) -> std::str
     FROM SQL OPERATOR '||';
 
 

--- a/edb/lib/stdgraphql.eql
+++ b/edb/lib/stdgraphql.eql
@@ -35,5 +35,5 @@ ALTER TYPE stdgraphql::Mutation {
 
 CREATE FUNCTION stdgraphql::short_name(name: std::str) -> std::str
     FROM EdgeQL $$
-        SELECT re_replace(r'.+?::(.+$)', r'\1', name) + 'Type'
+        SELECT re_replace(r'.+?::(.+$)', r'\1', name) ++ 'Type'
     $$;

--- a/edb/server/pgsql/backend.py
+++ b/edb/server/pgsql/backend.py
@@ -330,10 +330,6 @@ class Backend:
         plan.generate(block)
         ql_text = block.to_string()
 
-        if debug.flags.delta_execute:
-            debug.header('Delta Script')
-            debug.dump_code(ql_text, lexer='sql')
-
         await self._execute_ddl(ql_text)
         self.schema = schema
 

--- a/edb/server/pgsql/delta.py
+++ b/edb/server/pgsql/delta.py
@@ -595,7 +595,11 @@ class CreateOperator(OperatorCommand, CreateNamedObject,
             else:
                 oper_func_name = None
 
-            if not oper.get_params(schema).has_polymorphic(schema):
+            params = oper.get_params(schema)
+
+            if (not params.has_polymorphic(schema) or
+                    all(p.get_type(schema).is_array()
+                        for p in params.objects(schema))):
                 self.pgops.add(dbops.CreateOperatorAlias(
                     name=self.get_pg_name(schema, oper),
                     args=args,

--- a/tests/schemas/cards.eschema
+++ b/tests/schemas/cards.eschema
@@ -46,7 +46,7 @@ type Card extending Named:
     link owners := __source__.<deck[IS User]
     # computable property
     property elemental_cost :=
-        <str>__source__.cost + ' ' + __source__.element
+        <str>__source__.cost ++ ' ' ++ __source__.element
 
 
 type SpecialCard extending Card

--- a/tests/schemas/tutorial.eql
+++ b/tests/schemas/tutorial.eql
@@ -56,15 +56,15 @@ INSERT PullRequest {
         (INSERT Comment {
             author := A,
             body :=
-                "Sublime Text handles whitespace-separated scope list " +
-                "pretty well, but Atom (or the 'first-mate' library to be " +
+                "Sublime Text handles whitespace-separated scope list " ++
+                "pretty well, but Atom (or the 'first-mate' library to be " ++
                 "precise) would fail to do that.",
             created_on := <datetime>'Feb 1, 2016, 5:31 PM UTC',
         }),
         (INSERT Comment {
             author := B,
             body :=
-                "Thanks for catching that. We'll make sure to follow this " +
+                "Thanks for catching that. We'll make sure to follow this " ++
                 "practice.",
             created_on := <datetime>'Feb 2, 2016, 12:47 PM UTC',
         }),
@@ -184,7 +184,7 @@ INSERT PullRequest {
         (INSERT Comment {
             author := A,
             body :=
-                "Rebase your diff and make sure to add the extension in " +
+                "Rebase your diff and make sure to add the extension in " ++
                 "both places.",
             created_on := <datetime>'Dec 8, 2016, 4:20 PM UTC',
         }),
@@ -236,7 +236,7 @@ INSERT PullRequest {
         (INSERT Comment {
             author := C,
             body :=
-                "This PR adds support for Python syntax highlighting in " +
+                "This PR adds support for Python syntax highlighting in " ++
                 ".smk files, which are used by Snakemake.",
             created_on := <datetime>'Jan 24, 2018, 6:20 PM UTC',
         }),

--- a/tests/schemas/tutorial.eschema
+++ b/tests/schemas/tutorial.eschema
@@ -44,7 +44,7 @@ type User:
     required property firstname -> str
     required property lastname -> str
 
-    property fullname := (__source__.firstname + ' ' + __source__.lastname)
+    property fullname := (__source__.firstname ++ ' ' ++ __source__.lastname)
 
     multi link followees -> User
     multi link todo -> PullRequest

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -296,7 +296,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     SELECT '{long_func_name}'::text
                 $$;
 
-            CREATE FUNCTION test::my_sql_func6(a: std::str='a' + 'b')
+            CREATE FUNCTION test::my_sql_func6(a: std::str='a' ++ 'b')
                 -> std::str
                 FROM SQL $$
                     SELECT $1 || 'c'
@@ -332,7 +332,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             DROP FUNCTION test::my_sql_func2(foo: std::str);
             DROP FUNCTION test::my_sql_func4(VARIADIC s: std::str);
             DROP FUNCTION test::{long_func_name}();
-            DROP FUNCTION test::my_sql_func6(a: std::str='a' + 'b');
+            DROP FUNCTION test::my_sql_func6(a: std::str='a' ++ 'b');
             DROP FUNCTION test::my_sql_func7(s: array<std::int64>);
         """)
 
@@ -353,7 +353,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             CREATE FUNCTION test::my_edgeql_func1()
                 -> std::str
                 FROM EdgeQL $$
-                    SELECT 'sp' + 'am'
+                    SELECT 'sp' ++ 'am'
                 $$;
 
             CREATE FUNCTION test::my_edgeql_func2(s: std::str)

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -153,7 +153,7 @@ class TestDelete(tb.QueryTestCase):
                 (DELETE (
                     SELECT DeleteTest
                     FILTER DeleteTest.name = 'delete-test3'
-                )).name + '--DELETED';
+                )).name ++ '--DELETED';
         """)
 
         self.assert_data_shape(del_result, [
@@ -209,7 +209,7 @@ class TestDelete(tb.QueryTestCase):
             SELECT DeleteTest2 {
                 name,
                 foo := 'bar'
-            } FILTER DeleteTest2.name LIKE D.name[:2] + '%';
+            } FILTER DeleteTest2.name LIKE D.name[:2] ++ '%';
 
             WITH MODULE test
             SELECT (DELETE DeleteTest2) { name };

--- a/tests/test_edgeql_filter.py
+++ b/tests/test_edgeql_filter.py
@@ -358,7 +358,7 @@ class TestEdgeQLFilter(tb.QueryTestCase):
         await self.assert_query_result(r'''
             # base line for a cross product
             WITH MODULE test
-            SELECT _ := Issue.number + Status.name
+            SELECT _ := Issue.number ++ Status.name
             ORDER BY _;
 
             # interaction of filter and cross product
@@ -366,14 +366,14 @@ class TestEdgeQLFilter(tb.QueryTestCase):
             SELECT _ := (
                     SELECT Issue
                     FILTER Issue.owner.name = 'Elvis'
-                ).number + Status.name
+                ).number ++ Status.name
             ORDER BY _;
 
             WITH MODULE test
             SELECT _ := (
                     SELECT Issue
                     FILTER Issue.owner.name = 'Elvis'
-                ).number + Status.name
+                ).number ++ Status.name
             FILTER
                 # this FILTER is legal, but irrelevant, the same way as
                 # SELECT Issue.number + Status.name FILTER Status.name = 'Open'

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -201,7 +201,7 @@ class TestInsert(tb.QueryTestCase):
                 l2 := 0,
                 subordinates := (
                     SELECT Subordinate {
-                        @comment := (SELECT 'comment ' + Subordinate.name)
+                        @comment := (SELECT 'comment ' ++ Subordinate.name)
                     }
                     FILTER Subordinate.name IN {'subtest 3', 'subtest 4'}
                 )
@@ -486,7 +486,7 @@ class TestInsert(tb.QueryTestCase):
             });
 
             WITH MODULE test
-            FOR Q IN {(SELECT InsertTest{foo := 'foo' + <str> InsertTest.l2}
+            FOR Q IN {(SELECT InsertTest{foo := 'foo' ++ <str> InsertTest.l2}
                        FILTER .name = 'insert for 1')}
             UNION (INSERT InsertTest {
                 name := 'insert for 1',
@@ -823,7 +823,7 @@ class TestInsert(tb.QueryTestCase):
             WITH MODULE test
             FOR i IN {'1', '2', '3'} UNION (
                 INSERT Subordinate {
-                    name := 'linkproptest ' + i
+                    name := 'linkproptest ' ++ i
                 }
             );
 

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -479,7 +479,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         WITH
             MODULE test
         SELECT
-            Card.name + <str>count(Card.owners)
+            Card.name ++ <str>count(Card.owners)
 
 % OK %
         "FENCE": {
@@ -500,7 +500,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         WITH
             MODULE test
         SELECT
-            Card.element + ' ' + (SELECT Card).name
+            Card.element ++ ' ' ++ (SELECT Card).name
 
 % OK %
         "FENCE": {
@@ -706,7 +706,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_scope_tree_28(self):
         """
         WITH MODULE test
-        SELECT <str>count((WITH A := Card SELECT A.owners)) + Card.name
+        SELECT <str>count((WITH A := Card SELECT A.owners)) ++ Card.name
 
 % OK %
         "FENCE": {

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -996,7 +996,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(r'''
             # control query Q1
             WITH MODULE test
-            SELECT Card.element + ' ' + Card.name
+            SELECT Card.element ++ ' ' ++ Card.name
             FILTER Card.name > Card.element
             ORDER BY Card.name;
         ''', [
@@ -1015,7 +1015,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 MODULE test,
                 A := Card
             SELECT
-                A.element + ' ' + (WITH B := A SELECT B).name
+                A.element ++ ' ' ++ (WITH B := A SELECT B).name
             FILTER (
                 WITH C := A
                 SELECT (
@@ -1038,7 +1038,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 MODULE test,
                 A := Card
             SELECT
-                A.element + ' ' + (WITH B := A SELECT B).name
+                A.element ++ ' ' ++ (WITH B := A SELECT B).name
             FILTER (
                 WITH C := A
                 SELECT (
@@ -1058,7 +1058,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             WITH MODULE test
             SELECT
                 Card {
-                    foo := Card.element + <str>count(Card.name)
+                    foo := Card.element ++ <str>count(Card.name)
                 }
             FILTER
                 Card.name > Card.element
@@ -1079,7 +1079,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             # control query Q2
             WITH MODULE test
             # combination of element + SET OF with a common prefix
-            SELECT Card.name + <str>count(Card.owners)
+            SELECT Card.name ++ <str>count(Card.owners)
             FILTER
                 # some element filters
                 Card.name < Card.element
@@ -1100,7 +1100,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 MODULE test,
                 A := Card
             SELECT
-                A.name + (WITH B := A SELECT <str>count(B.owners))
+                A.name ++ (WITH B := A SELECT <str>count(B.owners))
             FILTER (
                 WITH C := A
                 SELECT (
@@ -1127,7 +1127,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 MODULE test,
                 A := Card
             SELECT
-                A.name + (WITH B := A SELECT <str>count(B.owners))
+                A.name ++ (WITH B := A SELECT <str>count(B.owners))
             FILTER (
                 WITH C := A
                 SELECT (
@@ -1150,7 +1150,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(r'''
             # control query Q3
             WITH MODULE test
-            SELECT Card.name + <str>count(Card.owners);
+            SELECT Card.name ++ <str>count(Card.owners);
         ''', [
             {'Imp1', 'Dragon2', 'Bog monster4', 'Giant turtle4', 'Dwarf2',
              'Golem3', 'Sprite2', 'Giant eagle2', 'Djinn2'}
@@ -1161,13 +1161,13 @@ class TestEdgeQLScope(tb.QueryTestCase):
             # semantically same as control query Q3, except that some
             # aliases are introduced
             WITH MODULE test
-            SELECT Card.name + <str>count((WITH A := Card SELECT A).owners);
+            SELECT Card.name ++ <str>count((WITH A := Card SELECT A).owners);
 
             WITH MODULE test
-            SELECT Card.name + <str>count((WITH A := Card SELECT A.owners));
+            SELECT Card.name ++ <str>count((WITH A := Card SELECT A.owners));
 
             WITH MODULE test
-            SELECT <str>count((WITH A := Card SELECT A.owners)) + Card.name;
+            SELECT <str>count((WITH A := Card SELECT A.owners)) ++ Card.name;
         ''', [
             {'Imp1', 'Dragon2', 'Bog monster4', 'Giant turtle4', 'Dwarf2',
              'Golem3', 'Sprite2', 'Giant eagle2', 'Djinn2'},
@@ -1204,13 +1204,13 @@ class TestEdgeQLScope(tb.QueryTestCase):
             # U2 is a combination of DETACHED and non-DETACHED expression
             WITH
                 MODULE test,
-                U2 := User.name + DETACHED User.name
-            SELECT U2 + U2;
+                U2 := User.name ++ DETACHED User.name
+            SELECT U2 ++ U2;
 
             # DETACHED is reused directly
             WITH MODULE test
-            SELECT User.name + DETACHED User.name +
-                   User.name + DETACHED User.name;
+            SELECT User.name ++ DETACHED User.name ++
+                   User.name ++ DETACHED User.name;
             """, [
             {u + u for u in
                 (a + b
@@ -1227,7 +1227,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
         # calculate some useful base expression
         names = await self.con.execute(r"""
             WITH MODULE test
-            SELECT User.name + <str>count(User.deck);
+            SELECT User.name ++ <str>count(User.deck);
         """)
         names = names[0]
 
@@ -1240,7 +1240,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 U0 := User.name + <str>count(User.deck),
                 # make a copy of U0 so that we can do cross product
                 U1 := U0
-            SELECT U0 + ' vs ' + U1
+            SELECT U0 ++ ' vs ' ++ U1
             # get rid of players matching themselves
             FILTER U0 != U1;
         """, [
@@ -1259,7 +1259,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 U0 := DETACHED User.name,
                 U1 := DETACHED User.name,
                 U2 := DETACHED User.name
-            SELECT User.name + U0 + U1 + U2;
+            SELECT User.name ++ U0 ++ U1 ++ U2;
 
             # same thing, but building it up differently
             WITH
@@ -1270,12 +1270,12 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 # cross product
                 U1 := U0,
                 # cross product of players
-                U2 := U0 + U1,
+                U2 := U0 ++ U1,
                 # a copy of the players cross product
                 U3 := U2
             # compute what is effectively a cross product of a cross
             # product of names (expecting 256 results)
-            SELECT U2 + U3;
+            SELECT U2 ++ U3;
             """, [
             {a + b + c + d
                 for a in names

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2312,7 +2312,7 @@ aa';
     def test_edgeql_syntax_insertfor_06(self):
         """
         FOR bar IN {(
-            UPDATE Bar SET {name := (name + 'bar')}
+            UPDATE Bar SET {name := (name ++ 'bar')}
         )}
         UNION (INSERT Foo{name := bar.name});
         """

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -117,7 +117,7 @@ class TestUpdate(tb.QueryTestCase):
             UPDATE UpdateTest
             FILTER UpdateTest.name = 'update-test2'
             SET {
-                comment := 'updated ' + UpdateTest.comment
+                comment := 'updated ' ++ UpdateTest.comment
             };
 
             WITH MODULE test
@@ -152,7 +152,7 @@ class TestUpdate(tb.QueryTestCase):
             WITH MODULE test
             UPDATE UpdateTest
             SET {
-                comment := UpdateTest.comment + "!",
+                comment := UpdateTest.comment ++ "!",
                 status := (SELECT Status FILTER Status.name = 'Closed')
             };
 
@@ -202,7 +202,7 @@ class TestUpdate(tb.QueryTestCase):
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test2'
                 SET {
-                    comment := 'updated ' + UpdateTest.comment
+                    comment := 'updated ' ++ UpdateTest.comment
                 }
             ) {
                 id,
@@ -225,7 +225,7 @@ class TestUpdate(tb.QueryTestCase):
             SELECT (
                 UPDATE UpdateTest
                 SET {
-                    comment := UpdateTest.comment + "!",
+                    comment := UpdateTest.comment ++ "!",
                     status := (SELECT Status FILTER Status.name = 'Closed')
                 }
             ) {
@@ -274,7 +274,7 @@ class TestUpdate(tb.QueryTestCase):
                     UPDATE UpdateTest
                     FILTER UpdateTest.name = 'update-test2'
                     SET {
-                        comment := 'updated ' + UpdateTest.comment
+                        comment := 'updated ' ++ UpdateTest.comment
                     }
                 )
             SELECT Status{name}
@@ -293,7 +293,7 @@ class TestUpdate(tb.QueryTestCase):
                 Q := (
                     UPDATE UpdateTest
                     SET {
-                        comment := UpdateTest.comment + "!",
+                        comment := UpdateTest.comment ++ "!",
                         status := (SELECT Status FILTER Status.name = 'Closed')
                     }
                 )
@@ -636,7 +636,7 @@ class TestUpdate(tb.QueryTestCase):
             SET {
                 annotated_tests := (
                     SELECT U2 {
-                        @note := 'note' + U2.name[-1]
+                        @note := 'note' ++ U2.name[-1]
                     } FILTER U2.name != 'update-test1'
                 )
             };

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -111,7 +111,7 @@ class TestSchema(tb.BaseSchemaTest):
             type Object:
                 property foo -> str
                 property bar -> str
-                property foo_plus_bar := __source__.foo + __source__.bar
+                property foo_plus_bar := __source__.foo ++ __source__.bar
         """)
 
         obj = schema.get('test::Object')
@@ -124,7 +124,7 @@ class TestSchema(tb.BaseSchemaTest):
             type Object:
                 multi property foo -> str
                 property bar -> str
-                property foo_plus_bar := __source__.foo + __source__.bar
+                property foo_plus_bar := __source__.foo ++ __source__.bar
         """)
 
         obj = schema.get('test::Object')


### PR DESCRIPTION
The current `+` operator is a poor choice for concatenation, especially
in the array case, since the latter may be interpreted as an
element-wise vector addition.  Instead, use `++` consistently as the
concatenation operator for all data types that support it.

Closes: #330.