### PR TITLE
Add test runner markers for more elaborate xfail marking

### DIFF
--- a/edb/tools/test/__init__.py
+++ b/edb/tools/test/__init__.py
@@ -27,9 +27,15 @@ import click
 
 from edb.tools import edbcommands
 
+from .decorators import not_implemented
+from .decorators import xfail
+
 from . import loader
 from . import runner
 from . import styles
+
+
+__all__ = ('not_implemented', 'xfail')
 
 
 @edbcommands.command()

--- a/edb/tools/test/decorators.py
+++ b/edb/tools/test/decorators.py
@@ -1,7 +1,7 @@
 #
 # This source file is part of the EdgeDB open source project.
 #
-# Copyright 2017-present MagicStack Inc. and the EdgeDB authors.
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,19 +17,21 @@
 #
 
 
-import click
+import unittest
 
 
-__all__ = ()
+def xfail(reason):
+    def decorator(test_item):
+        test_item.__et_xfail_reason__ = reason
+        return unittest.expectedFailure(test_item)
+
+    return decorator
 
 
-marker_passed = lambda t: t
-marker_errored = lambda t: click.style(t, fg='red', bold=True)
-marker_skipped = lambda t: click.style(t, fg='yellow')
-marker_failed = lambda t: click.style(t, fg='red', bold=True)
-marker_xfailed = lambda t: t
-marker_not_implemented = lambda t: t
-marker_upassed = lambda t: click.style(t, fg='yellow')
+def not_implemented(reason):
+    def decorator(test_item):
+        test_item.__et_xfail_reason__ = reason
+        test_item.__et_xfail_not_implemented__ = True
+        return unittest.expectedFailure(test_item)
 
-status = lambda t: click.style(t, fg='white', bold=True)
-warning = lambda t: click.style(t, fg='yellow')
+    return decorator


### PR DESCRIPTION
Currently, we use `@unittest.expectedFailure` regardless of the reason
of the test not passing.  It is useful to a) discriminate between bugs
and not-yet-implemented features; and b) be able to provide a textual
explanation for the test's failure.  This commit adds two decorators:
`edb.tools.test.xfail` and `edb.tools.test.not_implemented` to
implement this.