### PR TITLE
Implement new syntax for the SET command.

### DIFF
--- a/edb/lang/edgeql/ast.py
+++ b/edb/lang/edgeql/ast.py
@@ -100,17 +100,31 @@ class SortExpr(Clause):
 
 
 class BaseAlias(Clause):
-    pass
+    alias: str
 
 
 class AliasedExpr(BaseAlias):
     expr: Expr
-    alias: str
 
 
 class ModuleAliasDecl(BaseAlias):
     module: str
-    alias: str
+
+
+class BaseSessionSetting:
+    pass
+
+
+class SessionSettingModuleDecl(ModuleAliasDecl, BaseSessionSetting):
+    pass
+
+
+class SessionSettingConfigDecl(AliasedExpr, BaseSessionSetting):
+    pass
+
+
+class SetSessionState(Expr):
+    items: typing.List[BaseSessionSetting]
 
 
 class BaseObjectRef(Expr):
@@ -833,10 +847,6 @@ class AlterCast(AlterObject, CastCommand):
 
 class DropCast(DropObject, CastCommand):
     pass
-
-
-class SessionStateDecl(Expr):
-    items: typing.List[BaseAlias]
 
 
 class _Optional(Expr):

--- a/edb/lang/edgeql/codegen.py
+++ b/edb/lang/edgeql/codegen.py
@@ -304,7 +304,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
     def visit_ModuleAliasDecl(self, node):
         if node.alias:
             self.write(ident_to_str(node.alias))
-            self.write(' := ')
+            self.write(' AS ')
         self.write('MODULE ')
         self.write(any_ident_to_str(node.module))
 
@@ -1076,7 +1076,23 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self.write(' = ')
             self.visit(node.default)
 
-    def visit_SessionStateDecl(self, node):
+    def visit_SessionSettingConfigDecl(self, node):
+        self.write(' CONFIG ')
+        self.write(ident_to_str(node.alias))
+        self.write(' := ')
+        self.visit(node.expr)
+
+    def visit_SessionSettingModuleDecl(self, node):
+        if node.alias:
+            self.write(' ALIAS ')
+            self.write(ident_to_str(node.alias))
+            self.write(' AS MODULE ')
+            self.write(node.module)
+        else:
+            self.write(' MODULE')
+            self.write(node.module)
+
+    def visit_SetSessionState(self, node):
         self.write('SET')
         self._block_ws(1)
         self.visit_list(node.items)

--- a/edb/lang/edgeql/compiler/stmt.py
+++ b/edb/lang/edgeql/compiler/stmt.py
@@ -354,16 +354,16 @@ def compile_DeleteQuery(
     return result
 
 
-@dispatch.compile.register(qlast.SessionStateDecl)
-def compile_SessionStateDecl(
-        decl: qlast.SessionStateDecl, *,
+@dispatch.compile.register(qlast.SetSessionState)
+def compile_SetSessionState(
+        decl: qlast.SetSessionState, *,
         ctx: context.ContextLevel) -> irast.SessionStateCmd:
 
     aliases = {}
     testmode = False
 
     for item in decl.items:
-        if isinstance(item, qlast.ModuleAliasDecl):
+        if isinstance(item, qlast.SessionSettingModuleDecl):
             try:
                 module = ctx.env.schema.get(item.module)
             except s_err.ItemNotFoundError:
@@ -374,7 +374,8 @@ def compile_SessionStateDecl(
 
             aliases[item.alias] = module
 
-        elif item.alias == '__internal_testmode':
+        elif (isinstance(item, qlast.SessionSettingConfigDecl) and
+                item.alias == '__internal_testmode'):
             try:
                 testmode_ir = dispatch.compile(item.expr, ctx=ctx)
                 testmode = ireval.evaluate_to_python_val(

--- a/edb/lang/edgeql/parser/grammar/expressions.py
+++ b/edb/lang/edgeql/parser/grammar/expressions.py
@@ -227,7 +227,7 @@ class AliasDecl(Nonterm):
         self.val = qlast.ModuleAliasDecl(
             module='.'.join(kids[1].val))
 
-    def reduce_Identifier_ASSIGN_MODULE_ModuleName(self, *kids):
+    def reduce_Identifier_AS_MODULE_ModuleName(self, *kids):
         self.val = qlast.ModuleAliasDecl(
             alias=kids[0].val,
             module='.'.join(kids[3].val))

--- a/edb/lang/edgeql/parser/grammar/keywords.py
+++ b/edb/lang/edgeql/parser/grammar/keywords.py
@@ -29,6 +29,7 @@ UNRESERVED_KEYWORD, RESERVED_KEYWORD, TYPE_FUNC_NAME_KEYWORD = keyword_types
 unreserved_keywords = frozenset([
     "abstract",
     "after",
+    "alias",
     "allow",
     "as",
     "asc",
@@ -38,6 +39,7 @@ unreserved_keywords = frozenset([
     "by",
     "cardinality",
     "cast",
+    "config",
     "constraint",
     "database",
     "default",
@@ -121,7 +123,6 @@ future_reserved_keywords = frozenset([
 ])
 
 
-# NOTE: all operators are made into RESERVED keywords for reasons of style.
 reserved_keywords = future_reserved_keywords | frozenset([
     "__source__",
     "__subject__",

--- a/edb/lang/edgeql/parser/grammar/session.py
+++ b/edb/lang/edgeql/parser/grammar/session.py
@@ -32,8 +32,19 @@ class SessionStmt(Nonterm):
 
 
 class SetDecl(Nonterm):
-    def reduce_AliasDecl(self, *kids):
-        self.val = kids[0].val
+    def reduce_ALIAS_Identifier_AS_MODULE_ModuleName(self, *kids):
+        self.val = qlast.SessionSettingModuleDecl(
+            module='.'.join(kids[4].val),
+            alias=kids[1].val)
+
+    def reduce_MODULE_ModuleName(self, *kids):
+        self.val = qlast.SessionSettingModuleDecl(
+            module='.'.join(kids[1].val))
+
+    def reduce_CONFIG_Identifier_ASSIGN_Expr(self, *kids):
+        self.val = qlast.SessionSettingConfigDecl(
+            alias=kids[1].val,
+            expr=kids[3].val)
 
 
 class SetDeclList(ListNonterm, element=SetDecl,
@@ -43,6 +54,6 @@ class SetDeclList(ListNonterm, element=SetDecl,
 
 class SetStmt(Nonterm):
     def reduce_SET_SetDeclList(self, *kids):
-        self.val = qlast.SessionStateDecl(
+        self.val = qlast.SetSessionState(
             items=kids[1].val
         )

--- a/edb/server/_testbase.py
+++ b/edb/server/_testbase.py
@@ -229,7 +229,7 @@ class DatabaseTestCase(ConnectedTestCase):
 
     def setUp(self):
         self.loop.run_until_complete(
-            self.con.execute('SET __internal_testmode := true;'))
+            self.con.execute('SET CONFIG __internal_testmode := true;'))
 
         if self.ISOLATED_METHODS:
             self.loop.run_until_complete(

--- a/edb/server/planner.py
+++ b/edb/server/planner.py
@@ -73,7 +73,7 @@ async def plan_statement(stmt, backend, flags={}, *, timer):
         # BEGIN/COMMIT
         return TransactionStatement(stmt)
 
-    elif isinstance(stmt, qlast.SessionStateDecl):
+    elif isinstance(stmt, qlast.SetSessionState):
         # SET ...
         with timer.timeit('compile_eql_to_ir'):
             ir = ql_compiler.compile_ast_to_ir(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -577,7 +577,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             CREATE MODULE foo;
             CREATE MODULE bar;
 
-            SET MODULE foo, b := MODULE bar;
+            SET MODULE foo, ALIAS b AS MODULE bar;
 
             CREATE SCALAR TYPE foo_t EXTENDING int64 {
                 CREATE CONSTRAINT expression ON (__subject__ > 0);

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1752,7 +1752,7 @@ aa';
         """
         WITH
             MODULE test,
-            extra := MODULE lib.extra,
+            extra AS MODULE lib.extra,
             foo := Bar.foo,
             baz := (SELECT extra::Foo.baz)
         SELECT Bar {
@@ -3305,12 +3305,12 @@ aa';
 
     def test_edgeql_syntax_set_command_02(self):
         """
-        SET foo := MODULE default;
+        SET ALIAS foo AS MODULE default;
         """
 
     def test_edgeql_syntax_set_command_03(self):
         """
-        SET MODULE default, foo := (SELECT User);
+        SET MODULE default, CONFIG foo := (SELECT User);
         """
 
     def test_edgeql_syntax_ddl_view_01(self):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -93,7 +93,7 @@ class TestSession(tb.QueryTestCase):
 
     async def test_session_set_command_03(self):
         await self.assert_query_result("""
-            SET MODULE foo, bar := MODULE default;
+            SET MODULE foo, ALIAS bar AS MODULE default;
 
             SELECT (Entity.name, bar::User.name);
         """, [
@@ -108,7 +108,7 @@ class TestSession(tb.QueryTestCase):
                 err.EdgeQLError,
                 'expression aliases in SET are not supported yet'):
             await self.assert_query_result("""
-                SET foo := 1 + 1;
+                SET CONFIG foo := 1 + 1;
             """, [
                 None,
             ])
@@ -116,9 +116,9 @@ class TestSession(tb.QueryTestCase):
     async def test_session_set_command_05(self):
         # Check that local WITH overrides the session level setting.
         await self.assert_query_result("""
-            SET MODULE default, bar := MODULE foo;
+            SET MODULE default, ALIAS bar AS MODULE foo;
 
-            WITH MODULE foo, bar := MODULE default
+            WITH MODULE foo, bar AS MODULE default
             SELECT (Entity.name, bar::User.name);
         """, [
 


### PR DESCRIPTION
Supported variants:

* SET CONFIG name := expr;
* SET MODULE default;
* SET ALIAS my_foo AS MODULE foo;

Partially addresses issue #347.