### PR TITLE
Implement generic reference tracking in the schema

### DIFF
--- a/edb/lang/edgeql/optimizer.py
+++ b/edb/lang/edgeql/optimizer.py
@@ -290,8 +290,7 @@ class EdgeQLOptimizer:
         elif isinstance(expr, (qlast.AlterAddInherit,
                                qlast.AlterDropInherit)):
             for base in expr.bases:
-                base.module = self._process_module_ref(
-                    context, base.module)
+                self._process_expr(context, base)
 
     def _process_shape(self, context, shape):
         for spec in shape.elements:

--- a/edb/lang/schema/delta.py
+++ b/edb/lang/schema/delta.py
@@ -182,7 +182,7 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
     @classmethod
     def adapt(cls, obj):
         result = obj.copy_with_class(cls)
-        for op in obj:
+        for op in obj.get_subcommands():
             result.ops.add(type(cls).adapt(op))
         return result
 
@@ -233,6 +233,12 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
                 op.new_value, op.property, field, schema)
 
         return result
+
+    def has_attribute_value(self, attr_name):
+        for op in self.get_subcommands(type=AlterObjectProperty):
+            if op.property == attr_name:
+                return True
+        return False
 
     def get_attribute_value(self, attr_name):
         for op in self.get_subcommands(type=AlterObjectProperty):

--- a/edb/lang/schema/named.py
+++ b/edb/lang/schema/named.py
@@ -265,9 +265,9 @@ class AlterNamedObject(CreateOrAlterNamedObject, sd.AlterObject):
                 if isinstance(astcmd, qlast.AlterDropInherit):
                     dropped_bases.extend(
                         so.ObjectRef(
-                            classname=sn.Name(
-                                module=b.module,
-                                name=b.name
+                            name=sn.Name(
+                                module=b.maintype.module,
+                                name=b.maintype.name
                             )
                         )
                         for b in astcmd.bases
@@ -276,8 +276,9 @@ class AlterNamedObject(CreateOrAlterNamedObject, sd.AlterObject):
                 elif isinstance(astcmd, qlast.AlterAddInherit):
                     bases = [
                         so.ObjectRef(
-                            classname=sn.Name(
-                                module=b.module, name=b.name))
+                            name=sn.Name(
+                                module=b.maintype.module,
+                                name=b.maintype.name))
                         for b in astcmd.bases
                     ]
 

--- a/edb/lang/schema/referencing.py
+++ b/edb/lang/schema/referencing.py
@@ -42,8 +42,7 @@ class RefDict(struct.Struct):
 
 class RebaseReferencingObject(inheriting.RebaseNamedObject):
     def apply(self, schema, context):
-        schema, this_obj = super().apply(schema, context)
-
+        this_obj = schema.get(self.classname)
         objects = [this_obj] + list(this_obj.descendants(schema))
         for obj in objects:
             for refdict in this_obj.__class__.get_refdicts():
@@ -62,6 +61,7 @@ class RebaseReferencingObject(inheriting.RebaseNamedObject):
                         except KeyError:
                             del coll[ref_name]
 
+        schema, this_obj = super().apply(schema, context)
         return schema, this_obj
 
 

--- a/edb/server/_testbase.py
+++ b/edb/server/_testbase.py
@@ -540,6 +540,9 @@ class DDLTestCase(BaseQueryTestCase):
     # DDL test cases generally need to be serialized
     # to avoid deadlocks in parallel execution.
     SERIALIZED = True
+
+
+class NonIsolatedDDLTestCase(DDLTestCase):
     ISOLATED_METHODS = False
 
 

--- a/edb/server/pgsql/delta.py
+++ b/edb/server/pgsql/delta.py
@@ -319,6 +319,7 @@ class RebaseNamedObject(NamedObjectMetaCommand):
     def apply(self, schema, context):
         schema, obj = self.__class__.get_adaptee().apply(self, schema, context)
         schema, _ = NamedObjectMetaCommand.apply(self, schema, context)
+        self.updates = self.update(schema, context)
         return schema, obj
 
 
@@ -1800,6 +1801,7 @@ class RebaseObjectType(ObjectTypeMetaCommand,
         schema, result = s_objtypes.RebaseObjectType.apply(
             self, schema, context)
         schema, _ = ObjectTypeMetaCommand.apply(self, schema, context)
+        self.update(schema, context)
 
         if self.has_table(result, schema):
             objtype_ctx = context.get(s_objtypes.ObjectTypeCommandContext)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -585,7 +585,7 @@ class TestConstraintsSchemaMigration(tb.QueryTestCase):
                 """)
 
 
-class TestConstraintsDDL(tb.DDLTestCase):
+class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
     async def test_constraints_ddl_01(self):
         qry = """
             CREATE ABSTRACT LINK test::translated_label {

--- a/tests/test_link_target_delete.py
+++ b/tests/test_link_target_delete.py
@@ -29,7 +29,7 @@ from edb.lang.schema import links as s_links
 from edb.server import _testbase as stb
 
 
-class TestLinkTargetDeleteSchema(tb.BaseSchemaTest):
+class TestLinkTargetDeleteSchema(tb.BaseSchemaLoadTest):
     def test_schema_on_target_delete_01(self):
         schema = self.load_schema("""
             type Object:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -23,7 +23,7 @@ from edb.lang.schema import error as s_err
 from edb.lang.schema import pointers as s_pointers
 
 
-class TestSchema(tb.BaseSchemaTest):
+class TestSchema(tb.BaseSchemaLoadTest):
     def test_schema_inherited_01(self):
         """
             type UniqueName:


### PR DESCRIPTION
This adds generic tracking of object-to-object references in the schema for
fast lookup and integrity checking.  The new `Schema.get_referrers()` 
method returns a set of all schema objects referring to the specified 
object, optionally filtered by referrer type and field name.

The cast lookup has been switched to this infrastructure, and so the 
dedicated cast lookup index is no longer needed.