### PR TITLE
Make sure link endpoint deletion triggers get updated properly

### DIFF
--- a/edb/server/pgsql/common.py
+++ b/edb/server/pgsql/common.py
@@ -153,11 +153,27 @@ def _scalar_name_to_domain_name(name, catenate=True, prefix='edgedb_', *,
     return convert_name(name, aspect, catenate)
 
 
-def _get_backend_objtype_name(schema, objtype, catenate=True):
+def _get_backend_objtype_name(schema, objtype, catenate=True, aspect=None):
+    if aspect is None:
+        aspect = 'table'
+    if aspect not in (
+            'table',
+            'target-del-def-t', 'target-del-imm-t',
+            'source-del-def-t', 'source-del-imm-t',
+            'target-del-def-f', 'target-del-imm-f',
+            'source-del-def-f', 'source-del-imm-f'):
+        raise ValueError(
+            f'unexpected aspect for object type backend name: {aspect!r}')
+
     name = s_name.Name(module=objtype.get_name(schema).module,
                        name=str(objtype.id))
 
-    return convert_name(name, catenate=catenate)
+    if aspect != 'table':
+        suffix = aspect
+    else:
+        suffix = ''
+
+    return convert_name(name, suffix=suffix, catenate=catenate)
 
 
 def _link_name_to_table_name(name, catenate=True):
@@ -250,7 +266,7 @@ def _get_backend_constraint_name(
 
 def get_backend_name(schema, obj, catenate=True, *, aspect=None):
     if isinstance(obj, s_objtypes.ObjectType):
-        return _get_backend_objtype_name(schema, obj, catenate)
+        return _get_backend_objtype_name(schema, obj, catenate, aspect=aspect)
 
     elif isinstance(obj, s_props.Property):
         return _prop_name_to_table_name(obj.get_name(schema), catenate)

--- a/tests/schemas/link_tgt_del_migrated.eschema
+++ b/tests/schemas/link_tgt_del_migrated.eschema
@@ -36,7 +36,7 @@ type Source1 extending Named:
         on target delete delete source
 
     link tgt1_deferred_restrict -> Target1:
-        on target delete deferred restrict
+        on target delete restrict
 
     multi link tgt1_m2m_restrict -> Target1:
         on target delete restrict
@@ -53,9 +53,11 @@ type Source2 extending Named:
 type Source3 extending Source1
 
 
-type ObjectType4:
+abstract type AbstractObjectType:
     link foo -> Target1
 
 
-type ObjectType5:
-    link foo -> Target1
+type ObjectType4 extending AbstractObjectType
+
+
+type ObjectType5 extending AbstractObjectType


### PR DESCRIPTION
When a link is dropped or modified in any way, the endpoint deletion
policy triggers on the affected source and target types must be rebuilt.