### PR TITLE
docs: Update link and property docs to use the new cardinality syntax

### DIFF
--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -75,17 +75,17 @@ declaration in the context of a ``type`` declaration:
 .. eschema:synopsis::
 
     type <TypeName>:
-        [required] [readonly] [inherited] link <link-name>:
-            [ cardinality := {'11' | '1*' | '*1' | '**'} ]
+        [required] [inherited] [{multi | single}] link <link-name> -> <type>:
             [ expr := <computable-expr> ]
             [ default := <default-expr> ]
+            [ readonly := {true | false} ]
             [ <attribute-declarations> ]
             [ <constraint-declarations> ]
 
     # shorthand form for computable link declaration:
 
     type <TypeName>:
-        [inherited] link <link-name> := <computable-expr>
+        [inherited] [{multi | single}] link <link-name> := <computable-expr>
 
 
 Parameters:
@@ -97,29 +97,29 @@ Parameters:
     the *required* attribute, i.e it is not possible to make a
     required link non-required by extending it.
 
+:eschema:synopsis:`inherited`
+    This qualifier must be specified if the link is *inherited* from
+    one or more parent object types.
+
+:eschema:synopsis:`multi`
+    Specifies that there may be more than one instance of this link
+    in an object, in other words, ``Object.link`` may resolve to a set
+    of a size greater than one.
+
+:eschema:synopsis:`single`
+    Specifies that there may be at most *one* instance of this link
+    in an object, in other words, ``Object.link`` may resolve to a set
+    of a size not greater than one.  ``single`` is assumed if nether
+    ``multi`` nor ``single`` qualifier is specified.
+
 :eschema:synopsis:`readonly`
     If specified, the link is considered *read-only*.  Modifications
     of this link are prohibited once an object is created.
 
-:eschema:synopsis:`cardinality := <cardinality>`
-    Specifies the *cardinality* of this link, which, in order of
-    decreasing strictness, can be one of:
-
-    - ``'11'`` ("one-to-one") -- object may refer to exactly one other
-      object, and the referred object cannot be referred to by any other
-      object using this link.
-
-    - ``'1*'`` ("one-to-many") -- object may refer to multiple objects,
-      and the referred objects cannot be referred to by any other object
-      using this link.
-
-    - ``'*1'`` ("many-to-one") -- object may refer to exactly one other
-      object, and the other object may be referred to by other objects
-      using this link.  *This is the default*.
-
-    - ``'**'`` ("many-to-many") -- object may refer to multiple other
-      objects and the referred objects may be referred to by other objects
-      using this link.
+:eschema:synopsis:`default`
+    Specifies the default value for the link as an EdgeQL expression.
+    The default value is used in an ``INSERT`` statement if an explicit
+    value for this link is not specified.
 
 :eschema:synopsis:`<computable-expr>`
     If specified, designates this link as a *computable link*

--- a/docs/datamodel/props.rst
+++ b/docs/datamodel/props.rst
@@ -67,22 +67,25 @@ declaration in the context of a ``type`` or ``abstract link`` declaration:
 .. eschema:synopsis::
 
     type <TypeName>:
-        [required] [readonly] [inherited] property <prop-name>:
+        [required] [inherited] [{multi|single}] property <prop-name> -> <type>:
             [ expr := <computable-expr> ]
             [ default := <default-expr> ]
+            [ readonly := {true | false} ]
             [ <attribute-declarations> ]
+            [ <constraint-declarations> ]
 
     # shorthand form for computable property declaration:
 
     type <TypeName>:
-        [inherited] property <prop-name> := <computable-expr>
+        [inherited] [{multi|single}] property <prop-name> := <computable-expr>
 
     # link property declaration:
 
     abstract link <link-name>:
-        [readonly] [inherited] property <prop-name>:
+        [inherited] property <prop-name>:
             [ expr := <computable-expr> ]
             [ default := <default-expr> ]
+            [ readonly := {true | false} ]
             [ <attribute-declarations> ]
 
     # shorthand form for computable link property declaration:
@@ -104,9 +107,33 @@ Parameters:
 
         Link properties cannot be ``required``.
 
+:eschema:synopsis:`inherited`
+    This qualifier must be specified if the property is *inherited* from
+    one or more parent object types or links.
+
+:eschema:synopsis:`multi`
+    Specifies that there may be more than one instance of this property
+    in an object, in other words, ``Object.property`` may resolve to a set
+    of a size greater than one.
+
+:eschema:synopsis:`single`
+    Specifies that there may be at most *one* instance of this property
+    in an object, in other words, ``Object.property`` may resolve to a set
+    of a size not greater than one.  ``single`` is assumed if nether
+    ``multi`` nor ``single`` qualifier is specified.
+
+    .. note::
+
+        Link properties are always ``single``.
+
 :eschema:synopsis:`readonly`
     If specified, the property is considered *read-only*.  Modifications
     of this property are prohibited once an object or link is created.
+
+:eschema:synopsis:`default`
+    Specifies the default value for the property as an EdgeQL expression.
+    The default value is used in an ``INSERT`` statement if an explicit
+    value for this property is not specified.
 
 :eschema:synopsis:`<computable-expr>`
     If specified, designates this property as a *computable property*
@@ -118,6 +145,9 @@ Parameters:
 :eschema:synopsis:`<attribute-declarations>`
     :ref:`Schema attribute <ref_datamodel_attributes>` declarations.
 
+:eschema:synopsis:`<constraint-declarations>`
+    :ref:`Constraint <ref_datamodel_constraints>` declarations.
 
-Concrete links can also be defined using the
-:eql:stmt:`CREATE LINK <CREATE-LINK>` EdgeQL command.
+
+Concrete properties can also be defined using the
+:eql:stmt:`CREATE PROPERTY` EdgeQL command.

--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -199,11 +199,11 @@ specified *object type*.
 .. eql:synopsis::
 
     [ WITH <with-item> [, ...] ]
-    CREATE [ REQUIRED ] [ INHERITED ] LINK <name> TO <typename>
+    CREATE [ REQUIRED ] [{SINGLE | MULTI}] LINK <name> TO <type>
     [ "{" <action>; [...] "}" ] ;
 
     [ WITH <with-item> [, ...] ]
-    CREATE [ INHERITED ] LINK <name> := <expression> ;
+    CREATE [ REQUIRED ] [{SINGLE | MULTI}] LINK <name> := <expression> ;
 
 
 Description
@@ -224,12 +224,10 @@ The canonical form of ``CREATE LINK`` defines a concrete link *name*
 referring to the *typename* type.  If the optional ``REQUIRED``
 keyword is specified, the link is considered required.
 
-The ``INHERITED`` keyword is required when the containing object type
-has supertypes with the same link name, or when there is an abstract
-link with the same name defined in the same module as the containing
-object type.  *Inherited* links form a persistent connections in the
-schema.  Schema modifications to parent links propagate to the child
-link.
+The optional ``SINGLE`` and ``MULTI`` qualifiers specify how many
+instances of the link are allowed per object.  ``SINGLE`` specifies that
+there may be at most *one* instance, and ``MULTI`` specifies that there may
+be more than one.  ``SINGLE`` is the default.
 
 :eql:synopsis:`<action>`
     The following actions are allowed in the ``CREATE LINK`` block:
@@ -252,7 +250,7 @@ Define a new string link ``interests`` on the ``User`` object type:
 .. code-block:: edgeql
 
     ALTER TYPE User {
-        CREATE LINK interests -> str;
+        CREATE MULTI LINK interests -> str;
     };
 
 Define a new computable link ``followers_count`` on the
@@ -303,6 +301,12 @@ alter action.
         links can be renamed.  When a concrete or abstract link is
         renamed, all concrete links that inherit from it are also
         renamed.
+
+    :eql:synopsis:`SET SINGLE`
+        Change the maximum cardinality of the link set to *one*.
+
+    :eql:synopsis:`SET MULTI`
+        Change the maximum cardinality of the link set to *greater then one*.
 
     :eql:synopsis:`SET <attribute> := <value>;`
         Set link item's *attribute* to *value*.

--- a/docs/edgeql/ddl/props.rst
+++ b/docs/edgeql/ddl/props.rst
@@ -173,11 +173,11 @@ Define a concrete property on the specified link.
 .. eql:synopsis::
 
     [ WITH <with-item> [, ...] ]
-    CREATE [ INHERITED ] PROPERTY <name> TO <typename>
+    CREATE [{SINGLE | MULTI}] PROPERTY <name> -> <type>
     [ "{" <action>; [...] "}" ] ;
 
     [ WITH <with-item> [, ...] ]
-    CREATE [ INHERITED ] PROPERTY <name> := <expression> ;
+    CREATE [{SINGLE | MULTI}] PROPERTY <name> := <expression> ;
 
 Description
 -----------
@@ -197,12 +197,10 @@ Canonical Form
 The canonical form of ``CREATE PROPERTY`` defines a concrete
 property with the given *name* and referring to the *typename* type.
 
-The ``INHERITED`` keyword is required when the containing link
-has parents with the same link proeprty name, or when there is an
-abstract property with the same name defined in the same module
-as the containing link.  *Inherited* link properties form a persistent
-connections in the schema.  Schema modifications to parent link properties
-propagate to the child property.
+The optional ``SINGLE`` and ``MULTI`` qualifiers specify how many
+instances of the property are allowed per object.  ``SINGLE`` specifies that
+there may be at most *one* instance, and ``MULTI`` specifies that there may
+be more than one.  ``SINGLE`` is the default.
 
 :eql:synopsis:`<action>`
     The following actions are allowed in the
@@ -213,13 +211,12 @@ propagate to the child property.
         See :eql:stmt:`SET <SET ATTRIBUTE>` for details.
 
 
-Computable Link Form
---------------------
+Computable Property Form
+------------------------
 
 The computable form of ``CREATE PROPERTY`` defines a concrete
 *computable* property with the given *name*.  The type of the
-link is inferred from the *expression*.  The ``INHERITED`` keyword
-has the same meaning as in the canonical form.
+property is inferred from the *expression*.
 
 
 ALTER PROPERTY
@@ -258,6 +255,13 @@ alter action.
         links can be renamed.  When a concrete or abstract link is
         renamed, all concrete links that inherit from it are also
         renamed.
+
+    :eql:synopsis:`SET SINGLE`
+        Change the maximum cardinality of the property set to *one*.
+
+    :eql:synopsis:`SET MULTI`
+        Change the maximum cardinality of the property set to
+        *greater then one*.
 
     :eql:synopsis:`SET <attribute> := <value>;`
         Set link item's *attribute* to *value*.

--- a/docs/edgeql/statements/with.rst
+++ b/docs/edgeql/statements/with.rst
@@ -104,10 +104,9 @@ of the computable because it affects serialization.
     };
 
 Cardinality is normally statically inferred from the query, so
-overruling this inference may only be done to *relax* the cardinality.
-This means that the only valid cardinality specification is
-``CARDINALITY '*'``, when attempting to override a possibility that
-the cardinality is provably ``'1'``.
+overruling this inference may only be done to *relax* the cardinality,
+so it is not valid to specify the ``single`` qualifier for a computable
+expression that may return multiple items.
 
 
 Expressions

--- a/docs/graphql/graphql.rst
+++ b/docs/graphql/graphql.rst
@@ -17,8 +17,7 @@ containing the following schema:
         # a required property
         required property title -> str
         property synopsis -> str
-        link author -> Author:
-            cardinality := '*1'
+        link author -> Author
         property isbn -> str:
             constraint maxlength(10)
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -59,10 +59,8 @@ and ``Comment``.  Let's define the initial schema with a migration:
       required property status -> str
       required property created_on -> datetime
       required link author -> User
-      link assignees -> User:
-        cardinality := '**'
-      link comments -> Comment:
-        cardinality := '1*'
+      multi link assignees -> User
+      multi link comments -> Comment
 
     type Comment:
       required property body -> str
@@ -102,10 +100,8 @@ link.  Let's remove this duplication by declaring an abstract parent type
         constraint unique
       required property title -> str
       required property status -> str
-      link assignees -> User:
-        cardinality := '**'
-      link comments -> Comment:
-        cardinality := '1*'
+      multi link assignees -> User
+      multi link comments -> Comment
 
     # <changed>
     type Comment extending AuthoredText


### PR DESCRIPTION
The `cardinality` attribute is no more, the `multi` and `single`
qualifiers are used instead.  Also fix assorted inaccuracies in the
area.