### PR TITLE
Make sure that stdmode and testmode flags are used consistently.

### DIFF
--- a/edb/lang/schema/ddl.py
+++ b/edb/lang/schema/ddl.py
@@ -20,6 +20,7 @@
 from edb.lang import edgeql
 from edb.lang.schema import delta as s_delta
 
+from . import schema as s_schema
 
 # The below must be imported here to make sure we have all
 # necessary mappers from/to DDL AST.
@@ -67,7 +68,7 @@ def compile_migration(cmd, target_schema, current_schema):
         (cmd.classname.module, declarations)
     ])
 
-    stdmodules = std.STD_MODULES
+    stdmodules = s_schema.STD_MODULES
     moditems = target_schema.get_objects(type=modules.Module)
     modnames = {m.get_name(target_schema) for m in moditems} - stdmodules
     if len(modnames) != 1:

--- a/edb/lang/schema/modules.py
+++ b/edb/lang/schema/modules.py
@@ -31,6 +31,9 @@ class Module(attributes.AttributeSubject):
     # fully-qualified names.
     name = so.SchemaField(str)
 
+    def get_displayname(self, schema):
+        return self.get_name(schema)
+
 
 class ModuleCommandContext(sd.ObjectCommandContext):
     pass
@@ -60,5 +63,5 @@ class AlterModule(ModuleCommand, sd.CreateOrAlterObject):
     astnode = qlast.AlterModule
 
 
-class DeleteModule(ModuleCommand):
+class DeleteModule(ModuleCommand, sd.DeleteObject):
     astnode = qlast.DropModule

--- a/edb/lang/schema/operators.py
+++ b/edb/lang/schema/operators.py
@@ -67,7 +67,7 @@ class OperatorCommand(s_func.CallableCommand,
     def _cmd_tree_from_ast(cls, schema, astnode, context):
         if not context.stdmode and not context.testmode:
             raise ql_errors.EdgeQLError(
-                'user-defined operators are not yet supported',
+                'user-defined operators are not supported',
                 context=astnode.context
             )
 

--- a/edb/lang/schema/schema.py
+++ b/edb/lang/schema/schema.py
@@ -33,6 +33,10 @@ from . import operators as s_oper
 from . import types as s_types
 
 
+STD_LIB = ['std', 'schema', 'math']
+STD_MODULES = {'std', 'schema', 'stdgraphql', 'math'}
+
+
 _void = object()
 
 

--- a/edb/server/_testbase.py
+++ b/edb/server/_testbase.py
@@ -226,10 +226,15 @@ class DatabaseTestCase(ConnectedTestCase):
     # Some tests may want to manage transactions manually,
     # in which case ISOLATED_METHODS will be False.
     ISOLATED_METHODS = True
+    # Turns on "EdgeDB developer" mode which allows using restricted
+    # syntax like FROM SQL and similar. It allows modifying standard
+    # library (e.g. declaring casts).
+    INTERNAL_TESTMODE = True
 
     def setUp(self):
-        self.loop.run_until_complete(
-            self.con.execute('SET CONFIG __internal_testmode := true;'))
+        if self.INTERNAL_TESTMODE:
+            self.loop.run_until_complete(
+                self.con.execute('SET CONFIG __internal_testmode := true;'))
 
         if self.ISOLATED_METHODS:
             self.loop.run_until_complete(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -915,7 +915,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 client_errors.EdgeQLError,
                 r'cannot create.*test::ddlf_7\(a: SET OF std::int64\).*'
                 r'SET OF parameters in user-defined EdgeQL functions are '
-                r'not yet supported'):
+                r'not supported'):
 
             await self.con.execute(r'''
                 CREATE FUNCTION test::ddlf_7(a: SET OF int64) -> int64
@@ -1013,8 +1013,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 client_errors.EdgeQLError,
                 r'cannot create.*test::ddlf_12.*'
-                r'function returns a polymorphic type but has no '
-                r'polymorphic parameters'):
+                r'function returns a generic type but has no '
+                r'generic parameters'):
 
             await self.con.execute(r'''
                 CREATE FUNCTION test::ddlf_12(str: std::str) -> anytype

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -1,0 +1,263 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2018-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from edb.client import exceptions as client_errors
+from edb.server import _testbase as tb
+
+
+class TestEdgeQLUserDDL(tb.DDLTestCase):
+    INTERNAL_TESTMODE = False
+
+    async def test_edgeql_userddl_01(self):
+        # testing anytype polymorphism
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot create.*test::func_01.*'
+                r'generic types are not supported in '
+                r'user-defined functions'):
+            await self.con.execute('''
+                CREATE FUNCTION test::func_01(
+                    a: anytype
+                ) -> bool
+                    FROM EdgeQL $$
+                        SELECT a IS float32
+                    $$;
+            ''')
+
+    async def test_edgeql_userddl_02(self):
+        # testing anyreal polymorphism, which is an actual abstract
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot create.*test::func_02.*'
+                r'generic types are not supported in '
+                r'user-defined functions'):
+            await self.con.execute('''
+                CREATE FUNCTION test::func_02(
+                    a: anyreal
+                ) -> bool
+                    FROM EdgeQL $$
+                        SELECT a IS float32
+                    $$;
+            ''')
+
+    async def test_edgeql_userddl_03(self):
+        # testing anytype as return type
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot create.*test::func_03.*'
+                r'generic types are not supported in '
+                r'user-defined functions'):
+            await self.con.execute('''
+                CREATE FUNCTION test::func_03(
+                    a: str
+                ) -> anytype
+                    FROM EdgeQL $$
+                        SELECT a
+                    $$;
+            ''')
+
+    async def test_edgeql_userddl_04(self):
+        # testing anyreal as return type
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot create.*test::func_04.*'
+                r'generic types are not supported in '
+                r'user-defined functions'):
+            await self.con.execute('''
+                CREATE FUNCTION test::func_04(
+                    a: str
+                ) -> anyscalar
+                    FROM EdgeQL $$
+                        SELECT a
+                    $$;
+            ''')
+
+    async def test_edgeql_userddl_05(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot create.*test::func_05.*'
+                r'FROM SQL FUNCTION.*not supported in '
+                r'user-defined functions'):
+            await self.con.execute('''
+                CREATE FUNCTION test::func_05(
+                    a: str
+                ) -> str
+                    FROM SQL FUNCTION 'lower';
+            ''')
+
+    async def test_edgeql_userddl_06(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot create.*test::func_06.*'
+                r'FROM SQL.*not supported in '
+                r'user-defined functions'):
+            await self.con.execute('''
+                CREATE FUNCTION test::func_06(
+                    a: str
+                ) -> str
+                    FROM SQL $$ SELECT "a" $$;
+            ''')
+
+    async def test_edgeql_userddl_07(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'user-defined operators are not supported'):
+            await self.con.execute('''
+                CREATE INFIX OPERATOR
+                std::`+` (l: std::str, r: std::str) -> std::str
+                    FROM SQL OPERATOR r'||';
+            ''')
+
+    async def test_edgeql_userddl_08(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'user-defined casts are not supported'):
+            await self.con.execute('''
+                CREATE CAST FROM std::int64 TO std::timedelta {
+                    FROM SQL CAST;
+                    ALLOW ASSIGNMENT;
+                };
+            ''')
+
+    async def test_edgeql_userddl_09(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot create.*module std is read-only'):
+            await self.con.execute('''
+                CREATE FUNCTION std::func_09(
+                    a: str
+                ) -> str
+                    FROM EdgeQL $$
+                        SELECT a
+                    $$;
+            ''')
+
+    async def test_edgeql_userddl_10(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot create.*module math is read-only'):
+            await self.con.execute('''
+                CREATE FUNCTION math::func_10(
+                    a: str
+                ) -> str
+                    FROM EdgeQL $$
+                        SELECT a
+                    $$;
+            ''')
+
+    async def test_edgeql_userddl_11(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot create.*module std is read-only'):
+            await self.con.execute('''
+                CREATE TYPE std::Foo_11;
+            ''')
+
+    async def test_edgeql_userddl_12(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot create.*module math is read-only'):
+            await self.con.execute('''
+                CREATE TYPE math::Foo_11;
+            ''')
+
+    async def test_edgeql_userddl_13(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot delete.*module std is read-only'):
+            await self.con.execute('''
+                DROP TYPE std::Object;
+            ''')
+
+    async def test_edgeql_userddl_14(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot delete.*module stdgraphql is read-only'):
+            await self.con.execute('''
+                DROP TYPE stdgraphql::Query;
+            ''')
+
+    async def test_edgeql_userddl_15(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot alter.*module std is read-only'):
+            await self.con.execute('''
+                ALTER TYPE std::Object {
+                    CREATE PROPERTY std::foo_15 -> std::str;
+                };
+            ''')
+
+    async def test_edgeql_userddl_16(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot alter.*module stdgraphql is read-only'):
+            await self.con.execute('''
+                ALTER TYPE stdgraphql::Query {
+                    CREATE PROPERTY std::foo_15 -> std::str;
+                };
+            ''')
+
+    async def test_edgeql_userddl_17(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot delete.*module std is read-only'):
+            await self.con.execute('''
+                DROP MODULE std;
+            ''')
+
+    async def test_edgeql_userddl_18(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot delete.*module math is read-only'):
+            await self.con.execute('''
+                DROP MODULE math;
+            ''')
+
+    async def test_edgeql_userddl_19(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot create.*test::func_19.*'
+                r'SET OF parameters in user-defined EdgeQL '
+                r'functions are not supported'):
+            await self.con.execute('''
+                CREATE FUNCTION test::func_19(
+                    a: SET OF str
+                ) -> bool
+                    FROM EdgeQL $$
+                        SELECT EXISTS a
+                    $$;
+            ''')
+
+    async def test_edgeql_userddl_20(self):
+        await self.con.execute('''
+            CREATE FUNCTION test::func_20(
+                a: str
+            ) -> SET OF str
+                FROM EdgeQL $$
+                    SELECT {a, 'a'}
+                $$;
+        ''')
+
+        await self.assert_query_result(r'''
+            SELECT test::func_20('q');
+            SELECT count(test::func_20({'q', 'w'}));
+        ''', [
+            {'q', 'a'},
+            {4},
+        ])


### PR DESCRIPTION
Forbid usage of `FROM SQL` and polymorphic parameter and return types
for user-defined functions.

Add tests for other commands that should not be accessible at user-level
(creating new operators or casts).