### PR TITLE
Switch pointer refdict to unqualified name index

### DIFF
--- a/edb/lang/edgeql/compiler/expr.py
+++ b/edb/lang/edgeql/compiler/expr.py
@@ -527,7 +527,7 @@ def compile_type_check_op(
     left = dispatch.compile(expr.left, ctx=ctx)
     ltype = inference.infer_type(left, ctx.env)
     left = setgen.ptr_step_set(
-        left, source=ltype, ptr_name=('std', '__type__'),
+        left, source=ltype, ptr_name='__type__',
         direction=s_pointers.PointerDirection.Outbound,
         source_context=expr.context, ctx=ctx)
 

--- a/edb/lang/edgeql/compiler/inference/cardinality.py
+++ b/edb/lang/edgeql/compiler/inference/cardinality.py
@@ -192,7 +192,7 @@ def _is_ptr_or_self_ref(
                 ir_set.rptr is not None and
                 srccls.getptr(
                     schema,
-                    ir_set.rptr.ptrcls.get_shortname(schema)) is not None
+                    ir_set.rptr.ptrcls.get_shortname(schema).name) is not None
             ))
         )
 
@@ -218,15 +218,13 @@ def _extract_filters(
             elif _is_ptr_or_self_ref(left, result_set.stype, schema):
                 if infer_cardinality(right, scope_tree, schema) == ONE:
                     if left.stype == result_set.stype:
-                        ptr_filters.append(
-                            left.stype.getptr(schema, 'std::id'))
+                        ptr_filters.append(left.stype.getptr(schema, 'id'))
                     else:
                         ptr_filters.append(left.rptr.ptrcls)
             elif _is_ptr_or_self_ref(right, result_set.stype, schema):
                 if infer_cardinality(left, scope_tree, schema) == ONE:
                     if right.stype == result_set.stype:
-                        ptr_filters.append(
-                            right.stype.getptr(schema, 'std::id'))
+                        ptr_filters.append(right.stype.getptr(schema, 'id'))
                     else:
                         ptr_filters.append(right.rptr.ptrcls)
 

--- a/edb/lang/edgeql/compiler/viewgen.py
+++ b/edb/lang/edgeql/compiler/viewgen.py
@@ -112,7 +112,7 @@ def _process_view(
                 view_rptr=view_rptr, ctx=scopectx))
 
     if is_insert:
-        explicit_ptrs = {ptrcls.get_shortname(ctx.env.schema)
+        explicit_ptrs = {ptrcls.get_shortname(ctx.env.schema).name
                          for ptrcls in pointers}
 
         scls_pointers = stype.get_pointers(ctx.env.schema)
@@ -225,7 +225,7 @@ def _normalize_view_ptr_expr(
         raise RuntimeError(
             f'unexpected path length in view shape: {len(steps)}')
 
-    ptrname = (lexpr.ptr.module, lexpr.ptr.name)
+    ptrname = lexpr.ptr.name
     ptrcls_is_derived = False
 
     compexpr = shape_el.compexpr
@@ -355,12 +355,11 @@ def _normalize_view_ptr_expr(
             base_ptrcls = ptrcls = None
 
             ptr_module = (
-                ptrname[0] or
                 ctx.derived_target_module or
                 stype.get_name(ctx.env.schema).module
             )
 
-            ptr_name = sn.SchemaName(module=ptr_module, name=ptrname[1])
+            ptr_name = sn.SchemaName(module=ptr_module, name=ptrname)
 
         qlexpr = astutils.ensure_qlstmt(compexpr)
 

--- a/edb/lang/graphql/types.py
+++ b/edb/lang/graphql/types.py
@@ -187,9 +187,8 @@ class GQLCoreSchema:
         else:
             edb_type = self.edb_schema.get(typename)
             pointers = edb_type.get_pointers(self.edb_schema)
-            for name in sorted(pointers.shortnames(self.edb_schema),
-                               key=lambda x: x.name):
-                if name.name == '__type__':
+            for name in sorted(pointers.keys(self.edb_schema)):
+                if name == '__type__':
                     continue
 
                 self.edb_schema, ptr = edb_type.resolve_pointer(
@@ -204,7 +203,7 @@ class GQLCoreSchema:
                     else:
                         args = None
 
-                    fields[name.name] = GraphQLField(target, args=args)
+                    fields[name] = GraphQLField(target, args=args)
 
         return fields
 
@@ -219,14 +218,13 @@ class GQLCoreSchema:
 
         edb_type = self.edb_schema.get(typename)
         pointers = edb_type.get_pointers(self.edb_schema)
-        names = sorted(pointers.shortnames(self.edb_schema),
-                       key=lambda x: x.name)
+        names = sorted(pointers.keys(self.edb_schema))
         for name in names:
-            if name.name == '__type__':
+            if name == '__type__':
                 continue
-            if name.name in fields:
+            if name in fields:
                 raise g_errors.GraphQLCoreError(
-                    f"{name.name!r} of {typename} clashes with special "
+                    f"{name!r} of {typename} clashes with special "
                     "reserved fields required for GraphQL conversion"
                 )
 
@@ -240,7 +238,7 @@ class GQLCoreSchema:
             target = self._convert_edb_type(ptr.get_target(self.edb_schema))
             intype = self._gql_inobjtypes.get(f'Filter{target.name}')
             if intype:
-                fields[name.name] = GraphQLInputObjectField(intype)
+                fields[name] = GraphQLInputObjectField(intype)
 
         return fields
 
@@ -295,11 +293,10 @@ class GQLCoreSchema:
 
         edb_type = self.edb_schema.get(typename)
         pointers = edb_type.get_pointers(self.edb_schema)
-        names = sorted(pointers.shortnames(self.edb_schema),
-                       key=lambda x: x.name)
+        names = sorted(pointers.keys(self.edb_schema))
 
         for name in names:
-            if name.name == '__type__':
+            if name == '__type__':
                 continue
 
             self.edb_schema, ptr = edb_type.resolve_pointer(
@@ -314,7 +311,7 @@ class GQLCoreSchema:
             # that can be reflected into GraphQL
             intype = self._gql_inobjtypes.get(f'Filter{target.name}')
             if intype:
-                fields[name.name] = GraphQLInputObjectField(
+                fields[name] = GraphQLInputObjectField(
                     self._gql_ordertypes['Ordering']
                 )
 

--- a/edb/lang/ir/utils.py
+++ b/edb/lang/ir/utils.py
@@ -120,7 +120,7 @@ def get_id_path_id(
     source: s_sources.Source = path_id.target
     assert isinstance(source, s_objtypes.ObjectType)
     return path_id.extend(
-        source.getptr(schema, 'std::id'),
+        source.getptr(schema, 'id'),
         s_pointers.PointerDirection.Outbound,
         schema.get('std::uuid'),
         schema=schema)

--- a/edb/lang/schema/inheriting.py
+++ b/edb/lang/schema/inheriting.py
@@ -199,7 +199,7 @@ class RebaseInheritingObject(sd.ObjectCommand):
                 coll = obj.get_field_value(schema, attr)
                 local_coll = obj.get_field_value(schema, local_attr)
 
-                for ref_name in tuple(coll.shortnames(schema)):
+                for ref_name in tuple(coll.keys(schema)):
                     if not local_coll.has(schema, ref_name):
                         try:
                             obj.get_classref_origin(

--- a/edb/lang/schema/links.py
+++ b/edb/lang/schema/links.py
@@ -101,7 +101,7 @@ class Link(sources.Source, pointers.Pointer):
         src_n = sn.Name('std::source')
         pointers = self.get_pointers(schema)
 
-        if not pointers.has(schema, src_n):
+        if not pointers.has(schema, 'source'):
             source_pbase = schema.get(src_n)
             schema, source_p = source_pbase.derive(
                 schema, self, self.get_source(schema),
@@ -110,7 +110,7 @@ class Link(sources.Source, pointers.Pointer):
             schema = self.add_pointer(schema, source_p)
 
         tgt_n = sn.Name('std::target')
-        if not pointers.has(schema, tgt_n):
+        if not pointers.has(schema, 'target'):
             target_pbase = schema.get(tgt_n)
             schema, target_p = target_pbase.derive(
                 schema, self, self.get_target(schema),

--- a/edb/lang/schema/name.py
+++ b/edb/lang/schema/name.py
@@ -52,9 +52,6 @@ class SchemaName(str):
 
         return result
 
-    def __repr__(self):
-        return '<SchemaName %s>' % self
-
     def as_tuple(self):
         return (self.module, self.name)
 

--- a/edb/lang/schema/objects.py
+++ b/edb/lang/schema/objects.py
@@ -1385,28 +1385,6 @@ class ObjectCollection:
 
         return type(self)._container(result)
 
-    def shortnames(self, schema, *, allow_unresolved=False):
-        result = []
-
-        for item_id in self._ids:
-            if isinstance(item_id, ObjectRef):
-                try:
-                    obj = item_id._resolve_ref(schema)
-                except s_err.ItemNotFoundError:
-                    if allow_unresolved:
-                        result.append(
-                            sn.shortname_from_fullname(
-                                item_id.get_name(schema)))
-                    else:
-                        raise
-                else:
-                    result.append(obj.get_shortname(schema))
-            else:
-                obj = schema.get_by_id(item_id)
-                result.append(obj.get_shortname(schema))
-
-        return type(self)._container(result)
-
     def objects(self, schema):
         result = []
 
@@ -1550,13 +1528,21 @@ class ObjectIndexBase(ObjectCollection, container=tuple):
             return items.get(name, default)
 
 
-class ObjectIndexByFullname(ObjectIndexBase,
-                            key=lambda schema, o: o.get_name(schema)):
+class ObjectIndexByFullname(
+        ObjectIndexBase,
+        key=lambda schema, o: o.get_name(schema)):
     pass
 
 
-class ObjectIndexByShortname(ObjectIndexBase,
-                             key=lambda schema, o: o.get_shortname(schema)):
+class ObjectIndexByShortname(
+        ObjectIndexBase,
+        key=lambda schema, o: o.get_shortname(schema)):
+    pass
+
+
+class ObjectIndexByUnqualifiedName(
+        ObjectIndexBase,
+        key=lambda schema, o: o.get_shortname(schema).name):
     pass
 
 

--- a/edb/lang/schema/objtypes.py
+++ b/edb/lang/schema/objtypes.py
@@ -53,7 +53,11 @@ class ObjectType(BaseObjectType, constraints.ConsistencySubject,
 
     class ReversePointerResolver:
         @classmethod
-        def getptr_from_nqname(cls, schema, source, name):
+        def getptr(cls, schema, source, name):
+            if sn.Name.is_qualified(name):
+                raise ValueError(
+                    'references to concrete pointers must not be qualified')
+
             ptrs = set()
 
             for link in schema.get_objects(type=links.Link):
@@ -63,25 +67,6 @@ class ObjectType(BaseObjectType, constraints.ConsistencySubject,
                     ptrs.add(link)
 
             return ptrs
-
-        @classmethod
-        def getptr_from_fqname(cls, schema, source, name):
-            ptrs = set()
-
-            for link in schema.get_objects(type=links.Link):
-                if (link.get_shortname(schema) == name and
-                        link.get_target(schema) is not None and
-                        source.issubclass(schema, link.get_target(schema))):
-                    ptrs.add(link)
-
-            return ptrs
-
-        @classmethod
-        def getptr(cls, schema, source, name):
-            if sn.Name.is_qualified(name):
-                return cls.getptr_from_fqname(schema, source, name)
-            else:
-                return cls.getptr_from_nqname(schema, source, name)
 
         @classmethod
         def getptr_inherited_from(cls, source, schema,

--- a/edb/lang/schema/schema.py
+++ b/edb/lang/schema/schema.py
@@ -321,8 +321,9 @@ class Schema:
         name = data['name']
 
         if name in self._name_to_id:
-            err = f'{name!r} is already present in the schema {self!r}'
-            raise s_err.SchemaError(err)
+            raise s_err.SchemaError(
+                f'{type(scls).__name__} {name!r} is already present '
+                f'in the schema {self!r}')
 
         data = immu.Map(data)
 

--- a/edb/server/pgsql/compiler/dbobj.py
+++ b/edb/server/pgsql/compiler/dbobj.py
@@ -189,7 +189,7 @@ def range_for_ptrcls(
     corresponding to a set of specialized links computed from the given
     `ptrcls` taking source inheritance into account.
     """
-    linkname = ptrcls.get_shortname(env.schema)
+    linkname = ptrcls.get_shortname(env.schema).name
     endpoint = ptrcls.get_source(env.schema)
 
     tgt_col = pgtypes.get_pointer_storage_info(
@@ -197,7 +197,7 @@ def range_for_ptrcls(
         schema=env.schema).column_name
 
     cols = [
-        'std::source',
+        'source',
         tgt_col
     ]
 
@@ -465,10 +465,8 @@ def cols_for_pointer(
     cols = ['ptr_item_id']
 
     if isinstance(pointer, s_links.Link):
-        for ptr in pointer.get_pointers(env.schema).objects(env.schema):
-            cols.append(
-                common.edgedb_name_to_pg_name(ptr.get_shortname(env.schema)))
+        cols.extend(pointer.get_pointers(env.schema).keys(env.schema))
     else:
-        cols.extend(('std::source', 'std::target'))
+        cols.extend(('source', 'target'))
 
     return cols

--- a/edb/server/pgsql/compiler/relctx.py
+++ b/edb/server/pgsql/compiler/relctx.py
@@ -30,7 +30,6 @@ from edb.lang.schema import objtypes as s_objtypes
 from edb.lang.schema import pointers as s_pointers
 
 from edb.server.pgsql import ast as pgast
-from edb.server.pgsql import common
 from edb.server.pgsql import types as pg_types
 
 from . import astutils
@@ -394,22 +393,22 @@ def _new_mapped_pointer_rvar(
     if isinstance(ptrcls, s_links.Link):
         # XXX: fix this once Properties are Sources
         src_ptr_info = pg_types.get_pointer_storage_info(
-            ptrcls.getptr(ctx.env.schema, 'std::source'), resolve_type=False,
+            ptrcls.getptr(ctx.env.schema, 'source'), resolve_type=False,
             schema=ctx.env.schema)
         src_col = src_ptr_info.column_name
     else:
-        src_col = common.edgedb_name_to_pg_name('std::source')
+        src_col = 'source'
 
     source_ref = pgast.ColumnRef(name=[src_col], nullable=False)
 
     if isinstance(ptrcls, s_links.Link):
         # XXX: fix this once Properties are Sources
         tgt_ptr_info = pg_types.get_pointer_storage_info(
-            ptrcls.getptr(ctx.env.schema, 'std::target'), resolve_type=False,
+            ptrcls.getptr(ctx.env.schema, 'target'), resolve_type=False,
             schema=ctx.env.schema)
         tgt_col = tgt_ptr_info.column_name
     else:
-        tgt_col = common.edgedb_name_to_pg_name('std::target')
+        tgt_col = 'target'
 
     target_ref = pgast.ColumnRef(
         name=[tgt_col],
@@ -461,9 +460,7 @@ def new_static_class_rvar(
     clsname = pgast.StringConstant(
         val=ir_set.rptr.source.stype.material_type(ctx.env.schema).get_name(
             ctx.env.schema))
-    nameref = dbobj.get_column(
-        set_rvar, common.edgedb_name_to_pg_name('schema::name'),
-        nullable=False)
+    nameref = dbobj.get_column(set_rvar, 'name', nullable=False)
     condition = astutils.new_binop(nameref, clsname, op='=')
     substmt = pgast.SelectStmt()
     include_rvar(substmt, set_rvar, ir_set.path_id, ctx=ctx)

--- a/edb/server/pgsql/errormech.py
+++ b/edb/server/pgsql/errormech.py
@@ -56,10 +56,10 @@ class ErrorMech:
                 source_name = source.get_displayname(schema)
 
                 if err.column_name:
-                    pointer_name = sn.Name(err.column_name)
+                    pointer_name = err.column_name
 
             if pointer_name is not None:
-                pname = f'{source_name}.{pointer_name.name}'
+                pname = f'{source_name}.{pointer_name}'
 
                 return edgedb_error.MissingRequiredPointerError(
                     'missing value for required property {}'.format(pname),

--- a/edb/server/pgsql/types.py
+++ b/edb/server/pgsql/types.py
@@ -173,8 +173,7 @@ class PointerStorageInfo:
     def _source_table_info(cls, schema, pointer):
         table = common.get_backend_name(
             schema, pointer.get_source(schema), catenate=False)
-        ptr_name = pointer.get_shortname(schema)
-        col_name = common.edgedb_name_to_pg_name(ptr_name)
+        col_name = pointer.get_shortname(schema).name
         table_type = 'ObjectType'
 
         return table, table_type, col_name
@@ -183,9 +182,8 @@ class PointerStorageInfo:
     def _pointer_table_info(cls, schema, pointer):
         table = common.get_backend_name(
             schema, pointer, catenate=False)
-        col_name = 'std::target'
+        col_name = 'target'
         table_type = 'link'
-        col_name = common.edgedb_name_to_pg_name(col_name)
 
         return table, table_type, col_name
 
@@ -248,14 +246,12 @@ class PointerStorageInfo:
         if isinstance(pointer, irutils.TupleIndirectionLink):
             table = None
             table_type = 'ObjectType'
-            col_name = common.edgedb_name_to_pg_name(
-                pointer.get_shortname(schema).name)
+            col_name = pointer.get_shortname(schema).name
         elif is_lprop:
             table = common.get_backend_name(
                 schema, source, catenate=False)
             table_type = 'link'
-            col_name = common.edgedb_name_to_pg_name(
-                pointer.get_shortname(schema))
+            col_name = pointer.get_shortname(schema).name
         else:
             if isinstance(source, s_scalars.ScalarType):
                 # This is a pseudo-link on an scalar (__type__)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -678,18 +678,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ]
         ])
 
-    async def test_edgeql_ddl_20(self):
-        with self.assertRaisesRegex(
-                client_errors.EdgeQLError,
-                r'cannot create.*test::my_agg.*function:.+anytype.+cannot '
-                r'have a non-empty default'):
-            await self.con.execute(r"""
-                CREATE FUNCTION test::my_agg(
-                        s: anytype = [1]) -> array<anytype>
-                    FROM SQL FUNCTION "my_agg";
-            """)
-
-    async def test_edgeql_ddl_21(self):
+    async def test_edgeql_ddl_bad_01(self):
         with self.assertRaisesRegex(
                 client_errors.SchemaError,
                 r'unqualified name and no default module set'):
@@ -699,7 +688,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             """)
 
-    async def test_edgeql_ddl_22(self):
+    async def test_edgeql_ddl_bad_02(self):
         with self.assertRaisesRegex(
                 client_errors.SchemaError,
                 r'unqualified name and no default module set'):
@@ -709,7 +698,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             """)
 
-    async def test_edgeql_ddl_23(self):
+    async def test_edgeql_ddl_bad_03(self):
         with self.assertRaisesRegex(
                 client_errors.SchemaError,
                 r'unexpected number of subtypes, expecting 1'):
@@ -719,7 +708,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             """)
 
-    async def test_edgeql_ddl_24(self):
+    async def test_edgeql_ddl_bad_04(self):
         with self.assertRaisesRegex(
                 client_errors.SchemaError,
                 r'nested arrays are not supported'):
@@ -729,7 +718,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             """)
 
-    async def test_edgeql_ddl_25(self):
+    async def test_edgeql_ddl_bad_05(self):
         with self.assertRaisesRegex(
                 client_errors.SchemaError,
                 r'mixing named and unnamed tuple declaration is not '
@@ -740,7 +729,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             """)
 
-    async def test_edgeql_ddl_26(self):
+    async def test_edgeql_ddl_bad_06(self):
         with self.assertRaisesRegex(
                 client_errors.SchemaError,
                 r'unexpected number of subtypes, expecting 1'):
@@ -750,7 +739,56 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             """)
 
-    async def test_edgeql_ddl_27(self):
+    async def test_edgeql_ddl_link_bad_01(self):
+        with self.assertRaisesRegex(
+                client_errors.SchemaError,
+                f'link or property name length exceeds the maximum'):
+            await self.con.execute("""
+                CREATE ABSTRACT LINK test::f123456789_123456789_123456789_\
+123456789_123456789_123456789_123456789_123456789;
+            """)
+
+        with self.assertRaisesRegex(
+                client_errors.SchemaError,
+                f'link or property name length exceeds the maximum'):
+            await self.con.execute("""
+                CREATE TYPE test::Foo {
+                    CREATE LINK test::f123456789_123456789_123456789_\
+123456789_123456789_123456789_123456789_123456789 -> test::Foo;
+                };
+            """)
+
+    async def test_edgeql_ddl_prop_bad_01(self):
+        with self.assertRaisesRegex(
+                client_errors.SchemaError,
+                f'link or property name length exceeds the maximum'):
+            await self.con.execute("""
+                CREATE ABSTRACT PROPERTY test::f123456789_123456789_123456789_\
+123456789_123456789_123456789_123456789_123456789;
+            """)
+
+        with self.assertRaisesRegex(
+                client_errors.SchemaError,
+                f'link or property name length exceeds the maximum'):
+            await self.con.execute("""
+                CREATE TYPE test::Foo {
+                    CREATE PROPERTY test::f123456789_123456789_123456789_\
+123456789_123456789_123456789_123456789_123456789 -> std::str;
+                };
+            """)
+
+    async def test_edgeql_ddl_function_bad_01(self):
+        with self.assertRaisesRegex(
+                client_errors.EdgeQLError,
+                r'cannot create.*test::my_agg.*function:.+anytype.+cannot '
+                r'have a non-empty default'):
+            await self.con.execute(r"""
+                CREATE FUNCTION test::my_agg(
+                        s: anytype = [1]) -> array<anytype>
+                    FROM SQL FUNCTION "my_agg";
+            """)
+
+    async def test_edgeql_ddl_function_bad_02(self):
         with self.assertRaisesRegex(
                 client_errors.EdgeQLError,
                 r'invalid declaration.*unexpected type of the default'):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -79,6 +79,16 @@ class TestSchema(tb.BaseSchemaLoadTest):
         """
 
     @tb.must_fail(s_err.SchemaError,
+                  'link or property name length exceeds the maximum.*',
+                  position=42)
+    def test_schema_bad_link_03(self):
+        """
+            type Object:
+                link f123456789_123456789_123456789_123456789_123456789\
+_123456789_123456789_123456789 -> Object
+        """
+
+    @tb.must_fail(s_err.SchemaError,
                   'invalid property target, expected primitive type, '
                   'got ObjectType',
                   position=58)
@@ -96,6 +106,16 @@ class TestSchema(tb.BaseSchemaLoadTest):
         """
             type Object:
                 property foo := (SELECT Object)
+        """
+
+    @tb.must_fail(s_err.SchemaError,
+                  'link or property name length exceeds the maximum.*',
+                  position=42)
+    def test_schema_bad_prop_03(self):
+        """
+            type Object:
+                property f123456789_123456789_123456789_123456789_123456789\
+_123456789_123456789_123456789 -> str
         """
 
     @tb.must_fail(s_err.SchemaError,
@@ -152,9 +172,9 @@ class TestSchema(tb.BaseSchemaLoadTest):
         Obj4 = schema.get('test::Object4')
         Obj5 = schema.get('test::Object5')
         Obj6 = schema.get('test::Object6')
-        foo = Obj2.getptr(schema, 'test::foo')
-        foo_target = foo.getptr(schema, 'std::target')
-        bar = Obj5.getptr(schema, 'test::bar')
+        foo = Obj2.getptr(schema, 'foo')
+        foo_target = foo.getptr(schema, 'target')
+        bar = Obj5.getptr(schema, 'bar')
 
         self.assertEqual(
             schema.get_referrers(Obj1),


### PR DESCRIPTION
We already prohibit referencing links and properties by their
module-qualified name in path expressions.  This takes a step further
and switches the `pointers` refdict to use the unqualified name as the
key, making the unqualified name a unique identifier for the pointer in
the context of its source.

Given this change, the "pointer name" -> "backend column name"
translation is now a nop, which also means that we now restrict the
length of the unqualified pointer name to PostgreSQL's 63 characters.