### PR TITLE
Make everything orderable.

### DIFF
--- a/edb/lang/edgeql/compiler/func.py
+++ b/edb/lang/edgeql/compiler/func.py
@@ -351,15 +351,17 @@ def finalize_args(bound_call: polyres.BoundCall, *,
                 pathctx.register_set_in_scope(arg, ctx=ctx)
                 pathctx.mark_path_as_optional(arg.path_id, ctx=ctx)
 
-        paramtype = param.get_type(ctx.env.schema)
+        paramtype = barg.param_type
         param_kind = param.get_kind(ctx.env.schema)
         if param_kind is ft.ParameterKind.VARIADIC:
             # For variadic params, paramtype would be array<T>,
             # and we need T to cast the arguments.
             paramtype = list(paramtype.get_subtypes())[0]
 
-        if (not barg.valtype.issubclass(ctx.env.schema, paramtype)
-                and not paramtype.is_polymorphic(ctx.env.schema)):
+        val_material_type = barg.valtype.material_type(ctx.env.schema)
+        param_material_type = paramtype.material_type(ctx.env.schema)
+        if not val_material_type.issubclass(
+                ctx.env.schema, param_material_type):
             # The callable form was chosen via an implicit cast,
             # cast the arguments so that the backend has no
             # wiggle room to apply its own (potentially different)

--- a/edb/lang/edgeql/compiler/polyres.py
+++ b/edb/lang/edgeql/compiler/polyres.py
@@ -41,6 +41,7 @@ from . import setgen
 class BoundArg(typing.NamedTuple):
 
     param: typing.Optional[s_func.Parameter]
+    param_type: s_types.Type
     val: typing.Optional[irast.Base]
     valtype: s_types.Type
     cast_distance: int
@@ -173,7 +174,14 @@ def try_bind_call_args(
             ct = resolved_poly_base_type.find_common_implicitly_castable_type(
                 resolved, ctx.env.schema)
 
-            return 0 if ct is not None else -1
+            if ct is not None:
+                # If we found a common implicitly castable type, we
+                # refine our resolved_poly_base_type to be that as the
+                # more general case.
+                resolved_poly_base_type = ct
+                return 0
+            else:
+                return -1
 
         if arg_type.issubclass(schema, param_type):
             return 0
@@ -207,7 +215,7 @@ def try_bind_call_args(
                         typeref=irtyputils.type_to_typeref(schema, bytes_t)),
                     typehint=bytes_t,
                     ctx=ctx)
-                args = [BoundArg(None, argval, bytes_t, 0)]
+                args = [BoundArg(None, bytes_t, argval, bytes_t, 0)]
             return BoundCall(
                 func, args, set(),
                 func.get_return_type(schema),
@@ -248,16 +256,17 @@ def try_bind_call_args(
         pi += 1
 
         param_shortname = param.get_shortname(schema)
+        param_type = param.get_type(schema)
         if param_shortname in kwargs:
             matched_kwargs += 1
 
             arg_type, arg_val = kwargs[param_shortname]
-            cd = _get_cast_distance(arg_val, arg_type, param.get_type(schema))
+            cd = _get_cast_distance(arg_val, arg_type, param_type)
             if cd < 0:
                 return _NO_MATCH
 
             bound_param_args.append(
-                BoundArg(param, arg_val, arg_type, cd))
+                BoundArg(param, param_type, arg_val, arg_type, cd))
 
         else:
             if param.get_default(schema) is None:
@@ -267,7 +276,7 @@ def try_bind_call_args(
 
             has_missing_args = True
             bound_param_args.append(
-                BoundArg(param, None, param.get_type(schema), 0))
+                BoundArg(param, param_type, None, param_type, 0))
 
     if matched_kwargs != len(kwargs):
         # extra kwargs?
@@ -283,6 +292,7 @@ def try_bind_call_args(
                 # too many positional arguments
                 return _NO_MATCH
             param = params[pi]
+            param_type = param.get_type(schema)
             param_kind = param.get_kind(schema)
             pi += 1
 
@@ -297,7 +307,7 @@ def try_bind_call_args(
                     return _NO_MATCH
 
                 bound_param_args.append(
-                    BoundArg(param, arg_val, arg_type, cd))
+                    BoundArg(param, param_type, arg_val, arg_type, cd))
 
                 for arg_type, arg_val in args[ai:]:
                     cd = _get_cast_distance(arg_val, arg_type, var_type)
@@ -305,7 +315,7 @@ def try_bind_call_args(
                         return _NO_MATCH
 
                     bound_param_args.append(
-                        BoundArg(param, arg_val, arg_type, cd))
+                        BoundArg(param, param_type, arg_val, arg_type, cd))
 
                 break
 
@@ -314,7 +324,7 @@ def try_bind_call_args(
                 return _NO_MATCH
 
             bound_param_args.append(
-                BoundArg(param, arg_val, arg_type, cd))
+                BoundArg(param, param_type, arg_val, arg_type, cd))
 
         else:
             break
@@ -333,7 +343,7 @@ def try_bind_call_args(
             has_missing_args = True
             param_type = param.get_type(schema)
             bound_param_args.append(
-                BoundArg(param, None, param_type, 0))
+                BoundArg(param, param_type, None, param_type, 0))
 
         elif param_kind is _VARIADIC:
             has_empty_variadic = True
@@ -398,6 +408,7 @@ def try_bind_call_args(
 
                 bound_param_args[i] = BoundArg(
                     param,
+                    param_type,
                     default,
                     barg.valtype,
                     barg.cast_distance,
@@ -417,7 +428,7 @@ def try_bind_call_args(
                 value=bm.decode('ascii'),
                 typeref=irtyputils.type_to_typeref(ctx.env.schema, bytes_t)),
             typehint=bytes_t, ctx=ctx)
-        bound_param_args.insert(0, BoundArg(None, bm_set, bytes_t, 0))
+        bound_param_args.insert(0, BoundArg(None, bytes_t, bm_set, bytes_t, 0))
 
     return_type = func.get_return_type(schema)
     if return_type.is_polymorphic(schema):
@@ -426,6 +437,20 @@ def try_bind_call_args(
                 schema, resolved_poly_base_type)
         elif not in_polymorphic_func:
             return _NO_MATCH
+
+    # resolved_poly_base_type may be legitimately None within
+    # bodies of polymorphic functions
+    if resolved_poly_base_type is not None:
+        for i, barg in enumerate(bound_param_args):
+            if barg.param_type.is_polymorphic(schema):
+                bound_param_args[i] = BoundArg(
+                    barg.param,
+                    barg.param_type.to_nonpolymorphic(
+                        schema, resolved_poly_base_type),
+                    barg.val,
+                    barg.valtype,
+                    barg.cast_distance,
+                )
 
     return BoundCall(
         func, bound_param_args, null_args, return_type, has_empty_variadic)

--- a/edb/lang/schema/pseudo.py
+++ b/edb/lang/schema/pseudo.py
@@ -140,6 +140,9 @@ class AnyTuple(PseudoType):
         else:
             return concrete_type
 
+    def _to_nonpolymorphic(self, schema, concrete_type: s_types.Type):
+        return concrete_type
+
 
 class AnyTupleRef(so.ObjectRef):
 

--- a/edb/lib/std/20-genericfuncs.eql
+++ b/edb/lib/std/20-genericfuncs.eql
@@ -250,3 +250,23 @@ std::`!=` (l: anytuple, r: anytuple) -> std::bool
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL anytuple, r: OPTIONAL anytuple) -> std::bool
     FROM SQL EXPRESSION;
+
+
+CREATE INFIX OPERATOR
+std::`>=` (l: anytuple, r: anytuple) -> std::bool
+    FROM SQL OPERATOR '>=';
+
+
+CREATE INFIX OPERATOR
+std::`>` (l: anytuple, r: anytuple) -> std::bool
+    FROM SQL OPERATOR '>';
+
+
+CREATE INFIX OPERATOR
+std::`<=` (l: anytuple, r: anytuple) -> std::bool
+    FROM SQL OPERATOR '<=';
+
+
+CREATE INFIX OPERATOR
+std::`<` (l: anytuple, r: anytuple) -> std::bool
+    FROM SQL OPERATOR '<';

--- a/edb/lib/std/25-booloperators.eql
+++ b/edb/lib/std/25-booloperators.eql
@@ -72,6 +72,26 @@ std::`?!=` (l: OPTIONAL std::bool, r: OPTIONAL std::bool) -> std::bool
     FROM SQL EXPRESSION;
 
 
+CREATE INFIX OPERATOR
+std::`>=` (l: std::bool, r: std::bool) -> std::bool
+    FROM SQL OPERATOR '>=';
+
+
+CREATE INFIX OPERATOR
+std::`>` (l: std::bool, r: std::bool) -> std::bool
+    FROM SQL OPERATOR '>';
+
+
+CREATE INFIX OPERATOR
+std::`<=` (l: std::bool, r: std::bool) -> std::bool
+    FROM SQL OPERATOR '<=';
+
+
+CREATE INFIX OPERATOR
+std::`<` (l: std::bool, r: std::bool) -> std::bool
+    FROM SQL OPERATOR '<';
+
+
 ## Boolean casts
 ## -------------
 

--- a/edb/lib/std/25-numoperators.eql
+++ b/edb/lib/std/25-numoperators.eql
@@ -26,14 +26,26 @@
 # are very common.
 #
 # Our implicit casts do not coincide with PostgreSQL. In particular we
-# do not implicitly cast floats into decimals. The philosophy behind
-# that is that using decimal arithmetic should be opt-in. On the other
-# hand, if decimals are used they should not be accidentally switched
-# to floating point arithmetic. One of the consequences of this is
-# that we need to explicitly define operators for every legal
-# combination of floats and decimals (this concerns comparison
-# operators) as unlike PostgreSQL we cannot rely on every kind of
-# number casting implicitly into decimal.
+# do not implicitly cast between decimals and floats. The philosophy
+# behind that is that using decimal arithmetic should be opt-in. On
+# the other hand, if decimals are used they should not be accidentally
+# switched to floating point arithmetic. One of the consequences of
+# this is that we need to explicitly define arithmetic operators for
+# every legal combination of floats and decimals as unlike PostgreSQL
+# we cannot rely on implicit casts between decimals and other numeric
+# types.
+#
+# Floating point numbers are inherently imprecise. This means that
+# casting a given float into another representation and back may yield
+# a different value. This is especially important with float and
+# decimal casts as both directions can lose precision. Discussion
+# about precision loss of float to numeric casts can be found here:
+# https://www.postgresql.org/message-id/5A937D7E.60305%40anastigmatix.net
+# The practical consequence is that whenever the cast is needed, such
+# as for comparison operators, it is preferable to cast decimal into
+# float and not vice-versa. So we can go with Postgres behavior in
+# regards to the comparison operators (but not arithmetic) with
+# decimal as one of the operands.
 
 # EQUALITY
 
@@ -453,53 +465,13 @@ std::`>` (l: std::decimal, r: std::decimal) -> std::bool
 
 
 CREATE INFIX OPERATOR
-std::`>` (l: std::int16, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '>(numeric,numeric)';
+std::`>` (l: std::anyreal, r: std::decimal) -> std::bool
+    FROM SQL OPERATOR r'>';
 
 
 CREATE INFIX OPERATOR
-std::`>` (l: std::int32, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '>(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>` (l: std::int64, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '>(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>` (l: std::float32, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '>(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>` (l: std::float64, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '>(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>` (l: std::decimal, r: std::int16) -> std::bool
-    FROM SQL OPERATOR '>(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>` (l: std::decimal, r: std::int32) -> std::bool
-    FROM SQL OPERATOR '>(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>` (l: std::decimal, r: std::int64) -> std::bool
-    FROM SQL OPERATOR '>(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>` (l: std::decimal, r: std::float32) -> std::bool
-    FROM SQL OPERATOR '>(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>` (l: std::decimal, r: std::float64) -> std::bool
-    FROM SQL OPERATOR '>(numeric,numeric)';
+std::`>` (l: std::decimal, r: std::anyreal) -> std::bool
+    FROM SQL OPERATOR r'>';
 
 
 # GREATER OR EQUAL
@@ -595,53 +567,13 @@ std::`>=` (l: std::decimal, r: std::decimal) -> std::bool
 
 
 CREATE INFIX OPERATOR
-std::`>=` (l: std::int16, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '>=(numeric,numeric)';
+std::`>=` (l: std::anyreal, r: std::decimal) -> std::bool
+    FROM SQL OPERATOR r'>=';
 
 
 CREATE INFIX OPERATOR
-std::`>=` (l: std::int32, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '>=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>=` (l: std::int64, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '>=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>=` (l: std::float32, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '>=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>=` (l: std::float64, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '>=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>=` (l: std::decimal, r: std::int16) -> std::bool
-    FROM SQL OPERATOR '>=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>=` (l: std::decimal, r: std::int32) -> std::bool
-    FROM SQL OPERATOR '>=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>=` (l: std::decimal, r: std::int64) -> std::bool
-    FROM SQL OPERATOR '>=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>=` (l: std::decimal, r: std::float32) -> std::bool
-    FROM SQL OPERATOR '>=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`>=` (l: std::decimal, r: std::float64) -> std::bool
-    FROM SQL OPERATOR '>=(numeric,numeric)';
+std::`>=` (l: std::decimal, r: std::anyreal) -> std::bool
+    FROM SQL OPERATOR r'>=';
 
 
 # LESS THAN
@@ -737,53 +669,13 @@ std::`<` (l: std::decimal, r: std::decimal) -> std::bool
 
 
 CREATE INFIX OPERATOR
-std::`<` (l: std::int16, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '<(numeric,numeric)';
+std::`<` (l: std::anyreal, r: std::decimal) -> std::bool
+    FROM SQL OPERATOR r'<';
 
 
 CREATE INFIX OPERATOR
-std::`<` (l: std::int32, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '<(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<` (l: std::int64, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '<(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<` (l: std::float32, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '<(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<` (l: std::float64, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '<(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<` (l: std::decimal, r: std::int16) -> std::bool
-    FROM SQL OPERATOR '<(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<` (l: std::decimal, r: std::int32) -> std::bool
-    FROM SQL OPERATOR '<(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<` (l: std::decimal, r: std::int64) -> std::bool
-    FROM SQL OPERATOR '<(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<` (l: std::decimal, r: std::float32) -> std::bool
-    FROM SQL OPERATOR '<(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<` (l: std::decimal, r: std::float64) -> std::bool
-    FROM SQL OPERATOR '<(numeric,numeric)';
+std::`<` (l: std::decimal, r: std::anyreal) -> std::bool
+    FROM SQL OPERATOR r'<';
 
 
 # LESS THAN OR EQUAL
@@ -879,53 +771,13 @@ std::`<=` (l: std::decimal, r: std::decimal) -> std::bool
 
 
 CREATE INFIX OPERATOR
-std::`<=` (l: std::int16, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR r'<=(numeric,numeric)';
+std::`<=` (l: std::anyreal, r: std::decimal) -> std::bool
+    FROM SQL OPERATOR r'<=';
 
 
 CREATE INFIX OPERATOR
-std::`<=` (l: std::int32, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '<=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<=` (l: std::int64, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '<=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<=` (l: std::float32, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '<=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<=` (l: std::float64, r: std::decimal) -> std::bool
-    FROM SQL OPERATOR '<=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<=` (l: std::decimal, r: std::int16) -> std::bool
-    FROM SQL OPERATOR '<=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<=` (l: std::decimal, r: std::int32) -> std::bool
-    FROM SQL OPERATOR '<=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<=` (l: std::decimal, r: std::int64) -> std::bool
-    FROM SQL OPERATOR '<=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<=` (l: std::decimal, r: std::float32) -> std::bool
-    FROM SQL OPERATOR '<=(numeric,numeric)';
-
-
-CREATE INFIX OPERATOR
-std::`<=` (l: std::decimal, r: std::float64) -> std::bool
-    FROM SQL OPERATOR '<=(numeric,numeric)';
+std::`<=` (l: std::decimal, r: std::anyreal) -> std::bool
+    FROM SQL OPERATOR r'<=';
 
 
 # INFIX PLUS

--- a/edb/lib/std/30-arrayfuncs.eql
+++ b/edb/lib/std/30-arrayfuncs.eql
@@ -101,6 +101,30 @@ std::`?!=` (l: OPTIONAL array<anytype>,
     FROM SQL EXPRESSION;
 
 
+CREATE INFIX OPERATOR
+std::`>=` (l: OPTIONAL array<anytype>,
+           r: OPTIONAL array<anytype>) -> std::bool
+    FROM SQL OPERATOR '>=';
+
+
+CREATE INFIX OPERATOR
+std::`>` (l: OPTIONAL array<anytype>,
+          r: OPTIONAL array<anytype>) -> std::bool
+    FROM SQL OPERATOR '>';
+
+
+CREATE INFIX OPERATOR
+std::`<=` (l: OPTIONAL array<anytype>,
+           r: OPTIONAL array<anytype>) -> std::bool
+    FROM SQL OPERATOR '<=';
+
+
+CREATE INFIX OPERATOR
+std::`<` (l: OPTIONAL array<anytype>,
+          r: OPTIONAL array<anytype>) -> std::bool
+    FROM SQL OPERATOR '<';
+
+
 # Concatenation
 CREATE INFIX OPERATOR
 std::`++` (l: array<anytype>, r: array<anytype>) -> array<anytype>

--- a/edb/lib/std/30-bytesfuncs.eql
+++ b/edb/lib/std/30-bytesfuncs.eql
@@ -56,3 +56,23 @@ std::`?!=` (l: OPTIONAL std::bytes, r: OPTIONAL std::bytes) -> std::bool
 CREATE INFIX OPERATOR
 std::`++` (l: std::bytes, r: std::bytes) -> std::bytes
     FROM SQL OPERATOR r'||';
+
+
+CREATE INFIX OPERATOR
+std::`>=` (l: std::bytes, r: std::bytes) -> std::bool
+    FROM SQL OPERATOR '>=';
+
+
+CREATE INFIX OPERATOR
+std::`>` (l: std::bytes, r: std::bytes) -> std::bool
+    FROM SQL OPERATOR '>';
+
+
+CREATE INFIX OPERATOR
+std::`<=` (l: std::bytes, r: std::bytes) -> std::bool
+    FROM SQL OPERATOR '<=';
+
+
+CREATE INFIX OPERATOR
+std::`<` (l: std::bytes, r: std::bytes) -> std::bool
+    FROM SQL OPERATOR '<';

--- a/edb/lib/std/30-jsonfuncs.eql
+++ b/edb/lib/std/30-jsonfuncs.eql
@@ -76,6 +76,26 @@ std::`?!=` (l: OPTIONAL std::json, r: OPTIONAL std::json) -> std::bool
     FROM SQL EXPRESSION;
 
 
+CREATE INFIX OPERATOR
+std::`>=` (l: std::json, r: std::json) -> std::bool
+    FROM SQL OPERATOR '>=';
+
+
+CREATE INFIX OPERATOR
+std::`>` (l: std::json, r: std::json) -> std::bool
+    FROM SQL OPERATOR '>';
+
+
+CREATE INFIX OPERATOR
+std::`<=` (l: std::json, r: std::json) -> std::bool
+    FROM SQL OPERATOR '<=';
+
+
+CREATE INFIX OPERATOR
+std::`<` (l: std::json, r: std::json) -> std::bool
+    FROM SQL OPERATOR '<';
+
+
 ## CASTS
 
 # This is only a container cast, and subject to element type cast

--- a/edb/lib/std/30-uuidfuncs.eql
+++ b/edb/lib/std/30-uuidfuncs.eql
@@ -47,6 +47,26 @@ std::`?!=` (l: OPTIONAL std::uuid, r: OPTIONAL std::uuid) -> std::bool
     FROM SQL EXPRESSION;
 
 
+CREATE INFIX OPERATOR
+std::`>=` (l: std::uuid, r: std::uuid) -> std::bool
+    FROM SQL OPERATOR '>=';
+
+
+CREATE INFIX OPERATOR
+std::`>` (l: std::uuid, r: std::uuid) -> std::bool
+    FROM SQL OPERATOR '>';
+
+
+CREATE INFIX OPERATOR
+std::`<=` (l: std::uuid, r: std::uuid) -> std::bool
+    FROM SQL OPERATOR '<=';
+
+
+CREATE INFIX OPERATOR
+std::`<` (l: std::uuid, r: std::uuid) -> std::bool
+    FROM SQL OPERATOR '<';
+
+
 ## String casts.
 
 CREATE CAST FROM std::str TO std::uuid {

--- a/edb/lib/std/60-baseobject.eql
+++ b/edb/lib/std/60-baseobject.eql
@@ -39,6 +39,20 @@ CREATE ABSTRACT TYPE std::Object {
 };
 
 
+# 'FROM SQL EXPRESSION' creates an EdgeDB Operator for purposes of
+# introspection and validation by the EdgeQL compiler. However, no
+# object is created in Postgres and the EdgeQL->SQL compiler is expected
+# to produce some expression that will be valid.
+#
+# 'FROM SQL OPERATOR' does all of the above and it also creates an
+# actual Postgres operator. It is expected that the EdgeQL->SQL compiler
+# will specifically use that operator.
+
+# HACK: We use 'FROM SQL EXPRESSION' instead of 'FROM SQL OPERATOR'
+# here because in actuality Objects will be resolved as their uuids
+# and in the end it's the uuid operators that will be called in SQL.
+# On the other hand, if we use "FROM SQL OPERATOR", we will end up
+# clashing with the operators for uuid in Postgres.
 CREATE INFIX OPERATOR
 std::`=` (l: std::Object, r: std::Object) -> std::bool
     FROM SQL EXPRESSION;
@@ -56,6 +70,26 @@ std::`!=` (l: std::Object, r: std::Object) -> std::bool
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::Object, r: OPTIONAL std::Object) -> std::bool
+    FROM SQL EXPRESSION;
+
+
+CREATE INFIX OPERATOR
+std::`>=` (l: std::Object, r: std::Object) -> std::bool
+    FROM SQL EXPRESSION;
+
+
+CREATE INFIX OPERATOR
+std::`>` (l: std::Object, r: std::Object) -> std::bool
+    FROM SQL EXPRESSION;
+
+
+CREATE INFIX OPERATOR
+std::`<=` (l: std::Object, r: std::Object) -> std::bool
+    FROM SQL EXPRESSION;
+
+
+CREATE INFIX OPERATOR
+std::`<` (l: std::Object, r: std::Object) -> std::bool
     FROM SQL EXPRESSION;
 
 

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -559,6 +559,16 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             ['number', 'string', 'array', 'object', 'null'],
         ])
 
+    async def test_edgeql_json_object_01(self):
+        await self.assert_query_result(r'''
+            SELECT to_json('{"a":1,"b":2}') = to_json('{"b":2,"a":1}');
+            SELECT to_json('{"a":1,"b":2}') =
+                to_json('{"b":3,"a":1,"b":2}');
+        ''', [
+            [True],
+            [True],
+        ])
+
     async def test_edgeql_json_object_unpack_01(self):
         await self.assert_sorted_query_result(r'''
             SELECT json_object_unpack(to_json('{


### PR DESCRIPTION
There's a perferctly acceptable natural ordering for `bool` that is also
compatible with the ORDER BY clause.

It makes sense to define ordering for `uuid` and `bytes` as they are not
that different from strings in this perspective.

Objects can be ordered the same way as their id.

We can take the ordering that Postgres seems to define on its jsonb
type as the ordering for our json. This makes it possible to order json
in some stable fashion in the ORDER BY clause.

Add tests for validity of using different scalars in ORDER BY clause.