### PR TITLE
Fix assignment casts.

### DIFF
--- a/edb/lang/schema/schema.py
+++ b/edb/lang/schema/schema.py
@@ -505,6 +505,21 @@ class Schema:
 
             return frozenset(referrers)
 
+    @functools.lru_cache()
+    def get_all_assignment_casts(self):
+        referrers = set()
+        scls_type = s_casts.Cast
+        field_name = 'from_type'
+        for refs in self._refs_to.values():
+            for (st, fn), ids in refs.items():
+                if st is scls_type and fn == field_name:
+                    casts = [self._id_to_type[objid] for objid in ids]
+                    referrers.update(
+                        cast for cast in casts
+                        if cast.get_allow_assignment(self))
+
+        return frozenset(referrers)
+
     def get_by_id(self, obj_id, default=_void):
         try:
             return self._id_to_type[obj_id]

--- a/edb/lib/std/25-numoperators.eql
+++ b/edb/lib/std/25-numoperators.eql
@@ -1347,52 +1347,76 @@ CREATE CAST FROM std::decimal TO std::int16 {
 };
 
 
-CREATE CAST FROM std::decimal TO std::int32
+CREATE CAST FROM std::decimal TO std::int32 {
     FROM SQL CAST;
+    ALLOW ASSIGNMENT;
+};
 
 
-CREATE CAST FROM std::decimal TO std::int64
+CREATE CAST FROM std::decimal TO std::int64 {
     FROM SQL CAST;
+    ALLOW ASSIGNMENT;
+};
 
 
-CREATE CAST FROM std::decimal TO std::float64
+CREATE CAST FROM std::decimal TO std::float64 {
     FROM SQL CAST;
+    ALLOW ASSIGNMENT;
+};
 
 
-CREATE CAST FROM std::decimal TO std::float32
+CREATE CAST FROM std::decimal TO std::float32 {
     FROM SQL CAST;
+    ALLOW ASSIGNMENT;
+};
 
 
-CREATE CAST FROM std::float32 TO std::int16
+CREATE CAST FROM std::float32 TO std::int16 {
     FROM SQL CAST;
+    ALLOW ASSIGNMENT;
+};
 
 
-CREATE CAST FROM std::float32 TO std::int32
+CREATE CAST FROM std::float32 TO std::int32 {
     FROM SQL CAST;
+    ALLOW ASSIGNMENT;
+};
 
 
-CREATE CAST FROM std::float32 TO std::int64
+CREATE CAST FROM std::float32 TO std::int64 {
     FROM SQL CAST;
+    ALLOW ASSIGNMENT;
+};
 
 
-CREATE CAST FROM std::float32 TO std::decimal
+CREATE CAST FROM std::float32 TO std::decimal {
     FROM SQL CAST;
+    ALLOW ASSIGNMENT;
+};
 
 
-CREATE CAST FROM std::float64 TO std::int16
+CREATE CAST FROM std::float64 TO std::int16 {
     FROM SQL CAST;
+    ALLOW ASSIGNMENT;
+};
 
 
-CREATE CAST FROM std::float64 TO std::int32
+CREATE CAST FROM std::float64 TO std::int32 {
     FROM SQL CAST;
+    ALLOW ASSIGNMENT;
+};
 
 
-CREATE CAST FROM std::float64 TO std::int64
+CREATE CAST FROM std::float64 TO std::int64 {
     FROM SQL CAST;
+    ALLOW ASSIGNMENT;
+};
 
 
-CREATE CAST FROM std::float64 TO std::decimal
+CREATE CAST FROM std::float64 TO std::decimal {
     FROM SQL CAST;
+    ALLOW ASSIGNMENT;
+};
 
 
 ## String casts.

--- a/tests/schemas/casts.eschema
+++ b/tests/schemas/casts.eschema
@@ -32,6 +32,7 @@ type Test:
     property p_float64 -> float64
     property p_decimal -> decimal
 
+
 type JSONTest:
     property j_bool -> json
     property j_str -> json
@@ -46,3 +47,21 @@ type JSONTest:
     property j_float32 -> json
     property j_float64 -> json
     property j_decimal -> json
+
+
+type ScalarTest:
+    property p_bool -> bool
+    property p_uuid -> uuid
+    property p_str -> str
+    property p_datetime -> datetime
+    property p_naive_datetime -> naive_datetime
+    property p_naive_date -> naive_date
+    property p_naive_time -> naive_time
+    property p_timedelta -> timedelta
+    property p_int16 -> int16
+    property p_int32 -> int32
+    property p_int64 -> int64
+    property p_float32 -> float32
+    property p_float64 -> float64
+    property p_decimal -> decimal
+    property p_json -> json


### PR DESCRIPTION
Assignment casts between different numeric types had gaps so that it was
not possible to assign a `float32` to an `int32`, etc. In general the
assignment casts logic seemed to rely on these casts being transitive
just as implicit casts.

The new assignment casts are non-transitive and have to be explicitly
defined for all valid pairs. However, in broad terms, implicit casts can
be used to connect the end points of an explicit assignment cast.