### PR TITLE
Remove the dependency of IR on schema

### DIFF
--- a/edb/lang/common/ast/base.py
+++ b/edb/lang/common/ast/base.py
@@ -20,6 +20,7 @@
 import copy
 import collections.abc
 import functools
+import sys
 import typing
 
 import typing_inspect
@@ -53,8 +54,11 @@ class MetaAST(type):
         if '__annotations__' not in dct:
             return cls
 
+        globalns = sys.modules[cls.__module__].__dict__.copy()
+        globalns[cls.__name__] = cls
+
         try:
-            annos = typing.get_type_hints(cls)
+            annos = typing.get_type_hints(cls, globalns)
         except Exception:
             raise RuntimeError(
                 f'unable to resolve type annotations for '

--- a/edb/lang/edgeql/compiler/astutils.py
+++ b/edb/lang/edgeql/compiler/astutils.py
@@ -23,7 +23,9 @@
 import typing
 
 from edb.lang.edgeql import ast as qlast
+
 from edb.lang.ir import ast as irast
+from edb.lang.ir import typeutils as irtyputils
 
 from . import context
 from . import inference
@@ -114,7 +116,9 @@ def make_tuple(
         ctx: context.ContextLevel) -> irast.Tuple:
 
     tup = irast.Tuple(elements=elements, named=named)
-    tup.stype = inference.infer_type(tup, env=ctx.env)
+    tup.typeref = irtyputils.type_to_typeref(
+        ctx.env.schema,
+        inference.infer_type(tup, env=ctx.env))
     return tup
 
 
@@ -123,5 +127,7 @@ def make_array(
         ctx: context.ContextLevel) -> irast.Array:
 
     arr = irast.Array(elements=elements)
-    arr.stype = inference.infer_type(arr, env=ctx.env)
+    arr.typeref = irtyputils.type_to_typeref(
+        ctx.env.schema,
+        inference.infer_type(arr, env=ctx.env))
     return arr

--- a/edb/lang/edgeql/compiler/polyres.py
+++ b/edb/lang/edgeql/compiler/polyres.py
@@ -25,6 +25,7 @@ import typing
 from edb import errors
 
 from edb.lang.ir import ast as irast
+from edb.lang.ir import typeutils as irtyputils
 from edb.lang.ir import utils as irutils
 
 from edb.lang.schema import functions as s_func
@@ -201,7 +202,9 @@ def try_bind_call_args(
             if has_inlined_defaults:
                 bytes_t = schema.get('std::bytes')
                 argval = setgen.ensure_set(
-                    irast.BytesConstant(value='\x00', stype=bytes_t),
+                    irast.BytesConstant(
+                        value='\x00',
+                        typeref=irtyputils.type_to_typeref(schema, bytes_t)),
                     typehint=bytes_t,
                     ctx=ctx)
                 args = [BoundArg(None, argval, bytes_t, 0)]
@@ -383,10 +386,10 @@ def try_bind_call_args(
                     default_type = param_type
 
                 if has_inlined_defaults:
-                    default = irutils.new_empty_set(
-                        schema,
+                    default = setgen.new_empty_set(
                         stype=default_type,
-                        alias=param_shortname)
+                        alias=param_shortname,
+                        ctx=ctx)
 
                 default = setgen.ensure_set(
                     default,
@@ -410,7 +413,9 @@ def try_bind_call_args(
         bytes_t = schema.get('std::bytes')
         bm = defaults_mask.to_bytes(nparams // 8 + 1, 'little')
         bm_set = setgen.ensure_set(
-            irast.BytesConstant(value=bm.decode('ascii'), stype=bytes_t),
+            irast.BytesConstant(
+                value=bm.decode('ascii'),
+                typeref=irtyputils.type_to_typeref(ctx.env.schema, bytes_t)),
             typehint=bytes_t, ctx=ctx)
         bound_param_args.insert(0, BoundArg(None, bm_set, bytes_t, 0))
 

--- a/edb/lang/edgeql/compiler/schemactx.py
+++ b/edb/lang/edgeql/compiler/schemactx.py
@@ -55,6 +55,8 @@ def get_schema_object(
         name = name.name
     elif isinstance(name, qlast.AnyType):
         return s_pseudo.Any.create()
+    elif isinstance(name, qlast.AnyTuple):
+        return s_pseudo.AnyTuple.create()
 
     if module:
         name = sn.Name(name=name, module=module)

--- a/edb/lang/edgeql/compiler/typegen.py
+++ b/edb/lang/edgeql/compiler/typegen.py
@@ -26,6 +26,7 @@ import typing
 from edb import errors
 
 from edb.lang.ir import ast as irast
+from edb.lang.ir import typeutils as irtyputils
 
 from edb.lang.schema import abc as s_abc
 from edb.lang.schema import objects as s_obj
@@ -108,31 +109,9 @@ def _ql_typeexpr_to_ir_typeref(
 def _ql_typeref_to_ir_typeref(
         ql_t: qlast.TypeName, *,
         ctx: context.ContextLevel) -> irast.TypeRef:
-    maintype = ql_t.maintype
-    subtypes = ql_t.subtypes
 
-    if subtypes:
-        typ = irast.TypeRef(
-            maintype=maintype.name,
-            subtypes=[]
-        )
-
-        for subtype in subtypes:
-            subtype = ql_typeref_to_ir_typeref(subtype, ctx=ctx)
-            typ.subtypes.append(subtype)
-    else:
-        styp = schemactx.get_schema_type(maintype, ctx=ctx)
-        if styp.is_any():
-            typ = irast.AnyTypeRef()
-        elif styp.is_anytuple():
-            typ = irast.AnyTupleRef()
-        else:
-            typ = irast.TypeRef(
-                maintype=styp.get_name(ctx.env.schema),
-                subtypes=[]
-            )
-
-    return typ
+    stype = ql_typeref_to_type(ql_t, ctx=ctx)
+    return irtyputils.type_to_typeref(ctx.env.schema, stype)
 
 
 def ql_typeref_to_type(

--- a/edb/lang/ir/staeval.py
+++ b/edb/lang/ir/staeval.py
@@ -121,7 +121,7 @@ def evaluate_OperatorCall(
     qlconst = qlast.BaseConstant.from_python(value)
 
     result = ql_compiler.compile_constant_tree_to_ir(
-        qlconst, stype=opcall.stype, schema=schema)
+        qlconst, styperef=opcall.typeref, schema=schema)
 
     return result
 
@@ -139,7 +139,7 @@ def int_const_to_python(
         ir: irast.IntegerConstant,
         schema: s_schema.Schema) -> object:
 
-    if ir.stype.get_name(schema) == 'std::decimal':
+    if ir.typeref.name == 'std::decimal':
         return decimal.Decimal(ir.value)
     else:
         return int(ir.value)
@@ -150,7 +150,7 @@ def float_const_to_python(
         ir: irast.FloatConstant,
         schema: s_schema.Schema) -> object:
 
-    if ir.stype.get_name(schema) == 'std::decimal':
+    if ir.typeref.name == 'std::decimal':
         return decimal.Decimal(ir.value)
     else:
         return float(ir.value)

--- a/edb/lang/ir/typeutils.py
+++ b/edb/lang/ir/typeutils.py
@@ -1,0 +1,314 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2015-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+
+import typing
+
+from edb.lang.schema import abc as s_abc
+from edb.lang.schema import objtypes as s_objtypes
+from edb.lang.schema import pointers as s_pointers
+from edb.lang.schema import pseudo as s_pseudo
+from edb.lang.schema import types as s_types
+
+from . import ast as irast
+
+
+def is_scalar(typeref: irast.TypeRef) -> bool:
+    return typeref.is_scalar
+
+
+def is_object(typeref: irast.TypeRef) -> bool:
+    return (
+        not is_scalar(typeref)
+        and not is_collection(typeref)
+        and not is_generic(typeref)
+    )
+
+
+def is_view(typeref: irast.TypeRef) -> bool:
+    return typeref.is_view
+
+
+def is_collection(typeref: irast.TypeRef) -> bool:
+    return bool(typeref.collection)
+
+
+def is_array(typeref: irast.TypeRef) -> bool:
+    return typeref.collection == s_types.Array.schema_name
+
+
+def is_tuple(typeref: irast.TypeRef) -> bool:
+    return typeref.collection == s_types.Tuple.schema_name
+
+
+def is_any(typeref: irast.TypeRef) -> bool:
+    return isinstance(typeref, irast.AnyTypeRef)
+
+
+def is_anytuple(typeref: irast.TypeRef) -> bool:
+    return isinstance(typeref, irast.AnyTupleRef)
+
+
+def is_generic(typeref: irast.TypeRef) -> bool:
+    if is_collection(typeref):
+        return any(is_generic(st) for st in typeref.subtypes)
+    else:
+        return is_any(typeref) or is_anytuple(typeref)
+
+
+def is_abstract(typeref: irast.TypeRef) -> bool:
+    return typeref.is_abstract
+
+
+def type_to_typeref(schema, t: s_types.Type, *, _name=None) -> irast.TypeRef:
+
+    if t.is_anytuple():
+        result = irast.AnyTupleRef(
+            id=t.id,
+            name=t.get_name(schema),
+            displayname=t.get_displayname(schema),
+        )
+    elif t.is_any():
+        result = irast.AnyTypeRef(
+            id=t.id,
+            name=t.get_name(schema),
+            displayname=t.get_displayname(schema),
+        )
+    elif not isinstance(t, s_abc.Collection):
+        if t.get_is_virtual(schema):
+            children = frozenset(
+                type_to_typeref(schema, c) for c in t.children(schema)
+            )
+        else:
+            children = frozenset()
+
+        material_type = t.material_type(schema)
+        if material_type is not t:
+            material_typeref = type_to_typeref(schema, material_type)
+        else:
+            material_typeref = None
+
+        if (material_type.is_scalar()
+                and not material_type.get_is_abstract(schema)):
+            base_type = material_type.get_topmost_concrete_base(schema)
+            if base_type is material_type:
+                base_typeref = None
+            else:
+                base_typeref = type_to_typeref(schema, base_type)
+        else:
+            base_typeref = None
+
+        result = irast.TypeRef(
+            id=t.id,
+            name=t.get_name(schema),
+            material_type=material_typeref,
+            base_type=base_typeref,
+            displayname=t.get_displayname(schema),
+            children=children,
+            element_name=_name,
+            is_scalar=t.is_scalar(),
+            is_abstract=t.get_is_abstract(schema),
+            is_view=t.is_view(schema),
+        )
+    elif isinstance(t, s_abc.Tuple) and t.named:
+        result = irast.TypeRef(
+            id=t.id,
+            name=t.get_name(schema),
+            displayname=t.get_displayname(schema),
+            element_name=_name,
+            collection=t.schema_name,
+            subtypes=tuple(
+                type_to_typeref(schema, st, _name=sn)
+                for sn, st in t.element_types.items()
+            )
+        )
+    else:
+        result = irast.TypeRef(
+            id=t.id,
+            name=t.get_name(schema),
+            displayname=t.get_displayname(schema),
+            element_name=_name,
+            collection=t.schema_name,
+            subtypes=tuple(
+                type_to_typeref(schema, st)
+                for st in t.get_subtypes()
+            )
+        )
+
+    return result
+
+
+def ir_typeref_to_type(schema, typeref: irast.TypeRef) -> s_types.Type:
+    if is_anytuple(typeref):
+        return s_pseudo.AnyTuple.create()
+
+    elif is_any(typeref):
+        return s_pseudo.Any.create()
+
+    elif is_tuple(typeref):
+        named = False
+        subtypes = {}
+        for si, st in enumerate(typeref.subtypes):
+            if st.element_name:
+                named = True
+                type_name = st.element_name
+            else:
+                type_name = str(si)
+
+            subtypes[type_name] = ir_typeref_to_type(schema, st)
+
+        return s_types.Tuple.from_subtypes(
+            schema, subtypes, {'named': named})
+
+    elif is_array(typeref):
+        subtypes = []
+        for st in typeref.subtypes:
+            subtypes.append(ir_typeref_to_type(schema, st))
+
+        return s_types.Array.from_subtypes(schema, subtypes)
+
+    else:
+        return schema.get_by_id(typeref.id)
+
+
+def ptrref_from_ptrcls(
+        *,
+        source_ref: irast.TypeRef,
+        target_ref: irast.TypeRef,
+        ptrcls: s_pointers.PointerLike,
+        direction: s_pointers.PointerDirection,
+        parent_ptr: typing.Optional[irast.PointerRef]=None,
+        schema) -> irast.BasePointerRef:
+
+    kwargs = {}
+
+    if ptrcls.is_tuple_indirection():
+        ircls = irast.TupleIndirectionPointerRef
+    elif ptrcls.is_type_indirection():
+        ircls = irast.TypeIndirectionPointerRef
+        kwargs['optional'] = ptrcls.is_optional()
+    else:
+        ircls = irast.PointerRef
+        kwargs['id'] = ptrcls.id
+
+    if direction is s_pointers.PointerDirection.Inbound:
+        out_source = target_ref
+        out_target = source_ref
+    else:
+        out_source = source_ref
+        out_target = target_ref
+
+    out_cardinality = ptrcls.get_cardinality(schema)
+    if out_cardinality is None:
+        # The cardinality is not yet known.
+        dir_cardinality = None
+    elif ptrcls.singular(schema, direction):
+        dir_cardinality = irast.Cardinality.ONE
+    else:
+        dir_cardinality = irast.Cardinality.MANY
+
+    material_ptrcls = ptrcls.material_type(schema)
+    if material_ptrcls is not None and material_ptrcls is not ptrcls:
+        material_ptr = ptrref_from_ptrcls(
+            source_ref=source_ref,
+            target_ref=target_ref,
+            ptrcls=material_ptrcls,
+            direction=direction,
+            parent_ptr=parent_ptr,
+            schema=schema)
+    else:
+        material_ptr = None
+
+    if ptrcls.get_derived_from(schema) is not None:
+        derived_ptrcls = ptrcls.get_nearest_non_derived_parent(schema)
+        derived_from_ptr = ptrref_from_ptrcls(
+            source_ref=source_ref,
+            target_ref=target_ref,
+            ptrcls=derived_ptrcls,
+            direction=direction,
+            parent_ptr=parent_ptr,
+            schema=schema)
+    else:
+        derived_from_ptr = None
+
+    descendants = set()
+
+    source = ptrcls.get_source(schema)
+    if isinstance(source, s_objtypes.ObjectType):
+        ptrs = {material_ptrcls}
+        ptrname = ptrcls.get_shortname(schema).name
+        for descendant in source.descendants(schema):
+            ptr = descendant.getptr(schema, ptrname)
+            if ptr is not None:
+                desc_material_ptr = ptr.material_type(schema)
+                if desc_material_ptr not in ptrs:
+                    ptrs.add(desc_material_ptr)
+                    descendants.add(
+                        ptrref_from_ptrcls(
+                            source_ref=source_ref,
+                            target_ref=target_ref,
+                            ptrcls=desc_material_ptr,
+                            direction=direction,
+                            parent_ptr=parent_ptr,
+                            schema=schema,
+                        )
+                    )
+
+    kwargs.update(dict(
+        dir_source=source_ref,
+        dir_target=target_ref,
+        out_source=out_source,
+        out_target=out_target,
+        name=ptrcls.get_name(schema),
+        shortname=ptrcls.get_shortname(schema),
+        displayname=ptrcls.get_displayname(schema),
+        direction=direction,
+        parent_ptr=parent_ptr,
+        material_ptr=material_ptr,
+        derived_from_ptr=derived_from_ptr,
+        descendants=descendants,
+        has_properties=ptrcls.has_user_defined_properties(schema),
+        required=ptrcls.get_required(schema),
+        dir_cardinality=dir_cardinality,
+        out_cardinality=out_cardinality,
+    ))
+
+    return ircls(**kwargs)
+
+
+def ptrcls_from_ptrref(
+        ptrref: irast.BasePointerRef, *,
+        schema) -> s_pointers.PointerLike:
+
+    if isinstance(ptrref, irast.TupleIndirectionPointerRef):
+        ptrcls = irast.TupleIndirectionLink(
+            ptrref.name.name
+        )
+    elif isinstance(ptrref, irast.TypeIndirectionPointerRef):
+        ptrcls = irast.TypeIndirectionLink(
+            source=schema.get(ptrref.out_source.name),
+            target=schema.get(ptrref.out_target.name),
+            optional=ptrref.optional,
+            cardinality=ptrref.out_cardinality,
+        )
+    else:
+        ptrcls = schema.get_by_id(ptrref.id)
+
+    return ptrcls

--- a/edb/lang/ir/utils.py
+++ b/edb/lang/ir/utils.py
@@ -26,27 +26,8 @@ from edb.lang.common import ast
 
 from edb.lang.edgeql import functypes as ft
 
-from edb.lang.schema import abc as s_abc
-from edb.lang.schema import objtypes as s_objtypes
-from edb.lang.schema import name as s_name
-from edb.lang.schema import pointers as s_pointers
-from edb.lang.schema import pseudo as s_pseudo
-from edb.lang.schema import schema as s_schema
-from edb.lang.schema import sources as s_sources  # NOQA
-from edb.lang.schema import types as s_types  # NOQA
-
 from . import ast as irast
-
-
-def get_source_references(ir):
-    result = set()
-
-    flt = lambda n: isinstance(n, irast.Set) and n.expr is None
-    ir_sets = ast.find_children(ir, flt)
-    for ir_set in ir_sets:
-        result.add(ir_set.stype)
-
-    return result
+from . import typeutils
 
 
 def get_terminal_references(ir):
@@ -111,21 +92,8 @@ def is_empty_array_expr(ir):
 def is_untyped_empty_array_expr(ir):
     return (
         is_empty_array_expr(ir)
-        and (ir.stype is None or ir.stype.contains_any())
+        and (ir.typeref is None or typeutils.is_generic(ir.typeref))
     )
-
-
-def get_id_path_id(
-        path_id: irast.PathId, *,
-        schema: s_schema.Schema) -> irast.PathId:
-    """For PathId representing an object, return (PathId).(std::id)."""
-    source: s_sources.Source = path_id.target
-    assert isinstance(source, s_objtypes.ObjectType)
-    return path_id.extend(
-        source.getptr(schema, 'id'),
-        s_pointers.PointerDirection.Outbound,
-        schema.get('std::uuid'),
-        schema=schema)
 
 
 def get_subquery_shape(ir_expr):
@@ -167,12 +135,12 @@ def is_subquery_set(ir_expr):
     )
 
 
-def is_scalar_view_set(ir_expr, *, schema: s_schema.Schema):
+def is_scalar_view_set(ir_expr):
     return (
         isinstance(ir_expr, irast.Set) and
         len(ir_expr.path_id) == 1 and
         ir_expr.path_id.is_scalar_path() and
-        ir_expr.path_id.target.is_view(schema)
+        ir_expr.path_id.is_view_path()
     )
 
 
@@ -221,132 +189,6 @@ def wrap_stmt_set(ir_set):
     return stmt
 
 
-def new_empty_set(schema, *, stype=None, alias):
-    if stype is None:
-        path_id_scls = s_pseudo.Any.create()
-    else:
-        path_id_scls = stype
-
-    typename = s_name.Name(module='__expr__', name=alias)
-    path_id = irast.PathId.from_type(schema, path_id_scls, typename=typename)
-    return irast.EmptySet(path_id=path_id, stype=stype)
-
-
-class TupleIndirectionLink(s_pointers.PointerLike):
-    """A Link-alike that can be used in tuple indirection path ids."""
-
-    def __init__(self, element_name):
-        self._name = s_name.Name(module='__tuple__', name=str(element_name))
-
-    def __hash__(self):
-        return hash((self.__class__, self._name))
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return False
-
-        return self._name == other._name
-
-    def get_shortname(self, schema):
-        return self._name
-
-    def get_name(self, schema):
-        return self._name
-
-    def get_path_id_name(self, schema):
-        return self._name
-
-    def is_link_property(self, schema):
-        return False
-
-    def generic(self, schema):
-        return False
-
-    def get_source(self, schema):
-        return None
-
-    def singular(self, schema,
-                 direction=s_pointers.PointerDirection.Outbound) -> bool:
-        return True
-
-    def scalar(self):
-        return self._target.is_scalar()
-
-    def is_pure_computable(self, schema):
-        return False
-
-
-def tuple_indirection_path_id(tuple_path_id, element_name, element_type, *,
-                              schema):
-    return tuple_path_id.extend(
-        TupleIndirectionLink(element_name),
-        s_pointers.PointerDirection.Outbound,
-        element_type,
-        schema=schema
-    )
-
-
-class TypeIndirectionLink(s_pointers.PointerLike):
-    """A Link-alike that can be used in type indirection path ids."""
-
-    def __init__(self, source, target, *, optional, cardinality):
-        name = 'optindirection' if optional else 'indirection'
-        self._name = s_name.Name(module='__type__', name=name)
-        self._source = source
-        self._target = target
-        self._cardinality = cardinality
-        self._optional = optional
-
-    def get_name(self, schema):
-        return self._name
-
-    def get_shortname(self, schema):
-        return self._name
-
-    def get_path_id_name(self, schema):
-        return self._name
-
-    def is_link_property(self, schema):
-        return False
-
-    def generic(self, schema):
-        return False
-
-    def get_source(self, schema):
-        return self._source
-
-    def get_target(self, schema):
-        return self._target
-
-    def get_cardinality(self, schema):
-        return self._cardinality
-
-    def singular(self, schema,
-                 direction=s_pointers.PointerDirection.Outbound) -> bool:
-        if direction is s_pointers.PointerDirection.Outbound:
-            return self.get_cardinality(schema) is irast.Cardinality.ONE
-        else:
-            return True
-
-    def scalar(self):
-        return self._target.is_scalar()
-
-    def is_pure_computable(self, schema):
-        return False
-
-
-def type_indirection_path_id(path_id, target_type, *, optional: bool,
-                             cardinality: irast.Cardinality,
-                             schema):
-    return path_id.extend(
-        TypeIndirectionLink(path_id.target, target_type,
-                            optional=optional, cardinality=cardinality),
-        s_pointers.PointerDirection.Outbound,
-        target_type,
-        schema=schema
-    )
-
-
 def get_source_context_as_json(
         expr: irast.Base,
         exctype=errors.InternalServerError) -> typing.Optional[str]:
@@ -362,48 +204,3 @@ def get_source_context_as_json(
         details = None
 
     return details
-
-
-def typeref_to_type(schema, typeref: irast.TypeRef) -> s_types.Type:
-
-    if typeref.subtypes:
-        coll = s_types.Collection.get_class(typeref.maintype)
-        result = coll.from_subtypes(
-            schema, [typeref_to_type(schema, t) for t in typeref.subtypes])
-    else:
-        result = schema.get(typeref.maintype)
-
-    return result
-
-
-def type_to_typeref(schema, t: s_types.Type, *, _name=None) -> irast.TypeRef:
-
-    if t.is_anytuple():
-        result = irast.AnyTupleRef()
-    elif t.is_any():
-        result = irast.AnyTypeRef()
-    elif not isinstance(t, s_abc.Collection):
-        result = irast.TypeRef(
-            name=_name,
-            maintype=t.get_name(schema),
-        )
-    elif isinstance(t, s_abc.Tuple) and t.named:
-        result = irast.TypeRef(
-            name=_name,
-            maintype=t.schema_name,
-            subtypes=[
-                type_to_typeref(schema, st, _name=sn)
-                for sn, st in t.element_types.items()
-            ]
-        )
-    else:
-        result = irast.TypeRef(
-            name=_name,
-            maintype=t.schema_name,
-            subtypes=[
-                type_to_typeref(schema, st)
-                for st in t.get_subtypes()
-            ]
-        )
-
-    return result

--- a/edb/lang/schema/declarative.py
+++ b/edb/lang/schema/declarative.py
@@ -442,10 +442,18 @@ class DeclarationLoader:
                 self._schema, source, prop_target,
                 attrs=new_props)
 
+            if propdecl.cardinality is None:
+                if propdecl.expr is None:
+                    cardinality = qlast.Cardinality.ONE
+                else:
+                    cardinality = None
+            else:
+                cardinality = propdecl.cardinality
+
             self._schema = prop.update(self._schema, {
                 'declared_inherited': propdecl.inherited,
                 'required': bool(propdecl.required),
-                'cardinality': propdecl.cardinality,
+                'cardinality': cardinality,
             })
 
             if propdecl.expr is not None:
@@ -643,10 +651,18 @@ class DeclarationLoader:
                     attrs=new_props,
                     apply_defaults=not linkdecl.inherited)
 
+                if linkdecl.cardinality is None:
+                    if linkdecl.expr is None:
+                        cardinality = qlast.Cardinality.ONE
+                    else:
+                        cardinality = None
+                else:
+                    cardinality = linkdecl.cardinality
+
                 self._schema = link.update(self._schema, {
                     'spectargets': spectargets,
                     'required': bool(linkdecl.required),
-                    'cardinality': linkdecl.cardinality,
+                    'cardinality': cardinality,
                     'declared_inherited': linkdecl.inherited,
                 })
 

--- a/edb/lang/schema/inheriting.py
+++ b/edb/lang/schema/inheriting.py
@@ -707,10 +707,10 @@ class InheritingObject(derivable.DerivableObject):
                 return self._issubclass(schema, parent)
 
     def descendants(self, schema):
-        return schema._get_descendants(self)
+        return schema.get_descendants(self)
 
     def children(self, schema):
-        return schema._get_descendants(self, max_depth=0)
+        return schema.get_children(self)
 
     def acquire_ancestor_inheritance(self, schema, bases=None, *, dctx=None):
         if bases is None:

--- a/edb/server/pgsql/backend.py
+++ b/edb/server/pgsql/backend.py
@@ -442,8 +442,7 @@ class Backend:
             type_desc=type_desc, tuple_registry=tuples)
 
         sql_text, argmap = compiler.compile_ir_to_sql(
-            query_ir, schema=query_ir.schema,
-            output_format=output_format, timer=timer)
+            query_ir, output_format=output_format, timer=timer)
 
         argtypes = {}
         for k, v in query_ir.params.items():

--- a/edb/server/pgsql/compiler/astutils.py
+++ b/edb/server/pgsql/compiler/astutils.py
@@ -19,30 +19,20 @@
 
 import typing
 
-from edb.lang.schema import pointers as s_pointers
-
 from edb.server.pgsql import ast as pgast
 
 
 def tuple_element_for_shape_el(shape_el, value, *, ctx):
-    if shape_el.path_id.is_type_indirection_path(ctx.env.schema):
+    if shape_el.path_id.is_type_indirection_path():
         rptr = shape_el.rptr.source.rptr
     else:
         rptr = shape_el.rptr
-    ptrcls = rptr.ptrcls
-    ptrdir = rptr.direction or s_pointers.PointerDirection.Outbound
-    ptrname = ptrcls.get_shortname(ctx.env.schema)
-
-    attr_name = s_pointers.PointerVector(
-        name=ptrname.name,
-        module=ptrname.module,
-        direction=ptrdir,
-        target=ptrcls.get_far_endpoint(ctx.env.schema, ptrdir),
-        is_linkprop=ptrcls.is_link_property(ctx.env.schema))
+    ptrref = rptr.ptrref
+    ptrname = ptrref.shortname
 
     return pgast.TupleElement(
         path_id=shape_el.path_id,
-        name=attr_name,
+        name=ptrname,
         val=value,
     )
 

--- a/edb/server/pgsql/compiler/context.py
+++ b/edb/server/pgsql/compiler/context.py
@@ -137,13 +137,11 @@ class CompilerContext(compiler.CompilerContext):
 class Environment:
     """Static compilation environment."""
 
-    def __init__(self, *, schema, output_format, singleton_mode,
-                 use_named_params):
+    def __init__(self, *, output_format, singleton_mode, use_named_params):
         self.singleton_mode = singleton_mode
         self.aliases = aliases.AliasGenerator()
         self.root_rels = set()
         self.rel_overlays = collections.defaultdict(list)
         self.output_format = output_format
-        self.schema = schema
         self.tuple_formats = {}
         self.use_named_params = use_named_params

--- a/edb/server/pgsql/compiler/expr.py
+++ b/edb/server/pgsql/compiler/expr.py
@@ -265,18 +265,6 @@ def compile_IndexIndirection(
         subj = dispatch.compile(expr.expr, ctx=subctx)
         index = dispatch.compile(expr.index, ctx=subctx)
 
-    # If the index is some integer, cast it into int, because there's
-    # no backend function that handles indexes larger than int.
-    index_t = expr.index.stype
-    int_t = ctx.env.schema.get('std::anyint')
-    if index_t.issubclass(ctx.env.schema, int_t):
-        index = pgast.TypeCast(
-            arg=index,
-            type_name=pgast.TypeName(
-                name=('int',)
-            )
-        )
-
     result = pgast.FuncCall(
         name=('edgedb', '_index'),
         args=[subj, index, srcctx]
@@ -303,21 +291,6 @@ def compile_SliceIndirection(
             stop = pgast.NullConstant()
         else:
             stop = dispatch.compile(expr.stop, ctx=subctx)
-
-    # any integer indexes must be upcast into int to fit the helper
-    # function signature
-    start = pgast.TypeCast(
-        arg=start,
-        type_name=pgast.TypeName(
-            name=('int',)
-        )
-    )
-    stop = pgast.TypeCast(
-        arg=stop,
-        type_name=pgast.TypeName(
-            name=('int',)
-        )
-    )
 
     result = pgast.FuncCall(
         name=('edgedb', '_slice'),

--- a/edb/server/pgsql/compiler/shapecomp.py
+++ b/edb/server/pgsql/compiler/shapecomp.py
@@ -24,9 +24,6 @@ import typing
 from edb.lang.ir import ast as irast
 from edb.lang.ir import utils as irutils
 
-from edb.lang.schema import objtypes as s_objtypes
-from edb.lang.schema import pointers as s_pointers
-
 from edb.server.pgsql import ast as pgast
 
 from . import astutils
@@ -64,14 +61,13 @@ def compile_shape(
 
         for el in shape:
             rptr = el.rptr
-            ptrcls = rptr.ptrcls
-            ptrdir = rptr.direction or s_pointers.PointerDirection.Outbound
-            is_singleton = ptrcls.singular(ctx.env.schema, ptrdir)
+            ptrref = rptr.ptrref
+            is_singleton = ptrref.dir_cardinality is irast.Cardinality.ONE
 
             if (irutils.is_subquery_set(el) or
-                    isinstance(el.stype, s_objtypes.ObjectType) or
+                    el.path_id.is_objtype_path() or
                     not is_singleton or
-                    not ptrcls.get_required(ctx.env.schema)):
+                    not ptrref.required):
                 wrapper = relgen.set_as_subquery(
                     el, as_value=True, ctx=shapectx)
                 if not is_singleton:

--- a/edb/server/pgsql/compiler/stmt.py
+++ b/edb/server/pgsql/compiler/stmt.py
@@ -19,8 +19,6 @@
 
 from edb.lang.ir import ast as irast
 
-from edb.lang.schema import objtypes as s_objtypes
-
 from edb.server.pgsql import ast as pgast
 
 from . import astutils
@@ -144,7 +142,7 @@ def compile_GroupStmt(
             # object in each partition if GROUP BY input is
             # a ObjectType, otherwise we generate the id using
             # row_number().
-            if isinstance(stmt.subject.stype, s_objtypes.ObjectType):
+            if stmt.subject.path_id.is_objtype_path():
                 first_val = pathctx.get_path_identity_var(
                     gquery, stmt.subject.path_id, env=ctx.env)
             else:

--- a/edb/server/pgsql/delta.py
+++ b/edb/server/pgsql/delta.py
@@ -386,7 +386,7 @@ class FunctionCommand:
                 raise ValueError('expression not constant')
 
             sql_tree = compiler.compile_ir_to_sql_tree(
-                ir.expr, schema=ir.schema, singleton_mode=True)
+                ir.expr, singleton_mode=True)
             return codegen.SQLSourceGenerator.to_source(sql_tree)
 
         except Exception as ex:
@@ -446,7 +446,6 @@ class CreateFunction(FunctionCommand, CreateObject,
 
         sql_text, _ = compiler.compile_ir_to_sql(
             body_ir,
-            schema=body_ir.schema,
             ignore_shapes=True,
             use_named_params=True)
 
@@ -1561,7 +1560,7 @@ class CreateSourceIndex(SourceIndexCommand, CreateObject,
             location='selector')
 
         sql_tree = compiler.compile_ir_to_sql_tree(
-            ir.expr, schema=ir.schema, singleton_mode=True)
+            ir.expr, singleton_mode=True)
         sql_expr = codegen.SQLSourceGenerator.to_source(sql_tree)
 
         if isinstance(sql_tree, pg_ast.ImplicitRowExpr):

--- a/edb/server/pgsql/metaschema.py
+++ b/edb/server/pgsql/metaschema.py
@@ -1021,7 +1021,7 @@ class NormalizeArrayIndexFunction(dbops.Function):
     def __init__(self):
         super().__init__(
             name=('edgedb', '_normalize_array_index'),
-            args=[('index', ('int',)), ('length', ('int',))],
+            args=[('index', ('bigint',)), ('length', ('int',))],
             returns=('int',),
             volatility='immutable',
             strict=True,
@@ -1042,7 +1042,7 @@ class ArrayIndexWithBoundsFunction(dbops.Function):
     def __init__(self):
         super().__init__(
             name=('edgedb', '_index'),
-            args=[('val', ('anyarray',)), ('index', ('int',)),
+            args=[('val', ('anyarray',)), ('index', ('bigint',)),
                   ('det', ('text',))],
             returns=('anyelement',),
             volatility='immutable',
@@ -1072,8 +1072,8 @@ class ArraySliceFunction(dbops.Function):
     def __init__(self):
         super().__init__(
             name=('edgedb', '_slice'),
-            args=[('val', ('anyarray',)), ('start', ('int',)),
-                  ('stop', ('int',))],
+            args=[('val', ('anyarray',)), ('start', ('bigint',)),
+                  ('stop', ('bigint',))],
             returns=('anyarray',),
             volatility='immutable',
             text=self.text)
@@ -1096,7 +1096,7 @@ class StringIndexWithBoundsFunction(dbops.Function):
     def __init__(self):
         super().__init__(
             name=('edgedb', '_index'),
-            args=[('val', ('text',)), ('index', ('int',)),
+            args=[('val', ('text',)), ('index', ('bigint',)),
                   ('det', ('text',))],
             returns=('text',),
             volatility='immutable',
@@ -1121,7 +1121,7 @@ class BytesIndexWithBoundsFunction(dbops.Function):
     def __init__(self):
         super().__init__(
             name=('edgedb', '_index'),
-            args=[('val', ('bytea',)), ('index', ('int',)),
+            args=[('val', ('bytea',)), ('index', ('bigint',)),
                   ('det', ('text',))],
             returns=('bytea',),
             volatility='immutable',
@@ -1135,14 +1135,14 @@ class SubstrProxyFunction(dbops.Function):
         SELECT
             CASE
                 WHEN length < 0 THEN ''
-                ELSE substr(val, start, length)
+                ELSE substr(val, start::int, length)
             END
     '''
 
     def __init__(self):
         super().__init__(
             name=('edgedb', '_substr'),
-            args=[('val', ('anyelement',)), ('start', ('int',)),
+            args=[('val', ('anyelement',)), ('start', ('bigint',)),
                   ('length', ('int',))],
             returns=('anyelement',),
             volatility='immutable',
@@ -1218,7 +1218,7 @@ class StringSliceImplFunction(dbops.Function):
             name=('edgedb', '_str_slice'),
             args=[
                 ('val', ('anyelement',)),
-                ('start', ('int',)), ('stop', ('int',))
+                ('start', ('bigint',)), ('stop', ('bigint',))
             ],
             returns=('anyelement',),
             volatility='immutable',
@@ -1236,7 +1236,7 @@ class StringSliceFunction(dbops.Function):
             name=('edgedb', '_slice'),
             args=[
                 ('val', ('text',)),
-                ('start', ('int',)), ('stop', ('int',))
+                ('start', ('bigint',)), ('stop', ('bigint',))
             ],
             returns=('text',),
             volatility='immutable',
@@ -1254,7 +1254,7 @@ class BytesSliceFunction(dbops.Function):
             name=('edgedb', '_slice'),
             args=[
                 ('val', ('bytea',)),
-                ('start', ('int',)), ('stop', ('int',))
+                ('start', ('bigint',)), ('stop', ('bigint',))
             ],
             returns=('bytea',),
             volatility='immutable',
@@ -1321,7 +1321,7 @@ class JSONIndexByIntFunction(dbops.Function):
             )
             WHEN 'array' THEN (
                 edgedb._raise_exception_on_null(
-                    val -> index,
+                    val -> index::int,
                     'invalid_parameter_value',
                     'json index ' || index::text || ' is out of bounds',
                     det
@@ -1340,7 +1340,7 @@ class JSONIndexByIntFunction(dbops.Function):
     def __init__(self):
         super().__init__(
             name=('edgedb', '_index'),
-            args=[('val', ('jsonb',)), ('index', ('int',)),
+            args=[('val', ('jsonb',)), ('index', ('bigint',)),
                   ('det', ('text',))],
             returns=('jsonb',),
             volatility='immutable',
@@ -1364,8 +1364,8 @@ class JSONSliceFunction(dbops.Function):
     def __init__(self):
         super().__init__(
             name=('edgedb', '_slice'),
-            args=[('val', ('jsonb',)), ('start', ('int',)),
-                  ('stop', ('int',))],
+            args=[('val', ('jsonb',)), ('start', ('bigint',)),
+                  ('stop', ('bigint',))],
             returns=('jsonb',),
             volatility='immutable',
             text=self.text)

--- a/edb/server2/backend/compiler.py
+++ b/edb/server2/backend/compiler.py
@@ -177,7 +177,6 @@ class Compiler:
 
         sql_text, argmap = pg_compiler.compile_ir_to_sql(
             ir,
-            schema=ir.schema,
             pretty=debug.flags.edgeql_compile,
             output_format=ctx.output_format)
 

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -23,6 +23,7 @@ import textwrap
 from edb.lang import _testbase as tb
 
 from edb.lang.edgeql import compiler
+from edb.lang.edgeql.compiler import context
 from edb.lang.edgeql.compiler import inference
 
 from edb.lang.ir import ast as irast
@@ -37,8 +38,9 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
     def run_test(self, *, source, spec, expected):
         ir = compiler.compile_to_ir(source, self.schema)
 
+        env = context.Environment(path_scope=ir.scope_tree, schema=self.schema)
         cardinality = inference.infer_cardinality(
-            ir, scope_tree=ir.scope_tree, schema=self.schema)
+            ir, scope_tree=ir.scope_tree, env=env)
         expected_cardinality = irast.Cardinality(
             textwrap.dedent(expected).strip(' \n'))
         self.assertEqual(cardinality, expected_cardinality,

--- a/tests/test_edgeql_ir_pathid.py
+++ b/tests/test_edgeql_ir_pathid.py
@@ -45,18 +45,18 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
 
         self.assertIsNone(pid_1.rptr())
         self.assertIsNone(pid_1.rptr_dir())
-        self.assertIsNone(pid_1.rptr_name(self.schema.get))
+        self.assertIsNone(pid_1.rptr_name())
         self.assertIsNone(pid_1.src_path())
 
-        pid_2 = pid_1.extend(deck_ptr, schema=self.schema)
+        pid_2 = pid_1.extend(ptrcls=deck_ptr, schema=self.schema)
         self.assertEqual(
             str(pid_2),
             '(test::User).>(test::deck)[IS test::Card]')
 
-        self.assertEqual(pid_2.rptr(), deck_ptr)
+        self.assertEqual(pid_2.rptr().name, deck_ptr.get_name(self.schema))
         self.assertEqual(pid_2.rptr_dir(),
                          s_pointers.PointerDirection.Outbound)
-        self.assertEqual(pid_2.rptr_name(self.schema), 'test::deck')
+        self.assertEqual(pid_2.rptr_name(), 'test::deck')
         self.assertEqual(pid_2.src_path(), pid_1)
 
         ptr_pid = pid_2.ptr_path()
@@ -70,7 +70,7 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
 
         self.assertEqual(ptr_pid.tgt_path(), pid_2)
 
-        prop_pid = ptr_pid.extend(count_prop, schema=self.schema)
+        prop_pid = ptr_pid.extend(ptrcls=count_prop, schema=self.schema)
         self.assertEqual(
             str(prop_pid),
             '(test::User).>(test::deck)[IS test::Card]@'
@@ -88,9 +88,9 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
         count_prop = deck_ptr.getptr(self.schema, 'count')
 
         pid_1 = pathid.PathId.from_type(self.schema, User)
-        pid_2 = pid_1.extend(deck_ptr, schema=self.schema)
+        pid_2 = pid_1.extend(ptrcls=deck_ptr, schema=self.schema)
         ptr_pid = pid_2.ptr_path()
-        prop_pid = ptr_pid.extend(count_prop, schema=self.schema)
+        prop_pid = ptr_pid.extend(ptrcls=count_prop, schema=self.schema)
 
         self.assertTrue(pid_2.startswith(pid_1))
         self.assertFalse(pid_1.startswith(pid_2))
@@ -110,9 +110,9 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
 
         ns = frozenset(('foo',))
         pid_1 = pathid.PathId.from_type(self.schema, User, namespace=ns)
-        pid_2 = pid_1.extend(deck_ptr, schema=self.schema)
+        pid_2 = pid_1.extend(ptrcls=deck_ptr, schema=self.schema)
         ptr_pid = pid_2.ptr_path()
-        prop_pid = ptr_pid.extend(count_prop, schema=self.schema)
+        prop_pid = ptr_pid.extend(ptrcls=count_prop, schema=self.schema)
 
         self.assertEqual(pid_1.namespace, ns)
         self.assertEqual(pid_2.namespace, ns)
@@ -135,15 +135,15 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
         ns_2 = frozenset(('bar',))
 
         pid_1 = pathid.PathId.from_type(self.schema, Card)
-        pid_2 = pid_1.extend(owners_ptr, ns=ns_1, schema=self.schema)
-        pid_2_no_ns = pid_1.extend(owners_ptr, schema=self.schema)
+        pid_2 = pid_1.extend(ptrcls=owners_ptr, ns=ns_1, schema=self.schema)
+        pid_2_no_ns = pid_1.extend(ptrcls=owners_ptr, schema=self.schema)
 
         self.assertNotEqual(pid_2, pid_2_no_ns)
         self.assertEqual(pid_2.src_path(), pid_1)
 
-        pid_3 = pid_2.extend(deck_ptr, ns=ns_2, schema=self.schema)
+        pid_3 = pid_2.extend(ptrcls=deck_ptr, ns=ns_2, schema=self.schema)
         ptr_pid = pid_3.ptr_path()
-        prop_pid = ptr_pid.extend(count_prop, schema=self.schema)
+        prop_pid = ptr_pid.extend(ptrcls=count_prop, schema=self.schema)
 
         self.assertEqual(prop_pid.src_path().namespace, ns_1 | ns_2)
         self.assertEqual(prop_pid.src_path().src_path().namespace, ns_1)

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -233,7 +233,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 # FIXME: a different error should be used here, this
                 # one leaks postgres types
                 edgedb.InternalServerError,
-                r'cannot index json object by integer'):
+                r'cannot index json object by bigint'):
             await self.query(r"""
                 SELECT (to_json('{"a": 1, "b": null}'))[0];
             """)
@@ -345,7 +345,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 # FIXME: a different error should be used here, this
                 # one leaks postgres types
                 edgedb.InternalServerError,
-                r'cannot index json object by integer'):
+                r'cannot index json object by bigint'):
             await self.query(r"""
                 WITH
                     MODULE test,

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -262,3 +262,19 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
             {'q', 'a'},
             {4},
         ])
+
+    async def test_edgeql_userddl_21(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                r"'force_return_cast' is not a valid field"):
+            await self.query('''
+                CREATE FUNCTION test::func(
+                    a: str
+                ) -> bool
+                {
+                    FROM EdgeQL $$
+                        SELECT True;
+                    $$;
+                    SET force_return_cast := true;
+                };
+            ''')

--- a/tests/test_edgeql_utils.py
+++ b/tests/test_edgeql_utils.py
@@ -62,7 +62,7 @@ class TestEdgeQLUtils(tb.BaseEdgeQLCompilerTest):
 
         if expected_const_type is not None:
             self.assertEqual(
-                ir.expr.stype.get_displayname(self.__class__.schema),
+                ir.expr.typeref.displayname,
                 expected_const_type)
 
     def test_edgeql_utils_normalize_01(self):


### PR DESCRIPTION
At present, we record schema objects into IR directly, which
means that in order to process the IR, the derived schema must be kept
and passed around.  This also makes any IR serialization impractical, as
the associated schema would need to be serialized as well.

This change moves the necessary information from the schema objects into
the IR directly removing the IR dependency on the schema.