### PR TITLE
Disable constant folding except for concatenation

### DIFF
--- a/edb/lang/edgeql/compiler/__init__.py
+++ b/edb/lang/edgeql/compiler/__init__.py
@@ -110,7 +110,8 @@ def compile_ast_to_ir(tree,
                       result_view_name=None,
                       modaliases=None,
                       implicit_id_in_shapes=False,
-                      schema_view_mode=False):
+                      schema_view_mode=False,
+                      disable_constant_folding=False):
     """Compile given EdgeQL AST into EdgeDB IR."""
 
     if debug.flags.edgeql_compile:
@@ -123,7 +124,8 @@ def compile_ast_to_ir(tree,
         func=func, derived_target_module=derived_target_module,
         result_view_name=result_view_name,
         implicit_id_in_shapes=implicit_id_in_shapes,
-        schema_view_mode=schema_view_mode)
+        schema_view_mode=schema_view_mode,
+        disable_constant_folding=disable_constant_folding)
 
     ir_set = dispatch.compile(tree, ctx=ctx)
     ir_expr = stmtctx.fini_expression(ir_set, ctx=ctx)

--- a/edb/lang/edgeql/compiler/context.py
+++ b/edb/lang/edgeql/compiler/context.py
@@ -103,13 +103,19 @@ class Environment:
     set_types: typing.Dict[irast.Set, s_types.Type]
     """A dictionary of all Set instances and their schema types."""
 
-    def __init__(self, *, schema, path_scope, schema_view_mode: bool=False):
+    constant_folding: bool
+    """Enables constant folding optimization (enabled by default)."""
+
+    def __init__(self, *, schema, path_scope,
+                 schema_view_mode: bool=False,
+                 constant_folding: bool=True):
         self.schema = schema
         self.path_scope = path_scope
         self.schema_view_cache = {}
         self.query_parameters = {}
         self.schema_view_mode = schema_view_mode
         self.set_types = {}
+        self.constant_folding = constant_folding
 
 
 class ContextLevel(compiler.ContextLevel):

--- a/edb/lang/edgeql/compiler/expr.py
+++ b/edb/lang/edgeql/compiler/expr.py
@@ -80,9 +80,10 @@ def compile_BinOp(
         op_node = func.compile_operator(
             expr, op_name=expr.op, qlargs=[expr.left, expr.right], ctx=ctx)
 
-        folded = try_fold_binop(op_node.expr, ctx=ctx)
-        if folded is not None:
-            return folded
+        if ctx.env.constant_folding:
+            folded = try_fold_binop(op_node.expr, ctx=ctx)
+            if folded is not None:
+                return folded
 
     return setgen.ensure_set(op_node, ctx=ctx)
 

--- a/edb/lang/edgeql/compiler/stmtctx.py
+++ b/edb/lang/edgeql/compiler/stmtctx.py
@@ -60,6 +60,7 @@ def init_context(
         derived_target_module: typing.Optional[str]=None,
         result_view_name: typing.Optional[str]=None,
         schema_view_mode: bool=False,
+        disable_constant_folding: bool=False,
         implicit_id_in_shapes: bool=False) -> \
         context.ContextLevel:
     stack = context.CompilerContext()
@@ -69,6 +70,7 @@ def init_context(
     ctx.env = context.Environment(
         schema=schema,
         path_scope=irast.new_scope_tree(),
+        constant_folding=not disable_constant_folding,
         schema_view_mode=schema_view_mode)
 
     if singletons:

--- a/edb/lang/ir/staeval.py
+++ b/edb/lang/ir/staeval.py
@@ -76,27 +76,6 @@ def evaluate_BaseConstant(
 
 
 op_table = {
-    # Arithmetic
-    ('PREFIX', 'std::+'): lambda a: a,
-    ('PREFIX', 'std::-'): lambda a: -a,
-    ('INFIX', 'std::+'): lambda a, b: a + b,
-    ('INFIX', 'std::-'): lambda a, b: a - b,
-    ('INFIX', 'std::*'): lambda a, b: a * b,
-    ('INFIX', 'std::/'): lambda a, b: a / b,
-    ('INFIX', 'std:://'): lambda a, b: a // b,
-    ('INFIX', 'std::%'): lambda a, b: a % b,
-    ('INFIX', 'std::^'): lambda a, b: (
-        decimal.Decimal(a) ** decimal.Decimal(b)
-        if isinstance(a, int) else a ** b),
-
-    # Comparison
-    ('INFIX', 'std::='): lambda a, b: a == b,
-    ('INFIX', 'std::!='): lambda a, b: a != b,
-    ('INFIX', 'std::>'): lambda a, b: a > b,
-    ('INFIX', 'std::>='): lambda a, b: a >= b,
-    ('INFIX', 'std::<'): lambda a, b: a < b,
-    ('INFIX', 'std::<='): lambda a, b: a <= b,
-
     # Concatenation
     ('INFIX', 'std::++'): lambda a, b: a + b,
 }

--- a/edb/server2/backend/compiler.py
+++ b/edb/server2/backend/compiler.py
@@ -207,12 +207,17 @@ class Compiler:
             ql: qlast.Base) -> dbstate.BaseQuery:
 
         current_tx = ctx.state.current_tx()
+        config = current_tx.get_config()
+
+        disable_constant_folding = config.get(
+            '__internal_no_const_folding', False)
 
         ir = ql_compiler.compile_ast_to_ir(
             ql,
             schema=current_tx.get_schema(),
             modaliases=current_tx.get_modaliases(),
-            implicit_id_in_shapes=False)
+            implicit_id_in_shapes=False,
+            disable_constant_folding=disable_constant_folding)
 
         sql_text, argmap = pg_compiler.compile_ir_to_sql(
             ir,

--- a/edb/server2/backend/config.py
+++ b/edb/server2/backend/config.py
@@ -32,5 +32,6 @@ class setting(typing.NamedTuple):
 
 
 configs = immutables.Map(
+    __internal_no_const_folding=setting(type=bool, default=False),
     __internal_testmode=setting(type=bool, default=False),
 )

--- a/tests/test_edgeql_utils.py
+++ b/tests/test_edgeql_utils.py
@@ -65,13 +65,6 @@ class TestEdgeQLUtils(tb.BaseEdgeQLCompilerTest):
                 ir.expr.typeref.displayname,
                 expected_const_type)
 
-    def test_edgeql_utils_normalize_01(self):
-        self._assert_normalize_expr(
-            """SELECT 40 + 2""",
-            """SELECT 42""",
-            'std::int64',
-        )
-
     def test_edgeql_utils_normalize_02(self):
         self._assert_normalize_expr(
             """SELECT -10""",
@@ -110,55 +103,9 @@ class TestEdgeQLUtils(tb.BaseEdgeQLCompilerTest):
             """SELECT ('aaa')[2]"""
         )
 
-    def test_edgeql_utils_normalize_08(self):
-        self._assert_normalize_expr(
-            """SELECT 40 + 2 - 20 * +2 + (-10 // 2)""",
-            """SELECT -3""",
-            'std::int64',
-        )
-
-    def test_edgeql_utils_normalize_09(self):
-        self._assert_normalize_expr(
-            """SELECT 2 + (len('a')+1)""",
-            """SELECT (3 + std::len('a'))""",
-        )
-
-        self._assert_normalize_expr(
-            """SELECT (1 + len('a')) + 2""",
-            """SELECT (3 + std::len('a'))""",
-        )
-
-        self._assert_normalize_expr(
-            """SELECT 2 * (len('a')*1)""",
-            """SELECT (2 * std::len('a'))""",
-        )
-
-        self._assert_normalize_expr(
-            """SELECT (1 * len('a')) * 2""",
-            """SELECT (2 * std::len('a'))""",
-        )
-
-    def test_edgeql_utils_normalize_10(self):
-        self._assert_normalize_expr(
-            """SELECT 1 > 2""",
-            """SELECT false""",
-            'std::bool',
-        )
-
-        self._assert_normalize_expr(
-            """SELECT 1 = 1""",
-            """SELECT true""",
-            'std::bool',
-        )
-
-        self._assert_normalize_expr(
-            """SELECT 1 < (1 + 1)""",
-            """SELECT true""",
-            'std::bool',
-        )
-
     def test_edgeql_utils_normalize_11(self):
         self._assert_normalize_expr(
-            """SELECT 5 // 2""",
-            """SELECT 2""",
+            """SELECT 'a' ++ 'b'""",
+            """SELECT 'ab'""",
+            'std::str',
         )


### PR DESCRIPTION
* Drop support for constant folding of numerics etc.  Only
  str/bytes concatenation is now supported.  The primary motivation
  behind this change is to make sure we don't have broken edge cases
  in arithmetic.  Postgres works with ints/floats differently from
  Python and the current constant folding algorithm doesn't account for
  them.

* Reorganize expressions tests to make them more maintainable.