### PR TITLE
Add rudimentary support for the INTROSPECT operator

### DIFF
--- a/docs/datamodel/colltypes.rst
+++ b/docs/datamodel/colltypes.rst
@@ -38,8 +38,11 @@ heterogeneous data.
 
     .. code-block:: edgeql-repl
 
-        db> SELECT ('foo', 42).__type__.name;
-        {"std::tuple<std::str, std::int64>"}
+        db> SELECT ('foo', 42);
+        {('foo', 42)}
+
+        db> SELECT (INTROSPECT TYPEOF ('foo', 42)).name;
+        {"tuple<std::str, std::int64>"}
 
     Two tuples are equal if all of their elements are equal and in the same
     order.  Note that element names in named tuples are not significant for
@@ -75,5 +78,8 @@ heterogeneous data.
 
     .. code-block:: edgeql-repl
 
-        db> SELECT [1, 2].__type__;
-        {"std::array<std::int64>"}
+        db> SELECT [1, 2];
+        {[1, 2]}
+
+        db> SELECT (INTROSPECT TYPEOF [1, 2]).name;
+        {"array<std::int64>"}

--- a/docs/edgeql/expressions/tuples.rst
+++ b/docs/edgeql/expressions/tuples.rst
@@ -29,8 +29,8 @@ A tuple constructor automatically creates a corresponding
 
 .. code-block:: edgeql-repl
 
-    db> SELECT ('foo', 42).__type__.name;
-    std::tuple<std::str, std::int64>
+    db> SELECT (INTROSPECT TYPEOF ('foo', 42)).name;
+    tuple<std::str, std::int64>
 
 
 .. _ref_eql_expr_tuple_elref:

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -634,7 +634,8 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_TypeName(self, node):
         parenthesize = (
-            isinstance(node.parent, (edgeql_ast.IsOp, edgeql_ast.TypeOp)) and
+            isinstance(node.parent, (edgeql_ast.IsOp, edgeql_ast.TypeOp,
+                                     edgeql_ast.Introspect)) and
             node.subtypes is not None
         )
         if parenthesize:
@@ -657,6 +658,14 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self.write('>')
         if parenthesize:
             self.write(')')
+
+    def visit_Introspect(self, node):
+        self.write('INTROSPECT ')
+        self.visit(node.type)
+
+    def visit_TypeOf(self, node):
+        self.write('TYPEOF ')
+        self.visit(node.expr)
 
     # DDL nodes
 

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -85,6 +85,11 @@ def __infer_typeref(ir, scope_tree, env):
     return ONE
 
 
+@_infer_cardinality.register(irast.TypeIntrospection)
+def __infer_type_introspection(ir, scope_tree, env):
+    return ONE
+
+
 @_infer_cardinality.register(irast.Set)
 def __infer_set(ir, scope_tree, env):
     parent_fence = scope_tree.parent_fence

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -127,6 +127,21 @@ def __infer_set(ir, env):
     return env.set_types[ir]
 
 
+@_infer_type.register(irast.TypeIntrospection)
+def __infer_type_introspection(ir, env):
+    if irtyputils.is_scalar(ir.typeref):
+        return env.schema.get('schema::ScalarType')
+    elif irtyputils.is_object(ir.typeref):
+        return env.schema.get('schema::ObjectType')
+    elif irtyputils.is_array(ir.typeref):
+        return env.schema.get('schema::Array')
+    elif irtyputils.is_tuple(ir.typeref):
+        return env.schema.get('schema::Tuple')
+    else:
+        raise errors.QueryError(
+            'unexpected type in INTROSPECT', context=ir.context)
+
+
 @_infer_type.register(irast.OperatorCall)
 @_infer_type.register(irast.FunctionCall)
 def __infer_func_call(ir, env):

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1269,7 +1269,9 @@ class TypeName(Nonterm):
         self.val = kids[0].val
 
 
-# This is a type expression without angle brackets or parentheses
+# This is a type expression without angle brackets, so it
+# can be used without parentheses in a context where the
+# angle bracket has a different meaning.
 class TypeExpr(Nonterm):
     def reduce_SimpleTypeName(self, *kids):
         self.val = kids[0].val
@@ -1289,11 +1291,18 @@ class TypeExpr(Nonterm):
                                 right=kids[2].val)
 
 
-# This is a type expression with everything, it is meant to be used
-# inside parentheses or angle brackets.
+# This is a type expression which includes collection types,
+# so it can only be directly used in a context where the
+# angle bracket is unambiguous.
 class FullTypeExpr(Nonterm):
     def reduce_TypeName(self, *kids):
         self.val = kids[0].val
+
+    def reduce_TYPEOF_Expr(self, *kids):
+        self.val = qlast.TypeOf(expr=kids[1].val)
+
+    def reduce_LPAREN_FullTypeExpr_RPAREN(self, *kids):
+        self.val = kids[1].val
 
     def reduce_FullTypeExpr_PIPE_FullTypeExpr(self, *kids):
         self.val = qlast.TypeOp(left=kids[0].val, op='|',

--- a/edb/edgeql/parser/grammar/keywords.py
+++ b/edb/edgeql/parser/grammar/keywords.py
@@ -104,7 +104,6 @@ future_reserved_keywords = frozenset([
     "global",
     "grant",
     "import",
-    "introspect",
     "listen",
     "load",
     "lock",
@@ -120,7 +119,6 @@ future_reserved_keywords = frozenset([
     "revoke",
     "savepoint",
     "over",
-    "typeof",
     "when",
 ])
 
@@ -152,6 +150,7 @@ reserved_keywords = future_reserved_keywords | frozenset([
     "ilike",
     "in",
     "insert",
+    "introspect",
     "is",
     "like",
     "limit",
@@ -166,6 +165,7 @@ reserved_keywords = future_reserved_keywords | frozenset([
     "set",
     "start",
     "true",
+    "typeof",
     "update",
     "union",
     "variadic",

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -292,6 +292,11 @@ class TypeIndirectionPointer(Pointer):
     optional: bool
 
 
+class TypeIntrospection(Base):
+
+    typeref: TypeRef
+
+
 class Set(Base):
 
     path_id: PathId

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -282,20 +282,23 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
 
     async def test_edgeql_calls_10(self):
         await self.assert_query_result(r'''
-            SELECT sum({1, 2, 3}).__type__.name;
-            SELECT sum({<int32>1, 2, 3}).__type__.name;
-            SELECT sum({<float32>1, 2, 3}).__type__.name;
+            SELECT (INTROSPECT TYPEOF sum({1, 2, 3})).name;
+            SELECT (INTROSPECT TYPEOF sum({<int32>1, 2, 3})).name;
+            SELECT (INTROSPECT TYPEOF sum({<float32>1, 2, 3})).name;
 
-            SELECT sum({<float32>1, <int32>2, 3}).__type__.name;
-            SELECT sum({<int16>1, <int32>2, <decimal>3}).__type__.name;
+            SELECT (INTROSPECT TYPEOF sum({<float32>1, <int32>2, 3})).name;
+            SELECT (INTROSPECT TYPEOF
+                        sum({<int16>1, <int32>2, <decimal>3})).name;
 
-            SELECT sum({<int16>1, 2, <decimal>3}).__type__.name;
-            SELECT sum({1, <float32>2.1, <float64>3}).__type__.name;
-            SELECT sum({1.1, 2.2, 3.3}).__type__.name;
+            SELECT (INTROSPECT TYPEOF sum({<int16>1, 2, <decimal>3})).name;
+            SELECT (INTROSPECT TYPEOF sum({1, <float32>2.1, <float64>3})).name;
+            SELECT (INTROSPECT TYPEOF sum({1.1, 2.2, 3.3})).name;
 
-            SELECT sum({<float32>1, <int32>2, <float32>3}).__type__.name;
-            SELECT sum({<float32>1, <float32>2, <float32>3}).__type__.name;
-            SELECT sum({1.1, 2.2, 3}).__type__.name;
+            SELECT (INTROSPECT TYPEOF
+                        sum({<float32>1, <int32>2, <float32>3})).name;
+            SELECT (INTROSPECT TYPEOF
+                        sum({<float32>1, <float32>2, <float32>3})).name;
+            SELECT (INTROSPECT TYPEOF sum({1.1, 2.2, 3})).name;
         ''', [
             {'std::int64'},
             {'std::int64'},

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2459,6 +2459,34 @@ aa';
         SELECT ();
         """
 
+    def test_edgeql_syntax_introspect_01(self):
+        """
+        SELECT INTROSPECT std::int64;
+        """
+
+    def test_edgeql_syntax_introspect_02(self):
+        """
+        SELECT INTROSPECT (tuple<str>);
+        """
+
+    def test_edgeql_syntax_introspect_03(self):
+        """
+        SELECT INTROSPECT TYPEOF '1';
+        """
+
+    def test_edgeql_syntax_introspect_04(self):
+        """
+        SELECT INTROSPECT TYPEOF (3 + 2);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Unexpected '>'",
+                  line=2, col=38)
+    def test_edgeql_syntax_introspect_05(self):
+        """
+        SELECT INTROSPECT tuple<int64>;
+        """
+
     # DDL
     #
 


### PR DESCRIPTION
This adds support for the `INTROSPECT` operator, which is a way to
perform introspection of a given type expression.  Support for
the `TYPEOF` expression is added also, which is a way to perform
static compile-time type inference for an arbitrary expression.

Currently, `INTROSPECT` is limited to the types that are present in the
schema, i.e. introspection of collection types and views is not
supported yet.

I've also converted the uses of `__type__` on scalar expressions to
`INTROSPECT TYPEOF`, as `__type__` on non-object types is slated for
removal.

Issue #219.