### PR TITLE
Fix object JSON cast in binary output mode

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1272,7 +1272,11 @@ def process_set_as_type_cast(
                 and (irtyputils.is_collection(inner_set.typeref)
                      or irtyputils.is_object(inner_set.typeref))):
             subctx.expr_exposed = True
-            subctx.output_format = context.OutputFormat.JSON
+            # XXX: this is necessary until pathctx is converted
+            #      to use context levels instead of using env
+            #      directly.
+            orig_output_format = subctx.env.output_format
+            subctx.env.output_format = context.OutputFormat.JSON
             implicit_cast = True
         else:
             implicit_cast = False
@@ -1292,6 +1296,8 @@ def process_set_as_type_cast(
                 pathctx.put_path_value_var(
                     stmt, inner_set.path_id, serialized,
                     force=True, env=subctx.env)
+
+            subctx.env.output_format = orig_output_format
         else:
             set_expr = dispatch.compile(ir_set.expr, ctx=ctx)
 

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -135,3 +135,13 @@ class TestServerProto(tb.NonIsolatedDDLTestCase):
                 'select (<array<str>>$0)[0] ++ (<array<str>>$1)[0];',
                 ['aaa'], ['bbb']),
             edgedb.Set(('aaabbb',)))
+
+    async def test_server_proto_json_cast_01(self):
+        self.assertEqual(
+            await self.con.fetch('''
+                select <json>(
+                    select schema::Type{name} filter .name = 'std::bool'
+                )
+            '''),
+            edgedb.Set(('{"name": "std::bool"}',))
+        )


### PR DESCRIPTION
The fix is admittedly a big ugly, since it mutates the global
compiler environment, but fixing that properly would require a much
larger patch.