### PR TITLE
Make top-level DML statement return objects instead of count

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -280,9 +280,17 @@ def compile_InsertQuery(
             ctx=ictx)
 
         stmt_subject_stype = setgen.get_set_type(subject, ctx=ictx)
-        stmt.result = setgen.class_set(
+
+        result = setgen.class_set(
             stmt_subject_stype.material_type(ctx.env.schema),
             path_id=stmt.subject.path_id, ctx=ctx)
+
+        stmt.result = compile_query_subject(
+            result,
+            view_scls=ctx.view_scls,
+            view_name=ctx.toplevel_result_view_name,
+            compile_views=ictx.stmt is ictx.toplevel_stmt,
+            ctx=ictx)
 
         result = fini_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 
@@ -314,9 +322,17 @@ def compile_UpdateQuery(
             ctx=ictx)
 
         stmt_subject_stype = setgen.get_set_type(subject, ctx=ictx)
-        stmt.result = setgen.class_set(
+
+        result = setgen.class_set(
             stmt_subject_stype.material_type(ctx.env.schema),
             path_id=stmt.subject.path_id, ctx=ctx)
+
+        stmt.result = compile_query_subject(
+            result,
+            view_scls=ctx.view_scls,
+            view_name=ctx.toplevel_result_view_name,
+            compile_views=ictx.stmt is ictx.toplevel_stmt,
+            ctx=ictx)
 
         stmt.where = clauses.compile_where_clause(
             expr.where, ctx=ictx)
@@ -349,9 +365,16 @@ def compile_DeleteQuery(
             subject, shape=None, result_alias=expr.subject_alias, ctx=ictx)
 
         stmt_subject_stype = setgen.get_set_type(subject, ctx=ictx)
-        stmt.result = setgen.class_set(
+        result = setgen.class_set(
             stmt_subject_stype.material_type(ctx.env.schema),
             path_id=stmt.subject.path_id, ctx=ctx)
+
+        stmt.result = compile_query_subject(
+            result,
+            view_scls=ctx.view_scls,
+            view_name=ctx.toplevel_result_view_name,
+            compile_views=ictx.stmt is ictx.toplevel_stmt,
+            ctx=ictx)
 
         result = fini_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -167,14 +167,7 @@ def fini_dml_stmt(
         dbobj.add_rel_overlay(
             str(ir_stmt.subject.typeref.id), 'except', dml_cte, env=ctx.env)
 
-    if parent_ctx.toplevel_stmt is wrapper:
-        ret_ref = pathctx.get_path_identity_var(
-            wrapper, ir_stmt.subject.path_id, env=parent_ctx.env)
-        count = pgast.FuncCall(name=('count',), args=[ret_ref])
-        wrapper.target_list = [
-            pgast.ResTarget(val=count)
-        ]
-
+    clauses.compile_output(ir_stmt.result, ctx=ctx)
     clauses.fini_stmt(wrapper, ctx, parent_ctx)
 
     return wrapper

--- a/tests/test_deltas.py
+++ b/tests/test_deltas.py
@@ -71,9 +71,9 @@ class TestDeltas(tb.DDLTestCase):
 
             None,
 
-            [1],
+            [{}],
 
-            [1],
+            [{}],
 
             [{
                 'related': [{'name': 'Test', '@lang': None}],
@@ -188,8 +188,8 @@ class TestDeltas(tb.DDLTestCase):
             None,
             None,
 
-            [1],
-            [1],
+            [{}],
+            [{}],
 
             [{'номер': 456}, {'номер': 987}]
         ])

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -400,10 +400,10 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             SELECT test::call13([1, 2, 3, 4, 5]);
             SELECT test::call13(['a', 'b']);
         ''', [
-            [1],
-            [1],
-            [1],
-            [1],
+            [{}],
+            [{}],
+            [{}],
+            [{}],
         ])
 
         await self.query('''
@@ -429,9 +429,9 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             SELECT test::call13_2(['a', 'b']);
         ''', [
             [2],
-            [1],
-            [1],
-            [1],
+            [{}],
+            [{}],
+            [{}],
         ])
 
     async def test_edgeql_calls_14(self):
@@ -557,7 +557,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             SELECT test::call18(1, 2, 3);
             SELECT test::call18('a', 'b');
         ''', [
-            [1],
+            [{}],
             [3],
             [2],
         ])
@@ -743,7 +743,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             SELECT test::call26(['aaa']);
             SELECT test::call26([b'', b'aa']);
         ''', [
-            [1],
+            [{}],
             [2],
         ])
 
@@ -884,7 +884,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             ['aa'],
 
             [[1, 2]],
-            [1],
+            [{}],
 
             [1001],
             [1002],
@@ -894,9 +894,9 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
 
             [{"a": 1001, "b": 1002}],
 
-            [1],
-            [1],
-            [1],
+            [{}],
+            [{}],
+            [{}],
             [{"x": 1}],
         ])
 

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -823,12 +823,12 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             SELECT <float64>1;
             SELECT <decimal>1;
         ''', [
-            [1],
-            [1],
-            [1],
-            [1],
-            [1],
-            [1],
+            [{}],
+            [{}],
+            [{}],
+            [{}],
+            [{}],
+            [{}],
         ])
 
     async def test_edgeql_casts_numeric_07(self):
@@ -838,7 +838,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             await self.assert_query_result(f'''
                 SELECT <{t1}><{t2}>1;
             ''', [
-                [1],
+                [{}],
             ])
 
     async def test_edgeql_casts_numeric_08(self):

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -121,9 +121,9 @@ class TestEdgeQLDT(tb.QueryTestCase):
             SELECT Obj { seq_prop } ORDER BY Obj.seq_prop;
             SELECT Obj2 { seq_prop };
         ''', [
-            [1],
-            [1],
-            [1],
+            [{}],
+            [{}],
+            [{}],
             [
                 {'seq_prop': 1}, {'seq_prop': 2}
             ],

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -433,7 +433,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.assert_query_result(r"""
             SELECT test::int_func_1();
         """, [
-            [1],
+            [{}],
         ])
 
     async def test_edgeql_ddl_11(self):
@@ -494,7 +494,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 bar1,
             };
         """, [
-            [1],
+            [{}],
             [{'foo1': 'Victor', 'bar1': 'Victor'}]
         ])
 
@@ -526,9 +526,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 bar2,
             } ORDER BY TestSelfLink2.foo2;
         """, [
-            [1],
-            [1],
-            [1],
+            [{}],
+            [{}],
+            [{}],
             [
                 {'bar2': {}, 'foo2': 'Alice'},
                 {'bar2': {'Alice'}, 'foo2': 'Bob'},
@@ -569,7 +569,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 __typename4,
             };
         """, [
-            [1],
+            [{}],
             [{'__typename4': 'test::TestSelfLink4'}]
         ])
 
@@ -652,8 +652,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ORDER BY View2.foo;
         """, [
             None,
-            [1],
-            [1],
+            [{}],
+            [{}],
 
             [
                 {

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -62,8 +62,8 @@ class TestDelete(tb.QueryTestCase):
         """)
 
         self.assert_data_shape(result, [
-            [1],
-            [1]
+            [{}],
+            [{}]
         ])
 
     async def test_edgeql_delete_simple02(self):
@@ -106,7 +106,7 @@ class TestDelete(tb.QueryTestCase):
             WITH MODULE test
             SELECT DeleteTest ORDER BY DeleteTest.name;
         """, [
-            [0],
+            [],
             [{'id': id1}, {'id': id2}],
 
             [{'id': id1}],
@@ -177,9 +177,9 @@ class TestDelete(tb.QueryTestCase):
             WITH D := (DELETE test::DeleteTest)
             SELECT count(D);
         """, [
-            [1],
-            [1],
-            [1],
+            [{}],
+            [{}],
+            [{}],
             [3],
         ])
 
@@ -214,11 +214,11 @@ class TestDelete(tb.QueryTestCase):
             WITH MODULE test
             SELECT (DELETE DeleteTest2) { name };
         """, [
-            [1],
-            [1],
-            [1],
-            [1],
-            [1],
+            [{}],
+            [{}],
+            [{}],
+            [{}],
+            [{}],
             [{
                 'name': 'dt2.1',
                 'foo': 'bar',
@@ -255,10 +255,10 @@ class TestDelete(tb.QueryTestCase):
             WITH MODULE test
             SELECT (DELETE DeleteTest2) {name};
         """, [
-            [1],
-            [1],
-            [1],
-            [1],
+            [{}],
+            [{}],
+            [{}],
+            [{}],
             [{
                 'name': 'dt2.1',
                 'count': 3,
@@ -298,10 +298,10 @@ class TestDelete(tb.QueryTestCase):
             WITH MODULE test
             SELECT (DELETE DeleteTest2) {name};
         """, [
-            [1],
-            [1],
-            [1],
-            [1],
+            [{}],
+            [{}],
+            [{}],
+            [{}],
             [{
                 'name': 'dt2.1',
                 'count': 3

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2169,7 +2169,7 @@ class TestExpressions(tb.QueryTestCase):
             SELECT {1} = 1;
         """, [
             [],
-            [1],
+            [{}],
             ['foo'],
             [True],
         ])
@@ -2798,7 +2798,7 @@ class TestExpressions(tb.QueryTestCase):
             SELECT (1, ('a', 'b', (0.1, 0.2)), 2, 3).1.2;
             SELECT (1, ('a', 'b', (0.1, 0.2)), 2, 3).1.2.0;
         """, [
-            [1],
+            [{}],
             [['a', 'b', [0.1, 0.2]]],
             [[0.1, 0.2]],
             [0.1],
@@ -2811,7 +2811,7 @@ class TestExpressions(tb.QueryTestCase):
             WITH A := (1, ('a', 'b', (0.1, 0.2)), 2, 3) SELECT A.1.2;
             WITH A := (1, ('a', 'b', (0.1, 0.2)), 2, 3) SELECT A.1.2.0;
         """, [
-            [1],
+            [{}],
             [['a', 'b', [0.1, 0.2]]],
             [[0.1, 0.2]],
             [0.1],
@@ -2893,8 +2893,8 @@ class TestExpressions(tb.QueryTestCase):
             [{"e": 1}],
             [{"e": 1}],
 
-            [1],
-            [1],
+            [{}],
+            [{}],
         ])
 
     async def test_edgeql_expr_tuple_indirection_14(self):
@@ -3356,7 +3356,7 @@ class TestExpressions(tb.QueryTestCase):
             SELECT count({1, 2, 3});
             SELECT count({1, 2, 3, 2, 3});
         """, [
-            [1],
+            [{}],
             [3],
             [3],
 

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -130,7 +130,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             SELECT array_agg({3, 3, 2})[-1];
         ''')
         self.assert_data_shape(res, [
-            [1],
+            [{}],
             [2],
             [2],
         ])
@@ -428,7 +428,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             SELECT array_enumerate([(x:=(a:=2))]).0.x.a;
         ''', [
             [{"x": 1}],
-            [1],
+            [{}],
 
             [{"x": {"a": 2}}],
             [{"a": 2}],
@@ -483,8 +483,8 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             SELECT array_get([1, 2, 3], 20) ?? 42;
             SELECT array_get([1, 2, 3], -20) ?? 42;
         ''', [
-            [1],
-            [1],
+            [{}],
+            [{}],
             [2],
             [42],
             [42],
@@ -1290,7 +1290,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             SELECT len({['hello'], ['hello', 'world']});
         ''', [
             [0],
-            [1],
+            [{}],
             [2],
             [5],
             {1, 2},
@@ -1379,7 +1379,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         ''', [
             ['Elvis'],
             [3000],
-            [1],
+            [{}],
         ])
 
     async def test_edgeql_functions_max_01(self):
@@ -1624,11 +1624,11 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             SELECT round(<decimal>2.5);
         ''', [
             [],
-            [1],
-            [1],
-            [1],
+            [{}],
+            [{}],
+            [{}],
             [-1],
-            [1],
+            [{}],
             [-1],
 
             [-2],
@@ -1641,7 +1641,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [-3],
             [-2],
             [-1],
-            [1],
+            [{}],
             [2],
             [3],
         ])

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -76,13 +76,13 @@ class TestInsert(tb.QueryTestCase):
         """)
 
         self.assert_data_shape(result, [
-            [1],
+            [{}],
 
-            [1],
+            [{}],
 
-            [1],
+            [{}],
 
-            [1],
+            [{}],
 
             [{
                 'l2': 0,
@@ -360,7 +360,7 @@ class TestInsert(tb.QueryTestCase):
         self.assert_data_shape(
             res,
             [
-                [1],
+                [{}],
                 [{
                     'foo': 'ret2',
                 }],
@@ -805,7 +805,7 @@ class TestInsert(tb.QueryTestCase):
 
         self.assert_data_shape(
             res, [
-                [1],
+                [{}],
                 [{
                     'args': {'val': 'something'},
                 }],
@@ -849,7 +849,7 @@ class TestInsert(tb.QueryTestCase):
             } FILTER .l2 = 99;
         """, [
             [{}, ...],
-            {1},
+            [{}],
             [{
                 'l2': 99,
                 'subordinates': [{
@@ -882,7 +882,7 @@ class TestInsert(tb.QueryTestCase):
                 l3
             };
         """, [
-            {1},
+            [{}],
             [{
                 'l1': None,
                 'l2': 99,
@@ -927,7 +927,7 @@ class TestInsert(tb.QueryTestCase):
                 subordinates
             };
         """, [
-            {1},
+            [{}],
             [{
                 'l2': 99,
                 'subordinates': {},

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -63,7 +63,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             }');
         """, [
             ['qwerty'],
-            [1],
+            [{}],
             [0.023],
 
             [True],
@@ -98,7 +98,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             SELECT <bool>to_json('false');
         """, [
             ['qwerty'],
-            [1],
+            [{}],
             [0.023],
 
             [True],

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -2980,7 +2980,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 <str>Issue.time_estimate
             );
             """, [
-            [1],
+            [{}],
         ])
 
     async def test_edgeql_select_cross_13(self):
@@ -2993,7 +2993,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 (Issue, count(Issue.watchers))
             );
             """, [
-            [1],
+            [{}],
             [4],
         ])
 

--- a/tests/test_edgeql_tutorial.py
+++ b/tests/test_edgeql_tutorial.py
@@ -214,13 +214,13 @@ class TestEdgeQLTutorial(tb.QueryTestCase):
             None,
             None,
             None,
-            [1],
-            [1],
-            [1],
-            [1],
-            [1],
-            [1],
-            [1],
+            [{}],
+            [{}],
+            [{}],
+            [{}],
+            [{}],
+            [{}],
+            [{}],
             [{
                 'assignees': [{'login': 'bob'}, {'login': 'dave'}],
                 'author': {'login': 'carol'},
@@ -243,5 +243,5 @@ class TestEdgeQLTutorial(tb.QueryTestCase):
                 '__type__': {'name': 'default::PullRequest'},
                 'body': 'Several typos fixed.'
             }],
-            [2],
+            [{}, {}],
         ])

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -71,7 +71,7 @@ class TestUpdate(tb.QueryTestCase):
                 }
             } ORDER BY .name;
         """, [
-            [0],
+            [],
             self.original,
         ])
 
@@ -96,7 +96,7 @@ class TestUpdate(tb.QueryTestCase):
                 }
             } ORDER BY .name;
         """, [
-            [1],
+            [{}],
             [
                 {
                     'id': orig1['id'],
@@ -128,7 +128,7 @@ class TestUpdate(tb.QueryTestCase):
                 comment,
             } ORDER BY .name;
         """, [
-            [1],
+            [{}],
             [
                 {
                     'id': orig1['id'],
@@ -167,7 +167,7 @@ class TestUpdate(tb.QueryTestCase):
                 }
             } ORDER BY .name;
         """, [
-            [3],
+            [{}, {}, {}],
             [
                 {
                     'id': orig1['id'],
@@ -362,7 +362,7 @@ class TestUpdate(tb.QueryTestCase):
                 }
             } FILTER UpdateTest.name = 'update-test3';
         """, [
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test3',
@@ -387,7 +387,7 @@ class TestUpdate(tb.QueryTestCase):
             WITH MODULE test
             SELECT UpdateTest.comment;
         """, [
-            [3],
+            [{}, {}, {}],
             ['bad test'] * 3,
         ])
 
@@ -405,7 +405,7 @@ class TestUpdate(tb.QueryTestCase):
             WITH MODULE test
             SELECT UpdateTest.comment;
         """, [
-            [3],
+            [{}, {}, {}],
             ['bad test'] * 3,
         ])
 
@@ -426,7 +426,7 @@ class TestUpdate(tb.QueryTestCase):
                 } ORDER BY .name
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -458,7 +458,7 @@ class TestUpdate(tb.QueryTestCase):
                 } ORDER BY .name
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -486,7 +486,7 @@ class TestUpdate(tb.QueryTestCase):
                 } ORDER BY .name
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -540,14 +540,14 @@ class TestUpdate(tb.QueryTestCase):
                 } ORDER BY .name
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
+            [{}],
             [{
                 'name': 'update-test1',
                 'tags': [{
                     'name': 'fun',
                 }],
             }],
-            [1],
+            [{}],
             [{
                 'name': 'update-test1',
                 'tags': [{
@@ -577,7 +577,7 @@ class TestUpdate(tb.QueryTestCase):
                 } ORDER BY .name
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -612,7 +612,7 @@ class TestUpdate(tb.QueryTestCase):
                 } ORDER BY .name
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -651,7 +651,7 @@ class TestUpdate(tb.QueryTestCase):
                 } ORDER BY .name
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -891,7 +891,7 @@ class TestUpdate(tb.QueryTestCase):
                     ],
                 },
             ],
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -941,7 +941,7 @@ class TestUpdate(tb.QueryTestCase):
                 } ORDER BY @weight
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -978,7 +978,7 @@ class TestUpdate(tb.QueryTestCase):
                 } ORDER BY @weight
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -1012,7 +1012,7 @@ class TestUpdate(tb.QueryTestCase):
                 } ORDER BY @weight
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -1049,7 +1049,7 @@ class TestUpdate(tb.QueryTestCase):
                 }
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -1083,7 +1083,7 @@ class TestUpdate(tb.QueryTestCase):
                 }
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -1115,7 +1115,7 @@ class TestUpdate(tb.QueryTestCase):
                 }
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -1159,8 +1159,8 @@ class TestUpdate(tb.QueryTestCase):
                 }
             } FILTER UpdateTest.name = 'update-test1';
         """, [
-            [1],
-            [1],
+            [{}],
+            [{}],
             [
                 {
                     'name': 'update-test1',
@@ -1222,7 +1222,7 @@ class TestUpdate(tb.QueryTestCase):
             WITH MODULE test
             SELECT UpdateTest.comment;
         """, [
-            {3},
+            [{}, {}, {}],
             {},
         ])
 
@@ -1264,7 +1264,7 @@ class TestUpdate(tb.QueryTestCase):
             WITH MODULE test
             SELECT UpdateTest.status;
         """, [
-            {3},
+            [{}, {}, {}],
             {},
         ])
 

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -71,7 +71,7 @@ class TestIndexes(tb.DDLTestCase):
                 }]
             }],
 
-            [1],
+            [{}],
 
             [{
                 'first_name': 'Elon'

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -159,18 +159,18 @@ class TestTransactions(tb.QueryTestCase):
         """, [
             [],
             None,  # transaction start
-            [1],  # insert
-            [1],  # insert
+            [{}],  # insert
+            [{}],  # insert
             {'q1', 'q2'},
 
             None,  # transaction start
-            [1],  # insert
+            [{}],  # insert
             {'q1', 'q2', 'w1'},
             None,  # transaction rollback
             {'q1', 'q2'},
 
             None,  # transaction start
-            [1],  # insert
+            [{}],  # insert
             {'q1', 'q2', 'e1'},
             None,  # transaction commit
             {'q1', 'q2', 'e1'},


### PR DESCRIPTION
This reverts DML to its historic behavior, where the result is an
affected set of objects, even if the statement is top-level.  The prior
change that made this return a count was a dubious attempt of optimization,
so that the output of DML can be discarded.  However, this case should
be solved by a protocol context rather than this hardcoded behavior.