### PR TITLE
graphql: Fix a bug that was getting an incorrect __typename.

### DIFF
--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -587,7 +587,7 @@ class GQLBaseType(metaclass=GQLTypeMeta):
         if self.dummy:
             return eql, shape, filterable
 
-        if name == '__typename':
+        if name == '__typename' and not self.is_field_shadowed(name):
             eql = parse_fragment(
                 f'''stdgraphql::short_name(
                     {codegen.generate_source(parent)}.__type__.name)''')
@@ -623,10 +623,6 @@ class GQLQuery(GQLBaseType):
         super().__init__(schema, **kwargs)
         self._shadow_fields = ('__typename',)
 
-    @property
-    def short_name(self):
-        return self._name.rsplit('--', 1)[-1]
-
     def get_field_type(self, name, argsmap=None):
         fkey = (name, self.dummy)
         target = None
@@ -659,7 +655,3 @@ class GQLMutation(GQLBaseType):
     def __init__(self, schema, **kwargs):
         self.modules = schema.modules
         super().__init__(schema, **kwargs)
-
-    @property
-    def short_name(self):
-        return self._name.rsplit('--', 1)[-1]

--- a/tests/test_graphql_translator.py
+++ b/tests/test_graphql_translator.py
@@ -2502,7 +2502,7 @@ class TestGraphQLTranslation(TranslatorTest):
 % OK %
 
         SELECT stdgraphql::Query {
-            foo := stdgraphql::short_name(std::str.__type__.name),
+            foo := (SELECT stdgraphql::Query.__typename),
             User := (SELECT
                 test::User {
                     name,


### PR DESCRIPTION
Due to a bug `__typename` was trying to apply the path `.__type__.name`
to a scalar. This, in fact, should never be the case as only GraphQL
objects have fields and can therefore have the `__typename` field
specifically.