### PR TITLE
Add coverage support to the `edb test` command

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,23 +1,12 @@
-# .coveragerc to control coverage.py
 [run]
-branch = True
+branch = False
 
 [report]
-# Regexes for lines to exclude from consideration
 exclude_lines =
-    # Have to re-enable the standard pragma
     pragma: no cover
-
-    # Don't complain about missing debug-only code:
     def __repr__
     if debug
-
-    # Don't complain if tests don't hit defensive assertion code:
-    raise AssertionError
     raise NotImplementedError
-    raise .*InternalError
-
-    # Don't complain if non-runnable code isn't run:
     if __name__ == .__main__.
 
 show_missing = True

--- a/edb/common/devmode.py
+++ b/edb/common/devmode.py
@@ -17,7 +17,9 @@
 #
 
 
+import contextlib
 import hashlib
+import json
 import logging
 import os
 import pathlib
@@ -27,6 +29,68 @@ import typing
 
 
 logger = logging.getLogger('edb.devmode.cache')
+
+
+class CoverageConfig(typing.NamedTuple):
+
+    config: str
+    datadir: str
+    paths: typing.List[str]
+
+    def to_json(self) -> str:
+        return json.dumps(self._asdict())
+
+    @classmethod
+    def from_json(cls, js: str):
+        dct = json.loads(js)
+        return cls(**dct)
+
+    def save_to_environ(self):
+        os.environ.update({
+            'EDGEDB_TEST_COVERAGE': self.to_json()
+        })
+
+    @classmethod
+    def from_environ(cls) -> typing.Optional['CoverageConfig']:
+        config = os.environ.get('EDGEDB_TEST_COVERAGE')
+        if config is None:
+            return None
+        else:
+            return cls.from_json(config)
+
+    @classmethod
+    def new_custom_coverage_object(cls, **conf):
+        import coverage
+
+        cov = coverage.Coverage(**conf)
+
+        cov._warn_no_data = False
+        cov._warn_unimported_source = False
+        cov._warn_preimported_source = False
+
+        return cov
+
+    def new_coverage_object(self):
+        return self.new_custom_coverage_object(
+            config_file=self.config,
+            source=self.paths,
+            data_file=os.path.join(self.datadir, f'cov-{os.getpid()}'),
+        )
+
+    @classmethod
+    @contextlib.contextmanager
+    def enable_coverage_if_requested(cls):
+        cov_config = cls.from_environ()
+        if cov_config is None:
+            yield
+        else:
+            cov = cov_config.new_coverage_object()
+            cov.start()
+            try:
+                yield
+            finally:
+                cov.stop()
+                cov.save()
 
 
 def enable_dev_mode():

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -41,7 +41,6 @@ from . import cluster as edgedb_cluster
 from . import daemon
 from . import defines
 from . import logsetup
-from . import server
 
 
 logger = logging.getLogger('edb.server')
@@ -117,6 +116,12 @@ def _run_server(cluster, args, runstate_dir):
     _init_cluster(cluster, args)
 
     try:
+        # Import here to make sure that most of imports happen
+        # under coverage (if we're testing with it).  Otherwise
+        # coverage will fail to detect that "import edb..." lines
+        # actually were run.
+        from . import server
+
         ss = server.Server(
             loop=loop,
             cluster=cluster,
@@ -290,7 +295,8 @@ def main(**kwargs):
                 'edgedb-server-{}'.format(kwargs['port']))
             run_server(kwargs)
     else:
-        run_server(kwargs)
+        with devmode.CoverageConfig.enable_coverage_if_requested():
+            run_server(kwargs)
 
 
 def main_dev():

--- a/edb/server/procpool/amsg.py
+++ b/edb/server/procpool/amsg.py
@@ -181,6 +181,7 @@ class WorkerConnection:
     def _on_connection_lost(self, exc):
         self._con_lost_fut.set_exception(
             PoolClosedError('connection to the pool is closed'))
+        self._con_lost_fut._log_traceback = False
 
     async def reply(self, data):
         self._protocol.reply(data)

--- a/edb/server/procpool/pool.py
+++ b/edb/server/procpool/pool.py
@@ -117,7 +117,7 @@ class Worker:
         self._closed = True
         self._manager._stats_killed += 1
         self._manager._workers.discard(self)
-        self._proc.kill()
+        self._proc.terminate()
         await self._proc.wait()
 
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ EXTRA_DEPS = {
     'test': [
         'flake8~=3.6.0',
         'pycodestyle~=2.4.0',
+        'coverage~=4.5.2',
     ],
 
     'docs': [


### PR DESCRIPTION
It's now possible to measure test coverage with the `edb test` command.

Pass `--cov` (allowed to be specified multiple times) to measure
coverage of a particular edb package, e.g.:

* edb test --cov=edb
* edb test --cov=edb.edgeql.compiler
* edb test --cov=edb.edgeql.compiler --cov=edb.pgsql.compiler

The results will be printed to the stdout when tests are completed.
They will also be saved to the '.coverage' file, so that the 'coverage'
command line tooling can be used for further inspection.