### PR TITLE
docs: Update function declaration syntax.

### DIFF
--- a/docs/datamodel/functions.rst
+++ b/docs/datamodel/functions.rst
@@ -19,11 +19,19 @@ A function may be defined in EdgeDB Schema using the ``function`` declaration:
 
     # where <argspec> is:
 
-    [ <argkind> ] $<argname>: [ <typequal> ] <argtype> [ = <default> ]
+    [ <argkind> ] <argname>: [ <typequal> ] <argtype> [ = <default> ]
+
+    # <argkind> is:
+
+    [ { variadic | named only } ]
+
+    # <typequal> is:
+
+    [ { set of | optional } ]
 
     # and <returnspec> is:
 
-    [ { set of | optional } ] <rettype>
+    [ <typequal> ] <rettype>
 
 
 Parameters

--- a/docs/edgeql/ddl/functions.rst
+++ b/docs/edgeql/ddl/functions.rst
@@ -31,11 +31,19 @@ Define a new function.
 
     # where <argspec> is:
 
-    [ <argkind> ] $<argname>: [ <typequal> ] <argtype> [ = <default> ]
+    [ <argkind> ] <argname>: [ <typequal> ] <argtype> [ = <default> ]
+
+    # <argkind> is:
+
+    [ { VARIADIC | NAMED ONLY } ]
+
+    # <typequal> is:
+
+    [ { SET OF | OPTIONAL } ]
 
     # and <returnspec> is:
 
-    [ { SET OF | OPTIONAL } ] <rettype>
+    [ <typequal> ] <rettype>
 
 
 Description
@@ -177,7 +185,7 @@ Remove a function.
 
     # where <argspec> is:
 
-    [ $<argname>: ] [ <argmode> ] <argtype>
+    [ <argname>: ] [ <argmode> ] <argtype>
 
 
 Description


### PR DESCRIPTION
Remove the `$` from function declaration syntax and make `typequal`
production more explicit.