### PR TITLE
edgeql: Make the final semicolon optional.

### DIFF
--- a/edb/edgeql/parser/grammar/block.py
+++ b/edb/edgeql/parser/grammar/block.py
@@ -17,6 +17,8 @@
 #
 
 
+from edb.common import parsing
+
 from .expressions import Nonterm
 from .precedence import *  # NOQA
 from .tokens import *  # NOQA
@@ -39,14 +41,22 @@ class SingleStatement(Nonterm):
         self.val = kids[0].val
 
 
-class StatementBlock(Nonterm):
+class StatementBlock(parsing.ListNonterm, element=SingleStatement,
+                     separator=Semicolons):  # NOQA, Semicolons are from .ddl
+    pass
+
+
+class EdgeQLBlock(Nonterm):
     "%start"
 
-    def reduce_StatementBlock_SEMICOLON(self, *kids):
+    def reduce_StatementBlock_EOF(self, *kids):
         self.val = kids[0].val
 
-    def reduce_StatementBlock_SingleStatement_SEMICOLON(self, *kids):
-        self.val = kids[0].val + [kids[1].val]
+    def reduce_StatementBlock_Semicolons_EOF(self, *kids):
+        self.val = kids[0].val
 
-    def reduce_empty(self):
+    def reduce_Semicolons_EOF(self, *kids):
+        self.val = []
+
+    def reduce_EOF(self, *kids):
         self.val = []

--- a/edb/edgeql/parser/grammar/lexer.py
+++ b/edb/edgeql/parser/grammar/lexer.py
@@ -219,6 +219,10 @@ class EdgeQLLexer(lexer.Lexer):
         self._possible_long_token = {x[0] for x in self.MERGE_TOKENS}
         self._long_token_match = {x[1]: x[0] for x in self.MERGE_TOKENS}
 
+    def get_eof_token(self):
+        """Return an EOF token or None if no EOF token is wanted."""
+        return self.token_from_text('EOF', '')
+
     def token_from_text(self, rule_token, txt):
         if rule_token == 'BADSCONST':
             raise lexer.UnknownTokenError(

--- a/edb/edgeql/parser/grammar/single.py
+++ b/edb/edgeql/parser/grammar/single.py
@@ -27,11 +27,11 @@ from .ddl import *  # NOQA
 class SingleStatementOrExpression(Nonterm):
     "%start"
 
-    def reduce_Stmt(self, expr):
-        self.val = expr.val
+    def reduce_Stmt_EOF(self, *kids):
+        self.val = kids[0].val
 
-    def reduce_DDLStmt(self, expr):
-        self.val = expr.val
+    def reduce_DDLStmt_EOF(self, *kids):
+        self.val = kids[0].val
 
-    def reduce_Expr(self, expr):
-        self.val = expr.val
+    def reduce_Expr_EOF(self, *kids):
+        self.val = kids[0].val

--- a/edb/edgeql/parser/grammar/tokens.py
+++ b/edb/edgeql/parser/grammar/tokens.py
@@ -201,6 +201,10 @@ class T_OP(Token):
     pass
 
 
+class T_EOF(Token):
+    pass
+
+
 def _gen_keyword_tokens():
     # Define keyword tokens
 

--- a/edb/edgeql/parser/parser.py
+++ b/edb/edgeql/parser/parser.py
@@ -35,7 +35,7 @@ class EdgeQLParserBase(parsing.Parser):
             if msg.startswith('Unexpected token: '):
                 token = token or getattr(native_err, 'token', None)
 
-                if not token:
+                if not token or token.type == 'EOF':
                     msg = 'Unexpected end of line'
                 elif hasattr(token, 'val'):
                     msg = f'Unexpected {token.val!r}'

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -75,12 +75,25 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
         SeLeCT 1;
         """
 
-    # this is a statement syntax parser, not expressions, so
-    # semicolons are obligatory terminators
-    #
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=1, col=9)
-    def test_edgeql_syntax_nonstatement_01(self):
-        """SELECT 1"""
+    def test_edgeql_syntax_omit_semicolon_01(self):
+        """
+        SELECT 1
+
+% OK %
+
+        SELECT 1;
+        """
+
+    def test_edgeql_syntax_omit_semicolon_02(self):
+        """
+        SELECT 2;
+        SELECT 1
+
+% OK %
+
+        SELECT 2;
+        SELECT 1;
+        """
 
     # 1 + 2 is a valid expression, but it has to have SELECT keyword
     # to be a statement


### PR DESCRIPTION
Treat the EOF as a valid terminator instead of a semicolon.