### PR TITLE
edgeql: Make semicolons into statement separators.

### DIFF
--- a/edb/edgeql/parser/grammar/block.py
+++ b/edb/edgeql/parser/grammar/block.py
@@ -49,14 +49,8 @@ class StatementBlock(parsing.ListNonterm, element=SingleStatement,
 class EdgeQLBlock(Nonterm):
     "%start"
 
-    def reduce_StatementBlock_EOF(self, *kids):
+    def reduce_StatementBlock_OptSemicolons_EOF(self, *kids):
         self.val = kids[0].val
 
-    def reduce_StatementBlock_Semicolons_EOF(self, *kids):
-        self.val = kids[0].val
-
-    def reduce_Semicolons_EOF(self, *kids):
-        self.val = []
-
-    def reduce_EOF(self, *kids):
+    def reduce_OptSemicolons_EOF(self, *kids):
         self.val = []

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -198,12 +198,19 @@ class InnerDDLStmt(Nonterm):
 
 class Semicolons(Nonterm):
     # one or more semicolons
-    #
     def reduce_SEMICOLON(self, tok):
         self.val = tok
 
     def reduce_Semicolons_SEMICOLON(self, *kids):
         self.val = kids[0].val
+
+
+class OptSemicolons(Nonterm):
+    def reduce_Semicolons(self, *kids):
+        self.val = kids[0].val
+
+    def reduce_empty(self):
+        self.val = None
 
 
 class InnerDDLStmtBlock(ListNonterm, element=InnerDDLStmt,
@@ -272,10 +279,10 @@ def commands_block(parent, *commands, opt=True):
     #
     #   { [ ; ] CommandsList ; }
     clsdict = collections.OrderedDict()
-    clsdict['reduce_LBRACE_' + cmdlist.__name__ + '_Semicolons_RBRACE'] = \
+    clsdict['reduce_LBRACE_' + cmdlist.__name__ + '_OptSemicolons_RBRACE'] = \
         ProductionHelper._block
     clsdict['reduce_LBRACE_Semicolons_' + cmdlist.__name__ +
-            '_Semicolons_RBRACE'] = \
+            '_OptSemicolons_RBRACE'] = \
         ProductionHelper._block2
     if not opt:
         #
@@ -491,7 +498,7 @@ class CreateDeltaStmt(Nonterm):
 
     def reduce_CreateDelta_Commands(self, *kids):
         r"""%reduce CREATE MIGRATION NodeName \
-                    OptDeltaParents LBRACE InnerDDLStmtBlock Semicolons \
+                    OptDeltaParents LBRACE InnerDDLStmtBlock OptSemicolons \
                     RBRACE
         """
         self.val = qlast.CreateDelta(

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3188,6 +3188,20 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_property_05(self):
+        # omit optional semicolons
+        """
+        CREATE ABSTRACT PROPERTY std::property {
+            SET title := 'Base property'
+        }
+
+% OK %
+
+        CREATE ABSTRACT PROPERTY std::property {
+            SET title := 'Base property';
+        };
+        """
+
     def test_edgeql_syntax_ddl_module_01(self):
         """
         CREATE MODULE foo;
@@ -3278,6 +3292,22 @@ aa';
 
     def test_edgeql_syntax_ddl_type_08(self):
         """
+        ALTER TYPE mymod::Foo ALTER LINK foo {
+            SET MULTI;
+            DROP REQUIRED;
+        };
+        """
+
+    def test_edgeql_syntax_ddl_type_09(self):
+        # omit optional semicolons
+        """
+        ALTER TYPE mymod::Foo ALTER LINK foo {
+            SET MULTI;
+            DROP REQUIRED
+        }
+
+% OK %
+
         ALTER TYPE mymod::Foo ALTER LINK foo {
             SET MULTI;
             DROP REQUIRED;


### PR DESCRIPTION
Semicolons are now fully statement separators. They can be omitted at
EOF and before `}`. However, they still must appear after `}` if it is
followed by another statement.