### PR TITLE
Fix REPL handling of `;`

### DIFF
--- a/edb/repl/__init__.py
+++ b/edb/repl/__init__.py
@@ -114,7 +114,7 @@ class InputBuffer(pt_buffer.Buffer):
             except core_lexer.UnknownTokenError:
                 return True
 
-            if toks[-1].type == ';':
+            if toks[-1].type == 'EOF':
                 return False
 
         return True


### PR DESCRIPTION
The token that indicated end of input in REPL is now `EOF` not `;`.