### PR TITLE
Fix casting of tuples

### DIFF
--- a/edb/edgeql/compiler/cast.py
+++ b/edb/edgeql/compiler/cast.py
@@ -264,6 +264,11 @@ def _cast_tuple(
         srcctx: parsing.ParserContext,
         ctx: context.ContextLevel) -> irast.Base:
 
+    # Make sure the source tuple expression is pinned in the scope,
+    # so that we don't generate a cross-product of it by evaluating
+    # the tuple indirections.
+    pathctx.register_set_in_scope(ir_set, ctx=ctx)
+
     direct_cast = _find_cast(orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
 
     if direct_cast is not None:

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1299,6 +1299,10 @@ def process_set_as_type_cast(
                     stmt, inner_set.path_id, serialized,
                     force=True, env=subctx.env)
 
+                pathctx.put_path_serialized_var(
+                    stmt, inner_set.path_id, serialized,
+                    force=True, env=subctx.env)
+
             subctx.env.output_format = orig_output_format
         else:
             set_expr = dispatch.compile(ir_set.expr, ctx=ctx)

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -468,19 +468,17 @@ class TestServerProto(tb.QueryTestCase):
             edgedb.Set(('{"name": "std::bool"}',))
         )
 
-    @test.xfail('Looks like the description of output type is wrong')
     async def test_server_proto_json_cast_02(self):
         self.assertEqual(
             await self.con.fetch(
                 'select <json>{(1, 2), (3, 4)}'),
             ['[1, 2]', '[3, 4]'])
 
-    @test.xfail('Somehow this produces a cross-product of JSON arrays')
     async def test_server_proto_json_cast_03(self):
         self.assertEqual(
             await self.con.fetch_json(
                 'select <json>{(1, 2), (3, 4)}'),
-            '["[1, 2]", "[3, 4]"]')
+            '[[1, 2], [3, 4]]')
 
     async def test_server_proto_wait_cancel_01(self):
         # Test that client protocol handles waits interrupted


### PR DESCRIPTION
This PR contains two distinct fixes for tuple casting, 
one general, and one JSON-specific.