### PR TITLE
Remove support for __type__ pseudo-link on primitive types

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -407,14 +407,6 @@ def resolve_ptr(
 
             raise err
 
-    else:
-        if direction == s_pointers.PointerDirection.Outbound:
-            bptr = schemactx.get_schema_ptr(pointer_name, ctx=ctx)
-            schema_cls = ctx.env.schema.get('schema::ScalarType')
-            if bptr.get_shortname(ctx.env.schema) == 'std::__type__':
-                ctx.env.schema, ptr = bptr.derive(
-                    ctx.env.schema, near_endpoint, schema_cls)
-
     if ptr is None:
         # Reference to a property on non-object
         msg = 'invalid property reference on a primitive type expression'

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -32,7 +32,6 @@ from edb.schema import links as s_links
 from edb.schema import name as sn
 from edb.schema import nodes as s_nodes
 from edb.schema import pointers as s_pointers
-from edb.schema import sources as s_sources
 from edb.schema import types as s_types
 
 from edb.edgeql import ast as qlast
@@ -152,10 +151,7 @@ def _process_view(
         else:
             source = view_scls
 
-        if (ptrcls.get_source(ctx.env.schema) is source and
-                isinstance(source, s_sources.Source)):
-            # source may be an ScalarType in shapes that reference __type__,
-            # hence the isinstance check.
+        if ptrcls.get_source(ctx.env.schema) is source:
             ctx.env.schema = source.add_pointer(
                 ctx.env.schema, ptrcls, replace=True)
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -425,6 +425,7 @@ class TypeCheckOp(Expr):
     left: Set
     right: typing.Union[TypeRef, Array]
     op: str
+    result: typing.Optional[bool] = None
 
 
 class IfElseExpr(Expr):

--- a/edb/lib/std/30-arrayfuncs.eql
+++ b/edb/lib/std/30-arrayfuncs.eql
@@ -87,29 +87,25 @@ std::`?!=` (l: OPTIONAL array<anytype>,
 };
 
 CREATE INFIX OPERATOR
-std::`>=` (l: OPTIONAL array<anytype>,
-           r: OPTIONAL array<anytype>) -> std::bool {
+std::`>=` (l: array<anytype>, r: array<anytype>) -> std::bool {
     FROM SQL OPERATOR '>=';
     SET recursive := true;
 };
 
 CREATE INFIX OPERATOR
-std::`>` (l: OPTIONAL array<anytype>,
-          r: OPTIONAL array<anytype>) -> std::bool {
+std::`>` (l: array<anytype>, r: array<anytype>) -> std::bool {
     FROM SQL OPERATOR '>';
     SET recursive := true;
 };
 
 CREATE INFIX OPERATOR
-std::`<=` (l: OPTIONAL array<anytype>,
-           r: OPTIONAL array<anytype>) -> std::bool {
+std::`<=` (l: array<anytype>, r: array<anytype>) -> std::bool {
     FROM SQL OPERATOR '<=';
     SET recursive := true;
 };
 
 CREATE INFIX OPERATOR
-std::`<` (l: OPTIONAL array<anytype>,
-          r: OPTIONAL array<anytype>) -> std::bool {
+std::`<` (l: array<anytype>, r: array<anytype>) -> std::bool {
     FROM SQL OPERATOR '<';
     SET recursive := true;
 };

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -440,24 +440,6 @@ def new_rel_rvar(
     return dbobj.rvar_for_rel(stmt, lateral=lateral, env=ctx.env)
 
 
-def new_static_class_rvar(
-        ir_set: irast.Set, *,
-        lateral: bool=True,
-        ctx: context.CompilerContextLevel) -> pgast.BaseRangeVar:
-    set_rvar = new_root_rvar(ir_set, ctx=ctx)
-    source = ir_set.rptr.source.typeref
-    if source.material_type is not None:
-        source = source.material_type
-    clsname = pgast.StringConstant(val=str(source.id))
-    nameref = dbobj.get_column(set_rvar, 'id', nullable=False)
-    condition = astutils.new_binop(nameref, clsname, op='=')
-    substmt = pgast.SelectStmt()
-    include_rvar(substmt, set_rvar, ir_set.path_id, ctx=ctx)
-    substmt.where_clause = astutils.extend_binop(
-        substmt.where_clause, condition)
-    return new_rel_rvar(ir_set, substmt, ctx=ctx)
-
-
 def semi_join(
         stmt: pgast.Query, ir_set: irast.Set, src_rvar: pgast.BaseRangeVar, *,
         ctx: context.CompilerContextLevel) -> pgast.BaseRangeVar:

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -634,17 +634,6 @@ def process_set_as_path(
 
     rvars = []
 
-    # Path is a __type__ reference of a homogeneous set,
-    # e.g {1, 2}.__type__.
-    is_static_clsref = (
-        irtyputils.is_scalar(ir_source.typeref) and
-        ptrref.shortname == 'std::__type__'
-    )
-
-    if is_static_clsref:
-        rvar = relctx.new_static_class_rvar(ir_set, ctx=ctx)
-        return new_simple_set_rvar(ir_set, rvar, ['value', 'source'])
-
     if ir_set.path_id.is_type_indirection_path():
         get_set_rvar(ir_source, ctx=ctx)
         poly_rvar = relctx.new_poly_rvar(ir_set, ctx=ctx)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -234,6 +234,12 @@ class Collection(Type, s_abc.Collection):
     def contains_any(self):
         return any(st.contains_any() for st in self.get_subtypes())
 
+    def contains_object(self):
+        return any(
+            st.contains_object() if st.is_collection() else st.is_object_type()
+            for st in self.get_subtypes()
+        )
+
     def is_collection(self):
         return True
 
@@ -274,7 +280,7 @@ class Collection(Type, s_abc.Collection):
         my_types = self.get_subtypes()
 
         for pt, my in zip(parent_types, my_types):
-            if not pt.is_any() and not pt.issubclass(schema, my):
+            if not pt.is_any() and not my.issubclass(schema, pt):
                 return False
 
         return True

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -1161,9 +1161,12 @@ class TestExpressions(tb.QueryTestCase):
                     else:
                         rtype = 'float64'
 
-                query = f"""SELECT ({left} UNION {right}) IS {rtype};"""
+                query = f"""
+                    SELECT (INTROSPECT TYPEOF ({left} UNION {right})).name;
+                """
                 # this operation should always be valid
-                await self.assert_query_result(query, [{True}])
+                await self.assert_query_result(
+                    query, [{f'std::{rtype}'}])
 
     async def test_edgeql_expr_valid_setop_04(self):
         expected_error_msg = 'could not determine expression type'
@@ -1178,10 +1181,11 @@ class TestExpressions(tb.QueryTestCase):
                     await self.assert_query_result(query, [[2]])
 
                     query = f"""
-                        SELECT ({left} UNION {right}) IS {rdesc.typename};
+                        SELECT (INTROSPECT TYPEOF ({left} UNION {right})).name;
                     """
                     # this operation should always be valid
-                    await self.assert_query_result(query, [{True}])
+                    await self.assert_query_result(
+                        query, [{f'std::{rdesc.typename}'}])
 
                 else:
                     # every other combination must produce an error
@@ -1218,9 +1222,11 @@ class TestExpressions(tb.QueryTestCase):
                 # combination
                 await self.assert_query_result(query, [[2]])
 
-                query = f"""SELECT ({left} UNION {right}) IS decimal;"""
+                query = f"""
+                    SELECT (INTROSPECT TYPEOF ({left} UNION {right})).name;
+                """
                 # this operation should always be valid
-                await self.assert_query_result(query, [{True}])
+                await self.assert_query_result(query, [{'std::decimal'}])
 
         for left in get_test_values(decimal=True):
             for right in get_test_values(anyfloat=True):
@@ -1295,9 +1301,11 @@ class TestExpressions(tb.QueryTestCase):
                         else:
                             rtype = 'float64'
 
-                    query = f"""SELECT ({left} {op} {right}) IS {rtype};"""
+                    query = f"""
+                        SELECT (INTROSPECT TYPEOF ({left} {op} {right})).name;
+                    """
                     # this operation should always be valid
-                    await self.assert_query_result(query, [{True}])
+                    await self.assert_query_result(query, [{f'std::{rtype}'}])
 
     async def test_edgeql_expr_valid_setop_10(self):
         expected_error_msg = 'of related types'


### PR DESCRIPTION
Historically, scalar types and collections supported `.__type__` as a
way to determine the type of an expression.  Now that the `TYPEOF` and
`INTROSPECT` operators have been implemented, this hack is no longer
necessary.

This commit also fixes the `IS` operator on operands of primitive types.

`IS` on collections containing object types remains unsupported, as
implementing that requires a non-trivial transform and the use cases do
not seem clear enough.

See also: #219.
Closes: #161.