### PR TITLE
Make IR AST mostly immutable

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -246,9 +246,7 @@ def compile_constant_tree_to_ir(
 
     ir_set = dispatch.compile(const, ctx=ctx)
     result = ir_set.expr
-    if styperef is not None:
-        result.typeref = styperef
-        if hasattr(result, '_inferred_type_'):
-            del result._inferred_type_
+    if styperef is not None and result.typeref.id != styperef.id:
+        result = type(result)(value=result.value, typeref=styperef)
 
     return result

--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -20,15 +20,9 @@
 """EdgeQL compiler helpers for AST classification and basic transforms."""
 
 
-import typing
-
 from edb.edgeql import ast as qlast
 
 from edb.ir import ast as irast
-from edb.ir import typeutils as irtyputils
-
-from . import context
-from . import inference
 
 
 def extend_qlbinop(binop, *exprs, op='AND'):
@@ -108,26 +102,3 @@ def is_degenerate_select(qlstmt):
         qlstmt.offset is None and
         qlstmt.limit is None
     )
-
-
-def make_tuple(
-        elements: typing.List[irast.TupleElement], *,
-        named: bool,
-        ctx: context.ContextLevel) -> irast.Tuple:
-
-    tup = irast.Tuple(elements=elements, named=named)
-    tup.typeref = irtyputils.type_to_typeref(
-        ctx.env.schema,
-        inference.infer_type(tup, env=ctx.env))
-    return tup
-
-
-def make_array(
-        elements: typing.List[irast.Base], *,
-        ctx: context.ContextLevel) -> irast.Array:
-
-    arr = irast.Array(elements=elements)
-    arr.typeref = irtyputils.type_to_typeref(
-        ctx.env.schema,
-        inference.infer_type(arr, env=ctx.env))
-    return arr

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -103,6 +103,14 @@ class Environment:
     set_types: typing.Dict[irast.Set, s_types.Type]
     """A dictionary of all Set instances and their schema types."""
 
+    inferred_types: typing.Dict[irast.Base, s_types.Type]
+    """A dictionary of all expressions and their inferred schema types."""
+
+    inferred_cardinality: typing.Dict[
+        typing.Tuple[irast.Base, irast.ScopeTreeNode],
+        qltypes.Cardinality]
+    """A dictionary of all expressions and their inferred cardinality."""
+
     constant_folding: bool
     """Enables constant folding optimization (enabled by default)."""
 
@@ -121,6 +129,8 @@ class Environment:
         self.query_parameters = {}
         self.schema_view_mode = schema_view_mode
         self.set_types = {}
+        self.inferred_types = {}
+        self.inferred_cardinality = {}
         self.constant_folding = constant_folding
         self.view_shapes = collections.defaultdict(list)
         self.view_shapes_metadata = collections.defaultdict(

--- a/edb/edgeql/compiler/decompiler.py
+++ b/edb/edgeql/compiler/decompiler.py
@@ -78,11 +78,11 @@ class IRDecompiler(ast.visitor.NodeVisitor):
                 ptrref = rptr.ptrref
                 pname = ptrref.shortname
 
-                if irtyputils.is_object(rptr.target.typeref):
-                    if rptr.target.typeref.material_type is not None:
-                        typeref = rptr.target.typeref.material_type
+                if irtyputils.is_object(node.typeref):
+                    if node.typeref.material_type is not None:
+                        typeref = node.typeref.material_type
                     else:
-                        typeref = rptr.target.typeref
+                        typeref = node.typeref
 
                     stype = self.context.schema.get_by_id(typeref.id)
                     stype_name = stype.get_name(self.context.schema)

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -382,10 +382,9 @@ def __infer_tuple_indirection(ir, scope_tree, env):
 
 
 def infer_cardinality(ir, scope_tree, env):
-    try:
-        return ir._inferred_cardinality_[scope_tree]
-    except (AttributeError, KeyError):
-        pass
+    result = env.inferred_cardinality.get((ir, scope_tree))
+    if result is not None:
+        return result
 
     result = _infer_cardinality(ir, scope_tree, env)
 
@@ -395,11 +394,6 @@ def infer_cardinality(ir, scope_tree, env):
             'set produced by expression',
             context=ir.context)
 
-    try:
-        cache = ir._inferred_cardinality_
-    except AttributeError:
-        cache = ir._inferred_cardinality_ = {}
-
-    cache[scope_tree] = result
+    env.inferred_cardinality[ir, scope_tree] = result
 
     return result

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -437,10 +437,9 @@ def __infer_struct_indirection(ir, env):
 
 
 def infer_type(ir: irast.Base, env: context.Environment):
-    try:
-        return ir._inferred_type_
-    except AttributeError:
-        pass
+    result = env.inferred_types.get(ir)
+    if result is not None:
+        return result
 
     result = _infer_type(ir, env)
 
@@ -456,5 +455,6 @@ def infer_type(ir: irast.Base, env: context.Environment):
             'could not determine expression type',
             context=ir.context)
 
-    ir._inferred_type_ = result
+    env.inferred_types[ir] = result
+
     return result

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -27,6 +27,7 @@ from edb import errors
 from edb.edgeql import qltypes
 from edb.ir import ast as irast
 
+from edb.schema import name as s_name
 from edb.schema import objects as s_obj
 from edb.schema import pointers as s_pointers
 from edb.schema import types as s_types
@@ -68,6 +69,15 @@ def get_type_indirection_path_id(
         target=target_type,
         schema=ctx.env.schema
     )
+
+
+def get_expression_path_id(
+        stype: s_types.Type, alias: typing.Optional[str] = None, *,
+        ctx: context.ContextLevel) -> irast.PathId:
+    if alias is None:
+        alias = ctx.aliases.get('expr')
+    typename = s_name.Name(module='__derived__', name=alias)
+    return get_path_id(stype, typename=typename, ctx=ctx)
 
 
 def register_set_in_scope(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -206,7 +206,7 @@ def _normalize_view_ptr_expr(
                 derive_ptrcls(view_rptr, target_scls=view_scls, ctx=ctx)
             ptrsource = stype = view_rptr.ptrcls
         source = qlast.Source()
-    else:
+    else:  # pragma: no cover
         raise RuntimeError(
             f'unexpected path length in view shape: {len(steps)}')
 
@@ -381,11 +381,7 @@ def _normalize_view_ptr_expr(
                 ptrcls = derived_ptrcls
 
         ptr_cardinality = None
-
         ptr_target = inference.infer_type(irexpr, ctx.env)
-        if ptr_target is None:
-            msg = 'cannot determine expression result type'
-            raise errors.QueryError(msg, context=shape_el.context)
 
         if is_mutation and not ptr_target.assignment_castable_to(
                 base_ptrcls.get_target(ctx.env.schema), schema=ctx.env.schema):

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -96,21 +96,6 @@ def is_untyped_empty_array_expr(ir):
     )
 
 
-def get_subquery_shape(ir_expr):
-    if (isinstance(ir_expr, irast.Set) and
-            isinstance(ir_expr.expr, irast.Stmt) and
-            isinstance(ir_expr.expr.result, irast.Set)):
-        result = ir_expr.expr.result
-        if result.shape:
-            return result
-        elif is_view_set(result):
-            return get_subquery_shape(result)
-    elif ir_expr.view_source is not None:
-        return get_subquery_shape(ir_expr.view_source)
-    else:
-        return None
-
-
 def is_empty(ir_expr):
     return (
         isinstance(ir_expr, irast.EmptySet) or

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -24,8 +24,6 @@ from edb.testbase import lang as tb
 
 from edb.edgeql import compiler
 from edb.edgeql import qltypes
-from edb.edgeql.compiler import context
-from edb.edgeql.compiler import inference
 
 
 class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
@@ -36,13 +34,9 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def run_test(self, *, source, spec, expected):
         ir = compiler.compile_to_ir(source, self.schema)
-
-        env = context.Environment(path_scope=ir.scope_tree, schema=self.schema)
-        cardinality = inference.infer_cardinality(
-            ir, scope_tree=ir.scope_tree, env=env)
         expected_cardinality = qltypes.Cardinality(
             textwrap.dedent(expected).strip(' \n'))
-        self.assertEqual(cardinality, expected_cardinality,
+        self.assertEqual(ir.cardinality, expected_cardinality,
                          'unexpected cardinality:\n' + source)
 
     def test_edgeql_ir_card_inference_00(self):


### PR DESCRIPTION
IR immutability improves general robustness, as unexpected node
mutations will not break the assumptions of some code elsewhere, most
importantly, various caches.