### PR TITLE
Generate schema::Database.id based on the underlying oid

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -1785,11 +1785,18 @@ def _get_link_view(mcls, schema_cls, field, ptr, refdict, schema):
     return dbops.View(name=tabname(schema, ptr), query=link_query)
 
 
+DATABASE_ID_NAMESPACE = uuid.UUID('0e6fed66-204b-11e9-8666-cffd58a5240b')
+
+
 def _generate_database_view(schema):
     Database = schema.get('schema::Database')
 
     view_query = f'''
         SELECT
+            edgedb.uuid_generate_v5(
+                '{DATABASE_ID_NAMESPACE}'::uuid,
+                pg_database.oid::text)
+                            AS id,
             datname         AS name
         FROM
             pg_database

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -33,6 +33,7 @@ from edb.schema import objtypes as s_objtypes
 from edb.schema import name as sn
 from edb.schema import objects as s_obj
 from edb.schema import schema as s_schema
+from edb.schema import types as s_types
 
 from . import common
 from .common import quote_literal as ql
@@ -467,9 +468,6 @@ def _storable_in_pointer(ptrref: irast.PointerRef) -> bool:
     )
 
 
-TYPE_ID_NAMESPACE = uuid.UUID('00e50276-2502-11e7-97f2-27fe51238dbd')
-
-
 _TypeDescNode = collections.namedtuple(
     '_TypeDescNode', ['id', 'maintype', 'name', 'collection',
                       'subtypes', 'dimensions', 'is_root'],
@@ -497,7 +495,7 @@ class TypeDescNode(_TypeDescNode):
             f"{':'.join(str(d) for d in data['dimensions'])}"
         )
 
-        return uuid.uuid5(TYPE_ID_NAMESPACE, s)
+        return uuid.uuid5(s_types.TYPE_ID_NAMESPACE, s)
 
     def to_sql_expr(self):
         if self.subtypes:

--- a/edb/server/backend/sertypes.py
+++ b/edb/server/backend/sertypes.py
@@ -22,8 +22,6 @@ import uuid
 
 from edb import errors
 
-from edb.pgsql import types as pg_types
-
 from edb.schema import objects as s_obj
 from edb.schema import types as s_types
 
@@ -60,17 +58,17 @@ class TypeSerializer:
         string_id = f'{coll_type}\x00{":".join(subtypes)}'
         if element_names:
             string_id += f'\x00{":".join(element_names)}'
-        return uuid.uuid5(pg_types.TYPE_ID_NAMESPACE, string_id)
+        return uuid.uuid5(s_types.TYPE_ID_NAMESPACE, string_id)
 
     def _get_union_type_id(self, union_type):
         base_type_id = ','.join(
             str(c.id) for c in union_type.children(self.schema))
 
-        return uuid.uuid5(pg_types.TYPE_ID_NAMESPACE, base_type_id)
+        return uuid.uuid5(s_types.TYPE_ID_NAMESPACE, base_type_id)
 
     @classmethod
     def _get_set_type_id(cls, basetype_id):
-        return uuid.uuid5(pg_types.TYPE_ID_NAMESPACE,
+        return uuid.uuid5(s_types.TYPE_ID_NAMESPACE,
                           'set-of::' + str(basetype_id))
 
     def _register_type_id(self, type_id):

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -448,7 +448,6 @@ class TestIntrospection(tb.QueryTestCase):
             }]
         )
 
-    @test.xfail('There should be at least 1 Database.')
     async def test_edgeql_introspection_meta_01(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
There is no way to atomically associate the id with the database upon 
creation, so the next best thing is to generate ids using v5 UUIDs and 
database OIDs.