### PR TITLE
Add a way to disable server query cache

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -101,6 +101,9 @@ class flags(metaclass=FlagsMeta):
     print_locals = Flag(
         doc="Include values of local variables in tracebacks.")
 
+    disable_qcache = Flag(
+        doc="Disable server query cache. Parse/Execute will always recompile.")
+
 
 def header(*args):
     print('=' * 80)

--- a/edb/server/edgecon/edgecon.pxd
+++ b/edb/server/edgecon/edgecon.pxd
@@ -70,6 +70,7 @@ cdef class EdgeConnection:
         WriteBuffer _write_buf
 
         bint debug
+        bint query_cache_enabled
 
     cdef int32_t compute_parse_flags(self, compiled) except -1
     cdef is_json_mode(self, bytes mode)

--- a/edb/server/edgecon/edgecon.pyx
+++ b/edb/server/edgecon/edgecon.pyx
@@ -104,6 +104,8 @@ cdef class EdgeConnection:
         self._write_buf = None
 
         self.debug = debug.flags.server_proto
+        self.query_cache_enabled = not (debug.flags.disable_qcache or
+                                        debug.flags.edgeql_compile)
 
     def debug_print(self, *args):
         print(
@@ -175,7 +177,8 @@ cdef class EdgeConnection:
 
             # XXX implement auth
             self.dbview = self.server.new_view(
-                dbname=database, user=user)
+                dbname=database, user=user,
+                query_cache=self.query_cache_enabled)
             self.backend = await self.server.new_backend(
                 dbname=database, dbver=self.dbview.dbver)
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -77,8 +77,9 @@ class Server:
     def get_loop(self):
         return self._loop
 
-    def new_view(self, *, dbname, user):
-        return self._dbindex.new_view(dbname, user=user)
+    def new_view(self, *, dbname, user, query_cache):
+        return self._dbindex.new_view(
+            dbname, user=user, query_cache=query_cache)
 
     async def new_backend(self, *, dbname: str, dbver: int):
         return await self._backend_manager.new_backend(


### PR DESCRIPTION
Parse and Opportunistic Execute commands use cache compiled EdgeQL
queries to increase performance.  This cache, however, makes harder to
refactor the compiler without restarting the server.

This commit adds a new debug flag "disable_qcache" and also disables the
cache if the "edgeql_compile" flag is set.