### PR TITLE
Fix computable cardinality inference in the presence of LIMIT

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -415,7 +415,7 @@ def init_stmt(
 
     pending_own_ns = parent_ctx.pending_stmt_own_path_id_namespace
     if pending_own_ns:
-        ctx.path_scope.namespaces.update(pending_own_ns)
+        ctx.path_scope.add_namespaces(pending_own_ns)
 
     pending_full_ns = parent_ctx.pending_stmt_full_path_id_namespace
     if pending_full_ns:

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -283,7 +283,7 @@ def declare_view(
             # in the parent statement's fence node.
             view_path_id_ns = irast.WeakNamespace(ctx.aliases.get('ns'))
             subctx.path_id_namespace |= {view_path_id_ns}
-            ctx.path_scope.namespaces.add(view_path_id_ns)
+            ctx.path_scope.add_namespaces((view_path_id_ns,))
         else:
             cached_view_set = None
 

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -433,6 +433,20 @@ class ScopeTreeNode:
         else:
             return False
 
+    def add_namespaces(self, namespaces):
+        # Make sure we don't add namespaces that already appear
+        # in on of the ancestors.
+        namespaces = frozenset(namespaces) - self.get_effective_namespaces()
+        self.namespaces.update(namespaces)
+
+    def get_effective_namespaces(self):
+        namespaces = set()
+
+        for node, ans in self.ancestors_and_namespaces:
+            namespaces |= ans
+
+        return namespaces
+
     def remove(self):
         """Remove this node from the tree (subtree becomes independent)."""
         parent = self.parent

--- a/edb/server/backend/sertypes.py
+++ b/edb/server/backend/sertypes.py
@@ -33,6 +33,8 @@ _uint8_packer = struct.Struct('!B').pack
 EMPTY_TUPLE_ID = s_obj.get_known_type_id('empty-tuple').bytes
 EMPTY_TUPLE_DESC = b'\x04' + EMPTY_TUPLE_ID + b'\x00\x00'
 
+UUID_TYPE_ID = s_obj.get_known_type_id('std::uuid')
+
 NULL_TYPE_ID = b'\x00' * 16
 NULL_TYPE_DESC = b''
 
@@ -220,6 +222,10 @@ class TypeSerializer:
                 if el_lp:
                     flags |= self.EDGE_POINTER_IS_LINKPROP
                 if (implicit_id and el_name == 'id') or el_name == '__tid__':
+                    if el_type != UUID_TYPE_ID:
+                        raise errors.InternalServerError(
+                            f"{el_name!r} is expected to be a 'std::uuid' "
+                            f"singleton")
                     flags |= self.EDGE_POINTER_IS_IMPLICIT
                 if el_l:
                     flags |= self.EDGE_POINTER_IS_LINK

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -999,7 +999,8 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 SELECT User {
                     name,
                     friends: {
-                        name
+                        name,
+                        name_upper := str_upper(User.friends.name),
                     }  # User.friends is scoped from the enclosing shape
                     ORDER BY User.friends.name
                     LIMIT (count(User.friends) - 1)
@@ -1013,8 +1014,8 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 {
                     'name': 'Alice',
                     'friends': [
-                        {'name': 'Bob'},
-                        {'name': 'Carol'},
+                        {'name': 'Bob', 'name_upper': 'BOB'},
+                        {'name': 'Carol', 'name_upper': 'CAROL'},
                     ],
                 },
                 {


### PR DESCRIPTION
The LIMIT and OFFSET clauses put additional scope fencing around, which
is causing issues with correct computable cardinality inference,
including that of the implicit __tid__.

One culprit is an old LIMIT-specific scope hack, which is now
unnecessary, and, evidently, harmful.  Another is the fact that the
scope tree path namespace is sometimes set up incorrectly with duplicate
namespaces in descendant nodes, so prevent that from happening.