### PR TITLE
Allow ROLLBACK outside of a transaction

### DIFF
--- a/edb/server/backend/dbstate.py
+++ b/edb/server/backend/dbstate.py
@@ -356,9 +356,8 @@ class CompilerConnectionState:
             raise errors.TransactionError('already in transaction')
 
     def rollback_tx(self):
-        if self._current_tx.is_implicit():
-            raise errors.TransactionError(
-                'cannot rollback: not in transaction')
+        # Note that we might not be in a transaction as we allow
+        # ROLLBACKs outside of transaction blocks (just like Postgres).
 
         prior_state = self._current_tx._stack[0]
 

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1419,6 +1419,43 @@ class TestServerProto(tb.QueryTestCase):
                     DROP TYPE test::Tmp_tx_13;
                 ''')
 
+    async def test_server_proto_tx_14(self):
+        await self.con.execute('''
+            ROLLBACK;
+            ROLLBACK;
+            ROLLBACK;
+        ''')
+
+        self.assertEqual(
+            await self.con.fetch_value('SELECT 1;'),
+            1)
+
+        await self.con.execute('''
+            START TRANSACTION;
+            ROLLBACK;
+            ROLLBACK;
+            ROLLBACK;
+        ''')
+
+        self.assertEqual(
+            await self.con.fetch_value('SELECT 1;'),
+            1)
+
+        await self.con.execute('''
+            START TRANSACTION;
+        ''')
+
+        await self.con.execute('''
+            ROLLBACK;
+        ''')
+        await self.con.execute('''
+            ROLLBACK;
+        ''')
+
+        self.assertEqual(
+            await self.con.fetch_value('SELECT 1;'),
+            1)
+
 
 class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):
 


### PR DESCRIPTION
Allowing ROLLBACKS makes it possible to simply issue a ROLLBACK at the
end of a unittest or similar scenarious.  It's convenient.  Postgres
allows that too.