### PR TITLE
MIGRATION commands now require to run in a transaction

### DIFF
--- a/docs/datamodel/eschema/index.rst
+++ b/docs/datamodel/eschema/index.rst
@@ -20,10 +20,12 @@ represents a complete schema state for a particular
 Migrations
 ==========
 
-To apply a Schema to the database, the :eql:stmt:`CREATE MIGRATION` command
-must be used followed by :eql:stmt:`COMMIT MIGRATION`:
+To apply a Schema to the database, the :eql:stmt:`CREATE MIGRATION`
+command must be used followed by :eql:stmt:`COMMIT MIGRATION`:
 
 .. code-block:: edgeql
+
+    START TRANSACTION;
 
     CREATE MIGRATION init TO eschema $$
         type User:
@@ -31,6 +33,8 @@ must be used followed by :eql:stmt:`COMMIT MIGRATION`:
     $$;
 
     COMMIT MIGRATION init;
+
+    COMMIT;
 
 
 .. toctree::

--- a/docs/edgeql/ddl/migrations.rst
+++ b/docs/edgeql/ddl/migrations.rst
@@ -40,6 +40,9 @@ generates the necessary DDL commands automatically based on the current and
 the target state.  The second form uses explicit DDL command specifications
 for the migration.
 
+**Important:** ``CREATE MIGRATION`` and the follow-up
+:eql:stmt:`COMMIT MIGRATION` must be executed in a transaction block.
+
 
 Parameters
 ----------
@@ -89,10 +92,16 @@ Create a new migration for the "payments" module using explicit DDL:
 
 .. code-block:: edgeql
 
+    START TRANSACTION;
+
     CREATE MIGRATION payments::alter_tx {
         ALTER TYPE Payment CREATE PROPERTY amount -> str;
         ALTER TYPE CreditCard CREATE PROPERTY cvv -> str;
     };
+
+    COMMIT MIGRATION payments::alter_tx;
+
+    COMMIT;
 
 
 COMMIT MIGRATION
@@ -112,6 +121,8 @@ Description
 
 ``COMMIT MIGRATION`` runs the DDL commands defined by the given migration.
 Once the migration is committed, it cannot be dropped.
+
+**Important:** ``COMMIT MIGRATION`` must be executed in a transaction block.
 
 
 Parameters

--- a/edb/tools/docs/eql.py
+++ b/edb/tools/docs/eql.py
@@ -590,8 +590,9 @@ class EQLMigrationDirective(s_code.CodeBlock):
         migration_name = self.arguments[0]
         self.arguments = ['eschema']
 
-        pre = f'CREATE MIGRATION {migration_name} TO eschema $$\n\n'
-        suf = f'\n$$;\nCOMMIT MIGRATION {migration_name};'
+        pre = (f'START TRANSACTION;\n'
+               f'CREATE MIGRATION {migration_name} TO eschema $$\n\n')
+        suf = f'\n$$;\nCOMMIT MIGRATION {migration_name};\nCOMMIT;'
 
         pre_node = d_nodes.literal_block(pre, pre)
         pre_node['language'] = 'edgeql'

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -396,9 +396,10 @@ class TestConstraintsSchemaMigration(tb.QueryTestCase):
         with open(new_schema_f) as f:
             new_schema = f.read()
 
-        await self.con.execute(f'''
-            CREATE MIGRATION test::d1 TO eschema $${new_schema}$$;
-            COMMIT MIGRATION test::d1;
+        async with self.con.transaction():
+            await self.con.execute(f'''
+                CREATE MIGRATION test::d1 TO eschema $${new_schema}$$;
+                COMMIT MIGRATION test::d1;
             ''')
 
         async with self._run_and_rollback():
@@ -965,7 +966,8 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
                 edgedb.SchemaDefinitionError,
                 "constraint expression expected to return a bool value, "
                 "got 'int64'"):
-            await self.con.execute(qry)
+            async with self.con.transaction():
+                await self.con.execute(qry)
 
         qry = """
             CREATE TYPE User {

--- a/tests/test_docs_sphinx_ext.py
+++ b/tests/test_docs_sphinx_ext.py
@@ -808,7 +808,8 @@ class TestEQLMigration(unittest.TestCase, BaseDomainTest):
                 //container[@eql-migration="true"] / literal_block / text()
             '''),
             [
+                'START TRANSACTION;\n'
                 'CREATE MIGRATION foobar TO eschema $$\n\n',
                 'type User:\n    property name -> str',
-                '\n$$;\nCOMMIT MIGRATION foobar;'
+                '\n$$;\nCOMMIT MIGRATION foobar;\nCOMMIT;'
             ])

--- a/tests/test_edgeql_tutorial.py
+++ b/tests/test_edgeql_tutorial.py
@@ -24,8 +24,12 @@ from edb.testbase import server as tb
 
 class TestEdgeQLTutorial(tb.QueryTestCase):
 
+    ISOLATED_METHODS = False
+
     async def test_edgeql_tutorial(self):
         await self.con.execute('''
+            START TRANSACTION;
+
             CREATE MIGRATION m1 TO eschema $$
                 type User:
                     required property login -> str:
@@ -165,6 +169,8 @@ class TestEdgeQLTutorial(tb.QueryTestCase):
                     }),
                 }
             };
+
+            COMMIT;
         ''')
 
         await self.assert_query_result(

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1456,6 +1456,30 @@ class TestServerProto(tb.QueryTestCase):
             await self.con.fetch_value('SELECT 1;'),
             1)
 
+    async def test_server_proto_tx_15(self):
+        commands = [
+            '''
+            CREATE MIGRATION test::ttt TO eschema $$
+                type User:
+                    required property login -> str:
+                        constraint exclusive
+            $$;
+            ''',
+            '''GET MIGRATION test::ttt;''',
+            '''COMMIT MIGRATION test::ttt;''',
+        ]
+
+        for command in commands:
+            with self.annotate(command=command):
+                with self.assertRaisesRegex(
+                        edgedb.QueryError,
+                        'must be executed in a transaction'):
+                    await self.con.execute(command)
+
+        self.assertEqual(
+            await self.con.fetch_value('SELECT 1111;'),
+            1111)
+
 
 class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):
 


### PR DESCRIPTION
This is a temporary limitations.  Currently we don't persist
migrations in the DB; they exist only in a local server state.  To
serialize access to that local state a transaction is necessary.