### PR TITLE
docs: Move the cardinality section.

### DIFF
--- a/docs/edgeql/expressions/shapes.rst
+++ b/docs/edgeql/expressions/shapes.rst
@@ -130,3 +130,27 @@ the ``name`` and the ``email`` for that user.
             'email': 'alice@example.com'
         }
     }
+
+
+Cardinality
++++++++++++
+
+Typically the cardinality of an expression can be statically
+determined from the individual parts. Sometimes it is necessary to
+specify the cardinality explicitly. For example, when using
+computables in shapes it may be desirable to specify the cardinality
+of the computable because it affects serialization.
+
+.. code-block:: edgeql
+
+    WITH
+        MODULE example
+    SELECT User {
+        name,
+        multi nicknames := (SELECT 'Foo')
+    };
+
+Cardinality is normally statically inferred from the query, so
+overruling this inference may only be done to *relax* the cardinality,
+so it is not valid to specify the ``single`` qualifier for a computable
+expression that may return multiple items.

--- a/docs/edgeql/statements/with.rst
+++ b/docs/edgeql/statements/with.rst
@@ -85,30 +85,6 @@ Another use case is for giving short aliases to long module names
     FILTER .name = fbz::Baz.name;
 
 
-Cardinality
-+++++++++++
-
-Typically the cardinality of an expression can be statically
-determined from the individual parts. Sometimes it is necessary to
-specify the cardinality explicitly. For example, when using
-computables in shapes it may be desirable to specify the cardinality
-of the computable because it affects serialization.
-
-.. code-block:: edgeql
-
-    WITH
-        MODULE example
-    SELECT User {
-        name,
-        multi nicknames := (SELECT 'Foo')
-    };
-
-Cardinality is normally statically inferred from the query, so
-overruling this inference may only be done to *relax* the cardinality,
-so it is not valid to specify the ``single`` qualifier for a computable
-expression that may return multiple items.
-
-
 Expressions
 +++++++++++
 


### PR DESCRIPTION
Move the section about cardinality from the description of `WITH` block
and into the 'Shapes in Queries' section.