### PR TITLE
docs: Drop unnecessary `std::` from expressions.

### DIFF
--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -110,7 +110,7 @@ Parameters
     If specified, the constraint is defined as *delegated*, which means
     that it will not be enforced on the type it's declared on, and
     the enforcement will be delegated to the subtypes of this type.
-    This is particularly useful for :eql:constraint:`std::exclusive`
+    This is particularly useful for :eql:constraint:`exclusive`
     constraints in abstract types.
 
 :eschema:synopsis:`<constr_name>`

--- a/docs/datamodel/objects.rst
+++ b/docs/datamodel/objects.rst
@@ -13,7 +13,7 @@ objects and by links between objects.
 Every object has a globally unique *identity* represented by a ``UUID``
 value.  Object's identity is assigned on object's creation and never
 changes.  Referring to object's ``id`` property yields its identity as a
-:eql:type:`std::uuid` value.
+:eql:type:`uuid` value.
 
 Object types can *extend* other object types, in which case the extending
 type is called a *subtype* and types being extended are called *supertypes*.
@@ -33,7 +33,7 @@ types in EdgeDB extend ``std::Object`` directly or indirectly.
 
         abstract type Object:
             # Universally unique object identifier
-            required readonly property id -> std::uuid
+            required readonly property id -> uuid
 
             # Object type in the information schema.
             required readonly link __type__ -> schema::ObjectType

--- a/docs/edgeql/ddl/constraints.rst
+++ b/docs/edgeql/ddl/constraints.rst
@@ -259,7 +259,7 @@ Parameters
     If specified, the constraint is defined as *delegated*, which means
     that it will not be enforced on the type it's declared on, and
     the enforcement will be delegated to the subtypes of this type.
-    This is particularly useful for :eql:constraint:`std::exclusive`
+    This is particularly useful for :eql:constraint:`exclusive`
     constraints in abstract types.
 
 :eql:synopsis:`<name>`
@@ -297,7 +297,7 @@ Create a maximum length constraint on the property "name" of the "User" type:
 .. code-block:: edgeql
 
     ALTER TYPE User ALTER PROPERTY name
-    CREATE CONSTRAINT std::maxlength(100);
+    CREATE CONSTRAINT maxlength(100);
 
 
 ALTER CONSTRAINT
@@ -379,7 +379,7 @@ Change the error message on a maximum length constraint on the property
 .. code-block:: edgeql
 
     ALTER TYPE User ALTER PROPERTY name
-    ALTER CONSTRAINT std::maxlength
+    ALTER CONSTRAINT maxlength
     SET errmessage := 'User name too long';
 
 
@@ -427,4 +427,4 @@ Remove constraint "maxlength" from the property "name" of the
 .. code-block:: edgeql
 
     ALTER TYPE User ALTER PROPERTY name
-    DROP CONSTRAINT std::maxlength;
+    DROP CONSTRAINT maxlength;

--- a/docs/edgeql/ddl/indexes.rst
+++ b/docs/edgeql/ddl/indexes.rst
@@ -51,7 +51,7 @@ Create an object type ``User`` with an indexed ``title`` property:
 .. code-block:: edgeql
 
     CREATE TYPE User {
-        CREATE PROPERTY title -> std::str {
+        CREATE PROPERTY title -> str {
             SET default := '';
         };
 

--- a/docs/edgeql/ddl/scalars.rst
+++ b/docs/edgeql/ddl/scalars.rst
@@ -72,7 +72,7 @@ Create a new non-negative integer type:
 
 .. code-block:: edgeql
 
-    CREATE SCALAR TYPE posint64 EXTENDING std::int64 {
+    CREATE SCALAR TYPE posint64 EXTENDING int64 {
         CREATE CONSTRAINT min(0);
     };
 

--- a/docs/edgeql/expressions/index.rst
+++ b/docs/edgeql/expressions/index.rst
@@ -45,7 +45,7 @@ a cast string literal:
 
     SELECT <float32>'1.23';
     SELECT <timedelta>'1 day';
-    SELECT <std::decimal>'1.23';  # Same as SELECT 1.23n;
+    SELECT <decimal>'1.23';  # Same as SELECT 1.23n;
 
 
 .. _ref_eql_expr_index_setref:

--- a/docs/edgeql/expressions/tuples.rst
+++ b/docs/edgeql/expressions/tuples.rst
@@ -25,7 +25,7 @@ Named tuples are created using the following syntax:
 Note that *all* elements in a named tuple must have a name.
 
 A tuple constructor automatically creates a corresponding
-:eql:type:`std::tuple` type:
+:eql:type:`tuple` type:
 
 .. code-block:: edgeql-repl
 

--- a/docs/edgeql/functions/datetime.rst
+++ b/docs/edgeql/functions/datetime.rst
@@ -10,7 +10,7 @@ Date and Time
 
     .. code-block:: edgeql-repl
 
-        db> SELECT std::datetime_current();
+        db> SELECT datetime_current();
         {'2018-05-14T20:07:11.755827+00:00'}
 
 .. eql:function:: std::datetime_of_transaction() -> datetime

--- a/docs/edgeql/functions/string.rst
+++ b/docs/edgeql/functions/string.rst
@@ -148,7 +148,7 @@ String
 
     .. code-block:: edgeql-repl
 
-        db> SELECT std::re_match(r'\w{4}ql', 'I ❤️ edgeql');
+        db> SELECT re_match(r'\w{4}ql', 'I ❤️ edgeql');
         {['edgeql']}
 
 .. eql:function:: std::re_match_all(pattern: str, \
@@ -165,7 +165,7 @@ String
 
     .. code-block:: edgeql-repl
 
-        db> SELECT std::re_match_all(r'a\w+', 'an abstract concept');
+        db> SELECT re_match_all(r'a\w+', 'an abstract concept');
         {['an'], ['abstract']}
 
 .. eql:function:: std::re_replace(pattern: str, sub: str, \
@@ -185,8 +185,8 @@ String
 
     .. code-block:: edgeql-repl
 
-        db> SELECT std::re_replace(r'l', r'L', 'Hello World',
-                                   flags := 'g');
+        db> SELECT re_replace(r'l', r'L', 'Hello World',
+        ...                   flags := 'g');
         {'HeLLo WorLd'}
 
 .. eql:function:: std::re_test(pattern: str, string: str) -> bool
@@ -202,7 +202,7 @@ String
 
     .. code-block:: edgeql-repl
 
-        db> SELECT std::re_test(r'a', 'abc');
+        db> SELECT re_test(r'a', 'abc');
         {True}
 
 Regular Expressions

--- a/docs/edgeql/functions/sys.rst
+++ b/docs/edgeql/functions/sys.rst
@@ -13,7 +13,7 @@ System
     Make the current session sleep for *duration* time.
 
     *duration* can either be a number of seconds specified
-    as a floating point number, or a :eql:type:`std::timedelta`.
+    as a floating point number, or a :eql:type:`timedelta`.
 
     The function always returns ``true``.
 

--- a/docs/edgeql/statements/select.rst
+++ b/docs/edgeql/statements/select.rst
@@ -26,7 +26,7 @@ SELECT
 
 :eql:synopsis:`FILTER <filter-expr>`
     The optional ``FILTER`` clause, where :eql:synopsis:`<filter-expr>`
-    is any expression that has a result of type :eql:type:`std::bool`.
+    is any expression that has a result of type :eql:type:`bool`.
     The condition is evaluated for every element in the set produced by
     the ``SELECT`` clause.  The result of the evaluation of the
     ``FILTER`` clause is a set of boolean values.  If at least one value

--- a/docs/edgeql/statements/update.rst
+++ b/docs/edgeql/statements/update.rst
@@ -33,11 +33,11 @@ selected by *update-selector-expr* and, optinally, filtered by
     An arbitrary expression returning a set of objects to be updated.
 
 :eql:synopsis:`FILTER <filter-expr>`
-    An expression of type :eql:type:`std::bool` used to filter the
+    An expression of type :eql:type:`bool` used to filter the
     set of updated objects.
 
     :eql:synopsis:`<filter-expr>` is an expression that has a result
-    of type :eql:type:`std::bool`.  Only objects that satisfy the filter
+    of type :eql:type:`bool`.  Only objects that satisfy the filter
     expression will be updated.  See the description of the
     ``FILTER`` clause of the :eql:stmt:`SELECT` statement for more
     information.


### PR DESCRIPTION
In most cases writing `std::` is unnecessary since that is the default
module.