### PR TITLE
docs: The `id` value cannot be overridden.

### DIFF
--- a/docs/datamodel/objects.rst
+++ b/docs/datamodel/objects.rst
@@ -13,7 +13,9 @@ objects and by links between objects.
 Every object has a globally unique *identity* represented by a ``UUID``
 value.  Object's identity is assigned on object's creation and never
 changes.  Referring to object's ``id`` property yields its identity as a
-:eql:type:`uuid` value.
+:eql:type:`uuid` value.  Once set, the value of the ``id`` property
+cannot be changed or masked with a different :ref:`computable
+<ref_datamodel_computables>` expression.
 
 Object types can *extend* other object types, in which case the extending
 type is called a *subtype* and types being extended are called *supertypes*.


### PR DESCRIPTION
It's illegal to mask the `id` with a computable.