### PR TITLE
docs: Document on target delete triggers.

### DIFF
--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -81,6 +81,10 @@ declaration in the context of a ``type`` declaration:
             [ readonly := {true | false} ]
             [ <attribute-declarations> ]
             [ <constraint-declarations> ]
+            [ on target delete { restrict |
+                                 allow |
+                                 delete source |
+                                 deferred restrict } ]
 
     # shorthand form for computable link declaration:
 
@@ -133,6 +137,29 @@ Parameters:
 
 :eschema:synopsis:`<constraint-declarations>`
     :ref:`Constraint <ref_datamodel_constraints>` declarations.
+
+:eschema:synopsis:`on target delete`
+    On target delete options cover the situation when the target
+    object of a link is deleted without explicitly updating the link.
+
+:eschema:synopsis:`restrict`
+    Prohibit deleting the link target as long as the source object exists.
+    This is the default behavior.
+
+:eschema:synopsis:`allow`
+    Allow dropping the connection between the source and target when
+    the target is deleted.
+
+:eschema:synopsis:`delete source`
+    Delete the source object if any link target is deleted. This means
+    that for ``multi`` links the source object will be deleted
+    if even one of the link targets is deleted (e.g. automatically
+    dissolving a team when all team members are critical and one has
+    been deleted).
+
+:eschema:synopsis:`deferred restrict`
+    Same as ``restrict``, but the check is performed at the end of
+    transaction instead of immediately.
 
 
 Concrete links can also be defined using the

--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -233,6 +233,13 @@ be more than one.  ``SINGLE`` is the default.
     The following actions are allowed in the ``CREATE LINK`` block:
 
     * :eql:stmt:`SET ATTRIBUTE`
+    * ``ON TARGET DELETE RESTRICT``
+    * ``ON TARGET DELETE ALLOW``
+    * ``ON TARGET DELETE DELETE SOURCE``
+    * ``ON TARGET DELETE DEFERRED RESTRICT``
+
+    The details of what ``ON TARGET DELETE`` options mean are
+    described in :ref:`this section <ref_datamodel_links>`.
 
 
 Computable Link Form

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -49,8 +49,7 @@ NonesLast = NonesOrder.Last
 class LinkTargetDeleteAction(s_enum.StrEnum):
     RESTRICT = 'RESTRICT'
     DELETE_SOURCE = 'DELETE SOURCE'
-    SET_EMPTY = 'SET EMPTY'
-    SET_DEFAULT = 'SET DEFAULT'
+    ALLOW = 'ALLOW'
     DEFERRED_RESTRICT = 'DEFERRED RESTRICT'
 
 
@@ -70,7 +69,7 @@ class Expr(Base):
 
 
 class SubExpr(Base):
-    """A subexpression (used for ahcnors)."""
+    """A subexpression (used for anchors)."""
 
     expr: typing.Union[Expr, object]
     anchors: typing.Dict[typing.Union[str, ast.MetaAST],

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1168,13 +1168,9 @@ class OnTargetDeleteStmt(Nonterm):
         self.val = qlast.OnTargetDelete(
             cascade=qlast.LinkTargetDeleteAction.DELETE_SOURCE)
 
-    def reduce_ON_TARGET_DELETE_SET_EMPTY(self, *kids):
+    def reduce_ON_TARGET_DELETE_ALLOW(self, *kids):
         self.val = qlast.OnTargetDelete(
-            cascade=qlast.LinkTargetDeleteAction.SET_EMPTY)
-
-    def reduce_ON_TARGET_DELETE_SET_DEFAULT(self, *kids):
-        self.val = qlast.OnTargetDelete(
-            cascade=qlast.LinkTargetDeleteAction.SET_DEFAULT)
+            cascade=qlast.LinkTargetDeleteAction.ALLOW)
 
     def reduce_ON_TARGET_DELETE_DEFERRED_RESTRICT(self, *kids):
         self.val = qlast.OnTargetDelete(

--- a/edb/eschema/parser/grammar/declarations.py
+++ b/edb/eschema/parser/grammar/declarations.py
@@ -1006,13 +1006,9 @@ class OnDelete(Nonterm):
         self.val = esast.OnTargetDelete(
             cascade=qlast.LinkTargetDeleteAction.DELETE_SOURCE)
 
-    def reduce_ON_TARGET_DELETE_SET_EMPTY_NL(self, *kids):
+    def reduce_ON_TARGET_DELETE_ALLOW_NL(self, *kids):
         self.val = esast.OnTargetDelete(
-            cascade=qlast.LinkTargetDeleteAction.SET_EMPTY)
-
-    def reduce_ON_TARGET_DELETE_SET_DEFAULT_NL(self, *kids):
-        self.val = esast.OnTargetDelete(
-            cascade=qlast.LinkTargetDeleteAction.SET_DEFAULT)
+            cascade=qlast.LinkTargetDeleteAction.ALLOW)
 
     def reduce_ON_TARGET_DELETE_DEFERRED_RESTRICT_NL(self, *kids):
         self.val = esast.OnTargetDelete(

--- a/edb/eschema/parser/grammar/keywords.py
+++ b/edb/eschema/parser/grammar/keywords.py
@@ -31,6 +31,7 @@ UNRESERVED_KEYWORD, RESERVED_KEYWORD = keyword_types
 unreserved_keywords = frozenset([
     "abstract",
     "all",
+    "allow",
     "as",
     "attribute",
     "constraint",

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2747,7 +2747,7 @@ class UpdateEndpointDeleteActions(MetaCommand):
                 links, lambda l: l.get_on_target_delete(schema))
             near_endpoint, far_endpoint = 'target', 'source'
         else:
-            groups = [(DA.SET_EMPTY, links)]
+            groups = [(DA.ALLOW, links)]
             near_endpoint, far_endpoint = 'source', 'target'
 
         for action, links in groups:
@@ -2793,7 +2793,7 @@ class UpdateEndpointDeleteActions(MetaCommand):
 
                 chunks.append(text)
 
-            elif action == s_links.LinkTargetDeleteAction.SET_EMPTY:
+            elif action == s_links.LinkTargetDeleteAction.ALLOW:
                 for link in links:
                     link_table = common.get_backend_name(
                         schema, link)

--- a/tests/schemas/link_tgt_del.eschema
+++ b/tests/schemas/link_tgt_del.eschema
@@ -29,8 +29,8 @@ type Source1 extending Named:
     link tgt1_restrict -> Target1:
         on target delete restrict
 
-    link tgt1_set_empty -> Target1:
-        on target delete set empty
+    link tgt1_allow -> Target1:
+        on target delete allow
 
     link tgt1_del_source -> Target1:
         on target delete delete source
@@ -40,6 +40,9 @@ type Source1 extending Named:
 
     multi link tgt1_m2m_restrict -> Target1:
         on target delete restrict
+
+    multi link tgt1_m2m_allow -> Target1:
+        on target delete allow
 
     multi link tgt1_m2m_del_source -> Target1:
         on target delete delete source

--- a/tests/schemas/link_tgt_del_migrated.eschema
+++ b/tests/schemas/link_tgt_del_migrated.eschema
@@ -29,8 +29,8 @@ type Source1 extending Named:
     link tgt1_restrict -> Target1:
         on target delete restrict
 
-    link tgt1_set_empty -> Target1:
-        on target delete set empty
+    link tgt1_allow -> Target1:
+        on target delete allow
 
     link tgt1_del_source -> Target1:
         on target delete delete source
@@ -40,6 +40,9 @@ type Source1 extending Named:
 
     multi link tgt1_m2m_restrict -> Target1:
         on target delete restrict
+
+    multi link tgt1_m2m_allow -> Target1:
+        on target delete allow
 
     multi link tgt1_m2m_del_source -> Target1:
         on target delete delete source

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3308,12 +3308,9 @@ aa';
                 ON TARGET DELETE DELETE SOURCE;
             };
             CREATE LINK bar2 -> mymod::Bar {
-                ON TARGET DELETE SET EMPTY;
+                ON TARGET DELETE ALLOW;
             };
             CREATE LINK bar3 -> mymod::Bar {
-                ON TARGET DELETE SET DEFAULT;
-            };
-            CREATE LINK bar4 -> mymod::Bar {
                 ON TARGET DELETE DEFERRED RESTRICT;
             };
         };

--- a/tests/test_edgeql_tutorial.py
+++ b/tests/test_edgeql_tutorial.py
@@ -47,9 +47,9 @@ class TestEdgeQLTutorial(tb.QueryTestCase):
                     required property created_on -> datetime
                     required link author -> User
                     multi link assignees -> User:
-                        on target delete set empty
+                        on target delete allow
                     multi link comments -> Comment:
-                        on target delete set empty
+                        on target delete allow
 
 
                 type Comment:
@@ -77,9 +77,9 @@ class TestEdgeQLTutorial(tb.QueryTestCase):
                     required property title -> str
                     required property status -> str
                     multi link assignees -> User:
-                        on target delete set empty
+                        on target delete allow
                     multi link comments -> Comment:
-                        on target delete set empty
+                        on target delete allow
 
                 type Comment extending AuthoredText
             $$;

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -294,12 +294,9 @@ type Commit:
                 on target delete delete source
 
             link bar2 -> Bar:
-                on target delete set empty
+                on target delete allow
 
             link bar3 -> Bar:
-                on target delete set default
-
-            link bar4 -> Bar:
                 on target delete deferred restrict
         """
 


### PR DESCRIPTION
Document all the different behavior options for when a link target is
deleted without explicitly updating the link.