### PR TITLE
Fix an issue with repl mishandling multiple `;`

### DIFF
--- a/edb/common/lexer.py
+++ b/edb/common/lexer.py
@@ -217,8 +217,8 @@ class Lexer:
         if eof_tok is not None:
             yield eof_tok
 
-    def handle_error(self, txt):
-        raise UnknownTokenError(
+    def handle_error(self, txt, *, exc_type=UnknownTokenError):
+        raise exc_type(
             f"Unexpected '{txt}'",
             line=self.lineno, col=self.column, filename=self.filename)
 

--- a/edb/repl/__init__.py
+++ b/edb/repl/__init__.py
@@ -71,7 +71,8 @@ def is_multiline():
         return False
 
     if text.endswith(';'):
-        return not lexutils.split_edgeql(text)
+        _, incomplete = lexutils.split_edgeql(text, script_mode=False)
+        return incomplete is not None
 
     return True
 
@@ -331,10 +332,10 @@ class Cli:
                         results.append(
                             self.connection._execute_graphql(command))
                     elif qm is context.QueryMode.Normal:
-                        for query in lexutils.split_edgeql(command):
+                        for query in lexutils.split_edgeql(command)[0]:
                             results.append(self.connection.fetch(query))
                     else:
-                        for query in lexutils.split_edgeql(command):
+                        for query in lexutils.split_edgeql(command)[0]:
                             results.append(self.connection.fetch_json(query))
 
                 except KeyboardInterrupt:
@@ -378,7 +379,7 @@ class Cli:
 
 def execute_script(conn_args, data):
     con = edgedb.connect(**conn_args)
-    queries = lexutils.split_edgeql(data, script_mode=True)
+    queries = lexutils.split_edgeql(data)[0]
     ctx = context.ReplContext()
     for query in queries:
         ret = con.fetch(query)

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -114,7 +114,7 @@ class TestEdgeSchemaParser(EdgeQLSyntaxTest):
     def test_edgeql_syntax_constants_02(self):
         """
         SELECT 'a1';
-        SELECT "a1";
+        SELECT "a1";;;;;;;;;;;;
         SELECT r'a1';
         SELECT r"a1";
         SELECT $$a1$$;

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -25,67 +25,121 @@ from edb.repl import lexutils
 class TestReplLexutils(unittest.TestCase):
 
     def test_split_edgeql_01(self):
+        # test regular complete statements
         self.assertEqual(
-            lexutils.split_edgeql('select +  - 1;'),
-            ['select +  - 1;'])
+            lexutils.split_edgeql('select +  - 1;', script_mode=False),
+            (['select +  - 1;'], None))
 
         self.assertEqual(
-            lexutils.split_edgeql('select +  - 1;  '),
-            ['select +  - 1;  '])
+            lexutils.split_edgeql('select +  - 1;  ', script_mode=False),
+            (['select +  - 1;'], None))
 
         self.assertEqual(
-            lexutils.split_edgeql('  select +  - 1;  select ;;'),
-            ['  select +  - 1;', '  select ;', ';'])
+            lexutils.split_edgeql(
+                '  select +  - 1;  select ;;', script_mode=False),
+            (['select +  - 1;', 'select ;'], None))
+
+        self.assertEqual(
+            lexutils.split_edgeql(';;;', script_mode=False),
+            ([], None))
 
         self.assertEqual(
             lexutils.split_edgeql('''\
-                CREATE TYPE blah {
-                    set ;
-                    blah ;
-                };
-                select 1;
-                '''),
-            [
-                '''\
-                CREATE TYPE blah {
-                    set ;
-                    blah ;
-                };''',
-                '''
-                select 1;
-                '''
-            ])
-
-        self.assertIsNone(lexutils.split_edgeql('SELECT "aaa'))
-        self.assertIsNone(lexutils.split_edgeql('SELECT "as'))
-        self.assertIsNone(lexutils.split_edgeql('SELECT "as\n'))
-        self.assertIsNone(lexutils.split_edgeql(''))
-        self.assertIsNone(lexutils.split_edgeql(' '))
-        self.assertIsNone(lexutils.split_edgeql(' \n '))
-        self.assertIsNone(lexutils.split_edgeql(' \n sel \n '))
-
-        self.assertIsNone(
-            lexutils.split_edgeql('select +  - 1;  select 1'))
-
-        self.assertIsNone(
-            lexutils.split_edgeql('select +  - 1;  select {;}'))
-
-        self.assertIsNone(
-            lexutils.split_edgeql('select +  - 1;  select {;;;;}}}}'))
+                    CREATE TYPE blah {
+                        set ;
+                        blah ;
+                    };
+                    select 1;
+                ''', script_mode=False),
+            (
+                [
+                    '''CREATE TYPE blah {
+                        set ;
+                        blah ;
+                    };''',
+                    'select 1;'
+                ],
+                None
+            ))
 
     def test_split_edgeql_02(self):
+        # test multiline statements
+        self.assertEqual(
+            lexutils.split_edgeql('', script_mode=False),
+            ([], ''))
+        self.assertEqual(
+            lexutils.split_edgeql(' ', script_mode=False),
+            ([], ' '))
+        self.assertEqual(
+            lexutils.split_edgeql(' \n ', script_mode=False),
+            ([], ' \n '))
+        self.assertEqual(lexutils.split_edgeql(
+            ' \n sel \n ', script_mode=False),
+            ([], ' \n sel \n '))
+
+        self.assertEqual(
+            lexutils.split_edgeql('select +  - 1;  select 1',
+                                  script_mode=False),
+            (['select +  - 1;'], '  select 1'))
+
+        self.assertEqual(
+            lexutils.split_edgeql('select +  - 1;  select {;}',
+                                  script_mode=False),
+            (['select +  - 1;'], '  select {;}'))
+
+        self.assertEqual(
+            lexutils.split_edgeql('select +  - 1;  select {;;;;}}}}',
+                                  script_mode=False),
+            (['select +  - 1;'], '  select {;;;;}}}}'))
+
+    def test_split_edgeql_03(self):
+        # test multiline statements where the string is unterminated
+        self.assertEqual(
+            lexutils.split_edgeql('SELECT "aaa', script_mode=False),
+            ([], 'SELECT "aaa'))
+
+        self.assertEqual(
+            lexutils.split_edgeql('SELECT "as', script_mode=False),
+            ([], 'SELECT "as'))
+
+        self.assertEqual(
+            lexutils.split_edgeql('SELECT "as\n', script_mode=False),
+            ([], 'SELECT "as\n'))
+
+    def test_split_edgeql_04(self):
+        # test multiline statements where the ';' is not a separator
+        self.assertEqual(
+            lexutils.split_edgeql('SELECT "aaa;', script_mode=False),
+            ([], 'SELECT "aaa;'))
+
+        self.assertEqual(
+            lexutils.split_edgeql('SELECT 1 #;', script_mode=False),
+            ([], 'SELECT 1 #;'))
+
+    def test_split_edgeql_05(self):
+        # test invalid tokens
+        self.assertEqual(
+            lexutils.split_edgeql('SELECT 1 ~ 2;', script_mode=False),
+            (['SELECT 1 ~ 2;'], None))
+
+        self.assertEqual(
+            lexutils.split_edgeql('SELECT 1 ~ 2', script_mode=False),
+            ([], 'SELECT 1 ~ 2'))
+
+    def test_split_edgeql_06(self):
+        # test regular script mode
         self.assertEqual(
             lexutils.split_edgeql('select +  - 1;', script_mode=True),
-            ['select +  - 1;'])
+            (['select +  - 1;'], None))
 
         self.assertEqual(
             lexutils.split_edgeql('select +  - 1;  ', script_mode=True),
-            ['select +  - 1;'])
+            (['select +  - 1;'], None))
 
         self.assertEqual(
             lexutils.split_edgeql('  select +  - 1;  select ;;',
                                   script_mode=True),
-            ['select +  - 1;', 'select ;'])
+            (['select +  - 1;', 'select ;'], None))
 
         self.assertEqual(
             lexutils.split_edgeql('''\
@@ -95,37 +149,39 @@ class TestReplLexutils(unittest.TestCase):
                 };
                 select 1;
                 ''', script_mode=True),
-            [
+            ([
                 '''CREATE TYPE blah {
                     set ;
                     blah ;
                 };''',
                 '''select 1;'''
-            ])
+            ], None))
 
+    def test_split_edgeql_07(self):
+        # test script mode with various incomplete parts
         self.assertEqual(
-            lexutils.split_edgeql('', script_mode=True), None)
+            lexutils.split_edgeql('', script_mode=True), ([], None))
         self.assertEqual(
-            lexutils.split_edgeql(' ', script_mode=True), None)
+            lexutils.split_edgeql(' ', script_mode=True), ([], None))
         self.assertEqual(
-            lexutils.split_edgeql(' \n ', script_mode=True), None)
+            lexutils.split_edgeql(' \n ', script_mode=True), ([], None))
 
         self.assertEqual(
             lexutils.split_edgeql('select +  - 1;  select 1',
                                   script_mode=True),
-            ['select +  - 1;', 'select 1'])
+            (['select +  - 1;', 'select 1'], None))
 
         self.assertEqual(
             lexutils.split_edgeql('select +  - 1;  select {;}',
                                   script_mode=True),
-            ['select +  - 1;', 'select {;}'])
+            (['select +  - 1;', 'select {;}'], None))
 
         self.assertEqual(
             lexutils.split_edgeql('select +  - 1;  select {;;;;}}}} select',
                                   script_mode=True),
-            ['select +  - 1;', 'select {;;;;}}}} select'])
+            (['select +  - 1;', 'select {;;;;}}}} select'], None))
 
         self.assertEqual(
             lexutils.split_edgeql('select +  - 1;  select {;;;;}}}}; select',
                                   script_mode=True),
-            ['select +  - 1;', 'select {;;;;}}}};', 'select'])
+            (['select +  - 1;', 'select {;;;;}}}};', 'select'], None))


### PR DESCRIPTION
The `;` is supposed to be a separator, so multiple `;` in a row should
have no effect. REPL should not be attempting to execute a statement
that's just a `;`.