### PR TITLE
Implement std::IN as a derivative of std::=

### DIFF
--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -494,6 +494,12 @@ class OperatorCall(Call):
     # operand types.
     sql_operator: typing.Optional[typing.Tuple[str, ...]] = None
 
+    # The name of the origin operator if this is a derivative operator.
+    origin_name: sn.Name
+
+    # The module id of the origin operator if this is a derivative operator.
+    origin_module_id: uuid.UUID
+
 
 class TupleIndirection(ImmutableExpr):
 

--- a/edb/lib/std/25-setoperators.edgeql
+++ b/edb/lib/std/25-setoperators.edgeql
@@ -21,45 +21,24 @@
 ## --------------------------
 
 
+# The set membership operators (IN, NOT IN) are defined
+# in terms of the corresponding equality operator.
+
 CREATE INFIX OPERATOR
-std::`IN` (e: anytype, s: SET OF anytype) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+std::`IN` (e: anytype, s: SET OF anytype) -> std::bool
+{
     FROM SQL EXPRESSION;
+    SET volatility := 'IMMUTABLE';
+    SET derivative_of := 'std::=';
 };
 
 
 CREATE INFIX OPERATOR
-std::`IN` (e: decimal, s: SET OF float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+std::`NOT IN` (e: anytype, s: SET OF anytype) -> std::bool
+{
     FROM SQL EXPRESSION;
-};
-
-
-CREATE INFIX OPERATOR
-std::`IN` (e: float64, s: SET OF decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
-};
-
-
-CREATE INFIX OPERATOR
-std::`NOT IN` (e: anytype, s: SET OF anytype) -> std::bool {
-    SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
-};
-
-
-CREATE INFIX OPERATOR
-std::`NOT IN` (e: decimal, s: SET OF float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
-};
-
-
-CREATE INFIX OPERATOR
-std::`NOT IN` (e: float64, s: SET OF decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    SET derivative_of := 'std::!=';
 };
 
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -42,6 +42,7 @@ from edb.pgsql import types as pg_types
 from . import astutils
 from . import context
 from . import dispatch
+from . import expr as exprcomp
 from . import output
 from . import pathctx
 from . import relctx
@@ -1008,16 +1009,18 @@ def process_set_as_membership_expr(
                 )
 
     negated = expr.func_shortname == 'std::NOT IN'
-    op = '!=' if negated else '='
     sublink_type = pgast.SubLinkType.ALL if negated else pgast.SubLinkType.ANY
 
-    set_expr = astutils.new_binop(
-        lexpr=left_expr,
-        rexpr=pgast.SubLink(
-            type=sublink_type,
-            expr=right_rel,
-        ),
-        op=op,
+    set_expr = exprcomp.compile_operator(
+        expr,
+        [
+            left_expr,
+            pgast.SubLink(
+                type=sublink_type,
+                expr=right_rel,
+            ),
+        ],
+        ctx=ctx,
     )
 
     pathctx.put_path_value_var_if_not_exists(

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 36.07)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 40.91)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 40.96)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)


### PR DESCRIPTION
The membership operators, `std::IN` and `std::NOT IN` must be applicable
to the same domain as `std::=`, since `[NOT] IN` is basically an
element-wise application of `=`.  Blindly copying all the `=`
definitions would be tedious now and in the future, so introduce a
mechanism to declare an operator as a "derivative" of another operator,
which would tell the compiler to use the origin operator when doing
call resolution.  For simplicity, derivative operators cannot be
polymorphic.

Also fixes an issue with tuple inputs to `IN`, where the right operand was
erroneously passed as a TupleVar instead of a value.