### PR TITLE
Make type operation use consistent.

### DIFF
--- a/docs/datamodel/__toc__.rst
+++ b/docs/datamodel/__toc__.rst
@@ -18,6 +18,6 @@ Data Model
     constraints
     views
     attributes
-    modules
+    modules/index
     databases
     eschema/index

--- a/docs/datamodel/index.rst
+++ b/docs/datamodel/index.rst
@@ -48,14 +48,20 @@ There are several kinds of schema items:
 * :ref:`schema attribute definitions <ref_datamodel_attributes>`
 * :ref:`function definitions <ref_datamodel_functions>`
 
-There is also a special type ``anytype`` used to define polymorphic
-parameters in functions and operators:
+There are also a special types ``anytype`` and ``anytuple`` used to
+define polymorphic parameters in functions and operators:
 
 .. eql:type:: anytype
 
     :index: any anytype
 
     Generic type.
+
+.. eql:type:: anytuple
+
+    :index: any anytuple
+
+    Generic :eql:type:`tuple`.
 
 
 .. _ref_datamodel_inheritance:

--- a/docs/datamodel/modules/index.rst
+++ b/docs/datamodel/modules/index.rst
@@ -16,11 +16,19 @@ Schema objects can be referred to by a fully-qualified name using the
 Every EdgeDB schema contains the following standard modules:
 
 - ``std``: all standard types, functions and other declarations;
-- ``schema``: types describing the introspection schema;
-- ``__graphql__``: GraphQL-related types
+- ``schema``: types describing the :ref:`introspection schema
+  <ref_datamodel_modules_schema>`;
+- ``stdgraphql``: GraphQL helper types
 
 
 DDL
 ===
 
 Module can be defined using the :eql:stmt:`CREATE MODULE` EdgeQL command.
+
+
+.. toctree::
+    :maxdepth: 3
+    :hidden:
+
+    schema

--- a/docs/datamodel/modules/schema.rst
+++ b/docs/datamodel/modules/schema.rst
@@ -1,0 +1,30 @@
+.. _ref_datamodel_modules_schema:
+
+Schema
+======
+
+
+.. eql:type:: schema::Type
+
+    :index: schema type introspect introspection
+
+    Abstract base type for all the other types represented in the schema.
+
+.. eql:type:: schema::ScalarType
+
+    :index: schema scalar type introspect introspection
+
+    The introspection information for any :ref:`scalar type
+    <ref_datamodel_scalar_types>`.
+
+    It can be queried directly in the ``schema`` module or via
+    :eql:op:`INTROSPECT`.
+
+.. eql:type:: schema::ObjectType
+
+    :index: schema object type introspect introspection
+
+    The introspection information for any :eql:type:`Object`.
+
+    It can be queried directly in the ``schema`` module, via
+    :eql:type:`__type__ <Object>` or via :eql:op:`INTROSPECT`.

--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -193,7 +193,7 @@ CREATE LINK
 :eql-haswith:
 
 
-Define a new :ref:`concrete link <ref_datamodel_links>` for the
+Define a new :ref:`concrete link <ref_datamodel_links_concrete>` for the
 specified *object type*.
 
 .. eql:synopsis::
@@ -277,7 +277,7 @@ ALTER LINK
 :eql-haswith:
 
 
-Change the definition of a :ref:`concrete link <ref_datamodel_links>`
+Change the definition of a :ref:`concrete link <ref_datamodel_links_concrete>`
 on a given object type.
 
 .. eql:synopsis::

--- a/edb/common/context.py
+++ b/edb/common/context.py
@@ -240,6 +240,10 @@ def has_context(func):
         result = func(*args, **kwargs)
         obj, *args = args
 
+        # don't alter the context if no_autocontext flag is set
+        if getattr(obj, 'no_autocontext', False):
+            return result
+
         if len(args) == 1:
             # apparently it's a production rule that just returns its
             # only arg, so don't need to change the context

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -893,7 +893,7 @@ def get_targets(target: TypeExpr):
     if target is None:
         return []
     elif isinstance(target, TypeOp):
-        return get_targets(target.left) + get_targets(target.left)
+        return get_targets(target.left) + get_targets(target.right)
     else:
         return [target]
 

--- a/edb/eschema/ast.py
+++ b/edb/eschema/ast.py
@@ -65,7 +65,7 @@ class Pointer(Spec):
     name: qlast.ObjectRef
 
     # Computable links don't have a target
-    target: typing.Optional[typing.List[qlast.TypeName]]
+    target: typing.Optional[qlast.TypeExpr]
 
     attributes: typing.List[Attribute]
     constraints: typing.List[Constraint]

--- a/edb/eschema/parser/grammar/declarations.py
+++ b/edb/eschema/parser/grammar/declarations.py
@@ -132,6 +132,16 @@ class TypeList(Nonterm):
         self.val = kids[0].parse_as_typelist()
 
 
+class TypeExpr(Nonterm):
+    def reduce_LPAREN_TypeExpr_RPAREN(self, *kids):
+        self.val = kids[1].val
+
+    def reduce_RowRawString(self, *kids):
+        self.no_autocontext = True
+        # for type expression the typelist will only contain one entry
+        self.val = kids[0].parse_as_typelist()[0]
+
+
 class RowRawString(Nonterm):
     def reduce_RowRawString_RowRawStr(self, *kids):
         self.val = RawLiteral(
@@ -816,11 +826,11 @@ class Spec(Nonterm):
         self.val = PointerSpec(
             name=kids[0].val, target=None, spec=kids[1].val, expr=None)
 
-    def reduce_UnqualifiedObjectName_ARROW_TypeList_NL(self, *kids):
+    def reduce_UnqualifiedObjectName_ARROW_TypeExpr_NL(self, *kids):
         self.val = PointerSpec(
             name=kids[0].val, target=kids[2].val, spec=[], expr=None)
 
-    def reduce_UnqualifiedObjectName_ARROW_TypeList_DeclarationSpecsBlob(
+    def reduce_UnqualifiedObjectName_ARROW_TypeExpr_DeclarationSpecsBlob(
             self, *kids):
         self.val = PointerSpec(
             name=kids[0].val, target=kids[2].val, spec=kids[3].val, expr=None)

--- a/edb/lib/schema.eql
+++ b/edb/lib/schema.eql
@@ -54,13 +54,6 @@ CREATE ABSTRACT LINK std::__type__ {
 };
 
 
-ALTER TYPE std::Object {
-    CREATE LINK std::__type__ -> schema::Type {
-        SET readonly := True;
-    };
-};
-
-
 CREATE TYPE schema::Module EXTENDING schema::Object;
 
 
@@ -233,6 +226,13 @@ CREATE TYPE schema::DerivedLink EXTENDING (schema::Pointer, schema::Source);
 
 
 CREATE TYPE schema::Property EXTENDING schema::Pointer;
+
+
+ALTER TYPE std::Object {
+    CREATE LINK std::__type__ -> schema::ObjectType {
+        SET readonly := True;
+    };
+};
 
 
 ALTER TYPE schema::Pointer {

--- a/edb/tools/docs/eql.py
+++ b/edb/tools/docs/eql.py
@@ -296,7 +296,7 @@ INDEX_FIELD = EQLField(
 class EQLTypedField(EQLField):
 
     ignored_types = {
-        'type'
+        'type', 'object type', 'union type'
     }
 
     def __init__(self, name, names=(), label=None, rolename=None,

--- a/tests/schemas/issues.eschema
+++ b/tests/schemas/issues.eschema
@@ -94,7 +94,7 @@ type Issue extending Named, Owned, Text:
 
     multi link related_to -> Issue
 
-    multi link references -> File, URL, Publication
+    multi link references -> File | URL | Publication
 
     property tags -> array<str>
 

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -191,7 +191,7 @@ class TestIntrospection(tb.QueryTestCase):
                 'name': 'test::Comment',
                 'links': [{
                     'name': 'std::__type__',
-                    'target': {'name': 'schema::Type'},
+                    'target': {'name': 'schema::ObjectType'},
                     'cardinality': 'ONE',
                 }, {
                     'name': 'test::issue',

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -782,6 +782,28 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             }]
         )
 
+    async def test_edgeql_select_type_06(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE test
+            SELECT
+                Named.__type__ {
+                    name,
+                    is_abstract,
+                }
+            ORDER BY
+                Named.__type__.name;
+            ''',
+            [
+                {'name': 'test::File', 'is_abstract': False},
+                {'name': 'test::Issue', 'is_abstract': False},
+                {'name': 'test::Priority', 'is_abstract': False},
+                {'name': 'test::Status', 'is_abstract': False},
+                {'name': 'test::URL', 'is_abstract': False},
+                {'name': 'test::User', 'is_abstract': False}
+            ]
+        )
+
     @test.not_implemented('recursive queries are not implemented')
     async def test_edgeql_select_recursive_01(self):
         await self.assert_query_result(

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3387,6 +3387,21 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_type_10(self):
+        """
+        CREATE TYPE test::UserReport {
+            CREATE REQUIRED MULTI LINK relevant_user_data ->
+                test::User | test::Comment;
+        };
+
+% OK %
+
+        CREATE TYPE test::UserReport {
+            CREATE REQUIRED MULTI LINK relevant_user_data ->
+                (test::User | test::Comment);
+        };
+        """
+
     def test_edgeql_syntax_set_command_01(self):
         """
         SET MODULE default;

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -228,18 +228,18 @@ type Foo:
     def test_eschema_syntax_type_09(self):
         """
 type LogEntry extending OwnedObject, Text:
-    required link attachment -> Post, File, User
+    required link attachment -> Post | File | User
         """
 
     def test_eschema_syntax_type_10(self):
         """
 type `Log-Entry` extending `OwnedObject`, `Text`:
-    required link attachment -> `Post`, `File`, `User`
+    required link attachment -> `Post` | `File` | `User`
 
 % OK %
 
 type `Log-Entry` extending OwnedObject, Text:
-    required link attachment -> Post, File, User
+    required link attachment -> Post | File | User
         """
 
     @tb.must_fail(errors.SchemaSyntaxError, "Unexpected 'Commit'",
@@ -404,6 +404,12 @@ type User:
         """
 type User:
     required link todo -> tuple<str, tuple<str, array<str>>, array<float64>>
+        """
+
+    def test_eschema_syntax_link_target_type_05(self):
+        """
+        type UserReport:
+            required multi link relevant_user_data -> User | Comment
         """
 
     def test_eschema_syntax_index_01(self):


### PR DESCRIPTION
The way link targets were specified in eschema was different from DDL
for multiple type links.

DDL and EdgeQL operator `IS` make use of type union operator `|` instead
of a `,` to specify multiple types. This is now the case for eschema,
too.

Union types can now be specified as link targets in eschema and in DDL.
They can also be used as the RHS of the `IS` operator.

Union types do not yet implement the "common" property/link logic.

Documentation has been updated.