### PR TITLE
Streamline handling of type indirections in paths

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -324,20 +324,18 @@ class IsOp(Expr):
     right: TypeExpr
 
 
-class TypeFilter(Expr):
-    expr: Expr
+class TypeIndirection(Base):
     type: TypeExpr
 
 
 class Ptr(Base):
     ptr: ObjectRef
     direction: str
-    target: TypeExpr
     type: str
 
 
 class Path(Expr):
-    steps: typing.List[typing.Union[Expr, Ptr, TypeExpr]]
+    steps: typing.List[typing.Union[Expr, Ptr, TypeIndirection]]
     quantifier: Expr
     partial: bool = False
 

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -59,12 +59,14 @@ def get_tuple_indirection_path_id(
 
 def get_type_indirection_path_id(
         path_id: irast.PathId, target_type: s_types.Type, *,
-        optional: bool, cardinality: qltypes.Cardinality,
+        optional: bool, ancestral: bool, cardinality: qltypes.Cardinality,
         ctx: context.CompilerContext) -> irast.PathId:
     return path_id.extend(
         ptrcls=irast.TypeIndirectionLink(
             path_id.target, target_type,
-            optional=optional, cardinality=cardinality),
+            optional=optional,
+            ancestral=ancestral,
+            cardinality=cardinality),
         direction=s_pointers.PointerDirection.Outbound,
         target=target_type,
         schema=ctx.env.schema

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -592,8 +592,12 @@ def compile_query_subject(
             # the parent shape, ie. Spam { alias := Foo.bar }, so
             # `Spam.alias` should be a subclass of `Foo.bar` inheriting
             # its properties.
+            rptr = expr.rptr
+            # Unwind type indirections first.
+            while isinstance(rptr, irast.TypeIndirectionPointer):
+                rptr = rptr.source.rptr
             view_rptr.base_ptrcls = irtyputils.ptrcls_from_ptrref(
-                expr.rptr.ptrref, schema=ctx.env.schema)
+                rptr.ptrref, schema=ctx.env.schema)
         else:
             if expr.path_id.is_objtype_path():
                 ptr_metacls = s_links.Link

--- a/edb/edgeql/optimizer.py
+++ b/edb/edgeql/optimizer.py
@@ -238,8 +238,6 @@ class EdgeQLOptimizer:
 
         elif isinstance(expr, qlast.Ptr):
             self._process_expr(context, expr.ptr)
-            if expr.target:
-                self._process_expr(context, expr.target)
 
         elif isinstance(expr, qlast.CreateModule):
             pass

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -320,8 +320,14 @@ class GraphQLTranslator(ast.NodeVisitor):
         steps = []
         if include_base:
             base = spath[0].type
-            steps.append(qlast.ObjectRef(
-                module=base.module, name=base.short_name))
+            steps.append(qlast.TypeIndirection(
+                type=qlast.TypeName(
+                    maintype=qlast.ObjectRef(
+                        module=base.module,
+                        name=base.short_name
+                    ),
+                ),
+            ))
         steps.append(qlast.Ptr(
             ptr=qlast.ObjectRef(
                 name=node.name

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -191,10 +191,9 @@ class GQLCoreSchema:
                 if name == '__type__':
                     continue
 
-                self.edb_schema, ptr = edb_type.resolve_pointer(
-                    self.edb_schema, name)
+                ptr = edb_type.getptr(self.edb_schema, name)
                 target = self._get_target(ptr)
-                if target:
+                if target is not None:
                     if isinstance(ptr.get_target(self.edb_schema),
                                   s_objtypes.ObjectType):
                         args = self._get_args(
@@ -228,8 +227,7 @@ class GQLCoreSchema:
                     "reserved fields required for GraphQL conversion"
                 )
 
-            self.edb_schema, ptr = edb_type.resolve_pointer(
-                self.edb_schema, name)
+            ptr = edb_type.getptr(self.edb_schema, name)
 
             if not isinstance(ptr.get_target(self.edb_schema),
                               s_scalars.ScalarType):
@@ -299,8 +297,7 @@ class GQLCoreSchema:
             if name == '__type__':
                 continue
 
-            self.edb_schema, ptr = edb_type.resolve_pointer(
-                self.edb_schema, name)
+            ptr = edb_type.getptr(self.edb_schema, name)
 
             if not isinstance(ptr.get_target(self.edb_schema),
                               s_scalars.ScalarType):
@@ -538,8 +535,7 @@ class GQLBaseType(metaclass=GQLTypeMeta):
                 target = self.convert_edb_to_gql_type('std::str')
 
             else:
-                self.edb_schema, target = self.edb_base.resolve_pointer(
-                    self.edb_schema, name)
+                target = self.edb_base.getptr(self.edb_schema, name)
 
                 if target is not None:
                     target = self.convert_edb_to_gql_type(target)
@@ -549,8 +545,7 @@ class GQLBaseType(metaclass=GQLTypeMeta):
         return target
 
     def has_native_field(self, name):
-        self.edb_schema, ptr = self.edb_base.resolve_pointer(
-            self.edb_schema, name)
+        ptr = self.edb_base.getptr(self.edb_schema, name)
         return ptr is not None
 
     def issubclass(self, other):

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -210,13 +210,14 @@ class TupleIndirectionPointerRef(BasePointerRef):
 class TypeIndirectionLink(s_pointers.PointerLike):
     """A Link-alike that can be used in type indirection path ids."""
 
-    def __init__(self, source, target, *, optional, cardinality):
+    def __init__(self, source, target, *, optional, ancestral, cardinality):
         name = 'optindirection' if optional else 'indirection'
         self._name = sn.Name(module='__type__', name=name)
         self._source = source
         self._target = target
         self._cardinality = cardinality
         self._optional = optional
+        self._ancestral = ancestral
 
     def get_name(self, schema):
         return self._name
@@ -251,6 +252,9 @@ class TypeIndirectionLink(s_pointers.PointerLike):
     def is_optional(self):
         return self._optional
 
+    def is_ancestral(self):
+        return self._ancestral
+
     def generic(self, schema):
         return False
 
@@ -280,6 +284,7 @@ class TypeIndirectionLink(s_pointers.PointerLike):
 class TypeIndirectionPointerRef(BasePointerRef):
 
     optional: bool
+    ancestral: bool
 
 
 class Pointer(Base):

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -209,6 +209,7 @@ def ptrref_from_ptrcls(
     elif ptrcls.is_type_indirection():
         ircls = irast.TypeIndirectionPointerRef
         kwargs['optional'] = ptrcls.is_optional()
+        kwargs['ancestral'] = ptrcls.is_ancestral()
     else:
         ircls = irast.PointerRef
         kwargs['id'] = ptrcls.id
@@ -312,6 +313,7 @@ def ptrcls_from_ptrref(
             source=schema.get_by_id(ptrref.out_source.id),
             target=schema.get_by_id(ptrref.out_target.id),
             optional=ptrref.optional,
+            ancestral=ptrref.ancestral,
             cardinality=ptrref.out_cardinality,
         )
     else:

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -71,6 +71,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.disable_semi_join = set()
             self.unique_paths = set()
             self.force_optional = set()
+            self.join_target_type_filter = {}
 
             self.path_scope = collections.ChainMap()
             self.scope_tree = None
@@ -94,6 +95,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.disable_semi_join = prevlevel.disable_semi_join.copy()
             self.unique_paths = prevlevel.unique_paths.copy()
             self.force_optional = prevlevel.force_optional.copy()
+            self.join_target_type_filter = prevlevel.join_target_type_filter
 
             self.path_scope = prevlevel.path_scope
             self.scope_tree = prevlevel.scope_tree

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -131,12 +131,13 @@ def get_path_var(
                 # Foo.__type__.id gets resolved to the Foo.__type__
                 # column.
                 src_rptr = src_path_id.rptr()
-                while src_path_id.is_type_indirection_path():
+                pid = src_path_id
+                while pid.is_type_indirection_path():
                     # Skip type indirection step.
-                    src_src_path_id = src_path_id.src_path()
-                    if src_src_path_id is not None:
-                        src_rptr = src_src_path_id.rptr()
-                        src_path_id = src_src_path_id
+                    src_pid = pid.src_path()
+                    if src_pid is not None:
+                        src_rptr = src_pid.rptr()
+                        pid = src_pid
                     else:
                         break
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -299,11 +299,14 @@ def new_empty_rvar(
 
 def new_root_rvar(
         ir_set: irast.Set, *,
+        typeref: typing.Optional[irast.TypeRef]=None,
         ctx: context.CompilerContextLevel) -> pgast.BaseRangeVar:
     if not ir_set.path_id.is_objtype_path():
         raise ValueError('cannot create root rvar for non-object path')
+    if typeref is None:
+        typeref = ir_set.typeref
 
-    set_rvar = dbobj.range_for_set(ir_set, env=ctx.env)
+    set_rvar = dbobj.range_for_typeref(typeref, ir_set.path_id, env=ctx.env)
     pathctx.put_rvar_path_bond(set_rvar, ir_set.path_id)
     set_rvar.value_scope.add(ir_set.path_id)
 
@@ -447,7 +450,8 @@ def semi_join(
     rptr = ir_set.rptr
 
     # Target set range.
-    set_rvar = new_root_rvar(ir_set, ctx=ctx)
+    typeref = ctx.join_target_type_filter.get(ir_set, ir_set.typeref)
+    set_rvar = new_root_rvar(ir_set, typeref=typeref, ctx=ctx)
 
     # Link range.
     map_rvar = new_pointer_rvar(rptr, src_rvar=src_rvar, ctx=ctx)

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ BUILD_DEPS = [
 
 EXTRA_DEPS = {
     'test': [
-        'flake8~=3.6.0',
-        'pycodestyle~=2.4.0',
+        'flake8~=3.7.5',
+        'pycodestyle~=2.5.0',
         'coverage~=4.5.2',
         'requests-xml~=0.2.3',
     ],

--- a/tests/test_deltas.py
+++ b/tests/test_deltas.py
@@ -395,7 +395,7 @@ test::a -> array<std::int64>;
                 CREATE SINGLE PROPERTY test::__typename -> std::str {
                     SET computable := true;
                     SET default := SELECT
-                        __source__.__type__[IS schema::Type].name
+                        __source__.__type__.name
                     ;
                 };
             };

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4102,7 +4102,7 @@ class TestExpressions(tb.QueryTestCase):
                 edgedb.QueryError,
                 r'invalid type filter operand: std::int64 is not '
                 r'an object type',
-                position=23):
+                position=25):
 
             await self.con.execute('''\
                 SELECT 10[IS std::Object];
@@ -4123,7 +4123,7 @@ class TestExpressions(tb.QueryTestCase):
                 edgedb.QueryError,
                 r'invalid type filter operand: '
                 r'std::uuid is not an object type',
-                position=36):
+                position=32):
 
             await self.con.execute('''\
                 SELECT Object.id[IS uuid];

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1235,6 +1235,58 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
+    async def test_edgeql_select_polymorphic_09(self):
+        # Test simultaneous type indirection on source and target
+        # of a shape element.
+        await self.assert_query_result(
+            r'''
+            WITH MODULE test
+            SELECT Named {
+                name,
+                [IS Issue].references: File {
+                    name
+                }
+            }
+            FILTER .name ILIKE '%edgedb%'
+            ORDER BY .name;
+            ''',
+            [
+                {
+                    'name': 'Improve EdgeDB repl output rendering.',
+                    'references': [{'name': 'screenshot.png'}],
+                },
+                {
+                    'name': 'Release EdgeDB',
+                    'references': [],
+                },
+                {
+                    'name': 'edgedb.com',
+                    'references': [],
+                },
+            ],
+        )
+
+    async def test_edgeql_select_polymorphic_10(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE test
+            SELECT
+                count(Object[IS Named][IS Text])
+                != count(Object[IS Text]);
+            ''',
+            [True]
+        )
+
+        await self.assert_query_result(
+            r'''
+            WITH MODULE test
+            SELECT
+                count(User.<owner[IS Named][IS Text])
+                != count(User.<owner[IS Text]);
+            ''',
+            [True]
+        )
+
     async def test_edgeql_select_view_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1205,6 +1205,15 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_shape_30(self):
+        """
+        SELECT Named {
+            [IS Issue].references: File {
+                name
+            }
+        };
+        """
+
     def test_edgeql_syntax_shape_32(self):
         """
         SELECT User{
@@ -1471,6 +1480,7 @@ aa';
         SELECT Foo.bar[IS Baz];
         SELECT Foo.>bar[IS Baz];
         SELECT Foo.<bar[IS Baz];
+        SELECT Foo.<var[IS Baz][IS Spam].bar[IS Foo];
 
 % OK %
 
@@ -1483,6 +1493,7 @@ aa';
         SELECT Foo.bar[IS Baz];
         SELECT Foo.bar[IS Baz];
         SELECT Foo.<bar[IS Baz];
+        SELECT Foo.<var[IS Baz][IS Spam].bar[IS Foo];
         """
 
     def test_edgeql_syntax_path_02(self):
@@ -1543,31 +1554,37 @@ aa';
         SELECT Foo.bar[IS Case];
         """
 
-    # This is actually odd, but legal, simply filtering by type a
-    # particular array element.
-    #
     def test_edgeql_syntax_path_09(self):
         """
         SELECT Foo.bar[2][IS Baz];
 
 % OK %
 
-        SELECT (Foo.bar)[2][IS Baz];
+        SELECT ((Foo.bar)[2])[IS Baz];
         """
 
     def test_edgeql_syntax_path_10(self):
         """
         SELECT (Foo.bar)[2:4][IS Baz];
+% OK %
+
+        SELECT ((Foo.bar)[2:4])[IS Baz];
         """
 
     def test_edgeql_syntax_path_11(self):
         """
         SELECT (Foo.bar)[2:][IS Baz];
+% OK %
+
+        SELECT ((Foo.bar)[2:])[IS Baz];
         """
 
     def test_edgeql_syntax_path_12(self):
         """
         SELECT (Foo.bar)[:2][IS Baz];
+% OK %
+
+        SELECT ((Foo.bar)[:2])[IS Baz];
         """
 
     def test_edgeql_syntax_path_13(self):
@@ -1696,6 +1713,8 @@ aa';
     def test_edgeql_syntax_type_interpretation_02(self):
         """
         SELECT (Foo + Bar)[IS Spam].ham;
+% OK %
+        SELECT ((Foo + Bar))[IS Spam].ham;
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError, line=3, col=18)

--- a/tests/test_edgeql_utils.py
+++ b/tests/test_edgeql_utils.py
@@ -39,6 +39,9 @@ class TestEdgeQLUtils(tb.BaseEdgeQLCompilerTest):
         type Profile extending NamedObject:
             required property value -> str
 
+        type SpecialProfile extending Profile:
+            link parent -> SpecialProfile
+
         type User extending NamedObject:
             required property active -> bool
             multi link groups -> UserGroup
@@ -110,4 +113,22 @@ class TestEdgeQLUtils(tb.BaseEdgeQLCompilerTest):
             """SELECT 'a' ++ 'b'""",
             """SELECT 'ab'""",
             'std::str',
+        )
+
+    def test_edgeql_utils_normalize_12(self):
+        self._assert_normalize_expr(
+            """WITH MODULE test
+               SELECT User.profile[IS SpecialProfile].parent.value
+            """,
+            """SELECT test::User.profile[IS test::SpecialProfile].parent.value
+            """,
+        )
+
+    def test_edgeql_utils_normalize_13(self):
+        self._assert_normalize_expr(
+            """WITH MODULE test
+               SELECT User.profile[IS SpecialProfile][IS NamedObject].name
+            """,
+            "SELECT test::User.profile[IS test::SpecialProfile]"
+            "[IS test::NamedObject].name",
         )


### PR DESCRIPTION
The current situation with type indirections in paths (`[IS Type]`) is
fairly messy, mostly for historical reasons.  Originally, the `[IS ..]`
syntax (and its predecessors) were used to specify a concrete target
type for a link in a path, e.g. `Issue.references[IS File]`.
Subsequently, this was extended to arbitrary expressions, not just link
paths, so `Named[IS Text].body` became possible.  Finally, shapes also
have a dedicated syntax to specify either the source type indirection
(`{..., [IS Type].ptr}`), or the target type indirection
(`{..., link: Type }`).  All of these mechanisms are currently handled
slightly differently, and are specified in two AST places: `Ptr.target`
for shapes and link paths, and `TypeFilter` for all other expressions.
The `Ptr.target` mechanism also relies on a piece of complicated logic
in `Source.resolve_pointer()` to derive ad-hoc link instances that
satisfy a given path expression.

None of the existing complexity is really necessary, as the type
indirection is already treated as just another form of path indirection
(other being object pointer and link property references).  Given that
fact, all above variants can be represented with an indirection step, so

    Expr[IS Type] --> Path(steps = [Expr, TypeIndirection(Type)])

    Obj.link[IS Type] -> Path(steps = [Obj, Ptr(link),
                                       TypeIndirection(Type)]

    Obj { [IS Type].foo } is sugar for Obj { foo := Obj[IS Type].foo }

    Obj { foo: Type } is sugar for Obj { foo := Obj.foo[IS Type] }

This cleanup also fixes bugs inherent to the old construction,
so expressions like `Obj.link[IS Foo][IS Bar]` and
`Obj { [IS Type].foo: Target }` are now handled correctly.