### PR TITLE
docs: Minor tweak to attribute docs.

### DIFF
--- a/docs/datamodel/attributes.rst
+++ b/docs/datamodel/attributes.rst
@@ -4,12 +4,9 @@
 Schema Attributes
 =================
 
-*Schema attributes* are named values associated with schema items and are
-designed to hold arbitrary schema-level metadata.
-
-Every schema attribute is declared to have a specific
-:ref:`scalar type <ref_datamodel_scalar_types>` or a
-:ref:`collection type <ref_datamodel_collection_types>`.
+*Schema attributes* are named values associated with schema items and
+are designed to hold arbitrary schema-level metadata represented as a
+:eql:type:`str`.
 
 
 Definition

--- a/docs/edgeql/ddl/attributes.rst
+++ b/docs/edgeql/ddl/attributes.rst
@@ -118,7 +118,7 @@ Create an object type ``User`` and set its ``title`` attribute to
 .. code-block:: edgeql
 
     CREATE TYPE User {
-        SET ATTRIBUTE title := 'User type';
+        SET ATTRIBUTE title := "User type";
     };
 
 


### PR DESCRIPTION
Clarify that attributes can only be of type `str`.

Make the use of quotes consistent in text and examples for attribute
values.