### PR TITLE
docs: Fix the `code-block` spec for graphql schema.

### DIFF
--- a/docs/graphql/graphql.rst
+++ b/docs/graphql/graphql.rst
@@ -70,7 +70,7 @@ argument. The ``filter`` argument is customized to each specific type
 based on the available fields. In case of the sample schema, here's
 what the specification for the available filter arguments:
 
-.. code-block::
+.. code-block:: graphql-schema
 
     # this is Author-specific
     input FilterAuthor {
@@ -192,7 +192,7 @@ based on the available fields, much like the ``filter``. In case of
 the sample schema, here's what the specification for the available
 filter arguments:
 
-.. code-block::
+.. code-block:: graphql-schema
 
     # this is Author-specific
     input OrderAuthor {
@@ -259,7 +259,7 @@ The pagination works in a similar way to Relay Connections. In case of
 the sample schema, here's what the specification for the available
 filter arguments:
 
-.. code-block::
+.. code-block:: graphql-schema
 
     # a relevant Query definition snippet
     type Query {

--- a/edb/tools/docs/graphql.py
+++ b/edb/tools/docs/graphql.py
@@ -22,3 +22,4 @@ from edb.graphql.pygments import GraphQLLexer
 
 def setup_domain(app):
     app.add_lexer("graphql", GraphQLLexer())
+    app.add_lexer("graphql-schema", GraphQLLexer())

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -162,6 +162,10 @@ class TestDocSnippets(unittest.TestCase):
                 pass
             elif block.lang == 'graphql':
                 graphql_parser.parse(block.code)
+            elif block.lang == 'graphql-schema':
+                # The graphql-schema can be highlighted using graphql
+                # lexer, but it does not have a dedicated parser.
+                pass
             elif block.lang == 'json':
                 json.loads(block.code)
             elif block.lang == 'edgeql-repl':


### PR DESCRIPTION
The language used to specify the graphql schema is different from
graphql itself. However, there are enough similarities that a graphql
lexer can be used for highlighting purposes.