### PR TITLE
Stop relying on `edgedb-server` being on the PATH

### DIFF
--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -132,7 +132,11 @@ class Cluster:
 
         self._data_dir = data_dir
         self._location = data_dir
-        self._edgedb_cmd = ['edgedb-server', '-D', self._data_dir]
+        self._edgedb_cmd = [sys.executable, '-m', 'edb.server.main',
+                            '-D', self._data_dir]
+
+        if devmode.is_in_dev_mode():
+            self._edgedb_cmd.append('--devmode')
 
         if runstate_dir is not None:
             self._edgedb_cmd.extend(['--runstate-dir', runstate_dir])

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -349,3 +349,7 @@ def main(**kwargs):
 def main_dev():
     devmode.enable_dev_mode()
     main()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Refer to the server entrypoint by the Python module name.