### PR TITLE
edgeql: Augment DELETE syntax.

### DIFF
--- a/docs/edgeql/statements/delete.rst
+++ b/docs/edgeql/statements/delete.rst
@@ -10,18 +10,33 @@ DELETE
 
 .. eql:synopsis::
 
-    [ WITH <with-spec> [ , ... ] ]
-    DELETE <expr> ;
+    [ WITH <with-item> [, ...] ]
+
+    DELETE <expr>
+
+    [ FILTER <filter-expr> ]
+
+    [ ORDER BY <order-expr> [direction] [THEN ...] ]
+
+    [ OFFSET <offset-expr> ]
+
+    [ LIMIT  <limit-expr> ] ;
 
 :eql:synopsis:`WITH`
     Alias declarations.
 
     The ``WITH`` clause allows specifying module aliases as well
-    as expression aliases that can be referenced by the ``UPDATE``
+    as expression aliases that can be referenced by the ``DELETE``
     statement.  See :ref:`ref_eql_with` for more information.
 
-:eql:synopsis:`DELETE <expr>`
-    Remove objects returned by *expr* from the database.
+:eql:synopsis:`DELETE ...`
+    The entire :eql:synopsis:`DELETE ...` statement is syntactic
+    sugar for ``DELETE (SELECT ...)``. Therefore, the base
+    :eql:synopsis:`<expr>` and the following :eql:synopsis:`FILTER`,
+    :eql:synopsis:`ORDER BY`, :eql:synopsis:`OFFSET`, and
+    :eql:synopsis:`LIMIT` clauses shape the set to
+    be deleted the same way an explicit :ref:`SELECT
+    <ref_eql_statements_select>` would.
 
 
 Output
@@ -35,6 +50,14 @@ Examples
 ~~~~~~~~
 
 Here's a simple example of deleting a specific user:
+
+.. code-block:: edgeql
+
+    WITH MODULE example
+    DELETE User
+    FILTER User.name = 'Alice Smith';
+
+And here's the equivalent ``DELETE (SELECT ...)`` statement:
 
 .. code-block:: edgeql
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -336,10 +336,8 @@ Let's delete them now:
 
 .. code-block:: edgeql
 
-    DELETE (
-      SELECT AuthoredText
-      FILTER .author.login = 'carol'
-    );
+    DELETE AuthoredText
+    FILTER .author.login = 'carol';
 
 Result:
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -433,12 +433,16 @@ class ReturningStatement(Statement):
     result_alias: str
 
 
-class SelectQuery(ReturningStatement):
+class SelectClauseStatement(Statement):
     where: Expr
     orderby: typing.List[SortExpr]
     offset: Expr
     limit: Expr
     implicit: bool = False
+
+
+class SelectQuery(ReturningStatement, SelectClauseStatement):
+    pass
 
 
 class GroupQuery(SelectQuery, SubjStatement):
@@ -456,8 +460,8 @@ class UpdateQuery(SubjStatement):
     where: Expr
 
 
-class DeleteQuery(SubjStatement):
-    where: Expr
+class DeleteQuery(SubjStatement, SelectClauseStatement):
+    pass
 
 
 class ForQuery(SelectQuery):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -176,10 +176,18 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
         if parenthesise:
             self.write('(')
-        self._visit_aliases(node)
-        self.write('DELETE ')
-        self.visit(node.subject)
 
+        self._visit_aliases(node)
+
+        self.write('DELETE')
+        self._block_ws(1)
+        if node.subject_alias:
+            self.write(node.subject_alias, ' := ')
+        self.visit(node.subject)
+        self._block_ws(-1)
+        self._visit_filter(node)
+        self._visit_order(node)
+        self._visit_offset_limit(node)
         if parenthesise:
             self.write(')')
 

--- a/edb/edgeql/optimizer.py
+++ b/edb/edgeql/optimizer.py
@@ -180,13 +180,20 @@ class EdgeQLOptimizer:
         elif isinstance(expr, qlast.DeleteQuery):
             self._process_aliases(context, expr)
 
-            self._process_expr(context, expr.subject)
-
             if expr.where:
                 self._process_expr(context, expr.where)
 
-            if expr.result is not None:
-                self._process_expr(context, expr.result)
+            self._process_expr(context, expr.subject)
+
+            if expr.orderby:
+                for sort in expr.orderby:
+                    self._process_expr(context, sort.path)
+
+            if expr.offset:
+                self._process_expr(context, expr.offset)
+
+            if expr.limit:
+                self._process_expr(context, expr.limit)
 
         elif isinstance(expr, qlast.BinOp):
             self._process_expr(context, expr.left)

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -204,10 +204,15 @@ class SimpleUpdate(Nonterm):
 
 class SimpleDelete(Nonterm):
     def reduce_Delete(self, *kids):
-        "%reduce DELETE OptionallyAliasedExpr"
+        r"%reduce DELETE OptionallyAliasedExpr \
+                  OptFilterClause OptSortClause OptSelectLimit"
         self.val = qlast.DeleteQuery(
             subject=kids[1].val.expr,
             subject_alias=kids[1].val.alias,
+            where=kids[2].val,
+            orderby=kids[3].val,
+            offset=kids[4].val[0],
+            limit=kids[4].val[1],
         )
 
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2322,6 +2322,18 @@ aa';
         DELETE Foo{bar};
         """
 
+    def test_edgeql_syntax_delete_05(self):
+        """
+        WITH MODULE test
+        DELETE
+            User.name
+        FILTER
+            (User.age > 42)
+        ORDER BY
+            User.name ASC
+        OFFSET 2 LIMIT 5;
+        """
+
     def test_edgeql_syntax_update_01(self):
         """
         UPDATE Foo SET {bar := 42};


### PR DESCRIPTION
Make `DELETE ...` a sugar for `DELETE (SELECT ...)`i as this happens to
be the only sensible use of DELETE. This means that all the same
clauses as for SELECT are available for DELETE.

Update the documentation for DELETE.