### PR TITLE
Rename max* and min* constraints for consistency

### DIFF
--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -169,7 +169,7 @@ The standard library defines the following constraints:
         scalar type max_100 extending int64:
             constraint max(100)
 
-.. eql:constraint:: std::maxexclusive(max: anytype)
+.. eql:constraint:: std::max_ex(max: anytype)
 
     Specifies the maximum value (as an open interval) for the subject.
 
@@ -178,9 +178,9 @@ The standard library defines the following constraints:
     .. code-block:: eschema
 
         scalar type maxex_100 extending int64:
-            constraint maxexclusive(100)
+            constraint max_ex(100)
 
-.. eql:constraint:: std::maxlength(max: int64)
+.. eql:constraint:: std::max_len(max: int64)
 
     Specifies the maximum length of subject string representation.
 
@@ -189,7 +189,7 @@ The standard library defines the following constraints:
     .. code-block:: eschema
 
         scalar type username_t extending str:
-            constraint maxlength(30)
+            constraint max_len(30)
 
 .. eql:constraint:: std::min(min: anytype)
 
@@ -202,7 +202,7 @@ The standard library defines the following constraints:
         scalar type non_negative extending int64:
             constraint min(0)
 
-.. eql:constraint:: std::minexclusive(min: anytype)
+.. eql:constraint:: std::min_ex(min: anytype)
 
     Specifies the minimum value (as an open interval) for the subject.
 
@@ -211,9 +211,9 @@ The standard library defines the following constraints:
     .. code-block:: eschema
 
         scalar type positive_float extending float64:
-            constraint minexclusive(0)
+            constraint min_ex(0)
 
-.. eql:constraint:: std::minlength(min: int64)
+.. eql:constraint:: std::min_len(min: int64)
 
     Specifies the minimum length of subject string representation.
 
@@ -222,7 +222,7 @@ The standard library defines the following constraints:
     .. code-block:: eschema
 
         scalar type four_decimal_places extending int64:
-            constraint minlength(4)
+            constraint min_len(4)
 
 .. eql:constraint:: std::regexp(pattern: str)
 

--- a/docs/edgeql/ddl/constraints.rst
+++ b/docs/edgeql/ddl/constraints.rst
@@ -297,7 +297,7 @@ Create a maximum length constraint on the property "name" of the "User" type:
 .. code-block:: edgeql
 
     ALTER TYPE User ALTER PROPERTY name
-    CREATE CONSTRAINT maxlength(100);
+    CREATE CONSTRAINT max_len(100);
 
 
 ALTER CONSTRAINT
@@ -379,7 +379,7 @@ Change the error message on a maximum length constraint on the property
 .. code-block:: edgeql
 
     ALTER TYPE User ALTER PROPERTY name
-    ALTER CONSTRAINT maxlength
+    ALTER CONSTRAINT max_len
     SET errmessage := 'User name too long';
 
 
@@ -421,10 +421,10 @@ Parameters
 Examples
 --------
 
-Remove constraint "maxlength" from the property "name" of the
+Remove constraint "max_len" from the property "name" of the
 "User" type:
 
 .. code-block:: edgeql
 
     ALTER TYPE User ALTER PROPERTY name
-    DROP CONSTRAINT maxlength;
+    DROP CONSTRAINT max_len;

--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -366,7 +366,7 @@ Add a minimum-length constraint to link ``name`` of object type ``User``:
 
     ALTER TYPE User {
         ALTER LINK name {
-            CREATE CONSTRAINT minlength(3);
+            CREATE CONSTRAINT min_len(3);
         };
     };
 

--- a/docs/graphql/graphql.rst
+++ b/docs/graphql/graphql.rst
@@ -19,7 +19,7 @@ containing the following schema:
         property synopsis -> str
         link author -> Author
         property isbn -> str:
-            constraint maxlength(10)
+            constraint max_len(10)
 
 From the schema above EdgeDB will expose to GraphQL:
 

--- a/edb/lib/std/50-constraints.eql
+++ b/edb/lib/std/50-constraints.eql
@@ -67,7 +67,7 @@ std::min(min: anytype) EXTENDING std::constraint
 
 
 CREATE ABSTRACT CONSTRAINT
-std::minexclusive(min: anytype) EXTENDING std::min
+std::min_ex(min: anytype) EXTENDING std::min
 {
     SET errmessage := '{__subject__} must be greater than {min}.';
     SET expr := __subject__ > min;
@@ -82,7 +82,7 @@ std::length ON (len(<std::str>__subject__)) EXTENDING std::constraint
 
 
 CREATE ABSTRACT CONSTRAINT
-std::minlength(min: std::int64) EXTENDING (std::min, std::length)
+std::min_len(min: std::int64) EXTENDING (std::min, std::length)
 {
     SET errmessage :=
         '{__subject__} must be no shorter than {min} characters.';
@@ -98,14 +98,14 @@ std::regexp(pattern: anytype) EXTENDING std::constraint
 
 
 CREATE ABSTRACT CONSTRAINT
-std::maxlength(max: std::int64) EXTENDING (std::max, std::length)
+std::max_len(max: std::int64) EXTENDING (std::max, std::length)
 {
     SET errmessage := '{__subject__} must be no longer than {max} characters.';
 };
 
 
 CREATE ABSTRACT CONSTRAINT
-std::maxexclusive(max: anytype) EXTENDING std::max
+std::max_ex(max: anytype) EXTENDING std::max
 {
     SET errmessage := '{__subject__} must be less than {max}.';
 };

--- a/tests/schemas/constraints.eschema
+++ b/tests/schemas/constraints.eschema
@@ -18,14 +18,14 @@
 
 
 scalar type constraint_length extending str:
-    constraint maxlength(16)
-    constraint maxlength(10)
-    constraint minlength(5)
-    constraint minlength(8)
+    constraint max_len(16)
+    constraint max_len(10)
+    constraint min_len(5)
+    constraint min_len(8)
 
 
 scalar type constraint_length_2 extending constraint_length:
-    constraint minlength(9)
+    constraint min_len(9)
 
 
 scalar type constraint_minmax extending str:
@@ -88,7 +88,7 @@ type Object:
     property c_length -> constraint_length
     property c_length_2 -> constraint_length_2
     property c_length_3 -> constraint_length_2:
-        constraint minlength(10)
+        constraint min_len(10)
 
     property c_minmax -> constraint_minmax
     property c_strvalue -> constraint_strvalue

--- a/tests/schemas/constraints_migration/schema.eschema
+++ b/tests/schemas/constraints_migration/schema.eschema
@@ -18,14 +18,14 @@
 
 
 scalar type constraint_length extending str:
-    constraint maxlength(16)
-    constraint maxlength(10)
-    constraint minlength(5)
-    constraint minlength(8)
+    constraint max_len(16)
+    constraint max_len(10)
+    constraint min_len(5)
+    constraint min_len(8)
 
 
 scalar type constraint_length_2 extending constraint_length:
-    constraint minlength(9)
+    constraint min_len(9)
 
 
 scalar type constraint_minmax extending str:
@@ -78,7 +78,7 @@ type Object:
     property c_length -> constraint_length
     property c_length_2 -> constraint_length_2
     property c_length_3 -> constraint_length_2:
-        constraint minlength(10)
+        constraint min_len(10)
 
     property c_minmax -> constraint_minmax
     property c_strvalue -> constraint_strvalue

--- a/tests/schemas/constraints_migration/updated_schema.eschema
+++ b/tests/schemas/constraints_migration/updated_schema.eschema
@@ -18,14 +18,14 @@
 
 
 scalar type constraint_length extending str:
-    constraint maxlength(16)
-    constraint maxlength(10)
-    constraint minlength(5)
-    constraint minlength(8)
+    constraint max_len(16)
+    constraint max_len(10)
+    constraint min_len(5)
+    constraint min_len(8)
 
 
 scalar type constraint_length_2 extending constraint_length:
-    constraint minlength(9)
+    constraint min_len(9)
 
 
 scalar type constraint_minmax extending str:
@@ -83,7 +83,7 @@ type Object:
     property c_length -> constraint_length
     property c_length_2 -> constraint_length_2
     property c_length_3 -> constraint_length_2:
-        constraint minlength(10)
+        constraint min_len(10)
 
     property c_minmax -> constraint_minmax
     property c_strvalue -> constraint_strvalue

--- a/tests/schemas/issues.eschema
+++ b/tests/schemas/issues.eschema
@@ -21,7 +21,7 @@ abstract type Text:
     # This is an abstract object containing text.
     required property body -> str:
         # Maximum length of text is 10000 characters.
-        constraint maxlength(10000)
+        constraint max_len(10000)
 
 
 abstract type Named:

--- a/tests/test_docs_sphinx_ext.py
+++ b/tests/test_docs_sphinx_ext.py
@@ -397,12 +397,12 @@ class TestEqlConstraint(unittest.TestCase, BaseDomainTest):
 
             any.
 
-        .. eql:constraint:: std::maxlength(v: any)
+        .. eql:constraint:: std::max_len(v: any)
 
             blah
 
-        Testing :eql:constraint:`XXX <maxlength>` ref.
-        Testing :eql:constraint:`maxlength` ref.
+        Testing :eql:constraint:`XXX <max_len>` ref.
+        Testing :eql:constraint:`max_len` ref.
         '''
 
         out = self.build(src, format='xml')
@@ -418,10 +418,10 @@ class TestEqlConstraint(unittest.TestCase, BaseDomainTest):
             x.xpath('''
                 //paragraph /
                 reference[@eql-type="constraint" and
-                    @refid="constraint::std::maxlength"] /
+                    @refid="constraint::std::max_len"] /
                 literal / text()
             '''),
-            ['XXX', 'maxlength'])
+            ['XXX', 'max_len'])
 
     def test_sphinx_eql_constr_02(self):
         src = '''

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -437,7 +437,7 @@ class TestIntrospection(tb.QueryTestCase):
                 } FILTER .subject.name = 'test::body';
             """,
             [{
-                'name': 'std::maxlength',
+                'name': 'std::max_len',
                 'subject': {
                     'name': 'test::body'
                 },

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -162,7 +162,7 @@ abstract type OwnedObject:
         """
         abstract type Text:
             required property body -> str:
-                constraint maxlength (10000)
+                constraint max_len (10000)
         """
 
     def test_eschema_syntax_type_04(self):
@@ -661,13 +661,13 @@ scalar type special extending int:
     def test_eschema_syntax_scalar_11(self):
         """
 scalar type constraint_length extending str:
-     constraint maxlength(16+1, len(([1])))
+     constraint max_len(16+1, len(([1])))
         """
 
     def test_eschema_syntax_scalar_12(self):
         """
 scalar type constraint_length extending str:
-     constraint maxlength((16+(4*2))/((4)-1), len(([1])))
+     constraint max_len((16+(4*2))/((4)-1), len(([1])))
         """
 
     def test_eschema_syntax_constraint_01(self):
@@ -690,7 +690,7 @@ delegated constraint length:
 
     def test_eschema_syntax_constraint_03(self):
         """
-abstract constraint maxlength(param:anytype) extending max, length:
+abstract constraint max_len(param:anytype) extending max, length:
     errmessage := '{subject} must be no longer than {$param} characters.'
         """
 
@@ -703,7 +703,7 @@ abstract constraint max(param:anytype):
 abstract constraint length:
     subject := str::len(<str>__subject__)
 
-abstract constraint maxlength(param:anytype) extending max, length:
+abstract constraint max_len(param:anytype) extending max, length:
     errmessage := '{subject} must be no longer than {$param} characters.'
         """
 
@@ -719,10 +719,10 @@ abstract constraint maxldistance extending max, distance:
 
     @tb.must_fail(errors.SchemaSyntaxError,
                   r"missing type declaration.*`param`",
-                  line=2, col=31)
+                  line=2, col=29)
     def test_eschema_syntax_constraint_06(self):
         """
-abstract constraint maxlength(param) extending max, length
+abstract constraint max_len(param) extending max, length
         """
 
     @tb.must_fail(errors.SchemaSyntaxError,
@@ -754,7 +754,7 @@ type Foo:
     constraint maxldistance:
         errmessage := '{subject} must be no longer than {$param} meters.'
 
-    constraint maxlength(4)
+    constraint max_len(4)
         """
 
     def test_eschema_syntax_property_01(self):


### PR DESCRIPTION
Rename the following constraints:

* minexclusive -> min_ex
* maxexclusive -> max_ex
* minlength -> min_len
* maxlength -> max_len

The initial motivation was to rename just the {min|max}exclusive
constraints, because their name mentally clashes with std::exclusive.

{min|max}length were the also renamed to play nice with {min|max}_ex
names, as well as with the std::len function.