### PR TITLE
tests: Add view tests requiring cardinality inference.

### DIFF
--- a/tests/schemas/cards.eschema
+++ b/tests/schemas/cards.eschema
@@ -38,6 +38,8 @@ type User extending Named:
     property deck_cost := sum(__source__.deck.cost)
 
     multi link friends -> User
+    multi link awards -> Award:
+        constraint exclusive
 
 
 type Card extending Named:
@@ -50,3 +52,6 @@ type Card extending Named:
 
 
 type SpecialCard extending Card
+
+
+type Award extending Named

--- a/tests/schemas/cards_setup.eql
+++ b/tests/schemas/cards_setup.eql
@@ -80,6 +80,19 @@ INSERT SpecialCard {
     cost := 4
 };
 
+
+WITH MODULE test
+INSERT Award {
+    name := '1st'
+};
+
+
+WITH MODULE test
+INSERT Award {
+    name := '2nd'
+};
+
+
 # create players & decks
 WITH MODULE test
 INSERT User {
@@ -87,7 +100,8 @@ INSERT User {
     deck := (
         SELECT Card {@count := len(Card.element) - 2}
         FILTER .element IN {'Fire', 'Water'}
-    )
+    ),
+    awards := Award,
 };
 
 WITH MODULE test
@@ -95,7 +109,10 @@ INSERT User {
     name := 'Bob',
     deck := (
         SELECT Card {@count := 3} FILTER .element IN {'Earth', 'Water'}
-    )
+    ),
+    awards: {
+        name := '3rd'
+    }
 };
 
 WITH MODULE test

--- a/tests/schemas/cards_views_setup.eql
+++ b/tests/schemas/cards_views_setup.eql
@@ -85,3 +85,11 @@ CREATE VIEW test::AliasedFriends := (
     WITH MODULE test
     SELECT User { my_friends := User.friends, my_name := User.name }
 );
+
+
+CREATE VIEW test::AwardView := (
+    test::Award {
+        # this should be a single link, because awards are exclusive
+        winner := test::Award.<awards[IS test::User]
+    }
+);

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -1953,7 +1953,6 @@ class TestExpressions(tb.QueryTestCase):
             [True]
         )
 
-    @test.xfail('No method to generate code for TupleVar')
     async def test_edgeql_expr_valid_collection_23(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
One of these test cases shows the broken view in a sub-query.