### PR TITLE
Allow fully-qualified names in CONFIGURE

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -891,7 +891,7 @@ class _Optional(Expr):
 
 class ConfigOp(Expr):
 
-    name: str
+    name: ObjectRef
     system: bool
 
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1094,7 +1094,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self.write('CONFIGURE')
         self.write(' SYSTEM' if node.system else ' SESSION')
         self.write(' SET ')
-        self.write(ident_to_str(node.name))
+        self.visit(node.name)
         self.write(' := ')
         self.visit(node.expr)
 
@@ -1102,7 +1102,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self.write('CONFIGURE')
         self.write(' SYSTEM' if node.system else ' SESSION')
         self.write(' INSERT ')
-        self.write(ident_to_str(node.name))
+        self.visit(node.name)
         self.indentation += 1
         self._visit_shape(node.shape)
         self.indentation -= 1
@@ -1111,7 +1111,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self.write('CONFIGURE')
         self.write(' SYSTEM' if node.system else ' SESSION')
         self.write(' RESET ')
-        self.write(ident_to_str(node.name))
+        self.visit(node.name)
         self._visit_filter(node)
 
     def visit_SessionSetAliasDecl(self, node):

--- a/edb/edgeql/parser/grammar/config.py
+++ b/edb/edgeql/parser/grammar/config.py
@@ -34,19 +34,19 @@ class ConfigTarget(Nonterm):
 
 class ConfigOp(Nonterm):
 
-    def reduce_SET_Identifier_ASSIGN_Expr(self, *kids):
+    def reduce_SET_NodeName_ASSIGN_Expr(self, *kids):
         self.val = qlast.ConfigSet(
             name=kids[1].val,
             expr=kids[3].val,
         )
 
-    def reduce_INSERT_Identifier_Shape(self, *kids):
+    def reduce_INSERT_NodeName_Shape(self, *kids):
         self.val = qlast.ConfigInsert(
             name=kids[1].val,
             shape=kids[2].val,
         )
 
-    def reduce_RESET_Identifier_OptFilterClause(self, *kids):
+    def reduce_RESET_NodeName_OptFilterClause(self, *kids):
         self.val = qlast.ConfigReset(
             name=kids[1].val,
             where=kids[2].val,

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3435,10 +3435,16 @@ aa';
         """
         CONFIGURE SYSTEM SET foo := (SELECT User);
         CONFIGURE SESSION SET foo := (SELECT User);
+        CONFIGURE SYSTEM SET cfg::foo := (SELECT User);
+        CONFIGURE SESSION SET cfg::foo := (SELECT User);
         CONFIGURE SYSTEM RESET foo;
         CONFIGURE SESSION RESET foo;
+        CONFIGURE SYSTEM RESET cfg::foo;
+        CONFIGURE SESSION RESET cfg::foo;
         CONFIGURE SYSTEM INSERT Foo {bar := (SELECT 1)};
         CONFIGURE SESSION INSERT Foo {bar := (SELECT 1)};
+        CONFIGURE SYSTEM INSERT cfg::Foo {bar := (SELECT 1)};
+        CONFIGURE SESSION INSERT cfg::Foo {bar := (SELECT 1)};
         CONFIGURE SYSTEM RESET Foo FILTER (.bar = 2);
         CONFIGURE SESSION RESET Foo FILTER (.bar = 2);
         """


### PR DESCRIPTION
The `CONFIGURE` commands now allow referring to configuration parameters
by a fully-qualified name, for consistency with other commands.  The
only valid module is `cfg::`, and it is assumed when not specified
explicitly.