### PR TITLE
Rename schema::Database -> sys::Database

### DIFF
--- a/docs/datamodel/databases.rst
+++ b/docs/datamodel/databases.rst
@@ -13,4 +13,4 @@ cluster:
 
 .. code-block:: edgeql
 
-    SELECT schema::Database.name;
+    SELECT sys::Database.name;

--- a/edb/lib/schema.eql
+++ b/edb/lib/schema.eql
@@ -41,9 +41,6 @@ CREATE ABSTRACT TYPE schema::Object {
 };
 
 
-CREATE TYPE schema::Database EXTENDING schema::Object;
-
-
 # Base type for all *types*.
 CREATE ABSTRACT TYPE schema::Type EXTENDING schema::Object;
 CREATE TYPE schema::PseudoType EXTENDING schema::Type;

--- a/edb/lib/sys.eql
+++ b/edb/lib/sys.eql
@@ -20,6 +20,13 @@
 CREATE MODULE sys;
 
 
+CREATE TYPE sys::Database {
+    CREATE REQUIRED PROPERTY sys::name -> std::str {
+        SET readonly := True;
+    };
+};
+
+
 CREATE TYPE sys::Role {
     CREATE REQUIRED PROPERTY sys::name -> std::str {
         CREATE CONSTRAINT std::exclusive;

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -1942,7 +1942,7 @@ def _get_link_view(mcls, schema_cls, field, ptr, refdict, schema):
 
 
 def _generate_database_view(schema):
-    Database = schema.get('schema::Database')
+    Database = schema.get('sys::Database')
 
     view_query = f'''
         SELECT
@@ -1950,7 +1950,9 @@ def _generate_database_view(schema):
                 '{DATABASE_ID_NAMESPACE}'::uuid,
                 pg_database.oid::text)
                             AS id,
-            datname         AS name
+            datname         AS name,
+            (SELECT id FROM edgedb.Object
+                 WHERE name = 'sys::Database') AS __type__
         FROM
             pg_database
         WHERE

--- a/edb/repl/__init__.py
+++ b/edb/repl/__init__.py
@@ -257,7 +257,7 @@ class Cli:
     def command_list_dbs(self, args):
         result, _ = self.fetch(
             '''
-                SELECT name := schema::Database.name
+                SELECT name := sys::Database.name
                 ORDER BY name ASC
             ''',
             json=False

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2645,7 +2645,6 @@ class TestExpressions(tb.QueryTestCase):
                 'schema::Array',
                 'schema::Attribute',
                 'schema::AttributeSubject',
-                'schema::Database',
                 'schema::Delta',
                 'schema::DerivedLink',
                 'schema::DerivedObjectType',

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -451,10 +451,14 @@ class TestIntrospection(tb.QueryTestCase):
     async def test_edgeql_introspection_meta_01(self):
         await self.assert_query_result(
             r'''
-                SELECT count(schema::Database) > 0;
+                SELECT count(sys::Database) > 0;
             ''',
             [True],
         )
+
+        # regression test: sys::Database view must have a __tid__ column
+        dbs = await self.con.fetch('SELECT sys::Database')
+        self.assertTrue(len(dbs))
 
     async def test_edgeql_introspection_meta_02(self):
         await self.assert_query_result(
@@ -797,7 +801,7 @@ class TestIntrospection(tb.QueryTestCase):
 
     async def test_edgeql_introspection_database_01(self):
         res = await self.con.fetch_value(r"""
-            WITH MODULE schema
+            WITH MODULE sys
             SELECT count(Database.name);
         """)
 


### PR DESCRIPTION
A Database is, strictly speaking, not part of any schema, therefore the
'sys' module seems like a more appropriate place for it.