### PR TITLE
Remove implicit name-based link and pointer inheritance

### DIFF
--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -12,8 +12,7 @@ instances relate one *object* to one or more different objects.
 There are two kinds of link item declarations: *abstract links*,
 and *concrete links*.  Abstract links are defined on module level and are not
 tied to any particular object type.  Concrete links are defined on specific
-object types.  Concrete links automatically extend abstract links with the
-same name in the same module.
+object types.
 
 
 Definition
@@ -58,7 +57,7 @@ Parameters:
     :ref:`Schema attribute <ref_datamodel_attributes>` declarations.
 
 
-Abstract links can also be defined using the :eql:stmt:`CREATE ABSTRACT LINK`
+Abstract links can also be defined using the :eql:stmt:`CREATE LINK`
 EdgeQL command.
 
 
@@ -75,10 +74,12 @@ declaration in the context of a ``type`` declaration:
 .. eschema:synopsis::
 
     type <TypeName>:
-        [required] [inherited] [{multi | single}] link <link-name> -> <type>:
+        [required] [inherited] [{multi | single}] link <link-name> \
+            [ extending ( <parent-link> [, ...] )] -> <type>:
             [ expr := <computable-expr> ]
             [ default := <default-expr> ]
             [ readonly := {true | false} ]
+            [ <property-declarations> ]
             [ <attribute-declarations> ]
             [ <constraint-declarations> ]
             [ on target delete { restrict |
@@ -116,6 +117,19 @@ Parameters:
     of a size not greater than one.  ``single`` is assumed if nether
     ``multi`` nor ``single`` qualifier is specified.
 
+:eschema:synopsis:`extending <parent-link> [, ...]`
+    If specified, declares the *parents* of the link item.
+
+    Use of ``extending`` creates a persistent schema relationship
+    between this link and its parents.  Schema modifications
+    to the parent(s) propagate to the child.
+
+    If the same *property* name exists in more than one parent, or
+    is explicitly defined in the new link and at least one parent,
+    then the data types of the property targets must be *compatible*.
+    If there is no conflict, the link properties are merged to form a
+    single property in the new link item.
+
 :eschema:synopsis:`readonly`
     If specified, the link is considered *read-only*.  Modifications
     of this link are prohibited once an object is created.
@@ -131,6 +145,9 @@ Parameters:
     link cannot be *required* or *readonly* (the latter is implied and
     always true).  There is a shorthand form using the ``:=`` syntax,
     as shown in the synopsis above.
+
+:eschema:synopsis:`<property-declarations>`
+    :ref:`Property <ref_datamodel_props>` declarations.
 
 :eschema:synopsis:`<attribute-declarations>`
     :ref:`Schema attribute <ref_datamodel_attributes>` declarations.

--- a/docs/datamodel/props.rst
+++ b/docs/datamodel/props.rst
@@ -16,8 +16,7 @@ Every property is declared to have a specific
 There are two kinds of property item declarations: *abstract properties*,
 and *concrete properties*.  Abstract properties are defined on module level
 and are not tied to any particular object type or link.  Concrete properties
-are defined on specific object types.  Concrete properties automatically
-extend abstract properties with the same name in the same module.
+are defined on specific object types.
 
 
 Definition
@@ -53,7 +52,7 @@ Parameters:
 
 
 Abstract links can also be defined using the
-:eql:stmt:`CREATE ABSTRACT PROPERTY` EdgeQL command.
+:eql:stmt:`CREATE PROPERTY` EdgeQL command.
 
 
 .. _ref_datamodel_props_concrete:
@@ -67,7 +66,8 @@ declaration in the context of a ``type`` or ``abstract link`` declaration:
 .. eschema:synopsis::
 
     type <TypeName>:
-        [required] [inherited] [{multi|single}] property <prop-name> -> <type>:
+        [required] [inherited] [{multi|single}] property \
+            <prop-name> [ extending ( <parent-prop> [, ...] ) ] -> <type>:
             [ expr := <computable-expr> ]
             [ default := <default-expr> ]
             [ readonly := {true | false} ]
@@ -82,7 +82,8 @@ declaration in the context of a ``type`` or ``abstract link`` declaration:
     # link property declaration:
 
     abstract link <link-name>:
-        [inherited] property <prop-name>:
+        [inherited] property <prop-name> \
+            [ extending ( <parent-prop> [, ...] )] -> <type>:
             [ expr := <computable-expr> ]
             [ default := <default-expr> ]
             [ readonly := {true | false} ]
@@ -125,6 +126,13 @@ Parameters:
     .. note::
 
         Link properties are always ``single``.
+
+:eschema:synopsis:`extending <parent-prop> [, ...]`
+    If specified, declares the *parents* of the property item.
+
+    Use of ``extending`` creates a persistent schema relationship
+    between this property and its parents.  Schema modifications
+    to the parent(s) propagate to the child.
 
 :eschema:synopsis:`readonly`
     If specified, the property is considered *read-only*.  Modifications

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -673,6 +673,7 @@ class DropProperty(DropObject):
 
 class CreateConcretePointer(CreateObject):
 
+    bases: typing.List[TypeName]
     is_required: bool = False
     target: typing.Union[Expr, TypeExpr]
     cardinality: qltypes.Cardinality

--- a/edb/eschema/ast.py
+++ b/edb/eschema/ast.py
@@ -62,7 +62,9 @@ class Constraint(Spec):
 
 
 class Pointer(Spec):
-    name: qlast.ObjectRef
+    name: str
+
+    extends: typing.List[qlast.TypeName]
 
     # Computable links don't have a target
     target: typing.Optional[typing.List[qlast.TypeName]]

--- a/edb/eschema/codegen.py
+++ b/edb/eschema/codegen.py
@@ -140,7 +140,9 @@ class EdgeSchemaSourceGenerator(codegen.SourceGenerator):
 
         decl = node.__class__.__name__.lower()
         self.write(decl, ' ')
-        self.visit(node.name)
+        self.write(ident_to_str(node.name))
+        if node.extends:
+            self._visit_extends(node.extends)
 
         if node.expr:
             self._visit_assignment(node.expr)

--- a/edb/eschema/parser/grammar/declarations.py
+++ b/edb/eschema/parser/grammar/declarations.py
@@ -49,6 +49,7 @@ class NameWithParents(typing.NamedTuple):
 
 class PointerSpec(typing.NamedTuple):
     name: str
+    extends: typing.List[qlast.TypeName]
     target: typing.List[qlast.TypeName]
     spec: typing.List[esast.Base]
     expr: typing.Optional[qlast.Base]
@@ -808,32 +809,38 @@ class AssignmentBlob(parsing.Nonterm):
 
 
 class Spec(Nonterm):
-    def reduce_UnqualifiedObjectName_NL(self, *kids):
+    def reduce_NameAndExtends_NL(self, *kids):
         self.val = PointerSpec(
-            name=kids[0].val, target=None, spec=[], expr=None)
+            name=kids[0].val, extends=kids[0].val.extends,
+            target=None, spec=[], expr=None)
 
-    def reduce_UnqualifiedObjectName_DeclarationSpecsBlob(self, *kids):
+    def reduce_NameAndExtends_DeclarationSpecsBlob(self, *kids):
         self.val = PointerSpec(
-            name=kids[0].val, target=None, spec=kids[1].val, expr=None)
+            name=kids[0].val.name, extends=kids[0].val.extends,
+            target=None, spec=kids[1].val, expr=None)
 
-    def reduce_UnqualifiedObjectName_ARROW_TypeList_NL(self, *kids):
+    def reduce_NameAndExtends_ARROW_TypeList_NL(self, *kids):
         self.val = PointerSpec(
-            name=kids[0].val, target=kids[2].val, spec=[], expr=None)
+            name=kids[0].val.name, extends=kids[0].val.extends,
+            target=kids[2].val, spec=[], expr=None)
 
-    def reduce_UnqualifiedObjectName_ARROW_TypeList_DeclarationSpecsBlob(
+    def reduce_NameAndExtends_ARROW_TypeList_DeclarationSpecsBlob(
             self, *kids):
         self.val = PointerSpec(
-            name=kids[0].val, target=kids[2].val, spec=kids[3].val, expr=None)
+            name=kids[0].val.name, extends=kids[0].val.extends,
+            target=kids[2].val, spec=kids[3].val, expr=None)
 
-    def reduce_UnqualifiedObjectName_AssignmentBlob(self, *kids):
+    def reduce_NameAndExtends_AssignmentBlob(self, *kids):
         self.val = PointerSpec(
-            name=kids[0].val, target=None, spec=[], expr=kids[1].val)
+            name=kids[0].val.name, extends=kids[0].val.extends,
+            target=None, spec=[], expr=kids[1].val)
 
 
 class Link(Nonterm):
     def _process_pointerspec(self, p: PointerSpec):
         return esast.Link(
             name=p.name,
+            extends=p.extends,
             target=p.target,
             expr=p.expr,
             **_process_decl_body(
@@ -919,6 +926,7 @@ class Property(Nonterm):
     def _process_pointerspec(self, p: PointerSpec):
         return esast.Property(
             name=p.name,
+            extends=p.extends,
             target=p.target,
             expr=p.expr,
             **_process_decl_body(

--- a/edb/lib/_testmode.eql
+++ b/edb/lib/_testmode.eql
@@ -21,35 +21,35 @@
 # with --testmode.
 
 CREATE TYPE cfg::SessionConfig {
-    CREATE REQUIRED PROPERTY cfg::name -> std::str {
+    CREATE REQUIRED PROPERTY name -> std::str {
         CREATE CONSTRAINT std::exclusive;
     }
 };
 
 
 CREATE TYPE cfg::SystemConfig {
-    CREATE REQUIRED PROPERTY cfg::name -> std::str {
+    CREATE REQUIRED PROPERTY name -> std::str {
         CREATE CONSTRAINT std::exclusive;
     }
 };
 
 
 ALTER TYPE cfg::Config {
-    CREATE MULTI LINK cfg::sessobj -> cfg::SessionConfig;
-    CREATE MULTI LINK cfg::sysobj -> cfg::SystemConfig;
+    CREATE MULTI LINK sessobj -> cfg::SessionConfig;
+    CREATE MULTI LINK sysobj -> cfg::SystemConfig;
 
-    CREATE PROPERTY cfg::__internal_testvalue -> std::int64 {
+    CREATE PROPERTY __internal_testvalue -> std::int64 {
         SET ATTRIBUTE cfg::internal := 'true';
         SET ATTRIBUTE cfg::system := 'true';
         SET default := 0;
     };
 
-    CREATE PROPERTY cfg::__internal_no_const_folding -> std::bool {
+    CREATE PROPERTY __internal_no_const_folding -> std::bool {
         SET ATTRIBUTE cfg::internal := 'true';
         SET default := false;
     };
 
-    CREATE PROPERTY cfg::__internal_testmode -> std::bool {
+    CREATE PROPERTY __internal_testmode -> std::bool {
         SET ATTRIBUTE cfg::internal := 'true';
         SET default := false;
     };

--- a/edb/lib/cfg.eql
+++ b/edb/lib/cfg.eql
@@ -25,28 +25,28 @@ CREATE ABSTRACT ATTRIBUTE cfg::system;
 
 
 CREATE TYPE cfg::Port {
-    CREATE REQUIRED PROPERTY cfg::port -> std::int64 {
+    CREATE REQUIRED PROPERTY port -> std::int64 {
         CREATE CONSTRAINT std::exclusive;
         SET readonly := true;
     };
 
-    CREATE REQUIRED PROPERTY cfg::protocol -> std::str {
+    CREATE REQUIRED PROPERTY protocol -> std::str {
         SET readonly := true;
     };
 
-    CREATE REQUIRED PROPERTY cfg::database -> std::str {
+    CREATE REQUIRED PROPERTY database -> std::str {
         SET readonly := true;
     };
 
-    CREATE REQUIRED PROPERTY cfg::concurrency -> std::int64 {
+    CREATE REQUIRED PROPERTY concurrency -> std::int64 {
         SET readonly := true;
     };
 
-    CREATE REQUIRED PROPERTY cfg::user -> std::str {
+    CREATE REQUIRED PROPERTY user -> std::str {
         SET readonly := true;
     };
 
-    CREATE REQUIRED MULTI PROPERTY cfg::address -> std::str {
+    CREATE REQUIRED MULTI PROPERTY address -> std::str {
         SET readonly := true;
         SET default := {'localhost'};
     };
@@ -54,7 +54,7 @@ CREATE TYPE cfg::Port {
 
 
 CREATE TYPE cfg::Config {
-    CREATE MULTI LINK cfg::ports -> cfg::Port {
+    CREATE MULTI LINK ports -> cfg::Port {
         SET ATTRIBUTE cfg::system := 'true';
     };
 };

--- a/edb/lib/schema.eql
+++ b/edb/lib/schema.eql
@@ -37,7 +37,7 @@ CREATE SCALAR TYPE schema::operator_kind_t EXTENDING std::str {
 
 # Base type for all schema entities.
 CREATE ABSTRACT TYPE schema::Object {
-    CREATE REQUIRED PROPERTY schema::name -> std::str;
+    CREATE REQUIRED PROPERTY name -> std::str;
 };
 
 
@@ -46,13 +46,8 @@ CREATE ABSTRACT TYPE schema::Type EXTENDING schema::Object;
 CREATE TYPE schema::PseudoType EXTENDING schema::Type;
 
 
-CREATE ABSTRACT LINK std::__type__ {
-    SET readonly := True;
-};
-
-
 ALTER TYPE std::Object {
-    CREATE LINK std::__type__ -> schema::Type {
+    CREATE LINK __type__ -> schema::Type {
         SET readonly := True;
     };
 };
@@ -65,71 +60,63 @@ CREATE ABSTRACT TYPE schema::ContainerType EXTENDING schema::Type;
 
 
 CREATE TYPE schema::Array EXTENDING schema::ContainerType {
-    CREATE REQUIRED LINK schema::element_type -> schema::Type;
-    CREATE PROPERTY schema::dimensions -> array<std::int64>;
+    CREATE REQUIRED LINK element_type -> schema::Type;
+    CREATE PROPERTY dimensions -> array<std::int64>;
 };
 
 
 CREATE TYPE schema::TypeElement {
-    CREATE REQUIRED LINK schema::type -> schema::Type;
-    CREATE REQUIRED PROPERTY schema::num -> std::int64;
-    CREATE PROPERTY schema::name -> std::str;
+    CREATE REQUIRED LINK type -> schema::Type;
+    CREATE REQUIRED PROPERTY num -> std::int64;
+    CREATE PROPERTY name -> std::str;
 };
 
 
 CREATE TYPE schema::Tuple EXTENDING schema::ContainerType {
-    CREATE REQUIRED MULTI LINK schema::element_types -> schema::TypeElement {
+    CREATE REQUIRED MULTI LINK element_types -> schema::TypeElement {
         CREATE CONSTRAINT std::exclusive;
     };
 };
 
 
 CREATE TYPE schema::Delta EXTENDING schema::Object {
-    CREATE MULTI LINK schema::parents -> schema::Delta;
+    CREATE MULTI LINK parents -> schema::Delta;
 };
 
 
 CREATE TYPE schema::Attribute EXTENDING schema::Object {
-    CREATE PROPERTY schema::inheritable -> std::bool;
-};
-
-
-CREATE ABSTRACT LINK schema::attributes {
-    CREATE PROPERTY schema::value -> std::str;
+    CREATE PROPERTY inheritable -> std::bool;
 };
 
 
 CREATE ABSTRACT TYPE schema::AttributeSubject EXTENDING schema::Object {
-    CREATE MULTI LINK schema::attributes -> schema::Attribute;
+    CREATE MULTI LINK attributes -> schema::Attribute {
+        CREATE PROPERTY value -> std::str;
+    };
 };
 
 
 CREATE ABSTRACT TYPE schema::InheritingObject EXTENDING schema::Object {
-    CREATE MULTI LINK schema::bases -> schema::InheritingObject;
-    CREATE MULTI LINK schema::mro -> schema::InheritingObject;
+    CREATE MULTI LINK bases -> schema::InheritingObject;
+    CREATE MULTI LINK mro -> schema::InheritingObject;
 
-    CREATE PROPERTY schema::is_abstract -> std::bool {
+    CREATE PROPERTY is_abstract -> std::bool {
         SET default := false;
     };
 
-    CREATE PROPERTY schema::is_final -> std::bool {
+    CREATE PROPERTY is_final -> std::bool {
         SET default := false;
     };
 };
 
 
 CREATE TYPE schema::Parameter {
-    CREATE REQUIRED LINK schema::type -> schema::Type;
-    CREATE REQUIRED PROPERTY schema::typemod -> std::str;
-    CREATE REQUIRED PROPERTY schema::kind -> std::str;
-    CREATE REQUIRED PROPERTY schema::num -> std::int64;
-    CREATE PROPERTY schema::name -> std::str;
-    CREATE PROPERTY schema::default -> std::str;
-};
-
-
-CREATE ABSTRACT LINK schema::args {
-    CREATE PROPERTY schema::value -> std::str;
+    CREATE REQUIRED LINK type -> schema::Type;
+    CREATE REQUIRED PROPERTY typemod -> std::str;
+    CREATE REQUIRED PROPERTY kind -> std::str;
+    CREATE REQUIRED PROPERTY num -> std::int64;
+    CREATE PROPERTY name -> std::str;
+    CREATE PROPERTY default -> std::str;
 };
 
 
@@ -137,48 +124,49 @@ CREATE ABSTRACT TYPE schema::CallableObject
     EXTENDING schema::AttributeSubject
 {
 
-    CREATE MULTI LINK schema::params -> schema::Parameter {
+    CREATE MULTI LINK params -> schema::Parameter {
         CREATE CONSTRAINT std::exclusive;
     };
 
-    CREATE LINK schema::return_type -> schema::Type;
-    CREATE PROPERTY schema::return_typemod -> std::str;
+    CREATE LINK return_type -> schema::Type;
+    CREATE PROPERTY return_typemod -> std::str;
 };
 
 
 CREATE TYPE schema::Constraint EXTENDING
         (schema::CallableObject, schema::InheritingObject)
 {
-    CREATE MULTI LINK schema::args -> schema::Parameter {
+    CREATE MULTI LINK args -> schema::Parameter {
         CREATE CONSTRAINT std::exclusive;
+        CREATE PROPERTY value -> std::str;
     };
-    CREATE PROPERTY schema::expr -> std::str;
-    CREATE PROPERTY schema::subjectexpr -> std::str;
-    CREATE PROPERTY schema::finalexpr -> std::str;
-    CREATE PROPERTY schema::errmessage -> std::str;
+    CREATE PROPERTY expr -> std::str;
+    CREATE PROPERTY subjectexpr -> std::str;
+    CREATE PROPERTY finalexpr -> std::str;
+    CREATE PROPERTY errmessage -> std::str;
 };
 
 
 CREATE ABSTRACT TYPE schema::ConsistencySubject EXTENDING schema::Object {
-    CREATE MULTI LINK schema::constraints -> schema::Constraint {
+    CREATE MULTI LINK constraints -> schema::Constraint {
         CREATE CONSTRAINT std::exclusive;
     };
 };
 
 
 ALTER TYPE schema::Constraint {
-    CREATE LINK schema::subject :=
+    CREATE LINK subject :=
         __source__.<constraints[IS schema::ConsistencySubject];
 };
 
 
 CREATE TYPE schema::SourceIndex EXTENDING schema::Object {
-    CREATE PROPERTY schema::expr -> std::str;
+    CREATE PROPERTY expr -> std::str;
 };
 
 
 CREATE ABSTRACT TYPE schema::Source EXTENDING schema::Object {
-    CREATE MULTI LINK schema::indexes -> schema::SourceIndex {
+    CREATE MULTI LINK indexes -> schema::SourceIndex {
         CREATE CONSTRAINT std::exclusive;
     };
 };
@@ -188,13 +176,13 @@ CREATE ABSTRACT TYPE schema::Pointer EXTENDING
         (schema::InheritingObject, schema::ConsistencySubject,
          schema::AttributeSubject)
 {
-    CREATE REQUIRED PROPERTY schema::cardinality -> schema::cardinality_t;
-    CREATE REQUIRED PROPERTY schema::required -> std::bool;
+    CREATE REQUIRED PROPERTY cardinality -> schema::cardinality_t;
+    CREATE REQUIRED PROPERTY required -> std::bool;
 };
 
 
 ALTER TYPE schema::Source {
-    CREATE MULTI LINK schema::pointers -> schema::Pointer {
+    CREATE MULTI LINK pointers -> schema::Pointer {
         CREATE CONSTRAINT std::exclusive;
     };
 };
@@ -204,7 +192,7 @@ CREATE TYPE schema::ScalarType EXTENDING
         (schema::InheritingObject, schema::ConsistencySubject,
          schema::AttributeSubject, schema::Type)
 {
-    CREATE PROPERTY schema::default -> std::str;
+    CREATE PROPERTY default -> std::str;
 };
 
 
@@ -233,23 +221,20 @@ CREATE TYPE schema::Property EXTENDING schema::Pointer;
 
 
 ALTER TYPE schema::Pointer {
-    CREATE LINK schema::source -> schema::Source;
-    CREATE LINK schema::target -> schema::Type;
+    CREATE LINK source -> schema::Source;
+    CREATE LINK target -> schema::Type;
 };
 
 
 ALTER TYPE schema::Link {
-    CREATE LINK schema::properties := __source__.pointers;
-    CREATE PROPERTY schema::on_target_delete ->
-        schema::target_delete_action_t;
+    CREATE LINK properties := __source__.pointers;
+    CREATE PROPERTY on_target_delete -> schema::target_delete_action_t;
 };
 
 
 ALTER TYPE schema::ObjectType {
-    CREATE LINK schema::links :=
-        __source__.pointers[IS schema::Link];
-    CREATE LINK schema::properties :=
-        __source__.pointers[IS schema::Property];
+    CREATE LINK links := __source__.pointers[IS schema::Link];
+    CREATE LINK properties := __source__.pointers[IS schema::Property];
 };
 
 
@@ -257,14 +242,14 @@ CREATE TYPE schema::Function EXTENDING schema::CallableObject;
 
 
 CREATE TYPE schema::Operator EXTENDING schema::CallableObject {
-    CREATE PROPERTY schema::operator_kind -> schema::operator_kind_t;
-    CREATE LINK schema::commutator -> schema::Operator;
+    CREATE PROPERTY operator_kind -> schema::operator_kind_t;
+    CREATE LINK commutator -> schema::Operator;
 };
 
 
 CREATE TYPE schema::Cast EXTENDING schema::Object {
-    CREATE LINK schema::from_type -> schema::Type;
-    CREATE LINK schema::to_type -> schema::Type;
-    CREATE PROPERTY schema::allow_implicit -> std::bool;
-    CREATE PROPERTY schema::allow_assignment -> std::bool;
+    CREATE LINK from_type -> schema::Type;
+    CREATE LINK to_type -> schema::Type;
+    CREATE PROPERTY allow_implicit -> std::bool;
+    CREATE PROPERTY allow_assignment -> std::bool;
 };

--- a/edb/lib/std/60-baseobject.eql
+++ b/edb/lib/std/60-baseobject.eql
@@ -28,10 +28,8 @@ CREATE ABSTRACT PROPERTY std::target;
 
 CREATE ABSTRACT LINK std::link;
 
-CREATE ABSTRACT PROPERTY std::id EXTENDING std::property;
-
 CREATE ABSTRACT TYPE std::Object {
-    CREATE REQUIRED PROPERTY std::id -> std::uuid {
+    CREATE REQUIRED PROPERTY id -> std::uuid {
         SET default := (SELECT std::uuid_generate_v1mc());
         SET readonly := True;
         CREATE CONSTRAINT std::exclusive;

--- a/edb/lib/stdgraphql.eql
+++ b/edb/lib/stdgraphql.eql
@@ -23,13 +23,13 @@ CREATE MODULE stdgraphql;
 # these are just some placeholders for packaging GraphQL queries
 CREATE TYPE stdgraphql::Query;
 ALTER TYPE stdgraphql::Query {
-    CREATE PROPERTY stdgraphql::__typename := 'Query';
+    CREATE PROPERTY __typename := 'Query';
 };
 
 
 CREATE TYPE stdgraphql::Mutation;
 ALTER TYPE stdgraphql::Mutation {
-    CREATE PROPERTY stdgraphql::__typename := 'Mutation';
+    CREATE PROPERTY __typename := 'Mutation';
 };
 
 

--- a/edb/lib/sys.eql
+++ b/edb/lib/sys.eql
@@ -21,25 +21,25 @@ CREATE MODULE sys;
 
 
 CREATE TYPE sys::Database {
-    CREATE REQUIRED PROPERTY sys::name -> std::str {
+    CREATE REQUIRED PROPERTY name -> std::str {
         SET readonly := True;
     };
 };
 
 
 CREATE TYPE sys::Role {
-    CREATE REQUIRED PROPERTY sys::name -> std::str {
+    CREATE REQUIRED PROPERTY name -> std::str {
         CREATE CONSTRAINT std::exclusive;
     };
 
-    CREATE REQUIRED PROPERTY sys::allow_login -> std::bool;
-    CREATE REQUIRED PROPERTY sys::is_superuser -> std::bool;
-    CREATE PROPERTY sys::password -> std::str;
+    CREATE REQUIRED PROPERTY allow_login -> std::bool;
+    CREATE REQUIRED PROPERTY is_superuser -> std::bool;
+    CREATE PROPERTY password -> std::str;
 };
 
 
 ALTER TYPE sys::Role {
-    CREATE MULTI LINK sys::member_of -> sys::Role;
+    CREATE MULTI LINK member_of -> sys::Role;
 };
 
 

--- a/edb/pgsql/compiler/dbobj.py
+++ b/edb/pgsql/compiler/dbobj.py
@@ -172,6 +172,7 @@ def table_from_ptrref(
 def range_for_ptrref(
         ptrref: irast.BasePointerRef, *,
         include_overlays: bool=True,
+        only_self: bool=False,
         env: context.Environment) -> pgast.BaseRangeVar:
     """"Return a Range subclass corresponding to a given ptr step.
 
@@ -189,7 +190,12 @@ def range_for_ptrref(
 
     set_ops = []
 
-    for src_ptrref in {ptrref} | ptrref.descendants:
+    if only_self:
+        ptrrefs = {ptrref}
+    else:
+        ptrrefs = {ptrref} | ptrref.descendants
+
+    for src_ptrref in ptrrefs:
         table = table_from_ptrref(src_ptrref, env=env)
 
         qry = pgast.SelectStmt()

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -603,7 +603,7 @@ def process_link_update(
         mptrref = ptrref
 
     target_rvar = dbobj.range_for_ptrref(
-        mptrref, include_overlays=False, env=ctx.env)
+        mptrref, include_overlays=False, only_self=True, env=ctx.env)
     target_alias = target_rvar.alias.aliasname
 
     target_tab_name = (target_rvar.relation.schemaname,

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -585,9 +585,7 @@ class IntrospectionMech:
         for name, r in links_list.items():
             bases = tuple()
 
-            if r['source']:
-                bases = (sn.shortname_from_fullname(name), )
-            elif r['bases']:
+            if r['bases']:
                 bases = tuple(sn.Name(b) for b in r['bases'])
             elif name != 'std::link':
                 bases = (sn.Name('std::link'), )
@@ -698,9 +696,7 @@ class IntrospectionMech:
 
             bases = ()
 
-            if r['source']:
-                bases = (sn.shortname_from_fullname(name), )
-            elif r['bases']:
+            if r['bases']:
                 bases = tuple(sn.Name(b) for b in r['bases'])
             elif name != 'std::property':
                 bases = (sn.Name('std::property'), )

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -849,8 +849,8 @@ class RenameObject(ObjectCommand):
         return schema
 
     def apply(self, schema, context):
-        scls = self.get_object(schema)
-        self.scls = scls
+        parent_ctx = context.get(CommandContextToken)
+        scls = self.scls = parent_ctx.op.scls
 
         schema = self._rename_begin(schema, context, scls)
         schema = self._rename_innards(schema, context, scls)

--- a/edb/schema/derivable.py
+++ b/edb/schema/derivable.py
@@ -134,6 +134,23 @@ class DerivableObjectBase(s_abc.Object):
 
         return schema, derived
 
+    @classmethod
+    def derive_from_root(cls, schema, source, unqualified_name, *qualifiers,
+                         merge_bases=None, attrs=None, dctx=None):
+        root = schema.get(cls.get_default_base_name())
+        source_name = source.get_name(schema)
+        shortname = sn.Name(
+            module=source_name.module,
+            name=unqualified_name
+        )
+        name = sn.Name(
+            module=source_name.module,
+            name=sn.get_specialized_name(shortname, source_name, *qualifiers),
+        )
+
+        return root.derive(schema, source, *qualifiers, name=name,
+                           merge_bases=merge_bases, attrs=attrs, dctx=dctx)
+
 
 class DerivableObject(so.Object, DerivableObjectBase):
 
@@ -143,6 +160,13 @@ class DerivableObject(so.Object, DerivableObjectBase):
         bool,
         default=False, compcoef=None,
         introspectable=False, inheritable=False)
+
+    # Whether the object is a result of refdict inheritance
+    # merge.
+    inherited = so.SchemaField(
+        bool,
+        default=False, compcoef=None,
+        inheritable=False)
 
     @classmethod
     def inherit_pure(cls, schema, item, source, *, dctx=None):

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -893,11 +893,16 @@ class Object(s_abc.Object, metaclass=ObjectMeta):
         local_coll = self.get_explicit_field_value(schema, local_attr, None)
         all_coll = self.get_explicit_field_value(schema, attr, None)
 
+        refname = colltype.get_key_for(schema, obj)
+
         if local_coll is not None:
-            if not replace:
-                schema, local_coll = local_coll.add(schema, obj)
+            if obj.get_inherited(schema) and local_coll.has(schema, refname):
+                pass
             else:
-                schema, local_coll = local_coll.update(schema, [obj])
+                if not replace:
+                    schema, local_coll = local_coll.add(schema, obj)
+                else:
+                    schema, local_coll = local_coll.update(schema, [obj])
         else:
             local_coll = colltype.create(schema, [obj])
 

--- a/tests/schemas/cards.eschema
+++ b/tests/schemas/cards.eschema
@@ -22,22 +22,17 @@ abstract type Named:
         delegated constraint exclusive
 
 
-abstract link deck:
-    property count -> int64
-
-
-abstract link friends:
-    property nickname -> str
-    # how the friend responded to requests for a favor
-    #property favor -> array<bool>
-
-
 type User extending Named:
-    multi link deck -> Card
+    multi link deck -> Card:
+        property count -> int64
 
     property deck_cost := sum(__source__.deck.cost)
 
-    multi link friends -> User
+    multi link friends -> User:
+        property nickname -> str
+        # how the friend responded to requests for a favor
+        #property favor -> array<bool>
+
     multi link awards -> Award:
         constraint exclusive
 

--- a/tests/schemas/cards_views_setup.eql
+++ b/tests/schemas/cards_views_setup.eql
@@ -73,19 +73,12 @@ CREATE VIEW test::DaveCard := (
 );
 
 
-# FIXME: the computable in the view doesn't work without an explicit
-# abstract link
-CREATE ABSTRACT LINK test::my_friends;
-CREATE ABSTRACT PROPERTY test::my_name;
 CREATE VIEW test::AliasedFriends := (
     WITH MODULE test
     SELECT User { my_friends := User.friends, my_name := User.name }
 );
 
 
-# FIXME: the computable in the view doesn't work without an explicit
-# abstract link
-CREATE ABSTRACT LINK test::winner;
 CREATE VIEW test::AwardView := (
     test::Award {
         # this should be a single link, because awards are exclusive

--- a/tests/schemas/constraints.eschema
+++ b/tests/schemas/constraints.eschema
@@ -100,11 +100,13 @@ type UniqueName:
     property name -> str:
         constraint exclusive
 
-    link link_with_unique_property -> Object
+    link link_with_unique_property \
+        extending (link_with_unique_property) -> Object
 
-    link link_with_unique_property_inherited -> Object
+    link link_with_unique_property_inherited \
+        extending (link_with_unique_property_inherited) -> Object
 
-    link translated_label -> Label:
+    link translated_label extending (translated_label) -> Label:
         constraint exclusive on (__subject__@source, __subject__@lang)
         constraint exclusive on (__subject__@prop1)
 
@@ -117,9 +119,11 @@ type UniqueDescription:
     property description -> str:
         constraint exclusive
 
-    link another_link_with_unique_property -> Object
+    link another_link_with_unique_property \
+        extending (another_link_with_unique_property) -> Object
 
-    link another_link_with_unique_property_inherited -> Object
+    link another_link_with_unique_property_inherited \
+        extending (another_link_with_unique_property)  -> Object
 
 
 type UniqueDescriptionInherited extending UniqueDescription

--- a/tests/schemas/constraints_migration/schema.eschema
+++ b/tests/schemas/constraints_migration/schema.eschema
@@ -89,11 +89,13 @@ type UniqueName:
     property name -> str:
         constraint exclusive
 
-    link link_with_unique_property -> Object
+    link link_with_unique_property \
+        extending (link_with_unique_property) -> Object
 
-    link link_with_unique_property_inherited -> Object
+    link link_with_unique_property_inherited \
+        extending (link_with_unique_property_inherited) -> Object
 
-    link translated_label -> Label:
+    link translated_label extending (translated_label) -> Label:
         constraint exclusive on (__subject__@source, __subject__@lang)
         constraint exclusive on (__subject__@prop1)
 
@@ -106,9 +108,11 @@ type UniqueDescription:
     property description -> str:
         constraint exclusive
 
-    link another_link_with_unique_property -> Object
+    link another_link_with_unique_property \
+        extending (another_link_with_unique_property) -> Object
 
-    link another_link_with_unique_property_inherited -> Object
+    link another_link_with_unique_property_inherited \
+        extending (another_link_with_unique_property)  -> Object
 
 
 type UniqueDescriptionInherited extending UniqueDescription

--- a/tests/schemas/constraints_migration/updated_schema.eschema
+++ b/tests/schemas/constraints_migration/updated_schema.eschema
@@ -89,7 +89,7 @@ type Object:
     property c_strvalue -> constraint_strvalue
     property c_enum -> constraint_enum
 
-    link translated_label -> Label:
+    link translated_label extending (translated_label) -> Label:
         constraint exclusive on (__subject__@source, __subject__@lang)
         constraint exclusive on (__subject__@prop1)
 
@@ -101,11 +101,13 @@ type UniqueName:
     property name2 -> str:
         constraint exclusive
 
-    link link_with_unique_property -> Object
+    link link_with_unique_property \
+        extending (link_with_unique_property) -> Object
 
-    link link_with_unique_property_inherited -> Object
+    link link_with_unique_property_inherited \
+        extending (link_with_unique_property_inherited) -> Object
 
-    link translated_label -> Label:
+    link translated_label extending (translated_label) -> Label:
         constraint exclusive on (__subject__@source, __subject__@lang)
         constraint exclusive on (__subject__@prop1)
 
@@ -120,9 +122,11 @@ type UniqueNameGrandchild extending UniqueNameInherited
 type UniqueDescription:
     property description -> str
 
-    link another_link_with_unique_property -> Object
+    link another_link_with_unique_property \
+        extending (another_link_with_unique_property) -> Object
 
-    link another_link_with_unique_property_inherited -> Object
+    link another_link_with_unique_property_inherited \
+        extending (another_link_with_unique_property_inherited) -> Object
 
 
 type UniqueDescriptionInherited extending UniqueDescription

--- a/tests/schemas/insert.eschema
+++ b/tests/schemas/insert.eschema
@@ -17,9 +17,6 @@
 #
 
 
-abstract link subordinates:
-    property comment -> str
-
 type Subordinate:
     required property name -> str
 
@@ -29,7 +26,8 @@ type InsertTest:
     required property l2 -> int64
     property l3 -> str:
         default := "test"
-    multi link subordinates -> Subordinate
+    multi link subordinates -> Subordinate:
+        property comment -> str
 
 type Annotation:
     required property name -> str

--- a/tests/schemas/issues.eschema
+++ b/tests/schemas/issues.eschema
@@ -35,13 +35,10 @@ abstract type Dictionary extending Named:
         delegated constraint exclusive
 
 
-abstract link todo:
-    property rank -> int64:
-        default := 42
-
-
 type User extending Dictionary:
-    multi link todo -> Issue
+    multi link todo -> Issue:
+        property rank -> int64:
+            default := 42
 
 
 abstract type Owned:

--- a/tests/schemas/updates.eschema
+++ b/tests/schemas/updates.eschema
@@ -25,27 +25,21 @@ type Tag:
     required property name -> str:
         constraint exclusive
 
-abstract link annotated_status:
-    property note -> str
-
-abstract link weighted_tags:
-    property weight -> int64
-
-abstract link annotated_tests:
-    property note -> str
-
 type UpdateTest:
     required property name -> str
     property comment -> str
 
     # for testing singleton links
     link status -> Status
-    link annotated_status -> Status
+    link annotated_status -> Status:
+        property note -> str
 
     # for testing links to sets
     multi link tags -> Tag
-    multi link weighted_tags -> Tag
+    multi link weighted_tags -> Tag:
+        property weight -> int64
 
     # for testing links to sets of the same type as originator
     multi link related -> UpdateTest
-    multi link annotated_tests -> UpdateTest
+    multi link annotated_tests -> UpdateTest:
+        property note -> str

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -591,12 +591,12 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
     async def test_constraints_ddl_01(self):
         qry = """
             CREATE ABSTRACT LINK test::translated_label {
-                CREATE PROPERTY test::lang -> std::str;
-                CREATE PROPERTY test::prop1 -> std::str;
+                CREATE PROPERTY lang -> std::str;
+                CREATE PROPERTY prop1 -> std::str;
             };
 
             CREATE ABSTRACT LINK test::link_with_exclusive_property {
-                CREATE PROPERTY test::exclusive_property -> std::str {
+                CREATE PROPERTY exclusive_property -> std::str {
                     CREATE CONSTRAINT std::exclusive;
                 };
             };
@@ -605,11 +605,11 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
                 EXTENDING test::link_with_exclusive_property;
 
             CREATE TYPE test::UniqueName {
-                CREATE PROPERTY test::name -> std::str {
+                CREATE PROPERTY name -> std::str {
                     CREATE CONSTRAINT std::exclusive;
                 };
 
-                CREATE LINK test::link_with_exclusive_property -> std::Object;
+                CREATE LINK link_with_exclusive_property -> std::Object;
             };
         """
 
@@ -633,7 +633,7 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
 
         qry = """
             CREATE TYPE test::AbstractConstraintParent {
-                CREATE PROPERTY test::name -> std::str {
+                CREATE PROPERTY name -> std::str {
                     CREATE DELEGATED CONSTRAINT std::exclusive;
                 };
             };
@@ -686,11 +686,11 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
             };
 
             CREATE TYPE test::ConstraintOnTest1 {
-                CREATE PROPERTY test::foo -> std::str {
+                CREATE PROPERTY foo -> std::str {
                     CREATE CONSTRAINT test::mymax1(3);
                 };
 
-                CREATE PROPERTY test::bar -> std::str {
+                CREATE PROPERTY bar -> std::str {
                     CREATE CONSTRAINT test::mymax_ext1(3);
                 };
             };
@@ -823,11 +823,11 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
             };
 
             CREATE TYPE test::ConstraintOnTest2 {
-                CREATE PROPERTY test::foo -> std::str {
+                CREATE PROPERTY foo -> std::str {
                     CREATE CONSTRAINT test::mymax2(3) ON (len(__subject__));
                 };
 
-                CREATE PROPERTY test::bar -> std::str {
+                CREATE PROPERTY bar -> std::str {
                     CREATE CONSTRAINT std::max(3) ON (len(__subject__)) {
                         SET errmessage :=
                     # XXX: once simple string concat is possible here
@@ -906,7 +906,7 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
             };
 
             CREATE TYPE test::ConstraintOnTest3 {
-                CREATE PROPERTY test::foo -> std::str {
+                CREATE PROPERTY foo -> std::str {
                     CREATE CONSTRAINT test::mymax3(3) ON (len(__subject__));
                 };
             };
@@ -944,7 +944,7 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
                     };
 
                     CREATE TYPE test::InvalidConstraintTest2 {
-                        CREATE PROPERTY test::foo -> std::str {
+                        CREATE PROPERTY foo -> std::str {
                             CREATE CONSTRAINT test::max_int(3)
                                 ON (len(__subject__));
                         };
@@ -1011,7 +1011,7 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
             };
 
             CREATE TYPE test::ConstraintOnTest_err_06 {
-                CREATE PROPERTY test::foo -> std::str {
+                CREATE PROPERTY foo -> std::str {
                     CREATE CONSTRAINT test::mymax_er_06(3);
                 };
             };

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -35,12 +35,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_02(self):
         await self.con.execute("""
             CREATE ABSTRACT LINK test::test_object_link {
-                CREATE PROPERTY test::test_link_prop -> std::int64;
+                CREATE PROPERTY test_link_prop -> std::int64;
             };
 
             CREATE TYPE test::TestObjectType {
-                CREATE LINK test::test_object_link -> std::Object {
-                    CREATE PROPERTY test::test_link_prop -> std::int64 {
+                CREATE LINK test_object_link -> std::Object {
+                    CREATE PROPERTY test_link_prop -> std::int64 {
                         SET ATTRIBUTE title := 'Test Property';
                     };
                 };
@@ -50,7 +50,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_03(self):
         await self.con.execute("""
             CREATE ABSTRACT LINK test::test_object_link_prop {
-                CREATE PROPERTY test::link_prop1 -> std::str;
+                CREATE PROPERTY link_prop1 -> std::str;
             };
         """)
 
@@ -60,11 +60,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             CREATE TYPE test::B EXTENDING test::A;
 
             CREATE TYPE test::Object1 {
-                CREATE REQUIRED LINK test::a -> test::A;
+                CREATE REQUIRED LINK a -> test::A;
             };
 
             CREATE TYPE test::Object2 {
-                CREATE LINK test::a -> test::B;
+                CREATE LINK a -> test::B;
             };
 
             CREATE TYPE test::Object_12
@@ -75,8 +75,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.con.execute("""
             CREATE TYPE test::A5;
             CREATE TYPE test::Object5 {
-                CREATE REQUIRED LINK test::a -> test::A5;
-                CREATE REQUIRED PROPERTY test::b -> str;
+                CREATE REQUIRED LINK a -> test::A5;
+                CREATE REQUIRED PROPERTY b -> str;
             };
         """)
 
@@ -87,26 +87,26 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         name,
                         required,
                     }
-                    FILTER .name = 'test::a'
+                    FILTER .name = 'a'
                     ORDER BY .name,
 
                     properties: {
                         name,
                         required,
                     }
-                    FILTER .name = 'test::b'
+                    FILTER .name = 'b'
                     ORDER BY .name
                 }
                 FILTER .name = 'test::Object5';
             """,
             [{
                 'links': [{
-                    'name': 'test::a',
+                    'name': 'a',
                     'required': True,
                 }],
 
                 'properties': [{
-                    'name': 'test::b',
+                    'name': 'b',
                     'required': True,
                 }],
             }],
@@ -114,11 +114,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.con.execute("""
             ALTER TYPE test::Object5 {
-                ALTER LINK test::a DROP REQUIRED;
+                ALTER LINK a DROP REQUIRED;
             };
 
             ALTER TYPE test::Object5 {
-                ALTER PROPERTY test::b DROP REQUIRED;
+                ALTER PROPERTY b DROP REQUIRED;
             };
         """)
 
@@ -129,26 +129,26 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         name,
                         required,
                     }
-                    FILTER .name = 'test::a'
+                    FILTER .name = 'a'
                     ORDER BY .name,
 
                     properties: {
                         name,
                         required,
                     }
-                    FILTER .name = 'test::b'
+                    FILTER .name = 'b'
                     ORDER BY .name
                 }
                 FILTER .name = 'test::Object5';
             """,
             [{
                 'links': [{
-                    'name': 'test::a',
+                    'name': 'a',
                     'required': False,
                 }],
 
                 'properties': [{
-                    'name': 'test::b',
+                    'name': 'b',
                     'required': False,
                 }],
             }],
@@ -158,8 +158,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.con.execute("""
             CREATE TYPE test::A6;
             CREATE TYPE test::Object6 {
-                CREATE SINGLE LINK test::a -> test::A6;
-                CREATE SINGLE PROPERTY test::b -> str;
+                CREATE SINGLE LINK a -> test::A6;
+                CREATE SINGLE PROPERTY b -> str;
             };
         """)
 
@@ -170,26 +170,26 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         name,
                         cardinality,
                     }
-                    FILTER .name = 'test::a'
+                    FILTER .name = 'a'
                     ORDER BY .name,
 
                     properties: {
                         name,
                         cardinality,
                     }
-                    FILTER .name = 'test::b'
+                    FILTER .name = 'b'
                     ORDER BY .name
                 }
                 FILTER .name = 'test::Object6';
             """,
             [{
                 'links': [{
-                    'name': 'test::a',
+                    'name': 'a',
                     'cardinality': 'ONE',
                 }],
 
                 'properties': [{
-                    'name': 'test::b',
+                    'name': 'b',
                     'cardinality': 'ONE',
                 }],
             }],
@@ -197,11 +197,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.con.execute("""
             ALTER TYPE test::Object6 {
-                ALTER LINK test::a SET MULTI;
+                ALTER LINK a SET MULTI;
             };
 
             ALTER TYPE test::Object6 {
-                ALTER PROPERTY test::b SET MULTI;
+                ALTER PROPERTY b SET MULTI;
             };
         """)
 
@@ -212,26 +212,26 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         name,
                         cardinality,
                     }
-                    FILTER .name = 'test::a'
+                    FILTER .name = 'a'
                     ORDER BY .name,
 
                     properties: {
                         name,
                         cardinality,
                     }
-                    FILTER .name = 'test::b'
+                    FILTER .name = 'b'
                     ORDER BY .name
                 }
                 FILTER .name = 'test::Object6';
             """,
             [{
                 'links': [{
-                    'name': 'test::a',
+                    'name': 'a',
                     'cardinality': 'MANY',
                 }],
 
                 'properties': [{
-                    'name': 'test::b',
+                    'name': 'b',
                     'cardinality': 'MANY',
                 }],
             }],
@@ -490,10 +490,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_11(self):
         await self.con.execute(r"""
             CREATE TYPE test::TestContainerLinkObjectType {
-                CREATE PROPERTY test::test_array_link -> array<std::str>;
+                CREATE PROPERTY test_array_link -> array<std::str>;
                 # FIXME: for now dimention specs on the array are
                 # disabled pending a syntax change
-                # CREATE PROPERTY test::test_array_link_2 ->
+                # CREATE PROPERTY test_array_link_2 ->
                 #     array<std::str[10]>;
             };
         """)
@@ -504,7 +504,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r"Unexpected '`__subject__`'"):
             await self.con.execute(r"""
                 CREATE TYPE test::TestBadContainerLinkObjectType {
-                    CREATE PROPERTY test::foo -> std::str {
+                    CREATE PROPERTY foo -> std::str {
                         CREATE CONSTRAINT expression
                             ON (`__subject__` = 'foo');
                     };
@@ -517,7 +517,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 'reference to a non-existent schema item: self'):
             await self.con.execute(r"""
                 CREATE TYPE test::TestBadContainerLinkObjectType {
-                    CREATE PROPERTY test::foo -> std::str {
+                    CREATE PROPERTY foo -> std::str {
                         CREATE CONSTRAINT expression ON (`self` = 'foo');
                     };
                 };
@@ -527,8 +527,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_14(self):
         await self.con.execute("""
             CREATE TYPE test::TestSelfLink1 {
-                CREATE PROPERTY test::foo1 -> std::str;
-                CREATE PROPERTY test::bar1 -> std::str {
+                CREATE PROPERTY foo1 -> std::str;
+                CREATE PROPERTY bar1 -> std::str {
                     SET default := __source__.foo1;
                 };
             };
@@ -554,8 +554,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_15(self):
         await self.con.execute(r"""
             CREATE TYPE test::TestSelfLink2 {
-                CREATE PROPERTY test::foo2 -> std::str;
-                CREATE MULTI PROPERTY test::bar2 -> std::str {
+                CREATE PROPERTY foo2 -> std::str;
+                CREATE MULTI PROPERTY bar2 -> std::str {
                     # NOTE: this is a set of all TestSelfLink2.foo2
                     SET default := test::TestSelfLink2.foo2;
                 };
@@ -594,8 +594,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(edgedb.QueryError):
             await self.con.execute(r"""
                 CREATE TYPE test::TestSelfLink3 {
-                    CREATE PROPERTY test::foo3 -> std::str;
-                    CREATE PROPERTY test::bar3 -> std::str {
+                    CREATE PROPERTY foo3 -> std::str;
+                    CREATE PROPERTY bar3 -> std::str {
                         # NOTE: this is a set of all TestSelfLink3.foo3
                         SET default := test::TestSelfLink3.foo3;
                     };
@@ -606,7 +606,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_17(self):
         await self.con.execute("""
             CREATE TYPE test::TestSelfLink4 {
-                CREATE PROPERTY test::__typename4 -> std::str {
+                CREATE PROPERTY __typename4 -> std::str {
                     SET default := __source__.__type__.name;
                 };
             };
@@ -731,13 +731,119 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ]
         )
 
+    async def test_edgeql_ddl_20(self):
+        await self.con.execute("""
+            SET MODULE test;
+
+            CREATE TYPE A20 {
+                CREATE REQUIRED PROPERTY foo -> str;
+            };
+
+            CREATE TYPE B20 {
+                CREATE LINK l -> A20;
+            };
+        """)
+
+        await self.assert_query_result(
+            r"""
+                WITH MODULE schema
+                SELECT ObjectType {
+                    links: {
+                        name,
+                        bases: {
+                            name
+                        }
+                    } FILTER .name = 'l'
+                }
+                FILTER .name = 'test::B20'
+            """,
+            [
+                {
+                    'links': [{
+                        'name': 'l',
+                        'bases': [{
+                            'name': 'std::link',
+                        }],
+                    }],
+                },
+            ]
+        )
+
+        await self.con.execute("""
+            SET MODULE test;
+
+            CREATE ABSTRACT LINK l20;
+
+            ALTER TYPE B20 {
+                ALTER LINK l EXTENDING l20;
+            };
+        """)
+
+        await self.assert_query_result(
+            r"""
+                WITH MODULE schema
+                SELECT ObjectType {
+                    links: {
+                        name,
+                        bases: {
+                            name
+                        }
+                    } FILTER .name = 'l'
+                }
+                FILTER .name = 'test::B20'
+            """,
+            [
+                {
+                    'links': [{
+                        'name': 'l',
+                        'bases': [{
+                            'name': 'test::l20',
+                        }],
+                    }],
+                },
+            ]
+        )
+
+        await self.con.execute("""
+            SET MODULE test;
+
+            ALTER TYPE B20 {
+                ALTER LINK l DROP EXTENDING l20;
+            };
+        """)
+
+        await self.assert_query_result(
+            r"""
+                WITH MODULE schema
+                SELECT ObjectType {
+                    links: {
+                        name,
+                        bases: {
+                            name
+                        }
+                    } FILTER .name = 'l'
+                }
+                FILTER .name = 'test::B20'
+            """,
+            [
+                {
+                    'links': [{
+                        'name': 'l',
+                        'bases': [{
+                            'name': 'std::link',
+                        }],
+                    }],
+                },
+            ]
+        )
+
     async def test_edgeql_ddl_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidReferenceError,
                 r'unqualified name and no default module set'):
             await self.con.execute(r"""
                 CREATE TYPE test::Foo {
-                    CREATE PROPERTY test::bar -> array;
+                    CREATE PROPERTY bar -> array;
                 };
             """)
 
@@ -747,7 +853,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r'unqualified name and no default module set'):
             await self.con.execute(r"""
                 CREATE TYPE test::Foo {
-                    CREATE PROPERTY test::bar -> tuple;
+                    CREATE PROPERTY bar -> tuple;
                 };
             """)
 
@@ -757,7 +863,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r'unexpected number of subtypes, expecting 1'):
             await self.con.execute(r"""
                 CREATE TYPE test::Foo {
-                    CREATE PROPERTY test::bar -> array<int64, int64, int64>;
+                    CREATE PROPERTY bar -> array<int64, int64, int64>;
                 };
             """)
 
@@ -767,7 +873,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r'nested arrays are not supported'):
             await self.con.execute(r"""
                 CREATE TYPE test::Foo {
-                    CREATE PROPERTY test::bar -> array<array<int64>>;
+                    CREATE PROPERTY bar -> array<array<int64>>;
                 };
             """)
 
@@ -778,7 +884,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r'supported'):
             await self.con.execute(r"""
                 CREATE TYPE test::Foo {
-                    CREATE PROPERTY test::bar -> tuple<int64, foo:int64>;
+                    CREATE PROPERTY bar -> tuple<int64, foo:int64>;
                 };
             """)
 
@@ -788,7 +894,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r'unexpected number of subtypes, expecting 1'):
             await self.con.execute(r"""
                 CREATE TYPE test::Foo {
-                    CREATE PROPERTY test::bar -> array<>;
+                    CREATE PROPERTY bar -> array<>;
                 };
             """)
 
@@ -808,8 +914,19 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             async with self.con.transaction():
                 await self.con.execute("""
                     CREATE TYPE test::Foo {
-                        CREATE LINK test::f123456789_123456789_123456789_\
+                        CREATE LINK f123456789_123456789_123456789_\
 123456789_123456789_123456789_123456789_123456789 -> test::Foo;
+                    };
+                """)
+
+    async def test_edgeql_ddl_link_bad_02(self):
+        with self.assertRaisesRegex(
+                edgedb.EdgeQLSyntaxError,
+                f'unexpected fully-qualified name'):
+            async with self.con.transaction():
+                await self.con.execute("""
+                    CREATE TYPE test::Foo {
+                        CREATE LINK foo::bar -> test::Foo;
                     };
                 """)
 
@@ -829,8 +946,19 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             async with self.con.transaction():
                 await self.con.execute("""
                     CREATE TYPE test::Foo {
-                        CREATE PROPERTY test::f123456789_123456789_123456789_\
+                        CREATE PROPERTY f123456789_123456789_123456789_\
 123456789_123456789_123456789_123456789_123456789 -> std::str;
+                    };
+                """)
+
+    async def test_edgeql_ddl_property_bad_02(self):
+        with self.assertRaisesRegex(
+                edgedb.EdgeQLSyntaxError,
+                f'unexpected fully-qualified name'):
+            async with self.con.transaction():
+                await self.con.execute("""
+                    CREATE TYPE test::Foo {
+                        CREATE PROPERTY foo::bar -> test::Foo;
                     };
                 """)
 
@@ -1406,7 +1534,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.con.execute('''\
             CREATE TYPE test::CompProp;
             ALTER TYPE test::CompProp {
-                CREATE PROPERTY test::prop := 'I am a computable';
+                CREATE PROPERTY prop := 'I am a computable';
             };
             INSERT test::CompProp;
         ''')
@@ -1431,14 +1559,14 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         target: {
                             name
                         }
-                    } FILTER .name = 'test::prop'
+                    } FILTER .name = 'prop'
                 }
                 FILTER
                     .name = 'test::CompProp';
             ''',
             [{
                 'properties': [{
-                    'name': 'test::prop',
+                    'name': 'prop',
                     'target': {
                         'name': 'std::str'
                     }
@@ -1453,7 +1581,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute('''\
                 CREATE TYPE test::CompPropBad;
                 ALTER TYPE test::CompPropBad {
-                    CREATE PROPERTY test::prop := (SELECT std::Object LIMIT 1);
+                    CREATE PROPERTY prop := (SELECT std::Object LIMIT 1);
                 };
             ''')
 
@@ -1597,7 +1725,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             await self.con.execute("""
                 CREATE ABSTRACT LINK test::test_object_link_prop {
-                    CREATE PROPERTY test::link_prop1 -> anytype;
+                    CREATE PROPERTY link_prop1 -> anytype;
                 };
             """)
 
@@ -1608,7 +1736,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             await self.con.execute("""
                 CREATE TYPE test::AnyObject2 {
-                    CREATE LINK test::a -> anytype;
+                    CREATE LINK a -> anytype;
                 };
             """)
 
@@ -1619,7 +1747,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             await self.con.execute("""
                 CREATE TYPE test::AnyObject3 {
-                    CREATE PROPERTY test::a -> anytype;
+                    CREATE PROPERTY a -> anytype;
                 };
             """)
 
@@ -1630,7 +1758,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             await self.con.execute("""
                 CREATE TYPE test::AnyObject4 {
-                    CREATE PROPERTY test::a -> anyscalar;
+                    CREATE PROPERTY a -> anyscalar;
                 };
             """)
 
@@ -1641,7 +1769,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             await self.con.execute("""
                 CREATE TYPE test::AnyObject5 {
-                    CREATE PROPERTY test::a -> anyint;
+                    CREATE PROPERTY a -> anyint;
                 };
             """)
 
@@ -1652,8 +1780,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             await self.con.execute("""
                 CREATE TYPE test::AnyObject6 EXTENDING anytype {
-                    CREATE REQUIRED LINK test::a -> test::AnyObject6;
-                    CREATE REQUIRED PROPERTY test::b -> str;
+                    CREATE REQUIRED LINK a -> test::AnyObject6;
+                    CREATE REQUIRED PROPERTY b -> str;
                 };
             """)
 
@@ -1948,13 +2076,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_rename_03(self):
         await self.con.execute(r"""
             CREATE TYPE test::RenameObj03 {
-                CREATE PROPERTY test::name -> str;
+                CREATE PROPERTY name -> str;
             };
 
             INSERT test::RenameObj03 {name := 'rename 03'};
 
             ALTER TYPE test::RenameObj03 {
-                ALTER PROPERTY test::name {
+                ALTER PROPERTY name {
                     RENAME TO test::new_name_03;
                 };
             };
@@ -1974,12 +2102,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_rename_04(self):
         await self.con.execute("""
             CREATE ABSTRACT LINK test::rename_link_04 {
-                CREATE PROPERTY test::rename_prop_04 -> std::int64;
+                CREATE PROPERTY rename_prop_04 -> std::int64;
             };
 
             CREATE TYPE test::LinkedObj04;
             CREATE TYPE test::RenameObj04 {
-                CREATE MULTI LINK test::rename_link_04 -> test::LinkedObj04;
+                CREATE MULTI LINK rename_link_04 -> test::LinkedObj04;
             };
 
             INSERT test::LinkedObj04;
@@ -1988,8 +2116,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             };
 
             ALTER ABSTRACT LINK test::rename_link_04 {
-                ALTER PROPERTY test::rename_prop_04 {
-                    RENAME TO test::new_prop_04;
+                ALTER PROPERTY rename_prop_04 {
+                    RENAME TO new_prop_04;
                 };
             };
         """)

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -234,8 +234,8 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                             ObjectType.properties.name
                             FILTER
                                 ObjectType.properties.name IN {
-                                    'std::id',
-                                    'schema::name'
+                                    'id',
+                                    'name'
                                 }
                             ORDER BY ObjectType.properties.name ASC
                         )
@@ -244,7 +244,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                     ObjectType.name = 'schema::Object';
             """,
             [{
-                'l': ['schema::name', 'std::id']
+                'l': ['id', 'name']
             }]
         )
 

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -77,13 +77,13 @@ class TestIntrospection(tb.QueryTestCase):
                 'name': 'test::User',
                 'is_abstract': False,
                 'pointers': [{
-                    'name': 'std::__type__',
+                    'name': '__type__',
                 }, {
-                    'name': 'std::id',
+                    'name': 'id',
                 }, {
-                    'name': 'test::name',
+                    'name': 'name',
                 }, {
-                    'name': 'test::todo',
+                    'name': 'todo',
                 }]
             }]
         )
@@ -105,11 +105,11 @@ class TestIntrospection(tb.QueryTestCase):
                 'name': 'test::Owned',
                 'is_abstract': True,
                 'pointers': [{
-                    'name': 'std::__type__',
+                    'name': '__type__',
                 }, {
-                    'name': 'std::id',
+                    'name': 'id',
                 }, {
-                    'name': 'test::owner',
+                    'name': 'owner',
                 }]
             }]
         )
@@ -131,13 +131,13 @@ class TestIntrospection(tb.QueryTestCase):
                 'name': 'test::User',
                 'is_abstract': False,
                 'pointers': [{
-                    'name': 'std::__type__',
+                    'name': '__type__',
                 }, {
-                    'name': 'std::id',
+                    'name': 'id',
                 }, {
-                    'name': 'test::name',
+                    'name': 'name',
                 }, {
-                    'name': 'test::todo',
+                    'name': 'todo',
                 }]
             }]
         )
@@ -152,7 +152,7 @@ class TestIntrospection(tb.QueryTestCase):
                     pointers: {
                         name,
                         cardinality,
-                    } FILTER .name LIKE 'test::%'
+                    } FILTER .source.name LIKE 'test::%'
                       ORDER BY .name
                 }
                 FILTER ObjectType.name = 'test::User';
@@ -161,10 +161,10 @@ class TestIntrospection(tb.QueryTestCase):
                 'name': 'test::User',
                 'is_abstract': False,
                 'pointers': [{
-                    'name': 'test::name',
+                    'name': 'name',
                     'cardinality': 'ONE',
                 }, {
-                    'name': 'test::todo',
+                    'name': 'todo',
                     'cardinality': 'MANY',
                 }]
             }]
@@ -190,19 +190,19 @@ class TestIntrospection(tb.QueryTestCase):
             [{
                 'name': 'test::Comment',
                 'links': [{
-                    'name': 'std::__type__',
+                    'name': '__type__',
                     'target': {'name': 'schema::Type'},
                     'cardinality': 'ONE',
                 }, {
-                    'name': 'test::issue',
+                    'name': 'issue',
                     'target': {'name': 'test::Issue'},
                     'cardinality': 'ONE',
                 }, {
-                    'name': 'test::owner',
+                    'name': 'owner',
                     'target': {'name': 'test::User'},
                     'cardinality': 'ONE',
                 }, {
-                    'name': 'test::parent',
+                    'name': 'parent',
                     'target': {'name': 'test::Comment'},
                     'cardinality': 'ONE',
                 }]
@@ -272,7 +272,7 @@ class TestIntrospection(tb.QueryTestCase):
                                 name
                             }
                         }
-                    } FILTER .name = 'test::tags'
+                    } FILTER .name = 'tags'
                 }
                 FILTER
                     .name = 'test::Issue';
@@ -302,17 +302,17 @@ class TestIntrospection(tb.QueryTestCase):
                     } ORDER BY Link.properties.name
                 }
                 FILTER
-                    Link.name = 'test::todo'
+                    Link.name = 'todo'
                     AND EXISTS Link.source;
             """,
             [{
-                'name': 'test::todo',
+                'name': 'todo',
                 'properties': [{
-                    'name': 'std::source',
+                    'name': 'rank',
                 }, {
-                    'name': 'std::target',
+                    'name': 'source',
                 }, {
-                    'name': 'test::rank',
+                    'name': 'target',
                 }]
             }]
         )
@@ -674,7 +674,6 @@ class TestIntrospection(tb.QueryTestCase):
                 {'name': 'test::Owned'},
                 {'name': 'test::Text'},
                 {'name': 'test::my_enum'},
-                {'name': 'test::todo'},
             ]
         )
 
@@ -719,7 +718,7 @@ class TestIntrospection(tb.QueryTestCase):
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].name, 'std::Object')
-        self.assertEqual(result[0].links[0].name, 'std::__type__')
+        self.assertEqual(result[0].links[0].name, '__type__')
         self.assertIsNotNone(result[0].links[0].target.id)
         self.assertIsNotNone(result[0].properties[0].target.id)
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3312,22 +3312,28 @@ aa';
     def test_edgeql_syntax_ddl_type_02(self):
         """
         CREATE TYPE schema::TypeElement {
-            CREATE REQUIRED LINK schema::type -> schema::Type;
-            CREATE REQUIRED LINK schema::num -> std::int64;
-            CREATE LINK schema::name -> std::str;
+            CREATE REQUIRED LINK type -> schema::Type;
+            CREATE REQUIRED LINK num -> std::int64;
+            CREATE PROPERTY name EXTENDING (foo, bar) -> std::str;
+            CREATE LINK lnk EXTENDING l1 -> schema::Type;
+            CREATE LINK lnk1 EXTENDING (l1, l2) -> schema::Type;
+            CREATE LINK lnk2 EXTENDING (l1, l2) -> schema::Type {
+                CREATE PROPERTY lnk2_prop -> std::str;
+                CREATE PROPERTY lnk2_prop2 EXTENDING foo -> std::str;
+            };
         };
         """
 
     def test_edgeql_syntax_ddl_type_03(self):
         """
         ALTER TYPE schema::Object {
-            CREATE MULTI LINK schema::attributes -> schema::Attribute;
+            CREATE MULTI LINK attributes -> schema::Attribute;
         };
 
 % OK %
 
         ALTER TYPE schema::Object
-            CREATE MULTI LINK schema::attributes -> schema::Attribute;
+            CREATE MULTI LINK attributes -> schema::Attribute;
         """
 
     def test_edgeql_syntax_ddl_type_04(self):

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -200,7 +200,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 r'cannot alter.*module std is read-only'):
             await self.con.execute('''
                 ALTER TYPE std::Object {
-                    CREATE PROPERTY std::foo_15 -> std::str;
+                    CREATE PROPERTY foo_15 -> std::str;
                 };
             ''')
 
@@ -210,7 +210,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 r'cannot alter.*module stdgraphql is read-only'):
             await self.con.execute('''
                 ALTER TYPE stdgraphql::Query {
-                    CREATE PROPERTY std::foo_15 -> std::str;
+                    CREATE PROPERTY foo_15 -> std::str;
                 };
             ''')
 

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -197,7 +197,8 @@ type Issue extending `foo.bar`::NamedObject, OwnedObject, Text:
 
     link priority -> Priority
 
-    multi link watchers -> User
+    multi link watchers extending (orderable) -> User:
+        property foo extending (bar) -> str
 
     multi link time_spent_log -> LogEntry
 

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -36,7 +36,7 @@ class TestServerProto(tb.QueryTestCase):
         };
 
         CREATE TYPE test::TransactionTest EXTENDING std::Object {
-            CREATE PROPERTY test::name -> std::str;
+            CREATE PROPERTY name -> std::str;
         };
 
         # Used by is_testmode_on() to ensure that config modifications
@@ -1984,10 +1984,6 @@ class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):
         finally:
             await con2.close()
 
-    @test.xfail('''
-        The error is:
-        reference to a non-existent schema item: test::prop1
-    ''')
     async def test_server_proto_query_cache_invalidate_05(self):
         typename = 'CacheInv_05'
 
@@ -1996,11 +1992,11 @@ class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):
         try:
             await con2.execute(f'''
                 CREATE TYPE test::{typename} {{
-                    CREATE REQUIRED PROPERTY test::prop1 -> std::str;
+                    CREATE REQUIRED PROPERTY prop1 -> std::str;
                 }};
 
                 CREATE TYPE test::Other{typename} {{
-                    CREATE REQUIRED PROPERTY test::prop2 -> std::str;
+                    CREATE REQUIRED PROPERTY prop2 -> std::str;
                 }};
 
                 INSERT test::{typename} {{
@@ -2023,11 +2019,11 @@ class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):
                 DELETE (SELECT test::{typename});
 
                 ALTER TYPE test::{typename} {{
-                    DROP PROPERTY test::prop1;
+                    DROP PROPERTY prop1;
                 }};
 
                 ALTER TYPE test::{typename} {{
-                    CREATE REQUIRED LINK test::prop1 -> test::Other{typename};
+                    CREATE REQUIRED LINK prop1 -> test::Other{typename};
                 }};
 
                 INSERT test::{typename} {{
@@ -2122,7 +2118,7 @@ class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):
                 }};
 
                 CREATE TYPE test::{typename} {{
-                    CREATE REQUIRED LINK test::link1 -> test::Foo{typename};
+                    CREATE REQUIRED LINK link1 -> test::Foo{typename};
                 }};
 
                 INSERT test::Foo{typename};


### PR DESCRIPTION
Currently concrete links and properties automatically extend abstract links
and properties with the same name in the same module.  This behavior is
historical, since there was originally no way to define properties on
concrete links, so one had to define an abstract link of the same name with
properties and have all concrete links in the module magically inherit from
it.  Today, there is no such restriction, and, as such, implicit name-based
inheritance has no real value, and is a potential footgun.  Instead, there
is now an explicit syntax to
`extend` a link or a property:

    ALTER TYPE Foo { CREATE LINK bar EXTENDING spam -> Bar };