### PR TITLE
graphql: Base non-reflected modules on defined STD_MODULES.

### DIFF
--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -49,6 +49,7 @@ from edb.schema import modules as s_mod
 from edb.schema import pointers as s_pointers
 from edb.schema import objtypes as s_objtypes
 from edb.schema import scalars as s_scalars
+from edb.schema import schema as s_schema
 
 from . import errors as g_errors
 
@@ -95,6 +96,9 @@ GQL_TO_OPS_MAP = {
 }
 
 
+HIDDEN_MODULES = s_schema.STD_MODULES - {'std'}
+
+
 class GQLCoreSchema:
     def __init__(self, edb_schema):
         '''Create a graphql schema based on edgedb schema.'''
@@ -104,7 +108,7 @@ class GQLCoreSchema:
         self.modules = {
             m.get_name(self.edb_schema)
             for m in self.edb_schema.get_objects(type=s_mod.Module)
-        } - {'schema', 'stdgraphql', 'sys', 'cfg'}
+        } - HIDDEN_MODULES
         self.modules = list(self.modules)
         self.modules.sort()
 

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -34,8 +34,8 @@ from . import operators as s_oper
 from . import types as s_types
 
 
-STD_LIB = ['std', 'schema', 'math', 'sys', 'cfg']
-STD_MODULES = {'std', 'schema', 'stdgraphql', 'math', 'sys', 'cfg'}
+STD_LIB = ('std', 'schema', 'math', 'sys', 'cfg')
+STD_MODULES = frozenset({'std', 'schema', 'stdgraphql', 'math', 'sys', 'cfg'})
 
 
 _void = object()

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -194,7 +194,7 @@ async def _make_stdlib(testmode: bool):
     current_block = None
 
     std_texts = []
-    for modname in s_schema.STD_LIB + ['stdgraphql']:
+    for modname in s_schema.STD_LIB + ('stdgraphql',):
         std_texts.append(s_std.get_std_module_text(modname))
 
     if testmode:


### PR DESCRIPTION
Rather than using a hardcoded list of which modules should not be
exposed via GraphQL, use a slightly modified version of STD_MODULES.