### PR TITLE
Remove nested INSERT syntax sugar

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -239,28 +239,11 @@ def _normalize_view_ptr_expr(
 
     compexpr = shape_el.compexpr
     if compexpr is None and is_insert and shape_el.elements:
-        # Nested insert short form:
+        # Short shape form in INSERT, e.g
         #     INSERT Foo { bar: Spam { name := 'name' }}
-        # Expand to:
-        #     INSERT Foo { bar := (INSERT Spam { name := 'name' }) }
-        base_ptrcls = ptrcls = setgen.resolve_ptr(ptrsource, ptrname, ctx=ctx)
-
-        if target_typexpr is not None:
-            ptr_target = schemactx.get_schema_type(
-                target_typexpr.maintype, ctx=ctx)
-        else:
-            ptr_target = ptrcls.get_target(ctx.env.schema)
-
-        compexpr = qlast.InsertQuery(
-            subject=qlast.Path(
-                steps=[
-                    qlast.ObjectRef(
-                        name=ptr_target.get_name(ctx.env.schema).name,
-                        module=ptr_target.get_name(ctx.env.schema).module)
-                ]
-            ),
-            shape=shape_el.elements
-        )
+        # is prohibited.
+        raise errors.EdgeQLSyntaxError(
+            "unexpected ':'", context=steps[-1].context)
 
     if compexpr is None:
         base_ptrcls = ptrcls = setgen.resolve_ptr(ptrsource, ptrname, ctx=ctx)

--- a/tests/schemas/cards_setup.eql
+++ b/tests/schemas/cards_setup.eql
@@ -110,9 +110,9 @@ INSERT User {
     deck := (
         SELECT Card {@count := 3} FILTER .element IN {'Earth', 'Water'}
     ),
-    awards: {
+    awards := (INSERT Award {
         name := '3rd'
-    }
+    })
 };
 
 WITH MODULE test

--- a/tests/schemas/graphql_setup.eql
+++ b/tests/schemas/graphql_setup.eql
@@ -67,11 +67,11 @@ INSERT User {
     age := 27,
     active := True,
     score := 5.0,
-    profile: {
+    profile := (INSERT Profile {
         name := 'Alice profile',
         value := 'special',
         tags := ['1st', '2nd'],
-    }
+    })
 };
 
 INSERT Person {

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -237,9 +237,9 @@ class TestInsert(tb.QueryTestCase):
             INSERT InsertTest {
                 name := 'insert nested 3',
                 l2 := 0,
-                subordinates: Subordinate {
+                subordinates := (INSERT Subordinate {
                     name := 'nested sub 3.1'
-                }
+                })
             };
         ''')
 
@@ -267,10 +267,10 @@ class TestInsert(tb.QueryTestCase):
             INSERT InsertTest {
                 name := 'insert nested 4',
                 l2 := 0,
-                subordinates: Subordinate {
+                subordinates := (INSERT Subordinate {
                     name := 'nested sub 4.1',
                     @comment := 'comment 4.1',
-                }
+                })
             };
         ''')
 
@@ -380,6 +380,20 @@ class TestInsert(tb.QueryTestCase):
                 }]
             }]
         )
+
+    async def test_edgeql_insert_nested_07(self):
+        with self.assertRaisesRegex(
+                edgedb.EdgeQLSyntaxError,
+                "unexpected ':'"):
+            await self.con.execute('''
+                WITH MODULE test
+                INSERT InsertTest {
+                    subordinates: Subordinate {
+                        name := 'nested sub 4.1',
+                        @comment := 'comment 4.1',
+                    }
+                };
+            ''')
 
     async def test_edgeql_insert_returning_01(self):
         await self.con.execute('''

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2230,16 +2230,6 @@ aa';
         INSERT Foo LIMIT 5;
         """
 
-    def test_edgeql_syntax_insert_12(self):
-        """
-        INSERT Foo{
-            bar := 42,
-            baz: Baz{
-                spam := 'ham'
-            }
-        };
-        """
-
     def test_edgeql_syntax_insert_13(self):
         """
         INSERT Foo{


### PR DESCRIPTION
Currently the following syntax is supported:

    INSERT Object {
        link: [<TargetType>] {
	    ...
        }
    }

which is equivalent to:

    INSERT Object {
        link := (INSERT TargetType {
            ...
        })
    }

After some discussion, we decided that the shortcut syntax is
problematic, since it exactly matches the syntax in `SELECT` and
`UPDATE`, where it means "match this existing relationship hierarchy".
To avoid possible confusion, especially in the context of `UPDATE`,
remove the shortcut syntax support from `INSERT`.
`foo: [<Type>] [ { <shape> } ]` is now always a selection construct.