### PR TITLE
sdl: Make semicolons optional after blocks.

### DIFF
--- a/docs/datamodel/attributes.rst
+++ b/docs/datamodel/attributes.rst
@@ -61,7 +61,7 @@ For example:
 
     scalar type pr_status extending str {
         attribute title := 'Pull Request Status Type';
-    };
+    }
 
 Attributes can also be set using the :eql:stmt:`SET ATTRIBUTE` EdgeQL command.
 

--- a/docs/datamodel/computables.rst
+++ b/docs/datamodel/computables.rst
@@ -26,7 +26,7 @@ For example:
         property fullname :=
             (__source__.firstname + ' ' +
              __source__.lastname);
-     };
+     }
 
 Here we define the ``User`` type to contain the ``fullname`` computable
 property that is derived from user's first and last name.

--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -146,7 +146,7 @@ The standard library defines the following constraints:
 
         scalar type status_t extending str {
             constraint enum ('Open', 'Closed', 'Merged');
-        };
+        }
 
 .. eql:constraint:: std::expression on (expr)
 
@@ -158,7 +158,7 @@ The standard library defines the following constraints:
 
         scalar type starts_with_a extending str {
             constraint expression on (__subject__[0] = 'A');
-        };
+        }
 
 .. eql:constraint:: std::max(max: anytype)
 
@@ -170,7 +170,7 @@ The standard library defines the following constraints:
 
         scalar type max_100 extending int64 {
             constraint max(100);
-        };
+        }
 
 .. eql:constraint:: std::max_ex(max: anytype)
 
@@ -182,7 +182,7 @@ The standard library defines the following constraints:
 
         scalar type maxex_100 extending int64 {
             constraint max_ex(100);
-        };
+        }
 
 .. eql:constraint:: std::max_len(max: int64)
 
@@ -194,7 +194,7 @@ The standard library defines the following constraints:
 
         scalar type username_t extending str {
             constraint max_len(30);
-        };
+        }
 
 .. eql:constraint:: std::min(min: anytype)
 
@@ -206,7 +206,7 @@ The standard library defines the following constraints:
 
         scalar type non_negative extending int64 {
             constraint min(0);
-        };
+        }
 
 .. eql:constraint:: std::min_ex(min: anytype)
 
@@ -218,7 +218,7 @@ The standard library defines the following constraints:
 
         scalar type positive_float extending float64 {
             constraint min_ex(0);
-        };
+        }
 
 .. eql:constraint:: std::min_len(min: int64)
 
@@ -230,7 +230,7 @@ The standard library defines the following constraints:
 
         scalar type four_decimal_places extending int64 {
             constraint min_len(4);
-        };
+        }
 
 .. eql:constraint:: std::regexp(pattern: str)
 
@@ -245,7 +245,7 @@ The standard library defines the following constraints:
 
         scalar type letters_only_t extending str {
             constraint regexp(r'[A-Za-z]*');
-        };
+        }
 
 .. eql:constraint:: std::exclusive
 
@@ -268,11 +268,11 @@ The standard library defines the following constraints:
             # Make sure user names are unique.
             required property name -> str {
                 constraint exclusive;
-            };
+            }
 
             # Make sure none of the "owned" items belong
             # to any other user.
             multi link owns -> Item {
                 constraint exclusive;
-            };
-        };
+            }
+        }

--- a/docs/datamodel/eschema/index.rst
+++ b/docs/datamodel/eschema/index.rst
@@ -30,7 +30,7 @@ command must be used followed by :eql:stmt:`COMMIT MIGRATION`:
     CREATE MIGRATION init TO eschema $$
         type User {
             property name -> str;
-        };
+        }
     $$;
 
     COMMIT MIGRATION init;

--- a/docs/datamodel/index.rst
+++ b/docs/datamodel/index.rst
@@ -24,7 +24,7 @@ Here is an example of a simple EdgeDB type using the Edge Schema notation:
         property name -> str;
         property address -> str;
         link friends -> User;
-    };
+    }
 
 ``str`` in the above example is a
 :ref:`scalar type <ref_datamodel_scalar_types>`.  EdgeDB also supports

--- a/docs/datamodel/indexes.rst
+++ b/docs/datamodel/indexes.rst
@@ -19,7 +19,7 @@ or more properties directly:
     type User {
         property name -> str;
         index name_idx on (__subject__.name);
-    };
+    }
 
 With the above, ``User`` lookups by the ``name`` property will be faster,
 as the database will not have to scan an entire set of objects sequentially
@@ -39,7 +39,7 @@ of the host object type or link:
         property lastname -> str;
         index name_idx on (str_lower(__subject__.firstname + ' ' +
                                      __subject__.lastname));
-    };
+    }
 
 The index expression must not reference any variables other than
 the properties of the host object type or link.  All functions used

--- a/docs/datamodel/objects.rst
+++ b/docs/datamodel/objects.rst
@@ -39,7 +39,7 @@ types in EdgeDB extend ``std::Object`` directly or indirectly.
 
             # Object type in the information schema.
             required readonly link __type__ -> schema::ObjectType;
-        };
+        }
 
 
 Definition

--- a/docs/edgeql/expressions/shapes.rst
+++ b/docs/edgeql/expressions/shapes.rst
@@ -167,12 +167,12 @@ link as well. Consider the following schema:
 
     abstract link friends {
         property since -> datetime;
-    };
+    }
 
     type User {
         required property name -> str;
         multi link friends -> User;
-    };
+    }
 
 
 Suppose that for a certain query the link ``friends`` needs to be

--- a/docs/graphql/graphql.rst
+++ b/docs/graphql/graphql.rst
@@ -11,7 +11,7 @@ containing the following schema:
 
     type Author {
         property name -> str;
-    };
+    }
 
     type Book {
         # to make the examples simpler only the title is
@@ -21,8 +21,8 @@ containing the following schema:
         link author -> Author;
         property isbn -> str {
             constraint max_len(10);
-        };
-    };
+        }
+    }
 
 From the schema above EdgeDB will expose to GraphQL:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -44,15 +44,15 @@ and ``Comment``.  Let's define the initial schema with a migration:
     type User {
       required property login -> str {
         constraint exclusive;
-      };
+      }
       required property firstname -> str;
       required property lastname -> str;
-    };
+    }
 
     type PullRequest {
       required property number -> int64 {
         constraint exclusive;
-      };
+      }
       required property title -> str;
       required property body -> str;
       required property status -> str;
@@ -60,13 +60,13 @@ and ``Comment``.  Let's define the initial schema with a migration:
       required link author -> User;
       multi link assignees -> User;
       multi link comments -> Comment;
-    };
+    }
 
     type Comment {
       required property body -> str;
       required link author -> User;
       required property created_on -> datetime;
-    };
+    }
 
 With the above snippet we defined and applied a migration to a schema
 described using the :ref:`declarative schema language <ref_eschema>`.
@@ -84,17 +84,17 @@ link.  Let's remove this duplication by declaring an abstract parent type
     type User {
       required property login -> str {
         constraint exclusive;
-      };
+      }
       required property firstname -> str;
       required property lastname -> str;
-    };
+    }
 
     # <new>
     abstract type AuthoredText {
       required property body -> str;
       required link author -> User;
       required property created_on -> datetime;
-    };
+    }
     # </new>
 
     # <changed>
@@ -102,12 +102,12 @@ link.  Let's remove this duplication by declaring an abstract parent type
     # </changed>
       required property number -> int64 {
         constraint exclusive;
-      };
+      }
       required property title -> str;
       required property status -> str;
       multi link assignees -> User;
       multi link comments -> Comment;
-    };
+    }
 
     # <changed>
     type Comment extending AuthoredText;

--- a/tests/schemas/cards.eschema
+++ b/tests/schemas/cards.eschema
@@ -20,13 +20,13 @@
 abstract type Named {
     required property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type User extending Named {
     multi link deck -> Card {
         property count -> int64;
-    };
+    }
 
     property deck_cost := sum(__source__.deck.cost);
 
@@ -34,12 +34,12 @@ type User extending Named {
         property nickname -> str;
         # how the friend responded to requests for a favor
         #property favor -> array<bool>
-    };
+    }
 
     multi link awards -> Award {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type Card extending Named {
     required property element -> str;
@@ -48,7 +48,7 @@ type Card extending Named {
     # computable property
     property elemental_cost :=
         <str>__source__.cost ++ ' ' ++ __source__.element;
-};
+}
 
 type SpecialCard extending Card;
 

--- a/tests/schemas/casts.eschema
+++ b/tests/schemas/casts.eschema
@@ -19,7 +19,7 @@
 
 scalar type custom_str_t extending str {
     constraint regexp('[A-Z]+');
-};
+}
 
 type Test {
     property p_bool -> bool;
@@ -35,7 +35,7 @@ type Test {
     property p_float32 -> float32;
     property p_float64 -> float64;
     property p_decimal -> decimal;
-};
+}
 
 type JSONTest {
     property j_bool -> json;
@@ -51,7 +51,7 @@ type JSONTest {
     property j_float32 -> json;
     property j_float64 -> json;
     property j_decimal -> json;
-};
+}
 
 type ScalarTest {
     property p_bool -> bool;
@@ -69,4 +69,4 @@ type ScalarTest {
     property p_float64 -> float64;
     property p_decimal -> decimal;
     property p_json -> json;
-};
+}

--- a/tests/schemas/constraints.eschema
+++ b/tests/schemas/constraints.eschema
@@ -22,17 +22,17 @@ scalar type constraint_length extending str {
     constraint max_len(10);
     constraint min_len(5);
     constraint min_len(8);
-};
+}
 
 scalar type constraint_length_2 extending constraint_length {
     constraint min_len(9);
-};
+}
 
 scalar type constraint_minmax extending str {
     constraint min("99900000");
     constraint min("99990000");
     constraint max("9999999989");
-};
+}
 
 scalar type constraint_strvalue extending str {
     constraint expression on (__subject__[-1:] = '9');
@@ -42,34 +42,34 @@ scalar type constraint_strvalue extending str {
     constraint expression on (__subject__[0] = '9');
 
     constraint regexp(r"^\d+9{3,}.*$");
-};
+}
 
 # A variant of enum that uses an array argument instead of
 # a variadic.
 abstract constraint my_enum(enum: array<anytype>) {
     expr := contains(enum, __subject__);
-};
+}
 
 
 scalar type constraint_enum extending str {
    constraint enum('foo', 'bar');
-};
+}
 
 scalar type constraint_my_enum extending str {
    constraint my_enum(['foo', 'bar']);
-};
+}
 
 
 abstract link translated_label {
     property lang -> str;
     property prop1 -> str;
-};
+}
 
 abstract link link_with_unique_property {
     property unique_property -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 abstract link link_with_unique_property_inherited
     extending link_with_unique_property;
@@ -77,8 +77,8 @@ abstract link link_with_unique_property_inherited
 abstract link another_link_with_unique_property {
     property unique_property -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 abstract link another_link_with_unique_property_inherited
     extending another_link_with_unique_property;
@@ -86,7 +86,7 @@ abstract link another_link_with_unique_property_inherited
 
 type Label {
     property text -> str;
-};
+}
 
 type Object {
     property name -> str;
@@ -94,18 +94,18 @@ type Object {
     property c_length_2 -> constraint_length_2;
     property c_length_3 -> constraint_length_2 {
         constraint min_len(10);
-    };
+    }
 
     property c_minmax -> constraint_minmax;
     property c_strvalue -> constraint_strvalue;
     property c_enum -> constraint_enum;
     property c_my_enum -> constraint_my_enum;
-};
+}
 
 type UniqueName {
     property name -> str {
         constraint exclusive;
-    };
+    }
 
     link link_with_unique_property
         extending link_with_unique_property -> Object;
@@ -116,24 +116,24 @@ type UniqueName {
     link translated_label extending translated_label -> Label {
         constraint exclusive on ((__subject__@source, __subject__@lang));
         constraint exclusive on (__subject__@prop1);
-    };
-};
+    }
+}
 
 type UniqueNameInherited extending UniqueName {
     inherited property name -> str;
-};
+}
 
 type UniqueDescription {
     property description -> str {
         constraint exclusive;
-    };
+    }
 
     link another_link_with_unique_property
         extending another_link_with_unique_property -> Object;
 
     link another_link_with_unique_property_inherited
         extending another_link_with_unique_property  -> Object;
-};
+}
 
 type UniqueDescriptionInherited extending UniqueDescription;
 
@@ -141,8 +141,8 @@ type UniqueDescriptionInherited extending UniqueDescription;
 type UniqueName_2 {
     property name -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type UniqueName_2_Inherited extending UniqueName_2;
 
@@ -150,8 +150,8 @@ type UniqueName_2_Inherited extending UniqueName_2;
 type UniqueName_3 extending UniqueName_2 {
     inherited property name -> str {
         constraint exclusive on (str_lower(__subject__));
-    };
-};
+    }
+}
 
 type UniqueName_4 extending UniqueName_2_Inherited;
 
@@ -159,63 +159,63 @@ type MultiConstraint {
     property name -> str {
         constraint exclusive;
         constraint exclusive on (str_lower(__subject__));
-    };
+    }
 
     property m1 -> str;
-};
+}
 
 type ParentUniqueName {
     property name -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type ReceivingParent {
     property name -> str;
-};
+}
 
 type LosingParent extending ParentUniqueName {
     inherited property name -> str;
     property lp -> str;
-};
+}
 
 type AbstractConstraintParent {
     property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type AbstractConstraintParent2 {
     property name -> str {
         delegated constraint exclusive on (str_lower(__subject__));
-    };
-};
+    }
+}
 
 type AbstractConstraintPureChild extending AbstractConstraintParent;
 
 type AbstractConstraintMixedChild extending AbstractConstraintParent {
     inherited property name -> str {
         constraint exclusive on (str_lower(__subject__));
-    };
-};
+    }
+}
 
 type AbstractConstraintPropagated extending AbstractConstraintParent {
     inherited property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type AbstractConstraintParent3 {
     property name -> str {
         delegated constraint exclusive;
         delegated constraint exclusive on (str_lower(__subject__));
-    };
-};
+    }
+}
 
 type AbstractConstraintMultipleParentsFlattening
         extending AbstractConstraintParent, AbstractConstraintParent2 {
     property flat -> str;
-};
+}
 
 type LosingAbstractConstraintParent extending AbstractConstraintParent;
 
@@ -224,24 +224,24 @@ type LosingAbstractConstraintParent2 extending AbstractConstraintParent;
 type BecomingAbstractConstraint {
     property name -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type BecomingAbstractConstraintChild extending BecomingAbstractConstraint;
 
 type BecomingConcreteConstraint {
     property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type BecomingConcreteConstraintChild extending BecomingConcreteConstraint;
 
 type AbstractInheritingNonAbstract extending ParentUniqueName {
     inherited property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type AbstractInheritingNonAbstractChild
     extending AbstractInheritingNonAbstract;

--- a/tests/schemas/constraints_migration/schema.eschema
+++ b/tests/schemas/constraints_migration/schema.eschema
@@ -22,17 +22,17 @@ scalar type constraint_length extending str {
     constraint max_len(10);
     constraint min_len(5);
     constraint min_len(8);
-};
+}
 
 scalar type constraint_length_2 extending constraint_length {
     constraint min_len(9);
-};
+}
 
 scalar type constraint_minmax extending str {
     constraint min("99900000");
     constraint min("99990000");
     constraint max("9999999989");
-};
+}
 
 scalar type constraint_strvalue extending str {
     constraint expression on (__subject__[-1:] = '9');
@@ -42,22 +42,22 @@ scalar type constraint_strvalue extending str {
     constraint expression on (__subject__[0] = '9');
 
     constraint regexp(r"^\d+9{3,}.*$");
-};
+}
 
 scalar type constraint_enum extending str {
    constraint enum('foo', 'bar');
-};
+}
 
 abstract link translated_label {
     property lang -> str;
     property prop1 -> str;
-};
+}
 
 abstract link link_with_unique_property {
     property unique_property -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 abstract link link_with_unique_property_inherited
     extending link_with_unique_property;
@@ -65,15 +65,15 @@ abstract link link_with_unique_property_inherited
 abstract link another_link_with_unique_property {
     property unique_property -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 abstract link another_link_with_unique_property_inherited
     extending another_link_with_unique_property;
 
 type Label {
     property text -> str;
-};
+}
 
 type Object {
     property name -> str;
@@ -81,17 +81,17 @@ type Object {
     property c_length_2 -> constraint_length_2;
     property c_length_3 -> constraint_length_2 {
         constraint min_len(10);
-    };
+    }
 
     property c_minmax -> constraint_minmax;
     property c_strvalue -> constraint_strvalue;
     property c_enum -> constraint_enum;
-};
+}
 
 type UniqueName {
     property name -> str {
         constraint exclusive;
-    };
+    }
 
     link link_with_unique_property
         extending link_with_unique_property -> Object;
@@ -102,24 +102,24 @@ type UniqueName {
     link translated_label extending translated_label -> Label {
         constraint exclusive on ((__subject__@source, __subject__@lang));
         constraint exclusive on (__subject__@prop1);
-    };
-};
+    }
+}
 
 type UniqueNameInherited extending UniqueName {
     inherited property name -> str;
-};
+}
 
 type UniqueDescription {
     property description -> str {
         constraint exclusive;
-    };
+    }
 
     link another_link_with_unique_property
         extending another_link_with_unique_property -> Object;
 
     link another_link_with_unique_property_inherited
         extending another_link_with_unique_property  -> Object;
-};
+}
 
 type UniqueDescriptionInherited extending UniqueDescription;
 
@@ -127,8 +127,8 @@ type UniqueDescriptionInherited extending UniqueDescription;
 type UniqueName_2 {
     property name -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type UniqueName_2_Inherited extending UniqueName_2;
 
@@ -136,8 +136,8 @@ type UniqueName_2_Inherited extending UniqueName_2;
 type UniqueName_3 extending UniqueName_2 {
     inherited property name -> str {
         constraint exclusive on (str_lower(__subject__));
-    };
-};
+    }
+}
 
 type UniqueName_4 extending UniqueName_2_Inherited;
 
@@ -145,63 +145,63 @@ type MultiConstraint {
     property name -> str {
         constraint exclusive;
         constraint exclusive on (str_lower(__subject__));
-    };
+    }
 
     property m1 -> str;
-};
+}
 
 type ParentUniqueName {
     property name -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type ReceivingParent {
     property name -> str;
-};
+}
 
 type LosingParent extending ParentUniqueName {
     inherited property name -> str;
     property lp -> str;
-};
+}
 
 type AbstractConstraintParent {
     property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type AbstractConstraintParent2 {
     property name -> str {
         delegated constraint exclusive on (str_lower(__subject__));
-    };
-};
+    }
+}
 
 type AbstractConstraintPureChild extending AbstractConstraintParent;
 
 type AbstractConstraintMixedChild extending AbstractConstraintParent {
     inherited property name -> str {
         constraint exclusive on (str_lower(__subject__));
-    };
-};
+    }
+}
 
 type AbstractConstraintPropagated extending AbstractConstraintParent {
     inherited property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type AbstractConstraintParent3 {
     property name -> str {
         delegated constraint exclusive;
         delegated constraint exclusive on (str_lower(__subject__));
-    };
-};
+    }
+}
 
 type AbstractConstraintMultipleParentsFlattening
         extending AbstractConstraintParent, AbstractConstraintParent2 {
     property flat -> str;
-};
+}
 
 type LosingAbstractConstraintParent extending AbstractConstraintParent;
 
@@ -210,24 +210,24 @@ type LosingAbstractConstraintParent2 extending AbstractConstraintParent;
 type BecomingAbstractConstraint {
     property name -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type BecomingAbstractConstraintChild extending BecomingAbstractConstraint;
 
 type BecomingConcreteConstraint {
     property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type BecomingConcreteConstraintChild extending BecomingConcreteConstraint;
 
 type AbstractInheritingNonAbstract extending ParentUniqueName {
     inherited property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type AbstractInheritingNonAbstractChild
     extending AbstractInheritingNonAbstract;

--- a/tests/schemas/constraints_migration/updated_schema.eschema
+++ b/tests/schemas/constraints_migration/updated_schema.eschema
@@ -22,17 +22,17 @@ scalar type constraint_length extending str {
     constraint max_len(10);
     constraint min_len(5);
     constraint min_len(8);
-};
+}
 
 scalar type constraint_length_2 extending constraint_length {
     constraint min_len(9);
-};
+}
 
 scalar type constraint_minmax extending str {
     constraint min("99900000");
     constraint min("99990000");
     constraint max("9999999989");
-};
+}
 
 scalar type constraint_strvalue extending str {
     constraint expression on (__subject__[-1:] = '9');
@@ -42,26 +42,26 @@ scalar type constraint_strvalue extending str {
     constraint expression on (__subject__[0] = '9');
 
     constraint regexp(r"^\d+9{3,}.*$");
-};
+}
 
 scalar type constraint_enum extending str {
    constraint enum('foo', 'bar');
-};
+}
 
 abstract link translated_label {
     property lang -> str;
     property prop1 -> str;
-};
+}
 
 abstract link link_with_unique_property {
     property unique_property -> str {
         constraint exclusive;
-    };
+    }
 
     property unique_property2 -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 abstract link link_with_unique_property_inherited
     extending link_with_unique_property;
@@ -69,27 +69,27 @@ abstract link link_with_unique_property_inherited
 abstract link another_link_with_unique_property {
     property unique_property -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 abstract link another_link_with_unique_property_inherited
     extending another_link_with_unique_property;
 
 type Label {
     property text -> str;
-};
+}
 
 type Object {
     property name -> str {
         constraint exclusive;
         constraint exclusive on (std::str_lower(__subject__));
-    };
+    }
 
     property c_length -> constraint_length;
     property c_length_2 -> constraint_length_2;
     property c_length_3 -> constraint_length_2 {
         constraint min_len(10);
-    };
+    }
 
     property c_minmax -> constraint_minmax;
     property c_strvalue -> constraint_strvalue;
@@ -98,16 +98,16 @@ type Object {
     link translated_label extending translated_label -> Label {
         constraint exclusive on ((__subject__@source, __subject__@lang));
         constraint exclusive on (__subject__@prop1);
-    };
-};
+    }
+}
 
 type UniqueName {
     property name -> str {
         constraint exclusive;
-    };
+    }
     property name2 -> str {
         constraint exclusive;
-    };
+    }
 
     link link_with_unique_property
         extending link_with_unique_property -> Object;
@@ -118,12 +118,12 @@ type UniqueName {
     link translated_label extending translated_label -> Label {
         constraint exclusive on ((__subject__@source, __subject__@lang));
         constraint exclusive on (__subject__@prop1);
-    };
-};
+    }
+}
 
 type UniqueNameInherited extending UniqueName {
     inherited property name -> str;
-};
+}
 
 type UniqueNameGrandchild extending UniqueNameInherited;
 
@@ -135,15 +135,15 @@ type UniqueDescription {
 
     link another_link_with_unique_property_inherited
         extending another_link_with_unique_property_inherited -> Object;
-};
+}
 
 type UniqueDescriptionInherited extending UniqueDescription;
 
 type UniqueName_2_Renamed {
     property name -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type UniqueName_2_Inherited extending UniqueName_2_Renamed;
 
@@ -155,95 +155,95 @@ type MultiConstraint_Renamed {
     property name -> str {
         constraint exclusive;
         constraint exclusive on (str_lower(__subject__));
-    };
+    }
 
     property m1 -> str;
-};
+}
 
 type ParentUniqueName {
     property name -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type ReceivingParent extending ParentUniqueName {
     inherited property name -> str;
-};
+}
 
 type LosingParent {
     property name -> str;
     property lp -> str;
-};
+}
 
 type AbstractConstraintParent {
     property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type AbstractConstraintParent2 {
     property name -> str {
         delegated constraint exclusive on (str_lower(__subject__));
-    };
-};
+    }
+}
 
 type AbstractConstraintPureChild extending AbstractConstraintParent;
 
 type AbstractConstraintMixedChild extending AbstractConstraintParent {
     inherited property name -> str {
         constraint exclusive on (str_lower(__subject__));
-    };
-};
+    }
+}
 
 type AbstractConstraintPropagated extending AbstractConstraintParent {
     inherited property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type AbstractConstraintParent3 {
     property name -> str {
         delegated constraint exclusive;
         delegated constraint exclusive on (str_lower(__subject__));
-    };
-};
+    }
+}
 
 type AbstractConstraintMultipleParentsFlattening
         extending AbstractConstraintParent, AbstractConstraintParent2 {
     property flat -> str;
-};
+}
 
 type LosingAbstractConstraintParent {
     property name -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type LosingAbstractConstraintParent2 {
     property name -> str;
-};
+}
 
 type BecomingAbstractConstraint {
     property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type BecomingAbstractConstraintChild extending BecomingAbstractConstraint;
 
 type BecomingConcreteConstraint {
     property name -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type BecomingConcreteConstraintChild extending BecomingConcreteConstraint;
 
 type AbstractInheritingNonAbstract {
     property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type AbstractInheritingNonAbstractChild
     extending AbstractInheritingNonAbstract;

--- a/tests/schemas/graphql.eschema
+++ b/tests/schemas/graphql.eschema
@@ -19,23 +19,23 @@
 
 abstract type NamedObject {
     required property name -> str;
-};
+}
 
 type UserGroup extending NamedObject {
     multi link settings -> Setting {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type Setting extending NamedObject {
     required property value -> str;
-};
+}
 
 type Profile extending NamedObject {
     required property value -> str;
     property tags -> array<str>;
     multi property odd -> array<int64>;
-};
+}
 
 type User extending NamedObject {
     required property active -> bool;
@@ -43,6 +43,6 @@ type User extending NamedObject {
     required property age -> int64;
     required property score -> float64;
     link profile -> Profile;
-};
+}
 
 type Person extending User;

--- a/tests/schemas/graphql_other.eschema
+++ b/tests/schemas/graphql_other.eschema
@@ -20,4 +20,4 @@
 type Foo {
     property `select` -> str;
     property after -> str;
-};
+}

--- a/tests/schemas/insert.eschema
+++ b/tests/schemas/insert.eschema
@@ -19,7 +19,7 @@
 
 type Subordinate {
     required property name -> str;
-};
+}
 
 type InsertTest {
     property name -> str;
@@ -27,24 +27,24 @@ type InsertTest {
     required property l2 -> int64;
     property l3 -> str {
         default := "test";
-    };
+    }
     multi link subordinates -> Subordinate {
         property comment -> str;
-    };
-};
+    }
+}
 
 type Annotation {
     required property name -> str;
     property note -> str;
     link subject -> Object;
-};
+}
 
 type DefaultTest1 {
     property num -> int64 {
         default := 42;
-    };
+    }
     property foo -> str;
-};
+}
 
 type DefaultTest2 {
     property foo -> str;
@@ -55,36 +55,36 @@ type DefaultTest2 {
             ORDER BY DefaultTest1.num DESC
             LIMIT 1
         );
-    };
-};
+    }
+}
 
 type DefaultTest3 {
     required property foo -> float64 {
         # non-deterministic dynamic value
         default := random();
-    };
-};
+    }
+}
 
 type DefaultTest4 {
     required property bar -> int64 {
         # deterministic dynamic value
         default := (SELECT count(DefaultTest4));
-    };
-};
+    }
+}
 
 # types to test some inheritance issues
 type InputValue {
     property val -> str;
-};
+}
 
 abstract type Callable {
     multi link args -> InputValue;
-};
+}
 
 type Field extending Callable {
     # This link 'args' appears to be overriding the inherited 'args'
     # from Callable.
     inherited multi link args -> InputValue;
-};
+}
 
 type Directive extending Callable;

--- a/tests/schemas/inventory.eschema
+++ b/tests/schemas/inventory.eschema
@@ -20,11 +20,11 @@
 abstract type Named {
     required property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type Item extending Named {
     multi property tag_set1 -> str;
     multi property tag_set2 -> str;
     property tag_array -> array<str>;
-};
+}

--- a/tests/schemas/issues.eschema
+++ b/tests/schemas/issues.eschema
@@ -22,33 +22,33 @@ abstract type Text {
     required property body -> str {
         # Maximum length of text is 10000 characters.
         constraint max_len(10000);
-    };
-};
+    }
+}
 
 abstract type Named {
     required property name -> str;
-};
+}
 
 # Dictionary is a NamedObject variant, that enforces
 # name uniqueness across all instances if its subclass.
 abstract type Dictionary extending Named {
     inherited required property name -> str {
         delegated constraint exclusive;
-    };
-};
+    }
+}
 
 type User extending Dictionary {
     multi link todo -> Issue {
         property rank -> int64 {
             default := 42;
-        };
-    };
-};
+        }
+    }
+}
 
 abstract type Owned {
     # By default links are optional.
     required link owner -> User;
-};
+}
 
 type Status extending Dictionary;
 
@@ -59,20 +59,20 @@ type LogEntry extending Owned, Text {
     # will have all of their links and attributes,
     # in particular, owner and text links.
     required property spent_time -> int64;
-};
+}
 
 scalar type issue_num_t extending std::str;
 
 type Comment extending Text, Owned {
     required link issue -> Issue;
     link parent -> Comment;
-};
+}
 
 type Issue extending Named, Owned, Text {
     required property number -> issue_num_t {
         readonly := true;
         constraint exclusive;
-    };
+    }
     required link status -> Status;
 
     link priority -> Priority;
@@ -87,7 +87,7 @@ type Issue extending Named, Owned, Text {
         default := (SELECT datetime_current());
         # The default value of start_date will be a
         # result of the EdgeQL expression above.
-    };
+    }
     property due_date -> datetime;
 
     multi link related_to -> Issue;
@@ -95,18 +95,18 @@ type Issue extending Named, Owned, Text {
     multi link references -> File | URL | Publication;
 
     property tags -> array<str>;
-};
+}
 
 type File extending Named;
 
 type URL extending Named {
     required property address -> str;
-};
+}
 
 type Publication {
     required property title -> str;
-};
+}
 
 abstract constraint my_enum(enum: array<anytype>) {
     expr := contains($enum, __subject__);
-};
+}

--- a/tests/schemas/json.eschema
+++ b/tests/schemas/json.eschema
@@ -20,7 +20,7 @@
 type JSONTest {
     required property number -> int64 {
         constraint exclusive;
-    };
+    }
 
     # these properties are intended to have specific JSON types in them
     property j_string -> json;
@@ -34,4 +34,4 @@ type JSONTest {
 
     # these properties are used for testing casting
     property edb_string -> str;
-};
+}

--- a/tests/schemas/link_tgt_del.eschema
+++ b/tests/schemas/link_tgt_del.eschema
@@ -19,7 +19,7 @@
 
 abstract type Named {
     required property name -> str;
-};
+}
 
 type Target1 extending Named;
 type Target1Child extending Target1;
@@ -27,39 +27,39 @@ type Target1Child extending Target1;
 type Source1 extending Named {
     link tgt1_restrict -> Target1 {
         on target delete restrict;
-    };
+    }
     link tgt1_allow -> Target1 {
         on target delete allow;
-    };
+    }
     link tgt1_del_source -> Target1 {
         on target delete delete source;
-    };
+    }
     link tgt1_deferred_restrict -> Target1 {
         on target delete deferred restrict;
-    };
+    }
     multi link tgt1_m2m_restrict -> Target1 {
         on target delete restrict;
-    };
+    }
     multi link tgt1_m2m_allow -> Target1 {
         on target delete allow;
-    };
+    }
     multi link tgt1_m2m_del_source -> Target1 {
         on target delete delete source;
-    };
-};
+    }
+}
 
 type Source2 extending Named {
     link src1_del_source -> Source1 {
         on target delete delete source;
-    };
-};
+    }
+}
 
 type Source3 extending Source1;
 
 type ObjectType4 {
     link foo -> Target1;
-};
+}
 
 type ObjectType5 {
     link foo -> Target1;
-};
+}

--- a/tests/schemas/link_tgt_del_migrated.eschema
+++ b/tests/schemas/link_tgt_del_migrated.eschema
@@ -19,7 +19,7 @@
 
 abstract type Named {
     required property name -> str;
-};
+}
 
 type Target1 extending Named;
 type Target1Child extending Target1;
@@ -27,38 +27,38 @@ type Target1Child extending Target1;
 type Source1 extending Named {
     link tgt1_restrict -> Target1 {
         on target delete restrict;
-    };
+    }
     link tgt1_allow -> Target1 {
         on target delete allow;
-    };
+    }
     link tgt1_del_source -> Target1 {
         on target delete delete source;
-    };
+    }
     link tgt1_deferred_restrict -> Target1 {
         on target delete restrict;
-    };
+    }
     multi link tgt1_m2m_restrict -> Target1 {
         on target delete restrict;
-    };
+    }
     multi link tgt1_m2m_allow -> Target1 {
         on target delete allow;
-    };
+    }
     multi link tgt1_m2m_del_source -> Target1 {
         on target delete delete source;
-    };
-};
+    }
+}
 
 type Source2 extending Named {
     link src1_del_source -> Source1 {
         on target delete delete source;
-    };
-};
+    }
+}
 
 type Source3 extending Source1;
 
 abstract type AbstractObjectType {
     link foo -> Target1;
-};
+}
 
 type ObjectType4 extending AbstractObjectType;
 

--- a/tests/schemas/links_1.eschema
+++ b/tests/schemas/links_1.eschema
@@ -19,28 +19,28 @@
 
 type Target0 {
     property name -> str;
-};
+}
 
 type Target1 extending Target0 {
     inherited property name -> str;
-};
+}
 
 type ObjectType0 {
     link target -> Target0;
-};
+}
 
 type ObjectType1 {
     link target -> Target1;
-};
+}
 
 type ObjectType01 extending ObjectType0, ObjectType1;
 
 type ObjectType2 {
     required link target -> Target0;
-};
+}
 
 type ObjectType3 {
     required link target -> Target0;
-};
+}
 
 type ObjectType23 extending ObjectType2, ObjectType3;

--- a/tests/schemas/links_1_migrated.eschema
+++ b/tests/schemas/links_1_migrated.eschema
@@ -19,28 +19,28 @@
 
 type Target0 {
     property name -> str;
-};
+}
 
 type Target1 extending Target0 {
     inherited property name -> str;
-};
+}
 
 type ObjectType0 {
     link target -> Target0;
-};
+}
 
 type ObjectType1 {
     link target -> Target0;
-};
+}
 
 type ObjectType01 extending ObjectType0;
 
 type ObjectType2 {
     required link target -> Target0;
-};
+}
 
 type ObjectType3 {
     required link target2 -> Target0;
-};
+}
 
 type ObjectType23 extending ObjectType2, ObjectType3;

--- a/tests/schemas/updates.eschema
+++ b/tests/schemas/updates.eschema
@@ -20,14 +20,14 @@
 type Status {
     required property name -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type Tag {
     required property name -> str {
         constraint exclusive;
-    };
-};
+    }
+}
 
 type UpdateTest {
     required property name -> str;
@@ -37,17 +37,17 @@ type UpdateTest {
     link status -> Status;
     link annotated_status -> Status {
         property note -> str;
-    };
+    }
 
     # for testing links to sets
     multi link tags -> Tag;
     multi link weighted_tags -> Tag {
         property weight -> int64;
-    };
+    }
 
     # for testing links to sets of the same type as originator
     multi link related -> UpdateTest;
     multi link annotated_tests -> UpdateTest {
         property note -> str;
-    };
-};
+    }
+}

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -324,6 +324,84 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         };
         """
 
+    def test_eschema_syntax_type_25(self):
+        """
+        type Foo {
+            single property foo -> str
+        }
+
+        type Bar {
+            multi property bar -> str
+        }
+
+        type Baz {
+            required single property baz -> str
+        }
+
+        type Spam {
+            required multi property spam -> str
+        }
+
+        type Ham {
+            inherited required single property ham -> str
+        }
+
+        type Eggs {
+            inherited required multi property eggs -> str
+        }
+
+% OK %
+
+        type Foo {
+            single property foo -> str;
+        };
+
+        type Bar {
+            multi property bar -> str;
+        };
+
+        type Baz {
+            required single property baz -> str;
+        };
+
+        type Spam {
+            required multi property spam -> str;
+        };
+
+        type Ham {
+            inherited required single property ham -> str;
+        };
+
+        type Eggs {
+            inherited required multi property eggs -> str;
+        };
+        """
+
+    def test_eschema_syntax_type_26(self):
+        """
+        type Foo {
+            single property foo -> str {
+                constraint max_len (10000)
+            }
+
+            multi property bar -> str {
+                constraint max_len (10000)
+            }
+        }
+
+% OK %
+
+        type Foo {
+            single property foo -> str {
+                constraint max_len (10000);
+            };
+
+            multi property bar -> str {
+                constraint max_len (10000);
+            };
+        };
+        """
+
     def test_eschema_syntax_link_target_type_01(self):
         """
         type User {
@@ -1005,6 +1083,99 @@ abstract property foo {
                     array<tuple<int, Foo>>>
                 > {
             from sql function 'some_other_func';
+        };
+        """
+
+    def test_eschema_syntax_function_18(self):
+        """
+        function len1() -> std::int64
+            from sql function 'length1';
+
+        function len2() -> std::int64
+            from sql function 'length2';
+
+        function len3() -> std::int64
+            from sql function 'length3';
+
+        function len4() -> std::int64
+            from sql function 'length4';
+
+% OK %
+
+        function len1() ->  std::int64 {
+            from SQL function 'length1';
+        };
+        function len2() ->  std::int64 {
+            from SQL function 'length2';
+        };
+        function len3() ->  std::int64 {
+            from SQL function 'length3';
+        };
+        function len4() ->  std::int64 {
+            from SQL function 'length4';
+        };
+        """
+
+    def test_eschema_syntax_function_19(self):
+        """
+        function len1() ->  std::int64 {
+            from SQL function 'length1'
+        }
+        function len2() ->  std::int64 {
+            from SQL function 'length2'
+        }
+        function len3() ->  std::int64 {
+            from SQL function 'length3'
+        }
+        function len4() ->  std::int64 {
+            from SQL function 'length4'
+        }
+
+
+% OK %
+
+        function len1() ->  std::int64 {
+            from SQL function 'length1';
+        };
+        function len2() ->  std::int64 {
+            from SQL function 'length2';
+        };
+        function len3() ->  std::int64 {
+            from SQL function 'length3';
+        };
+        function len4() ->  std::int64 {
+            from SQL function 'length4';
+        };
+        """
+
+    def test_eschema_syntax_function_20(self):
+        """
+        function len1() ->  std::int64 {
+            from SQL function 'length1'
+        }
+        function len2() ->  std::int64
+            from SQL function 'length2';
+
+        function len3() ->  std::int64 {
+            from SQL function 'length3'
+        }
+        function len4() ->  std::int64
+            from SQL function 'length4';
+
+
+% OK %
+
+        function len1() ->  std::int64 {
+            from SQL function 'length1';
+        };
+        function len2() ->  std::int64 {
+            from SQL function 'length2';
+        };
+        function len3() ->  std::int64 {
+            from SQL function 'length3';
+        };
+        function len4() ->  std::int64 {
+            from SQL function 'length4';
         };
         """
 


### PR DESCRIPTION
For SDL declarations semicolons are only required as separators
for single-line declarations (ones which don't have a sub-block).
Semicolons are still separators, so the last semicolon before end
of file can be omitted as well.

Examples in documetation are updated with fewer semicolons in
schema code blocks.