### PR TITLE
Switch storage of "single" links to inline relation attributes

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -571,6 +571,10 @@ class CreateExtendingObject(CreateObject):
 class Rename(DDL):
     new_name: ObjectRef
 
+    @property
+    def name(self) -> ObjectRef:
+        return self.new_name
+
 
 class Delta:
     pass

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -325,3 +325,13 @@ def ptrcls_from_ptrref(
 def is_id_ptrref(
         ptrref: irast.BasePointerRef):
     return ptrref.shortname == 'std::id'
+
+
+def is_inbound_ptrref(
+        ptrref: irast.BasePointerRef):
+    return ptrref.direction is s_pointers.PointerDirection.Inbound
+
+
+def is_computable_ptrref(
+        ptrref: irast.BasePointerRef):
+    return ptrref.derived_from_ptr is not None

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -154,12 +154,8 @@ def get_scalar_backend_name(id, module_id, catenate=True, *, aspect=None):
 def get_objtype_backend_name(id, module_id, *, catenate=True, aspect=None):
     if aspect is None:
         aspect = 'table'
-    if aspect not in (
-            'table',
-            'target-del-def-t', 'target-del-imm-t',
-            'source-del-def-t', 'source-del-imm-t',
-            'target-del-def-f', 'target-del-imm-f',
-            'source-del-def-f', 'source-del-imm-f'):
+    if aspect != 'table' and not re.match(
+            r'(source|target)-del-(def|imm)-(inl|otl)-(f|t)', aspect):
         raise ValueError(
             f'unexpected aspect for object type backend name: {aspect!r}')
 

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -150,3 +150,4 @@ class Environment:
         self.output_format = output_format
         self.tuple_formats = {}
         self.use_named_params = use_named_params
+        self.ptrref_source_visibility = {}

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -495,7 +495,7 @@ def process_update_body(
             ptr_info = pg_types.get_ptrref_storage_info(
                 ptrref, resolve_type=True, link_bias=False)
 
-            if ptr_info.table_type == 'ObjectType':
+            if ptr_info.table_type == 'ObjectType' and updvalue is not None:
                 with subctx.newscope() as scopectx:
                     # First, process all internal link updates
                     updvalue = pgast.TypeCast(

--- a/edb/pgsql/dbops/base.py
+++ b/edb/pgsql/dbops/base.py
@@ -376,6 +376,9 @@ class Query(Command):
         else:
             return self.text
 
+    def code(self, block: PLBlock) -> str:
+        return self.text
+
     def __repr__(self):
         return f'<Query {self.text!r}>'
 

--- a/edb/pgsql/dbops/indexes.py
+++ b/edb/pgsql/dbops/indexes.py
@@ -82,11 +82,15 @@ class Index(tables.InheritableTableObject):
         return base.pack_name(self.table_name[1] + '__' + self.name)
 
     def add_columns(self, columns):
-        self._columns.update(columns)
+        for col in columns:
+            if isinstance(col, str):
+                self._columns.add(col)
+            else:
+                self._columns.add(col.name)
 
     def declare_pl_desc_var(self, block: base.PLBlock) -> str:
         desc_var = block.declare_var(('edgedb', 'intro_index_desc_t'))
-        cols = ', '.join(ql(c.name) for c in self.columns)
+        cols = ', '.join(ql(c) for c in self.columns)
 
         code = textwrap.dedent(f'''\
             {desc_var}.table_name := ARRAY[
@@ -162,7 +166,7 @@ class Index(tables.InheritableTableObject):
 
     @property
     def columns(self):
-        return iter(self._columns)
+        return list(self._columns)
 
     def get_type(self):
         return 'INDEX'

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -471,6 +471,14 @@ class CommandContext:
             if isinstance(item, cls):
                 return item
 
+    def get_ancestor(self, cls):
+        if issubclass(cls, Command):
+            cls = cls.get_context_class()
+
+        for item in list(reversed(self.stack))[1:]:
+            if isinstance(item, cls):
+                return item
+
     def top(self):
         if self.stack:
             return self.stack[0]
@@ -896,6 +904,8 @@ class RenameObject(ObjectCommand):
             name_b32 = new_name.name[6:].replace('_', '=')
             new_nname = base64.b32decode(name_b32).decode()
             new_name = sn.Name(module=new_name.module, name=new_nname)
+        else:
+            new_name = cls._classname_from_ast(schema, astnode, context)
 
         return rename_class(
             metaclass=parent_class,

--- a/tests/schemas/links_1_migrated.eschema
+++ b/tests/schemas/links_1_migrated.eschema
@@ -40,7 +40,7 @@ type ObjectType2 {
 }
 
 type ObjectType3 {
-    required link target2 -> Target0;
+    required link target -> Target0;
 }
 
 type ObjectType23 extending ObjectType2, ObjectType3;


### PR DESCRIPTION
Currently, all links, regardless of cardinality, are represented as a
(source, target) table.  For "single" links this is suboptimal, since an
extra join is required when traversing the link.  The concept of an
"inline" storage is already used for `__type__`, so this change merely
extends it for all non-multi links and fixes the bugs and omissions this
had exposed.

The downside of this change is that changing the cardinality of a link
is now less trivial and requires moving the data during the migration.