### PR TITLE
Update docs and doc tools.

### DIFF
--- a/docs/datamodel/attributes.rst
+++ b/docs/datamodel/attributes.rst
@@ -15,25 +15,25 @@ Definition
 An attribute may be defined in EdgeDB Schema using the ``attribute``
 declaration:
 
-.. eschema:synopsis::
+.. sdl:synopsis::
 
     abstract [ inheritable ] attribute <attr-name>:
         [ <attribute-declarations> ]
 
 Parameters:
 
-:eschema:synopsis:`<attr-name>`
+:sdl:synopsis:`<attr-name>`
     Specifies the name of the attribute.  Customarily, attribute names
     are lowercase, with words separated by underscores as necessary for
     readability.
 
-:eschema:synopsis:`inheritable`
+:sdl:synopsis:`inheritable`
     The attributes are non-inheritable by default.  That is, if a schema item
     has an attribute defined on it, the descendants of that schema item will
     not automatically inherit the attribute.  Normal inheritance behavior can
     be turned on by declaring the attribute with the *inheritable* qualifier.
 
-:eschema:synopsis:`<attribute-declarations>`
+:sdl:synopsis:`<attribute-declarations>`
     Schema attribute declarations for this attribute.  Schema attributes
     are considered schema items, and can have attributes themselves.
 
@@ -47,17 +47,17 @@ Setting Attributes
 
 Attributes may be set in EdgeDB Schema using the following syntax:
 
-.. eschema:synopsis::
+.. sdl:synopsis::
 
     attribute <attr-name> := <constant-string-value>
 
-Here :eschema:synopsis:`<attr-name>` is the name of the previously
-defined attribute, and :eschema:synopsis:`<constant-string-value>`
+Here :sdl:synopsis:`<attr-name>` is the name of the previously
+defined attribute, and :sdl:synopsis:`<constant-string-value>`
 is a valid constant expression that evaluates to a string.
 
 For example:
 
-.. code-block:: eschema
+.. code-block:: sdl
 
     scalar type pr_status extending str {
         attribute title := 'Pull Request Status Type';

--- a/docs/datamodel/computables.rst
+++ b/docs/datamodel/computables.rst
@@ -18,7 +18,7 @@ some value that is derived from the values of existing properties and links.
 
 For example:
 
-.. code-block:: eschema
+.. code-block:: sdl
 
     type User {
         required property firstname -> str;

--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -21,7 +21,7 @@ Abstract Constraints
 An *abstract constraint* may be defined in EdgeDB Schema using the
 ``abstract constraint`` declaration:
 
-.. eschema:synopsis::
+.. sdl:synopsis::
 
     abstract constraint <constr-name> [( [<argspec>] [, ...] )]
             [on (<subject-expr>)]
@@ -38,31 +38,31 @@ An *abstract constraint* may be defined in EdgeDB Schema using the
 Parameters
 ~~~~~~~~~~
 
-:eschema:synopsis:`<constr-name>`
+:sdl:synopsis:`<constr-name>`
     The name of the constraint.
 
-:eschema:synopsis:`<argspec>`
+:sdl:synopsis:`<argspec>`
     An optional list of constraint arguments.
-    :eschema:synopsis:`<argname>` optionally specifies
-    the argument name, and :eschema:synopsis:`<argtype>`
+    :sdl:synopsis:`<argname>` optionally specifies
+    the argument name, and :sdl:synopsis:`<argtype>`
     specifies the argument type.
 
-:eschema:synopsis:`<subject-expr>`
+:sdl:synopsis:`<subject-expr>`
     An optional expression defining the *subject* of the constraint.
     If not specified, the subject is the value of the schema item on
     which the constraint is defined.
 
-:eschema:synopsis:`extending <parent_constr> [, ...]`
+:sdl:synopsis:`extending <parent_constr> [, ...]`
     If specified, declares the *parent* constraints for this constraint.
 
-:eschema:synopsis:`expr := <constr_expression>`
+:sdl:synopsis:`expr := <constr_expression>`
     An boolean expression that returns ``true`` for valid data and
     ``false`` for invalid data.  The expression may refer to special
     variables: ``__self__`` for the value of the scalar type, link or
     property value; and ``__subject__`` which is the constraint's subject
-    expression as defined by :eschema:synopsis:`<subject-expr>`.
+    expression as defined by :sdl:synopsis:`<subject-expr>`.
 
-:eschema:synopsis:`errmessage := <error_message>`
+:sdl:synopsis:`errmessage := <error_message>`
     An optional string literal defining the error message template that
     is raised when the constraint is violated.  The template is a formatted
     string that may refer to constraint context variables in curly braces.
@@ -72,7 +72,7 @@ Parameters
     - ``__self__`` -- the value of the ``title`` attribute of the scalar type,
       property or link on which the constraint is defined.
 
-:eschema:synopsis:`<attribute_declarations>`
+:sdl:synopsis:`<attribute_declarations>`
     :ref:`Schema attribute <ref_datamodel_attributes>` declarations.
 
 
@@ -83,7 +83,7 @@ A *concrete constraint* may be defined in EdgeDB Schema using the
 ``constraint`` declaration in the context of a ``scalar type``, ``property``,
 or ``link`` declaration:
 
-.. eschema:synopsis::
+.. sdl:synopsis::
 
     { scalar type | type | abstract link } <subject-item>:
         <constraint-declaration>
@@ -106,28 +106,28 @@ or ``link`` declaration:
 Parameters
 ~~~~~~~~~~
 
-:eschema:synopsis:`delegated`
+:sdl:synopsis:`delegated`
     If specified, the constraint is defined as *delegated*, which means
     that it will not be enforced on the type it's declared on, and
     the enforcement will be delegated to the subtypes of this type.
     This is particularly useful for :eql:constraint:`exclusive`
     constraints in abstract types.
 
-:eschema:synopsis:`<constr_name>`
+:sdl:synopsis:`<constr_name>`
     The name of the previously defined abstract constraint.
 
-:eschema:synopsis:`<argname>`
+:sdl:synopsis:`<argname>`
     The name of an argument.
 
-:eschema:synopsis:`<argvalue>`
+:sdl:synopsis:`<argvalue>`
     The value of an argument as a literal constant of the correct type.
 
-:eschema:synopsis:`<subject-expr>`
+:sdl:synopsis:`<subject-expr>`
     An optional expression defining the *subject* of the constraint.
     If not specified, the subject is the value of the schema item on
     which the constraint is defined.
 
-:eschema:synopsis:`<attribute-declarations>`
+:sdl:synopsis:`<attribute-declarations>`
     :ref:`Schema attribute <ref_datamodel_attributes>` declarations.
 
 
@@ -142,7 +142,7 @@ The standard library defines the following constraints:
 
     Example:
 
-    .. code-block:: eschema
+    .. code-block:: sdl
 
         scalar type status_t extending str {
             constraint enum ('Open', 'Closed', 'Merged');
@@ -154,7 +154,7 @@ The standard library defines the following constraints:
 
     Example:
 
-    .. code-block:: eschema
+    .. code-block:: sdl
 
         scalar type starts_with_a extending str {
             constraint expression on (__subject__[0] = 'A');
@@ -166,7 +166,7 @@ The standard library defines the following constraints:
 
     Example:
 
-    .. code-block:: eschema
+    .. code-block:: sdl
 
         scalar type max_100 extending int64 {
             constraint max(100);
@@ -178,7 +178,7 @@ The standard library defines the following constraints:
 
     Example:
 
-    .. code-block:: eschema
+    .. code-block:: sdl
 
         scalar type maxex_100 extending int64 {
             constraint max_ex(100);
@@ -190,7 +190,7 @@ The standard library defines the following constraints:
 
     Example:
 
-    .. code-block:: eschema
+    .. code-block:: sdl
 
         scalar type username_t extending str {
             constraint max_len(30);
@@ -202,7 +202,7 @@ The standard library defines the following constraints:
 
     Example:
 
-    .. code-block:: eschema
+    .. code-block:: sdl
 
         scalar type non_negative extending int64 {
             constraint min(0);
@@ -214,7 +214,7 @@ The standard library defines the following constraints:
 
     Example:
 
-    .. code-block:: eschema
+    .. code-block:: sdl
 
         scalar type positive_float extending float64 {
             constraint min_ex(0);
@@ -226,7 +226,7 @@ The standard library defines the following constraints:
 
     Example:
 
-    .. code-block:: eschema
+    .. code-block:: sdl
 
         scalar type four_decimal_places extending int64 {
             constraint min_len(4);
@@ -241,7 +241,7 @@ The standard library defines the following constraints:
 
     Example:
 
-    .. code-block:: eschema
+    .. code-block:: sdl
 
         scalar type letters_only_t extending str {
             constraint regexp(r'[A-Za-z]*');
@@ -262,7 +262,7 @@ The standard library defines the following constraints:
 
     Example:
 
-    .. code-block:: eschema
+    .. code-block:: sdl
 
         type User {
             # Make sure user names are unique.

--- a/docs/datamodel/functions.rst
+++ b/docs/datamodel/functions.rst
@@ -10,7 +10,7 @@ Definition
 
 A function may be defined in EdgeDB Schema using the ``function`` declaration:
 
-.. eschema:synopsis::
+.. sdl:synopsis::
 
     function <funcname> ([<argspec>] [, ...]) -> <returnspec>:
         from <language> := <functionbody>
@@ -37,7 +37,7 @@ A function may be defined in EdgeDB Schema using the ``function`` declaration:
 Parameters
 ----------
 
-:eschema:synopsis:`<funcname>`
+:sdl:synopsis:`<funcname>`
     The function name.
 
 :eql:synopsis:`<argkind>`
@@ -70,16 +70,16 @@ Parameters
     if the argument is an empty set.  The default behavior is to return
     an empty set if the argument is not marked as ``optional``.
 
-:eschema:synopsis:`<argtype>`
+:sdl:synopsis:`<argtype>`
     The data type of the function's arguments
     (optionally module-qualified).
 
-:eschema:synopsis:`<default>`
+:sdl:synopsis:`<default>`
     An expression to be used as default value if the parameter is not
     specified.  The expression has to be of a type compatible with the
     type of the argument.
 
-:eschema:synopsis:`<rettype>`
+:sdl:synopsis:`<rettype>`
     The return data type (optionally module-qualified).
     The ``set of`` modifier indicates that the function will return
     a non-singleton set.
@@ -87,11 +87,11 @@ Parameters
     The ``optional`` qualifier indicates that the function may return
     an empty set.
 
-:eschema:synopsis:`<language>`
+:sdl:synopsis:`<language>`
     The name of the language that the function is implemented in.
     The only currently supported value is ``edgeql``.
 
-:eschema:synopsis:`<functionbody>`
+:sdl:synopsis:`<functionbody>`
     A string constant defining the function.
 
 

--- a/docs/datamodel/index.rst
+++ b/docs/datamodel/index.rst
@@ -18,7 +18,7 @@ of named *properties* and *links* to other types.
 
 Here is an example of a simple EdgeDB type using the Edge Schema notation:
 
-.. code-block:: eschema
+.. code-block:: sdl
 
     type User {
         property name -> str;

--- a/docs/datamodel/indexes.rst
+++ b/docs/datamodel/indexes.rst
@@ -14,7 +14,7 @@ that expression.
 The simplest form of index is an index, which references one
 or more properties directly:
 
-.. code-block:: eschema
+.. code-block:: sdl
 
     type User {
         property name -> str;
@@ -32,7 +32,7 @@ to find the matching objects:
 Indexes may be defined using an arbitrary expression that references properties
 of the host object type or link:
 
-.. code-block:: eschema
+.. code-block:: sdl
 
     type User {
         property firstname -> str;
@@ -58,7 +58,7 @@ Definition
 Indexes may be defined in EdgeDB Schema in the context of a ``type`` or
 ``abstract link`` declaration using the following two forms:
 
-.. eschema:synopsis::
+.. sdl:synopsis::
 
     { type <TypeName> | abstract link <link-name> }:
         index <index-name> := <index-expr>
@@ -72,15 +72,15 @@ Indexes may be defined in EdgeDB Schema in the context of a ``type`` or
 Parameters
 ----------
 
-:eschema:synopsis:`<index-name>`
+:sdl:synopsis:`<index-name>`
     The name of the index.  No module name can be specified, indexes are
     always created in the same module as the host type or link.  Index
     names must be unique within their host.
 
-:eschema:synopsis:`<index-expr>`
+:sdl:synopsis:`<index-expr>`
     An expression based on one or more properties of the host schema item.
 
-:eschema:synopsis:`[ <attr-name> := <attr-value> ]`
+:sdl:synopsis:`[ <attr-name> := <attr-value> ]`
     An optional list of schema attribute values for the index. See
     :ref:`schema attributes <ref_datamodel_attributes>` for more information.
 

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -24,7 +24,7 @@ Abstract Links
 An *abstract link* may be defined in EdgeDB Schema using the ``abstract link``
 declaration:
 
-.. eschema:synopsis::
+.. sdl:synopsis::
 
     abstract link <link_name> [ extending [(] <parent-link> [, ...] [)]]:
         [ <property-declarations> ]
@@ -32,12 +32,12 @@ declaration:
 
 Parameters:
 
-:eschema:synopsis:`<link-name>`
+:sdl:synopsis:`<link-name>`
     Specifies the name of the link item.  Customarily, link names
     are lowercase, with words separated by underscores as necessary for
     readability.
 
-:eschema:synopsis:`extending <parent-link> [, ...]`
+:sdl:synopsis:`extending <parent-link> [, ...]`
     If specified, declares the *parents* of the link item.
 
     Use of ``extending`` creates a persistent schema relationship
@@ -50,10 +50,10 @@ Parameters:
     If there is no conflict, the link properties are merged to form a
     single property in the new link item.
 
-:eschema:synopsis:`<property-declarations>`
+:sdl:synopsis:`<property-declarations>`
     :ref:`Property <ref_datamodel_props>` declarations.
 
-:eschema:synopsis:`<attribute-declarations>`
+:sdl:synopsis:`<attribute-declarations>`
     :ref:`Schema attribute <ref_datamodel_attributes>` declarations.
 
 
@@ -71,7 +71,7 @@ Concrete Links
 A *concrete link* may be defined in EdgeDB Schema using the ``link``
 declaration in the context of a ``type`` declaration:
 
-.. eschema:synopsis::
+.. sdl:synopsis::
 
     type <TypeName>:
         [required] [inherited] [{multi | single}] link <link-name> \
@@ -95,29 +95,29 @@ declaration in the context of a ``type`` declaration:
 
 Parameters:
 
-:eschema:synopsis:`required`
+:sdl:synopsis:`required`
     If specified, the link is considered *required* for the parent
     object type.  It is an error for an object to have a required
     link resolve to an empty value.  Child links **always** inherit
     the *required* attribute, i.e it is not possible to make a
     required link non-required by extending it.
 
-:eschema:synopsis:`inherited`
+:sdl:synopsis:`inherited`
     This qualifier must be specified if the link is *inherited* from
     one or more parent object types.
 
-:eschema:synopsis:`multi`
+:sdl:synopsis:`multi`
     Specifies that there may be more than one instance of this link
     in an object, in other words, ``Object.link`` may resolve to a set
     of a size greater than one.
 
-:eschema:synopsis:`single`
+:sdl:synopsis:`single`
     Specifies that there may be at most *one* instance of this link
     in an object, in other words, ``Object.link`` may resolve to a set
     of a size not greater than one.  ``single`` is assumed if nether
     ``multi`` nor ``single`` qualifier is specified.
 
-:eschema:synopsis:`extending <parent-link> [, ...]`
+:sdl:synopsis:`extending <parent-link> [, ...]`
     If specified, declares the *parents* of the link item.
 
     Use of ``extending`` creates a persistent schema relationship
@@ -130,51 +130,51 @@ Parameters:
     If there is no conflict, the link properties are merged to form a
     single property in the new link item.
 
-:eschema:synopsis:`readonly`
+:sdl:synopsis:`readonly`
     If specified, the link is considered *read-only*.  Modifications
     of this link are prohibited once an object is created.
 
-:eschema:synopsis:`default`
+:sdl:synopsis:`default`
     Specifies the default value for the link as an EdgeQL expression.
     The default value is used in an ``INSERT`` statement if an explicit
     value for this link is not specified.
 
-:eschema:synopsis:`<computable-expr>`
+:sdl:synopsis:`<computable-expr>`
     If specified, designates this link as a *computable link*
     (see :ref:`Computables <ref_datamodel_computables>`).  A computable
     link cannot be *required* or *readonly* (the latter is implied and
     always true).  There is a shorthand form using the ``:=`` syntax,
     as shown in the synopsis above.
 
-:eschema:synopsis:`<property-declarations>`
+:sdl:synopsis:`<property-declarations>`
     :ref:`Property <ref_datamodel_props>` declarations.
 
-:eschema:synopsis:`<attribute-declarations>`
+:sdl:synopsis:`<attribute-declarations>`
     :ref:`Schema attribute <ref_datamodel_attributes>` declarations.
 
-:eschema:synopsis:`<constraint-declarations>`
+:sdl:synopsis:`<constraint-declarations>`
     :ref:`Constraint <ref_datamodel_constraints>` declarations.
 
-:eschema:synopsis:`on target delete`
+:sdl:synopsis:`on target delete`
     On target delete options cover the situation when the target
     object of a link is deleted without explicitly updating the link.
 
-:eschema:synopsis:`restrict`
+:sdl:synopsis:`restrict`
     Prohibit deleting the link target as long as the source object exists.
     This is the default behavior.
 
-:eschema:synopsis:`allow`
+:sdl:synopsis:`allow`
     Allow dropping the connection between the source and target when
     the target is deleted.
 
-:eschema:synopsis:`delete source`
+:sdl:synopsis:`delete source`
     Delete the source object if any link target is deleted. This means
     that for ``multi`` links the source object will be deleted
     if even one of the link targets is deleted (e.g. automatically
     dissolving a team when all team members are critical and one has
     been deleted).
 
-:eschema:synopsis:`deferred restrict`
+:sdl:synopsis:`deferred restrict`
     Same as ``restrict``, but the check is performed at the end of
     transaction instead of immediately.
 

--- a/docs/datamodel/objects.rst
+++ b/docs/datamodel/objects.rst
@@ -31,7 +31,7 @@ types in EdgeDB extend ``std::Object`` directly or indirectly.
 
     Definition:
 
-    .. code-block:: eschema
+    .. code-block:: sdl
 
         abstract type Object {
             # Universally unique object identifier
@@ -47,7 +47,7 @@ Definition
 
 Object types may be defined in EdgeDB Schema using the ``type`` keyword:
 
-.. eschema:synopsis::
+.. sdl:synopsis::
 
     [abstract] type <TypeName> [extending [(] <supertype> [, ...] [)]]:
         [ <property-declarations> ]
@@ -58,14 +58,14 @@ Object types may be defined in EdgeDB Schema using the ``type`` keyword:
 
 Parameters:
 
-:eschema:synopsis:`abstract`
+:sdl:synopsis:`abstract`
     If specified, the declared type will be *abstract*.
 
-:eschema:synopsis:`<TypeName>`
+:sdl:synopsis:`<TypeName>`
     Specifies the name of the object type.  Customarily, object type names
     use the CapWords convention.
 
-:eschema:synopsis:`extending <supertype> [, ...]`
+:sdl:synopsis:`extending <supertype> [, ...]`
     If specified, declares the *supertypes* of the new type.
 
     Use of ``extending`` creates a persistent type relationship
@@ -81,16 +81,16 @@ Parameters:
     be *compatible*.  If there is no conflict, the links are merged to
     form a single link in the new type.
 
-:eschema:synopsis:`<property-declarations>`
+:sdl:synopsis:`<property-declarations>`
     :ref:`Property <ref_datamodel_props>` declarations.
 
-:eschema:synopsis:`<link-declarations>`
+:sdl:synopsis:`<link-declarations>`
     :ref:`Link <ref_datamodel_links>` declarations.
 
-:eschema:synopsis:`<index-declarations>`
+:sdl:synopsis:`<index-declarations>`
     :ref:`Index <ref_datamodel_indexes>` declarations.
 
-:eschema:synopsis:`<attribute-declarations>`
+:sdl:synopsis:`<attribute-declarations>`
     :ref:`Schema attribute <ref_datamodel_attributes>` declarations.
 
 

--- a/docs/datamodel/props.rst
+++ b/docs/datamodel/props.rst
@@ -28,26 +28,26 @@ Abstract Properties
 An *abstract property* may be defined in EdgeDB Schema using the
 ``abstract property`` declaration:
 
-.. eschema:synopsis::
+.. sdl:synopsis::
 
     abstract property <prop-name> [ extending [(] <parent-prop> [, ...] [)]]:
         [ <attribute-declarations> ]
 
 Parameters:
 
-:eschema:synopsis:`<prop-name>`
+:sdl:synopsis:`<prop-name>`
     Specifies the name of the property item.  Customarily, property names
     are lowercase, with words separated by underscores as necessary for
     readability.
 
-:eschema:synopsis:`extending <parent-prop> [, ...]`
+:sdl:synopsis:`extending <parent-prop> [, ...]`
     If specified, declares the *parents* of the property item.
 
     Use of ``extending`` creates a persistent schema relationship
     between this property and its parents.  Schema modifications
     to the parent(s) propagate to the child.
 
-:eschema:synopsis:`<attribute-declarations>`
+:sdl:synopsis:`<attribute-declarations>`
     :ref:`Schema attribute <ref_datamodel_attributes>` declarations.
 
 
@@ -63,7 +63,7 @@ Concrete Properties
 A *concrete property* may be defined in EdgeDB Schema using the ``property``
 declaration in the context of a ``type`` or ``abstract link`` declaration:
 
-.. eschema:synopsis::
+.. sdl:synopsis::
 
     type <TypeName>:
         [required] [inherited] [{multi|single}] property \
@@ -97,7 +97,7 @@ declaration in the context of a ``type`` or ``abstract link`` declaration:
 
 Parameters:
 
-:eschema:synopsis:`required`
+:sdl:synopsis:`required`
     If specified, the property is considered *required* for the
     parent object type.  It is an error for an object to have a required
     property resolve to an empty value.  Child properties **always**
@@ -108,16 +108,16 @@ Parameters:
 
         Link properties cannot be ``required``.
 
-:eschema:synopsis:`inherited`
+:sdl:synopsis:`inherited`
     This qualifier must be specified if the property is *inherited* from
     one or more parent object types or links.
 
-:eschema:synopsis:`multi`
+:sdl:synopsis:`multi`
     Specifies that there may be more than one instance of this property
     in an object, in other words, ``Object.property`` may resolve to a set
     of a size greater than one.
 
-:eschema:synopsis:`single`
+:sdl:synopsis:`single`
     Specifies that there may be at most *one* instance of this property
     in an object, in other words, ``Object.property`` may resolve to a set
     of a size not greater than one.  ``single`` is assumed if nether
@@ -127,33 +127,33 @@ Parameters:
 
         Link properties are always ``single``.
 
-:eschema:synopsis:`extending <parent-prop> [, ...]`
+:sdl:synopsis:`extending <parent-prop> [, ...]`
     If specified, declares the *parents* of the property item.
 
     Use of ``extending`` creates a persistent schema relationship
     between this property and its parents.  Schema modifications
     to the parent(s) propagate to the child.
 
-:eschema:synopsis:`readonly`
+:sdl:synopsis:`readonly`
     If specified, the property is considered *read-only*.  Modifications
     of this property are prohibited once an object or link is created.
 
-:eschema:synopsis:`default`
+:sdl:synopsis:`default`
     Specifies the default value for the property as an EdgeQL expression.
     The default value is used in an ``INSERT`` statement if an explicit
     value for this property is not specified.
 
-:eschema:synopsis:`<computable-expr>`
+:sdl:synopsis:`<computable-expr>`
     If specified, designates this property as a *computable property*
     (see :ref:`Computables <ref_datamodel_computables>`).  A computable
     property cannot be *required* or *readonly* (the latter is implied and
     always true).  There is a shorthand form using the ``:=`` syntax,
     as shown in the synopsis above.
 
-:eschema:synopsis:`<attribute-declarations>`
+:sdl:synopsis:`<attribute-declarations>`
     :ref:`Schema attribute <ref_datamodel_attributes>` declarations.
 
-:eschema:synopsis:`<constraint-declarations>`
+:sdl:synopsis:`<constraint-declarations>`
     :ref:`Constraint <ref_datamodel_constraints>` declarations.
 
 

--- a/docs/datamodel/views.rst
+++ b/docs/datamodel/views.rst
@@ -16,7 +16,7 @@ Definition
 
 A view may be defined in EdgeDB Schema using the ``view`` declaration:
 
-.. eschema:synopsis::
+.. sdl:synopsis::
 
     view <view-name>:
         expr := <view-expr>
@@ -26,13 +26,13 @@ A view may be defined in EdgeDB Schema using the ``view`` declaration:
 Parameters
 ----------
 
-:eschema:synopsis:`<view-name>`
+:sdl:synopsis:`<view-name>`
     Specifies the name of the view.
 
-:eschema:synopsis:`<view-expr>`
+:sdl:synopsis:`<view-expr>`
     An expression defining the *shape* and the contents of the view.
 
-:eschema:synopsis:`<attribute-declarations>`
+:sdl:synopsis:`<attribute-declarations>`
     :ref:`Schema attribute <ref_datamodel_attributes>` declarations.
 
 

--- a/docs/edgeql/expressions/shapes.rst
+++ b/docs/edgeql/expressions/shapes.rst
@@ -163,7 +163,7 @@ A query could use a shape to create an alias to a real link. In this
 case, the link properties on that link are preserved on the aliased
 link as well. Consider the following schema:
 
-.. code-block:: eschema
+.. code-block:: sdl
 
     abstract link friends {
         property since -> datetime;

--- a/docs/graphql/graphql.rst
+++ b/docs/graphql/graphql.rst
@@ -7,7 +7,7 @@ Basics
 For the purposes of this section we will consider ``default`` module
 containing the following schema:
 
-.. code-block:: eschema
+.. code-block:: sdl
 
     type Author {
         property name -> str;

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -39,34 +39,39 @@ To manipulate and query data in EdgeDB we must first define a schema.
 We will be working with three object types: ``User``, ``PullRequest``,
 and ``Comment``.  Let's define the initial schema with a migration:
 
-.. eql:migration:: m1
+.. code-block:: edgeql
 
-    type User {
-      required property login -> str {
-        constraint exclusive;
-      }
-      required property firstname -> str;
-      required property lastname -> str;
-    }
+    START TRANSACTION;
+    CREATE MIGRATION m1 TO {
+        type User {
+          required property login -> str {
+            constraint exclusive;
+          }
+          required property firstname -> str;
+          required property lastname -> str;
+        }
 
-    type PullRequest {
-      required property number -> int64 {
-        constraint exclusive;
-      }
-      required property title -> str;
-      required property body -> str;
-      required property status -> str;
-      required property created_on -> datetime;
-      required link author -> User;
-      multi link assignees -> User;
-      multi link comments -> Comment;
-    }
+        type PullRequest {
+          required property number -> int64 {
+            constraint exclusive;
+          }
+          required property title -> str;
+          required property body -> str;
+          required property status -> str;
+          required property created_on -> datetime;
+          required link author -> User;
+          multi link assignees -> User;
+          multi link comments -> Comment;
+        }
 
-    type Comment {
-      required property body -> str;
-      required link author -> User;
-      required property created_on -> datetime;
-    }
+        type Comment {
+          required property body -> str;
+          required link author -> User;
+          required property created_on -> datetime;
+        }
+    };
+    COMMIT MIGRATION m1;
+    COMMIT;
 
 With the above snippet we defined and applied a migration to a schema
 described using the :ref:`declarative schema language <ref_eschema>`.
@@ -79,39 +84,44 @@ link.  Let's remove this duplication by declaring an abstract parent type
 ``AuthoredText`` and :ref:`extending <ref_datamodel_inheritance>`
 ``Comment`` and ``PullRequest`` from it:
 
-.. eql:migration:: m2
+.. code-block:: edgeql
 
-    type User {
-      required property login -> str {
-        constraint exclusive;
-      }
-      required property firstname -> str;
-      required property lastname -> str;
-    }
+    START TRANSACTION;
+    CREATE MIGRATION m2 TO {
+        type User {
+          required property login -> str {
+            constraint exclusive;
+          }
+          required property firstname -> str;
+          required property lastname -> str;
+        }
 
-    # <new>
-    abstract type AuthoredText {
-      required property body -> str;
-      required link author -> User;
-      required property created_on -> datetime;
-    }
-    # </new>
+        # <new>
+        abstract type AuthoredText {
+          required property body -> str;
+          required link author -> User;
+          required property created_on -> datetime;
+        }
+        # </new>
 
-    # <changed>
-    type PullRequest extending AuthoredText {
-    # </changed>
-      required property number -> int64 {
-        constraint exclusive;
-      }
-      required property title -> str;
-      required property status -> str;
-      multi link assignees -> User;
-      multi link comments -> Comment;
-    }
+        # <changed>
+        type PullRequest extending AuthoredText {
+        # </changed>
+          required property number -> int64 {
+            constraint exclusive;
+          }
+          required property title -> str;
+          required property status -> str;
+          multi link assignees -> User;
+          multi link comments -> Comment;
+        }
 
-    # <changed>
-    type Comment extending AuthoredText;
-    # </changed>
+        # <changed>
+        type Comment extending AuthoredText;
+        # </changed>
+    };
+    COMMIT MIGRATION m2;
+    COMMIT;
 
 
 Inserting Data

--- a/edb/tools/docs/__init__.py
+++ b/edb/tools/docs/__init__.py
@@ -21,7 +21,7 @@ from docutils import nodes as d_nodes
 from sphinx import transforms as s_transforms
 
 from . import eql
-from . import eschema
+from . import sdl
 from . import graphql
 from . import shared
 
@@ -46,7 +46,7 @@ class ProhibitedNodeTransform(s_transforms.SphinxTransform):
 
 def setup(app):
     eql.setup_domain(app)
-    eschema.setup_domain(app)
+    sdl.setup_domain(app)
     graphql.setup_domain(app)
 
     app.add_transform(ProhibitedNodeTransform)

--- a/edb/tools/docs/eql.py
+++ b/edb/tools/docs/eql.py
@@ -581,36 +581,6 @@ class EQLSynopsisDirective(s_code.CodeBlock):
         return super().run()
 
 
-class EQLMigrationDirective(s_code.CodeBlock):
-
-    has_content = True
-    optional_arguments = 0
-    required_arguments = 1
-    option_spec = {}
-
-    def run(self):
-        migration_name = self.arguments[0]
-        self.arguments = ['eschema']
-
-        pre = (f'START TRANSACTION;\n'
-               f'CREATE MIGRATION {migration_name} TO {{\n\n')
-        suf = f'\n}};\nCOMMIT MIGRATION {migration_name};\nCOMMIT;'
-
-        pre_node = d_nodes.literal_block(pre, pre)
-        pre_node['language'] = 'edgeql'
-        suf_node = d_nodes.literal_block(suf, suf)
-        suf_node['language'] = 'edgeql'
-
-        cnt = d_nodes.container()
-        cnt['eql-migration'] = 'true'
-        cnt += [
-            pre_node,
-            *super().run(),
-            suf_node,
-        ]
-        return [cnt]
-
-
 class EQLReactElement(d_rst.Directive):
 
     has_content = False
@@ -857,7 +827,6 @@ class EdgeQLDomain(s_domains.Domain):
         'keyword': EQLKeywordDirective,
         'operator': EQLOperatorDirective,
         'synopsis': EQLSynopsisDirective,
-        'migration': EQLMigrationDirective,
         'react-element': EQLReactElement,
     }
 

--- a/edb/tools/docs/sdl.py
+++ b/edb/tools/docs/sdl.py
@@ -25,7 +25,7 @@ from sphinx.directives import code as s_code
 from . import shared
 
 
-class EschemaSynopsisDirective(s_code.CodeBlock):
+class SDLSynopsisDirective(s_code.CodeBlock):
 
     has_content = True
     optional_arguments = 0
@@ -33,26 +33,26 @@ class EschemaSynopsisDirective(s_code.CodeBlock):
     option_spec = {}
 
     def run(self):
-        self.arguments = ['eschema-synopsis']
+        self.arguments = ['sdl-synopsis']
         return super().run()
 
 
-class EschemaDomain(s_domains.Domain):
+class SDLDomain(s_domains.Domain):
 
-    name = "eschema"
-    label = "EdgeDB Schema"
+    name = "sdl"
+    label = "EdgeDB Schema Definition Language"
 
     directives = {
-        'synopsis': EschemaSynopsisDirective,
+        'synopsis': SDLSynopsisDirective,
     }
 
 
 def setup_domain(app):
-    app.add_lexer("eschema", EdgeQLLexer())
-    app.add_lexer("eschema-synopsis", EdgeQLLexer())
+    app.add_lexer("sdl", EdgeQLLexer())
+    app.add_lexer("sdl-synopsis", EdgeQLLexer())
 
     app.add_role(
-        'eschema:synopsis',
-        shared.InlineCodeRole('eschema-synopsis'))
+        'sdl:synopsis',
+        shared.InlineCodeRole('sdl-synopsis'))
 
-    app.add_domain(EschemaDomain)
+    app.add_domain(SDLDomain)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -205,7 +205,7 @@ class TestDocSnippets(unittest.TestCase):
             for snippet in code:
                 if lang == 'edgeql':
                     edgeql_parser.parse_block(snippet)
-                elif lang == 'eschema':
+                elif lang == 'sdl':
                     schema_parser.parse(snippet)
                 elif lang == 'edgeql-result':
                     # REPL results

--- a/tests/test_docs_sphinx_ext.py
+++ b/tests/test_docs_sphinx_ext.py
@@ -799,30 +799,3 @@ class TestBlockquote(unittest.TestCase, BaseDomainTest):
 
         with self.assert_fails('title reference'):
             self.build(src, format='html')
-
-
-@unittest.skipIf(requests_xml is None, 'requests-xml package is not installed')
-class TestEQLMigration(unittest.TestCase, BaseDomainTest):
-
-    def test_sphinx_eql_migration_01(self):
-        src = '''
-        .. eql:migration:: foobar
-
-            type User {
-                property name -> str;
-            };
-        '''
-
-        out = self.build(src, format='xml')
-        x = requests_xml.XML(xml=out)
-
-        self.assertEqual(
-            x.xpath('''
-                //container[@eql-migration="true"] / literal_block / text()
-            '''),
-            [
-                'START TRANSACTION;\n'
-                'CREATE MIGRATION foobar TO {\n\n',
-                'type User {\n    property name -> str;\n};',
-                '\n};\nCOMMIT MIGRATION foobar;\nCOMMIT;'
-            ])


### PR DESCRIPTION
Drop `eql:migration` directive as it can now be expressed fully via
`edgeql` codeblock.

Rename `eschema` to `sdl`.