### PR TITLE
Capture server error traceback and attach it to the error packet

### DIFF
--- a/edb/common/markup/serializer/base.py
+++ b/edb/common/markup/serializer/base.py
@@ -198,18 +198,6 @@ def serialize_traceback(obj, *, ctx):
 
 @serializer.register(BaseException)
 def serialize_exception(obj, *, ctx):
-    try:
-        # Serializing an exception to markup maybe a very time-wise
-        # expensive operation.
-        #
-        # However, it should be safe to cache results, as we serialize
-        # exceptions just before they get printed or logged, after the
-        # point of adding new contexts.
-        #
-        return obj.__sx_markup_cached__
-    except AttributeError:
-        pass
-
     cause = context = None
     if obj.__cause__ is not None and obj.__cause__ is not obj:
         cause = serialize(obj.__cause__, ctx=ctx)
@@ -226,7 +214,7 @@ def serialize_exception(obj, *, ctx):
         else:
             contexts.append(serialize(ex_context, ctx=ctx))
 
-    obj_traceback = getattr(obj, '__mm_traceback__', obj.__traceback__)
+    obj_traceback = obj.__traceback__
     if obj_traceback:
         traceback = elements.lang.ExceptionContext(
             title='Traceback', body=[serialize(obj_traceback, ctx=ctx)])
@@ -248,7 +236,6 @@ def serialize_exception(obj, *, ctx):
         classname=obj.__class__.__name__, msg=str(obj), contexts=contexts,
         cause=cause, context=context, id=id(obj))
 
-    obj.__sx_markup_cached__ = markup
     return markup
 
 

--- a/edb/repl/context.py
+++ b/edb/repl/context.py
@@ -40,6 +40,7 @@ class ReplContext:
     introspect_types: bool = False
     query_mode: QueryMode = QueryMode.Normal
     typenames: typing.Optional[typing.Dict[uuid.UUID, str]] = None
+    last_exception: typing.Optional[Exception] = None
 
     def toggle_query_mode(self):
         self.query_mode = self.query_mode.cycle()

--- a/edb/repl/render.py
+++ b/edb/repl/render.py
@@ -330,3 +330,17 @@ def render_error(repl_ctx: context.ReplContext, error):
         print(style.exc_title.apply(error))
     else:
         print(error)
+
+
+def render_exception(repl_ctx: context.ReplContext, exc, *, query=None):
+    print(f'{type(exc).__name__}: {exc}')
+
+    if isinstance(exc, edgedb.EdgeDBError):
+        if exc.hint:
+            print(f'Hint: {exc.hint}')
+
+        if query and exc.line >= 0 and exc.col >= 0:
+            for lineno, line in enumerate(query.split('\n'), 1):
+                print('###', line)
+                if lineno == exc.line:
+                    print('###', ' ' * (exc.col - 1) + '^')

--- a/edb/server/procpool/pool.py
+++ b/edb/server/procpool/pool.py
@@ -106,10 +106,13 @@ class Worker:
             return data[0]
         elif status == 1:
             exc, tb = data
-            exc.__text_traceback__ = tb
+            exc.__formatted_error__ = tb
             raise exc
         else:
-            raise RuntimeError(data[0])
+            exc = RuntimeError(
+                'could not serialize result in worker subprocess')
+            exc.__formatted_error__ = data[0]
+            raise exc
 
     async def close(self):
         if self._closed:

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -43,6 +43,7 @@ import warnings
 import click
 
 import edb
+import edgedb
 
 from edb.common import devmode
 from edb.testbase import server as tb
@@ -806,6 +807,15 @@ class ParallelTextTestRunner:
                            fg=fg, bold=True)
                 self._fill('-', fg=fg)
                 if _is_exc_info(err):
+                    if isinstance(err[1], edgedb.EdgeDBError):
+                        srv_tb = err[1]._attrs.get('T')
+                        if srv_tb:
+                            self._echo('Server Traceback:',
+                                       fg='red', bold=True)
+                            self._echo(srv_tb)
+                            self._echo('Test Traceback:',
+                                       fg='red', bold=True)
+
                     err = unittest.result.TestResult._exc_info_to_string(
                         result, err, test)
                 self._echo(err)


### PR DESCRIPTION
* For EdgeDB clients it means that they can now render the server-side
  traceback;

* REPL got a new '\errverbose' command (similar to the one in psql)
  that renders server traceback among other things.

* REPL now renders "hint" and code context, if available.

* `edb test` will now render server tracebacks.