### PR TITLE
docs: Flesh out the ESDL docs section.

### DIFF
--- a/docs/edgeql/__toc__.rst
+++ b/docs/edgeql/__toc__.rst
@@ -9,6 +9,7 @@ EdgeQL
     overview
     expressions/index
     statements/index
+    sdl/index
     ddl/index
     operators/__toc__
     functions/index

--- a/docs/edgeql/ddl/attributes.rst
+++ b/docs/edgeql/ddl/attributes.rst
@@ -13,7 +13,7 @@ CREATE ABSTRACT ATTRIBUTE
 
 :eql-statement:
 
-Define a new :ref:`schema attribute <ref_datamodel_attributes>`.
+Define a new :ref:`schema attribute <ref_eql_sdl_schema_attributes>`.
 
 .. eql:synopsis::
 

--- a/docs/edgeql/ddl/constraints.rst
+++ b/docs/edgeql/ddl/constraints.rst
@@ -14,7 +14,7 @@ CREATE ABSTRACT CONSTRAINT
 :eql-statement:
 :eql-haswith:
 
-Define a new :ref:`abstract constraint <ref_datamodel_constraints>`.
+Define a new abstract :ref:`constraint <ref_eql_sdl_constraints>`.
 
 .. eql:synopsis::
 

--- a/docs/edgeql/ddl/functions.rst
+++ b/docs/edgeql/ddl/functions.rst
@@ -5,7 +5,7 @@ Functions
 =========
 
 This section describes the DDL commands pertaining to
-:ref:`functions <ref_datamodel_functions>`.
+:ref:`functions <ref_eql_sdl_functions>`.
 
 
 CREATE FUNCTION

--- a/docs/edgeql/ddl/index.rst
+++ b/docs/edgeql/ddl/index.rst
@@ -5,8 +5,8 @@ Data Definition
 
 EdgeQL includes a set of commands to manipulate all aspects of the
 database schema.  It is called the *data definition language* or *DDL*,
-and is a low-level equivalent to
-:ref:`EdgeDB Schema <ref_eschema>`.
+and is a low-level equivalent to :ref:`EdgeDB schema definition language
+<ref_eql_sdl>`.
 
 .. toctree::
     :maxdepth: 3

--- a/docs/edgeql/ddl/indexes.rst
+++ b/docs/edgeql/ddl/indexes.rst
@@ -14,7 +14,7 @@ CREATE INDEX
 :eql-statement:
 
 
-Define an new :ref:`index <ref_datamodel_indexes>` for a given object
+Define an new :ref:`index <ref_eql_sdl_indexes>` for a given object
 type or link.
 
 .. eql:synopsis::

--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -14,7 +14,7 @@ CREATE LINK
 :eql-statement:
 :eql-haswith:
 
-Define a new :ref:`link <ref_datamodel_links>`.
+Define a new :ref:`link <ref_eql_sdl_links>`.
 
 .. eql:synopsis::
 

--- a/docs/edgeql/ddl/objects.rst
+++ b/docs/edgeql/ddl/objects.rst
@@ -15,12 +15,12 @@ CREATE TYPE
 :eql-haswith:
 
 
-Define a new :ref:`object type <ref_datamodel_object_types>`.
+Define a new :ref:`object type <ref_eql_sdl_object_types>`.
 
 .. eql:synopsis::
 
     [ WITH <with-item> [, ...] ]
-    CREATE [ABSTRACT] TYPE <name> [ EXTENDING <base> [, ...] ]
+    CREATE [ABSTRACT] TYPE <name> [ EXTENDING <supertype> [, ...] ]
     [ "{" <subcommand>; [...] "}" ] ;
 
 Description
@@ -49,7 +49,7 @@ Parameters
 :eql:synopsis:`<name>`
     The name (optionally module-qualified) of the new type.
 
-:eql:synopsis:`EXTENDING <base> [, ...]`
+:eql:synopsis:`EXTENDING <supertype> [, ...]`
     Optional clause specifying the *supertypes* of the new type.
 
     Use of ``EXTENDING`` creates a persistent type relationship
@@ -78,6 +78,10 @@ Parameters
     :eql:synopsis:`CREATE LINK`
         Define a concrete link on the object type.
         See :eql:stmt:`CREATE LINK` for details.
+
+    :eql:synopsis:`CREATE PROPERTY`
+        Define a concrete link on the object type.
+        See :eql:stmt:`CREATE PROPERTY` for details.
 
 
 .. TODO: write examples

--- a/docs/edgeql/ddl/props.rst
+++ b/docs/edgeql/ddl/props.rst
@@ -14,7 +14,7 @@ CREATE PROPERTY
 :eql-statement:
 :eql-haswith:
 
-Define a new :ref:`property <ref_datamodel_props>`.
+Define a new :ref:`property <ref_eql_sdl_props>`.
 
 .. eql:synopsis::
 

--- a/docs/edgeql/ddl/scalars.rst
+++ b/docs/edgeql/ddl/scalars.rst
@@ -14,12 +14,12 @@ CREATE SCALAR TYPE
 :eql-statement:
 :eql-haswith:
 
-Define a new :ref:`scalar type <ref_datamodel_scalar_types>`.
+Define a new :ref:`scalar type <ref_eql_sdl_scalars>`.
 
 .. eql:synopsis::
 
     [ WITH <with-item> [, ...] ]
-    CREATE [ABSTRACT] SCALAR TYPE <name> [ EXTENDING <base> ]
+    CREATE [ABSTRACT] SCALAR TYPE <name> [ EXTENDING <supertype> ]
     [ "{" <action>; [...] "}" ] ;
 
 
@@ -40,12 +40,12 @@ If the ``ABSTRACT`` keyword is specified, the created type will be
 All non-abstract scalar types must have an underlying core
 implementation.  For user-defined scalar types this means that
 ``CREATE SCALAR TYPE`` must specify another non-abstract scalar type
-as its *base*.
+as its *supertype*.
 
 The most common use of ``CREATE SCALAR TYPE`` is to define a scalar
 subtype with constraints.
 
-:eql:synopsis:`EXTENDING <base>`
+:eql:synopsis:`EXTENDING <supertype>`
     Optional clause specifying the *supertype* of the new type.
 
     Use of ``EXTENDING`` creates a persistent type relationship

--- a/docs/edgeql/ddl/views.rst
+++ b/docs/edgeql/ddl/views.rst
@@ -14,7 +14,7 @@ CREATE VIEW
 :eql-statement:
 :eql-haswith:
 
-Define a new :ref:`view <ref_datamodel_views>`.
+Define a new :ref:`view <ref_eql_sdl_views>`.
 
 .. eql:synopsis::
 
@@ -24,7 +24,7 @@ Define a new :ref:`view <ref_datamodel_views>`.
     [ WITH <with-item> [, ...] ]
     CREATE VIEW <view-name> "{"
         SET expr := <view-expr>;
-        [ SET <attr-name> := <attr-value>; ... ]
+        [ SET ATTRIBUTE <attr-name> := <attr-value>; ... ]
     "}" ;
 
     # where <with-item> is:
@@ -53,7 +53,7 @@ Parameters
 :eql:synopsis:`<view-expr>`
     An expression that defines the *shape* and the contents of the view.
 
-:eql:synopsis:`SET <attr-name> := <attr-value>;`
+:eql:synopsis:`SET ATTRIBUTE <attr-name> := <attr-value>;`
     An optional list of schema attribute values for the view.
     See :eql:stmt:`SET ATTRIBUTE` for details.
 

--- a/docs/edgeql/sdl/attributes.rst
+++ b/docs/edgeql/sdl/attributes.rst
@@ -1,0 +1,36 @@
+.. _ref_eql_sdl_schema_attributes:
+
+=================
+Schema Attributes
+=================
+
+This section describes the SDL declarations pertaining to
+:ref:`schema attributes <ref_datamodel_attributes>`.
+
+Define a new attribute corresponding to the :ref:`more explicit DDL
+commands <ref_eql_ddl_schema_attributes>`.
+
+.. sdl:synopsis::
+
+    [ abstract ] [ inheritable ] attribute <name>
+    [ "{" <attribute-declarations>; [...] "}" ] ;
+
+
+Description
+-----------
+
+:sdl:synopsis:`abstract`
+    If specified, the declared attribute will be *abstract*.
+
+:sdl:synopsis:`inheritable`
+    The attributes are non-inheritable by default.  That is, if a
+    schema item has an attribute defined on it, the descendants of
+    that schema item will not automatically inherit the attribute.
+    Normal inheritance behavior can be turned on by declaring the
+    attribute with the *inheritable* qualifier.
+
+:sdl:synopsis:`<name>`
+    Specifies the name of the attribute.
+
+:sdl:synopsis:`<attribute-declarations>`
+    Attributes can have attribute declarations.

--- a/docs/edgeql/sdl/constraints.rst
+++ b/docs/edgeql/sdl/constraints.rst
@@ -1,0 +1,77 @@
+.. _ref_eql_sdl_constraints:
+
+===========
+Constraints
+===========
+
+This section describes the SDL declarations pertaining to
+:ref:`constraints <ref_datamodel_constraints>`.
+
+Define a constraint corresponding to the :ref:`more explicit DDL
+commands <ref_eql_ddl_constraints>`.
+
+.. sdl:synopsis::
+
+    [{abstract | delegated}] constraint <name> [ ( [<argspec>] [, ...] ) ]
+        [ on ( <subject-expr> ) ]
+        [ extending <base> [, ...] ]
+    "{"
+        [ expr := <constr-expression> ; ]
+        [ errmessage := <error-message> ; ]
+        [ <attribute-declarations> ]
+        [ ... ]
+    "}" ;
+
+    # where <argspec> is:
+
+    [ $<argname>: ] <argtype>
+
+
+Description
+-----------
+
+:sdl:synopsis:`abstract`
+    If specified, the declared constraint will be *abstract*.
+
+:sdl:synopsis:`delegated`
+    If specified, the constraint is defined as *delegated*, which means
+    that it will not be enforced on the type it's declared on, and
+    the enforcement will be delegated to the subtypes of this type.
+    This is particularly useful for :eql:constraint:`exclusive`
+    constraints in abstract types.
+
+:sdl:synopsis:`<name>`
+    The name (optionally module-qualified) of the new constraint.
+
+:sdl:synopsis:`<argspec>`
+    An optional list of constraint arguments.
+    :sdl:synopsis:`<argname>` optionally specifies
+    the argument name, and :sdl:synopsis:`<argtype>`
+    specifies the argument type.
+
+:sdl:synopsis:`<subject-expr>`
+    An optional expression defining the *subject* of the constraint.
+    If not specified, the subject is the value of the schema item on
+    which the concrete constraint is defined.  The expression must refer
+    to the original subject of the constraint as ``__subject__``.
+
+:sdl:synopsis:`extending <base> [, ...]`
+    If specified, declares the *parent* constraints for this constraint.
+
+:sdl:synopsis:`expr := <constr_expression>`
+    A boolean expression that returns ``true`` for valid data and
+    ``false`` for invalid data.  The expression may refer to the subject
+    of the constraint as ``__subject__``.
+
+:sdl:synopsis:`errmessage := <error_message>`
+    An optional string literal defining the error message template that
+    is raised when the constraint is violated.  The template is a formatted
+    string that may refer to constraint context variables in curly braces.
+    The template may refer to the following:
+
+    - ``$argname`` -- the value of the specified constraint argument
+    - ``__subject__`` -- the value of the ``title`` attribute of the scalar
+      type, property or link on which the constraint is defined.
+
+:sdl:synopsis:`<attribute-declarations>`
+    :ref:`Schema attribute <ref_eql_sdl_schema_attributes>` declarations.

--- a/docs/edgeql/sdl/functions.rst
+++ b/docs/edgeql/sdl/functions.rst
@@ -1,0 +1,105 @@
+.. _ref_eql_sdl_functions:
+
+=========
+Functions
+=========
+
+This section describes the SDL declarations pertaining to
+:ref:`functions <ref_datamodel_functions>`.
+
+Define a new function corresponding to the :ref:`more explicit DDL
+commands <ref_eql_ddl_functions>`.
+
+.. sdl:synopsis::
+
+    function <name> ([ <argspec> ] [, ... ]) -> <returnspec>
+    from <language> <functionbody> ;
+
+    function <name> ([ <argspec> ] [, ... ]) -> <returnspec>
+    "{"
+        from <language> <functionbody> ;
+        [ <attribute-declarations> ]
+    "}" ;
+
+    # where <argspec> is:
+
+    [ <argkind> ] <argname>: [ <typequal> ] <argtype> [ = <default> ]
+
+    # <argkind> is:
+
+    [ { variadic | named only } ]
+
+    # <typequal> is:
+
+    [ { set of | optional } ]
+
+    # and <returnspec> is:
+
+    [ <typequal> ] <rettype>
+
+
+Description
+-----------
+
+:sdl:synopsis:`<name>`
+    The name (optionally module-qualified) of the function to create.
+
+:sdl:synopsis:`<argkind>`
+    The kind of an argument: ``variadic`` or ``named only``.
+
+    If not specified, the argument is called *positional*.
+
+    The ``variadic`` modifier indicates that the function takes an
+    arbitrary number of arguments of the specified type.  The passed
+    arguments will be passed as as array of the argument type.
+    Positional arguments cannot follow a ``variadic`` argument.
+    ``variadic`` parameters cannot have a default value.
+
+    The ``named only`` modifier indicates that the argument can only
+    be passed using that specific name.  Positional arguments cannot
+    follow a ``named only`` argument.
+
+:sdl:synopsis:`<argname>`
+    The name of an argument.  If ``named only`` modifier is used this
+    argument *must* be passed using this name only.
+
+:sdl:synopsis:`<typequal>`
+    The type qualifier: ``set of`` or ``optional``.
+
+    The ``set of`` qualifier indicates that the function is taking the
+    argument as a *whole set*, as opposed to being called on the input
+    product element-by-element.
+
+    The ``optional`` qualifier indicates that the function will be called
+    if the argument is an empty set.  The default behavior is to return
+    an empty set if the argument is not marked as ``optional``.
+
+:sdl:synopsis:`<argtype>`
+    The data type of the function's arguments
+    (optionally module-qualified).
+
+:sdl:synopsis:`<default>`
+    An expression to be used as default value if the parameter is not
+    specified.  The expression has to be of a type compatible with the
+    type of the argument.
+
+:sdl:synopsis:`<rettype>`
+    The return data type (optionally module-qualified).
+
+    The ``set of`` modifier indicates that the function will return
+    a non-singleton set.
+
+    The ``optional`` qualifier indicates that the function may return
+    an empty set.
+
+:sdl:synopsis:`<language>`
+    The name of the language that the function is implemented in.
+    Currently it can only be ``edgeql``.
+
+:sdl:synopsis:`<functionbody>`
+    A string constant defining the function.  It is often helpful
+    to use :ref:`dollar quoting <ref_eql_lexical_dollar_quoting>`
+    to write the function definition string.
+
+:sdl:synopsis:`<attribute-declarations>`
+    :ref:`Schema attribute <ref_eql_sdl_schema_attributes>` declarations.

--- a/docs/edgeql/sdl/index.rst
+++ b/docs/edgeql/sdl/index.rst
@@ -1,0 +1,35 @@
+.. _ref_eql_sdl:
+
+Schema Definition
+=================
+
+This section describes the high-level language used to define EdgeDB
+schema.  It is called the *EdgeDB schema definition language* or
+*ESDL*.  There's a correspondence between this declarative high-level
+language and the imperative low-level
+:ref:`DDL <ref_eql_ddl>`.
+
+ESDL is a declarative language optimized for human readability and
+expressing the state of the EdgeDB schema without getting into the
+details of how to arrive at that state.  Each *.esdl* file represents
+a complete schema state for a particular
+:ref:`module <ref_datamodel_modules>`.
+
+Syntactically, an ESDL declaration mirrors the ``CREATE`` DDL for the
+corresponding entity, but with all of the ``CREATE`` and ``SET``
+keywords omitted.
+
+
+.. toctree::
+    :maxdepth: 3
+    :hidden:
+
+    objects
+    scalars
+    links
+    props
+    views
+    indexes
+    constraints
+    functions
+    attributes

--- a/docs/edgeql/sdl/indexes.rst
+++ b/docs/edgeql/sdl/indexes.rst
@@ -1,0 +1,27 @@
+.. _ref_eql_sdl_indexes:
+
+=======
+Indexes
+=======
+
+This section describes the SDL declarations pertaining to
+:ref:`indexes <ref_datamodel_indexes>`.
+
+Define a new index corresponding to the :ref:`more explicit DDL
+commands <ref_eql_ddl_indexes>`.
+
+.. sdl:synopsis::
+
+    index <index-name> ON <index-expr> ;
+
+
+Description
+-----------
+
+:sdl:synopsis:`<index-name>`
+    The name of the index to be created.  No module name can be specified,
+    indexes are always created in the same module as the parent type or
+    link.
+
+:sdl:synopsis:`<index-expr>`
+    The specific expression for which the index is made.

--- a/docs/edgeql/sdl/links.rst
+++ b/docs/edgeql/sdl/links.rst
@@ -1,0 +1,26 @@
+.. _ref_eql_sdl_links:
+
+=====
+Links
+=====
+
+This section describes the SDL declarations pertaining to
+:ref:`links <ref_datamodel_links>`.
+
+Define a new link corresponding to the :ref:`more explicit DDL
+commands <ref_eql_ddl_links>`.
+
+.. sdl:synopsis::
+
+    # Concrete link form used inside type declaration:
+    [ required ] [{single | multi}] link <name>
+      [ extending <base> [, ...] ] -> <type>
+      [ "{" <subcommand>; [...] "}" ] ;
+
+    # Computable link form used inside type declaration:
+    [ required ] [{single | multi}] link <name> := <expression>;
+
+    # Abstract link form:
+    abstract link [<module>::]<name> [extending <base> [, ...]]
+    [ "{" <subcommand>; [...] "}" ]
+

--- a/docs/edgeql/sdl/objects.rst
+++ b/docs/edgeql/sdl/objects.rst
@@ -1,0 +1,60 @@
+.. _ref_eql_sdl_object_types:
+
+============
+Object Types
+============
+
+This section describes the SDL declarations pertaining to
+:ref:`object types <ref_datamodel_object_types>`.
+
+Define a new object type corresponding to the :ref:`more explicit DDL
+commands <ref_eql_ddl_object_types>`.
+
+.. sdl:synopsis::
+
+    [abstract] type <TypeName> [extending <supertype> [, ...] ]
+    [ "{"
+        [ <property-declarations> ]
+        [ <link-declarations> ]
+        [ <index-declarations> ]
+        [ <attribute-declarations> ]
+        ...
+      "}" ]
+
+Description
+-----------
+
+:sdl:synopsis:`abstract`
+    If specified, the declared type will be *abstract*.
+
+:sdl:synopsis:`<TypeName>`
+    Specifies the name of the object type.  Customarily, object type names
+    use the CapWords convention.
+
+:sdl:synopsis:`extending <supertype> [, ...]`
+    If specified, declares the *supertypes* of the new type.
+
+    Use of ``extending`` creates a persistent type relationship
+    between the new subtype and its supertype(s).  Schema modifications
+    to the supertype(s) propagate to the subtype.
+
+    References to supertypes in queries will also include objects of
+    the subtype.
+
+    If the same *link* or *property* name exists in more than one
+    supertype, or is explicitly defined in the subtype and at
+    least one supertype then the data types of the link targets must
+    be *compatible*.  If there is no conflict, the links are merged to
+    form a single link in the new type.
+
+:sdl:synopsis:`<property-declarations>`
+    :ref:`Property <ref_eql_sdl_props>` declarations.
+
+:sdl:synopsis:`<link-declarations>`
+    :ref:`Link <ref_eql_sdl_links>` declarations.
+
+:sdl:synopsis:`<index-declarations>`
+    :ref:`Index <ref_eql_sdl_indexes>` declarations.
+
+:sdl:synopsis:`<attribute-declarations>`
+    :ref:`Schema attribute <ref_eql_sdl_schema_attributes>` declarations.

--- a/docs/edgeql/sdl/props.rst
+++ b/docs/edgeql/sdl/props.rst
@@ -1,0 +1,26 @@
+.. _ref_eql_sdl_props:
+
+==========
+Properties
+==========
+
+This section describes the SDL declarations pertaining to
+:ref:`properties <ref_datamodel_props>`.
+
+Define a new property corresponding to the :ref:`more explicit DDL
+commands <ref_eql_ddl_props>`.
+
+.. sdl:synopsis::
+
+
+    # Concrete property form used inside type declaration:
+    [ required ] [{single | multi}] property <name>
+      [ extending <base> [, ...] ] -> <type>
+      [ "{" <subcommand>; [...] "}" ] ;
+
+    # Computable property form used inside type declaration:
+    [ required ] [{single | multi}] property <name> := <expression>;
+
+    # Abstract property form:
+    abstract property [<module>::]<name> [extending <base> [, ...]]
+    [ "{" <subcommand>; [...] "}" ]

--- a/docs/edgeql/sdl/scalars.rst
+++ b/docs/edgeql/sdl/scalars.rst
@@ -1,0 +1,57 @@
+.. _ref_eql_sdl_scalars:
+
+============
+Scalar Types
+============
+
+This section describes the SDL declarations pertaining to
+:ref:`scalar types <ref_datamodel_scalar_types>`.
+
+Define a new scalar type corresponding to the :ref:`more explicit DDL
+commands <ref_eql_ddl_scalars>`.
+
+
+.. sdl:synopsis::
+
+    [abstract] scalar type <TypeName> [extending <supertype> [, ...] ]
+    [ "{"
+        [ <constraint-declarations> ]
+        [ <attribute-declarations> ]
+        ...
+      "}" ]
+
+
+Description
+-----------
+
+:sdl:synopsis:`abstract`
+    If specified, the declared type will be *abstract*.
+
+:sdl:synopsis:`<TypeName>`
+    Specifies the name of the scalar type.  Customarily, scalar type names
+    use the CapWords convention.
+
+:sdl:synopsis:`extending <supertype> [, ...]`
+    If specified, declares the *supertypes* of the new type.
+
+    Use of ``extending`` creates a persistent type relationship
+    between the new subtype and its supertype(s).  Schema modifications
+    to the supertype(s) propagate to the subtype.
+
+:sdl:synopsis:`<constraint-declarations>`
+    :ref:`Constraint <ref_eql_sdl_constraints>` declarations.
+
+:sdl:synopsis:`<attribute-declarations>`
+    :ref:`Schema attribute <ref_eql_sdl_schema_attributes>` declarations.
+
+
+Examples
+--------
+
+Create a new non-negative integer type:
+
+.. code-block:: sdl
+
+    scalar type posint64 extending int64 {
+        constraint min(0);
+    }

--- a/docs/edgeql/sdl/views.rst
+++ b/docs/edgeql/sdl/views.rst
@@ -1,0 +1,33 @@
+.. _ref_eql_sdl_views:
+
+=====
+Views
+=====
+
+This section describes the SDL declarations pertaining to
+:ref:`views <ref_datamodel_views>`.
+
+Define a new view corresponding to the :ref:`more explicit DDL
+commands <ref_eql_ddl_views>`.
+
+.. sdl:synopsis::
+
+    view <view-name> := <view-expr> ;
+
+    view <view-name> "{"
+        expr := <view-expr>;
+        [ <attribute-declarations> ]
+    "}" ;
+
+
+Description
+-----------
+
+:sdl:synopsis:`<view-name>`
+    The name (optionally module-qualified) of a view to be created.
+
+:sdl:synopsis:`<view-expr>`
+    An expression that defines the *shape* and the contents of the view.
+
+:sdl:synopsis:`<attribute-declarations>`
+    :ref:`Schema attribute <ref_eql_sdl_schema_attributes>` declarations.


### PR DESCRIPTION
A minimalistic section mirroring the DDL and showing the syntax
synopsis for ESDL.