### PR TITLE
Add support for managing roles via a CLI

### DIFF
--- a/edb/cli/__init__.py
+++ b/edb/cli/__init__.py
@@ -1,0 +1,102 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import sys
+
+import click
+
+from edb.common import devmode as dm
+from edb.server import defines as edgedb_defines
+
+from edb import repl
+
+
+@click.group(
+    invoke_without_command=True,
+    context_settings=dict(help_option_names=['-?', '--help']))
+@click.pass_context
+@click.option('-h', '--host')
+@click.option('-p', '--port', type=int)
+@click.option('-u', '--user')
+@click.option('-d', '--database')
+@click.option('--admin', is_flag=True)
+@click.option('--password/--no-password', default=None)
+@click.option('--password-from-stdin', is_flag=True)
+def cli(ctx, host, port, user, database, admin, password, password_from_stdin):
+    ctx.ensure_object(dict)
+
+    if admin:
+        if not user:
+            user = edgedb_defines.EDGEDB_SUPERUSER
+        if not database:
+            database = edgedb_defines.EDGEDB_SUPERUSER_DB
+
+    if password is None and password_from_stdin:
+        password = True
+
+    password_prompt = None
+
+    if password:
+        if password_from_stdin:
+            password = sys.stdin.readline().strip('\r\n')
+        else:
+            password = _password_prompt()
+    elif password is None:
+        password_prompt = _password_prompt
+    else:
+        password = None
+
+    if ctx.invoked_subcommand is None:
+        repl.main(
+            host=host, port=port, user=user,
+            database=database, password=password,
+            password_prompt=password_prompt,
+            admin=admin,
+        )
+    else:
+        ctx.obj['host'] = host
+        ctx.obj['port'] = port
+        ctx.obj['user'] = user
+        ctx.obj['database'] = database
+        ctx.obj['password'] = password
+        ctx.obj['password_prompt'] = password_prompt
+        ctx.obj['admin'] = admin
+
+
+def _password_prompt():
+    if sys.stdin.isatty():
+        password = click.prompt(
+            'Password', hide_input=True)
+    else:
+        raise click.UsageError(
+            'password required and input is not a TTY, please '
+            'use --password-from-stdin to provide the password value'
+        )
+
+    return password
+
+
+def cli_dev():
+    dm.enable_dev_mode()
+    cli()
+
+
+# Import subcommands to register them
+
+from . import mng  # noqa

--- a/edb/cli/mng.py
+++ b/edb/cli/mng.py
@@ -1,0 +1,182 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import sys
+
+import click
+
+import edgedb
+
+from edb.cli import cli
+from edb.edgeql.quote import quote_literal as ql, quote_ident as qi
+
+
+def connect(ctx):
+    try:
+        conn = edgedb.connect(
+            host=ctx.obj['host'], port=ctx.obj['port'],
+            user=ctx.obj['user'], database=ctx.obj['database'],
+            admin=ctx.obj['admin'], password=ctx.obj['password'],
+        )
+    except edgedb.AuthenticationError:
+        if (ctx.obj['password'] is None
+                and ctx.obj['password_prompt'] is not None):
+            password = ctx.obj['password_prompt']
+
+            conn = edgedb.connect(
+                host=ctx.obj['host'], port=ctx.obj['port'],
+                user=ctx.obj['user'], database=ctx.obj['database'],
+                admin=ctx.obj['admin'], password=password,
+            )
+        else:
+            raise
+
+    ctx.obj['conn'] = conn
+    ctx.call_on_close(lambda: conn.close())
+
+
+@cli.group()
+@click.pass_context
+def create(ctx):
+    connect(ctx)
+
+
+@cli.group()
+@click.pass_context
+def alter(ctx):
+    connect(ctx)
+
+
+@cli.group()
+@click.pass_context
+def drop(ctx):
+    connect(ctx)
+
+
+def options(options):
+    def _decorator(func):
+        for option in reversed(options):
+            func = option(func)
+        return func
+
+    return _decorator
+
+
+_role_options = [
+    click.option('--password/--no-password', default=None),
+    click.option('--password-from-stdin', is_flag=True, default=False),
+    click.option('--allow-login/--no-allow-login', default=None),
+]
+
+
+def _process_role_options(ctx, password, password_from_stdin, allow_login):
+    if password is None and password_from_stdin:
+        password = True
+
+    if password is not None:
+        if password:
+            if password_from_stdin:
+                password_value = ql(sys.stdin.readline().strip('\r\n'))
+            elif sys.stdin.isatty():
+                password_value = ql(click.prompt(
+                    'Password',
+                    hide_input=True,
+                    confirmation_prompt=True,
+                    type=str,
+                ))
+            else:
+                raise click.UsageError(
+                    'input is not a TTY, please use --password-from-stdin '
+                    'to provide the password value'
+                )
+        else:
+            password_value = '{}'
+    else:
+        password_value = None
+
+    if allow_login is not None:
+        allow_login_value = 'true' if allow_login else 'false'
+    else:
+        allow_login_value = None
+
+    alters = []
+    if password_value is not None:
+        alters.append(f'SET password := {password_value}')
+    if allow_login_value is not None:
+        alters.append(f'SET allow_login := {allow_login_value}')
+
+    if not alters:
+        raise click.UsageError(
+            'please specify an attribute to alter', ctx=ctx,
+        )
+
+    return alters
+
+
+@create.command(name='role')
+@click.argument('role-name', type=str)
+@options(_role_options)
+@click.pass_context
+def create_role(ctx, role_name, **kwargs):
+    attrs = ";\n".join(_process_role_options(ctx, **kwargs))
+
+    qry = f'''
+        CREATE ROLE {qi(role_name)} {{
+            {attrs}
+        }}
+    '''
+
+    try:
+        ctx.obj['conn'].execute(qry)
+    except edgedb.EdgeDBError as e:
+        raise click.ClickException(str(e)) from e
+
+
+@alter.command(name='role')
+@click.argument('role-name', type=str)
+@options(_role_options)
+@click.pass_context
+def alter_role(ctx, role_name, **kwargs):
+
+    attrs = ";\n".join(_process_role_options(ctx, **kwargs))
+
+    qry = f'''
+        ALTER ROLE {qi(role_name)} {{
+            {attrs}
+        }}
+    '''
+
+    try:
+        ctx.obj['conn'].execute(qry)
+    except edgedb.EdgeDBError as e:
+        raise click.ClickException(str(e)) from e
+
+
+@drop.command(name='role')
+@click.argument('role-name', type=str)
+@click.pass_context
+def drop_role(ctx, role_name, **kwargs):
+    qry = f'''
+        DROP ROLE {qi(role_name)};
+    '''
+
+    try:
+        ctx.obj['conn'].execute(qry)
+    except edgedb.EdgeDBError as e:
+        raise click.ClickException(str(e)) from e

--- a/edb/edgeql/quote.py
+++ b/edb/edgeql/quote.py
@@ -65,3 +65,33 @@ def disambiguate_identifier(text, *, allow_reserved=False):
         return '`{}`'.format(text)
     else:
         return text
+
+
+def needs_quoting(string, allow_reserved):
+    isalnum = (
+        string and not string[0].isdecimal()
+        and string.replace('_', 'a').isalnum()
+    )
+
+    string = string.lower()
+
+    is_reserved = (
+        string != '__type__'
+        and string in keywords.by_type[keywords.RESERVED_KEYWORD]
+    )
+
+    return (
+        not isalnum
+        or (not allow_reserved and is_reserved)
+    )
+
+
+def _quote_ident(string):
+    return '`' + string.replace('`', '``') + '`'
+
+
+def quote_ident(string, *, force=False, allow_reserved=False):
+    if force or needs_quoting(string, allow_reserved):
+        return _quote_ident(string)
+    else:
+        return string

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -277,7 +277,8 @@ class Cluster:
                         database=edgedb_defines.EDGEDB_SUPERUSER_DB,
                         user=edgedb_defines.EDGEDB_SUPERUSER,
                         timeout=timeout)
-                except (OSError, asyncio.TimeoutError):
+                except (OSError, asyncio.TimeoutError,
+                        edgedb.ClientConnectionError):
                     timeout -= (time.monotonic() - started)
                     if timeout > 0.05:
                         await asyncio.sleep(0.05)

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -222,13 +222,23 @@ class ConnectedTestCaseMixin:
                       database=edgedb_defines.EDGEDB_SUPERUSER_DB,
                       user=edgedb_defines.EDGEDB_SUPERUSER,
                       password='test'):
+        conargs = cls.get_connect_args(
+            cluster=cluster, database=database, user=user, password=password)
+        return await edgedb.async_connect(**conargs)
+
+    @classmethod
+    def get_connect_args(cls, *,
+                         cluster=None,
+                         database=edgedb_defines.EDGEDB_SUPERUSER_DB,
+                         user=edgedb_defines.EDGEDB_SUPERUSER,
+                         password='test'):
         if cluster is None:
             cluster = cls.cluster
         conargs = cluster.get_connect_args().copy()
         conargs.update(dict(user=user,
                             password=password,
                             database=database))
-        return await edgedb.async_connect(**conargs)
+        return conargs
 
     def _run_and_rollback(self):
         return RollbackChanges(self)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ from setuptools.command import develop as setuptools_develop
 
 RUNTIME_DEPS = [
     'asyncpg~=0.18.2',
-    'click~=6.7',
+    'click~=7.0',
     'httptools>=0.0.13',
     'immutables>=0.9',
     'parsing~=1.6.1',
@@ -416,7 +416,7 @@ setuptools.setup(
     },
     entry_points={
         'console_scripts': [
-            'edgedb = edb.repl:main',
+            'edgedb = edb.cli:cli',
             'edgedb-server = edb.server.main:main',
         ]
     },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,98 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import click.testing
+
+import edgedb
+
+from edb import cli
+
+from edb.testbase import server as tb
+
+
+class TestCLI(tb.ConnectedTestCase):
+
+    ISOLATED_METHODS = False
+
+    def _run_cli(self, *args, input=None):
+        conn_args = self.get_connect_args()
+
+        cmd_args = (
+            '--host', conn_args['host'],
+            '--port', conn_args['port'],
+            '--user', conn_args['user'],
+        ) + args
+
+        if conn_args['password']:
+            cmd_args = ('--password-from-stdin',) + cmd_args
+            if input is not None:
+                input = f"{conn_args['password']}\n{input}"
+            else:
+                input = f"{conn_args['password']}\n"
+
+        runner = click.testing.CliRunner()
+        return runner.invoke(
+            cli.cli, args=cmd_args, input=input,
+            catch_exceptions=False)
+
+    async def test_cli_role(self):
+        self._run_cli('create', 'role', 'foo', '--allow-login',
+                      '--password-from-stdin',
+                      input='foo-pass\n')
+
+        conn = await self.connect(
+            user='foo',
+            password='foo-pass',
+        )
+        await conn.close()
+
+        self._run_cli('alter', 'role', 'foo', '--no-allow-login')
+
+        # good password, but allow_login is False
+        with self.assertRaisesRegex(
+                edgedb.AuthenticationError,
+                'authentication failed'):
+            await self.connect(
+                user='foo',
+                password='foo-pass',
+            )
+
+        self._run_cli('alter', 'role', 'foo', '--allow-login',
+                      '--password-from-stdin',
+                      input='foo-new-pass\n')
+
+        conn = await self.connect(
+            user='foo',
+            password='foo-new-pass',
+        )
+        await conn.close()
+
+        self._run_cli('drop', 'role', 'foo')
+
+        with self.assertRaisesRegex(
+                edgedb.AuthenticationError,
+                'authentication failed'):
+            await self.connect(
+                user='foo',
+                password='foo-new-pass',
+            )
+
+        result = self._run_cli('create', 'role', 'foo', '--allow-login',
+                               '--password', input='foo-pass\n')
+        self.assertIn(b'input is not a TTY', result.stdout_bytes)

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -21,7 +21,7 @@ import edgedb
 from edb.testbase import server as tb
 
 
-class TestServerAuth(tb.QueryTestCase):
+class TestServerAuth(tb.ConnectedTestCase):
 
     ISOLATED_METHODS = False
 


### PR DESCRIPTION
This is the first command of a series of CLI commands that allow
basic manipulation of the EdgeDB instance and its schema using command
line syntax.  The basic notion is that `edgedb {create|alter|drop} ...`
follow a familiar DDL syntax, minus the unnecessary punctuation.

`edgedb {create,alter,drop} role` is chosen to be implemented as the first
such command to make it easier to set up a role from the command line
during initial EdgeDB setup.