### PR TITLE
Raise an exception on invalid input to mean(), var(), and stddev()

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -150,6 +150,7 @@ def compile_FunctionCall(
         func_sql_function=func.get_from_function(env.schema),
         force_return_cast=func.get_force_return_cast(env.schema),
         sql_func_has_out_params=func.get_sql_func_has_out_params(env.schema),
+        error_on_null_result=func.get_error_on_null_result(env.schema),
         params_typemods=params_typemods,
         context=expr.context,
         typeref=irtyputils.type_to_typeref(env.schema, rtype),

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -40,6 +40,10 @@ class EdgeDBErrorMeta(type):
 
         return cls
 
+    @classmethod
+    def get_error_class_from_code(mcls, code):
+        return mcls._error_map[code]
+
 
 class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -498,9 +498,12 @@ class FunctionCall(Call):
     # The underlying SQL function has OUT parameters.
     sql_func_has_out_params: bool = False
 
+    # Error to raise if the underlying SQL function returns NULL.
+    error_on_null_result: typing.Optional[str] = None
+
     # Set to the type of the variadic parameter of the bound function
     # (or None, if the function has no variadic parameters.)
-    variadic_param_type: typing.Optional[TypeRef]
+    variadic_param_type: typing.Optional[TypeRef] = None
 
 
 class OperatorCall(Call):

--- a/edb/lib/math.edgeql
+++ b/edb/lib/math.edgeql
@@ -127,6 +127,8 @@ CREATE FUNCTION
 math::mean(vals: SET OF std::decimal) -> std::decimal
 {
     FROM SQL FUNCTION 'avg';
+    SET error_on_null_result := 'invalid input to mean(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -136,6 +138,8 @@ math::mean(vals: SET OF std::int64) -> std::float64
     FROM SQL FUNCTION 'avg';
     # SQL 'avg' returns numeric on integer inputs.
     SET force_return_cast := true;
+    SET error_on_null_result := 'invalid input to mean(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -143,6 +147,8 @@ CREATE FUNCTION
 math::mean(vals: SET OF std::float64) -> std::float64
 {
     FROM SQL FUNCTION 'avg';
+    SET error_on_null_result := 'invalid input to mean(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -152,6 +158,8 @@ CREATE FUNCTION
 math::stddev(vals: SET OF std::decimal) -> std::decimal
 {
     FROM SQL FUNCTION 'stddev';
+    SET error_on_null_result := 'invalid input to stddev(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -161,6 +169,8 @@ math::stddev(vals: SET OF std::int64) -> std::float64
     FROM SQL FUNCTION 'stddev';
     # SQL 'stddev' returns numeric on integer inputs.
     SET force_return_cast := true;
+    SET error_on_null_result := 'invalid input to stddev(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -168,6 +178,8 @@ CREATE FUNCTION
 math::stddev(vals: SET OF std::float64) -> std::float64
 {
     FROM SQL FUNCTION 'stddev';
+    SET error_on_null_result := 'invalid input to stddev(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -177,6 +189,8 @@ CREATE FUNCTION
 math::stddev_pop(vals: SET OF std::decimal) -> std::decimal
 {
     FROM SQL FUNCTION 'stddev_pop';
+    SET error_on_null_result := 'invalid input to stddev_pop(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -186,6 +200,8 @@ math::stddev_pop(vals: SET OF std::int64) -> std::float64
     FROM SQL FUNCTION 'stddev_pop';
     # SQL 'stddev_pop' returns numeric on integer inputs.
     SET force_return_cast := true;
+    SET error_on_null_result := 'invalid input to stddev_pop(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -193,6 +209,8 @@ CREATE FUNCTION
 math::stddev_pop(vals: SET OF std::float64) -> std::float64
 {
     FROM SQL FUNCTION 'stddev_pop';
+    SET error_on_null_result := 'invalid input to stddev_pop(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -202,6 +220,8 @@ CREATE FUNCTION
 math::var(vals: SET OF std::decimal) -> OPTIONAL std::decimal
 {
     FROM SQL FUNCTION 'variance';
+    SET error_on_null_result := 'invalid input to var(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -211,6 +231,8 @@ math::var(vals: SET OF std::int64) -> OPTIONAL std::float64
     FROM SQL FUNCTION 'variance';
     # SQL 'var' returns numeric on integer inputs.
     SET force_return_cast := true;
+    SET error_on_null_result := 'invalid input to var(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -218,6 +240,8 @@ CREATE FUNCTION
 math::var(vals: SET OF std::float64) -> OPTIONAL std::float64
 {
     FROM SQL FUNCTION 'variance';
+    SET error_on_null_result := 'invalid input to var(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -227,6 +251,8 @@ CREATE FUNCTION
 math::var_pop(vals: SET OF std::decimal) -> OPTIONAL std::decimal
 {
     FROM SQL FUNCTION 'var_pop';
+    SET error_on_null_result := 'invalid input to var_pop(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -236,6 +262,8 @@ math::var_pop(vals: SET OF std::int64) -> OPTIONAL std::float64
     FROM SQL FUNCTION 'var_pop';
     # SQL 'var_pop' returns numeric on integer inputs.
     SET force_return_cast := true;
+    SET error_on_null_result := 'invalid input to var_pop(): not ' ++
+                                'enough elements in input set';
 };
 
 
@@ -243,4 +271,6 @@ CREATE FUNCTION
 math::var_pop(vals: SET OF std::float64) -> OPTIONAL std::float64
 {
     FROM SQL FUNCTION 'var_pop';
+    SET error_on_null_result := 'invalid input to var_pop(): not ' ++
+                                'enough elements in input set';
 };

--- a/edb/pgsql/datasources/schema/functions.py
+++ b/edb/pgsql/datasources/schema/functions.py
@@ -37,6 +37,7 @@ async def fetch(
                 f.from_expr,
                 f.force_return_cast,
                 f.sql_func_has_out_params,
+                f.error_on_null_result,
                 f.initial_value,
                 edgedb._resolve_type(f.return_type) AS return_type,
                 edgedb._resolve_type_name(f.params) AS params

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -382,6 +382,7 @@ class IntrospectionMech:
                 'from_expr': row['from_expr'],
                 'force_return_cast': row['force_return_cast'],
                 'sql_func_has_out_params': row['sql_func_has_out_params'],
+                'error_on_null_result': row['error_on_null_result'],
                 'code': row['code'],
                 'initial_value': row['initial_value'],
                 'return_type': self.unpack_typeref(row['return_type'], schema)

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1193,11 +1193,7 @@ class AlterObjectProperty(Command):
             new_value = s_expr.Expression(
                 text=edgeql.generate_source(astnode.value, pretty=False))
         else:
-            if isinstance(astnode.value, qlast.BaseConstant):
-                new_value = qlcompiler.evaluate_ast_to_python_val(
-                    astnode.value, schema=schema)
-
-            elif isinstance(astnode.value, qlast.Tuple):
+            if isinstance(astnode.value, qlast.Tuple):
                 new_value = tuple(
                     qlcompiler.evaluate_ast_to_python_val(
                         el.value, schema=schema)
@@ -1216,9 +1212,8 @@ class AlterObjectProperty(Command):
                 new_value = None
 
             else:
-                raise ValueError(
-                    f'unexpected value in attribute {propname}: '
-                    f'{astnode.value!r}')
+                new_value = qlcompiler.evaluate_ast_to_python_val(
+                    astnode.value, schema=schema)
 
         return cls(property=propname, new_value=new_value)
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -568,6 +568,9 @@ class Function(CallableObject, s_abc.Function):
     sql_func_has_out_params = so.SchemaField(
         bool, default=False, compcoef=0.9, introspectable=False)
 
+    error_on_null_result = so.SchemaField(
+        str, default=None, compcoef=0.9, introspectable=False)
+
     initial_value = so.SchemaField(
         expr.Expression, default=None, compcoef=0.4, coerce=True,
         allow_ddl_set=True)

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -110,7 +110,7 @@ def get_runstate_path(data_dir: os.PathLike) -> os.PathLike:
     if devmode.is_in_dev_mode():
         return data_dir
     else:
-        return pathlib.Path(get_build_metadata_value('RUNSTATEDIR'))
+        return pathlib.Path(get_build_metadata_value('RUNSTATE_DIR'))
 
 
 class ClusterError(Exception):

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2873,8 +2873,7 @@ class TestExpressions(tb.QueryTestCase):
 
     async def test_edgeql_expr_array_15(self):
         with self.assertRaisesRegex(
-                # FIXME: possibly a different error should be used here
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'array index 10 is out of bounds'):
             await self.con.execute("""
                 SELECT [1, 2, 3][10];
@@ -2882,8 +2881,7 @@ class TestExpressions(tb.QueryTestCase):
 
     async def test_edgeql_expr_array_16(self):
         with self.assertRaisesRegex(
-                # FIXME: possibly a different error should be used here
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'array index -10 is out of bounds'):
             await self.con.execute("""
                 SELECT [1, 2, 3][-10];
@@ -3081,8 +3079,7 @@ class TestExpressions(tb.QueryTestCase):
 
     async def test_edgeql_expr_string_03(self):
         with self.assertRaisesRegex(
-                # FIXME: possibly a different error should be used here
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'string index 10 is out of bounds'):
             await self.con.fetchall_json("""
                 SELECT '123'[10];
@@ -3090,8 +3087,7 @@ class TestExpressions(tb.QueryTestCase):
 
     async def test_edgeql_expr_string_04(self):
         with self.assertRaisesRegex(
-                # FIXME: possibly a different error should be used here
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'string index -10 is out of bounds'):
             await self.con.fetchall("""
                 SELECT '123'[-10];

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -23,7 +23,6 @@ import os.path
 import edgedb
 
 from edb.testbase import server as tb
-from edb.tools import test
 
 
 class TestEdgeQLFunctions(tb.QueryTestCase):
@@ -1300,7 +1299,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             ['2018-05-07T20:01:22.306916+00:00'],
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall('SELECT to_datetime("2017-10-10", "")')
@@ -1321,7 +1320,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             ['2018-05-07'],
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall(
@@ -1335,7 +1334,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             ['15:01:22.306916'],
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall('SELECT to_naive_time("12:00:00", "")')
@@ -1461,22 +1460,22 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         # Empty format string shouldn't produce an empty set.
         #
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall(r'''SELECT to_str(1, "")''')
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall(r'''SELECT to_str(1.1, "")''')
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall(r'''SELECT to_str(1.1n, "")''')
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall(
@@ -1539,7 +1538,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {' '}
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall(r'''
@@ -1547,7 +1546,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                     SELECT to_str(DT, '');
                 ''')
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall(r'''
@@ -1615,7 +1614,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {'foo'},
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall(r'''
@@ -1623,7 +1622,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                     SELECT to_str(DT, '');
                 ''')
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall(r'''
@@ -1702,7 +1701,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {'987654321st'},
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall(r'''SELECT to_str(987654321, '');''',)
@@ -1763,7 +1762,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {' 1.2346e+22'},
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall(
@@ -1790,7 +1789,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {' '},
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall(
@@ -1862,7 +1861,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {987654321},
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall('''SELECT to_int64('1', '')''')
@@ -1933,7 +1932,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {987654321},
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall('''SELECT to_int32('1', '')''')
@@ -2004,7 +2003,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {4321},
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall('''SELECT to_int16('1', '')''')
@@ -2030,7 +2029,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {123.456789},
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall('''SELECT to_float64('1', '')''')
@@ -2056,7 +2055,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {123.457},
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall('''SELECT to_float32('1', '')''')
@@ -2082,7 +2081,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {123.456789},
         )
 
-        with self.assertRaisesRegex(edgedb.InternalServerError,
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall('''SELECT to_decimal('1', '')''')
@@ -3619,12 +3618,11 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {True},
         )
 
-    @test.not_implemented(
-        "We don't yet validate that the return cardinality is 1 here")
     async def test_edgeql_functions_math_mean_09(self):
         with self.assertRaisesRegex(
-                edgedb.InternalServerError,
-                r"mean in undefined for an empty set"):
+                edgedb.InvalidValueError,
+                r"invalid input to mean\(\): "
+                r"not enough elements in input set"):
             await self.con.fetchall(r'''
                 SELECT math::mean(<int64>{});
             ''')
@@ -3686,26 +3684,20 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {True},
         )
 
-    @test.not_implemented('''
-        We don't yet validate that the return cardinality is 1 here.
-        Standard deviation is not defined for sets with fewer than 2 elements.
-    ''')
     async def test_edgeql_functions_math_stddev_03(self):
         with self.assertRaisesRegex(
-                edgedb.InternalServerError,
-                r"stddev in undefined for input set.+< 2"):
+                edgedb.InvalidValueError,
+                r"invalid input to stddev\(\): not enough "
+                r"elements in input set"):
             await self.con.fetchall(r'''
                 SELECT math::stddev(<int64>{});
             ''')
 
-    @test.not_implemented('''
-        We don't yet validate that the return cardinality is 1 here.
-        Standard deviation is not defined for sets with fewer than 2 elements.
-    ''')
     async def test_edgeql_functions_math_stddev_04(self):
         with self.assertRaisesRegex(
-                edgedb.InternalServerError,
-                r"stddev in undefined for input set.+< 2"):
+                edgedb.InvalidValueError,
+                r"invalid input to stddev\(\): not enough "
+                r"elements in input set"):
             await self.con.fetchall(r'''
                 SELECT math::stddev(1);
             ''')
@@ -3767,14 +3759,11 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {True},
         )
 
-    @test.not_implemented('''
-        We don't yet validate that the return cardinality is 1 here.
-        Population standard deviation is not defined for an empty set.
-    ''')
     async def test_edgeql_functions_math_stddev_pop_04(self):
         with self.assertRaisesRegex(
-                edgedb.InternalServerError,
-                r"stddev_pop in undefined for an empty set"):
+                edgedb.InvalidValueError,
+                r"invalid input to stddev_pop\(\): not enough "
+                r"elements in input set"):
             await self.con.fetchall(r'''
                 SELECT math::stddev_pop(<int64>{});
             ''')
@@ -3889,26 +3878,20 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {True},
         )
 
-    @test.not_implemented('''
-        We don't yet validate that the return cardinality is 1 here.
-        Variance is not defined for sets with fewer than 2 elements.
-    ''')
     async def test_edgeql_functions_math_var_04(self):
         with self.assertRaisesRegex(
-                edgedb.InternalServerError,
-                r"var in undefined for input set.+< 2"):
+                edgedb.InvalidValueError,
+                r"invalid input to var\(\): not enough "
+                r"elements in input set"):
             await self.con.fetchall(r'''
                 SELECT math::var(<int64>{});
             ''')
 
-    @test.not_implemented('''
-        We don't yet validate that the return cardinality is 1 here.
-        Variance is not defined for sets with fewer than 2 elements.
-    ''')
     async def test_edgeql_functions_math_var_05(self):
         with self.assertRaisesRegex(
-                edgedb.InternalServerError,
-                r"var in undefined for input set.+< 2"):
+                edgedb.InvalidValueError,
+                r"invalid input to var\(\): not enough "
+                r"elements in input set"):
             await self.con.fetchall(r'''
                 SELECT math::var(1);
             ''')
@@ -3991,14 +3974,11 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {True},
         )
 
-    @test.not_implemented('''
-        We don't yet validate that the return cardinality is 1 here.
-        Population variance is not defined for an empty set.
-    ''')
     async def test_edgeql_functions_math_var_pop_04(self):
         with self.assertRaisesRegex(
-                edgedb.InternalServerError,
-                r"var_pop in undefined for an empty set"):
+                edgedb.InvalidValueError,
+                r"invalid input to var_pop\(\): not enough "
+                r"elements in input set"):
             await self.con.fetchall(r'''
                 SELECT math::var_pop(<int64>{});
             ''')

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -250,8 +250,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_04(self):
         with self.assertRaisesRegex(
-                # FIXME: maybe a different error type should be used here
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'json index 10 is out of bounds'):
             await self.con.fetchall(r"""
                 SELECT (to_json('[1, "a", 3]'))[10];
@@ -259,8 +258,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_05(self):
         with self.assertRaisesRegex(
-                # FIXME: maybe a different error type should be used here
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'json index -10 is out of bounds'):
             await self.con.fetchall(r"""
                 SELECT (to_json('[1, "a", 3]'))[-10];
@@ -268,9 +266,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_06(self):
         with self.assertRaisesRegex(
-                # FIXME: a different error should be used here, this
-                # one leaks postgres types
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'cannot index json array by text'):
             await self.con.fetchall(r"""
                 SELECT (to_json('[1, "a", 3]'))['1'];
@@ -278,8 +274,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_07(self):
         with self.assertRaisesRegex(
-                # FIXME: maybe a different error type should be used here
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r"json index 'c' is out of bounds"):
             await self.con.fetchall(r"""
                 SELECT (to_json('{"a": 1, "b": null}'))["c"];
@@ -287,9 +282,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_08(self):
         with self.assertRaisesRegex(
-                # FIXME: a different error should be used here, this
-                # one leaks postgres types
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'cannot index json object by bigint'):
             await self.con.execute(r"""
                 SELECT (to_json('{"a": 1, "b": null}'))[0];
@@ -297,9 +290,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_09(self):
         with self.assertRaisesRegex(
-                # FIXME: a different error should be used here, this
-                # one leaks postgres types
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'cannot index json null'):
             await self.con.fetchall(r"""
                 SELECT (to_json('null'))[0];
@@ -307,9 +298,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_10(self):
         with self.assertRaisesRegex(
-                # FIXME: a different error should be used here, this
-                # one leaks postgres types
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'cannot index json boolean'):
             await self.con.execute(r"""
                 SELECT (to_json('true'))[0];
@@ -317,9 +306,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_11(self):
         with self.assertRaisesRegex(
-                # FIXME: a different error should be used here, this
-                # one leaks postgres types
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'cannot index json number'):
             await self.con.execute(r"""
                 SELECT (to_json('123'))[0];
@@ -327,8 +314,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_12(self):
         with self.assertRaisesRegex(
-                # FIXME: currently JSON strings cannot be indexed or sliced
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'cannot index json string'):
             await self.con.execute(r"""
                 SELECT (to_json('"qwerty"'))[0];
@@ -357,8 +343,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_14(self):
         with self.assertRaisesRegex(
-                # FIXME: maybe a different error type should be used here
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'json index 10 is out of bounds'):
             await self.con.fetchall(r"""
                 WITH
@@ -369,8 +354,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_15(self):
         with self.assertRaisesRegex(
-                # FIXME: maybe a different error type should be used here
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'json index -10 is out of bounds'):
             await self.con.fetchall(r"""
                 WITH
@@ -381,9 +365,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_16(self):
         with self.assertRaisesRegex(
-                # FIXME: a different error should be used here, this
-                # one leaks postgres types
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'cannot index json array by text'):
             await self.con.fetchall(r"""
                 WITH
@@ -394,8 +376,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_17(self):
         with self.assertRaisesRegex(
-                # FIXME: maybe a different error type should be used here
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r"json index 'c' is out of bounds"):
             await self.con.execute(r"""
                 WITH
@@ -406,9 +387,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_18(self):
         with self.assertRaisesRegex(
-                # FIXME: a different error should be used here, this
-                # one leaks postgres types
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'cannot index json object by bigint'):
             await self.con.fetchall(r"""
                 WITH
@@ -419,9 +398,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_19(self):
         with self.assertRaisesRegex(
-                # FIXME: a different error should be used here, this
-                # one leaks postgres types
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'cannot index json null'):
             await self.con.execute(r"""
                 WITH
@@ -432,9 +409,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_20(self):
         with self.assertRaisesRegex(
-                # FIXME: a different error should be used here, this
-                # one leaks postgres types
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'cannot index json boolean'):
             await self.con.execute(r"""
                 WITH
@@ -445,9 +420,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_21(self):
         with self.assertRaisesRegex(
-                # FIXME: a different error should be used here, this
-                # one leaks postgres types
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'cannot index json number'):
             await self.con.fetchall(r"""
                 WITH
@@ -458,8 +431,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_accessor_22(self):
         with self.assertRaisesRegex(
-                # FIXME: currently JSON strings cannot be indexed or sliced
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'cannot index json string'):
             await self.con.execute(r"""
                 WITH
@@ -790,7 +762,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 # FIXME: a different error should be used here, this
                 # one leaks postgres types
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'cannot call jsonb_each on a non-object'):
             await self.con.fetchall_json(r'''
                 WITH
@@ -1612,7 +1584,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_str_function_02(self):
         with self.assertRaisesRegex(
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r"format 'foo' is invalid"):
             async with self.con.transaction():
                 await self.con.fetchall(r'''
@@ -1620,7 +1592,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 ''')
 
         with self.assertRaisesRegex(
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r'"fmt" argument must be a non-empty string'):
             async with self.con.transaction():
                 await self.con.fetchall_json(r'''
@@ -1628,7 +1600,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 ''')
 
         with self.assertRaisesRegex(
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r"format 'PRETTY' is invalid"):
             async with self.con.transaction():
                 await self.con.fetchall(r'''
@@ -1636,7 +1608,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 ''')
 
         with self.assertRaisesRegex(
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r"format 'Pretty' is invalid"):
             async with self.con.transaction():
                 await self.con.fetchall_json(r'''
@@ -1644,7 +1616,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 ''')
 
         with self.assertRaisesRegex(
-                edgedb.InternalServerError,
+                edgedb.InvalidValueError,
                 r"format 'p' is invalid"):
             async with self.con.transaction():
                 await self.con.fetchall(r'''


### PR DESCRIPTION
`math::mean()` is not defined on empty input set, `var()` and `stddev()`
are not defined on sets with cardinality less than 2.  Rather then
silently returning an empty set (which is a result of an underlying SQL
function returning NULL), raise an explicit exception.

This commit also adds a missing `InvalidValueError` mapping that fixes
the incorrect error being raised on parameter validation errors.  This
commit also wires in support for passing the query source context on
runtime errors, if available.