### PR TITLE
Add support for collection types in schema

### DIFF
--- a/edb/edgeql/compiler/cast.py
+++ b/edb/edgeql/compiler/cast.py
@@ -32,6 +32,7 @@ from edb.ir import utils as irutils
 
 from edb.schema import casts as s_casts
 from edb.schema import functions as s_func
+from edb.schema import modules as s_mod
 from edb.schema import types as s_types
 
 from edb.edgeql import ast as qlast
@@ -158,7 +159,8 @@ def _cast_to_ir(
         from_type=orig_typeref,
         to_type=new_typeref,
         cast_name=cast_name,
-        cast_module_id=ctx.env.schema.get(cast_name.module).id,
+        cast_module_id=ctx.env.schema.get_global(
+            s_mod.Module, cast_name.module).id,
         sql_function=cast.get_from_function(ctx.env.schema),
         sql_cast=cast.get_from_cast(ctx.env.schema),
         sql_expr=bool(cast.get_code(ctx.env.schema)),

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -30,6 +30,7 @@ from edb.ir import utils as irutils
 
 from edb.schema import functions as s_func
 from edb.schema import inheriting as s_inh
+from edb.schema import modules as s_mod
 from edb.schema import name as sn
 from edb.schema import types as s_types
 
@@ -144,7 +145,8 @@ def compile_FunctionCall(
 
     fcall = irast.FunctionCall(
         args=args,
-        func_module_id=env.schema.get(func_name.module).id,
+        func_module_id=env.schema.get_global(
+            s_mod.Module, func_name.module).id,
         func_shortname=func_name,
         func_polymorphic=is_polymorphic,
         func_sql_function=func.get_from_function(env.schema),
@@ -343,7 +345,8 @@ def compile_operator(
 
     node = irast.OperatorCall(
         args=args,
-        func_module_id=env.schema.get(oper_name.module).id,
+        func_module_id=env.schema.get_global(
+            s_mod.Module, oper_name.module).id,
         func_shortname=oper_name,
         func_polymorphic=is_polymorphic,
         func_sql_function=oper.get_from_function(env.schema),

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -68,7 +68,7 @@ def init_context(
         context.ContextLevel:
     stack = context.CompilerContext()
     ctx = stack.current
-    if not schema.get('__derived__', None):
+    if not schema.get_global(s_mod.Module, '__derived__', None):
         schema, _ = s_mod.Module.create_in_schema(schema, name='__derived__')
     ctx.env = context.Environment(
         schema=schema,

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -401,7 +401,7 @@ class DeclarationLoader:
                 if not isinstance(prop_target, (s_scalars.ScalarType,
                                                 s_types.Collection)):
                     raise errors.InvalidPropertyTargetError(
-                        f'invalid property target, expected primitive type, '
+                        f'invalid property type: expected primitive type, '
                         f'got {prop_target.__class__.__name__}',
                         context=propdecl.target[0].context
                     )
@@ -738,7 +738,7 @@ class DeclarationLoader:
                 if not isinstance(expr_type, (s_scalars.ScalarType,
                                               s_types.Collection)):
                     raise errors.InvalidPropertyTargetError(
-                        f'invalid property target, expected primitive type, '
+                        f'invalid property type: expected primitive type, '
                         f'got {expr_type.__class__.__name__}',
                         context=ptrdecl.expr.context
                     )

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -851,7 +851,7 @@ class DropIndexStmt(Nonterm):
 
 
 class AlterTargetStmt(Nonterm):
-    def reduce_ALTER_TYPE_NodeNameList(self, *kids):
+    def reduce_ALTER_TYPE_FullTypeExpr(self, *kids):
         self.val = qlast.AlterTarget(target=kids[2].val)
 
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -22,7 +22,7 @@ import uuid
 
 from edb.common import ast, compiler, parsing
 
-from edb.schema import modules as s_modules
+from edb.schema import modules as s_mod
 from edb.schema import name as sn
 from edb.schema import objects as so
 from edb.schema import pointers as s_pointers
@@ -599,7 +599,7 @@ class DeleteStmt(MutatingStmt, FilteredStmt):
 
 class SessionStateCmd(Command):
 
-    modaliases: typing.Dict[typing.Optional[str], s_modules.Module]
+    modaliases: typing.Dict[typing.Optional[str], s_mod.Module]
     testmode: bool
 
 

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -24,6 +24,7 @@ import typing
 from edb.edgeql import qltypes
 
 from edb.schema import abc as s_abc
+from edb.schema import modules as s_mod
 from edb.schema import objtypes as s_objtypes
 from edb.schema import pointers as s_pointers
 from edb.schema import pseudo as s_pseudo
@@ -120,7 +121,7 @@ def type_to_typeref(schema, t: s_types.Type, *,
             name = typename
         else:
             name = t.get_name(schema)
-        module = schema.get(name.module)
+        module = schema.get_global(s_mod.Module, name.module)
 
         result = irast.TypeRef(
             id=t.id,
@@ -214,7 +215,8 @@ def ptrref_from_ptrcls(
         ircls = irast.PointerRef
         kwargs['id'] = ptrcls.id
         name = ptrcls.get_name(schema)
-        kwargs['module_id'] = schema.get(name.module).id
+        kwargs['module_id'] = schema.get_global(
+            s_mod.Module, name.module).id
 
     if direction is s_pointers.PointerDirection.Inbound:
         out_source = target_ref

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -258,36 +258,36 @@ def get_index_backend_name(id, module_id, catenate=True, *, aspect=None):
 def get_backend_name(schema, obj, catenate=True, *, aspect=None):
     if isinstance(obj, s_objtypes.ObjectType):
         name = obj.get_name(schema)
-        module = schema.get(name.module)
+        module = schema.get_global(s_mod.Module, name.module)
         return get_objtype_backend_name(
             obj.id, module.id, catenate=catenate, aspect=aspect)
 
     elif isinstance(obj, s_pointers.PointerLike):
         name = obj.get_name(schema)
-        module = schema.get(name.module)
+        module = schema.get_global(s_mod.Module, name.module)
         return get_pointer_backend_name(obj.id, module.id, catenate=catenate)
 
     elif isinstance(obj, s_scalars.ScalarType):
         name = obj.get_name(schema)
-        module = schema.get(name.module)
+        module = schema.get_global(s_mod.Module, name.module)
         return get_scalar_backend_name(obj.id, module.id, catenate=catenate,
                                        aspect=aspect)
 
     elif isinstance(obj, s_opers.Operator):
         name = obj.get_shortname(schema)
-        module = schema.get(name.module)
+        module = schema.get_global(s_mod.Module, name.module)
         return get_operator_backend_name(
             name, module.id, catenate, aspect=aspect)
 
     elif isinstance(obj, s_casts.Cast):
         name = obj.get_name(schema)
-        module = schema.get(name.module)
+        module = schema.get_global(s_mod.Module, name.module)
         return get_cast_backend_name(
             name, module.id, catenate, aspect=aspect)
 
     elif isinstance(obj, s_func.Function):
         name = obj.get_shortname(schema)
-        module = schema.get(name.module)
+        module = schema.get_global(s_mod.Module, name.module)
         return get_function_backend_name(
             name, module.id, catenate)
 
@@ -296,7 +296,7 @@ def get_backend_name(schema, obj, catenate=True, *, aspect=None):
 
     elif isinstance(obj, s_constr.Constraint):
         name = obj.get_name(schema)
-        module = schema.get(name.module)
+        module = schema.get_global(s_mod.Module, name.module)
         return get_constraint_backend_name(
             obj.id, module.id, catenate, aspect=aspect)
 

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -31,6 +31,7 @@ from edb.schema import objtypes as s_objtypes
 from edb.schema import operators as s_opers
 from edb.schema import pointers as s_pointers
 from edb.schema import scalars as s_scalars
+from edb.schema import types as s_types
 
 from . import keywords as pg_keywords
 
@@ -255,6 +256,12 @@ def get_index_backend_name(id, module_id, catenate=True, *, aspect=None):
     return convert_name(name, aspect, catenate)
 
 
+def get_tuple_backend_name(id, catenate=True, *, aspect=None):
+
+    name = s_name.Name(module='edgedb', name=f'{id}_t')
+    return convert_name(name, aspect, catenate, prefix='')
+
+
 def get_backend_name(schema, obj, catenate=True, *, aspect=None):
     if isinstance(obj, s_objtypes.ObjectType):
         name = obj.get_name(schema)
@@ -299,6 +306,10 @@ def get_backend_name(schema, obj, catenate=True, *, aspect=None):
         module = schema.get_global(s_mod.Module, name.module)
         return get_constraint_backend_name(
             obj.id, module.id, catenate, aspect=aspect)
+
+    elif isinstance(obj, s_types.BaseTuple):
+        return get_tuple_backend_name(
+            obj.id, catenate, aspect=aspect)
 
     else:
         raise ValueError(f'cannot determine backend name for {obj!r}')

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -43,6 +43,7 @@ def compile_ir_to_sql_tree(
         ir_expr: irast.Base, *,
         output_format: typing.Optional[OutputFormat]=None,
         ignore_shapes: bool=False,
+        explicit_top_cast: typing.Optional[irast.TypeRef]=None,
         singleton_mode: bool=False,
         use_named_params: bool=False,
         expected_cardinality_one: bool=False) -> pgast.Base:
@@ -59,9 +60,9 @@ def compile_ir_to_sql_tree(
         ctx.env = context.Environment(
             output_format=output_format,
             expected_cardinality_one=expected_cardinality_one,
-            use_named_params=use_named_params)
-        if ignore_shapes:
-            ctx.expr_exposed = False
+            use_named_params=use_named_params,
+            ignore_object_shapes=ignore_shapes,
+            explicit_top_cast=explicit_top_cast)
         qtree = dispatch.compile(ir_expr, ctx=ctx)
 
     except Exception as e:  # pragma: no cover
@@ -78,6 +79,7 @@ def compile_ir_to_sql(
         ir_expr: irast.Base, *,
         output_format: typing.Optional[OutputFormat]=None,
         ignore_shapes: bool=False,
+        explicit_top_cast: typing.Optional[irast.TypeRef]=None,
         timer=None,
         use_named_params: bool=False,
         expected_cardinality_one: bool=False,
@@ -88,6 +90,7 @@ def compile_ir_to_sql(
             ir_expr,
             output_format=output_format,
             ignore_shapes=ignore_shapes,
+            explicit_top_cast=explicit_top_cast,
             use_named_params=use_named_params,
             expected_cardinality_one=expected_cardinality_one)
     else:
@@ -96,6 +99,7 @@ def compile_ir_to_sql(
                 ir_expr,
                 output_format=output_format,
                 ignore_shapes=ignore_shapes,
+                explicit_top_cast=explicit_top_cast,
                 use_named_params=use_named_params,
                 expected_cardinality_one=expected_cardinality_one)
 

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -145,7 +145,8 @@ class Environment:
     """Static compilation environment."""
 
     def __init__(self, *, output_format, use_named_params,
-                 expected_cardinality_one):
+                 expected_cardinality_one, ignore_object_shapes,
+                 explicit_top_cast):
         self.aliases = aliases.AliasGenerator()
         self.root_rels = set()
         self.rel_overlays = collections.defaultdict(list)
@@ -154,3 +155,5 @@ class Environment:
         self.use_named_params = use_named_params
         self.ptrref_source_visibility = {}
         self.expected_cardinality_one = expected_cardinality_one
+        self.ignore_object_shapes = ignore_object_shapes
+        self.explicit_top_cast = explicit_top_cast

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -61,7 +61,7 @@ def compile_Set(
             return config.top_output_as_config_op(
                 ir_set, ctx.rel, env=ctx.env)
         else:
-            return output.top_output_as_value(ctx.rel, env=ctx.env)
+            return output.top_output_as_value(ctx.rel, ir_set, env=ctx.env)
     else:
         value = pathctx.get_path_value_var(
             ctx.rel, ir_set.path_id, env=ctx.env)
@@ -92,7 +92,8 @@ def _compile_set_impl(
         # this helps in GROUP BY queries.
         value = dispatch.compile(ir_set.expr, ctx=ctx)
         pathctx.put_path_value_var(ctx.rel, ir_set.path_id, value, env=ctx.env)
-        if output.in_serialization_ctx(ctx) and ir_set.shape:
+        if (output.in_serialization_ctx(ctx) and ir_set.shape
+                and not ctx.env.ignore_object_shapes):
             _compile_shape(ir_set, shape=ir_set.shape, ctx=ctx)
 
     elif ir_set.path_scope_id is not None and not is_toplevel:
@@ -526,7 +527,8 @@ def _compile_set(
 
     relgen.get_set_rvar(ir_set, ctx=ctx)
 
-    if output.in_serialization_ctx(ctx) and ir_set.shape:
+    if (output.in_serialization_ctx(ctx) and ir_set.shape
+            and not ctx.env.ignore_object_shapes):
         _compile_shape(ir_set, shape=ir_set.shape, ctx=ctx)
 
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1452,7 +1452,7 @@ class CreateSourceIndex(SourceIndexCommand, CreateObject,
             # list.
             sql_expr = sql_expr[1:-1]
 
-        module = schema.get(index.get_name(schema).module)
+        module = schema.get_global(s_mod.Module, index.get_name(schema).module)
         index_name = common.get_index_backend_name(
             index.id, module.id, catenate=False)
         pg_index = dbops.Index(
@@ -1481,7 +1481,8 @@ class RenameSourceIndex(SourceIndexCommand, RenameObject,
         index_ctx = context.get(s_indexes.SourceIndexCommandContext)
 
         orig_schema = index_ctx.original_schema
-        module = schema.get(index.get_name(orig_schema).module)
+        module = schema.get_global(
+            s_mod.Module, index.get_name(orig_schema).module)
         orig_idx_name = common.get_index_backend_name(
             index.id, module.id, catenate=False)
 
@@ -1525,7 +1526,8 @@ class DeleteSourceIndex(SourceIndexCommand, DeleteObject,
             #
             table_name = common.get_backend_name(
                 schema, source.scls, catenate=False)
-            module = schema.get(index.get_name(orig_schema).module)
+            module = schema.get_global(
+                s_mod.Module, index.get_name(orig_schema).module)
             orig_idx_name = common.get_index_backend_name(
                 index.id, module.id, catenate=False)
             index = dbops.Index(
@@ -3294,7 +3296,7 @@ class AlterModule(ModuleMetaCommand, adapts=s_mod.AlterModule):
 
 class DeleteModule(ModuleMetaCommand, adapts=s_mod.DeleteModule):
     def apply(self, schema, context):
-        module = schema.get(self.classname)
+        module = self.get_object(schema)
         schema_name = common.get_backend_name(schema, module)
 
         schema, _ = CompositeObjectMetaCommand.apply(self, schema, context)

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -274,6 +274,10 @@ class IntrospectionMech:
                     kind=param_data['kind'])
                 params.append(param)
 
+                p_type = param.get_type(schema)
+                if p_type.is_collection():
+                    schema, _ = p_type.as_schema_coll(schema)
+
             return schema, params
         else:
             return schema, []
@@ -295,6 +299,10 @@ class IntrospectionMech:
 
             schema, params = self._decode_func_params(schema, row, param_map)
 
+            r_type = self.unpack_typeref(row['return_type'], schema)
+            if r_type.is_collection():
+                schema, _ = r_type.as_schema_coll(schema)
+
             oper_data = {
                 'id': row['id'],
                 'name': name,
@@ -308,7 +316,7 @@ class IntrospectionMech:
                 'force_return_cast': row['force_return_cast'],
                 'code': row['code'],
                 'recursive': row['recursive'],
-                'return_type': self.unpack_typeref(row['return_type'], schema)
+                'return_type': r_type,
             }
 
             schema, oper = s_opers.Operator.create_in_schema(
@@ -372,6 +380,10 @@ class IntrospectionMech:
 
             schema, params = self._decode_func_params(schema, row, param_map)
 
+            r_type = self.unpack_typeref(row['return_type'], schema)
+            if r_type.is_collection():
+                schema, _ = r_type.as_schema_coll(schema)
+
             func_data = {
                 'id': row['id'],
                 'name': name,
@@ -385,7 +397,7 @@ class IntrospectionMech:
                 'error_on_null_result': row['error_on_null_result'],
                 'code': row['code'],
                 'initial_value': row['initial_value'],
-                'return_type': self.unpack_typeref(row['return_type'], schema)
+                'return_type': r_type,
             }
 
             schema, _ = s_funcs.Function.create_in_schema(schema, **func_data)
@@ -717,6 +729,9 @@ class IntrospectionMech:
             required = r['required']
             target = self.unpack_typeref(r['target'], schema)
             basemap[name] = bases
+
+            if target.is_collection():
+                schema, _ = target.as_schema_coll(schema)
 
             if r['cardinality']:
                 cardinality = qltypes.Cardinality(r['cardinality'])

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -36,6 +36,7 @@ from edb.schema import database as s_db
 from edb.schema import deltas  # NoQA
 from edb.schema import expr as s_expr
 from edb.schema import inheriting as s_inheriting
+from edb.schema import modules as s_mod
 from edb.schema import name as sn
 from edb.schema import objects as s_obj
 from edb.schema import pointers as s_pointers
@@ -2179,7 +2180,7 @@ def _make_json_caster(schema, json_casts, stype, context):
     else:
         if cast.get_code(schema):
             cast_name = cast.get_name(schema)
-            cast_module = schema.get(cast_name.module)
+            cast_module = schema.get_global(s_mod.Module, cast_name.module)
             func_name = common.get_cast_backend_name(
                 cast_name, cast_module.id, aspect='function')
         else:

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -88,10 +88,11 @@ def delta_schemas(schema1, schema2):
 
 def delta_module(schema1, schema2, modname):
     from . import derivable
+    from . import modules as s_mod
 
     result = DeltaRoot()
 
-    module2 = schema2.get(modname, None)
+    module2 = schema2.get_global(s_mod.Module, modname, None)
 
     global_adds_mods = []
     global_dels = []
@@ -719,14 +720,15 @@ class UnqualifiedObjectCommand(ObjectCommand):
     def _classname_from_ast(cls, schema, astnode, context):
         return astnode.name.name
 
-
-class GlobalObjectCommand(UnqualifiedObjectCommand):
-
     def get_object(self, schema, *, name=None):
         metaclass = self.get_schema_metaclass()
         if name is None:
             name = self.classname
         return schema.get_global(metaclass, name)
+
+
+class GlobalObjectCommand(UnqualifiedObjectCommand):
+    pass
 
 
 class CreateOrAlterObject(ObjectCommand):

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1546,6 +1546,35 @@ class ObjectIndexByUnqualifiedName(
     pass
 
 
+class ObjectDict(ObjectCollection, container=tuple):
+
+    @classmethod
+    def create(cls, schema, data: typing.Mapping[object, Object]):
+
+        result = super().create(schema, data.values())
+        result._keys = tuple(data.keys())
+        return result
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self._ids == other._ids and self._keys == other.__keys
+
+    def __hash__(self):
+        return hash((self._ids, self._keys))
+
+    def dump(self, schema):
+        objs = ", ".join(f"{self._keys[i]}: {o.dump(schema)}"
+                         for i, o in enumerate(self.objects(schema)))
+        return f'<{type(self).__name__} objects={objs} at {id(self):#x}>'
+
+    def keys(self, schema):
+        return self._keys
+
+    def items(self, schema):
+        return tuple(zip(self._keys, self.objects(schema)))
+
+
 class ObjectSet(ObjectCollection, container=frozenset):
 
     def __repr__(self):

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -30,7 +30,6 @@ from . import delta as sd
 from . import functions as s_func
 from . import name as sn
 from . import objects as so
-from . import utils
 
 
 class Operator(s_func.CallableObject, s_abc.Operator):
@@ -244,17 +243,6 @@ class CreateOperator(s_func.CreateCallableObject, OperatorCommand):
         cmd.add(sd.AlterObjectProperty(
             property='operator_kind',
             new_value=astnode.kind,
-        ))
-
-        cmd.add(sd.AlterObjectProperty(
-            property='return_type',
-            new_value=utils.ast_to_typeref(
-                astnode.returning, modaliases=modaliases, schema=schema)
-        ))
-
-        cmd.add(sd.AlterObjectProperty(
-            property='return_typemod',
-            new_value=astnode.returning_typemod
         ))
 
         if astnode.code is not None:

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -245,6 +245,8 @@ def merge_weak_bool(target, sources, field_name, *, schema):
 def find_item_suggestions(
         name, modaliases, schema, *, item_types=None, limit=3,
         collection=None):
+    from . import modules as s_mod
+
     if isinstance(name, sn.Name):
         orig_modname = name.module
         short_name = name.name
@@ -260,7 +262,7 @@ def find_item_suggestions(
         suggestions.extend(collection)
     else:
         if modname:
-            module = schema.get(modname, None)
+            module = schema.get_global(s_mod.Module, modname, None)
             if module:
                 suggestions.extend(schema.get_objects(modules=[modname]))
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -46,6 +46,7 @@ from edb.schema import database as s_db
 from edb.schema import ddl as s_ddl
 from edb.schema import delta as s_delta
 from edb.schema import deltas as s_deltas
+from edb.schema import modules as s_mod
 from edb.schema import schema as s_schema
 from edb.schema import types as s_types
 
@@ -600,7 +601,7 @@ class Compiler(BaseCompiler):
 
         if isinstance(ql, qlast.SessionSetAliasDecl):
             try:
-                schema.get(ql.module)
+                schema.get_global(s_mod.Module, ql.module)
             except errors.InvalidReferenceError:
                 raise errors.UnknownModuleError(
                     f'module {ql.module!r} does not exist') from None

--- a/ext/recordext.c
+++ b/ext/recordext.c
@@ -24,6 +24,7 @@
 #include "funcapi.h"
 #include "nodes/makefuncs.h"
 #include "parser/parse_func.h"
+#include "parser/parse_type.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
@@ -102,7 +103,7 @@ row_getattr_by_num(PG_FUNCTION_ARGS)
 
 	ReleaseTupleDesc(tup_desc);
 
-	if (att_type != val_type)
+	if (att_type != val_type && !(val_type == RECORDOID && ISCOMPLEX(att_type)))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("expected tuple attribute type \"%s\", got \"%s\"",

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1934,16 +1934,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
     @test.xfail('''
-        The two types are created in different modules. They shouldn't
-        clash. Currently they clash because the LINK/PROPERTY is given
-        by a short name (much like it would be in SDL) and it
-        expands into "default::clash" for both cases. Which implicitly
-        creates an ABSTRACT LINK and an ABSTRACT PROPERTY with the
-        clashing name in default module.
-
-        Had this been written in SDL it would have worked since
-        the implicit LINK/PROPERTY would have been made in test or
-        test_other module.
+        This fails due to incomplete cleanup when DROP TYPE is executed,
+        so the final DROP MODULE fails to execute since there are
+        still objects within it.
     ''')
     async def test_edgeql_ddl_modules_01(self):
         try:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -102,7 +102,7 @@ _123456789_123456789_123456789 -> Object
         """
 
     @tb.must_fail(errors.InvalidPropertyTargetError,
-                  'invalid property target, expected primitive type, '
+                  'invalid property type: expected primitive type, '
                   'got ObjectType',
                   position=59)
     def test_schema_bad_prop_01(self):
@@ -113,7 +113,7 @@ _123456789_123456789_123456789 -> Object
         """
 
     @tb.must_fail(errors.InvalidPropertyTargetError,
-                  'invalid property target, expected primitive type, '
+                  'invalid property type: expected primitive type, '
                   'got ObjectType',
                   position=59)
     def test_schema_bad_prop_02(self):


### PR DESCRIPTION
Collection types are now supported much better in various schema contexts,
such as property types, and function parameter and return types.

Arrays of tuples are still not supported because casting record[] to a 
specific composite type array is not implemented in Postgres.