### PR TITLE
Change the built-in constraint names.

### DIFF
--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -22,7 +22,7 @@ Standard Constraints
 
 The standard library defines the following constraints:
 
-.. eql:constraint:: std::enum(VARIADIC members: anytype)
+.. eql:constraint:: std::one_of(VARIADIC members: anytype)
 
     Specifies the list of allowed values directly.
 
@@ -31,7 +31,7 @@ The standard library defines the following constraints:
     .. code-block:: sdl
 
         scalar type status_t extending str {
-            constraint enum ('Open', 'Closed', 'Merged');
+            constraint one_of ('Open', 'Closed', 'Merged');
         }
 
 .. eql:constraint:: std::expression on (expr)
@@ -46,7 +46,7 @@ The standard library defines the following constraints:
             constraint expression on (__subject__[0] = 'A');
         }
 
-.. eql:constraint:: std::max(max: anytype)
+.. eql:constraint:: std::max_value(max: anytype)
 
     Specifies the maximum value for the subject.
 
@@ -55,10 +55,10 @@ The standard library defines the following constraints:
     .. code-block:: sdl
 
         scalar type max_100 extending int64 {
-            constraint max(100);
+            constraint max_value(100);
         }
 
-.. eql:constraint:: std::max_ex(max: anytype)
+.. eql:constraint:: std::max_ex_value(max: anytype)
 
     Specifies the maximum value (as an open interval) for the subject.
 
@@ -67,10 +67,10 @@ The standard library defines the following constraints:
     .. code-block:: sdl
 
         scalar type maxex_100 extending int64 {
-            constraint max_ex(100);
+            constraint max_ex_value(100);
         }
 
-.. eql:constraint:: std::max_len(max: int64)
+.. eql:constraint:: std::max_len_value(max: int64)
 
     Specifies the maximum length of subject string representation.
 
@@ -79,10 +79,10 @@ The standard library defines the following constraints:
     .. code-block:: sdl
 
         scalar type username_t extending str {
-            constraint max_len(30);
+            constraint max_len_value(30);
         }
 
-.. eql:constraint:: std::min(min: anytype)
+.. eql:constraint:: std::min_value(min: anytype)
 
     Specifies the minimum value for the subject.
 
@@ -91,10 +91,10 @@ The standard library defines the following constraints:
     .. code-block:: sdl
 
         scalar type non_negative extending int64 {
-            constraint min(0);
+            constraint min_value(0);
         }
 
-.. eql:constraint:: std::min_ex(min: anytype)
+.. eql:constraint:: std::min_ex_value(min: anytype)
 
     Specifies the minimum value (as an open interval) for the subject.
 
@@ -103,10 +103,10 @@ The standard library defines the following constraints:
     .. code-block:: sdl
 
         scalar type positive_float extending float64 {
-            constraint min_ex(0);
+            constraint min_ex_value(0);
         }
 
-.. eql:constraint:: std::min_len(min: int64)
+.. eql:constraint:: std::min_len_value(min: int64)
 
     Specifies the minimum length of subject string representation.
 
@@ -115,7 +115,7 @@ The standard library defines the following constraints:
     .. code-block:: sdl
 
         scalar type four_decimal_places extending int64 {
-            constraint min_len(4);
+            constraint min_len_value(4);
         }
 
 .. eql:constraint:: std::regexp(pattern: str)

--- a/docs/edgeql/ddl/constraints.rst
+++ b/docs/edgeql/ddl/constraints.rst
@@ -297,7 +297,7 @@ Create a maximum length constraint on the property "name" of the "User" type:
 .. code-block:: edgeql
 
     ALTER TYPE User ALTER PROPERTY name
-    CREATE CONSTRAINT max_len(100);
+    CREATE CONSTRAINT max_len_value(100);
 
 
 ALTER CONSTRAINT
@@ -379,7 +379,7 @@ Change the error message on a maximum length constraint on the property
 .. code-block:: edgeql
 
     ALTER TYPE User ALTER PROPERTY name
-    ALTER CONSTRAINT max_len
+    ALTER CONSTRAINT max_len_value
     SET errmessage := 'User name too long';
 
 
@@ -421,10 +421,10 @@ Parameters
 Examples
 --------
 
-Remove constraint "max_len" from the property "name" of the
+Remove constraint "max_len_value" from the property "name" of the
 "User" type:
 
 .. code-block:: edgeql
 
     ALTER TYPE User ALTER PROPERTY name
-    DROP CONSTRAINT max_len;
+    DROP CONSTRAINT max_len_value;

--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -296,7 +296,7 @@ Add a minimum-length constraint to link ``name`` of object type ``User``:
 
     ALTER TYPE User {
         ALTER LINK name {
-            CREATE CONSTRAINT min_len(3);
+            CREATE CONSTRAINT min_len_value(3);
         };
     };
 

--- a/docs/edgeql/ddl/scalars.rst
+++ b/docs/edgeql/ddl/scalars.rst
@@ -73,7 +73,7 @@ Create a new non-negative integer type:
 .. code-block:: edgeql
 
     CREATE SCALAR TYPE posint64 EXTENDING int64 {
-        CREATE CONSTRAINT min(0);
+        CREATE CONSTRAINT min_value(0);
     };
 
 
@@ -136,7 +136,7 @@ Define a new constraint on a scalar type:
 .. code-block:: edgeql
 
     ALTER SCALAR TYPE posint64 {
-        CREATE CONSTRAINT max(100);
+        CREATE CONSTRAINT max_value(100);
     };
 
 

--- a/docs/edgeql/sdl/scalars.rst
+++ b/docs/edgeql/sdl/scalars.rst
@@ -53,5 +53,5 @@ Create a new non-negative integer type:
 .. code-block:: sdl
 
     scalar type posint64 extending int64 {
-        constraint min(0);
+        constraint min_value(0);
     }

--- a/docs/graphql/graphql.rst
+++ b/docs/graphql/graphql.rst
@@ -20,7 +20,7 @@ containing the following schema:
         property synopsis -> str;
         link author -> Author;
         property isbn -> str {
-            constraint max_len(10);
+            constraint max_len_value(10);
         }
     }
 

--- a/edb/edgeql/pygments/meta.py
+++ b/edb/edgeql/pygments/meta.py
@@ -192,16 +192,16 @@ class EdgeQL:
     )
     constraint_builtins = (
         "constraint",
-        "enum",
         "exclusive",
         "expression",
-        "len_constraint",
-        "max",
-        "max_ex",
-        "max_len",
-        "min",
-        "min_ex",
-        "min_len",
+        "len_value",
+        "max_ex_value",
+        "max_len_value",
+        "max_value",
+        "min_ex_value",
+        "min_len_value",
+        "min_value",
+        "one_of",
         "regexp",
     )
     fn_builtins = (

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -23,16 +23,16 @@
 CREATE MODULE schema;
 
 CREATE SCALAR TYPE schema::cardinality_t EXTENDING std::str {
-    CREATE CONSTRAINT std::enum ('ONE', 'MANY');
+    CREATE CONSTRAINT std::one_of ('ONE', 'MANY');
 };
 
 CREATE SCALAR TYPE schema::target_delete_action_t EXTENDING std::str {
-    CREATE CONSTRAINT std::enum ('RESTRICT', 'DELETE SOURCE', 'SET EMPTY',
-                                 'SET DEFAULT', 'DEFERRED RESTRICT');
+    CREATE CONSTRAINT std::one_of ('RESTRICT', 'DELETE SOURCE', 'SET EMPTY',
+                                   'SET DEFAULT', 'DEFERRED RESTRICT');
 };
 
 CREATE SCALAR TYPE schema::operator_kind_t EXTENDING std::str {
-    CREATE CONSTRAINT std::enum ('INFIX', 'POSTFIX', 'PREFIX', 'TERNARY');
+    CREATE CONSTRAINT std::one_of ('INFIX', 'POSTFIX', 'PREFIX', 'TERNARY');
 };
 
 # Base type for all schema entities.

--- a/edb/lib/std/50-constraints.edgeql
+++ b/edb/lib/std/50-constraints.edgeql
@@ -43,15 +43,15 @@ std::expression EXTENDING std::constraint
 
 
 CREATE ABSTRACT CONSTRAINT
-std::max(max: anytype) EXTENDING std::constraint
+std::exclusive EXTENDING std::constraint
 {
-    SET errmessage := 'Maximum allowed value for {__subject__} is {max}.';
-    SET expr := __subject__ <= max;
+    SET errmessage := '{__subject__} violates exclusivity constraint';
+    SET expr := std::_is_exclusive(__subject__);
 };
 
 
 CREATE ABSTRACT CONSTRAINT
-std::enum(VARIADIC vals: anytype) EXTENDING std::constraint
+std::one_of(VARIADIC vals: anytype) EXTENDING std::constraint
 {
     SET errmessage := '{__subject__} must be one of: {vals}.';
     SET expr := contains(vals, __subject__);
@@ -59,7 +59,22 @@ std::enum(VARIADIC vals: anytype) EXTENDING std::constraint
 
 
 CREATE ABSTRACT CONSTRAINT
-std::min(min: anytype) EXTENDING std::constraint
+std::len_value ON (len(<std::str>__subject__)) EXTENDING std::constraint
+{
+    SET errmessage := 'invalid {__subject__}';
+};
+
+
+CREATE ABSTRACT CONSTRAINT
+std::max_value(max: anytype) EXTENDING std::constraint
+{
+    SET errmessage := 'Maximum allowed value for {__subject__} is {max}.';
+    SET expr := __subject__ <= max;
+};
+
+
+CREATE ABSTRACT CONSTRAINT
+std::min_value(min: anytype) EXTENDING std::constraint
 {
     SET errmessage := 'Minimum allowed value for {__subject__} is {min}.';
     SET expr := __subject__ >= min;
@@ -67,25 +82,17 @@ std::min(min: anytype) EXTENDING std::constraint
 
 
 CREATE ABSTRACT CONSTRAINT
-std::min_ex(min: anytype) EXTENDING std::min
+std::max_ex_value(max: anytype) EXTENDING std::max_value
+{
+    SET errmessage := '{__subject__} must be less than {max}.';
+};
+
+
+CREATE ABSTRACT CONSTRAINT
+std::min_ex_value(min: anytype) EXTENDING std::min_value
 {
     SET errmessage := '{__subject__} must be greater than {min}.';
     SET expr := __subject__ > min;
-};
-
-
-CREATE ABSTRACT CONSTRAINT
-std::len_constraint ON (len(<std::str>__subject__)) EXTENDING std::constraint
-{
-    SET errmessage := 'invalid {__subject__}';
-};
-
-
-CREATE ABSTRACT CONSTRAINT
-std::min_len(min: std::int64) EXTENDING std::min, std::len_constraint
-{
-    SET errmessage :=
-        '{__subject__} must be no shorter than {min} characters.';
 };
 
 
@@ -98,22 +105,15 @@ std::regexp(pattern: anytype) EXTENDING std::constraint
 
 
 CREATE ABSTRACT CONSTRAINT
-std::max_len(max: std::int64) EXTENDING std::max, std::len_constraint
+std::max_len_value(max: std::int64) EXTENDING std::max_value, std::len_value
 {
     SET errmessage := '{__subject__} must be no longer than {max} characters.';
 };
 
 
 CREATE ABSTRACT CONSTRAINT
-std::max_ex(max: anytype) EXTENDING std::max
+std::min_len_value(min: std::int64) EXTENDING std::min_value, std::len_value
 {
-    SET errmessage := '{__subject__} must be less than {max}.';
-};
-
-
-CREATE ABSTRACT CONSTRAINT
-std::exclusive EXTENDING std::constraint
-{
-    SET errmessage := '{__subject__} violates exclusivity constraint';
-    SET expr := std::_is_exclusive(__subject__);
+    SET errmessage :=
+        '{__subject__} must be no shorter than {min} characters.';
 };

--- a/tests/schemas/constraints.esdl
+++ b/tests/schemas/constraints.esdl
@@ -18,20 +18,20 @@
 
 
 scalar type constraint_length extending str {
-    constraint max_len(16);
-    constraint max_len(10);
-    constraint min_len(5);
-    constraint min_len(8);
+    constraint max_len_value(16);
+    constraint max_len_value(10);
+    constraint min_len_value(5);
+    constraint min_len_value(8);
 }
 
 scalar type constraint_length_2 extending constraint_length {
-    constraint min_len(9);
+    constraint min_len_value(9);
 }
 
 scalar type constraint_minmax extending str {
-    constraint min("99900000");
-    constraint min("99990000");
-    constraint max("9999999989");
+    constraint min_value("99900000");
+    constraint min_value("99990000");
+    constraint max_value("9999999989");
 }
 
 scalar type constraint_strvalue extending str {
@@ -44,19 +44,19 @@ scalar type constraint_strvalue extending str {
     constraint regexp(r"^\d+9{3,}.*$");
 }
 
-# A variant of enum that uses an array argument instead of
+# A variant of one_of that uses an array argument instead of
 # a variadic.
-abstract constraint my_enum(enum: array<anytype>) {
-    expr := contains(enum, __subject__);
+abstract constraint my_one_of(one_of: array<anytype>) {
+    expr := contains(one_of, __subject__);
 }
 
 
 scalar type constraint_enum extending str {
-   constraint enum('foo', 'bar');
+   constraint one_of('foo', 'bar');
 }
 
 scalar type constraint_my_enum extending str {
-   constraint my_enum(['foo', 'bar']);
+   constraint my_one_of(['foo', 'bar']);
 }
 
 
@@ -93,7 +93,7 @@ type Object {
     property c_length -> constraint_length;
     property c_length_2 -> constraint_length_2;
     property c_length_3 -> constraint_length_2 {
-        constraint min_len(10);
+        constraint min_len_value(10);
     }
 
     property c_minmax -> constraint_minmax;

--- a/tests/schemas/constraints_migration/schema.esdl
+++ b/tests/schemas/constraints_migration/schema.esdl
@@ -18,20 +18,20 @@
 
 
 scalar type constraint_length extending str {
-    constraint max_len(16);
-    constraint max_len(10);
-    constraint min_len(5);
-    constraint min_len(8);
+    constraint max_len_value(16);
+    constraint max_len_value(10);
+    constraint min_len_value(5);
+    constraint min_len_value(8);
 }
 
 scalar type constraint_length_2 extending constraint_length {
-    constraint min_len(9);
+    constraint min_len_value(9);
 }
 
 scalar type constraint_minmax extending str {
-    constraint min("99900000");
-    constraint min("99990000");
-    constraint max("9999999989");
+    constraint min_value("99900000");
+    constraint min_value("99990000");
+    constraint max_value("9999999989");
 }
 
 scalar type constraint_strvalue extending str {
@@ -45,7 +45,7 @@ scalar type constraint_strvalue extending str {
 }
 
 scalar type constraint_enum extending str {
-   constraint enum('foo', 'bar');
+   constraint one_of('foo', 'bar');
 }
 
 abstract link translated_label {
@@ -80,7 +80,7 @@ type Object {
     property c_length -> constraint_length;
     property c_length_2 -> constraint_length_2;
     property c_length_3 -> constraint_length_2 {
-        constraint min_len(10);
+        constraint min_len_value(10);
     }
 
     property c_minmax -> constraint_minmax;

--- a/tests/schemas/constraints_migration/updated_schema.esdl
+++ b/tests/schemas/constraints_migration/updated_schema.esdl
@@ -18,20 +18,20 @@
 
 
 scalar type constraint_length extending str {
-    constraint max_len(16);
-    constraint max_len(10);
-    constraint min_len(5);
-    constraint min_len(8);
+    constraint max_len_value(16);
+    constraint max_len_value(10);
+    constraint min_len_value(5);
+    constraint min_len_value(8);
 }
 
 scalar type constraint_length_2 extending constraint_length {
-    constraint min_len(9);
+    constraint min_len_value(9);
 }
 
 scalar type constraint_minmax extending str {
-    constraint min("99900000");
-    constraint min("99990000");
-    constraint max("9999999989");
+    constraint min_value("99900000");
+    constraint min_value("99990000");
+    constraint max_value("9999999989");
 }
 
 scalar type constraint_strvalue extending str {
@@ -45,7 +45,7 @@ scalar type constraint_strvalue extending str {
 }
 
 scalar type constraint_enum extending str {
-   constraint enum('foo', 'bar');
+   constraint one_of('foo', 'bar');
 }
 
 abstract link translated_label {
@@ -88,7 +88,7 @@ type Object {
     property c_length -> constraint_length;
     property c_length_2 -> constraint_length_2;
     property c_length_3 -> constraint_length_2 {
-        constraint min_len(10);
+        constraint min_len_value(10);
     }
 
     property c_minmax -> constraint_minmax;

--- a/tests/schemas/issues.esdl
+++ b/tests/schemas/issues.esdl
@@ -21,7 +21,7 @@ abstract type Text {
     # This is an abstract object containing text.
     required property body -> str {
         # Maximum length of text is 10000 characters.
-        constraint max_len(10000);
+        constraint max_len_value(10000);
     }
 }
 
@@ -107,6 +107,6 @@ type Publication {
     required property title -> str;
 }
 
-abstract constraint my_enum(enum: array<anytype>) {
-    expr := contains($enum, __subject__);
+abstract constraint my_one_of(one_of: array<anytype>) {
+    expr := contains(one_of, __subject__);
 }

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -679,7 +679,7 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
             };
 
             CREATE ABSTRACT CONSTRAINT test::mymax_ext1(max: std::int64)
-                    ON (len(__subject__)) EXTENDING std::max
+                    ON (len(__subject__)) EXTENDING std::max_value
             {
                 SET errmessage :=
                     '{__subject__} must be no longer than {max} characters.';
@@ -828,7 +828,7 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
                 };
 
                 CREATE PROPERTY bar -> std::str {
-                    CREATE CONSTRAINT std::max(3) ON (len(__subject__)) {
+                    CREATE CONSTRAINT std::max_value(3) ON (len(__subject__)) {
                         SET errmessage :=
                     # XXX: once simple string concat is possible here
                     #      formatting can be saner

--- a/tests/test_deltas.py
+++ b/tests/test_deltas.py
@@ -80,7 +80,7 @@ class TestDeltas(tb.DDLTestCase):
             CREATE SCALAR TYPE test::a1 EXTENDING std::str;
 
             ALTER SCALAR TYPE test::a1 {
-                CREATE CONSTRAINT std::enum('a', 'b') {
+                CREATE CONSTRAINT std::one_of('a', 'b') {
                     SET ATTRIBUTE description :=
                         'test_delta_drop_01_constraint';
                 };
@@ -97,7 +97,7 @@ class TestDeltas(tb.DDLTestCase):
             """,
             [
                 {
-                    'name': 'std::enum',
+                    'name': 'std::one_of',
                 }
             ],
         )

--- a/tests/test_docs_sphinx_ext.py
+++ b/tests/test_docs_sphinx_ext.py
@@ -397,12 +397,12 @@ class TestEqlConstraint(unittest.TestCase, BaseDomainTest):
 
             any.
 
-        .. eql:constraint:: std::max_len(v: any)
+        .. eql:constraint:: std::max_len_value(v: any)
 
             blah
 
-        Testing :eql:constraint:`XXX <max_len>` ref.
-        Testing :eql:constraint:`max_len` ref.
+        Testing :eql:constraint:`XXX <max_len_value>` ref.
+        Testing :eql:constraint:`max_len_value` ref.
         '''
 
         out = self.build(src, format='xml')
@@ -418,14 +418,14 @@ class TestEqlConstraint(unittest.TestCase, BaseDomainTest):
             x.xpath('''
                 //paragraph /
                 reference[@eql-type="constraint" and
-                    @refid="constraint::std::max_len"] /
+                    @refid="constraint::std::max_len_value"] /
                 literal / text()
             '''),
-            ['XXX', 'max_len'])
+            ['XXX', 'max_len_value'])
 
     def test_sphinx_eql_constr_02(self):
         src = '''
-        .. eql:constraint:: std::len_constraint on (len(<std::str>__subject__))
+        .. eql:constraint:: std::len_value on (len(<std::str>__subject__))
 
             blah
         '''
@@ -440,7 +440,7 @@ class TestEqlConstraint(unittest.TestCase, BaseDomainTest):
 
         self.assertEqual(
             sig.xpath('@eql-signature'),
-            ['std::len_constraint ON (len(<std::str>__subject__))'])
+            ['std::len_value ON (len(<std::str>__subject__))'])
 
         self.assertEqual(
             sig.xpath('@eql-subjexpr'),

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -332,11 +332,11 @@ class TestIntrospection(tb.QueryTestCase):
                         }
                     }
                 } FILTER
-                    .name LIKE '%my_enum%' AND
+                    .name LIKE '%my_one_of%' AND
                     NOT EXISTS .<constraints;
             """,
             [{
-                'name': 'test::my_enum',
+                'name': 'test::my_one_of',
                 'params': [
                     {
                         'num': 0,
@@ -367,11 +367,11 @@ class TestIntrospection(tb.QueryTestCase):
                         }
                     }
                 } FILTER
-                    .name LIKE '%my_enum%' AND
+                    .name LIKE '%my_one_of%' AND
                     NOT EXISTS .<constraints;
             """,
             [{
-                'name': 'test::my_enum',
+                'name': 'test::my_one_of',
                 'params': [
                     {
                         'num': 0,
@@ -402,11 +402,11 @@ class TestIntrospection(tb.QueryTestCase):
                         }
                     }
                 } FILTER
-                    .name LIKE '%std::enum%' AND
+                    .name LIKE '%std::one_of%' AND
                     NOT EXISTS .<constraints;
             """,
             [{
-                'name': 'std::enum',
+                'name': 'std::one_of',
                 'params': [
                     {
                         'num': 0,
@@ -437,7 +437,7 @@ class TestIntrospection(tb.QueryTestCase):
                 } FILTER .subject.name = 'test::body';
             """,
             [{
-                'name': 'std::max_len',
+                'name': 'std::max_len_value',
                 'subject': {
                     'name': 'test::body'
                 },
@@ -673,7 +673,7 @@ class TestIntrospection(tb.QueryTestCase):
                 {'name': 'test::Named'},
                 {'name': 'test::Owned'},
                 {'name': 'test::Text'},
-                {'name': 'test::my_enum'},
+                {'name': 'test::my_one_of'},
             ]
         )
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2886,7 +2886,7 @@ aa';
     def test_edgeql_syntax_ddl_constraint_07(self):
         """
         CREATE SCALAR TYPE std::decimal_rounding_t EXTENDING std::str {
-            CREATE CONSTRAINT max(99) ON (<int64>__subject__);
+            CREATE CONSTRAINT max_value(99) ON (<int64>__subject__);
         };
         """
 

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -92,7 +92,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         abstract type Text {
             required property body -> str {
-                constraint max_len (10000);
+                constraint max_len_value (10000);
             };
         };
         """
@@ -381,11 +381,11 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         type Foo {
             single property foo -> str {
-                constraint max_len (10000)
+                constraint max_len_value (10000)
             }
 
             multi property bar -> str {
-                constraint max_len (10000)
+                constraint max_len_value (10000)
             }
         }
 
@@ -393,11 +393,11 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
 
         type Foo {
             single property foo -> str {
-                constraint max_len (10000);
+                constraint max_len_value (10000);
             };
 
             multi property bar -> str {
-                constraint max_len (10000);
+                constraint max_len_value (10000);
             };
         };
         """
@@ -511,8 +511,8 @@ type LogEntry extending    OwnedObject,    Text {
     def test_eschema_syntax_scalar_03(self):
         r"""
         scalar type basic extending int {
-            delegated constraint min(0);
-            constraint max(123456);
+            delegated constraint min_value(0);
+            constraint max_value(123456);
             constraint must_be_even;
 
             title := 'Basic ScalarType';
@@ -523,8 +523,8 @@ type LogEntry extending    OwnedObject,    Text {
     def test_eschema_syntax_scalar_04(self):
         """
         scalar type basic extending int {
-            constraint min(0);
-            constraint max(123456);
+            constraint min_value(0);
+            constraint max_value(123456);
             delegated constraint expr on (__subject__ % 2 = 0);
 
             title := 'Basic ScalarType';
@@ -539,8 +539,8 @@ type LogEntry extending    OwnedObject,    Text {
                 prop :=
                     (__subject__ % 2 = 0);
             };
-            constraint min(0);
-            constraint max(123456);
+            constraint min_value(0);
+            constraint max_value(123456);
 
             title := 'Basic ScalarType';
             default := 2;
@@ -550,8 +550,8 @@ type LogEntry extending    OwnedObject,    Text {
     def test_eschema_syntax_scalar_06(self):
         """
         scalar type basic extending int {
-            constraint min(0);
-            constraint max(123456);
+            constraint min_value(0);
+            constraint max_value(123456);
             constraint expr {
                 abc := (__subject__ % 2 = 0);
             };
@@ -601,27 +601,27 @@ type LogEntry extending    OwnedObject,    Text {
     def test_eschema_syntax_scalar_11(self):
         """
         scalar type constraint_length extending str {
-             constraint max_len(16+1, len(([1])));
+             constraint max_len_value(16+1, len(([1])));
         };
         """
 
     def test_eschema_syntax_scalar_12(self):
         """
         scalar type constraint_length extending str {
-             constraint max_len((16+(4*2))/((4)-1), len(([1])));
+             constraint max_len_value((16+(4*2))/((4)-1), len(([1])));
         };
         """
 
     def test_eschema_syntax_constraint_01(self):
         """
-        abstract constraint max(param:anytype) on (()) {
+        abstract constraint max_value(param:anytype) on (()) {
             expr := __subject__ <= $param;
             errmessage := 'Maximum allowed value for {subject} is {$param}.';
         };
 
 % OK %
 
-        abstract constraint max(param:anytype) on (()) {
+        abstract constraint max_value(param:anytype) on (()) {
             expr := (__subject__ <= $param);
             errmessage := 'Maximum allowed value for {subject} is {$param}.';
         };
@@ -639,7 +639,8 @@ type LogEntry extending    OwnedObject,    Text {
 
     def test_eschema_syntax_constraint_03(self):
         """
-        abstract constraint max_len(param:anytype) extending max, length {
+        abstract constraint max_len_value(param:anytype)
+                extending max, length {
             errmessage :=
                 '{subject} must be no longer than {$param} characters.';
         };
@@ -647,7 +648,7 @@ type LogEntry extending    OwnedObject,    Text {
 
     def test_eschema_syntax_constraint_04(self):
         """
-        abstract constraint max(param:anytype) {
+        abstract constraint max_value(param:anytype) {
             expr := (__subject__ <= $param);
             errmessage := 'Maximum allowed value for {subject} is {$param}.';
         };
@@ -656,7 +657,8 @@ type LogEntry extending    OwnedObject,    Text {
             subject := str::len(<str>__subject__);
         };
 
-        abstract constraint max_len(param:anytype) extending max, length {
+        abstract constraint max_len_value(param:anytype)
+                extending max_value, length {
             errmessage :=
                 '{subject} must be no longer than {$param} characters.';
         };
@@ -676,10 +678,10 @@ type LogEntry extending    OwnedObject,    Text {
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
                   r"missing type declaration.*`param`",
-                  line=2, col=37)
+                  line=2, col=43)
     def test_eschema_syntax_constraint_06(self):
         """
-        abstract constraint max_len(param) extending max, length;
+        abstract constraint max_len_value(param) extending max, length;
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -717,7 +719,7 @@ type LogEntry extending    OwnedObject,    Text {
                     '{__subject__} must be no longer than {$param} meters.';
             };
 
-            constraint max_len(4);
+            constraint max_len_value(4);
         };
         """
 
@@ -798,8 +800,8 @@ abstract property foo {
 
         abstract link coollink {
             property foo -> int64 {
-                constraint min(0);
-                constraint max(123456);
+                constraint min_value(0);
+                constraint max_value(123456);
                 constraint expr on (__subject__ % 2 = 0) {
                     title := 'aaa';
                 };


### PR DESCRIPTION
The standard library, tests and cocumentation are now using the new
constraint names that should no longer clash with funciton names.