### PR TITLE
edgeql: Enforce the use of parentheses in "ON (...)" constructs.

### DIFF
--- a/docs/datamodel/indexes.rst
+++ b/docs/datamodel/indexes.rst
@@ -18,7 +18,7 @@ or more properties directly:
 
     type User {
         property name -> str;
-        index name_idx on __subject__.name;
+        index name_idx on (__subject__.name);
     }
 
 With the above, ``User`` lookups by the ``name`` property will be faster,
@@ -37,8 +37,8 @@ of the host object type or link:
     type User {
         property firstname -> str;
         property lastname -> str;
-        index name_idx on str_lower(
-            __subject__.firstname + ' ' + __subject__.lastname);
+        index name_idx on (str_lower(
+            __subject__.firstname + ' ' + __subject__.lastname));
     }
 
 The index expression must not reference any variables other than

--- a/docs/edgeql/ddl/indexes.rst
+++ b/docs/edgeql/ddl/indexes.rst
@@ -19,7 +19,7 @@ type or link.
 
 .. eql:synopsis::
 
-    CREATE INDEX <index-name> ON <index-expr> ;
+    CREATE INDEX <index-name> ON ( <index-expr> );
 
 
 Description
@@ -50,7 +50,7 @@ Create an object type ``User`` with an indexed ``title`` property:
             SET default := '';
         };
 
-        CREATE INDEX title_name ON __subject__.title;
+        CREATE INDEX title_name ON (__subject__.title);
     };
 
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -929,7 +929,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 self.visit_list(node.args, newlines=False)
                 self.write(')')
             if node.subjectexpr:
-                self.write(' on (')
+                self.write(' ON (')
                 self.visit(node.subjectexpr)
                 self.write(')')
 
@@ -1059,8 +1059,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_CreateIndex(self, node):
         def after_name():
-            self.write(' ON ')
+            self.write(' ON (')
             self.visit(node.expr)
+            self.write(')')
         self._visit_CreateObject(node, 'INDEX', after_name=after_name)
 
     def visit_DropIndex(self, node):

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -98,8 +98,11 @@ class OptExtending(Nonterm):
 
 
 class OnExpr(Nonterm):
-    def reduce_ON_LPAREN_Expr_RPAREN(self, *kids):
-        self.val = kids[2].val
+    # NOTE: the reason why we need parentheses around the expression
+    # is to disambiguate whether the '{' following the expression is
+    # meant to be a shape or a nested DDL/SDL block.
+    def reduce_ON_ParenExpr(self, *kids):
+        self.val = kids[1].val
 
 
 class OptOnExpr(Nonterm):

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -833,10 +833,10 @@ class DropAttributeStmt(Nonterm):
 # CREATE INDEX
 #
 class CreateIndexStmt(Nonterm):
-    def reduce_CREATE_INDEX_NodeName_ON_Expr(self, *kids):
+    def reduce_CREATE_INDEX_NodeName_OnExpr(self, *kids):
         self.val = qlast.CreateIndex(
             name=kids[2].val,
-            expr=kids[4].val
+            expr=kids[3].val
         )
 
 

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -559,10 +559,10 @@ class AttributeDeclarationShort(Nonterm):
 # CREATE INDEX
 #
 class IndexDeclaration(Nonterm):
-    def reduce_INDEX_ShortNodeName_ON_Expr(self, *kids):
+    def reduce_INDEX_ShortNodeName_OnExpr(self, *kids):
         self.val = qlast.IndexDeclaration(
             name=kids[1].val,
-            expression=kids[3].val
+            expression=kids[2].val
         )
 
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2898,6 +2898,37 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_constraint_09(self):
+        """
+        CREATE TYPE Foo {
+            CREATE LINK bar -> Bar {
+                CREATE CONSTRAINT my_constraint ON (
+                    # It's possible to use shapes in the "ON" expression.
+                    # This would be ambiguous without parentheses.
+                    __source__{
+                        baz := __source__.a + __source__.b
+                    }.baz
+                ) {
+                    SET ATTRIBUTE title := 'special';
+                };
+            };
+        };
+
+% OK %
+
+        CREATE TYPE Foo {
+            CREATE LINK bar -> Bar {
+                CREATE CONSTRAINT my_constraint ON (
+                    (__source__{
+                        baz := (__source__.a + __source__.b)
+                    }).baz
+                ) {
+                    SET ATTRIBUTE title := 'special';
+                };
+            };
+        };
+        """
+
     def test_edgeql_syntax_ddl_function_01(self):
         """
         CREATE FUNCTION std::strlen(string: std::str) -> std::int64
@@ -3490,9 +3521,11 @@ aa';
 
     def test_edgeql_syntax_ddl_index_01(self):
         """
-        CREATE INDEX title_name ON Foo;
+        CREATE INDEX title_name ON (Foo);
 
-        CREATE INDEX title_name ON __subject__.title;
+        CREATE INDEX title_name ON (__subject__.title);
+
+        CREATE INDEX title_name ON (SELECT __subject__.title);
 
         DROP INDEX title_name;
         """


### PR DESCRIPTION
The syntactical construct "ON Expr { ..." is ambiguous. The "{" can be
the start of a shape or a sub-command block. Thus the parentheses are
required for disambiguating the grammar.

This also means that "INDEX ... ON (...)" should use parentheses.
Currently the reason is consistency, but in principle the INDEX commands
should support nested blocks for setting attributes.