### PR TITLE
Add initial support for enumerated types

### DIFF
--- a/docs/datamodel/scalars/enum.rst
+++ b/docs/datamodel/scalars/enum.rst
@@ -1,0 +1,27 @@
+.. _ref_datamodel_scalars_enum:
+
+Enumerated Types
+================
+
+.. eql:type:: std::enum
+
+    :index: enum
+
+    An enumerated type is a data type consisting of an order list of values.
+
+    An enumeration type can be declared in a schema declaration using
+    the following syntax:
+
+    .. eql:synopsis::
+
+        enum "<" <enum-values> ">"
+
+    Where :eql:synopsis:`<enum-values>` is a comma-separated list of
+    quoted string constants comprising the enum type.  Currently, the
+    only valid application of the enum declaration is to define an
+    enumerated scalar type:
+
+    .. code-block:: edgeql-repl
+
+        db> CREATE SCALAR TYPE my_enum_t EXTENDING enum<'One', 'Two'>;
+        CREATE TYPE

--- a/docs/datamodel/scalars/index.rst
+++ b/docs/datamodel/scalars/index.rst
@@ -34,6 +34,8 @@ The standard EdgeDB scalar types are:
 
 - :ref:`JSON type <ref_datamodel_scalars_json>`
 
+- :ref:`Enum types <ref_datamodel_scalars_enum>`
+
 
 .. toctree::
     :maxdepth: 3
@@ -47,3 +49,4 @@ The standard EdgeDB scalar types are:
     sequence
     uuid
     json
+    enum

--- a/docs/edgeql/ddl/scalars.rst
+++ b/docs/edgeql/ddl/scalars.rst
@@ -39,7 +39,7 @@ If the ``ABSTRACT`` keyword is specified, the created type will be
 
 All non-abstract scalar types must have an underlying core
 implementation.  For user-defined scalar types this means that
-``CREATE SCALAR TYPE`` must specify another non-abstract scalar type
+``CREATE SCALAR TYPE`` must have another non-abstract scalar type
 as its *supertype*.
 
 The most common use of ``CREATE SCALAR TYPE`` is to define a scalar
@@ -47,6 +47,10 @@ subtype with constraints.
 
 :eql:synopsis:`EXTENDING <supertype>`
     Optional clause specifying the *supertype* of the new type.
+
+    If :eql:synopsis:`<supertype>` is an
+    :eql:type:`enumerated type <std::enum>` declaration then
+    an enumerated scalar type is defined.
 
     Use of ``EXTENDING`` creates a persistent type relationship
     between the new subtype and its supertype(s).  Schema modifications
@@ -75,6 +79,13 @@ Create a new non-negative integer type:
     CREATE SCALAR TYPE posint64 EXTENDING int64 {
         CREATE CONSTRAINT min_value(0);
     };
+
+
+Create a new enumerated type:
+
+.. code-block:: edgeql
+
+    CREATE SCALAR TYPE my_color_t EXTENDING enum<'black', 'white', 'red'>;
 
 
 ALTER SCALAR TYPE

--- a/edb/api/types.txt
+++ b/edb/api/types.txt
@@ -40,6 +40,8 @@
 #
 #    array:         <type=6> <uuid> <pos>
 #
+#    enum:          <type=7> <uuid> <count> <str>+
+#
 #    type_anno      <type=f0..ff> <uuid> <str>
 #                   -- A type annotation;  0xf0 <= <type> <= 0xff.
 #                      Drivers should ignore unknown type annotations.

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -292,6 +292,11 @@ class TypeOf(TypeExpr):
     expr: Expr
 
 
+class TypeExprLiteral(TypeExpr):
+    # Literal type exprs are used in enum declarations.
+    val: StringConstant
+
+
 class TypeName(TypeExpr):
     name: str  # name is used for types in named tuples
     maintype: BaseObjectRef

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -76,7 +76,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         )
 
     def generic_visit(self, node, *args, **kwargs):
-        if isinstance(node. qlast.SDL):
+        if isinstance(node, qlast.SDL):
             raise EdgeQLSourceGeneratorError(
                 f'No method to generate code for {node.__class__.__name__}')
         else:
@@ -656,6 +656,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
     def visit_NoneTest(self, node):
         self.visit(node.expr)
         self.write(' IS None')
+
+    def visit_TypeExprLiteral(self, node):
+        self.visit(node.val)
 
     def visit_TypeName(self, node):
         parenthesize = (

--- a/edb/edgeql/compiler/cast.py
+++ b/edb/edgeql/compiler/cast.py
@@ -238,8 +238,13 @@ def _find_cast(
         ctx: context.ContextLevel) -> typing.Optional[s_casts.Cast]:
 
     casts = ctx.env.schema.get_casts_to_type(new_stype)
-    if not casts:
-        return None
+    if not casts and not new_stype.is_collection():
+        for t in new_stype.get_mro(ctx.env.schema).objects(ctx.env.schema):
+            casts = ctx.env.schema.get_casts_to_type(t)
+            if casts:
+                break
+        else:
+            return None
 
     args = [
         (orig_stype, None),

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -84,8 +84,21 @@ class OptSemicolons(Nonterm):
         self.val = None
 
 
-class Extending(Nonterm):
+class ExtendingSimple(Nonterm):
     def reduce_EXTENDING_SimpleTypeNameList(self, *kids):
+        self.val = kids[1].val
+
+
+class OptExtendingSimple(Nonterm):
+    def reduce_ExtendingSimple(self, *kids):
+        self.val = kids[0].val
+
+    def reduce_empty(self, *kids):
+        self.val = []
+
+
+class Extending(Nonterm):
+    def reduce_EXTENDING_TypeNameList(self, *kids):
         self.val = kids[1].val
 
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -383,12 +383,27 @@ class OptInheritPosition(Nonterm):
         self.val = None
 
 
-class AlterExtending(Nonterm):
+class AlterSimpleExtending(Nonterm):
     def reduce_EXTENDING_SimpleTypeNameList_OptInheritPosition(self, *kids):
         self.val = qlast.AlterAddInherit(bases=kids[1].val,
                                          position=kids[2].val)
 
     def reduce_DROP_EXTENDING_SimpleTypeNameList(self, *kids):
+        self.val = qlast.AlterDropInherit(bases=kids[2].val)
+
+    def reduce_AlterAbstract(self, *kids):
+        self.val = kids[0].val
+
+    def reduce_AlterFinal(self, *kids):
+        self.val = kids[0].val
+
+
+class AlterExtending(Nonterm):
+    def reduce_EXTENDING_TypeNameList_OptInheritPosition(self, *kids):
+        self.val = qlast.AlterAddInherit(bases=kids[1].val,
+                                         position=kids[2].val)
+
+    def reduce_DROP_EXTENDING_TypeNameList(self, *kids):
         self.val = qlast.AlterDropInherit(bases=kids[2].val)
 
     def reduce_AlterAbstract(self, *kids):
@@ -619,7 +634,7 @@ class DropRoleStmt(Nonterm):
 class CreateConstraintStmt(Nonterm):
     def reduce_CreateConstraint(self, *kids):
         r"""%reduce CREATE ABSTRACT CONSTRAINT NodeName OptOnExpr \
-                    OptExtending OptCreateCommandsBlock"""
+                    OptExtendingSimple OptCreateCommandsBlock"""
         self.val = qlast.CreateConstraint(
             name=kids[3].val,
             subjectexpr=kids[4].val,
@@ -629,7 +644,7 @@ class CreateConstraintStmt(Nonterm):
 
     def reduce_CreateConstraint_CreateFunctionArgs(self, *kids):
         r"""%reduce CREATE ABSTRACT CONSTRAINT NodeName CreateFunctionArgs \
-                    OptOnExpr OptExtending OptCreateCommandsBlock"""
+                    OptOnExpr OptExtendingSimple OptCreateCommandsBlock"""
         self.val = qlast.CreateConstraint(
             name=kids[3].val,
             params=kids[4].val,
@@ -798,7 +813,7 @@ class DropScalarTypeStmt(Nonterm):
 #
 class CreateAttributeStmt(Nonterm):
     def reduce_CreateAttribute(self, *kids):
-        r"""%reduce CREATE ABSTRACT ATTRIBUTE NodeName OptExtending \
+        r"""%reduce CREATE ABSTRACT ATTRIBUTE NodeName OptExtendingSimple \
                     OptCreateCommandsBlock"""
         self.val = qlast.CreateAttribute(
             name=kids[3].val,
@@ -809,7 +824,7 @@ class CreateAttributeStmt(Nonterm):
 
     def reduce_CreateInheritableAttribute(self, *kids):
         r"""%reduce CREATE ABSTRACT INHERITABLE ATTRIBUTE
-                    NodeName OptExtending OptCreateCommandsBlock"""
+                    NodeName OptExtendingSimple OptCreateCommandsBlock"""
         self.val = qlast.CreateAttribute(
             name=kids[4].val,
             bases=kids[5].val,
@@ -860,7 +875,7 @@ class AlterTargetStmt(Nonterm):
 #
 class CreatePropertyStmt(Nonterm):
     def reduce_CreateProperty(self, *kids):
-        r"""%reduce CREATE ABSTRACT PROPERTY NodeName OptExtending \
+        r"""%reduce CREATE ABSTRACT PROPERTY NodeName OptExtendingSimple \
                     OptCreateCommandsBlock \
         """
         self.val = qlast.CreateProperty(
@@ -922,8 +937,9 @@ commands_block(
 class CreateConcretePropertyStmt(Nonterm):
     def reduce_CreateRegularProperty(self, *kids):
         """%reduce
-            CREATE OptPtrQuals PROPERTY UnqualifiedPointerName OptExtending
-            ARROW FullTypeExpr OptCreateConcretePropertyCommandsBlock
+            CREATE OptPtrQuals PROPERTY UnqualifiedPointerName
+            OptExtendingSimple ARROW FullTypeExpr
+            OptCreateConcretePropertyCommandsBlock
         """
         self.val = qlast.CreateConcreteProperty(
             name=kids[3].val,
@@ -1039,7 +1055,7 @@ commands_block(
 class CreateLinkStmt(Nonterm):
     def reduce_CreateLink(self, *kids):
         r"""%reduce \
-            CREATE ABSTRACT LINK NodeName OptExtending \
+            CREATE ABSTRACT LINK NodeName OptExtendingSimple \
             OptCreateLinkCommandsBlock \
         """
         self.val = qlast.CreateLink(
@@ -1059,7 +1075,7 @@ commands_block(
     SetFieldStmt,
     SetAttributeValueStmt,
     DropAttributeValueStmt,
-    AlterExtending,
+    AlterSimpleExtending,
     CreateConcreteConstraintStmt,
     AlterConcreteConstraintStmt,
     DropConcreteConstraintStmt,
@@ -1147,7 +1163,7 @@ commands_block(
 class CreateConcreteLinkStmt(Nonterm):
     def reduce_CreateRegularLink(self, *kids):
         """%reduce
-            CREATE OptPtrQuals LINK UnqualifiedPointerName OptExtending
+            CREATE OptPtrQuals LINK UnqualifiedPointerName OptExtendingSimple
             ARROW FullTypeExpr OptCreateConcreteLinkCommandsBlock
         """
         self.val = qlast.CreateConcreteLink(
@@ -1180,7 +1196,7 @@ commands_block(
     SetCardinalityStmt,
     SetRequiredStmt,
     AlterTargetStmt,
-    AlterExtending,
+    AlterSimpleExtending,
     CreateConcreteConstraintStmt,
     AlterConcreteConstraintStmt,
     DropConcreteConstraintStmt,
@@ -1239,7 +1255,7 @@ class CreateObjectTypeStmt(Nonterm):
     def reduce_CreateAbstractObjectTypeStmt(self, *kids):
         r"""%reduce \
             CREATE ABSTRACT TYPE NodeName \
-            OptExtending OptCreateObjectTypeCommandsBlock \
+            OptExtendingSimple OptCreateObjectTypeCommandsBlock \
         """
         self.val = qlast.CreateObjectType(
             name=kids[3].val,
@@ -1251,7 +1267,7 @@ class CreateObjectTypeStmt(Nonterm):
     def reduce_CreateRegularObjectTypeStmt(self, *kids):
         r"""%reduce \
             CREATE TYPE NodeName \
-            OptExtending OptCreateObjectTypeCommandsBlock \
+            OptExtendingSimple OptCreateObjectTypeCommandsBlock \
         """
         self.val = qlast.CreateObjectType(
             name=kids[2].val,
@@ -1271,7 +1287,7 @@ commands_block(
     SetFieldStmt,
     SetAttributeValueStmt,
     DropAttributeValueStmt,
-    AlterExtending,
+    AlterSimpleExtending,
     CreateConcretePropertyStmt,
     AlterConcretePropertyStmt,
     DropConcretePropertyStmt,

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1286,6 +1286,11 @@ class TypeName(Nonterm):
         self.val = kids[0].val
 
 
+class TypeNameList(ListNonterm, element=TypeName,
+                   separator=tokens.T_COMMA):
+    pass
+
+
 # This is a type expression without angle brackets, so it
 # can be used without parentheses in a context where the
 # angle bracket has a different meaning.
@@ -1337,6 +1342,11 @@ class Subtype(Nonterm):
     def reduce_Identifier_COLON_FullTypeExpr(self, *kids):
         self.val = kids[2].val
         self.val.name = kids[0].val
+
+    def reduce_EscapedStringConstant(self, *kids):
+        self.val = qlast.TypeExprLiteral(
+            val=kids[0].val,
+        )
 
 
 class SubtypeList(ListNonterm, element=Subtype, separator=tokens.T_COMMA):

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -330,7 +330,7 @@ sdl_commands_block(
 class ConstraintDeclaration(Nonterm):
     def reduce_CreateConstraint(self, *kids):
         r"""%reduce ABSTRACT CONSTRAINT ShortNodeName OptOnExpr \
-                    OptExtending CreateSDLCommandsBlock"""
+                    OptExtendingSimple CreateSDLCommandsBlock"""
         self.val = qlast.ConstraintDeclaration(
             abstract=True,
             name=kids[2].val.name,
@@ -341,7 +341,7 @@ class ConstraintDeclaration(Nonterm):
 
     def reduce_CreateConstraint_CreateFunctionArgs(self, *kids):
         r"""%reduce ABSTRACT CONSTRAINT ShortNodeName CreateFunctionArgs \
-                    OptOnExpr OptExtending CreateSDLCommandsBlock"""
+                    OptOnExpr OptExtendingSimple CreateSDLCommandsBlock"""
         self.val = qlast.ConstraintDeclaration(
             abstract=True,
             name=kids[2].val.name,
@@ -355,7 +355,7 @@ class ConstraintDeclaration(Nonterm):
 class ConstraintDeclarationShort(Nonterm):
     def reduce_CreateConstraint(self, *kids):
         r"""%reduce ABSTRACT CONSTRAINT ShortNodeName OptOnExpr \
-                    OptExtending"""
+                    OptExtendingSimple"""
         self.val = qlast.ConstraintDeclaration(
             abstract=True,
             name=kids[2].val.name,
@@ -365,7 +365,7 @@ class ConstraintDeclarationShort(Nonterm):
 
     def reduce_CreateConstraint_CreateFunctionArgs(self, *kids):
         r"""%reduce ABSTRACT CONSTRAINT ShortNodeName CreateFunctionArgs \
-                    OptOnExpr OptExtending"""
+                    OptOnExpr OptExtendingSimple"""
         self.val = qlast.ConstraintDeclaration(
             abstract=True,
             name=kids[2].val.name,
@@ -512,7 +512,7 @@ class ScalarTypeDeclarationShort(Nonterm):
 #
 class AttributeDeclaration(Nonterm):
     def reduce_CreateAttribute(self, *kids):
-        r"""%reduce ABSTRACT ATTRIBUTE ShortNodeName OptExtending \
+        r"""%reduce ABSTRACT ATTRIBUTE ShortNodeName OptExtendingSimple \
                     CreateSDLCommandsBlock"""
         self.val = qlast.AttributeDeclaration(
             abstract=True,
@@ -524,7 +524,7 @@ class AttributeDeclaration(Nonterm):
 
     def reduce_CreateInheritableAttribute(self, *kids):
         r"""%reduce ABSTRACT INHERITABLE ATTRIBUTE
-                    ShortNodeName OptExtending CreateSDLCommandsBlock"""
+                    ShortNodeName OptExtendingSimple CreateSDLCommandsBlock"""
         self.val = qlast.AttributeDeclaration(
             abstract=True,
             name=kids[3].val.name,
@@ -536,7 +536,7 @@ class AttributeDeclaration(Nonterm):
 
 class AttributeDeclarationShort(Nonterm):
     def reduce_CreateAttribute(self, *kids):
-        r"""%reduce ABSTRACT ATTRIBUTE ShortNodeName OptExtending"""
+        r"""%reduce ABSTRACT ATTRIBUTE ShortNodeName OptExtendingSimple"""
         self.val = qlast.AttributeDeclaration(
             abstract=True,
             name=kids[2].val.name,
@@ -546,7 +546,7 @@ class AttributeDeclarationShort(Nonterm):
 
     def reduce_CreateInheritableAttribute(self, *kids):
         r"""%reduce ABSTRACT INHERITABLE ATTRIBUTE
-                    ShortNodeName OptExtending"""
+                    ShortNodeName OptExtendingSimple"""
         self.val = qlast.AttributeDeclaration(
             abstract=True,
             name=kids[3].val.name,
@@ -571,7 +571,7 @@ class IndexDeclaration(Nonterm):
 #
 class PropertyDeclaration(Nonterm):
     def reduce_CreateProperty(self, *kids):
-        r"""%reduce ABSTRACT PROPERTY ShortNodeName OptExtending \
+        r"""%reduce ABSTRACT PROPERTY ShortNodeName OptExtendingSimple \
                     CreateSDLCommandsBlock \
         """
         self.val = qlast.PropertyDeclaration(
@@ -584,7 +584,7 @@ class PropertyDeclaration(Nonterm):
 
 class PropertyDeclarationShort(Nonterm):
     def reduce_CreateProperty(self, *kids):
-        r"""%reduce ABSTRACT PROPERTY ShortNodeName OptExtending"""
+        r"""%reduce ABSTRACT PROPERTY ShortNodeName OptExtendingSimple"""
         self.val = qlast.PropertyDeclaration(
             abstract=True,
             name=kids[2].val.name,
@@ -608,7 +608,7 @@ sdl_commands_block(
 class ConcretePropertyBlock(Nonterm):
     def reduce_CreateRegularProperty(self, *kids):
         """%reduce
-            PROPERTY ShortNodeName OptExtending
+            PROPERTY ShortNodeName OptExtendingSimple
             ARROW FullTypeExpr CreateConcretePropertySDLCommandsBlock
         """
         self.val = qlast.Property(
@@ -620,7 +620,7 @@ class ConcretePropertyBlock(Nonterm):
 
     def reduce_CreateQualifiedRegularProperty(self, *kids):
         """%reduce
-            PtrQuals PROPERTY ShortNodeName OptExtending
+            PtrQuals PROPERTY ShortNodeName OptExtendingSimple
             ARROW FullTypeExpr CreateConcretePropertySDLCommandsBlock
         """
         self.val = qlast.Property(
@@ -637,7 +637,7 @@ class ConcretePropertyBlock(Nonterm):
 class ConcretePropertyShort(Nonterm):
     def reduce_CreateRegularProperty(self, *kids):
         """%reduce
-            PROPERTY ShortNodeName OptExtending
+            PROPERTY ShortNodeName OptExtendingSimple
             ARROW FullTypeExpr
         """
         self.val = qlast.Property(
@@ -648,7 +648,7 @@ class ConcretePropertyShort(Nonterm):
 
     def reduce_CreateQualifiedRegularProperty(self, *kids):
         """%reduce
-            PtrQuals PROPERTY ShortNodeName OptExtending
+            PtrQuals PROPERTY ShortNodeName OptExtendingSimple
             ARROW FullTypeExpr
         """
         self.val = qlast.Property(
@@ -701,7 +701,7 @@ sdl_commands_block(
 class LinkDeclaration(Nonterm):
     def reduce_CreateLink(self, *kids):
         r"""%reduce \
-            ABSTRACT LINK ShortNodeName OptExtending \
+            ABSTRACT LINK ShortNodeName OptExtendingSimple \
             CreateLinkSDLCommandsBlock \
         """
         self.val = qlast.LinkDeclaration(
@@ -715,7 +715,7 @@ class LinkDeclaration(Nonterm):
 class LinkDeclarationShort(Nonterm):
     def reduce_CreateLink(self, *kids):
         r"""%reduce \
-            ABSTRACT LINK ShortNodeName OptExtending"""
+            ABSTRACT LINK ShortNodeName OptExtendingSimple"""
         self.val = qlast.LinkDeclaration(
             abstract=True,
             name=kids[2].val.name,
@@ -763,7 +763,7 @@ sdl_commands_block(
 class ConcreteLinkBlock(Nonterm):
     def reduce_CreateRegularLink(self, *kids):
         """%reduce
-            LINK ShortNodeName OptExtending
+            LINK ShortNodeName OptExtendingSimple
             ARROW FullTypeExpr CreateConcreteLinkSDLCommandsBlock
         """
         self.val = qlast.Link(
@@ -775,7 +775,7 @@ class ConcreteLinkBlock(Nonterm):
 
     def reduce_CreateQualifiedRegularLink(self, *kids):
         """%reduce
-            PtrQuals LINK ShortNodeName OptExtending
+            PtrQuals LINK ShortNodeName OptExtendingSimple
             ARROW FullTypeExpr CreateConcreteLinkSDLCommandsBlock
         """
         self.val = qlast.Link(
@@ -792,7 +792,7 @@ class ConcreteLinkBlock(Nonterm):
 class ConcreteLinkShort(Nonterm):
     def reduce_CreateRegularLink(self, *kids):
         """%reduce
-            LINK ShortNodeName OptExtending
+            LINK ShortNodeName OptExtendingSimple
             ARROW FullTypeExpr
         """
         self.val = qlast.Link(
@@ -803,7 +803,7 @@ class ConcreteLinkShort(Nonterm):
 
     def reduce_CreateQualifiedRegularLink(self, *kids):
         """%reduce
-            PtrQuals LINK ShortNodeName OptExtending
+            PtrQuals LINK ShortNodeName OptExtendingSimple
             ARROW FullTypeExpr
         """
         self.val = qlast.Link(
@@ -856,7 +856,7 @@ sdl_commands_block(
 class ObjectTypeDeclaration(Nonterm):
     def reduce_CreateAbstractObjectTypeStmt(self, *kids):
         r"""%reduce \
-            ABSTRACT TYPE ShortNodeName OptExtending \
+            ABSTRACT TYPE ShortNodeName OptExtendingSimple \
             CreateObjectTypeSDLCommandsBlock \
         """
         self.val = qlast.ObjectTypeDeclaration(
@@ -868,7 +868,7 @@ class ObjectTypeDeclaration(Nonterm):
 
     def reduce_CreateRegularObjectTypeStmt(self, *kids):
         r"""%reduce \
-            TYPE ShortNodeName OptExtending \
+            TYPE ShortNodeName OptExtendingSimple \
             CreateObjectTypeSDLCommandsBlock \
         """
         self.val = qlast.ObjectTypeDeclaration(
@@ -881,7 +881,7 @@ class ObjectTypeDeclaration(Nonterm):
 class ObjectTypeDeclarationShort(Nonterm):
     def reduce_CreateAbstractObjectTypeStmt(self, *kids):
         r"""%reduce \
-            ABSTRACT TYPE ShortNodeName OptExtending"""
+            ABSTRACT TYPE ShortNodeName OptExtendingSimple"""
         self.val = qlast.ObjectTypeDeclaration(
             abstract=True,
             name=kids[2].val.name,
@@ -890,7 +890,7 @@ class ObjectTypeDeclarationShort(Nonterm):
 
     def reduce_CreateRegularObjectTypeStmt(self, *kids):
         r"""%reduce \
-            TYPE ShortNodeName OptExtending"""
+            TYPE ShortNodeName OptExtendingSimple"""
         self.val = qlast.ObjectTypeDeclaration(
             name=kids[1].val.name,
             extends=kids[2].val,

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -195,6 +195,7 @@ CREATE TYPE schema::ScalarType
         schema::AttributeSubject, schema::Type
 {
     CREATE PROPERTY default -> std::str;
+    CREATE PROPERTY enum_values -> array<std::str>;
 };
 
 

--- a/edb/lib/std/10-scalars.edgeql
+++ b/edb/lib/std/10-scalars.edgeql
@@ -58,3 +58,5 @@ CREATE SCALAR TYPE std::float64 EXTENDING std::anyfloat;
 CREATE SCALAR TYPE std::decimal EXTENDING std::anyreal;
 
 CREATE ABSTRACT SCALAR TYPE std::sequence EXTENDING std::int64;
+
+CREATE ABSTRACT SCALAR TYPE std::anyenum EXTENDING std::anyscalar;

--- a/edb/lib/std/25-enumoperators.edgeql
+++ b/edb/lib/std/25-enumoperators.edgeql
@@ -1,0 +1,72 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+## Standard enum operators
+## -----------------------
+
+
+CREATE INFIX OPERATOR
+std::`=` (l: std::anyenum, r: std::anyenum) -> std::bool
+    FROM SQL OPERATOR r'=';
+
+
+CREATE INFIX OPERATOR
+std::`?=` (l: OPTIONAL std::anyenum, r: OPTIONAL std::anyenum) -> std::bool
+    FROM SQL EXPRESSION;
+
+
+CREATE INFIX OPERATOR
+std::`!=` (l: std::anyenum, r: std::anyenum) -> std::bool
+    FROM SQL OPERATOR r'<>';
+
+
+CREATE INFIX OPERATOR
+std::`?!=` (l: OPTIONAL std::anyenum, r: OPTIONAL std::anyenum) -> std::bool
+    FROM SQL EXPRESSION;
+
+
+CREATE INFIX OPERATOR
+std::`>=` (l: std::anyenum, r: std::anyenum) -> std::bool
+    FROM SQL OPERATOR '>=';
+
+
+CREATE INFIX OPERATOR
+std::`>` (l: std::anyenum, r: std::anyenum) -> std::bool
+    FROM SQL OPERATOR '>';
+
+
+CREATE INFIX OPERATOR
+std::`<=` (l: std::anyenum, r: std::anyenum) -> std::bool
+    FROM SQL OPERATOR '<=';
+
+
+CREATE INFIX OPERATOR
+std::`<` (l: std::anyenum, r: std::anyenum) -> std::bool
+    FROM SQL OPERATOR '<';
+
+
+## Boolean casts
+## -------------
+
+CREATE CAST FROM std::str TO std::anyenum
+    FROM SQL CAST;
+
+
+CREATE CAST FROM std::anyenum TO std::str
+    FROM SQL CAST;

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -145,7 +145,7 @@ def convert_name(name, suffix='', catenate=True, prefix='edgedb_'):
 def get_scalar_backend_name(id, module_id, catenate=True, *, aspect=None):
     if aspect is None:
         aspect = 'domain'
-    if aspect not in ('domain', 'sequence'):
+    if aspect not in ('domain', 'sequence', 'enum'):
         raise ValueError(
             f'unexpected aspect for scalar backend name: {aspect!r}')
     name = s_name.Name(module=str(module_id), name=str(id))

--- a/edb/pgsql/datasources/schema/scalars.py
+++ b/edb/pgsql/datasources/schema/scalars.py
@@ -34,7 +34,9 @@ async def fetch(
             c.is_final AS is_final,
             c.view_type AS view_type,
             c.expr AS expr,
+            c.enum_values AS enum_values,
             edgedb._resolve_type_name(c.bases) AS bases,
+            edgedb._resolve_type_name(c.mro) AS mro,
             c.default AS default
         FROM
             edgedb.ScalarType c

--- a/edb/pgsql/dbops/__init__.py
+++ b/edb/pgsql/dbops/__init__.py
@@ -25,6 +25,7 @@ from .ddl import *  # NOQA
 from .dml import *  # NOQA
 from .databases import *  # NOQA
 from .domains import *  # NOQA
+from .enums import *  # NOQA
 from .extensions import *  # NOQA
 from .functions import *  # NOQA
 from .indexes import *  # NOQA

--- a/edb/pgsql/dbops/enums.py
+++ b/edb/pgsql/dbops/enums.py
@@ -1,0 +1,163 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import textwrap
+
+from ..common import qname as qn
+from ..common import quote_ident as qi
+from ..common import quote_literal as ql
+
+from . import base
+from . import ddl
+
+
+class EnumExists(base.Condition):
+    def __init__(self, name):
+        self.name = name
+
+    def code(self, block: base.PLBlock) -> str:
+        return textwrap.dedent(f'''\
+            SELECT
+                t.typname
+            FROM
+                pg_catalog.pg_type t
+                INNER JOIN pg_namespace nsp
+                    ON (t.typnamespace = nsp.oid)
+            WHERE
+                nsp.nspname = {ql(self.name[0])}
+                AND t.typname = {ql(self.name[1])}
+                AND t.typtype = 'e'
+        ''')
+
+
+class CreateEnum(ddl.SchemaObjectOperation):
+    def __init__(
+            self, name, values, *, conditions=None, neg_conditions=None,
+            priority=0):
+        super().__init__(
+            name, conditions=conditions, neg_conditions=neg_conditions,
+            priority=priority)
+        self.values = values
+
+    def code(self, block: base.PLBlock) -> str:
+        vals = ', '.join(ql(v) for v in self.values)
+        return f'CREATE TYPE {qn(*self.name)} AS ENUM ({vals})'
+
+
+class RenameEnum(base.CommandGroup):
+    def __init__(
+            self, name, new_name, *, conditions=None, neg_conditions=None,
+            priority=0):
+        super().__init__(
+            conditions=conditions, neg_conditions=neg_conditions,
+            priority=priority)
+
+        if name[0] != new_name[0]:
+            cmd = AlterEnumSetSchema(name, new_name[0])
+            self.add_command(cmd)
+            name = (new_name[0], name[1])
+
+        if name[1] != new_name[1]:
+            cmd = AlterEnumRenameTo(name, new_name[1])
+            self.add_command(cmd)
+
+
+class AlterEnumSetSchema(ddl.DDLOperation):
+    def __init__(
+            self, name, new_schema, *, conditions=None, neg_conditions=None,
+            priority=0):
+        super().__init__(
+            conditions=conditions, neg_conditions=neg_conditions,
+            priority=priority)
+        self.name = name
+        self.new_schema = new_schema
+
+    def code(self, block: base.PLBlock) -> str:
+        return (f'ALTER TYPE {qn(*self.name)} '
+                f'SET SCHEMA {qi(self.new_schema)}')
+
+
+class AlterEnumRenameTo(ddl.DDLOperation):
+    def __init__(
+            self, name, new_name, *, conditions=None, neg_conditions=None,
+            priority=0):
+        super().__init__(
+            conditions=conditions, neg_conditions=neg_conditions,
+            priority=priority)
+        self.name = name
+        self.new_name = new_name
+
+    def code(self, block: base.PLBlock) -> str:
+        return (f'ALTER TYPE {qn(*self.name)} '
+                f'RENAME TO {qi(self.new_name)}')
+
+
+class AlterEnum(ddl.DDLOperation):
+    def __init__(
+            self, name, *, conditions=None, neg_conditions=None, priority=0):
+        super().__init__(
+            conditions=conditions, neg_conditions=neg_conditions,
+            priority=priority)
+        self.name = name
+
+    def prefix_code(self) -> str:
+        return f'ALTER TYPE {qn(*self.name)}'
+
+    def __repr__(self):
+        return '<edb.sync.%s %s>' % (self.__class__.__name__, self.name)
+
+
+class AlterEnumAddValue(AlterEnum):
+    def __init__(self, name, value, *, before=None, after=None,
+                 conditional=False):
+        super().__init__(name)
+        self.value = value
+        self.before = before
+        self.after = after
+        self.conditional = conditional
+
+    def code(self, block: base.PLBlock) -> str:
+        code = self.prefix_code()
+        code += ' ADD VALUE'
+        if self.conditional:
+            code += ' IF NOT EXISTS'
+        code += f' {ql(self.value)}'
+        if self.before:
+            code += f' BEFORE {ql(self.before)}'
+        elif self.after:
+            code += f' AFTER {ql(self.before)}'
+
+        return code
+
+
+class AlterEnumRenameValue(AlterEnum):
+    def __init__(self, name, old_value, new_value):
+        super().__init__(name)
+        self.old_value = old_value
+        self.new_value = new_value
+
+    def code(self, block: base.PLBlock) -> str:
+        code = self.prefix_code()
+        code += f' RENAME VALUE {ql(self.old_value)} TO {ql(self.new_value)}'
+        return code
+
+
+class DropEnum(ddl.SchemaObjectOperation):
+    def code(self, block: base.PLBlock) -> str:
+        return f'DROP TYPE {qn(*self.name)}'

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -208,7 +208,8 @@ class IntrospectionMech:
                 'default': (s_expr.Expression(**row['default'])
                             if row['default'] else None),
                 'expr': (s_expr.Expression(**row['expr'])
-                         if row['expr'] else None)
+                         if row['expr'] else None),
+                'enum_values': row['enum_values'],
             }
 
             if scalar_data['bases']:
@@ -253,7 +254,7 @@ class IntrospectionMech:
 
     async def order_scalars(self, schema):
         for scalar in schema.get_objects(type=s_scalars.ScalarType):
-            schema = scalar.acquire_ancestor_inheritance(schema)
+            schema = scalar.finalize(schema)
         return schema
 
     def _decode_func_params(self, schema, row, param_map):

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -119,6 +119,8 @@ def pg_type_from_scalar(
 
     if topbase:
         base = scalar.get_topmost_concrete_base(schema)
+    elif scalar.is_enum(schema):
+        base = scalar
     else:
         base = get_scalar_base(schema, scalar.material_type(schema))
 

--- a/edb/repl/__init__.py
+++ b/edb/repl/__init__.py
@@ -165,7 +165,11 @@ class Cli:
         return toolbar
 
     def introspect_db(self, con):
-        names = con.fetchall('SELECT schema::ObjectType { name }')
+        names = con.fetchall('''
+            WITH MODULE schema
+            SELECT Type { name }
+            FILTER Type IS (ObjectType | ScalarType);
+        ''')
         self.context.typenames = {n.id: n.name for n in names}
 
     def build_propmpt(self):

--- a/edb/repl/render.py
+++ b/edb/repl/render.py
@@ -227,6 +227,16 @@ class BinaryRenderer:
         buf.write("<timedelta>", style.code_comment)
         buf.write(repr(str(o)), style.code_string)
 
+    @walk.register(edgedb.EnumValue)
+    def _enum(o: edgedb.EnumValue, repl_ctx: context.ReplContext, buf):
+        if not repl_ctx.introspect_types:
+            typename = 'enum'
+        else:
+            typename = repl_ctx.typenames.get(o.__tid__, 'enum')
+
+        buf.write(f"<{typename}>", style.code_comment)
+        buf.write(f"'{o}'", style.code_string)
+
 
 class JSONRenderer:
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -937,8 +937,8 @@ class AlterObject(CreateOrAlterObject):
             for astcmd in astnode.commands:
                 if isinstance(astcmd, qlast.AlterDropInherit):
                     dropped_bases.extend(
-                        utils.ast_objref_to_objref(
-                            b.maintype,
+                        utils.ast_to_typeref(
+                            b,
                             metaclass=cls.get_schema_metaclass(),
                             modaliases=context.modaliases,
                             schema=schema,
@@ -948,8 +948,8 @@ class AlterObject(CreateOrAlterObject):
 
                 elif isinstance(astcmd, qlast.AlterAddInherit):
                     bases = [
-                        utils.ast_objref_to_objref(
-                            b.maintype,
+                        utils.ast_to_typeref(
+                            b,
                             metaclass=cls.get_schema_metaclass(),
                             modaliases=context.modaliases,
                             schema=schema,

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -101,6 +101,9 @@ class Type(so.Object, derivable.DerivableObjectBase, s_abc.Type):
     def is_tuple(self):
         return False
 
+    def is_enum(self, schema):
+        return False
+
     def test_polymorphic(self, schema, poly: 'Type') -> bool:
         """Check if this type can be matched by a polymorphic type.
 

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -763,7 +763,10 @@ cdef class EdgeConnection:
     async def _execute_system_config(self, query_unit):
         data = await self.backend.pgcon.simple_query(
             b';'.join(query_unit.sql), ignore_data=False)
-        config_ops = [config.Operation.from_json(r[0]) for r in data]
+        if data:
+            config_ops = [config.Operation.from_json(r[0]) for r in data]
+        else:
+            config_ops = []
         await self.dbview.apply_config_ops(config_ops)
 
     async def _execute(self, query_unit, bind_args,

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2804,6 +2804,11 @@ aa';
         CREATE SCALAR TYPE anytype EXTENDING int64;
         """
 
+    def test_edgeql_syntax_ddl_scalar_03(self):
+        """
+        CREATE SCALAR TYPE myenum EXTENDING enum<'foo', 'bar'>;
+        """
+
     def test_edgeql_syntax_ddl_attribute_01(self):
         """
         CREATE ABSTRACT ATTRIBUTE std::paramtypes;

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -116,3 +116,7 @@ class TestServerAuth(tb.ConnectedTestCase):
             await self.con.fetchall('''
                 CONFIGURE SYSTEM RESET Auth FILTER .name = 'test-2'
             ''')
+
+            await self.con.fetchall('''
+                DROP ROLE foo;
+            ''')

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -467,6 +467,11 @@ class TestServerConfig(tb.QueryTestCase):
             []
         )
 
+        # Repeat reset that doesn't match anything this time.
+        await self.con.fetchall('''
+            CONFIGURE SYSTEM RESET SystemConfig FILTER .name = 'test_03_01';
+        ''')
+
         await self.con.fetchall('''
             CONFIGURE SYSTEM INSERT SystemConfig {
                 name := 'test_03',


### PR DESCRIPTION
Enumerated types are a special class of a scalar type that are defined as a
list of explicit string values using the following syntax:

CREATE SCALAR TYPE <name> EXTENDING enum<'val1'[,...'valN']>

Over the wire, and in text serialization, the enum values are transferred 
as strings, but they sort according to the order of enum value definitions, 
and every enum type is distinct, i.e. there is no implicit cast between 
them.

Currently, there is no way to alter the composition of enumerated type 
after it was created.