### PR TITLE
Stop acessing collection internals directly

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -506,7 +506,7 @@ def compile_type_check_op(
         pathctx.register_set_in_scope(left, ctx=ctx)
         result = None
     else:
-        if ltype.is_collection() and ltype.contains_object():
+        if ltype.is_collection() and ltype.contains_object(ctx.env.schema):
             raise errors.QueryError(
                 f'type checks on non-primitive collections are not supported'
             )

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -337,7 +337,7 @@ def __infer_index(ir, env):
                 f'{int_t.get_name(env.schema)} was expected',
                 context=ir.index.context)
 
-        result = node_type.element_type
+        result = node_type.get_subtypes(env.schema)[0]
 
     elif (node_type.is_any() or
             (node_type.is_scalar() and

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -301,7 +301,7 @@ def try_bind_call_args(
                 raise RuntimeError('unprocessed NAMED ONLY parameter')
 
             if param_kind is _VARIADIC:
-                var_type = param.get_type(schema).get_subtypes()[0]
+                var_type = param.get_type(schema).get_subtypes(schema)[0]
                 cd = _get_cast_distance(arg_val, arg_type, var_type)
                 if cd < 0:
                     return _NO_MATCH

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -59,7 +59,7 @@ def type_to_ql_typeref(t: s_obj.Object, *,
             ),
             subtypes=[
                 type_to_ql_typeref(st, _name=sn, ctx=ctx)
-                for sn, st in t.element_types.items()
+                for sn, st in t.iter_subtypes(ctx.env.schema)
             ]
         )
     else:
@@ -70,7 +70,7 @@ def type_to_ql_typeref(t: s_obj.Object, *,
             ),
             subtypes=[
                 type_to_ql_typeref(st, ctx=ctx)
-                for st in t.get_subtypes()
+                for st in t.get_subtypes(ctx.env.schema)
             ]
         )
 

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -354,7 +354,7 @@ class DeclarationLoader:
 
         for dep in list(deps):
             if isinstance(dep, s_abc.Collection):
-                deps.update(dep.get_subtypes())
+                deps.update(dep.get_subtypes(self._schema))
                 deps.discard(dep)
 
         # Add dependency on all builtin scalars unconditionally

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -166,7 +166,8 @@ class GQLCoreSchema:
         # only arrays can be validly wrapped, other containers don't
         # produce a valid graphql type
         if isinstance(edb_target, s_abc.Array):
-            el_type = self._convert_edb_type(edb_target.element_type)
+            el_type = self._convert_edb_type(
+                edb_target.get_subtypes(self.edb_schema)[0])
             if el_type:
                 target = GraphQLList(GraphQLNonNull(el_type))
         elif isinstance(edb_target, s_objtypes.ObjectType):

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -143,7 +143,7 @@ def type_to_typeref(schema, t: s_types.Type, *,
             collection=t.schema_name,
             subtypes=tuple(
                 type_to_typeref(schema, st, _name=sn)
-                for sn, st in t.element_types.items()
+                for sn, st in t.iter_subtypes(schema)
             )
         )
     else:
@@ -154,7 +154,7 @@ def type_to_typeref(schema, t: s_types.Type, *,
             collection=t.schema_name,
             subtypes=tuple(
                 type_to_typeref(schema, st)
-                for st in t.get_subtypes()
+                for st in t.get_subtypes(schema)
             )
         )
 

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -165,7 +165,7 @@ def pg_type_from_object(
             return ('anyarray',)
         else:
             tp = pg_type_from_object(
-                schema, obj.element_type, topbase=topbase,
+                schema, obj.get_subtypes(schema)[0], topbase=topbase,
                 persistent_tuples=persistent_tuples)
             if len(tp) == 1:
                 return (tp[0] + '[]',)
@@ -563,9 +563,9 @@ class TypeDesc:
         for i, (tn, t) in enumerate(types):
             if isinstance(t, s_abc.Collection):
                 if isinstance(t, s_abc.Tuple) and t.named:
-                    stypes = list(t.element_types.items())
+                    stypes = list(t.iter_subtypes(schema))
                 else:
-                    stypes = [(None, st) for st in t.get_subtypes()]
+                    stypes = [(None, st) for st in t.get_subtypes(schema)]
 
                 subtypes = cls._get_typedesc(
                     schema, stypes, typedesc, is_root=False)

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1308,7 +1308,7 @@ def ensure_schema_collection(schema, coll_type, parent_cmd, *,
         raise ValueError(
             f'{coll_type.get_displayname(schema)} is not a collection')
 
-    if coll_type.contains_array_of_tuples():
+    if coll_type.contains_array_of_tuples(schema):
         raise errors.UnsupportedFeatureError(
             'arrays of tuples are not supported at the schema level',
             context=src_context,

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -432,7 +432,7 @@ class CallableObject(attributes.AttributeSubject):
             pt = param.get_type(schema)
             if isinstance(pt, s_abc.Collection):
                 quals.append(pt.schema_name)
-                for st in pt.get_subtypes():
+                for st in pt.get_subtypes(schema):
                     quals.append(st.get_name(schema))
             else:
                 quals.append(pt.get_name(schema))

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -136,7 +136,7 @@ class CreateInheritingObject(InheritingObjectCommand, sd.CreateObject):
         bases = so.ObjectList.create(schema, base_refs)
 
         for base in bases.objects(schema):
-            if base.is_type() and base.contains_any():
+            if base.is_type() and base.contains_any(schema):
                 base_type_name = base.get_displayname(schema)
                 raise errors.SchemaError(
                     f"{base_type_name!r} cannot be a parent type")

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -199,7 +199,7 @@ class CreateProperty(PropertyCommand,
 
             if (target_type.is_object_type()
                     or (target_type.is_collection()
-                        and target_type.contains_object())):
+                        and target_type.contains_object(schema))):
                 raise errors.InvalidPropertyTargetError(
                     f'invalid property type: expected a scalar type, '
                     f'or a scalar collection, got '

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -75,7 +75,7 @@ class ScalarType(nodes.Node, constraints.ConsistencySubject,
                 if ptypes:
                     for ptype in ptypes:
                         if isinstance(ptype, s_abc.Collection):
-                            subtypes = ptype.get_subtypes()
+                            subtypes = ptype.get_subtypes(schema)
                         else:
                             subtypes = [ptype]
 

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -155,7 +155,7 @@ def typeref_to_ast(schema, t: so.Object) -> ql_ast.TypeName:
                 name=t.schema_name
             ),
             subtypes=[
-                typeref_to_ast(schema, st) for st in t.get_subtypes()
+                typeref_to_ast(schema, st) for st in t.get_subtypes(schema)
             ]
         )
 

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -102,10 +102,10 @@ class TypeSerializer:
         if isinstance(t, s_types.Tuple):
             subtypes = [self._describe_type(st, view_shapes,
                                             view_shapes_metadata)
-                        for st in t.get_subtypes()]
+                        for st in t.get_subtypes(self.schema)]
 
             if t.named:
-                element_names = list(t.element_types)
+                element_names = list(t.get_element_names(self.schema))
                 assert len(element_names) == len(subtypes)
 
                 type_id = self._get_collection_type_id(
@@ -141,7 +141,7 @@ class TypeSerializer:
         elif isinstance(t, s_types.Array):
             subtypes = [self._describe_type(st, view_shapes,
                                             view_shapes_metadata)
-                        for st in t.get_subtypes()]
+                        for st in t.get_subtypes(self.schema)]
 
             assert len(subtypes) == 1
             type_id = self._get_collection_type_id(t.schema_name, subtypes)


### PR DESCRIPTION
Lots of code is reaching directly into collection type attributes.  This
is bad and will break if the collection type is a schema object.  Fix
this, and make sure the accessor APIs are schema-aware.