### PR TITLE
docs: Clarify the usage of `__subject__`.

### DIFF
--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -14,7 +14,8 @@ the instances of that scalar, thus the values that the scalar can
 take will be restricted.  Whereas for link or property constraints
 the *subjects* are the targets of those links or properties,
 restricting what objects or values those links and properties may
-reference.
+reference.  The *subject* of a constraint can be referred to in
+the constraint expression as ``__subject__``.
 
 
 Standard Constraints

--- a/docs/datamodel/indexes.rst
+++ b/docs/datamodel/indexes.rst
@@ -11,6 +11,10 @@ database that, for a given set of objects or links, a particular expression
 must be *indexed* to allow for faster evaluation of queries which use
 that expression.
 
+The *subject* of an index is either the object or the abstract link on
+which the index is defined. It can be referred to in the index
+expression as ``__subject__``.
+
 The simplest form of index is an index, which references one
 or more properties directly:
 
@@ -30,7 +34,7 @@ to find the matching objects:
     SELECT User FILTER User.name = 'Alice';
 
 Indexes may be defined using an arbitrary expression that references properties
-of the host object type or link:
+of the host object type:
 
 .. code-block:: sdl
 
@@ -41,9 +45,18 @@ of the host object type or link:
             __subject__.firstname + ' ' + __subject__.lastname));
     }
 
-The index expression must not reference any variables other than
-the properties of the host object type or link.  All functions used
-in the expression must not be set-returning.
+Similarly indexes may refer to the link properties if the *subject* is a link:
+
+.. code-block:: sdl
+
+    abstract link friends_base {
+        property nickname -> str;
+        index nickname_idx on (__subject__@nickname);
+    }
+
+The index expression must not reference any variables other than the
+properties of the index *subject*.  All functions used in the
+expression must not be set-returning.
 
 .. note::
 

--- a/docs/edgeql/ddl/constraints.rst
+++ b/docs/edgeql/ddl/constraints.rst
@@ -282,6 +282,11 @@ Parameters
     ``__subject__``.  Note also that ``<subject-expr>`` itself has to
     be parenthesized.
 
+    .. note::
+
+        Currently EdgeDB only supports constraint expressions on scalar
+        types and properties.
+
 :eql:synopsis:`SET errmessage := <error_message>`
     An optional string literal defining the error message template that
     is raised when the constraint is violated.  See the relevant

--- a/docs/edgeql/sdl/constraints.rst
+++ b/docs/edgeql/sdl/constraints.rst
@@ -83,6 +83,11 @@ Description
     ``__subject__``.  Note also that ``<subject-expr>`` itself has to
     be parenthesized.
 
+    .. note::
+
+        Currently EdgeDB only supports constraint expressions on scalar
+        types and properties.
+
 :sdl:synopsis:`extending <base> [, ...]`
     If specified, declares the *parent* constraints for this constraint.
 


### PR DESCRIPTION
Update the descriptions of `INDEX` and `CONSTRAINT` to clarify how
`__subject__` is used.