### PR TITLE
docs: Fix incorrect usage of abstract links/properties.

### DIFF
--- a/docs/edgeql/expressions/shapes.rst
+++ b/docs/edgeql/expressions/shapes.rst
@@ -165,13 +165,11 @@ link as well. Consider the following schema:
 
 .. code-block:: sdl
 
-    abstract link friends {
-        property since -> datetime;
-    }
-
     type User {
         required property name -> str;
-        multi link friends -> User;
+        multi link friends -> User {
+            property since -> datetime;
+        }
     }
 
 

--- a/docs/edgeql/sdl/links.rst
+++ b/docs/edgeql/sdl/links.rst
@@ -11,11 +11,11 @@ This section describes the SDL declarations pertaining to
 Examples
 --------
 
-Declare an *abstract* link "friends" with a helpful title:
+Declare an *abstract* link "friends_base" with a helpful title:
 
 .. code-block:: sdl
 
-    abstract link friends {
+    abstract link friends_base {
         # declare a specific title for the link
         attribute title := 'Close contacts';
     }
@@ -28,7 +28,7 @@ Declare a *concrete* link "friends" within a "User" type:
         property name -> str;
         property address -> str;
         # define a concrete link "friends"
-        multi link friends -> User;
+        multi link friends extending friends_base-> User;
 
         index user_name_idx on (__subject__.name);
     }

--- a/docs/edgeql/sdl/props.rst
+++ b/docs/edgeql/sdl/props.rst
@@ -11,11 +11,11 @@ This section describes the SDL declarations pertaining to
 Examples
 --------
 
-Declare an *abstract* property "address" with a helpful title:
+Declare an *abstract* property "address_base" with a helpful title:
 
 .. code-block:: sdl
 
-    abstract link address {
+    abstract property address_base {
         # declare a specific title for the link
         attribute title := 'Mailing address';
     }
@@ -27,7 +27,7 @@ Declare *concrete* properties "name" and "address" within a "User" type:
     type User {
         # define concrete properties
         property name -> str;
-        property address -> str;
+        property address extending address_base -> str;
 
         multi link friends -> User;
 


### PR DESCRIPTION
Examples of abstract links and properties now include an explicit
`extending` of those abstract links and properties when used in types.