### PR TITLE
Fix deficiencies in the enum implementation

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -1565,7 +1565,8 @@ def _field_to_column(field):
     elif issubclass(ftype, s_expr.ExpressionList):
         coltype = 'edgedb.expression_t[]'
 
-    elif issubclass(ftype, typed.TypedList) and issubclass(ftype.type, str):
+    elif (issubclass(ftype, (typed.TypedList, typed.FrozenTypedList))
+            and issubclass(ftype.type, str)):
         coltype = 'text[]'
 
     elif issubclass(ftype, dict):

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -261,6 +261,13 @@ class Constraint(inheriting.InheritingObject, s_func.CallableObject,
     def create_concrete_constraint(
             cls, schema, subject, *, name, subjectexpr=None,
             sourcectx=None, args=[], modaliases=None, **kwargs):
+
+        if subject.is_scalar() and subject.is_enum(schema):
+            raise errors.UnsupportedFeatureError(
+                f'constraints cannot be defined on an enumerated type',
+                context=sourcectx,
+            )
+
         constr_base, attrs = cls.get_concrete_constraint_attrs(
             schema, subject, name=name, subjectexpr=subjectexpr,
             sourcectx=sourcectx, args=args, modaliases=modaliases, **kwargs)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2502,6 +2502,21 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Recover.
         await self.con.execute('ROLLBACK TO SAVEPOINT t1;')
 
+        await self.con.execute('DECLARE SAVEPOINT t2;')
+
+        with self.assertRaisesRegex(
+                edgedb.UnsupportedFeatureError,
+                'constraints cannot be defined on an enumerated type'):
+            await self.con.execute('''
+                CREATE SCALAR TYPE test::my_enum_3
+                    EXTENDING enum<'foo', 'bar', 'baz'> {
+                    CREATE CONSTRAINT expression ON (__subject__ = 'bar')
+                };
+            ''')
+
+        # Recover.
+        await self.con.execute('ROLLBACK TO SAVEPOINT t2;')
+
         await self.con.execute('''
             ALTER SCALAR TYPE test::my_enum_2
                 RENAME TO test::my_enum_3;


### PR DESCRIPTION
It appears that subtyping enums in Postgres strips away the ability to
apply any operators on them, so stop using domains of enums, prohibit
enumerated type subclassing, defaults, and constraints on enumerated
types.  This also adds support for enums in SDL and adds handling for
the most common enum data validation error.