### PR TITLE
docs: Separate data model from syntax synopsis.

### DIFF
--- a/docs/datamodel/colltypes.rst
+++ b/docs/datamodel/colltypes.rst
@@ -7,6 +7,28 @@ Collection Types
 *Collection types* are special generic types used to group homogeneous or
 heterogeneous data.
 
+.. eql:type:: std::array
+
+    :index: array
+
+    Arrays represent a one-dimensional homogeneous ordered list.
+
+    Array indexing starts at zero.
+
+    With the exception of other array types, any type can be used as an
+    array element type.
+
+    An :ref:`array type <ref_eql_types_array>` is created implicitly
+    when an :ref:`array constructor <ref_eql_expr_array_ctor>` is
+    used:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT [1, 2];
+        {[1, 2]}
+
+    The syntax of an array type declaration can be found in :ref:`this
+    section <ref_eql_types_array>`.
 
 .. eql:type:: std::tuple
 
@@ -17,32 +39,16 @@ heterogeneous data.
     Tuple elements can optionally have names,
     in which case the tuple is called a *named tuple*.
 
-    A tuple type can be explicitly declared in an expression or schema
-    declaration using the following syntax:
-
-    .. eql:synopsis::
-
-        tuple "<" <element-type>, [<element-type>, ...] ">"
-
-    A named tuple:
-
-    .. eql:synopsis::
-
-        tuple "<" <element-name> := <element-type> [, ... ] ">"
-
     Any type can be used as a tuple element type.
 
-    A tuple type is created implicitly when a
-    :ref:`tuple constructor <ref_eql_expr_tuple_ctor>` is
+    A :ref:`tuple type <ref_eql_types_tuple>` is created implicitly
+    when a :ref:`tuple constructor <ref_eql_expr_tuple_ctor>` is
     used:
 
     .. code-block:: edgeql-repl
 
         db> SELECT ('foo', 42);
         {('foo', 42)}
-
-        db> SELECT (INTROSPECT TYPEOF ('foo', 42)).name;
-        {"tuple<std::str, std::int64>"}
 
     Two tuples are equal if all of their elements are equal and in the same
     order.  Note that element names in named tuples are not significant for
@@ -53,33 +59,5 @@ heterogeneous data.
         db> SELECT (1, 2, 3) = (a := 1, b := 2, c := 3);
         {true}
 
-
-.. eql:type:: std::array
-
-    :index: array
-
-    Arrays represent a one-dimensional homogeneous ordered list.
-
-    Array indexing starts at zero.
-
-    An array type can be explicitly defined in an expression or schema
-    declaration using the following syntax:
-
-    .. eql:synopsis::
-
-        array "<" <element_type> ">"
-
-    With the exception of other array types, any type can be used as an
-    array element type.
-
-    An array type is created implicitly when an
-    :ref:`array constructor <ref_eql_expr_array_ctor>` is
-    used:
-
-    .. code-block:: edgeql-repl
-
-        db> SELECT [1, 2];
-        {[1, 2]}
-
-        db> SELECT (INTROSPECT TYPEOF [1, 2]).name;
-        {"array<std::int64>"}
+    The syntax of a tuple type declaration can be found in :ref:`this
+    section <ref_eql_types_tuple>`.

--- a/docs/datamodel/scalars/bool.rst
+++ b/docs/datamodel/scalars/bool.rst
@@ -5,4 +5,44 @@ Boolean Type
 
 .. eql:type:: std::bool
 
-    A boolean type with possible values of ``TRUE`` and ``FALSE``.
+    A boolean type with possible values of ``true`` and ``false``.
+
+    EdgeQL has case-insensitive keywords and that includes the boolean
+    literals:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT (True, true, TRUE);
+        {(true, true, true)}
+        db> SELECT (False, false, FALSE);
+        {(false, false, false)}
+
+    A boolean value may arise as a result of a :ref:`logical
+    <ref_eql_operators_logical>` or :ref:`comparison
+    <ref_eql_operators_comparison>` operations as well as :eql:op:`IN`
+    and :eql:op:`NOT IN <IN>`:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT true AND 2 < 3;
+        {true}
+        db> SELECT '!' IN {'hello', 'world'};
+        {false}
+
+    It is also possible to :ref:`cast <ref_eql_expr_typecast>` between
+    :eql:type:`bool`, :eql:type:`str`, and :eql:type:`json`:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT <json>true;
+        {'true'}
+        db> SELECT <bool>'True';
+        {true}
+
+    :ref:`Filter <ref_eql_statements_select_filter>` clauses must
+    always evaluate to a boolean:
+
+    .. code-block:: edgeql
+
+        SELECT User
+        FILTER .name ILIKE 'alice';

--- a/docs/datamodel/scalars/bytes.rst
+++ b/docs/datamodel/scalars/bytes.rst
@@ -6,3 +6,22 @@ Bytes
 .. eql:type:: std::bytes
 
     A sequence of bytes.
+
+    Bytes cannot be cast into any other type. They represent raw data.
+
+    There's a special byte literal:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT b'Hello, world';
+        {b'Hello, world'}
+        db> SELECT b'Hello,\x20world\x01';
+        {b'Hello, world\x01'}
+
+    There are also some :ref:`generic <ref_eql_functions_generic>`
+    functions that can operate on bytes:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT contains(b'qwerty', b'42');
+        {false}

--- a/docs/datamodel/scalars/datetime.rst
+++ b/docs/datamodel/scalars/datetime.rst
@@ -7,17 +7,64 @@ Date and Time
 
     A type representing date, time, and time zone.
 
+    :ref:`Casting <ref_eql_expr_typecast>` is required to obtain a
+    :eql:type:`datetime` value in an expression:
+
+    .. code-block:: edgeql
+
+        SELECT <datetime>'2018-05-07T15:01:22.306916+00';
+        SELECT <datetime>'2018-05-07T15:01:22+00';
+
+    See functions :eql:func:`datetime_get`, :eql:func:`to_datetime`,
+    and :eql:func:`to_str` for more ways of working with
+    :eql:type:`datetime`.
+
 .. eql:type:: std::naive_datetime
 
     A type representing date and time without time zone.
+
+    :ref:`Casting <ref_eql_expr_typecast>` is required to obtain a
+    :eql:type:`naive_datetime` value in an expression:
+
+    .. code-block:: edgeql
+
+        SELECT <naive_datetime>'2018-05-07T15:01:22.306916';
+        SELECT <naive_datetime>'2018-05-07T15:01:22';
+
+    See functions :eql:func:`datetime_get`, :eql:func:`to_naive_datetime`,
+    and :eql:func:`to_str` for more ways of working with
+    :eql:type:`naive_datetime`.
 
 .. eql:type:: std::naive_date
 
     A type representing date without time zone.
 
+    :ref:`Casting <ref_eql_expr_typecast>` is required to obtain a
+    :eql:type:`naive_date` value in an expression:
+
+    .. code-block:: edgeql
+
+        SELECT <naive_date>'2018-05-07';
+
+    See functions :eql:func:`date_get`, :eql:func:`to_naive_date`,
+    and :eql:func:`to_str` for more ways of working with
+    :eql:type:`naive_date`.
+
 .. eql:type:: std::naive_time
 
     A type representing time without time zone.
+
+    :ref:`Casting <ref_eql_expr_typecast>` is required to obtain a
+    :eql:type:`naive_time` value in an expression:
+
+    .. code-block:: edgeql
+
+        SELECT <naive_time>'15:01:22.306916';
+        SELECT <naive_time>'15:01:22';
+
+    See functions :eql:func:`time_get`, :eql:func:`to_naive_time`,
+    and :eql:func:`to_str` for more ways of working with
+    :eql:type:`naive_time`.
 
 .. eql:type:: std::timedelta
 
@@ -61,3 +108,7 @@ Date and Time
         db> SELECT <timedelta>
         ...     '12 decades 2403 months 3987 days 12348943ms';
         {'320 years 3 mons 3987 days 03:25:48.943'}
+
+    See functions :eql:func:`timedelta_get`, :eql:func:`to_timedelta`,
+    and :eql:func:`to_str` for more ways of working with
+    :eql:type:`timedelta`.

--- a/docs/datamodel/scalars/enum.rst
+++ b/docs/datamodel/scalars/enum.rst
@@ -10,18 +10,18 @@ Enumerated Types
     An enumerated type is a data type consisting of an order list of values.
 
     An enumeration type can be declared in a schema declaration using
-    the following syntax:
+    the following :ref:`syntax <ref_eql_types_enum>`:
 
-    .. eql:synopsis::
+    .. code-block:: sdl
 
-        enum "<" <enum-values> ">"
+        scalar type color_enum_t extending enum<'red', 'green', 'blue'>;
 
-    Where :eql:synopsis:`<enum-values>` is a comma-separated list of
-    quoted string constants comprising the enum type.  Currently, the
-    only valid application of the enum declaration is to define an
-    enumerated scalar type:
+    :ref:`Casting <ref_eql_expr_typecast>` is required to obtain an
+    enum value in an expression:
 
     .. code-block:: edgeql-repl
 
-        db> CREATE SCALAR TYPE my_enum_t EXTENDING enum<'One', 'Two'>;
-        CREATE TYPE
+        db> SELECT 'red' IS color_enum_t;
+        {false}
+        db> SELECT <color_enum_t>'red' IS color_enum_t;
+        {true}

--- a/docs/datamodel/scalars/json.rst
+++ b/docs/datamodel/scalars/json.rst
@@ -6,3 +6,35 @@ JSON
 .. eql:type:: std::json
 
     Arbitrary JSON data.
+
+    Any other type (except for :eql:type`bytes`) can be :ref:`cast
+    <ref_eql_expr_typecast>` to and from :eql:type:`json`:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT <json>42;
+        {'42'}
+        db> SELECT <bool>to_json('true');
+        {true}
+
+    Note that when a :eql:type:`str` is cast into a :eql:type:`json`,
+    the result is JSON string value. Same applies for casting back
+    from :eql:type:`json` - only a JSON string value can be cast into
+    a :eql:type:`str`:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT <json>'Hello, world';
+        {'"Hello, world"'}
+
+    There are :ref:`converter <ref_eql_functions_converters>`
+    functions that can be used to dump or parse a :eql:type:`json`
+    value to or from a :eql:type:`str`:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT to_json('[1, "a"]');
+        {'[1, "a"]'}
+        db> SELECT to_str(<json>[1, 2]);
+        {'[1, 2]'}
+

--- a/docs/datamodel/scalars/numeric.rst
+++ b/docs/datamodel/scalars/numeric.rst
@@ -3,11 +3,17 @@
 Numeric Types
 =============
 
+It's possbile to explicitly :ref:`cast <ref_eql_expr_typecast>`
+between any numeric types. All numeric types can also be cast to and
+from :eql:type:`str` and :eql:type:`json`.
+
 .. eql:type:: std::int16
 
     :index: int integer
 
     A 16-bit signed integer.
+
+    An integer value in range from ``-32768`` to ``+32767`` (inclusive).
 
 .. eql:type:: std::int32
 
@@ -15,11 +21,17 @@ Numeric Types
 
     A 32-bit signed integer.
 
+    An integer value in range from ``-2147483648`` to ``+2147483647``
+    (inclusive).
+
 .. eql:type:: std::int64
 
     :index: int integer
 
     A 64-bit signed integer.
+
+    An integer value in range from ``-9223372036854775808`` to
+    ``+9223372036854775807`` (inclusive).
 
 .. eql:type:: std::float32
 
@@ -27,7 +39,9 @@ Numeric Types
 
     A variable precision, inexact number.
 
-    Minimal guaranteed precision is at least 6 decimal digits.
+    Minimal guaranteed precision is at least 6 decimal digits. The
+    approximate range of a ``float32`` is ``-3.4e+38`` to
+    ``+3.4e+38``.
 
 .. eql:type:: std::float64
 
@@ -35,7 +49,8 @@ Numeric Types
 
     A variable precision, inexact number.
 
-    Minimal guaranteed precision is at least 15 decimal digits.
+    Minimal guaranteed precision is at least 15 decimal digits. The
+    approximate range of a ``float32`` is ``-1.7e+308`` to ``+1.7e+308``.
 
 .. eql:type:: std::decimal
 
@@ -54,3 +69,12 @@ Numeric Types
     All of the following types can be explicitly cast into decimal:
     :eql:type:`str`, :eql:type:`int16`, :eql:type:`int32`,
     :eql:type:`int64`, :eql:type:`float32`, and :eql:type:`float64`.
+
+    A decimal type has it's own literal:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT 42n IS decimal;
+        {true}
+        db> SELECT 1.23n IS decimal;
+        {true}

--- a/docs/datamodel/scalars/str.rst
+++ b/docs/datamodel/scalars/str.rst
@@ -6,3 +6,35 @@ Strings
 .. eql:type:: std::str
 
     A unicode string of text.
+
+    Any other type (except for :eql:type`bytes`) can be :ref:`cast
+    <ref_eql_expr_typecast>` to and from a string:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT <str>42;
+        {'42'}
+        db> SELECT <bool>'true';
+        {true}
+
+    Note that when a :eql:type:`str` is cast into a :eql:type:`json`,
+    the result is JSON string value. Same applies for casting back
+    from :eql:type:`json` - only a JSON string value can be cast into
+    a :eql:type:`str`:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT <json>'Hello, world';
+        {'"Hello, world"'}
+
+    There are :ref:`converter <ref_eql_functions_converters>`
+    functions that can be used to dump or parse a :eql:type:`json`
+    value to or from a :eql:type:`str`:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT to_json('[1, "a"]');
+        {'[1, "a"]'}
+        db> SELECT to_str(<json>[1, 2]);
+        {'[1, 2]'}
+

--- a/docs/datamodel/scalars/uuid.rst
+++ b/docs/datamodel/scalars/uuid.rst
@@ -8,3 +8,6 @@ UUID Type
     Universally Unique Identifiers (UUID).
 
     For formal definition see RFC 4122 and ISO/IEC 9834-8:2005.
+
+    Every :eql:type:`Object` has a globally unique property ``id``
+    represented by a UUID value.

--- a/docs/edgeql/__toc__.rst
+++ b/docs/edgeql/__toc__.rst
@@ -7,6 +7,7 @@ EdgeQL
     :hidden:
 
     overview
+    types
     expressions/index
     statements/index
     sdl/index

--- a/docs/edgeql/ddl/props.rst
+++ b/docs/edgeql/ddl/props.rst
@@ -93,6 +93,10 @@ Parameters
     If there is no conflict, the link properties are merged to form a
     single property in the new link item.
 
+:eql:synopsis:`<type>`
+    The type must be a valid :ref:`type expression <ref_eql_types>`
+    denoting a non-abstract scalar or a container type.
+
 :eql:synopsis:`<subcommand>`
     Optional sequence of subcommands related to the new link item.
 

--- a/docs/edgeql/expressions/index.rst
+++ b/docs/edgeql/expressions/index.rst
@@ -154,7 +154,8 @@ the specified type:
 
     "<" <type> ">" <expression>
 
-The :eql:synopsis:`<type>` must be a non-abstract scalar or a container type.
+The :eql:synopsis:`<type>` must be a valid :ref:`type expression
+<ref_eql_types>` denoting a non-abstract scalar or a container type.
 
 For example, the following expression casts an integer value into a string:
 

--- a/docs/edgeql/expressions/tuples.rst
+++ b/docs/edgeql/expressions/tuples.rst
@@ -25,12 +25,7 @@ Named tuples are created using the following syntax:
 Note that *all* elements in a named tuple must have a name.
 
 A tuple constructor automatically creates a corresponding
-:eql:type:`tuple` type:
-
-.. code-block:: edgeql-repl
-
-    db> SELECT (INTROSPECT TYPEOF ('foo', 42)).name;
-    tuple<std::str, std::int64>
+:ref:`tuple type <ref_eql_types_tuple>`.
 
 
 .. _ref_eql_expr_tuple_elref:

--- a/docs/edgeql/functions/generic.rst
+++ b/docs/edgeql/functions/generic.rst
@@ -42,11 +42,11 @@ This section describes generic functions provided by EdgeDB.
     A polymorphic function to test if a sequence contains a certain element.
 
     When the *haystack* is :eql:type:`str` or :eql:type:`bytes`,
-    return ``TRUE`` if *needle* is contained as a subsequence in it
-    and ``FALSE`` otherwise.
+    return ``true`` if *needle* is contained as a subsequence in it
+    and ``false`` otherwise.
 
-    When the *haystack* is an :eql:type:`array`, return ``TRUE`` if
-    the array contains the specified element and ``FALSE`` otherwise.
+    When the *haystack* is an :eql:type:`array`, return ``true`` if
+    the array contains the specified element and ``false`` otherwise.
 
     .. code-block:: edgeql-repl
 

--- a/docs/edgeql/functions/setagg.rst
+++ b/docs/edgeql/functions/setagg.rst
@@ -49,8 +49,8 @@ Aggregates
 
     Generalized boolean :eql:op:`AND` applied to the set of *values*.
 
-    The result is ``TRUE`` if all of the *values* are ``TRUE`` or the
-    set of *values* is ``{}``. Return ``FALSE`` otherwise.
+    The result is ``true`` if all of the *values* are ``true`` or the
+    set of *values* is ``{}``. Return ``false`` otherwise.
 
     .. code-block:: edgeql-repl
 
@@ -66,8 +66,8 @@ Aggregates
 
     Generalized boolean :eql:op:`OR` applied to the set of *values*.
 
-    The result is ``TRUE`` if any of the *values* are ``TRUE``. Return
-    ``FALSE`` otherwise.
+    The result is ``true`` if any of the *values* are ``true``. Return
+    ``false`` otherwise.
 
     .. code-block:: edgeql-repl
 

--- a/docs/edgeql/operators/comparison.rst
+++ b/docs/edgeql/operators/comparison.rst
@@ -94,7 +94,7 @@ EdgeDB supports the following comparison operators:
     :optype B: anytype
     :resulttype: bool
 
-    ``TRUE`` if ``A`` is less than ``B``.
+    ``true`` if ``A`` is less than ``B``.
 
     .. code-block:: edgeql-repl
 
@@ -108,7 +108,7 @@ EdgeDB supports the following comparison operators:
     :optype B: anytype
     :resulttype: bool
 
-    ``TRUE`` if ``A`` is greater than ``B``.
+    ``true`` if ``A`` is greater than ``B``.
 
     .. code-block:: edgeql-repl
 
@@ -122,7 +122,7 @@ EdgeDB supports the following comparison operators:
     :optype B: anytype
     :resulttype: bool
 
-    ``TRUE`` if ``A`` is less than or equal to ``B``.
+    ``true`` if ``A`` is less than or equal to ``B``.
 
     .. code-block:: edgeql-repl
 
@@ -136,7 +136,7 @@ EdgeDB supports the following comparison operators:
     :optype B: anytype
     :resulttype: bool
 
-    ``TRUE`` if ``A`` is greater than or equal to ``B``.
+    ``true`` if ``A`` is greater than or equal to ``B``.
 
     .. code-block:: edgeql-repl
 

--- a/docs/edgeql/operators/logical.rst
+++ b/docs/edgeql/operators/logical.rst
@@ -55,19 +55,19 @@ The truth tables are as follows:
 +-------+-------+-----------+----------+
 |   a   |   b   |  a AND b  |  a OR b  |
 +=======+=======+===========+==========+
-| TRUE  | TRUE  |   TRUE    |   TRUE   |
+| true  | true  |   true    |   true   |
 +-------+-------+-----------+----------+
-| TRUE  | FALSE |   FALSE   |   TRUE   |
+| true  | false |   false   |   true   |
 +-------+-------+-----------+----------+
-| FALSE | TRUE  |   FALSE   |   TRUE   |
+| false | true  |   false   |   true   |
 +-------+-------+-----------+----------+
-| FALSE | FALSE |   FALSE   |   FALSE  |
+| false | false |   false   |   false  |
 +-------+-------+-----------+----------+
 
 +-------+---------+
 |   a   |  NOT a  |
 +=======+=========+
-| TRUE  |  FALSE  |
+| true  |  false  |
 +-------+---------+
-| FALSE |  TRUE   |
+| false |  true   |
 +-------+---------+

--- a/docs/edgeql/operators/type.rst
+++ b/docs/edgeql/operators/type.rst
@@ -51,7 +51,8 @@ the specified type:
 
     "<" <type> ">" <expression>
 
-The *type* must be a non-abstract scalar or a container type.
+The :eql:synopsis:`<type>` must be a valid :ref:`type expression
+<ref_eql_types>` denoting a non-abstract scalar or a container type.
 
 Type cast is a run-time operation.  The cast will succeed only if a
 type conversion was defined for the type pair, and if the source value

--- a/docs/edgeql/sdl/props.rst
+++ b/docs/edgeql/sdl/props.rst
@@ -43,7 +43,6 @@ commands <ref_eql_ddl_props>`.
 
 .. sdl:synopsis::
 
-
     # Concrete property form used inside type declaration:
     [ required ] [{single | multi}] property <name>
       [ extending <base> [, ...] ] -> <type>

--- a/docs/edgeql/statements/select.rst
+++ b/docs/edgeql/statements/select.rst
@@ -192,6 +192,8 @@ The above query retrieves the top 3 open Issues with the closest due
 date.
 
 
+.. _ref_eql_statements_select_filter:
+
 Filter
 ------
 

--- a/docs/edgeql/types.rst
+++ b/docs/edgeql/types.rst
@@ -1,0 +1,116 @@
+.. _ref_eql_types:
+
+
+Types Syntax
+============
+
+Most types are just referred to by their name, however, EdgeQL has a
+special syntax for referring to :eql:type:`array`,
+:eql:type:`tuple`, and :eql:type:`enum` types. This syntax is used in
+:ref:`property <ref_eql_sdl_props>`, :ref:`scalar
+<ref_eql_sdl_scalars>`, or :ref:`function <ref_eql_sdl_functions>`
+declarations as well as in type expressions involving :eql:op:`IS`
+or a :ref:`cast <ref_eql_expr_typecast>`.
+
+
+.. _ref_eql_types_array:
+
+Array
+-----
+
+An array type can be explicitly defined in an expression or schema
+declaration using the following syntax:
+
+.. eql:synopsis::
+
+    array "<" <element_type> ">"
+
+With the exception of other array types, any :ref:`scalar
+<ref_datamodel_scalar_types>` or :ref:`collection
+<ref_datamodel_collection_types>` type can be used as an array element
+type.
+
+Here's an example of using this syntax in a schema definition:
+
+.. code-block:: sdl
+
+    type User {
+        required property name -> str;
+        property favorites -> array<str>;
+    }
+
+Here's a few examples of using array types in EdgeQL queries:
+
+.. code-block:: edgeql-repl
+
+    db> SELECT <array<int64>>['1', '2', '3'];
+    {[1, 2, 3]}
+    db> SELECT [1, 2, 3] IS (array<int64>);
+    {true}
+    db> SELECT [(1, 'a')] IS (array<tuple<int64, str>>);
+    {true}
+
+
+.. _ref_eql_types_tuple:
+
+Tuple
+-----
+
+A tuple type can be explicitly declared in an expression or schema
+declaration using the following syntax:
+
+.. eql:synopsis::
+
+    tuple "<" <element-type>, [<element-type>, ...] ">"
+
+A named tuple:
+
+.. eql:synopsis::
+
+    tuple "<" <element-name> : <element-type> [, ... ] ">"
+
+Any type can be used as a tuple element type.
+
+Here's an example of using this syntax in a schema definition:
+
+.. code-block:: sdl
+
+    type GameElement {
+        required property name -> str;
+        required property position -> tuple<x: int64, y: int64>;
+    }
+
+Here's a few examples of using tuple types in EdgeQL queries:
+
+.. code-block:: edgeql-repl
+
+    db> SELECT <tuple<int64, str>>('1', 3);
+    {(1, '3')}
+    db> SELECT <tuple<x: int64, y: int64>>(1, 2);
+    {(x := 1, y := 2)}
+    db> SELECT (1, '3') IS (tuple<int64, str>);
+    {true}
+    db> SELECT ([1, 2], 'a') IS (tuple<array<int64>, str>);
+    {true}
+
+
+.. _ref_eql_types_enum:
+
+Enum
+----
+
+An enumeration type can be declared in a schema declaration using
+the following syntax:
+
+.. eql:synopsis::
+
+    enum "<" <enum-values> ">"
+
+Where :eql:synopsis:`<enum-values>` is a comma-separated list of
+quoted string constants comprising the enum type.  Currently, the
+only valid application of the enum declaration is to define an
+enumerated scalar type:
+
+.. code-block:: sdl
+
+    scalar type color_enum_t extending enum<'red', 'green', 'blue'>;


### PR DESCRIPTION
Remove synopsis from Data Model section.

Create a new section in EdgeQL for type syntax and type expressions.
Move all the type-specific syntax into this section.