### PR TITLE
protocol: Add headers to all major messages

### DIFF
--- a/edb/server/mng_port/edgecon.pxd
+++ b/edb/server/mng_port/edgecon.pxd
@@ -88,3 +88,5 @@ cdef class EdgeConnection:
 
     cdef WriteBuffer make_describe_msg(self, query_unit)
     cdef WriteBuffer make_command_complete_msg(self, query_unit)
+
+    cdef inline reject_headers(self)


### PR DESCRIPTION
As of right now we don't have any headers so all we do is send an
int16 0 in the beginning of each message.  In the future, however,
we'll be able to attach additional meta-information to messages
without breaking the protocol.