### PR TITLE
Add support for protocol negotiation

### DIFF
--- a/edb/server/mng_port/edgecon.pxd
+++ b/edb/server/mng_port/edgecon.pxd
@@ -90,3 +90,4 @@ cdef class EdgeConnection:
     cdef WriteBuffer make_command_complete_msg(self, query_unit)
 
     cdef inline reject_headers(self)
+    cdef dict parse_headers(self)


### PR DESCRIPTION
The initial message sent by the client is now a regular framed
`ProtocolVersion` message.  It contains the major and the minor versions
of the protocol, as well as an arbitrary set of protocol extensions that
consist of the extension name and an optional set of extension options.

If the server fully supports the requested protocol version and the
requested extensions, it proceeds directly to the authentication phase.
Otherwise a `NegotiateProtocolVersion` message is sent back to the
client with the same format as the initial `ProtocolVersion` message
containing the version and the extensions that the server can support.