### PR TITLE
Implement strict separation between timezone-aware and local date/time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs cython postgres pygments
+.PHONY: docs cython postgres postgres-ext pygments
 
 SPHINXOPTS:="-W -n"
 
@@ -15,6 +15,10 @@ docs:
 
 postgres:
 	python setup.py build_postgres
+
+
+postgres-ext:
+	python setup.py build_postgres_ext
 
 
 pygments:

--- a/docs/datamodel/scalars/datetime.rst
+++ b/docs/datamodel/scalars/datetime.rst
@@ -3,9 +3,26 @@
 Date and Time
 =============
 
+EdgeDB has two classes of date/time types:
+
+* a timezone-aware :eql:type:`std::datetime` type;
+
+* a set of "local" date/time objects, not attached to any particular
+  timezone: :eql:type:`std::local_datetime`, :eql:type:`std::local_date`,
+  and :eql:type:`std::local_time`.
+
+All date/time :ref:`operators <ref_eql_operators_datetime>`,
+:ref:`functions <ref_eql_functions_datetime>`,
+:ref:`type converters <ref_eql_functions_converters>`, and type casts
+are designed to maintain a strict separation between timezone-aware
+and "local" date/time values.
+
+EdgeDB stores and outputs timezone-aware values in UTC.
+
+
 .. eql:type:: std::datetime
 
-    A type representing date, time, and time zone.
+    A timezone-aware type representing date and time.
 
     :ref:`Casting <ref_eql_expr_typecast>` is required to obtain a
     :eql:type:`datetime` value in an expression:
@@ -14,6 +31,16 @@ Date and Time
 
         SELECT <datetime>'2018-05-07T15:01:22.306916+00';
         SELECT <datetime>'2018-05-07T15:01:22+00';
+
+    Note that when casting from strings a timezone is always required:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT <datetime>'January 01 2019';
+        InvalidValueError: an explicit timezone is required
+
+        db> SELECT <datetime>'January 01 2019 UTC';
+        {<datetime>'2019-01-01T00:00:00+00:00'}
 
     See functions :eql:func:`datetime_get`, :eql:func:`to_datetime`,
     and :eql:func:`to_str` for more ways of working with
@@ -30,6 +57,17 @@ Date and Time
 
         SELECT <local_datetime>'2018-05-07T15:01:22.306916';
         SELECT <local_datetime>'2018-05-07T15:01:22';
+
+    Note that when casting from strings a timezone must not be
+    included:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT <local_datetime>'January 01 2019 UTC';
+        InvalidValueError: invalid input syntax for type std::local_datetime
+
+        db> SELECT <local_datetime>'January 01 2019';
+        {<local_datetime>'2019-01-01T00:00:00'}
 
     See functions :eql:func:`datetime_get`, :eql:func:`to_local_datetime`,
     and :eql:func:`to_str` for more ways of working with
@@ -109,6 +147,17 @@ Date and Time
         ...     '12 decades 2403 months 3987 days 12348943ms';
         {'320 years 3 mons 3987 days 03:25:48.943'}
 
+    All date/time types support the ``+`` and ``-`` arithmetic operations
+    with time intervals:
+
+    .. code-block:: edgeql-repl
+
+        db> select <datetime>'January 01 2019 UTC' - <timedelta>'1 day';
+        {<datetime>'2018-12-31T00:00:00+00:00'}
+        db> select <local_time>'22:00' + <timedelta>'1 hour';
+        {<local_time>'23:00:00'}
+
     See functions :eql:func:`timedelta_get`, :eql:func:`to_timedelta`,
-    and :eql:func:`to_str` for more ways of working with
-    :eql:type:`timedelta`.
+    and :eql:func:`to_str` and date/time :
+    :ref:`operators <ref_eql_operators_datetime>` for more ways of
+    working with :eql:type:`timedelta`.

--- a/docs/edgeql/functions/converters.rst
+++ b/docs/edgeql/functions/converters.rst
@@ -33,8 +33,8 @@ simple cast is not sufficient to specify how data must be converted,
 the functions below allow more options for such conversions.
 
 .. eql:function:: std::to_datetime(s: str, fmt: OPTIONAL str={}) -> datetime
-                  std::to_datetime(year: int64, month: int64, day: int64, \
-                    hour: int64, min: int64, sec: float64) -> datetime
+                  std::to_datetime(local: local_datetime, zone: str) \
+                    -> datetime
                   std::to_datetime(year: int64, month: int64, day: int64, \
                     hour: int64, min: int64, sec: float64, timezone: str) \
                     -> datetime
@@ -58,10 +58,18 @@ the functions below allow more options for such conversions.
         ...                    'Mon DDth, YYYY HH24:MI:SS TZM');
         {<datetime>'2018-05-07T15:01:22+00:00'}
 
-    Alternatively, the :eql:type:`datetime` value can be given in
-    terms of its component parts: *year*, *month*, *day*, *hour*,
-    *min*, *sec*, and possibly *timezone* (if the *timezone* is not
-    specified, the DB timezone will be assumed).
+    Alternatively, the :eql:type:`datetime` value can be constructed
+    from a :eql:type:`std::local_datetime` value:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT to_datetime(
+        ...   <local_datetime>'January 1, 2019 12:00AM', 'HKT');
+        {<datetime>'2018-12-31T16:00:00+00:00'}
+
+    Yet another way to construct a the :eql:type:`datetime` value
+    is to specify it in terms of its component parts: *year*, *month*,
+    *day*, *hour*, *min*, *sec*, and *timezone*:
 
     .. code-block:: edgeql-repl
 
@@ -74,6 +82,8 @@ the functions below allow more options for such conversions.
 
 
 .. eql:function:: std::to_local_datetime(s: str, fmt: OPTIONAL str={}) \
+                    -> local_datetime
+                  std::to_local_datetime(dt: datetime, zone: str) \
                     -> local_datetime
                   std::to_local_datetime(year: int64, month: int64, \
                     day: int64, hour: int64, min: int64, sec: float64) \
@@ -98,6 +108,16 @@ the functions below allow more options for such conversions.
         db> SELECT to_local_datetime(
         ...     2018, 5, 7, 15, 1, 22.306916);
         {<local_datetime>'2018-05-07T15:01:22.306916'}
+
+    A timezone-aware :eql:type:`datetime` type can be converted
+    to local datetime in the specified timezone:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT to_local_datetime(
+        ...   <datetime>'December 31, 2018 10:00PM GMT+8',
+        ...   'US/Central');
+        {<local_datetime>'2019-01-01T00:00:00'}
 
     For more details on formatting see :ref:`here
     <ref_eql_functions_converters_datetime_fmt>`.
@@ -126,11 +146,23 @@ the functions below allow more options for such conversions.
         db> SELECT to_local_date(2018, 5, 7);
         {<local_date>'2018-05-07'}
 
+    A timezone-aware :eql:type:`datetime` type can be converted
+    to local date in the specified timezone:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT to_local_date(
+        ...   <datetime>'December 31, 2018 10:00PM GMT+8',
+        ...   'US/Central');
+        {<local_date>'2019-01-01'}
+
     For more details on formatting see :ref:`here
     <ref_eql_functions_converters_datetime_fmt>`.
 
 
 .. eql:function:: std::to_local_time(s: str, fmt: OPTIONAL str={}) \
+                    -> local_time
+                  std::to_local_time(dt: datetime, zone: str) \
                     -> local_time
                   std::to_local_time(hour: int64, min: int64, sec: float64) \
                     -> local_time
@@ -152,6 +184,16 @@ the functions below allow more options for such conversions.
         {<local_time>'15:01:22'}
         db> SELECT to_local_time(15, 1, 22.306916);
         {<local_time>'15:01:22.306916'}
+
+    A timezone-aware :eql:type:`datetime` type can be converted
+    to local date in the specified timezone:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT to_local_time(
+        ...   <datetime>'December 31, 2018 10:00PM GMT+8',
+        ...   'US/Pacific');
+        {<local_date>'22:00:00'}
 
     For more details on formatting see :ref:`here
     <ref_eql_functions_converters_datetime_fmt>`.

--- a/docs/edgeql/functions/datetime.rst
+++ b/docs/edgeql/functions/datetime.rst
@@ -52,16 +52,10 @@ Date and Time
     - ``'quarter'`` - the quarter of the year (1-4)
     - ``'second'`` - the seconds, including fractional value from 0 up to and
       not including 60
-    - ``'timezone'`` - the time zone offset from UTC, measured in seconds
-    - ``'timezone_hour'`` - the hour component of time zone offset
-    - ``'timezone_minute'`` - the minute component of time zone offset
     - ``'week'`` - the number of the ISO 8601 week-numbering week of
       the year. ISO weeks are defined to start on Mondays and the
       first week of a year must contain Jan 4 of that year.
     - ``'year'`` - the year
-
-    For :eql:type:`local_datetime` inputs the elements ``'timezone'``,
-    ``'timezone_hour'``, and ``'timezone_minute'`` are invalid.
 
     .. code-block:: edgeql-repl
 

--- a/docs/edgeql/operators/mathop.rst
+++ b/docs/edgeql/operators/mathop.rst
@@ -1,11 +1,15 @@
 .. _ref_eql_operators_math:
 
-============
-Mathematical
-============
+==========
+Arithmetic
+==========
 
-This section describes mathematical operators
+This section describes arithmetic operators
 provided by EdgeDB.
+
+
+Numerical
+=========
 
 .. eql:operator:: PLUS: A + B
 
@@ -135,3 +139,69 @@ provided by EdgeDB.
 
         db> SELECT 2 ^ 4;
         {16}
+
+
+.. _ref_eql_operators_datetime:
+
+Date and Time
+=============
+
+.. eql:operator:: DTPLUS: A + B
+
+    :optype A: datetime or local_datetime or local_time or \
+               local_date or timedelta
+    :optype B: datetime or local_datetime or local_time or \
+               local_date or timedelta
+    :resulttype: datetime or local_datetime or local_time or \
+                 local_date or timedelta
+    :index: plus add
+
+    Time interval addition.
+
+    .. code-block:: edgeql-repl
+
+        db> select <local_time>'22:00' + <timedelta>'1 hour';
+        {<local_time>'23:00:00'}
+        db> select  <timedelta>'1 hour' + <local_time>'22:00';
+        {<local_time>'23:00:00'}
+        db> select  <timedelta>'1 hour' + <timedelta>'2 hours';
+        {<timedelta>'3:00:00'}
+
+
+.. eql:operator:: DTMINUS: A - B
+
+    :optype A: datetime or local_datetime or local_time or \
+               local_date or timedelta
+    :optype B: datetime or local_datetime or local_time or \
+               local_date or timedelta
+    :resulttype: datetime or local_datetime or local_time or \
+                 local_date or timedelta
+    :index: minus subtract
+
+    Time interval and date/time subtraction.
+
+    .. code-block:: edgeql-repl
+
+        db> select <datetime>'January 01 2019 UTC' - <timedelta>'1 day';
+        {<datetime>'2018-12-31T00:00:00+00:00'}
+        db> select <datetime>'January 01 2019 UTC' -
+        ...   <datetime>'January 02 2019 UTC';
+        {<timedelta>'-1 day, 0:00:00'}
+        db> select  <timedelta>'1 hour' - <timedelta>'2 hours';
+        {<timedelta>'-1 day, 23:00:00'}
+
+    It is an error to subtract a date/time object from a time interval:
+
+    .. code-block:: edgeql-repl
+
+        db> select <timedelta>'1 day' - <datetime>'January 01 2019 UTC';
+        QueryError: operator '-' cannot be applied to operands ...
+
+    It is also an error to subtract timezone-aware :eql:type:`std::datetime`
+    to or from :eql:type:`std::local_datetime`:
+
+    .. code-block:: edgeql-repl
+
+    db> select <datetime>'January 01 2019 UTC' -
+    ...   <local_datetime>'January 02 2019';
+    QueryError: operator '-' cannot be applied to operands ...

--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -435,18 +435,6 @@ std::`-` (v: std::timedelta) -> std::timedelta
 ## Date/time casts
 ## ---------------
 
-CREATE CAST FROM std::datetime TO std::local_datetime
-    FROM SQL CAST;
-
-
-CREATE CAST FROM std::datetime TO std::local_date
-    FROM SQL CAST;
-
-
-CREATE CAST FROM std::datetime TO std::local_time
-    FROM SQL CAST;
-
-
 CREATE CAST FROM std::local_datetime TO std::local_date
     FROM SQL CAST;
 
@@ -462,19 +450,19 @@ CREATE CAST FROM std::local_date TO std::local_datetime
 ## String casts
 
 CREATE CAST FROM std::str TO std::datetime
-    FROM SQL CAST;
+    FROM SQL FUNCTION 'edgedb.timestamptz_in';
 
 
 CREATE CAST FROM std::str TO std::local_datetime
-    FROM SQL CAST;
+    FROM SQL FUNCTION 'edgedb.timestamp_in';
 
 
 CREATE CAST FROM std::str TO std::local_date
-    FROM SQL CAST;
+    FROM SQL FUNCTION 'edgedb.date_in';
 
 
 CREATE CAST FROM std::str TO std::local_time
-    FROM SQL CAST;
+    FROM SQL FUNCTION 'edgedb.time_in';
 
 
 CREATE CAST FROM std::str TO std::timedelta

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -314,7 +314,7 @@ std::to_datetime(s: std::str, fmt: OPTIONAL str={}) -> std::datetime
                 NULL::timestamptz)
         ELSE
             edgedb._raise_exception_on_null(
-                to_timestamp("s", "fmt"),
+                edgedb.to_timestamptz("s", "fmt"),
                 'invalid_parameter_value',
                 'to_datetime(): format ''' || "fmt" || ''' is invalid',
                 ''
@@ -326,15 +326,11 @@ std::to_datetime(s: std::str, fmt: OPTIONAL str={}) -> std::datetime
 
 
 CREATE FUNCTION
-std::to_datetime(year: std::int64, month: std::int64, day: std::int64,
-                 hour: std::int64, min: std::int64, sec: std::float64)
+std::to_datetime(local: std::local_datetime, zone: std::str)
     -> std::datetime
 {
     FROM SQL $$
-    SELECT make_timestamptz(
-        "year"::int, "month"::int, "day"::int,
-        "hour"::int, "min"::int, "sec"
-    )
+    SELECT timezone("zone", "local");
     $$;
 };
 
@@ -370,7 +366,7 @@ std::to_local_datetime(s: std::str, fmt: OPTIONAL str={})
                 NULL::timestamp)
         ELSE
             edgedb._raise_exception_on_null(
-                to_timestamp("s", "fmt")::timestamp,
+                edgedb.to_timestamp("s", "fmt")::timestamp,
                 'invalid_parameter_value',
                 'to_local_datetime(): format ''' || "fmt" || ''' is invalid',
                 ''
@@ -391,6 +387,16 @@ std::to_local_datetime(year: std::int64, month: std::int64, day: std::int64,
         "year"::int, "month"::int, "day"::int,
         "hour"::int, "min"::int, "sec"
     )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_local_datetime(dt: std::datetime, zone: std::str)
+    -> std::local_datetime
+{
+    FROM SQL $$
+    SELECT timezone("zone", "dt");
     $$;
 };
 
@@ -417,6 +423,16 @@ std::to_local_date(s: std::str, fmt: OPTIONAL str={}) -> std::local_date
             )
         END
     )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_local_date(dt: std::datetime, zone: std::str)
+    -> std::local_date
+{
+    FROM SQL $$
+    SELECT timezone("zone", "dt")::date;
     $$;
 };
 
@@ -453,6 +469,16 @@ std::to_local_time(s: std::str, fmt: OPTIONAL str={}) -> std::local_time
             )
         END
     )
+    $$;
+};
+
+
+CREATE FUNCTION
+std::to_local_time(dt: std::datetime, zone: std::str)
+    -> std::local_time
+{
+    FROM SQL $$
+    SELECT timezone("zone", "dt")::time;
     $$;
 };
 

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -223,7 +223,7 @@ def compile_TypeCast(
             func_name = common.get_cast_backend_name(
                 expr.cast_name, expr.cast_module_id, aspect='function')
         else:
-            func_name = (expr.sql_function,)
+            func_name = tuple(expr.sql_function.split('.'))
 
         return pgast.FuncCall(
             name=func_name,

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -49,6 +49,9 @@ class PGError(enum.Enum):
 
     ReadOnlySQLTransactionError = '25006'
 
+    InvalidDatetimeFormatError = '22007'
+    DatetimeError = '22008'
+
 
 constraint_errors = frozenset({
     PGError.IntegrityConstraintViolationError,
@@ -235,5 +238,8 @@ def interpret_backend_error(schema, fields):
     elif code == PGError.ReadOnlySQLTransactionError:
         return errors.TransactionError(
             'cannot execute query in a read-only transaction')
+
+    elif code in {PGError.InvalidDatetimeFormatError, PGError.DatetimeError}:
+        return errors.InvalidValueError(translate_pgtype(schema, message))
 
     return errors.InternalServerError(message)

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -214,10 +214,11 @@ def run_server(args):
             'client_min_messages': 'INFO',
             'listen_addresses': '',  # we use Unix sockets
             'unix_socket_permissions': '0700',
+            # We always enforce UTC timezone:
+            # * timestamptz is stored in UTC anyways;
+            # * this makes the DB server more predictable.
+            'TimeZone': 'UTC',
         }
-
-        if args['timezone']:
-            server_settings['TimeZone'] = args['timezone']
 
         cluster = edgedb_cluster.get_pg_cluster(args['data_dir'])
         cluster_status = cluster.get_status()
@@ -333,9 +334,6 @@ _server_options = [
     click.option(
         '--pidfile', type=str, default='/run/edgedb/',
         help='path to PID file directory'),
-    click.option(
-        '--timezone', type=str,
-        help='timezone for displaying and interpreting timestamps'),
     click.option(
         '--daemon-user', type=int),
     click.option(

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -161,7 +161,7 @@ def _init_cluster(data_dir=None, *, cleanup_atexit=True, init_settings={}):
     if cluster.get_status() == 'not-initialized':
         cluster.init(server_settings=init_settings)
 
-    cluster.start(port='dynamic', timezone='UTC')
+    cluster.start(port='dynamic')
     cluster.set_superuser_password('test')
 
     if cleanup_atexit:

--- a/edb/tools/inittestdb.py
+++ b/edb/tools/inittestdb.py
@@ -87,7 +87,7 @@ def inittestdb(*, data_dir, jobs, tests_dir):
 
     try:
         cluster.init()
-        cluster.start(port='dynamic', timezone='UTC')
+        cluster.start(port='dynamic')
         cluster.trust_local_connections()
     except BaseException:
         if os.path.exists(data_dir):

--- a/ext/Makefile
+++ b/ext/Makefile
@@ -17,7 +17,7 @@
 #
 
 MODULE_big = edbsys
-OBJS = module.o recordext.o numop.o $(WIN32RES)
+OBJS = module.o datetime.o recordext.o numop.o $(WIN32RES)
 
 EXTENSION = edbsys
 DATA = edbsys--1.0.sql

--- a/ext/datetime.c
+++ b/ext/datetime.c
@@ -1,0 +1,376 @@
+/*
+ * Portions Copyright (c) 2019 MagicStack Inc. and the EdgeDB authors.
+ *
+ * Portions Copyright (c) 1996-2018, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, The Regents of the University of California
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written agreement
+ * is hereby granted, provided that the above copyright notice and this
+ * paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+ * DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+
+#include "postgres.h"
+#include "fmgr.h"
+#include "utils/builtins.h"
+#include "utils/datetime.h"
+#include "utils/formatting.h"
+#include "utils/nabstime.h"
+#include "utils/guc.h"
+
+
+static int	tm2time(struct pg_tm *tm, fsec_t fsec, TimeADT *result);
+
+
+/* A version of to_timestamp() which errors out if the provided
+ * datetime format contains a timezone.
+ */
+PG_FUNCTION_INFO_V1(edb_to_timestamp);
+
+Datum
+edb_to_timestamp(PG_FUNCTION_ARGS)
+{
+	text	   *date_txt = PG_GETARG_TEXT_PP(0);
+	text	   *fmt = PG_GETARG_TEXT_PP(1);
+	Timestamp	result;
+	struct pg_tm tm;
+	fsec_t		fsec;
+
+	EdgeDBToTimestamp(date_txt, fmt, &tm, &fsec, EDGEDB_TZ_PROHIBITED);
+
+	if (tm.tm_zone)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_DATETIME_FORMAT),
+				 errmsg("cannot convert to timestamp: "
+				 	    "there is an explicit timezone")));
+
+	if (tm2timestamp(&tm, fsec, NULL, &result) != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("timestamp out of range")));
+
+	PG_RETURN_TIMESTAMP(result);
+}
+
+
+/* A version of to_timestamptz() which errors out if the provided
+ * datetime format contains *no* timezone.
+ */
+PG_FUNCTION_INFO_V1(edb_to_timestamptz);
+
+Datum
+edb_to_timestamptz(PG_FUNCTION_ARGS)
+{
+	text	   *date_txt = PG_GETARG_TEXT_PP(0);
+	text	   *fmt = PG_GETARG_TEXT_PP(1);
+	Timestamp	result;
+	int			tz;
+	struct pg_tm tm;
+	fsec_t		fsec;
+	int			dterr;
+
+	EdgeDBToTimestamp(date_txt, fmt, &tm, &fsec, EDGEDB_TZ_REQUIRED);
+
+	if (!tm.tm_zone)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_DATETIME_FORMAT),
+				 errmsg("cannot convert to timestamptz: "
+				 	    "there is no explicit timezone")));
+
+	dterr = DecodeTimezone((char *) tm.tm_zone, &tz);
+	if (dterr)
+		DateTimeParseError(dterr, text_to_cstring(date_txt), "timestamptz");
+
+	if (tm2timestamp(&tm, fsec, &tz, &result) != 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("timestamp out of range")));
+
+	PG_RETURN_TIMESTAMP(result);
+}
+
+
+/* A version of time_in() which errors out if the provided
+ * text contains a timezone.
+ */
+PG_FUNCTION_INFO_V1(edb_time_in);
+
+Datum
+edb_time_in(PG_FUNCTION_ARGS)
+{
+	text	   *txt = PG_GETARG_TEXT_PP(0);
+	char	   *str;
+
+	TimeADT		result;
+	fsec_t		fsec;
+	struct pg_tm tt,
+			   *tm = &tt;
+	int			nf;
+	int			dterr;
+	char		workbuf[MAXDATELEN + 1];
+	char	   *field[MAXDATEFIELDS];
+	int			dtype;
+	int			ftype[MAXDATEFIELDS];
+
+	str = text_to_cstring(txt);
+
+	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
+						  field, ftype, MAXDATEFIELDS, &nf);
+	if (dterr == 0)
+		dterr = DecodeTimeOnly(field, ftype, nf, &dtype, tm, &fsec, NULL);
+	if (dterr != 0)
+		DateTimeParseError(dterr, str, "time");
+
+	switch (dtype)
+	{
+		case DTK_TIME:
+			break;
+
+		case DTK_DATE:
+		case DTK_EPOCH:
+		case DTK_CURRENT:
+		case DTK_LATE:
+		case DTK_EARLY:
+		case DTK_INVALID:
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_DATETIME_FORMAT),
+					 errmsg("time value \"%s\" is not supported", str)));
+			break;
+
+		default:
+			DateTimeParseError(DTERR_BAD_FORMAT, str, "date");
+			break;
+	}
+
+	tm2time(tm, fsec, &result);
+	pfree(str);
+
+	PG_RETURN_TIMEADT(result);
+}
+
+
+/* A version of date_in() which errors out if the provided
+ * text contains a timezone.
+ */
+PG_FUNCTION_INFO_V1(edb_date_in);
+
+Datum
+edb_date_in(PG_FUNCTION_ARGS)
+{
+	text	   *txt = PG_GETARG_TEXT_PP(0);
+	char	   *str;
+	DateADT		date;
+	fsec_t		fsec;
+	struct pg_tm tt,
+			   *tm = &tt;
+	int			dtype;
+	int			nf;
+	int			dterr;
+	char	   *field[MAXDATEFIELDS];
+	int			ftype[MAXDATEFIELDS];
+	char		workbuf[MAXDATELEN + 1];
+
+	str = text_to_cstring(txt);
+
+	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
+						  field, ftype, MAXDATEFIELDS, &nf);
+	if (dterr == 0)
+		dterr = DecodeDateTime(field, ftype, nf, &dtype, tm, &fsec, NULL);
+	if (dterr != 0)
+		DateTimeParseError(dterr, str, "date");
+
+	switch (dtype)
+	{
+		case DTK_DATE:
+			break;
+
+		case DTK_EPOCH:
+			GetEpochTime(tm);
+			break;
+
+		case DTK_CURRENT:
+		case DTK_LATE:
+		case DTK_EARLY:
+		case DTK_INVALID:
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_DATETIME_FORMAT),
+					 errmsg("date value \"%s\" is not supported", str)));
+			break;
+
+		default:
+			DateTimeParseError(DTERR_BAD_FORMAT, str, "date");
+			break;
+	}
+
+	/* Prevent overflow in Julian-day routines */
+	if (!IS_VALID_JULIAN(tm->tm_year, tm->tm_mon, tm->tm_mday))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("date out of range: \"%s\"", str)));
+
+	date = date2j(tm->tm_year, tm->tm_mon, tm->tm_mday) - POSTGRES_EPOCH_JDATE;
+
+	/* Now check for just-out-of-range dates */
+	if (!IS_VALID_DATE(date))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("date out of range: \"%s\"", str)));
+
+	pfree(str);
+	PG_RETURN_DATEADT(date);
+}
+
+
+/* A version of timestamp_in() which errors out if the provided
+ * text contains a timezone.
+ */
+PG_FUNCTION_INFO_V1(edb_timestamp_in);
+
+Datum
+edb_timestamp_in(PG_FUNCTION_ARGS)
+{
+	text	   *txt = PG_GETARG_TEXT_PP(0);
+	char	   *str;
+
+	Timestamp	result;
+	fsec_t		fsec;
+	struct pg_tm tt,
+			   *tm = &tt;
+	int			dtype;
+	int			nf;
+	int			dterr;
+	char	   *field[MAXDATEFIELDS];
+	int			ftype[MAXDATEFIELDS];
+	char		workbuf[MAXDATELEN + MAXDATEFIELDS];
+
+	str = text_to_cstring(txt);
+
+	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
+						  field, ftype, MAXDATEFIELDS, &nf);
+	if (dterr == 0)
+		dterr = DecodeDateTime(field, ftype, nf, &dtype, tm, &fsec, NULL);
+	if (dterr != 0)
+		DateTimeParseError(dterr, str, "timestamp");
+
+	switch (dtype)
+	{
+		case DTK_DATE:
+			if (tm2timestamp(tm, fsec, NULL, &result) != 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_DATETIME_FORMAT),
+						 errmsg("timestamp out of range: \"%s\"", str)));
+			break;
+
+		case DTK_EPOCH:
+			result = SetEpochTimestamp();
+			break;
+
+		case DTK_CURRENT:
+		case DTK_LATE:
+		case DTK_EARLY:
+		case DTK_INVALID:
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("timestamp value \"%s\" is not supported", str)));
+			break;
+
+		default:
+			elog(ERROR, "unexpected dtype %d while parsing timestamp \"%s\"",
+				 dtype, str);
+			TIMESTAMP_NOEND(result);
+	}
+
+	pfree(str);
+	PG_RETURN_TIMESTAMP(result);
+}
+
+
+/* A version of timestamptz_in() which errors out if the provided
+ * text does not contain a timezone.
+ */
+PG_FUNCTION_INFO_V1(edb_timestamptz_in);
+
+Datum
+edb_timestamptz_in(PG_FUNCTION_ARGS)
+{
+	text	   *txt = PG_GETARG_TEXT_PP(0);
+	char	   *str;
+
+	TimestampTz result;
+	fsec_t		fsec;
+	struct pg_tm tt,
+			   *tm = &tt;
+	int			tz;
+	int			dtype;
+	int			nf;
+	int			dterr;
+	char	   *field[MAXDATEFIELDS];
+	int			ftype[MAXDATEFIELDS];
+	char		workbuf[MAXDATELEN + MAXDATEFIELDS];
+
+	str = text_to_cstring(txt);
+
+	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
+						  field, ftype, MAXDATEFIELDS, &nf);
+	if (dterr == 0)
+		dterr = EdgeDBDecodeDateTime(
+			field, ftype, nf, &dtype, tm, &fsec, &tz, EDGEDB_TZ_REQUIRED);
+	if (dterr != 0)
+		DateTimeParseError(dterr, str, "timestamptz");
+
+	switch (dtype)
+	{
+		case DTK_DATE:
+			if (tm2timestamp(tm, fsec, &tz, &result) != 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+						 errmsg("timestamptz out of range: \"%s\"", str)));
+			break;
+
+		case DTK_EPOCH:
+			result = SetEpochTimestamp();
+			break;
+
+		case DTK_CURRENT:
+		case DTK_LATE:
+		case DTK_EARLY:
+		case DTK_INVALID:
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_DATETIME_FORMAT),
+					 errmsg("timestamptz value \"%s\" is not supported", str)));
+			break;
+
+		default:
+			elog(ERROR, "unexpected dtype %d while parsing timestamptz \"%s\"",
+				 dtype, str);
+			TIMESTAMP_NOEND(result);
+	}
+
+	pfree(str);
+	PG_RETURN_TIMESTAMPTZ(result);
+}
+
+
+/* tm2time()
+ * Convert a tm structure to a time data type.
+ */
+static int
+tm2time(struct pg_tm *tm, fsec_t fsec, TimeADT *result)
+{
+	*result = ((((tm->tm_hour * MINS_PER_HOUR + tm->tm_min) * SECS_PER_MINUTE) +
+			tm->tm_sec) * USECS_PER_SEC) + fsec;
+	return 0;
+}

--- a/ext/edbsys--1.0.sql
+++ b/ext/edbsys--1.0.sql
@@ -19,6 +19,39 @@
 
 
 --
+-- Custom variants of to_timestamp()
+--
+CREATE FUNCTION to_timestamp(text, text)
+RETURNS timestamp
+AS '$libdir/edbsys', 'edb_to_timestamp'
+LANGUAGE C CALLED ON NULL INPUT IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION to_timestamptz(text, text)
+RETURNS timestamptz
+AS '$libdir/edbsys', 'edb_to_timestamptz'
+LANGUAGE C CALLED ON NULL INPUT IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION time_in(text)
+RETURNS time
+AS '$libdir/edbsys', 'edb_time_in'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION date_in(text)
+RETURNS date
+AS '$libdir/edbsys', 'edb_date_in'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION timestamp_in(text)
+RETURNS timestamp
+AS '$libdir/edbsys', 'edb_timestamp_in'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION timestamptz_in(text)
+RETURNS timestamptz
+AS '$libdir/edbsys', 'edb_timestamptz_in'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+--
 -- Return the given attribute value from a row value.
 --
 CREATE FUNCTION row_getattr_by_num(record, integer, anyelement)

--- a/setup.py
+++ b/setup.py
@@ -326,6 +326,23 @@ class build_postgres(setuptools.Command):
             pathlib.Path('build').resolve())
 
 
+class build_postgres_ext(setuptools.Command):
+
+    description = "build postgres extensions"
+
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self, *args, **kwargs):
+        _compile_postgres_extensions(
+            pathlib.Path('build').resolve())
+
+
 class build_ext(distutils_build_ext.build_ext):
 
     user_options = distutils_build_ext.build_ext.user_options + [
@@ -424,6 +441,7 @@ setuptools.setup(
         'build_ext': build_ext,
         'develop': develop,
         'build_postgres': build_postgres,
+        'build_postgres_ext': build_postgres_ext,
     },
     entry_points={
         'console_scripts': [

--- a/tests/schemas/issues_filter_setup.edgeql
+++ b/tests/schemas/issues_filter_setup.edgeql
@@ -61,7 +61,7 @@ INSERT Issue {
     body := 'Implicit path existence does not apply to NOT EXISTS.',
     owner := (SELECT User FILTER User.name = 'Elvis'),
     status := (SELECT Status FILTER Status.name = 'Open'),
-    due_date := <datetime>'2020/01/15',
+    due_date := <datetime>'2020/01/15T00:00:00+00:00',
 };
 
 WITH MODULE test
@@ -72,7 +72,7 @@ INSERT Issue {
     owner := (SELECT User FILTER User.name = 'Yury'),
     status := (SELECT Status FILTER Status.name = 'Open'),
     time_estimate := 9999,
-    due_date := <datetime>'2020/01/15',
+    due_date := <datetime>'2020/01/15T00:00:00+00:00',
 };
 
 WITH MODULE test

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -43,17 +43,20 @@ class TestEdgeQLDT(tb.QueryTestCase):
 
     async def test_edgeql_dt_datetime_01(self):
         await self.assert_query_result(
-            r'''SELECT <datetime>'2017-10-10' + <timedelta>'1 day';''',
+            r'''SELECT <datetime>'2017-10-10T00:00:00+00' +
+                <timedelta>'1 day';''',
             ['2017-10-11T00:00:00+00:00'],
         )
 
         await self.assert_query_result(
-            r'''SELECT <timedelta>'1 day' + <datetime>'2017-10-10';''',
+            r'''SELECT <timedelta>'1 day' +
+                <datetime>'2017-10-10 00:00:00+00';''',
             ['2017-10-11T00:00:00+00:00'],
         )
 
         await self.assert_query_result(
-            r'''SELECT <datetime>'2017-10-10' - <timedelta>'1 day';''',
+            r'''SELECT <datetime>'2017-10-10T00:00:00+00' -
+                <timedelta>'1 day';''',
             ['2017-10-09T00:00:00+00:00'],
         )
 
@@ -72,32 +75,37 @@ class TestEdgeQLDT(tb.QueryTestCase):
                 "operator '-' cannot be applied.*timedelta.*datetime"):
 
             await self.con.fetchall("""
-                SELECT <timedelta>'1 day' - <datetime>'2017-10-10';
+                SELECT <timedelta>'1 day' - <datetime>'2017-10-10T00:00:00+00';
             """)
 
     async def test_edgeql_dt_datetime_02(self):
         await self.assert_query_result(
-            r'''SELECT <str><datetime>'2017-10-10';''',
+            r'''SELECT <str><datetime>'2017-10-10T00:00:00+00';''',
             ['2017-10-10T00:00:00+00:00'],
         )
 
         await self.assert_query_result(
-            r'''SELECT <str>(<datetime>'2017-10-10' - <timedelta>'1 day');''',
+            r'''SELECT <str>(<datetime>'2017-10-10T00:00:00+00' -
+                             <timedelta>'1 day');
+            ''',
             ['2017-10-09T00:00:00+00:00'],
         )
 
     async def test_edgeql_dt_datetime_03(self):
         await self.assert_query_result(
-            r'''SELECT <tuple<str,datetime>>('foo', '2020-10-10');''',
-            [['foo', '2020-10-10T00:00:00+00:00']],
+            r'''SELECT <tuple<str,datetime>>(
+                'foo', '2017-10-10T00:00:00+00');
+            ''',
+            [['foo', '2017-10-10T00:00:00+00:00']],
         )
 
         await self.assert_query_result(
             r'''
-                SELECT (<tuple<str,datetime>>('foo', '2020-10-10')).1 +
+                SELECT (<tuple<str,datetime>>(
+                    'foo', '2017-10-10T00:00:00+00')).1 +
                    <timedelta>'1 month';
             ''',
-            ['2020-11-10T00:00:00+00:00'],
+            ['2017-11-10T00:00:00+00:00'],
         )
 
     async def test_edgeql_dt_local_datetime_01(self):

--- a/tests/test_edgeql_filter.py
+++ b/tests/test_edgeql_filter.py
@@ -42,7 +42,8 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                 FILTER
                     User.<owner[IS Issue].time_estimate > 9000
                     AND
-                    User.<owner[IS Issue].due_date = <datetime>'2020/01/15'
+                    User.<owner[IS Issue].due_date =
+                        <datetime>'2020/01/15T00:00:00+00:00'
                 ORDER BY User.name;
             ''',
             # Only one Issue satisfies this and its owner is Yury.
@@ -69,7 +70,8 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                                 ) OR
                                 NOT (
                                     EXISTS I.due_date
-                                    AND I.due_date = <datetime>'2020/01/15'
+                                    AND I.due_date =
+                                        <datetime>'2020/01/15T00:00:00+00:00'
                                 )
                             )
                     )
@@ -96,7 +98,8 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                                 NOT EXISTS I.time_estimate OR
                                 NOT EXISTS I.due_date OR
                                 I.time_estimate <= 9000 OR
-                                I.due_date != <datetime>'2020/01/15'
+                                I.due_date !=
+                                    <datetime>'2020/01/15T00:00:00+00:00'
                             )
                     )
                 ORDER BY User.name;
@@ -122,7 +125,7 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                         NOT EXISTS (User.<owner[IS Issue].time_estimate > 9000)
                         OR
                         NOT EXISTS (U2.<owner[IS Issue].due_date =
-                            <datetime>'2020/01/15')
+                            <datetime>'2020/01/15T00:00:00+00:00')
                     )
                     AND
                     # making sure it's the same Issue in both sub-clauses

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -1278,14 +1278,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 SELECT <str>to_datetime(
-                    2018, 5, 7, 15, 1, 22.306916);
-            ''',
-            ['2018-05-07T15:01:22.306916+00:00'],
-        )
-
-        await self.assert_query_result(
-            r'''
-                SELECT <str>to_datetime(
                     2018, 5, 7, 15, 1, 22.306916, 'EST');
             ''',
             ['2018-05-07T20:01:22.306916+00:00'],
@@ -1304,7 +1296,27 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             async with self.con.transaction():
                 await self.con.fetchall('SELECT to_datetime("2017-10-10", "")')
 
+    async def test_edgeql_functions_to_datetime_02(self):
+        await self.assert_query_result(
+            r'''
+                SELECT <str>to_datetime(
+                    to_local_datetime(2018, 5, 7, 15, 1, 22.306916),
+                    'EST')
+            ''',
+            ['2018-05-07T20:01:22.306916+00:00'],
+        )
+
     async def test_edgeql_functions_to_local_datetime_01(self):
+        await self.assert_query_result(
+            r'''
+                SELECT <str>to_local_datetime(
+                    <datetime>'2018-05-07T20:01:22.306916+00:00',
+                    'US/Pacific');
+            ''',
+            ['2018-05-07T13:01:22.306916'],
+        )
+
+    async def test_edgeql_functions_to_local_datetime_02(self):
         await self.assert_query_result(
             r'''
                 SELECT <str>to_local_datetime(2018, 5, 7, 15, 1, 22.306916);
@@ -1326,6 +1338,16 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                 await self.con.fetchall(
                     'SELECT to_local_date("2017-10-10", "")')
 
+    async def test_edgeql_functions_to_local_date_02(self):
+        await self.assert_query_result(
+            r'''
+                SELECT <str>to_local_date(
+                    <datetime>'2018-05-07T20:01:22.306916+00:00',
+                    'US/Pacific');
+            ''',
+            ['2018-05-07'],
+        )
+
     async def test_edgeql_functions_to_local_time_01(self):
         await self.assert_query_result(
             r'''
@@ -1338,6 +1360,16 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall('SELECT to_local_time("12:00:00", "")')
+
+    async def test_edgeql_functions_to_local_time_02(self):
+        await self.assert_query_result(
+            r'''
+                SELECT <str>to_local_time(
+                    <datetime>'2018-05-07T20:01:22.306916+00:00',
+                    'US/Pacific');
+            ''',
+            ['13:01:22.306916'],
+        )
 
     async def test_edgeql_functions_to_timedelta_01(self):
         await self.assert_query_result(
@@ -1420,7 +1452,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH D := <local_date>datetime_current()
+            WITH D := to_local_date(datetime_current(), 'UTC')
             SELECT <str>D = to_str(D);
             ''',
             [True],
@@ -1428,7 +1460,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH NT := <local_time>datetime_current()
+            WITH NT := to_local_time(datetime_current(), 'UTC')
             SELECT <str>NT = to_str(NT);
             ''',
             [True],


### PR DESCRIPTION
* It's no longer possible to cast a string without an explicit
  timezone into a std::datetime.  Likewise, std::local_time,
  std::local_date, and std::local_datetime reject string values
  with a timezone.