### PR TITLE
Implement `edgedb configure` CLI command

### DIFF
--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -61,11 +61,6 @@ CREATE TYPE cfg::SCRAM EXTENDING cfg::AuthMethod;
 
 
 CREATE TYPE cfg::Auth {
-    CREATE REQUIRED PROPERTY name -> std::str {
-        CREATE CONSTRAINT std::exclusive;
-        SET readonly := true;
-    };
-
     CREATE REQUIRED PROPERTY priority -> std::int64 {
         CREATE CONSTRAINT std::exclusive;
         SET readonly := true;
@@ -88,6 +83,10 @@ CREATE TYPE cfg::Auth {
 
     CREATE SINGLE LINK method -> cfg::AuthMethod {
         CREATE CONSTRAINT std::exclusive;
+    };
+
+    CREATE PROPERTY comment -> std::str {
+        SET readonly := true;
     };
 };
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -392,7 +392,6 @@ async def _configure(schema, conn, cluster, insecure=False):
     if insecure:
         scripts.append('''
             CONFIGURE SYSTEM INSERT Auth {
-                name := 'default',
                 priority := 0,
                 method := (INSERT Trust),
             };

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -269,8 +269,7 @@ class Cluster:
     def trust_local_connections(self):
         self._admin_query('''
             CONFIGURE SYSTEM INSERT Auth {
-                name := 'default',
-                host := 'loalhost',
+                host := 'localhost',
                 priority := 0,
                 method := (INSERT Trust),
             }

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -64,7 +64,7 @@ class TestServerAuth(tb.ConnectedTestCase):
 
         await self.con.fetchall('''
             CONFIGURE SYSTEM INSERT Auth {
-                name := 'test',
+                comment := 'test',
                 priority := 0,
                 method := (INSERT Trust),
             }
@@ -94,7 +94,7 @@ class TestServerAuth(tb.ConnectedTestCase):
             # insert password auth with a higher priority
             await self.con.fetchall('''
                 CONFIGURE SYSTEM INSERT Auth {
-                    name := 'test-2',
+                    comment := 'test-2',
                     priority := -1,
                     method := (INSERT SCRAM),
                 }
@@ -110,11 +110,11 @@ class TestServerAuth(tb.ConnectedTestCase):
                 )
         finally:
             await self.con.fetchall('''
-                CONFIGURE SYSTEM RESET Auth FILTER .name = 'test'
+                CONFIGURE SYSTEM RESET Auth FILTER .comment = 'test'
             ''')
 
             await self.con.fetchall('''
-                CONFIGURE SYSTEM RESET Auth FILTER .name = 'test-2'
+                CONFIGURE SYSTEM RESET Auth FILTER .comment = 'test-2'
             ''')
 
             await self.con.fetchall('''


### PR DESCRIPTION
The new `configure` CLI subcommand allows for reasonably complete control
over the system configuration and is largely equivalent to the
`CONFIGURE SYSTEM` statement.

The available subcommands mirror those of `CONFIGURE SYSTEM`:

    edgedb configure set <param> <value>
    edgedb configure reset <param>
    edgedb configure insert <cfgobj> --prop1=val1 --prop2=val2 ...
    edgedb configure reset <cfgobj> --prop1=val1 ...