### PR TITLE
Add support for view declarations to SDL

### DIFF
--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -72,7 +72,11 @@ def compile_migration(cmd, target_schema, current_schema):
 
     stdmodules = s_schema.STD_MODULES
     moditems = target_schema.get_objects(type=modules.Module)
-    modnames = {m.get_name(target_schema) for m in moditems} - stdmodules
+    modnames = (
+        {m.get_name(target_schema) for m in moditems}
+        - stdmodules
+        - {'__derived__'}
+    )
     if len(modnames) != 1:
         raise RuntimeError('unexpected delta module structure')
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1087,10 +1087,6 @@ class AlterObject(CreateOrAlterObject):
 
     def _alter_refs(self, schema, context, scls, refdict):
         for op in self.get_subcommands(metaclass=refdict.ref_cls):
-            derived_from = op.get_attribute_value('derived_from')
-            if derived_from is not None:
-                continue
-
             schema, _ = op.apply(schema, context=context)
         return schema
 

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -51,11 +51,15 @@ def sort_objects(schema, objects):
 
         if isinstance(obj, inheriting.InheritingObject):
             obj_bases = obj.get_bases(schema)
+            derived_from = obj.get_derived_from(schema)
         else:
             obj_bases = None
+            derived_from = None
+
+        deps = g[obj.get_name(schema)]['deps']
 
         if obj_bases:
-            g[obj.get_name(schema)]['deps'].extend(
+            deps.extend(
                 b.get_name(schema)
                 for b in obj_bases.objects(schema))
 
@@ -63,6 +67,9 @@ def sort_objects(schema, objects):
                 base_name = base.get_name(schema)
                 if base_name.module != obj.get_name(schema).module:
                     g[base_name] = {'item': base, 'merge': [], 'deps': []}
+
+        if derived_from is not None:
+            deps.append(derived_from.get_name(schema))
 
     if not g:
         return ordered.OrderedSet()

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -53,3 +53,16 @@ type Card extending Named {
 type SpecialCard extending Card;
 
 type Award extending Named;
+
+
+view WaterOrEarthCard := (
+    SELECT Card {
+        owned_by_alice := EXISTS (SELECT Card.<deck[IS User].name = 'Alice')
+    }
+    FILTER .element = 'Water' OR .element = 'Earth'
+);
+
+
+view EarthOrFireCard {
+    expr := (SELECT Card FILTER .element = 'Fire' OR .element = 'Earth')
+};

--- a/tests/test_edgeql_views.py
+++ b/tests/test_edgeql_views.py
@@ -715,3 +715,45 @@ class TestEdgeQLViews(tb.QueryTestCase):
             """,
             res
         )
+
+    async def test_edgeql_views_esdl_01(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test
+                SELECT WaterOrEarthCard {
+                    name,
+                    owned_by_alice,
+                }
+                FILTER .name ILIKE {'%turtle%', 'dwarf'}
+                ORDER BY .name;
+            """,
+            [
+                {
+                    'name': 'Dwarf',
+                    'owned_by_alice': True,
+                },
+                {
+                    'name': 'Giant turtle',
+                    'owned_by_alice': True,
+                },
+            ]
+        )
+
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test
+                SELECT EarthOrFireCard {
+                    name,
+                }
+                FILTER .name = {'Imp', 'Dwarf'}
+                ORDER BY .name;
+            """,
+            [
+                {
+                    'name': 'Dwarf'
+                },
+                {
+                    'name': 'Imp'
+                },
+            ]
+        )


### PR DESCRIPTION
There is now limited support for view declarations in SDL.  Most notable
limitation currently is that views are processed _last_, so any
references to them in other expressions in the same SDL module will
fail to resolve.  This stems from the lack of dependency resolution on
the expression level.