### PR TITLE
Make std::bool parsing logic strict.

### DIFF
--- a/edb/lib/std/25-booloperators.edgeql
+++ b/edb/lib/std/25-booloperators.edgeql
@@ -96,7 +96,7 @@ std::`<` (l: std::bool, r: std::bool) -> std::bool
 ## -------------
 
 CREATE CAST FROM std::str TO std::bool
-    FROM SQL CAST;
+    FROM SQL FUNCTION 'edgedb.bool_in';
 
 
 CREATE CAST FROM std::bool TO std::str

--- a/ext/Makefile
+++ b/ext/Makefile
@@ -17,7 +17,7 @@
 #
 
 MODULE_big = edbsys
-OBJS = module.o datetime.o recordext.o numop.o $(WIN32RES)
+OBJS = module.o datetime.o bool.o recordext.o numop.o $(WIN32RES)
 
 EXTENSION = edbsys
 DATA = edbsys--1.0.sql

--- a/ext/bool.c
+++ b/ext/bool.c
@@ -1,0 +1,88 @@
+/*
+ * Portions Copyright (c) 2019 MagicStack Inc. and the EdgeDB authors.
+ *
+ * Portions Copyright (c) 1996-2018, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, The Regents of the University of California
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written agreement
+ * is hereby granted, provided that the above copyright notice and this
+ * paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+ * DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+
+#include "postgres.h"
+#include "fmgr.h"
+#include "utils/builtins.h"
+
+
+/* A version of boolin() that only accepts variants of "true" and "false"
+ * as valid text representation of std::bool.
+ */
+PG_FUNCTION_INFO_V1(edb_bool_in);
+
+Datum
+edb_bool_in(PG_FUNCTION_ARGS)
+{
+	text	   *txt = PG_GETARG_TEXT_PP(0);
+	char	   *in_str;
+	char	   *str;
+	size_t		len;
+	bool		result;
+	bool		valid;
+
+	in_str = text_to_cstring(txt);
+
+	str = in_str;
+	while (isspace((unsigned char) *str))
+		str++;
+
+	len = strlen(str);
+	while (len > 0 && isspace((unsigned char) str[len - 1]))
+		len--;
+
+	result = false;
+	valid = false;
+	switch (*str)
+	{
+		case 't':
+		case 'T':
+			if (pg_strncasecmp(str, "true", len) == 0)
+			{
+				result = true;
+				valid = true;
+			}
+			break;
+		case 'f':
+		case 'F':
+			if (pg_strncasecmp(str, "false", len) == 0)
+			{
+				result = false;
+				valid = true;
+			}
+			break;
+		default:
+			break;
+	}
+
+	pfree(in_str);
+
+	if (!valid)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("invalid syntax for bool: \"%s\"", in_str)));
+
+	PG_RETURN_BOOL(result);
+}

--- a/ext/datetime.c
+++ b/ext/datetime.c
@@ -29,7 +29,6 @@
 #include "utils/datetime.h"
 #include "utils/formatting.h"
 #include "utils/nabstime.h"
-#include "utils/guc.h"
 
 
 static int	tm2time(struct pg_tm *tm, fsec_t fsec, TimeADT *result);

--- a/ext/edbsys--1.0.sql
+++ b/ext/edbsys--1.0.sql
@@ -19,8 +19,9 @@
 
 
 --
--- Custom variants of to_timestamp()
+-- Custom variants of date/time functions.
 --
+
 CREATE FUNCTION to_timestamp(text, text)
 RETURNS timestamp
 AS '$libdir/edbsys', 'edb_to_timestamp'
@@ -50,6 +51,16 @@ CREATE FUNCTION timestamptz_in(text)
 RETURNS timestamptz
 AS '$libdir/edbsys', 'edb_timestamptz_in'
 LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+
+--
+-- Custom variant of the bool cast.
+--
+CREATE FUNCTION bool_in(text)
+RETURNS boolean
+AS '$libdir/edbsys', 'edb_bool_in'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
 
 --
 -- Return the given attribute value from a row value.

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2250,68 +2250,6 @@ class TestExpressions(tb.QueryTestCase):
             [[123, 11]],
         )
 
-    async def test_edgeql_expr_cast_06(self):
-        await self.assert_query_result(
-            r'''SELECT <array<bool>>['t', 'tr', 'tru', 'true'];''',
-            [[True, True, True, True]],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <array<bool>>['T', 'TR', 'TRU', 'TRUE'];''',
-            [[True, True, True, True]],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <array<bool>>['True', 'TrUe', '1'];''',
-            [[True, True, True]],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <array<bool>>['y', 'ye', 'yes'];''',
-            [[True, True, True]],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <array<bool>>['Y', 'YE', 'YES'];''',
-            [[True, True, True]],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <array<bool>>['Yes', 'yEs', 'YeS'];''',
-            [[True, True, True]],
-        )
-
-    async def test_edgeql_expr_cast_07(self):
-        await self.assert_query_result(
-            r'''SELECT <array<bool>>['f', 'fa', 'fal', 'fals', 'false'];''',
-            [[False, False, False, False, False]],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <array<bool>>['F', 'FA', 'FAL', 'FALS', 'FALSE'];''',
-            [[False, False, False, False, False]],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <array<bool>>['False', 'FaLSe', '0'];''',
-            [[False, False, False]],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <array<bool>>['n', 'no'];''',
-            [[False, False]],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <array<bool>>['N', 'NO'];''',
-            [[False, False]],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <array<bool>>['No', 'nO'];''',
-            [[False, False]],
-        )
-
     async def test_edgeql_expr_cast_08(self):
         with self.assertRaisesRegex(edgedb.QueryError,
                                     r'cannot cast.*tuple.*to.*array.*'):


### PR DESCRIPTION
We now only accept 'true' or 'false' (case-insensitive and with
optional whitespace) as valid string boolean representations:

* <bool>'true', <bool>'True', <bool>'  fAlse' -- are all fine;
* <bool>'yes', <bool>'1' -- are now illegal.