### PR TITLE
Prevent schema objects with live references from being dropped

### DIFF
--- a/edb/schema/abc.py
+++ b/edb/schema/abc.py
@@ -33,15 +33,19 @@ class Constraint(Object):
     pass
 
 
-class Function(Object):
+class Callable(Object):
     pass
 
 
-class Operator(Object):
+class Function(Callable):
     pass
 
 
-class Cast(Object):
+class Operator(Callable):
+    pass
+
+
+class Cast(Callable):
     pass
 
 
@@ -70,4 +74,16 @@ class Tuple(Collection):
 
 
 class Array(Collection):
+    pass
+
+
+class Pointer(Object):
+    pass
+
+
+class Property(Pointer):
+    pass
+
+
+class Link(Pointer):
     pass

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -23,6 +23,7 @@ from edb.edgeql import ast as qlast
 
 from edb import errors
 
+from . import abc as s_abc
 from . import constraints
 from . import delta as sd
 from . import indexes
@@ -83,7 +84,7 @@ def merge_actions(target: so.Object, sources: typing.List[so.Object],
         return ours
 
 
-class Link(sources.Source, pointers.Pointer):
+class Link(sources.Source, pointers.Pointer, s_abc.Link):
 
     schema_class_displayname = 'link'
 

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -21,6 +21,7 @@ from edb.edgeql import ast as qlast
 
 from edb import errors
 
+from . import abc as s_abc
 from . import constraints
 from . import delta as sd
 from . import inheriting
@@ -32,7 +33,7 @@ from . import sources
 from . import utils
 
 
-class Property(pointers.Pointer):
+class Property(pointers.Pointer, s_abc.Property):
 
     schema_class_displayname = 'property'
 
@@ -326,6 +327,8 @@ class DeleteProperty(PropertyCommand, inheriting.DeleteInheritingObject):
             target = prop.get_target(schema)
 
             if target.is_collection():
-                sd.cleanup_schema_collection(schema, target, prop, cmd)
+                sd.cleanup_schema_collection(
+                    schema, target, prop, cmd, context=context,
+                    src_context=astnode.context)
 
         return cmd

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -101,7 +101,7 @@ class PointerLike:
 
 
 class Pointer(constraints.ConsistencySubject, attributes.AttributeSubject,
-              PointerLike):
+              PointerLike, s_abc.Pointer):
 
     source = so.SchemaField(
         so.Object,


### PR DESCRIPTION
Use schema reference tracking to prohibit dropping schema objects that
have at least one live schema object referencing it.  This mechanism
obviously relies on the completeness of the schema reference tracking,
so this protection is not complete yet.  Most notably, expressions are
not considered as sources of references yet, so it's still possible to
corrupt the schema by dropping an object used in a view, for example.
Nonetheless, this is an important step toward ensuring that the schema
is always consistent.