### PR TITLE
edgeql: Rename some schema types.

### DIFF
--- a/docs/edgeql/introspection/indexes.rst
+++ b/docs/edgeql/introspection/indexes.rst
@@ -7,7 +7,7 @@ Indexes
 This section describes introspection of :ref:`indexes
 <ref_datamodel_indexes>`.
 
-Introspection of the ``schema::SourceIndex``:
+Introspection of the ``schema::Index``:
 
 .. code-block:: edgeql-repl
 
@@ -21,10 +21,10 @@ Introspection of the ``schema::SourceIndex``:
     ...         name,
     ...     }
     ... }
-    ... FILTER .name = 'schema::SourceIndex';
+    ... FILTER .name = 'schema::Index';
     {
         Object {
-            name: 'schema::SourceIndex',
+            name: 'schema::Index',
             links: {Object { name: '__type__' }},
             properties: {
                 Object { name: 'expr' },
@@ -57,7 +57,7 @@ Introspection of ``user_name_idx``:
 .. code-block:: edgeql-repl
 
     db> WITH MODULE schema
-    ... SELECT SourceIndex {
+    ... SELECT Index {
     ...     name,
     ...     expr,
     ... }

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -589,7 +589,7 @@ class DeclarationLoader:
                 anchors={qlast.Subject: subject},
                 inline_anchors=True)
 
-            self._schema, index = s_indexes.SourceIndex.create_in_schema(
+            self._schema, index = s_indexes.Index.create_in_schema(
                 self._schema,
                 name=der_name,
                 expr=s_expr.Expression(text=index_expr),

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -56,10 +56,10 @@ ALTER TYPE std::Object {
 CREATE TYPE schema::Module EXTENDING schema::Object;
 
 
-CREATE ABSTRACT TYPE schema::ContainerType EXTENDING schema::Type;
+CREATE ABSTRACT TYPE schema::CollectionType EXTENDING schema::Type;
 
 
-CREATE TYPE schema::Array EXTENDING schema::ContainerType {
+CREATE TYPE schema::Array EXTENDING schema::CollectionType {
     CREATE REQUIRED LINK element_type -> schema::Type;
     CREATE PROPERTY dimensions -> array<std::int16>;
 };
@@ -72,7 +72,7 @@ CREATE TYPE schema::TypeElement {
 };
 
 
-CREATE TYPE schema::Tuple EXTENDING schema::ContainerType {
+CREATE TYPE schema::Tuple EXTENDING schema::CollectionType {
     CREATE MULTI LINK element_types -> schema::TypeElement {
         CREATE CONSTRAINT std::exclusive;
     };
@@ -160,13 +160,13 @@ ALTER TYPE schema::Constraint {
 };
 
 
-CREATE TYPE schema::SourceIndex EXTENDING schema::Object {
+CREATE TYPE schema::Index EXTENDING schema::Object {
     CREATE PROPERTY expr -> std::str;
 };
 
 
 CREATE ABSTRACT TYPE schema::Source EXTENDING schema::Object {
-    CREATE MULTI LINK indexes -> schema::SourceIndex {
+    CREATE MULTI LINK indexes -> schema::Index {
         CREATE CONSTRAINT std::exclusive;
     };
 };

--- a/edb/pgsql/datasources/schema/indexes.py
+++ b/edb/pgsql/datasources/schema/indexes.py
@@ -36,7 +36,7 @@ async def fetch(
                 edgedb._resolve_type_name(i.subject)
                                 AS subject_name
             FROM
-                edgedb.SourceIndex i
+                edgedb.Index i
             WHERE
                 ($1::text[] IS NULL
                  OR split_part(i.name, '::', 1) = any($1::text[]))

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1509,16 +1509,14 @@ class CompositeObjectMetaCommand(ObjectMetaCommand):
         return schema
 
 
-class SourceIndexCommand(sd.ObjectCommand,
-                         metaclass=ReferencedObjectCommandMeta):
-    _table = metaschema.get_metaclass_table(s_indexes.SourceIndex)
+class IndexCommand(sd.ObjectCommand, metaclass=ReferencedObjectCommandMeta):
+    _table = metaschema.get_metaclass_table(s_indexes.Index)
 
     def get_table(self, schema):
         return self._table
 
 
-class CreateSourceIndex(SourceIndexCommand, CreateObject,
-                        adapts=s_indexes.CreateSourceIndex):
+class CreateIndex(IndexCommand, CreateObject, adapts=s_indexes.CreateIndex):
 
     def apply(self, schema, context):
         schema, index = CreateObject.apply(self, schema, context)
@@ -1555,11 +1553,10 @@ class CreateSourceIndex(SourceIndexCommand, CreateObject,
         return schema, index
 
 
-class RenameSourceIndex(SourceIndexCommand, RenameObject,
-                        adapts=s_indexes.RenameSourceIndex):
+class RenameIndex(IndexCommand, RenameObject, adapts=s_indexes.RenameIndex):
 
     def apply(self, schema, context):
-        schema, index = s_indexes.RenameSourceIndex.apply(
+        schema, index = s_indexes.RenameIndex.apply(
             self, schema, context)
         schema, _ = RenameObject.apply(self, schema, context)
 
@@ -1569,7 +1566,7 @@ class RenameSourceIndex(SourceIndexCommand, RenameObject,
         orig_table_name = common.get_backend_name(
             subject.original_schema, index, catenate=False)
 
-        index_ctx = context.get(s_indexes.SourceIndexCommandContext)
+        index_ctx = context.get(s_indexes.IndexCommandContext)
 
         orig_schema = index_ctx.original_schema
         module = schema.get_global(
@@ -1589,21 +1586,19 @@ class RenameSourceIndex(SourceIndexCommand, RenameObject,
         return schema, index
 
 
-class AlterSourceIndex(SourceIndexCommand, AlterObject,
-                       adapts=s_indexes.AlterSourceIndex):
+class AlterIndex(IndexCommand, AlterObject, adapts=s_indexes.AlterIndex):
     def apply(self, schema, context=None):
-        schema, result = s_indexes.AlterSourceIndex.apply(
+        schema, result = s_indexes.AlterIndex.apply(
             self, schema, context)
         schema, _ = AlterObject.apply(self, schema, context)
         return schema, result
 
 
-class DeleteSourceIndex(SourceIndexCommand, DeleteObject,
-                        adapts=s_indexes.DeleteSourceIndex):
+class DeleteIndex(IndexCommand, DeleteObject, adapts=s_indexes.DeleteIndex):
 
     def apply(self, schema, context=None):
         orig_schema = schema
-        schema, index = s_indexes.DeleteSourceIndex.apply(
+        schema, index = s_indexes.DeleteIndex.apply(
             self, schema, context)
         schema, _ = DeleteObject.apply(self, schema, context)
 

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -571,7 +571,7 @@ class IntrospectionMech:
                             f'the corresponding PostgreSQL index is missing.'
                 ) from None
 
-            schema, index = s_indexes.SourceIndex.create_in_schema(
+            schema, index = s_indexes.Index.create_in_schema(
                 schema,
                 id=index_data['id'],
                 name=index_name,

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -29,7 +29,7 @@ from . import referencing
 from . import utils as s_utils
 
 
-class SourceIndex(inheriting.InheritingObject):
+class Index(inheriting.InheritingObject):
 
     subject = so.SchemaField(so.Object)
 
@@ -49,7 +49,7 @@ class IndexableSubject(inheriting.InheritingObject):
     indexes_refs = so.RefDict(
         attr='indexes',
         local_attr='own_indexes',
-        ref_cls=SourceIndex)
+        ref_cls=Index)
 
     indexes = so.SchemaField(
         so.ObjectIndexByShortname,
@@ -73,14 +73,14 @@ class IndexSourceCommand(inheriting.InheritingObjectCommand):
     pass
 
 
-class SourceIndexCommandContext(sd.ObjectCommandContext):
+class IndexCommandContext(sd.ObjectCommandContext):
     pass
 
 
-class SourceIndexCommand(referencing.ReferencedObjectCommand,
-                         schema_metaclass=SourceIndex,
-                         context_class=SourceIndexCommandContext,
-                         referrer_context_class=IndexSourceCommandContext):
+class IndexCommand(referencing.ReferencedObjectCommand,
+                   schema_metaclass=Index,
+                   context_class=IndexCommandContext,
+                   referrer_context_class=IndexSourceCommandContext):
     @classmethod
     def _classname_from_ast(cls, schema, astnode, context):
         parent_ctx = context.get(sd.CommandContextToken)
@@ -94,7 +94,7 @@ class SourceIndexCommand(referencing.ReferencedObjectCommand,
         return sn.Name(name=idx_name, module=subject_name.module)
 
 
-class CreateSourceIndex(SourceIndexCommand, sd.CreateObject):
+class CreateIndex(IndexCommand, sd.CreateObject):
     astnode = qlast.CreateIndex
 
     @classmethod
@@ -137,13 +137,13 @@ class CreateSourceIndex(SourceIndexCommand, sd.CreateObject):
             super()._apply_field_ast(schema, context, node, op)
 
 
-class RenameSourceIndex(SourceIndexCommand, sd.RenameObject):
+class RenameIndex(IndexCommand, sd.RenameObject):
     pass
 
 
-class AlterSourceIndex(SourceIndexCommand, sd.AlterObject):
+class AlterIndex(IndexCommand, sd.AlterObject):
     pass
 
 
-class DeleteSourceIndex(SourceIndexCommand, sd.DeleteObject):
+class DeleteIndex(IndexCommand, sd.DeleteObject):
     astnode = qlast.DropIndex

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -474,7 +474,7 @@ class CreateLink(LinkCommand, referencing.CreateReferencedInheritingObject):
         objtype = context.get(LinkSourceCommandContext)
 
         if not objtype:
-            for op in self.get_subcommands(type=indexes.SourceIndexCommand):
+            for op in self.get_subcommands(type=indexes.IndexCommand):
                 self._append_subcmd_ast(schema, node, op, context)
 
         for op in self.get_subcommands(type=constraints.ConstraintCommand):
@@ -611,7 +611,7 @@ class AlterLink(LinkCommand, sd.AlterObject):
         objtype = context.get(LinkSourceCommandContext)
 
         if not objtype:
-            for op in self.get_subcommands(type=indexes.SourceIndexCommand):
+            for op in self.get_subcommands(type=indexes.IndexCommand):
                 self._append_subcmd_ast(schema, node, op, context)
 
         for op in self.get_subcommands(type=constraints.ConstraintCommand):
@@ -663,7 +663,7 @@ class DeleteLink(LinkCommand, sd.DeleteObject):
             self._append_subcmd_ast(schema, node, op, context)
 
         if not objtype:
-            for op in self.get_subcommands(type=indexes.SourceIndexCommand):
+            for op in self.get_subcommands(type=indexes.IndexCommand):
                 self._append_subcmd_ast(schema, node, op, context)
 
         for op in self.get_subcommands(type=constraints.ConstraintCommand):

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -606,12 +606,12 @@ class TestIntrospection(tb.QueryTestCase):
         )
 
     @test.xfail('''
-        ContainerType queries cause the following error:
+        CollectionType queries cause the following error:
         relation "edgedbss.6b1e0cfa-1511-11e9-8f2e-b5ee4369b429" does not exist
     ''')
     async def test_edgeql_introspection_meta_06(self):
         await self.assert_query_result(
-            r'''SELECT count(schema::ContainerType) > 0;''',
+            r'''SELECT count(schema::CollectionType) > 0;''',
             [True],
         )
 
@@ -626,32 +626,34 @@ class TestIntrospection(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
-            r'''SELECT count(schema::ContainerType) < count(schema::Type);''',
+            r'''SELECT count(schema::CollectionType) < count(schema::Type);''',
             [True],
         )
 
         await self.assert_query_result(
-            r'''SELECT count(schema::Array) < count(schema::ContainerType);''',
+            r'''SELECT count(schema::Array) <
+                    count(schema::CollectionType);''',
             [True],
         )
 
         await self.assert_query_result(
-            r'''SELECT count(schema::Tuple) < count(schema::ContainerType);''',
+            r'''SELECT count(schema::Tuple) <
+                    count(schema::CollectionType);''',
             [True],
         )
 
         await self.assert_query_result(
-            r'''SELECT DISTINCT (schema::ContainerType IS schema::Type);''',
+            r'''SELECT DISTINCT (schema::CollectionType IS schema::Type);''',
             [True],
         )
 
         await self.assert_query_result(
-            r'''SELECT DISTINCT (schema::Array IS schema::ContainerType);''',
+            r'''SELECT DISTINCT (schema::Array IS schema::CollectionType);''',
             [True],
         )
 
         await self.assert_query_result(
-            r'''SELECT DISTINCT (schema::Tuple IS schema::ContainerType);''',
+            r'''SELECT DISTINCT (schema::Tuple IS schema::CollectionType);''',
             [True],
         )
 


### PR DESCRIPTION
`SourceIndex` is now `Index`.
`ContainerType` is now `CollectionType`.