### PR TITLE
Allow shortcut paths in simple computable expressions

### DIFF
--- a/docs/datamodel/computables.rst
+++ b/docs/datamodel/computables.rst
@@ -36,6 +36,18 @@ last name:
              __source__.lastname);
     }
 
+If the computable expression is simple (i.e. not a subquery), shortcut
+paths may also be used instead of explicit references to ``__source__``:
+
+.. code-block:: sdl
+
+    type User {
+        required property firstname -> str;
+        required property lastname -> str;
+        property fullname := (
+            .firstname ++ ' ' ++ .lastname);
+    }
+
 Computables are also often used in :ref:`views <ref_datamodel_views>`.
 For example, using the ``User`` from the above example, a ``UserView``
 can be defined with a ``lastname_first`` computable which lists the
@@ -46,8 +58,7 @@ lists:
 
     view UserView := User {
         lastname_first := (
-            __source__.lastname ++ ', ' ++
-            __source__.firstname)
+            .lastname ++ ', ' ++ .firstname)
     }
 
 Computables can be used in :ref:`shapes <ref_eql_expr_shapes>`, too:
@@ -56,6 +67,5 @@ Computables can be used in :ref:`shapes <ref_eql_expr_shapes>`, too:
 
     SELECT User {
         lastname_first := (
-            __source__.lastname ++ ', ' ++
-            __source__.firstname)
+            .lastname ++ ', ' ++ .firstname)
     };

--- a/docs/tutorial/queries.rst
+++ b/docs/tutorial/queries.rst
@@ -235,10 +235,9 @@ the ``first_name`` and ``last_name`` properties. This time we will use
     .........         property first_name -> str;
     .........         required property last_name -> str;
     .........         property name :=
-    .........             __source__.first_name ++ ' ' ++
-    .........             __source__.last_name
-    .........             IF EXISTS __source__.first_name ELSE
-    .........             __source__.last_name;
+    .........             .first_name ++ ' ' ++ .last_name
+    .........             IF EXISTS .first_name
+    .........             ELSE .last_name;
     .........     }
     ......... };
     CREATE MIGRATION

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -791,6 +791,7 @@ def computable_ptr_set(
             source_scls, ptrcls=ptrcls, rptr=rptr)
         subctx.anchors[qlast.Source] = source_set
         subctx.empty_result_type_hint = ptrcls.get_target(ctx.env.schema)
+        subctx.partial_path_prefix = source_set
 
         if isinstance(qlexpr, qlast.Statement) and unnest_fence:
             subctx.stmt_metadata[qlexpr] = context.StatementMetadata(

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -68,6 +68,10 @@ def compile_SelectQuery(
     with ctx.subquery() as sctx:
         stmt = irast.SelectStmt()
         init_stmt(stmt, expr, ctx=sctx, parent_ctx=ctx)
+        if expr.implicit:
+            # Make sure path prefix does not get blown away by
+            # implicit subqueries.
+            sctx.partial_path_prefix = ctx.partial_path_prefix
 
         compile_limit_offset = False
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -366,6 +366,8 @@ def _normalize_view_ptr_expr(
                 is_insert=is_insert, is_update=is_update)
 
             shape_expr_ctx.path_scope.unnest_fence = True
+            shape_expr_ctx.partial_path_prefix = setgen.class_set(
+                view_scls, path_id=path_id, ctx=shape_expr_ctx)
 
             if is_mutation and ptrcls is not None:
                 shape_expr_ctx.expr_exposed = True

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -761,6 +761,7 @@ class DeclarationLoader:
             expr, self._schema,
             modaliases=module_aliases,
             anchors={qlast.Source: source},
+            path_prefix_anchor=qlast.Source,
             singletons=[source])
 
         expr_type = ir.stype

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -87,11 +87,13 @@ def index_parameters(ql_args: typing.List[qlast.Base], *,
 
 
 def normalize_tree(expr, schema, *, modaliases=None, anchors=None,
-                   inline_anchors=False, singletons=None):
+                   path_prefix_anchor=None, inline_anchors=False,
+                   singletons=None):
 
     ir = compiler.compile_ast_to_ir(
         expr, schema, modaliases=modaliases,
-        anchors=anchors, singletons=singletons)
+        anchors=anchors, path_prefix_anchor=path_prefix_anchor,
+        singletons=singletons)
 
     edgeql_tree = compiler.decompile_ir(
         ir, inline_anchors=inline_anchors, schema=ir.schema)

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -155,8 +155,7 @@ CREATE ABSTRACT TYPE schema::ConsistencySubject EXTENDING schema::Object {
 
 
 ALTER TYPE schema::Constraint {
-    CREATE LINK subject :=
-        __source__.<constraints[IS schema::ConsistencySubject];
+    CREATE LINK subject := .<constraints[IS schema::ConsistencySubject];
 };
 
 
@@ -233,14 +232,14 @@ ALTER TYPE schema::Pointer {
 
 
 ALTER TYPE schema::Link {
-    CREATE LINK properties := __source__.pointers;
+    CREATE LINK properties := .pointers;
     CREATE PROPERTY on_target_delete -> schema::target_delete_action_t;
 };
 
 
 ALTER TYPE schema::ObjectType {
-    CREATE LINK links := __source__.pointers[IS schema::Link];
-    CREATE LINK properties := __source__.pointers[IS schema::Property];
+    CREATE LINK links := .pointers[IS schema::Link];
+    CREATE LINK properties := .pointers[IS schema::Property];
 };
 
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -484,7 +484,10 @@ class PointerCommand(constraints.ConsistencySubjectCommand,
             )
 
         ir, _, target_expr = ql_utils.normalize_tree(
-            expr, schema, anchors={qlast.Source: source}, singletons=[source],
+            expr, schema,
+            anchors={qlast.Source: source},
+            path_prefix_anchor=qlast.Source,
+            singletons=[source],
             modaliases=context.modaliases)
 
         target = utils.reduce_to_typeref(schema, ir.stype)

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -28,7 +28,7 @@ type User extending Named {
         property count -> int64;
     }
 
-    property deck_cost := sum(__source__.deck.cost);
+    property deck_cost := sum(.deck.cost);
 
     multi link friends -> User {
         property nickname -> str;
@@ -46,8 +46,7 @@ type Card extending Named {
     required property cost -> int64;
     link owners := __source__.<deck[IS User];
     # computable property
-    property elemental_cost :=
-        <str>__source__.cost ++ ' ' ++ __source__.element;
+    property elemental_cost := <str>.cost ++ ' ' ++ .element;
 }
 
 type SpecialCard extending Card;

--- a/tests/test_deltas.py
+++ b/tests/test_deltas.py
@@ -419,7 +419,7 @@ a EXTENDING std::property -> array<std::int64>;
             CREATE MIGRATION test::d4 TO {
                 abstract type Foo {
                     property bar -> str;
-                    property __typename := __source__.__type__.name;
+                    property __typename := .__type__.name;
                 };
             };
         """)

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -4713,14 +4713,16 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             SELECT Issue {
                 number,
                 watchers: {
-                    name
+                    name,
+                    name_upper := str_upper(.name)
                 } FILTER .name = 'Yury'
             } FILTER .status.name = 'Open' AND .owner.name = 'Elvis';
             ''',
             [{
                 'number': '1',
                 'watchers': [{
-                    'name': 'Yury'
+                    'name': 'Yury',
+                    'name_upper': 'YURY',
                 }]
             }]
         )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -163,17 +163,19 @@ class TestSession(tb.QueryTestCase):
             await self.con.execute('''
                 ALTER TYPE User {
                     CREATE PROPERTY aaa := len(
-                        'yes' IF __source__ IS User ELSE 'no')
+                        'yes' IF __source__ IS User ELSE 'no');
+                    CREATE PROPERTY name_upper := str_upper(.name);
                 }
             ''')
 
             await self.assert_query_result(
                 """
-                    SELECT User {name, aaa};
+                    SELECT User {name, aaa, name_upper};
                 """,
                 [{
                     'name': 'user',
                     'aaa': 3,
+                    'name_upper': 'USER',
                 }]
             )
         finally:


### PR DESCRIPTION
This adds support for shortcut paths (`.foo.bar`) in simple
computable expressions.  This applies both to schema-level computables,
as well as ad-hoc shape computables in queries.  So, instead of

    type Foo { property comp := __source__.prop1 ++ __source__.prop2 }

one can now write

    type Foo { property comp := .prop1 ++ .prop2 }

and instead of

    SELECT Foo { comp := Foo.prop1 ++ Foo.prop2 }

this:

    SELECT Foo { comp := .prop1 ++ .prop2 }

This is especially useful in deeply nested shapes.