### PR TITLE
Make representation of schema objects consistent and more user friendly

### DIFF
--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -268,7 +268,7 @@ def __infer_slice(ir, env):
     else:
         # the base type is not valid
         raise errors.QueryError(
-            f'cannot slice {node_type.get_name(env.schema)}',
+            f'{node_type.get_verbosename(env.schema)} cannot be sliced',
             context=ir.start.context)
 
     for index in [ir.start, ir.stop]:
@@ -278,8 +278,8 @@ def __infer_slice(ir, env):
             if not index_type.implicitly_castable_to(int_t, env.schema):
                 raise errors.QueryError(
                     f'cannot slice {base_name} by '
-                    f'{index_type.get_name(env.schema)}, '
-                    f'{int_t.get_name(env.schema)} was expected',
+                    f'{index_type.get_displayname(env.schema)}, '
+                    f'{int_t.get_displayname(env.schema)} was expected',
                     context=index.context)
 
     return node_type
@@ -301,8 +301,9 @@ def __infer_index(ir, env):
 
         if not index_type.implicitly_castable_to(int_t, env.schema):
             raise errors.QueryError(
-                f'cannot index string by {index_type.get_name(env.schema)}, '
-                f'{int_t.get_name(env.schema)} was expected',
+                f'cannot index string by '
+                f'{index_type.get_displayname(env.schema)}, '
+                f'{int_t.get_displayname(env.schema)} was expected',
                 context=ir.index.context)
 
         result = str_t
@@ -311,8 +312,9 @@ def __infer_index(ir, env):
 
         if not index_type.implicitly_castable_to(int_t, env.schema):
             raise errors.QueryError(
-                f'cannot index bytes by {index_type.get_name(env.schema)}, '
-                f'{int_t.get_name(env.schema)} was expected',
+                f'cannot index bytes by '
+                f'{index_type.get_displayname(env.schema)}, '
+                f'{int_t.get_displayname(env.schema)} was expected',
                 context=ir.index.context)
 
         result = bytes_t
@@ -323,9 +325,10 @@ def __infer_index(ir, env):
                 index_type.implicitly_castable_to(str_t, env.schema)):
 
             raise errors.QueryError(
-                f'cannot index json by {index_type.get_name(env.schema)}, '
-                f'{int_t.get_name(env.schema)} or '
-                f'{str_t.get_name(env.schema)} was expected',
+                f'cannot index json by '
+                f'{index_type.get_displayname(env.schema)}, '
+                f'{int_t.get_displayname(env.schema)} or '
+                f'{str_t.get_displayname(env.schema)} was expected',
                 context=ir.index.context)
 
         result = json_t
@@ -334,8 +337,9 @@ def __infer_index(ir, env):
 
         if not index_type.implicitly_castable_to(int_t, env.schema):
             raise errors.QueryError(
-                f'cannot index array by {index_type.get_name(env.schema)}, '
-                f'{int_t.get_name(env.schema)} was expected',
+                f'cannot index array by '
+                f'{index_type.get_displayname(env.schema)}, '
+                f'{int_t.get_displayname(env.schema)} was expected',
                 context=ir.index.context)
 
         result = node_type.get_subtypes(env.schema)[0]
@@ -349,7 +353,8 @@ def __infer_index(ir, env):
 
     else:
         raise errors.QueryError(
-            f'cannot index {node_type.get_name(env.schema)}',
+            f'index indirection cannot be applied to '
+            f'{node_type.get_verbosename(env.schema)}',
             context=ir.index.context)
 
     return result

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -92,7 +92,7 @@ def register_set_in_scope(
     try:
         path_scope.attach_path(ir_set.path_id)
     except irast.InvalidScopeConfiguration as e:
-        raise errors.EdgeQLSyntaxError(
+        raise errors.QueryError(
             e.args[0], context=ir_set.context) from e
 
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -682,8 +682,8 @@ def ensure_set(
             not stype.implicitly_castable_to(typehint, ctx.env.schema)):
         raise errors.QueryError(
             f'expecting expression of type '
-            f'{typehint.get_name(ctx.env.schema)}, '
-            f'got {stype.get_name(ctx.env.schema)}',
+            f'{typehint.get_displayname(ctx.env.schema)}, '
+            f'got {stype.get_displayname(ctx.env.schema)}',
             context=expr.context
         )
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -399,8 +399,7 @@ def _infer_pointer_cardinality(
             raise errors.QueryError(
                 f'possibly more than one element returned by an '
                 f'expression for a computable '
-                f'{ptrcls.schema_class_displayname} '
-                f'{ptrcls.get_displayname(ctx.env.schema)!r} '
+                f'{ptrcls.get_verbosename(ctx.env.schema)} '
                 f"declared as 'single'",
                 context=source_ctx
             )
@@ -467,7 +466,7 @@ def once_pointer_cardinality_is_inferred(
 
     pending = ctx.pending_cardinality.get(ptrcls)
     if pending is None:
-        raise ValueError(
+        raise errors.InternalServerError(
             f'{ptrcls.get_name(ctx.env.schema)!r} is not pending '
             f'the cardinality inference')
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -399,22 +399,22 @@ def _normalize_view_ptr_expr(
             # Validate that the insert/update expression is
             # of the correct class.
             ptrcls_sn = ptrcls.get_shortname(ctx.env.schema)
-            lname = f'({ptrsource.get_name(ctx.env.schema)}).{ptrcls_sn.name}'
             expected = [
                 repr(str(base_ptrcls.get_target(
-                    ctx.env.schema).get_name(ctx.env.schema)))
+                    ctx.env.schema).get_displayname(ctx.env.schema)))
             ]
 
             if ptrcls.is_property(ctx.env.schema):
                 ercls = errors.InvalidPropertyTargetError
-                ptrkind = 'property'
             else:
                 ercls = errors.InvalidLinkTargetError
-                ptrkind = 'link'
+
+            ptr_vn = ptrcls.get_verbosename(ctx.env.schema, with_parent=True)
+
             raise ercls(
-                f'invalid target for {ptrkind} {str(lname)!r}: '
-                f'{str(ptr_target.get_name(ctx.env.schema))!r} (expecting '
-                f'{" or ".join(expected)})'
+                f'invalid target for {ptr_vn}: '
+                f'{str(ptr_target.get_displayname(ctx.env.schema))!r} '
+                f'(expecting {" or ".join(expected)})'
             )
 
     if (qlexpr is not None or

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -60,6 +60,7 @@ _DECL_MAP = {
     qlast.ObjectTypeDeclaration: s_objtypes.ObjectType,
     qlast.ConstraintDeclaration: s_constr.Constraint,
     qlast.LinkDeclaration: s_links.Link,
+    qlast.PropertyDeclaration: s_props.Property,
     qlast.AttributeDeclaration: s_attrs.Attribute,
 }
 
@@ -803,7 +804,8 @@ class DeclarationLoader:
                 if ptrdecl.cardinality is qltypes.Cardinality.ONE:
                     raise errors.SchemaError(
                         f'computable expression possibly returns more than '
-                        f'one value, but the {ptr.schema_class_displayname!r} '
+                        f'one value, but the '
+                        f'{ptr.get_schema_class_displayname()} '
                         f'is declared as "single"',
                         context=expr.context)
 

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from . import typeutils
 
 from edb.schema import abc as s_abc
+from edb.schema import name as s_name
 from edb.schema import pointers as s_pointers
 from edb.schema import types as s_types
 
@@ -259,7 +260,8 @@ class PathId:
 
         path = self._path
 
-        result += f'{path[0].name_hint.name}'
+        start_name = s_name.shortname_from_fullname(path[0].name_hint)
+        result += f'{start_name.name}'
 
         for i in range(1, len(path) - 1, 2):
             ptr_name = path[i][0].shortname

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -364,8 +364,8 @@ class ScopeTreeNode:
                                 f'reference to '
                                 f'{offending_node.path_id.pformat()!r} '
                                 f'changes the interpretation of '
-                                f'{existing.path_id.pformat()!r} in '
-                                f'an outer scope',
+                                f'{existing.path_id.pformat()!r} '
+                                f'elsewhere in the query',
                                 offending_node=offending_node,
                                 existing_node=existing
                             )

--- a/edb/schema/attributes.py
+++ b/edb/schema/attributes.py
@@ -40,6 +40,10 @@ class Attribute(inheriting.InheritingObject):
     inheritable = so.SchemaField(
         bool, default=False, compcoef=0.2)
 
+    def get_verbosename(self, schema, *, with_parent: bool=False) -> str:
+        vn = super().get_verbosename(schema)
+        return f"abstract {vn}"
+
 
 class AttributeValue(inheriting.InheritingObject):
 
@@ -59,6 +63,19 @@ class AttributeValue(inheriting.InheritingObject):
         return '<{}: at 0x{:x}>'.format(self.__class__.__name__, id(self))
 
     __repr__ = __str__
+
+    @classmethod
+    def get_schema_class_displayname(cls):
+        return 'attribute'
+
+    def get_verbosename(self, schema, *, with_parent: bool=False) -> str:
+        vn = super().get_verbosename(schema)
+        if with_parent:
+            pvn = self.get_subject(schema).get_verbosename(
+                schema, with_parent=True)
+            return f'{vn} of {pvn}'
+        else:
+            return vn
 
 
 class AttributeSubject(so.Object):

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -64,6 +64,19 @@ class Constraint(inheriting.InheritingObject, s_func.CallableObject,
     errmessage = so.SchemaField(
         str, default=None, compcoef=0.971, allow_ddl_set=True)
 
+    def get_verbosename(self, schema, *, with_parent: bool=False) -> str:
+        is_abstract = self.generic(schema)
+        vn = super().get_verbosename(schema)
+        if is_abstract:
+            return f'abstract {vn}'
+        else:
+            if with_parent:
+                pvn = self.get_subject(schema).get_verbosename(
+                    schema, with_parent=True)
+                return f'{vn} of {pvn}'
+            else:
+                return vn
+
     def generic(self, schema):
         return self.get_subject(schema) is None
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -28,7 +28,6 @@ from edb.edgeql import ast as qlast
 
 from edb.common import markup, ordered, struct, typed
 
-from . import abc as s_abc
 from . import expr as s_expr
 from . import name as sn
 from . import objects as so
@@ -1137,35 +1136,14 @@ class DeleteObject(ObjectCommand):
                         or ref.get_shortname(schema) == 'std::source'):
                     continue
 
-                dn = ref.get_displayname(schema)
-                if isinstance(ref, s_abc.Link):
-                    source = ref.get_source(schema)
-                    source_dn = source.get_displayname(schema)
-                    ref_str = f'link {dn} of {source_dn}'
-                elif isinstance(ref, s_abc.Property):
-                    source = ref.get_source(schema)
-                    source_dn = source.get_displayname(schema)
-                    ref_str = f'property {dn} of {source_dn}'
-                elif isinstance(ref, s_abc.Parameter):
-                    callables = [
-                        c for c in schema.get_referrers(ref)
-                        if isinstance(c, s_abc.Callable)
-                    ]
-                    if callables:
-                        callable_dn = callables[0].get_displayname(schema)
-                        ref_str = f'parameter {dn} of {callable_dn}'
-                    else:
-                        ref_str = dn
-                else:
-                    ref_str = dn
+                ref_strs.append(ref.get_verbosename(schema, with_parent=True))
 
-                ref_strs.append(ref_str)
-
+            vn = self.scls.get_verbosename(schema, with_parent=True)
             dn = self.scls.get_displayname(schema)
             detail = '; '.join(f'{ref_str} depends on {dn}'
                                for ref_str in ref_strs)
             raise errors.SchemaError(
-                f'cannot drop {dn} because '
+                f'cannot drop {vn} because '
                 f'other objects in the schema depend on it',
                 details=detail,
             )

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -210,6 +210,19 @@ class Parameter(so.Object, s_abc.Parameter):
         else:
             return fullname
 
+    def get_verbosename(self, schema, *, with_parent: bool=False) -> str:
+        vn = super().get_verbosename(schema)
+        if with_parent:
+            pfns = [r for r in schema.get_referrers(self)
+                    if isinstance(r, CallableObject)]
+            if pfns:
+                pvn = pfns[0].get_verbosename(schema, with_parent=True)
+                return f'{vn} of {pvn}'
+            else:
+                return vn
+        else:
+            return vn
+
     def get_shortname(self, schema) -> str:
         fullname = self.get_name(schema)
         return self.paramname_from_fullname(fullname)
@@ -626,6 +639,11 @@ class Function(CallableObject, s_abc.Function):
         # support non-constant defaults.
         return bool(self.get_language(schema) is qlast.Language.EdgeQL and
                     self.get_params(schema).find_named_only(schema))
+
+    def get_verbosename(self, schema, *, with_parent: bool=False) -> str:
+        params = self.get_params(schema)
+        sn = self.get_shortname(schema)
+        return f'function {sn}{params.as_str(schema)}'
 
 
 class FunctionCommandContext(CallableCommandContext):

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -308,7 +308,9 @@ def _merge_mro(schema, obj, mros):
                 break
         else:
             raise errors.SchemaError(
-                f"Could not find consistent MRO for {obj.get_name(schema)}")
+                f"Could not find consistent ancestor order for "
+                f"{obj.get_verbosename(schema)}"
+            )
 
         result.append(candidate)
 
@@ -708,7 +710,7 @@ class InheritingObject(derivable.DerivableObject):
                 return ancestor
 
         raise errors.SchemaError(
-            f'{self.get_name(schema)} has no non-abstract ancestors')
+            f'{self.get_verbosename(schema)} has no non-abstract ancestors')
 
     def compute_mro(self, schema):
         return compute_mro(schema, self)

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -86,8 +86,6 @@ def merge_actions(target: so.Object, sources: typing.List[so.Object],
 
 class Link(sources.Source, pointers.Pointer, s_abc.Link):
 
-    schema_class_displayname = 'link'
-
     spectargets = so.SchemaField(
         so.ObjectSet,
         default=so.ObjectSet,

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -35,8 +35,6 @@ from . import utils
 
 class Property(pointers.Pointer, s_abc.Property):
 
-    schema_class_displayname = 'property'
-
     def derive(self, schema, source, target=None, attrs=None, **kwargs):
         if target is None:
             target = self.get_target(schema)
@@ -104,7 +102,7 @@ class Property(pointers.Pointer, s_abc.Property):
     def is_link_property(self, schema):
         source = self.get_source(schema)
         if source is None:
-            raise ValueError(f'{self.get_name(schema)} is abstract')
+            raise ValueError(f'{self.get_verbosename(schema)} is abstract')
         return isinstance(source, pointers.Pointer)
 
     @classmethod

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -452,6 +452,11 @@ class Object(s_abc.Object, metaclass=ObjectMeta):
     def get_displayname(self, schema) -> str:
         return str(self.get_shortname(schema))
 
+    def get_verbosename(self, schema, *, with_parent: bool=False) -> str:
+        clsname = self.get_schema_class_displayname()
+        dname = self.get_displayname(schema)
+        return f"{clsname} '{dname}'"
+
     def __init__(self, *, _private_init):
         pass
 
@@ -462,6 +467,10 @@ class Object(s_abc.Object, metaclass=ObjectMeta):
 
     def __hash__(self):
         return hash((self.id, type(self)))
+
+    @classmethod
+    def get_schema_class_displayname(cls):
+        return cls.__name__.lower()
 
     @classmethod
     def _prepare_id(cls, id: typing.Optional[uuid.UUID],

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -42,6 +42,10 @@ class BaseObjectType(sources.Source, nodes.Node):
 class ObjectType(BaseObjectType, constraints.ConsistencySubject,
                  attributes.AttributeSubject, s_abc.ObjectType):
 
+    @classmethod
+    def get_schema_class_displayname(cls):
+        return 'object type'
+
     def is_object_type(self):
         return True
 

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -80,6 +80,9 @@ class Operator(s_func.CallableObject, s_abc.Operator):
         else:
             raise ValueError('unexpected operator kind')
 
+    def get_verbosename(self, schema, *, with_parent: bool=False) -> str:
+        return f'operator "{self.get_display_signature(schema)}"'
+
 
 class OperatorCommandContext(s_func.CallableCommandContext):
     pass

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -54,6 +54,10 @@ class ScalarType(nodes.Node, constraints.ConsistencySubject,
         coerce=True, compcoef=0.8,
     )
 
+    @classmethod
+    def get_schema_class_displayname(cls):
+        return 'scalar type'
+
     def _get_deps(self, schema):
         deps = super()._get_deps(schema)
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -221,6 +221,9 @@ class Collection(Type, s_abc.Collection):
     def get_shortname(self, schema):
         return self.name
 
+    def get_verbosename(self, schema, *, with_parent=False):
+        return self.get_displayname(schema)
+
     def get_view_type(self, schema):
         return self.view_type
 

--- a/tests/test_deltas.py
+++ b/tests/test_deltas.py
@@ -176,17 +176,17 @@ class TestDeltas(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaError,
-                'cannot drop test::DropA.*other objects'):
+                'cannot drop object type.*test::DropA.*other objects'):
             await self.con.execute('DROP TYPE test::DropA')
 
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaError,
-                'cannot drop test::dropattr.*other objects'):
+                'cannot drop abstract attr.*test::dropattr.*other objects'):
             await self.con.execute('DROP ABSTRACT ATTRIBUTE test::dropattr')
 
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaError,
-                'cannot drop l1_parent.*other objects'):
+                'cannot drop abstract link.*test::l1_parent.*other objects'):
             await self.con.execute('DROP ABSTRACT LINK test::l1_parent')
 
         async with self.assertRaisesRegexTx(
@@ -265,7 +265,8 @@ class TestDeltaLinkInheritance(tb.DDLTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.InvalidLinkTargetError,
-                r"invalid target for link '\(test::ObjectType01\)\.target': "
+                r"invalid target for link 'target' of object type "
+                r"'test::ObjectType01': "
                 r"'test::Target0' \(expecting 'test::Target1'\)"):
             # Target0 is not allowed to be targeted by ObjectType01, since
             # ObjectType01 inherits from ObjectType1 which requires more

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1880,7 +1880,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_extending_01(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r"Could not find consistent MRO for test::Merged1"):
+                r"Could not find consistent ancestor order for "
+                r"object type 'test::Merged1'"):
 
             await self.con.execute(r"""
                 CREATE TYPE test::ExtA1;

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -761,7 +761,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         }
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
+    @tb.must_fail(errors.QueryError,
                   "reference to 'User.name' changes the interpretation",
                   line=4, col=9)
     def test_edgeql_ir_scope_tree_bad_01(self):
@@ -771,7 +771,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         FILTER User.name
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
+    @tb.must_fail(errors.QueryError,
                   "reference to 'User' changes the interpretation",
                   line=4, col=9)
     def test_edgeql_ir_scope_tree_bad_02(self):
@@ -781,7 +781,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         FILTER User.deck@count
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
+    @tb.must_fail(errors.QueryError,
                   "reference to 'User' changes the interpretation",
                   line=3, col=35)
     def test_edgeql_ir_scope_tree_bad_03(self):
@@ -790,11 +790,25 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         SELECT User.deck { foo := User }
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
+    @tb.must_fail(errors.QueryError,
                   "reference to 'User.name' changes the interpretation",
                   line=3, col=40)
     def test_edgeql_ir_scope_tree_bad_04(self):
         """
         WITH MODULE test
         UPDATE User.deck SET { name := User.name }
+        """
+
+    @tb.must_fail(errors.QueryError,
+                  "reference to 'U.r' changes the interpretation",
+                  line=7, col=58)
+    def test_edgeql_ir_scope_tree_bad_05(self):
+        """
+        WITH
+            MODULE test,
+            U := User {id, r := random()}
+        SELECT
+            (
+                users := array_agg((SELECT U.id ORDER BY U.r LIMIT 10))
+            )
         """

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -4981,7 +4981,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_precedence_01(self):
         with self.assertRaisesRegex(
-                edgedb.QueryError, r'cannot index.*int'):
+                edgedb.QueryError, r'index indirection cannot.*int64.*'):
 
             await self.con.fetchall("""
                 # index access is higher precedence than cast
@@ -4990,7 +4990,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_precedence_02(self):
         with self.assertRaisesRegex(
-                edgedb.QueryError, r'cannot index.*int'):
+                edgedb.QueryError, r'index indirection cannot.*int64.*'):
 
             await self.con.fetchall("""
                 WITH MODULE test


### PR DESCRIPTION
The new `get_verbosename()` method returns a pretty description of a
schema object, optionally with context.  For example, links can be shown
as "link 'foo' of object type 'test::Bar'".  Use this new facility
instead of raw `get_name()` and, in certain places, instead of
`get_displayname()`.

Closes: #491