### PR TITLE
Fix a minor issue with pygments highlighter.

### DIFF
--- a/edb/edgeql/pygments/__init__.py
+++ b/edb/edgeql/pygments/__init__.py
@@ -125,10 +125,9 @@ class EdgeQLLexer(RegexLexer):
                         )
                         |
                         (?: \d+\.\d+)
-
-                        (n)?
                     )
+                    n?
             ''', token.Number),
-            (r'(?<!\w)\d+(n?)', token.Number),
+            (r'(?<!\w)\d+n?', token.Number),
         ],
     }


### PR DESCRIPTION
The literal `12e3n` now correctly highlights the `n` as part of the
number.