### PR TITLE
Ignore IPv6 component of 'localhost'

### DIFF
--- a/edb/server/http/port.py
+++ b/edb/server/http/port.py
@@ -106,9 +106,10 @@ class BaseHttpPort(baseport.Port):
             self._pgcons.put_nowait(con_task.result())
             self._pgcons_list.append(con_task.result())
 
+        nethost = await self._fix_localhost(self._nethost, self._netport)
         srv = await self._loop.create_server(
             self.build_protocol,
-            host=self._nethost, port=self._netport)
+            host=nethost, port=self._netport)
 
         self._servers.append(srv)
 


### PR DESCRIPTION
On many systems 'localhost' resolves to _both_ IPv4 and IPv6
addresses, even if the system is not capable or configured to
handle the IPv6 connections.  Due to the common nature of this
issue explicitly disable the AF_INET6 component of 'localhost'.