### PR TITLE
Fix repl script mode

### DIFF
--- a/edb/cli/__init__.py
+++ b/edb/cli/__init__.py
@@ -63,12 +63,14 @@ def cli(ctx, host, port, user, database, admin, password, password_from_stdin):
         password = None
 
     if ctx.invoked_subcommand is None:
-        repl.main(
+        status = repl.main(
             host=host, port=port, user=user,
             database=database, password=password,
             password_prompt=password_prompt,
             admin=admin,
         )
+
+        sys.exit(status)
     else:
         ctx.obj['host'] = host
         ctx.obj['port'] = port

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,3 +72,7 @@ class TestCLI(tb.ConnectedTestCase, tb.CLITestCaseMixin):
         result = self.run_cli('create', 'role', 'foo', '--allow-login',
                               '--password', input='foo-pass\n')
         self.assertIn('input is not a TTY', result.output)
+
+    async def test_cli_repl_script(self):
+        result = self.run_cli(input='SELECT 1 + 1')
+        self.assertEqual(list(result.output.split('\n'))[0], '{2}')


### PR DESCRIPTION
Unbreak the "script from stdin" mode: fix handling of password prompt,
as well as exception rendering and exit code.