### PR TITLE
docs: Clean up SDL docs

### DIFF
--- a/docs/edgeql/__toc__.rst
+++ b/docs/edgeql/__toc__.rst
@@ -7,6 +7,7 @@ EdgeQL
     :hidden:
 
     overview
+    admin/index
     expressions/__toc__
     statements/index
     funcops/index

--- a/docs/edgeql/admin/databases.rst
+++ b/docs/edgeql/admin/databases.rst
@@ -1,10 +1,10 @@
-.. _ref_eql_ddl_databases:
+.. _ref_admin_databases:
 
 =========
 Databases
 =========
 
-This section describes the DDL commands pertaining to
+This section describes the administrative commands pertaining to
 :ref:`databases <ref_datamodel_databases>`.
 
 

--- a/docs/edgeql/admin/index.rst
+++ b/docs/edgeql/admin/index.rst
@@ -1,0 +1,15 @@
+.. _ref_admin:
+
+Administration
+==============
+
+Commands for managing :ref:`databases <ref_admin_databases>` and
+:ref:`roles <ref_admin_roles>`.
+
+
+.. toctree::
+    :maxdepth: 3
+    :hidden:
+
+    databases
+    roles

--- a/docs/edgeql/admin/roles.rst
+++ b/docs/edgeql/admin/roles.rst
@@ -1,0 +1,151 @@
+.. _ref_admin_roles:
+
+=====
+Roles
+=====
+
+This section describes the administrative commands pertaining to *roles*.
+
+
+CREATE ROLE
+===========
+
+:eql-statement:
+
+Create a role.
+
+.. eql:synopsis::
+
+    CREATE ROLE <name> [ EXTENDING <base> [, ...] ]
+    "{" <subcommand>; [...] "}" ;
+
+    # where <subcommand> is one of
+
+      SET allow_login := {true | false}
+      SET is_superuser := {true | false}
+      SET password := <password>
+      SET ATTRIBUTE <attribute> := <value>
+
+
+Description
+-----------
+
+``CREATE ROLE`` defines a new role.
+
+:eql:synopsis:`<name>`
+    The name of the role to create.
+
+:eql:synopsis:`EXTENDING <base> [, ...]`
+    If specified, declares the *parent* roles for this role.
+
+The following subcommands are allowed in the ``CREATE ROLE`` block:
+
+:eql:synopsis:`SET allow_login := {true | false}`
+    A boolean flag that controls whether this role can be used to log
+    into EdgeDB. It is ``false`` by default.
+
+:eql:synopsis:`SET is_superuser := {true | false}`
+    A boolean flag that determines whether this role is a "superuser".
+    A "superuser" can override all access restrictions within EdgeDB.
+    It is ``false`` by default.
+
+:eql:synopsis:`SET password := <password>`
+    Set the password for the role.
+
+:eql:synopsis:`SET ATTRIBUTE <attribute> := <value>;`
+    Set role *attribute* to *value*.
+    See :eql:stmt:`SET ATTRIBUTE` for details.
+
+
+Examples
+--------
+
+Create a new role:
+
+.. code-block:: edgeql
+
+    CREATE ROLE alice {
+        SET allow_login := true;
+        SET password := 'wonderland';
+    };
+
+
+ALTER ROLE
+==========
+
+:eql-statement:
+
+Alter an existing role.
+
+.. eql:synopsis::
+
+    ALTER ROLE <name> "{" <subcommand>; [...] "}" ;
+
+    # where <subcommand> is one of
+
+      RENAME TO <newname>
+      SET allow_login := {true | false}
+      SET is_superuser := {true | false}
+      SET password := <password>
+      SET ATTRIBUTE <attribute> := <value>
+      DROP ATTRIBUTE <attribute>
+
+
+Description
+-----------
+
+``ALTER ROLE`` changes the settings of an existing role.
+
+
+:eql:synopsis:`<name>`
+    The name of the role to alter.
+
+The following subcommands are allowed in the ``ALTER ROLE`` block:
+
+:eql:synopsis:`RENAME TO <newname>`
+    Change the name of the role to *newname*.
+
+:eql:synopsis:`DROP ATTRIBUTE <attribute>;`
+    Remove role :eql:synopsis:`<attribute>`.
+    See :eql:stmt:`DROP ATTRIBUTE <DROP ATTRIBUTE>` for details.
+
+All the subcommands allowed in the ``CREATE ROLE`` block are also
+valid subcommands for ``ALTER ROLE`` block.
+
+
+Examples
+--------
+
+Alter a role:
+
+.. code-block:: edgeql
+
+    ALTER ROLE alice {
+        SET allow_login := false;
+    };
+
+
+DROP ROLE
+=========
+
+:eql-statement:
+
+Remove a role.
+
+.. eql:synopsis::
+
+    DROP ROLE <name> ;
+
+Description
+-----------
+
+``DROP ROLE`` removes an existing role.
+
+Examples
+--------
+
+Remove a role:
+
+.. code-block:: edgeql
+
+    DROP ROLE alice;

--- a/docs/edgeql/ddl/attributes.rst
+++ b/docs/edgeql/ddl/attributes.rst
@@ -19,7 +19,10 @@ CREATE ABSTRACT ATTRIBUTE
 
     [ WITH <with-item> [, ...] ]
     CREATE ABSTRACT [ INHERITABLE ] ATTRIBUTE <name>
-    [ "{" <subdefinition>; [...] "}" ] ;
+    [ "{"
+        SET ATTRIBUTE <attribute> := <value> ;
+        [...]
+      "}" ] ;
 
 
 Description
@@ -38,13 +41,13 @@ has an attribute defined on it, the descendants of that schema item will
 not automatically inherit the attribute.  Normal inheritance behavior can
 be turned on by declaring the attribute with the *INHERITABLE* qualifier.
 
-:eql:synopsis:`<subdefinition>`
-    Optional sequence of subdefinitions related to the new attribute.
+The following subcommands are allowed in the
+``CREATE ABSTRACT ATTRIBUTE`` block:
 
-    The following subdefinitions are allowed in the
-    ``CREATE ABSTRACT ATTRIBUTE`` block:
-
-    * :eql:stmt:`SET ATTRIBUTE`
+:eql:synopsis:`SET ATTRIBUTE <attribute> := <value>`
+    Attributes can also have attributes. Set the *attribute* of the
+    enclosing attribute to a specific *value*.
+    See :eql:stmt:`SET ATTRIBUTE` for details.
 
 
 Examples
@@ -105,7 +108,7 @@ Description
 *attribute* refers to the name of a defined attribute, and
 *value* must be a constant EdgeQL expression evaluating into a string.
 
-This statement can only be used as a subdefinition in another
+This statement can only be used as a subcommand in another
 DDL statement.
 
 
@@ -143,7 +146,7 @@ Description
 *attribute* refers to the name of a defined attribute.  The attribute
 value does not have to exist on a schema item.
 
-This statement can only be used as a subdefinition in another
+This statement can only be used as a subcommand in another
 DDL statement.
 
 

--- a/docs/edgeql/ddl/constraints.rst
+++ b/docs/edgeql/ddl/constraints.rst
@@ -20,18 +20,19 @@ CREATE ABSTRACT CONSTRAINT
 
     [ WITH [ <module-alias> := ] MODULE <module-name> ]
     CREATE ABSTRACT CONSTRAINT <name> [ ( [<argspec>] [, ...] ) ]
-        [ ON ( <subject-expr> ) ]
-        [ EXTENDING <base> [, ...] ]
-    "{"
-        [ SET expr := <constr-expression> ; ]
-        [ SET errmessage := <error-message> ; ]
-        [ SET <attr-name> := <attr-value> ; ]
-        [ ... ]
-    "}" ;
+      [ ON ( <subject-expr> ) ]
+      [ EXTENDING <base> [, ...] ]
+    "{" <subcommand>; [...] "}" ;
 
     # where <argspec> is:
 
-    [ $<argname>: ] <argtype>
+      [ $<argname>: ] <argtype>
+
+    # where <subcommand> is one of
+
+      SET expr := <constr-expression>
+      SET errmessage := <error-message>
+      SET ATTRIBUTE <attribute> := <value>
 
 
 Description
@@ -74,6 +75,9 @@ Parameters
 :eql:synopsis:`EXTENDING <base> [, ...]`
     If specified, declares the *parent* constraints for this constraint.
 
+The following subcommands are allowed in the ``CERATE ABSTRACT
+CONSTRAINT`` block:
+
 :eql:synopsis:`SET expr := <constr_expression>`
     A boolean expression that returns ``true`` for valid data and
     ``false`` for invalid data.  The expression may refer to the subject
@@ -89,8 +93,8 @@ Parameters
     - ``__subject__`` -- the value of the ``title`` attribute of the scalar
       type, property or link on which the constraint is defined.
 
-:eql:synopsis:`SET <attr-name> := <attr-value>;`
-    An optional list of attribute values for the constraint.
+:eql:synopsis:`SET ATTRIBUTE <attribute> := <value>;`
+    Set constraint *attribute* to *value*.
     See :eql:stmt:`SET ATTRIBUTE` for details.
 
 
@@ -122,13 +126,15 @@ Alter the definition of an
 
     [ WITH [ <module-alias> := ] MODULE <module-name> ]
     ALTER ABSTRACT CONSTRAINT <name>
-    "{"
-        [ RENAME TO <new-name> ; ]
-        [ SET expr := <constr-expression> ; ]
-        [ SET errmessage := <error-message> ; ]
-        [ SET <attr-name> := <attr-value> ; ]
-        [ ... ]
-    "}" ;
+    "{" <subcommand>; [...] "}" ;
+
+    # where <subcommand> is one of
+
+      RENAME TO <newname>
+      SET expr := <constr-expression>
+      SET errmessage := <error-message>
+      SET ATTRIBUTE <attribute> := <value>
+      DROP ATTRIBUTE <attribute>
 
 
 Description
@@ -151,17 +157,20 @@ Parameters
 :eql:synopsis:`<name>`
     The name (optionally module-qualified) of the constraint to alter.
 
-:eql:synopsis:`RENAME TO <new-name>`
-    Change the name of the constraint to *new-name*.  All concrete
+The following subcommands are allowed in the ``ALTER ABSTRACT
+CONSTRAINT`` block:
+
+:eql:synopsis:`RENAME TO <newname>`
+    Change the name of the constraint to *newname*.  All concrete
     constraints inheriting from this constraint are also renamed.
 
-:eql:synopsis:`SET expr := <constr_expression>`
-    Changes the constraint expression.  See the relevant paragraph in
-    :eql:stmt:`CREATE ABSTRACT CONSTRAINT` for details on constraint
-    expressions.
+:eql:synopsis:`DROP ATTRIBUTE <attribute>;`
+    Remove constraint :eql:synopsis:`<attribute>`.
+    See :eql:stmt:`DROP ATTRIBUTE <DROP ATTRIBUTE>` for details.
 
-:eql:synopsis:`SET errmessage := <error_message>`
-    Changes the constraint error message.
+All the subcommands allowed in the ``CREATE ABSTRACT CONSTRAINT``
+block are also valid subcommands for ``ALTER ABSTRACT CONSTRAINT``
+block.
 
 
 DROP ABSTRACT CONSTRAINT
@@ -222,17 +231,18 @@ Define a concrete constraint on the specified schema item.
 
     [ WITH [ <module-alias> := ] MODULE <module-name> ]
     CREATE [ DELEGATED ] CONSTRAINT <name>
-        [ ( [<argspec>] [, ...] ) ]
-        [ ON ( <subject-expr> ) ]
-    "{"
-        [ SET errmessage := <error-message> ; ]
-        [ SET <attr-name> := <attr-value> ; ]
-        [ ... ]
-    "}" ;
+      [ ( [<argspec>] [, ...] ) ]
+      [ ON ( <subject-expr> ) ]
+    "{" <subcommand>; [...] "}" ;
 
     # where <argspec> is:
 
-    [ $<argname> := ] <argvalue>
+      [ $<argname>: ] <argtype>
+
+    # where <subcommand> is one of
+
+      SET errmessage := <error-message>
+      SET ATTRIBUTE <attribute> := <value>
 
 
 Description
@@ -287,6 +297,8 @@ Parameters
         Currently EdgeDB only supports constraint expressions on scalar
         types and properties.
 
+The following subcommands are allowed in the ``CERATE CONSTRAINT`` block:
+
 :eql:synopsis:`SET errmessage := <error_message>`
     An optional string literal defining the error message template that
     is raised when the constraint is violated.  See the relevant
@@ -320,28 +332,28 @@ Alter the definition of a concrete constraint on the specified schema item.
 
     [ WITH [ <module-alias> := ] MODULE <module-name> [, ...] ]
     ALTER CONSTRAINT <name>
-    "{"
-        <action>; [ ... ]
-    "}" ;
+    "{" <subcommand>; [ ... ] "}" ;
 
     # -- or --
 
     [ WITH [ <module-alias> := ] MODULE <module-name> [, ...] ]
-    ALTER CONSTRAINT <name> <action> ;
+    ALTER CONSTRAINT <name> <subcommand> ;
 
-    # where <action> is one of:
+    # where <subcommand> is one of:
 
-        SET DELEGATED ;
-        DROP DELEGATED ;
-        SET errmessage := <error-message> ;
-        SET <attr-name> := <attr-value> ;
+      SET DELEGATED
+      DROP DELEGATED
+      RENAME TO <newname>
+      SET errmessage := <error-message>
+      SET ATTRIBUTE <attribute> := <value>
+      DROP ATTRIBUTE <attribute>
 
 
 Description
 -----------
 
 ``ALTER CONSTRAINT`` changes the definition of a concrete constraint.
-As for most ``ALTER`` commands, both single- and multi-action forms are
+As for most ``ALTER`` commands, both single- and multi-command forms are
 supported.
 
 
@@ -358,26 +370,23 @@ Parameters
     The name (optionally module-qualified) of the concrete constraint
     that is being altered.
 
+The following subcommands are allowed in the ``ALTER CONSTRAINT`` block:
+
 :eql:synopsis:`SET DELEGATED`
     Makes the constraint delegated.
 
 :eql:synopsis:`DROP DELEGATED`
     Makes the constraint non-delegated.
 
-:eql:synopsis:`SET errmessage := <error_message>`
-    Changes the message template of an error which is raised when
-    the constraint is violated.  See the relevant paragraph in
-    :eql:stmt:`CREATE ABSTRACT CONSTRAINT` for the rules of error
-    message template syntax.
-
-:eql:synopsis:`SET <attr-name> := <attr-value>;`
-    Set constraint *attribute* to *value*.
-    See :eql:stmt:`SET ATTRIBUTE` for details.
+:eql:synopsis:`RENAME TO <newname>`
+    Change the name of the constraint to :eql:synopsis:`<newname>`.
 
 :eql:synopsis:`DROP ATTRIBUTE <attribute>;`
     Remove constraint *attribute*.
     See :eql:stmt:`DROP ATTRIBUTE` for details.
 
+All the subcommands allowed in the ``CREATE CONSTRAINT`` block are also
+valid subcommands for ``ALTER CONSTRAINT`` block.
 
 Examples
 --------

--- a/docs/edgeql/ddl/functions.rst
+++ b/docs/edgeql/ddl/functions.rst
@@ -25,25 +25,28 @@ CREATE FUNCTION
 
     [ WITH <with-item> [, ...] ]
     CREATE FUNCTION <name> ([ <argspec> ] [, ... ]) -> <returnspec>
-    "{"
-        <subcommand> [, ...]
-    "}" ;
+    "{" <subcommand> [, ...] "}" ;
 
     # where <argspec> is:
 
-    [ <argkind> ] <argname>: [ <typequal> ] <argtype> [ = <default> ]
+      [ <argkind> ] <argname>: [ <typequal> ] <argtype> [ = <default> ]
 
     # <argkind> is:
 
-    [ { VARIADIC | NAMED ONLY } ]
+      [ { VARIADIC | NAMED ONLY } ]
 
     # <typequal> is:
 
-    [ { SET OF | OPTIONAL } ]
+      [ { SET OF | OPTIONAL } ]
 
     # and <returnspec> is:
 
-    [ <typequal> ] <rettype>
+      [ <typequal> ] <rettype>
+
+    # where <subcommand> is one of
+
+      FROM <language> <functionbody>
+      SET ATTRIBUTE <attribute> := <value>
 
 
 Description
@@ -129,11 +132,11 @@ Subcommands
 ``CREATE FUNCTION`` allows specifying the following subcommands in its
 block:
 
-:eql:synopsis:`SET ATTRIBUTE <attribute> := <value>;`
+:eql:synopsis:`SET ATTRIBUTE <attribute> := <value>`
     Set the functions's *attribute* to *value*.
     See :eql:stmt:`SET ATTRIBUTE` for details.
 
-:eql:synopsis:`FROM <language> <functionbody>;`
+:eql:synopsis:`FROM <language> <functionbody>`
     See the meaning of *language* and *functionbody* above.
 
 

--- a/docs/edgeql/ddl/index.rst
+++ b/docs/edgeql/ddl/index.rst
@@ -1,7 +1,10 @@
 .. _ref_eql_ddl:
 
-Data Definition
-===============
+Data Definition (DDL)
+=====================
+
+:edb-alt-title: Data Definition Language
+
 
 EdgeQL includes a set of commands to manipulate all aspects of the
 database schema.  It is called the *data definition language* or *DDL*,
@@ -32,7 +35,6 @@ another, the other type has to be created first. For example:
     :maxdepth: 3
     :hidden:
 
-    databases
     modules
     objects
     scalars

--- a/docs/edgeql/ddl/migrations.rst
+++ b/docs/edgeql/ddl/migrations.rst
@@ -66,7 +66,7 @@ Parameters
     definition language<ref_eql_sdl>`.
 
 :eql:synopsis:`<ddl-command>`
-    A list of arbitrary DDL commands.  :ref:`Database <ref_eql_ddl_databases>`,
+    A list of arbitrary DDL commands.  :ref:`Database <ref_admin_databases>`,
     :ref:`module <ref_eql_ddl_modules>`, and migration commands cannot be
     used here.
 

--- a/docs/edgeql/ddl/objects.rst
+++ b/docs/edgeql/ddl/objects.rst
@@ -23,6 +23,13 @@ CREATE TYPE
     CREATE [ABSTRACT] TYPE <name> [ EXTENDING <supertype> [, ...] ]
     [ "{" <subcommand>; [...] "}" ] ;
 
+    # where <subcommand> is one of
+
+      SET ATTRIBUTE <attribute> := <value>
+      CREATE LINK <link-name> ...
+      CREATE PROPERTY <property-name> ...
+      CREATE INDEX <index-name> ON <index-expr>
+
 Description
 -----------
 
@@ -65,24 +72,24 @@ Parameters
     If there is no conflict, the links are merged to form a single
     link in the new type.
 
-:eql:synopsis:`<subcommand>`
-    Optional sequence of subcommands related to the new object type.
+The following subcommands are allowed in the ``CREATE TYPE`` block:
 
-    The following subcommands are allowed in the ``CREATE TYPE``
-    block:
+:eql:synopsis:`SET ATTRIBUTE <attribute> := <value>`
+    Set object type *attribute* to *value*.
+    See :eql:stmt:`SET ATTRIBUTE` for details.
 
-    :eql:synopsis:`SET ATTRIBUTE <attribute> := <value>;`
-        Set link item's *attribute* to *value*.
-        See :eql:stmt:`SET ATTRIBUTE` for details.
+:eql:synopsis:`CREATE LINK <link-name> ...`
+    Define a new link for this object type.  See
+    :eql:stmt:`CREATE LINK` for details.
 
-    :eql:synopsis:`CREATE LINK`
-        Define a concrete link on the object type.
-        See :eql:stmt:`CREATE LINK` for details.
+:eql:synopsis:`CREATE PROPERTY <property-name> ...`
+    Define a new property for this object type.  See
+    :eql:stmt:`CREATE PROPERTY` for details.
 
-    :eql:synopsis:`CREATE PROPERTY`
-        Define a concrete link on the object type.
-        See :eql:stmt:`CREATE PROPERTY` for details.
-
+:eql:synopsis:`CREATE INDEX <index-name> ON <index-expr>`
+    Define a new :ref:`index <ref_datamodel_indexes>` named
+    *index-name* using *index-expr* for this object type.  See
+    :eql:stmt:`CREATE INDEX` for details.
 
 .. TODO: write examples
 
@@ -103,25 +110,25 @@ Change the definition of an
 
     [ WITH <with-item> [, ...] ]
     ALTER TYPE <name>
-    [ "{" <action>; [...] "}" ] ;
+    [ "{" <subcommand>; [...] "}" ] ;
 
     [ WITH <with-item> [, ...] ]
-    ALTER TYPE <name> <action> ;
+    ALTER TYPE <name> <subcommand> ;
 
-    # where <action> is one of
+    # where <subcommand> is one of
 
-        RENAME TO <newname>;
-        EXTENDING <parent> [, ...]
-        SET ATTRIBUTE <attribute> := <value>;
-        DROP ATTRIBUTE <attribute>;
-        CREATE LINK <link-name> ...
-        ALTER LINK <link-name> ...
-        DROP LINK <link-name> ...
-        CREATE PROPERTY <property-name> ...
-        ALTER PROPERTY <property-name> ...
-        DROP PROPERTY <property-name> ...
-        CREATE INDEX <index-name> ON <index-expr>;
-        DROP INDEX <index-name>;
+      RENAME TO <newname>
+      EXTENDING <parent> [, ...]
+      SET ATTRIBUTE <attribute> := <value>
+      DROP ATTRIBUTE <attribute>
+      CREATE LINK <link-name> ...
+      ALTER LINK <link-name> ...
+      DROP LINK <link-name> ...
+      CREATE PROPERTY <property-name> ...
+      ALTER PROPERTY <property-name> ...
+      DROP PROPERTY <property-name> ...
+      CREATE INDEX <index-name> ON <index-expr>
+      DROP INDEX <index-name>
 
 
 Description
@@ -134,6 +141,8 @@ with a module name.
 Parameters
 ----------
 
+The following subcommands are allowed in the ``ALTER TYPE`` block:
+
 :eql:synopsis:`WITH <with-item> [, ...]`
     Alias declarations.
 
@@ -144,15 +153,15 @@ Parameters
 :eql:synopsis:`<name>`
     The name (optionally module-qualified) of the type being altered.
 
-:eql:synopsis:`EXTENDING ...`
-    Alter the supertype list.  The full syntax of this action is:
+:eql:synopsis:`EXTENDING <parent> [, ...]`
+    Alter the supertype list.  The full syntax of this subcommand is:
 
     .. eql:synopsis::
 
          EXTENDING <parent> [, ...]
             [ FIRST | LAST | BEFORE <exparent> | AFTER <exparent> ]
 
-    This action makes the type a subtype of the specified list
+    This subcommand makes the type a subtype of the specified list
     of supertypes.  The requirements for the parent-child relationship
     are the same as when creating an object type.
 
@@ -167,42 +176,32 @@ Parameters
     * ``AFTER <parent>`` -- insert parent(s) after an existing
       *parent*.
 
-:eql:synopsis:`SET ATTRIBUTE <attribute> := <value>;`
-    Set object type *attribute* to *value*.
-    See :eql:stmt:`SET ATTRIBUTE` for details.
-
-:eql:synopsis:`DROP ATTRIBUTE <attribute>;`
+:eql:synopsis:`DROP ATTRIBUTE <attribute>`
     Remove object type *attribute*.
     See :eql:stmt:`DROP ATTRIBUTE <DROP ATTRIBUTE>` for details.
-
-:eql:synopsis:`CREATE LINK <link-name> ...`
-    Define a new link for this object type.  See
-    :eql:stmt:`CREATE LINK` for details.
 
 :eql:synopsis:`ALTER LINK <link-name> ...`
     Alter the definition of a link for this object type.  See
     :eql:stmt:`ALTER LINK` for details.
 
-:eql:synopsis:`DROP LINK <link-name>;`
+:eql:synopsis:`DROP LINK <link-name>`
     Remove a link item from this object type.  See
     :eql:stmt:`DROP LINK` for details.
-
-:eql:synopsis:`CREATE PROPERTY <property-name> ...`
-    Define a new property item for this object type.  See
-    :eql:stmt:`CREATE PROPERTY` for details.
 
 :eql:synopsis:`ALTER PROPERTY <property-name> ...`
     Alter the definition of a property item for this object type.
     See :eql:stmt:`ALTER PROPERTY` for details.
 
-:eql:synopsis:`DROP PROPERTY <property-name>;`
+:eql:synopsis:`DROP PROPERTY <property-name>`
     Remove a property item from this object type.  See
     :eql:stmt:`DROP PROPERTY` for details.
 
-:eql:synopsis:`CREATE INDEX <index-name> ON <index-expr>;`
-    Define a new :ref:`index <ref_datamodel_indexes>` named *index-name*
-    using *index-expr* for this object type.  See :eql:stmt:`CREATE INDEX`
-    for details.
+:eql:synopsis:`DROP INDEX <index-name>`
+    Remove an :ref:`index <ref_datamodel_indexes>` named *index-name*
+    from this object type.  See :eql:stmt:`DROP INDEX` for details.
+
+All the subcommands allowed in the ``CREATE TYPE`` block are also
+valid subcommands for ``ALTER TYPE`` block.
 
 
 .. TODO: write examples

--- a/docs/edgeql/ddl/scalars.rst
+++ b/docs/edgeql/ddl/scalars.rst
@@ -20,7 +20,12 @@ CREATE SCALAR TYPE
 
     [ WITH <with-item> [, ...] ]
     CREATE [ABSTRACT] SCALAR TYPE <name> [ EXTENDING <supertype> ]
-    [ "{" <action>; [...] "}" ] ;
+    [ "{" <subcommand>; [...] "}" ] ;
+
+    # where <subcommand> is one of
+
+      SET ATTRIBUTE <attribute> := <value>
+      CREATE CONSTRAINT <constraint-name> ...
 
 
 Description
@@ -56,17 +61,15 @@ subtype with constraints.
     between the new subtype and its supertype(s).  Schema modifications
     to the supertype(s) propagate to the subtype.
 
-:eql:synopsis:`<action>`
-    The following actions are allowed in the ``CREATE SCALAR TYPE``
-    block:
+The following subcommands are allowed in the ``CREATE SCALAR TYPE`` block:
 
-    :eql:synopsis:`SET ATTRIBUTE <attribute> := <value>;`
-        Set link item's *attribute* to *value*.
-        See :eql:stmt:`SET ATTRIBUTE` for details.
+:eql:synopsis:`SET ATTRIBUTE <attribute> := <value>;`
+    Set scalar type's *attribute* to *value*.
+    See :eql:stmt:`SET ATTRIBUTE` for details.
 
-    :eql:synopsis:`CREATE CONSTRAINT`
-        Define a concrete constraint on the scalar type.
-        See :eql:stmt:`CREATE CONSTRAINT` for details.
+:eql:synopsis:`CREATE CONSTRAINT <constraint-name> ...`
+    Define a new constraint for this scalar type.  See
+    :eql:stmt:`CREATE CONSTRAINT` for details.
 
 
 Examples
@@ -85,7 +88,8 @@ Create a new enumerated type:
 
 .. code-block:: edgeql
 
-    CREATE SCALAR TYPE my_color_t EXTENDING enum<'black', 'white', 'red'>;
+    CREATE SCALAR TYPE my_color_t
+        EXTENDING enum<'black', 'white', 'red'>;
 
 
 ALTER SCALAR TYPE
@@ -101,7 +105,17 @@ Alter the definition of a :ref:`scalar type <ref_datamodel_scalar_types>`.
 
     [ WITH <with-item> [, ...] ]
     ALTER SCALAR TYPE <name>
-    "{" <action>; [...] "}" ;
+    "{" <subcommand>; [...] "}" ;
+
+    # where <subcommand> is one of
+
+      RENAME TO <newname>
+      EXTENDING ...
+      SET ATTRIBUTE <attribute> := <value>
+      DROP ATTRIBUTE <attribute>
+      CREATE CONSTRAINT <constraint-name> ...
+      ALTER CONSTRAINT <constraint-name> ...
+      DROP CONSTRAINT <constraint-name> ...
 
 
 Description
@@ -111,32 +125,29 @@ Description
 *name* must be a name of an existing scalar type, optionally qualified
 with a module name.
 
-:eql:synopsis:`<action>`
-    The following actions are allowed in the
-    ``ALTER SCALAR TYPE`` block:
+The following subcommands are allowed in the ``ALTER SCALAR TYPE`` block:
 
-    :eql:synopsis:`RENAME TO <newname>;`
-        Change the name of the scalar type to *newname*.
+:eql:synopsis:`RENAME TO <newname>;`
+    Change the name of the scalar type to *newname*.
 
-    :eql:synopsis:`SET ATTRIBUTE <attribute> := <value>;`
-        Set scalar type's *attribute* to *value*.
-        See :eql:stmt:`SET ATTRIBUTE` for details.
+:eql:synopsis:`EXTENDING ...`
+    Alter the supertype list.  It works the same way as in
+    :eql:stmt:`ALTER TYPE`.
 
-    :eql:synopsis:`DROP ATTRIBUTE <attribute>;`
-        Remove scalar type's *attribute* to *value*.
-        See :eql:stmt:`DROP ATTRIBUTE <DROP ATTRIBUTE>` for details.
+:eql:synopsis:`DROP ATTRIBUTE <attribute>`
+    Remove scalar type's *attribute* to *value*.
+    See :eql:stmt:`DROP ATTRIBUTE <DROP ATTRIBUTE>` for details.
 
-    :eql:synopsis:`CREATE CONSTRAINT <constraint-name> ...`
-        Define a new constraint for this scalar type.  See
-        :eql:stmt:`CREATE CONSTRAINT` for details.
+:eql:synopsis:`ALTER CONSTRAINT <constraint-name> ...`
+    Alter the definition of a constraint for this scalar type.  See
+    :eql:stmt:`ALTER CONSTRAINT` for details.
 
-    :eql:synopsis:`ALTER CONSTRAINT <constraint-name> ...`
-        Alter the definition of a constraint for this scalar type.  See
-        :eql:stmt:`ALTER CONSTRAINT` for details.
+:eql:synopsis:`DROP CONSTRAINT <constraint-name>`
+    Remove a constraint from this scalar type.  See
+    :eql:stmt:`DROP CONSTRAINT` for details.
 
-    :eql:synopsis:`DROP CONSTRAINT <constraint-name>;`
-        Remove a constraint from this scalar type.  See
-        :eql:stmt:`DROP CONSTRAINT` for details.
+All the subcommands allowed in the ``CREATE SCALAR TYPE`` block are also
+valid subcommands for ``ALTER SCALAR TYPE`` block.
 
 
 Examples

--- a/docs/edgeql/sdl/attributes.rst
+++ b/docs/edgeql/sdl/attributes.rst
@@ -44,18 +44,10 @@ commands <ref_eql_ddl_schema_attributes>`.
 Description
 -----------
 
-:sdl:synopsis:`abstract`
-    If specified, the declared attribute will be *abstract*.
-
-:sdl:synopsis:`inheritable`
-    The attributes are non-inheritable by default.  That is, if a
-    schema item has an attribute defined on it, the descendants of
-    that schema item will not automatically inherit the attribute.
-    Normal inheritance behavior can be turned on by declaring the
-    attribute with the *inheritable* qualifier.
-
-:sdl:synopsis:`<name>`
-    Specifies the name of the attribute.
+The core of the declaration is identical to
+:eql:stmt:`CREATE ABSTRACT ATTRIBUTE`, while the valid SDL
+sub-declarations are listed below:
 
 :sdl:synopsis:`<attribute-declarations>`
-    Attributes can have attribute declarations.
+    Attributes can also have attributes. Set the *attribute* of the
+    enclosing attribute to a specific value.

--- a/docs/edgeql/sdl/constraints.rst
+++ b/docs/edgeql/sdl/constraints.rst
@@ -56,55 +56,10 @@ commands <ref_eql_ddl_constraints>`.
 Description
 -----------
 
-:sdl:synopsis:`abstract`
-    If specified, the declared constraint will be *abstract*.
-
-:sdl:synopsis:`delegated`
-    If specified, the constraint is defined as *delegated*, which means
-    that it will not be enforced on the type it's declared on, and
-    the enforcement will be delegated to the subtypes of this type.
-    This is particularly useful for :eql:constraint:`exclusive`
-    constraints in abstract types.
-
-:sdl:synopsis:`<name>`
-    The name (optionally module-qualified) of the new constraint.
-
-:sdl:synopsis:`<argspec>`
-    An optional list of constraint arguments.
-    :sdl:synopsis:`<argname>` optionally specifies
-    the argument name, and :sdl:synopsis:`<argtype>`
-    specifies the argument type.
-
-:sdl:synopsis:`on ( <subject-expr> )`
-    An optional expression defining the *subject* of the constraint.
-    If not specified, the subject is the value of the schema item on
-    which the concrete constraint is defined.  The expression must
-    refer to the original subject of the constraint as
-    ``__subject__``.  Note also that ``<subject-expr>`` itself has to
-    be parenthesized.
-
-    .. note::
-
-        Currently EdgeDB only supports constraint expressions on scalar
-        types and properties.
-
-:sdl:synopsis:`extending <base> [, ...]`
-    If specified, declares the *parent* constraints for this constraint.
-
-:sdl:synopsis:`expr := <constr_expression>`
-    A boolean expression that returns ``true`` for valid data and
-    ``false`` for invalid data.  The expression may refer to the subject
-    of the constraint as ``__subject__``.
-
-:sdl:synopsis:`errmessage := <error_message>`
-    An optional string literal defining the error message template that
-    is raised when the constraint is violated.  The template is a formatted
-    string that may refer to constraint context variables in curly braces.
-    The template may refer to the following:
-
-    - ``$argname`` -- the value of the specified constraint argument
-    - ``__subject__`` -- the value of the ``title`` attribute of the scalar
-      type, property or link on which the constraint is defined.
+The core of the declaration is identical to
+:eql:stmt:`CREATE CONSTRAINT <CREATE ABSTRACT CONSTRAINT>`,
+while the valid SDL sub-declarations are listed below:
 
 :sdl:synopsis:`<attribute-declarations>`
-    :ref:`Schema attribute <ref_eql_sdl_schema_attributes>` declarations.
+    Set constraint :ref:`attribute <ref_eql_sdl_schema_attributes>`
+    to a given *value*.

--- a/docs/edgeql/sdl/functions.rst
+++ b/docs/edgeql/sdl/functions.rst
@@ -59,65 +59,9 @@ commands <ref_eql_ddl_functions>`.
 Description
 -----------
 
-:sdl:synopsis:`<name>`
-    The name (optionally module-qualified) of the function to create.
-
-:sdl:synopsis:`<argkind>`
-    The kind of an argument: ``variadic`` or ``named only``.
-
-    If not specified, the argument is called *positional*.
-
-    The ``variadic`` modifier indicates that the function takes an
-    arbitrary number of arguments of the specified type.  The passed
-    arguments will be passed as as array of the argument type.
-    Positional arguments cannot follow a ``variadic`` argument.
-    ``variadic`` parameters cannot have a default value.
-
-    The ``named only`` modifier indicates that the argument can only
-    be passed using that specific name.  Positional arguments cannot
-    follow a ``named only`` argument.
-
-:sdl:synopsis:`<argname>`
-    The name of an argument.  If ``named only`` modifier is used this
-    argument *must* be passed using this name only.
-
-:sdl:synopsis:`<typequal>`
-    The type qualifier: ``set of`` or ``optional``.
-
-    The ``set of`` qualifier indicates that the function is taking the
-    argument as a *whole set*, as opposed to being called on the input
-    product element-by-element.
-
-    The ``optional`` qualifier indicates that the function will be called
-    if the argument is an empty set.  The default behavior is to return
-    an empty set if the argument is not marked as ``optional``.
-
-:sdl:synopsis:`<argtype>`
-    The data type of the function's arguments
-    (optionally module-qualified).
-
-:sdl:synopsis:`<default>`
-    An expression to be used as default value if the parameter is not
-    specified.  The expression has to be of a type compatible with the
-    type of the argument.
-
-:sdl:synopsis:`<rettype>`
-    The return data type (optionally module-qualified).
-
-    The ``set of`` modifier indicates that the function will return
-    a non-singleton set.
-
-    The ``optional`` qualifier indicates that the function may return
-    an empty set.
-
-:sdl:synopsis:`<language>`
-    The name of the language that the function is implemented in.
-    Currently it can only be ``edgeql``.
-
-:sdl:synopsis:`<functionbody>`
-    A string constant defining the function.  It is often helpful
-    to use :ref:`dollar quoting <ref_eql_lexical_dollar_quoting>`
-    to write the function definition string.
+The core of the declaration is identical to :eql:stmt:`CREATE FUNCTION`,
+while the valid SDL sub-declarations are listed below:
 
 :sdl:synopsis:`<attribute-declarations>`
-    :ref:`Schema attribute <ref_eql_sdl_schema_attributes>` declarations.
+    Set function :ref:`attribute <ref_eql_sdl_schema_attributes>`
+    to a given *value*.

--- a/docs/edgeql/sdl/index.rst
+++ b/docs/edgeql/sdl/index.rst
@@ -1,10 +1,13 @@
 .. _ref_eql_sdl:
 
-Schema Definition
-=================
+Schema Definition (SDL)
+=======================
+
+:edb-alt-title: Schema Definition Language
+
 
 This section describes the high-level language used to define EdgeDB
-schema.  It is called the *EdgeDB schema definition language* or
+schema.  It is called the EdgeDB *schema definition language* or
 *SDL*.  There's a correspondence between this declarative high-level
 language and the imperative low-level :ref:`DDL <ref_eql_ddl>`.
 

--- a/docs/edgeql/sdl/indexes.rst
+++ b/docs/edgeql/sdl/indexes.rst
@@ -34,17 +34,10 @@ commands <ref_eql_ddl_indexes>`.
 
 .. sdl:synopsis::
 
-    index <index-name> ON ( <index-expr> ) ;
+    index <index-name> on ( <index-expr> ) ;
 
 
 Description
 -----------
 
-:sdl:synopsis:`<index-name>`
-    The name of the index to be created.  No module name can be specified,
-    indexes are always created in the same module as the parent type or
-    link.
-
-:sdl:synopsis:`on ( <index-expr> )`
-    The specific expression for which the index is made.  Note also
-    that ``<index-expr>`` itself has to be parenthesized.
+The core of the declaration is identical to :eql:stmt:`CREATE INDEX`.

--- a/docs/edgeql/sdl/links.rst
+++ b/docs/edgeql/sdl/links.rst
@@ -45,12 +45,47 @@ commands <ref_eql_ddl_links>`.
     # Concrete link form used inside type declaration:
     [ required ] [{single | multi}] link <name>
       [ extending <base> [, ...] ] -> <type>
-      [ "{" <subcommand>; [...] "}" ] ;
+      [ "{"
+          [ default := <expression> ; ]
+          [ readonly := {true | false} ; ]
+          [ on target delete <action> ; ]
+          [ <attribute-declarations> ]
+          [ <property-declarations> ]
+          [ <constraint-declarations> ]
+          ...
+        "}" ]
+
 
     # Computable link form used inside type declaration:
     [ required ] [{single | multi}] link <name> := <expression>;
 
     # Abstract link form:
-    abstract link [<module>::]<name> [extending <base> [, ...]]
-    [ "{" <subcommand>; [...] "}" ]
+    abstract link <name> [extending <base> [, ...]]
+    [ "{"
+        [ readonly := {true | false} ; ]
+        [ <attribute-declarations> ]
+        [ <property-declarations> ]
+        [ <constraint-declarations> ]
+        [ <index-declarations> ]
+        ...
+      "}" ]
 
+Description
+-----------
+
+The core of the declaration is identical to :eql:stmt:`CREATE LINK`,
+while the valid SDL sub-declarations are listed below:
+
+:sdl:synopsis:`<attribute-declarations>`
+    Set link :ref:`attribute <ref_eql_sdl_schema_attributes>`
+    to a given *value*.
+
+:sdl:synopsis:`<property-declarations>`
+    Define a concrete :ref:`property <ref_eql_sdl_props>` on the link.
+
+:sdl:synopsis:`<constraint-declarations>`
+    Define a concrete :ref:`constraint <ref_eql_sdl_constraints>` on the link.
+
+:sdl:synopsis:`<index-declarations>`
+    Define an :ref:`index <ref_eql_sdl_indexes>` for this abstract
+    link. Note that this index can only refer to link properties.

--- a/docs/edgeql/sdl/objects.rst
+++ b/docs/edgeql/sdl/objects.rst
@@ -35,47 +35,28 @@ commands <ref_eql_ddl_object_types>`.
 
     [abstract] type <TypeName> [extending <supertype> [, ...] ]
     [ "{"
+        [ <attribute-declarations> ]
         [ <property-declarations> ]
         [ <link-declarations> ]
         [ <index-declarations> ]
-        [ <attribute-declarations> ]
         ...
       "}" ]
 
 Description
 -----------
 
-:sdl:synopsis:`abstract`
-    If specified, the declared type will be *abstract*.
-
-:sdl:synopsis:`<TypeName>`
-    Specifies the name of the object type.  Customarily, object type names
-    use the CapWords convention.
-
-:sdl:synopsis:`extending <supertype> [, ...]`
-    If specified, declares the *supertypes* of the new type.
-
-    Use of ``extending`` creates a persistent type relationship
-    between the new subtype and its supertype(s).  Schema modifications
-    to the supertype(s) propagate to the subtype.
-
-    References to supertypes in queries will also include objects of
-    the subtype.
-
-    If the same *link* or *property* name exists in more than one
-    supertype, or is explicitly defined in the subtype and at
-    least one supertype then the data types of the link targets must
-    be *compatible*.  If there is no conflict, the links are merged to
-    form a single link in the new type.
-
-:sdl:synopsis:`<property-declarations>`
-    :ref:`Property <ref_eql_sdl_props>` declarations.
-
-:sdl:synopsis:`<link-declarations>`
-    :ref:`Link <ref_eql_sdl_links>` declarations.
-
-:sdl:synopsis:`<index-declarations>`
-    :ref:`Index <ref_eql_sdl_indexes>` declarations.
+The core of the declaration is identical to :eql:stmt:`CREATE TYPE`,
+while the valid SDL sub-declarations are listed below:
 
 :sdl:synopsis:`<attribute-declarations>`
-    :ref:`Schema attribute <ref_eql_sdl_schema_attributes>` declarations.
+    Set object type :ref:`attribute <ref_eql_sdl_schema_attributes>`
+    to a given *value*.
+
+:sdl:synopsis:`<property-declarations>`
+    Define a concrete :ref:`property <ref_eql_sdl_props>` for this object type.
+
+:sdl:synopsis:`<link-declarations>`
+    Define a concrete :ref:`link <ref_eql_sdl_links>` for this object type.
+
+:sdl:synopsis:`<index-declarations>`
+    Define an :ref:`index <ref_eql_sdl_indexes>` for this object type.

--- a/docs/edgeql/sdl/props.rst
+++ b/docs/edgeql/sdl/props.rst
@@ -46,11 +46,35 @@ commands <ref_eql_ddl_props>`.
     # Concrete property form used inside type declaration:
     [ required ] [{single | multi}] property <name>
       [ extending <base> [, ...] ] -> <type>
-      [ "{" <subcommand>; [...] "}" ] ;
+      [ "{"
+          [ default := <expression> ; ]
+          [ readonly := {true | false} ; ]
+          [ <attribute-declarations> ]
+          [ <constraint-declarations> ]
+          ...
+        "}" ]
 
     # Computable property form used inside type declaration:
     [ required ] [{single | multi}] property <name> := <expression>;
 
     # Abstract property form:
     abstract property [<module>::]<name> [extending <base> [, ...]]
-    [ "{" <subcommand>; [...] "}" ]
+    [ "{"
+        [ readonly := {true | false} ; ]
+        [ <attribute-declarations> ]
+        ...
+      "}" ]
+
+Description
+-----------
+
+The core of the declaration is identical to :eql:stmt:`CREATE PROPERTY`,
+while the valid SDL sub-declarations are listed below:
+
+:sdl:synopsis:`<attribute-declarations>`
+    Set property :ref:`attribute <ref_eql_sdl_schema_attributes>`
+    to a given *value*.
+
+:sdl:synopsis:`<constraint-declarations>`
+    Define a concrete :ref:`constraint <ref_eql_sdl_constraints>` on
+    the property.

--- a/docs/edgeql/sdl/scalars.rst
+++ b/docs/edgeql/sdl/scalars.rst
@@ -30,8 +30,8 @@ commands <ref_eql_ddl_scalars>`.
 
     [abstract] scalar type <TypeName> [extending <supertype> [, ...] ]
     [ "{"
-        [ <constraint-declarations> ]
         [ <attribute-declarations> ]
+        [ <constraint-declarations> ]
         ...
       "}" ]
 
@@ -39,22 +39,14 @@ commands <ref_eql_ddl_scalars>`.
 Description
 -----------
 
-:sdl:synopsis:`abstract`
-    If specified, the declared type will be *abstract*.
-
-:sdl:synopsis:`<TypeName>`
-    Specifies the name of the scalar type.  Customarily, scalar type names
-    use the CapWords convention.
-
-:sdl:synopsis:`extending <supertype> [, ...]`
-    If specified, declares the *supertypes* of the new type.
-
-    Use of ``extending`` creates a persistent type relationship
-    between the new subtype and its supertype(s).  Schema modifications
-    to the supertype(s) propagate to the subtype.
-
-:sdl:synopsis:`<constraint-declarations>`
-    :ref:`Constraint <ref_eql_sdl_constraints>` declarations.
+The core of the declaration is identical to
+:eql:stmt:`CREATE SCALAR TYPE`, while the valid SDL sub-declarations
+are listed below:
 
 :sdl:synopsis:`<attribute-declarations>`
-    :ref:`Schema attribute <ref_eql_sdl_schema_attributes>` declarations.
+    Set scalar type :ref:`attribute <ref_eql_sdl_schema_attributes>`
+    to a given *value*.
+
+:sdl:synopsis:`<constraint-declarations>`
+    Define a concrete :ref:`constraint <ref_eql_sdl_constraints>` for
+    this scalar type.

--- a/docs/edgeql/sdl/views.rst
+++ b/docs/edgeql/sdl/views.rst
@@ -41,11 +41,9 @@ commands <ref_eql_ddl_views>`.
 Description
 -----------
 
-:sdl:synopsis:`<view-name>`
-    The name (optionally module-qualified) of a view to be created.
-
-:sdl:synopsis:`<view-expr>`
-    An expression that defines the *shape* and the contents of the view.
+The core of the declaration is identical to :eql:stmt:`CREATE VIEW`,
+while the valid SDL sub-declarations are listed below:
 
 :sdl:synopsis:`<attribute-declarations>`
-    :ref:`Schema attribute <ref_eql_sdl_schema_attributes>` declarations.
+    Set view :ref:`attribute <ref_eql_sdl_schema_attributes>`
+    to a given *value*.

--- a/docs/tutorial/createdb.rst
+++ b/docs/tutorial/createdb.rst
@@ -10,7 +10,7 @@ First step in a brand new project is to create the database for it:
     db> CREATE DATABASE tutorial;
     CREATE
 
-The above :ref:`command <ref_eql_ddl_databases>` creates a new
+The above :ref:`command <ref_admin_databases>` creates a new
 :ref:`database <ref_datamodel_databases>` in the EdgeDB instance. Now
 we should connect to it:
 

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -385,6 +385,11 @@ class IntrospectionMech:
             if r_type.is_collection():
                 schema, _ = r_type.as_schema_coll(schema)
 
+            if row['initial_value']:
+                initial_value = s_expr.Expression(**row['initial_value'])
+            else:
+                initial_value = None
+
             func_data = {
                 'id': row['id'],
                 'name': name,
@@ -397,7 +402,7 @@ class IntrospectionMech:
                 'sql_func_has_out_params': row['sql_func_has_out_params'],
                 'error_on_null_result': row['error_on_null_result'],
                 'code': row['code'],
-                'initial_value': row['initial_value'],
+                'initial_value': initial_value,
                 'return_type': r_type,
             }
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -631,8 +631,7 @@ class Function(CallableObject, s_abc.Function):
         str, default=None, compcoef=0.9, introspectable=False)
 
     initial_value = so.SchemaField(
-        expr.Expression, default=None, compcoef=0.4, coerce=True,
-        allow_ddl_set=True)
+        expr.Expression, default=None, compcoef=0.4, coerce=True)
 
     def has_inlined_defaults(self, schema):
         # This can be relaxed to just `language is EdgeQL` when we

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -34,8 +34,7 @@ class Index(inheriting.InheritingObject):
     subject = so.SchemaField(so.Object)
 
     expr = so.SchemaField(
-        s_expr.Expression, coerce=True, compcoef=0.909,
-        allow_ddl_set=True)
+        s_expr.Expression, coerce=True, compcoef=0.909)
 
     def __repr__(self):
         cls = self.__class__


### PR DESCRIPTION
Rather than duplicating the synopsys description refer to DDL for most
things and make a separate mention of the nested sub-declarations (liked
to SDL declarations).