### PR TITLE
edgeql: Forbid setting 'default' on abstract links and properties.

### DIFF
--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -432,6 +432,13 @@ class CreateLink(LinkCommand, referencing.CreateReferencedInheritingObject):
 
             cls._parse_default(cmd)
 
+        else:
+            # this is an abstract link then
+            if cmd.get_attribute_value('default') is not None:
+                raise errors.SchemaDefinitionError(
+                    f"'default' is not a valid field for an abstact link",
+                    context=astnode.context)
+
         return cmd
 
     def _get_ast_node(self, context):

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -222,6 +222,13 @@ class CreateProperty(PropertyCommand,
 
             cls._parse_default(cmd)
 
+        else:
+            # this is an abstract property then
+            if cmd.get_attribute_value('default') is not None:
+                raise errors.SchemaDefinitionError(
+                    f"'default' is not a valid field for an abstact property",
+                    context=astnode.context)
+
         return cmd
 
     def _get_ast_node(self, context):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1020,6 +1020,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     };
                 """)
 
+    async def test_edgeql_ddl_link_bad_03(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                f"'default' is not a valid field for an abstact link"):
+            async with self.con.transaction():
+                await self.con.execute("""
+                    CREATE ABSTRACT LINK test::bar {
+                        SET default := Object;
+                    };
+                """)
+
     async def test_edgeql_ddl_prop_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
@@ -1049,6 +1060,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 await self.con.execute("""
                     CREATE TYPE test::Foo {
                         CREATE PROPERTY foo::bar -> test::Foo;
+                    };
+                """)
+
+    async def test_edgeql_ddl_property_bad_03(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                f"'default' is not a valid field for an abstact property"):
+            async with self.con.transaction():
+                await self.con.execute("""
+                    CREATE ABSTRACT PROPERTY test::bar {
+                        SET default := 'bad';
                     };
                 """)
 


### PR DESCRIPTION
Only concrete links and properties can have a default value.

Add tests validating this error.