### PR TITLE
docs: Cross-reference the formatting tables from functions.

### DIFF
--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -136,6 +136,8 @@ The standard library defines the following constraints:
             constraint regexp(r'[A-Za-z]*');
         }
 
+    See :ref:`here <string_regexp>` for more details on regexp patterns.
+
 .. eql:constraint:: std::exclusive
 
     Specifies that the link or property value must be exclusive (unique).

--- a/docs/edgeql/funcops/datetime.rst
+++ b/docs/edgeql/funcops/datetime.rst
@@ -450,8 +450,9 @@ Date and Time
 
     The :eql:type:`datetime` value can be parsed from the input
     :eql:type:`str` *s*. By default, the input is expected to conform
-    to ISO 8601 format. However, the optional argument *fmt* can be
-    used to override the input format to other forms.
+    to ISO 8601 format. However, the optional argument *fmt* can
+    be used to override the :ref:`input format
+    <ref_eql_functions_converters_datetime_fmt>` to other forms.
 
     .. code-block:: edgeql-repl
 
@@ -482,9 +483,6 @@ Date and Time
         ...     2018, 5, 7, 15, 1, 22.306916, 'UTC');
         {<datetime>'2018-05-07T15:01:22.306916+00:00'}
 
-    For more details on formatting see :ref:`here
-    <ref_eql_functions_converters_datetime_fmt>`.
-
 
 ------------
 
@@ -505,6 +503,9 @@ Date and Time
     value can be parsed from the input :eql:type:`str` *s* with an
     optional *fmt* argument or it can be given in terms of its
     component parts: *year*, *month*, *day*, *hour*, *min*, *sec*.
+
+    For more details on formatting see :ref:`here
+    <ref_eql_functions_converters_datetime_fmt>`.
 
     .. code-block:: edgeql-repl
 
@@ -527,9 +528,6 @@ Date and Time
         ...   'US/Central');
         {<local_datetime>'2019-01-01T00:00:00'}
 
-    For more details on formatting see :ref:`here
-    <ref_eql_functions_converters_datetime_fmt>`.
-
 
 ------------
 
@@ -549,6 +547,9 @@ Date and Time
     optional *fmt* argument or it can be given in terms of its
     component parts: *year*, *month*, *day*.
 
+    For more details on formatting see :ref:`here
+    <ref_eql_functions_converters_datetime_fmt>`.
+
     .. code-block:: edgeql-repl
 
         db> SELECT to_local_date('2018-05-07');
@@ -567,9 +568,6 @@ Date and Time
         ...   <datetime>'December 31, 2018 10:00PM GMT+8',
         ...   'US/Central');
         {<local_date>'2019-01-01'}
-
-    For more details on formatting see :ref:`here
-    <ref_eql_functions_converters_datetime_fmt>`.
 
 
 ------------
@@ -591,6 +589,9 @@ Date and Time
     optional *fmt* argument or it can be given in terms of its
     component parts: *hour*, *min*, *sec*.
 
+    For more details on formatting see :ref:`here
+    <ref_eql_functions_converters_datetime_fmt>`.
+
     .. code-block:: edgeql-repl
 
         db> SELECT to_local_time('15:01:22.306916');
@@ -609,9 +610,6 @@ Date and Time
         ...   <datetime>'December 31, 2018 10:00PM GMT+8',
         ...   'US/Pacific');
         {<local_date>'22:00:00'}
-
-    For more details on formatting see :ref:`here
-    <ref_eql_functions_converters_datetime_fmt>`.
 
 
 ------------
@@ -643,6 +641,3 @@ Date and Time
         {<duration>'1:20:45'}
         db> SELECT to_duration(seconds := 4845);
         {<duration>'1:20:45'}
-
-    For more details on formatting see :ref:`here
-    <ref_eql_functions_converters_datetime_fmt>`.

--- a/docs/edgeql/funcops/string.rst
+++ b/docs/edgeql/funcops/string.rst
@@ -382,10 +382,10 @@ String
 
     Find the first regular expression match in a string.
 
-    Given an input *string* and a regular expression *pattern* find
-    the first match for the regular expression within the *string*.
-    Return the match, each match represented by an
-    :eql:type:`array\<str\>` of matched groups.
+    Given an input *string* and a regular expression :ref:`pattern
+    <string_regexp>` find the first match for the regular expression
+    within the *string*. Return the match, each match represented by
+    an :eql:type:`array\<str\>` of matched groups.
 
     .. code-block:: edgeql-repl
 
@@ -403,10 +403,10 @@ String
 
     Find all regular expression matches in a string.
 
-    Given an input *string* and a regular expression *pattern*
-    repeatedly match the regular expression within the *string*.
-    Return the set of all matches, each match represented by an
-    :eql:type:`array\<str\>` of matched groups.
+    Given an input *string* and a regular expression :ref:`pattern
+    <string_regexp>` repeatedly match the regular expression within
+    the *string*. Return the set of all matches, each match
+    represented by an :eql:type:`array\<str\>` of matched groups.
 
     .. code-block:: edgeql-repl
 
@@ -426,11 +426,11 @@ String
 
     Replace matching substrings in a given string.
 
-    Given an input *string* and a regular expression *pattern* replace
-    matching substrings with the replacement string *sub*. Optional
-    :ref:`flag <string_regexp_flags>` argument can be used to specify
-    additional regular expression flags. Return the string resulting
-    from substring replacement.
+    Given an input *string* and a regular expression :ref:`pattern
+    <string_regexp>` replace matching substrings with the replacement
+    string *sub*. Optional :ref:`flag <string_regexp_flags>` argument
+    can be used to specify additional regular expression flags. Return
+    the string resulting from substring replacement.
 
     .. code-block:: edgeql-repl
 
@@ -448,10 +448,10 @@ String
 
     Test if a regular expression has a match in a string.
 
-    Given an input *string* and a regular expression *pattern* test
-    whether there is a match for the regular expression within the
-    *string*. Return ``true`` if there is a match, ``false``
-    otherwise.
+    Given an input *string* and a regular expression :ref:`pattern
+    <string_regexp>` test whether there is a match for the regular
+    expression within the *string*. Return ``true`` if there is a
+    match, ``false`` otherwise.
 
     .. code-block:: edgeql-repl
 
@@ -489,6 +489,9 @@ String
     :eql:func:`to_local_date`, :eql:func:`to_local_time`,
     :eql:func:`to_duration`, correspondingly.
 
+    For valid date and time formatting patterns see
+    :ref:`here <ref_eql_functions_converters_datetime_fmt>`.
+
     .. code-block:: edgeql-repl
 
         db> SELECT to_str(<datetime>'2018-05-07 15:01:22.306916-05',
@@ -501,6 +504,9 @@ String
     reverse of: :eql:func:`to_decimal`, :eql:func:`to_int16`,
     :eql:func:`to_int32`, :eql:func:`to_int64`,
     :eql:func:`to_float32`, :eql:func:`to_float64`.
+
+    For valid number formatting patterns see
+    :ref:`here <ref_eql_functions_converters_number_fmt>`.
 
     See also :eql:func:`to_json`.
 
@@ -537,7 +543,6 @@ String
             "b": "hello"
         }'}
 
-
     When converting :eql:type:`arrays <array>`, a *delimiter* argument
     is required:
 
@@ -549,6 +554,8 @@ String
 
 ----------
 
+
+.. _string_regexp:
 
 Regular Expressions
 -------------------


### PR DESCRIPTION
Regular expression functions and converter functions use special
formatting specs that are described separately. Now the functions
contain a link to the corresponding spec.