### PR TITLE
Make the "repeatable read" isolation level the default.

### DIFF
--- a/docs/edgeql/statements/tx_start.rst
+++ b/docs/edgeql/statements/tx_start.rst
@@ -70,15 +70,16 @@ The :eql:synopsis:`<transaction-mode>` can be one of the following:
     transactions, one of them will be rolled back with a
     serialization_failure error.
 
-    This is the default.
-
 :eql:synopsis:`ISOLATION REPEATABLE READ`
     All statements of the current transaction can only see data
     committed before the first query or data-modification statement
     was executed in this transaction.
 
+    This is the default.
+
 :eql:synopsis:`READ WRITE`
     Sets the transaction access mode to read/write.
+
     This is the default.
 
 :eql:synopsis:`READ ONLY`

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -218,8 +218,7 @@ def run_server(args):
             # * timestamptz is stored in UTC anyways;
             # * this makes the DB server more predictable.
             'TimeZone': 'UTC',
-            'default_transaction_isolation': 'serializable',
-            'max_pred_locks_per_transaction': '512',
+            'default_transaction_isolation': 'repeatable read',
         }
 
         cluster = edgedb_cluster.get_pg_cluster(args['data_dir'])

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1664,7 +1664,7 @@ class TestServerProto(tb.QueryTestCase):
                     stmt += f' ISOLATION {isol}'
                     expected = isol.lower()
                 else:
-                    expected = 'serializable'
+                    expected = 'repeatable read'
 
                 await self.con.execute(stmt)
                 self.assertEqual(
@@ -1680,8 +1680,8 @@ class TestServerProto(tb.QueryTestCase):
         con1 = self.con
         con2 = await self.connect(database=con1.dbname)
 
-        tx1 = con1.transaction()
-        tx2 = con2.transaction()
+        tx1 = con1.transaction(isolation='serializable')
+        tx2 = con2.transaction(isolation='serializable')
         await tx1.start()
         await tx2.start()
 


### PR DESCRIPTION
Turns out that it's too early to use 'serializable' as default because
of how we implement the exclusive constraint.  We'll consider
re-enabling serializable by default in future alpha releases.