### PR TITLE
graphql: Update exposure of our scalars.

### DIFF
--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -46,3 +46,21 @@ type User extending NamedObject {
 }
 
 type Person extending User;
+
+type ScalarTest {
+    property p_bool -> bool;
+    property p_str -> str;
+    property p_datetime -> datetime;
+    property p_local_datetime -> local_datetime;
+    property p_local_date -> local_date;
+    property p_local_time -> local_time;
+    property p_duration -> duration;
+    property p_int16 -> int16;
+    property p_int32 -> int32;
+    property p_int64 -> int64;
+    property p_float32 -> float32;
+    property p_float64 -> float64;
+    property p_decimal -> decimal;
+    property p_json -> json;
+    property p_bytes -> bytes;
+}

--- a/tests/schemas/graphql_setup.edgeql
+++ b/tests/schemas/graphql_setup.edgeql
@@ -99,3 +99,22 @@ INSERT Foo {
     after := 'q',
     color := <color_enum_t>'BLUE',
 };
+
+INSERT ScalarTest {
+    p_bool := True,
+    p_str := 'Hello',
+    p_datetime := <datetime>'2018-05-07T20:01:22.306916+00:00',
+    p_local_datetime := <local_datetime>'2018-05-07T20:01:22.306916',
+    p_local_date := <local_date>'2018-05-07',
+    p_local_time := <local_time>'20:01:22.306916',
+    p_duration := <duration>'20 hrs',
+    p_int16 := 12345,
+    p_int32 := 1234567890,
+    p_int64 := 1234567890123,
+    p_float32 := 2.5,
+    p_float64 := 2.5,
+    p_decimal := <decimal>
+        '123456789123456789123456789.123456789123456789123456789',
+    p_json := to_json('{"foo": [1, null, "bar"]}'),
+    p_bytes := b'Hello World',
+};

--- a/tests/test_http_graphql.py
+++ b/tests/test_http_graphql.py
@@ -1690,6 +1690,72 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             ]
         })
 
+    def test_graphql_functional_scalars_01(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                ScalarTest {
+                    p_bool
+                    p_str
+                    p_datetime
+                    p_local_datetime
+                    p_local_date
+                    p_local_time
+                    p_duration
+                    p_int16
+                    p_int32
+                    p_int64
+                    p_float32
+                    p_float64
+                    p_decimal
+                }
+            }
+        """, {
+            "ScalarTest": [{
+                'p_bool': True,
+                'p_str': 'Hello',
+                'p_datetime': '2018-05-07T20:01:22.306916+00:00',
+                'p_local_datetime': '2018-05-07T20:01:22.306916',
+                'p_local_date': '2018-05-07',
+                'p_local_time': '20:01:22.306916',
+                'p_duration': '20:00:00',
+                'p_int16': 12345,
+                'p_int32': 1234567890,
+                'p_int64': 1234567890123,
+                'p_float32': 2.5,
+                'p_float64': 2.5,
+                'p_decimal':
+                    123456789123456789123456789.123456789123456789123456789,
+            }]
+        })
+
+    def test_graphql_functional_scalars_02(self):
+        # JSON is special since it has to be serialized into its
+        # string representation
+        self.assert_graphql_query_result(r"""
+            query {
+                ScalarTest {
+                    p_json
+                }
+            }
+        """, {
+            "ScalarTest": [{
+                'p_json': '{"foo": [1, null, "bar"]}',
+            }]
+        })
+
+    def test_graphql_functional_scalars_03(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'Cannot query field "p_bytes" on type "ScalarTest"',
+                _line=4, _col=25):
+            self.graphql_query(r"""
+                query {
+                    ScalarTest {
+                        p_bytes
+                    }
+                }
+            """)
+
     def test_graphql_functional_schema_01(self):
         self.assert_graphql_query_result(r"""
             query {


### PR DESCRIPTION
Skip properties that store `bytes`. Expose `json` as its `str`
representation. Expose various date/time scalars as their `str`
representations.
