### PR TITLE
graphql: Update the type-reflection logic.

### DIFF
--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -849,8 +849,8 @@ class GraphQLTranslator:
         name = qlast.Path(steps=name)
 
         ftype = target.get_field_type(fname)
-        typename = ftype.short_name
-        if typename not in {'str', 'uuid'}:
+        typename = ftype.name
+        if typename not in {'std::str', 'std::uuid'}:
             gql_type = gt.EDB_TO_GQL_SCALARS_MAP.get(typename)
             if gql_type == graphql.GraphQLString:
                 # potentially need to cast the 'name' side into a
@@ -864,7 +864,8 @@ class GraphQLTranslator:
 
         value = self.visit(node.value)
         # we need to cast a target string into <uuid> or enum
-        if typename == 'uuid' and not isinstance(value.right, qlast.TypeCast):
+        if typename == 'std::uuid' and not isinstance(
+                value.right, qlast.TypeCast):
             value.right = qlast.TypeCast(
                 expr=value.right,
                 type=qlast.TypeName(maintype=qlast.ObjectRef(name='uuid')),

--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -47,6 +47,10 @@ type User extending NamedObject {
 
 type Person extending User;
 
+scalar type positive_int_t extending int64 {
+    constraint min_value(0);
+}
+
 type ScalarTest {
     property p_bool -> bool;
     property p_str -> str;
@@ -63,4 +67,9 @@ type ScalarTest {
     property p_decimal -> decimal;
     property p_json -> json;
     property p_bytes -> bytes;
+
+    property p_posint -> positive_int_t;
+    property p_array_str -> array<str>;
+    property p_array_json -> array<json>;
+    property p_array_bytes -> array<bytes>;
 }

--- a/tests/schemas/graphql_setup.edgeql
+++ b/tests/schemas/graphql_setup.edgeql
@@ -117,4 +117,9 @@ INSERT ScalarTest {
         '123456789123456789123456789.123456789123456789123456789',
     p_json := to_json('{"foo": [1, null, "bar"]}'),
     p_bytes := b'Hello World',
+
+    p_posint := 42,
+    p_array_str := ['hello', 'world'],
+    p_array_json := [<json>'hello', <json>'world'],
+    p_array_bytes := [b'hello', b'world'],
 };

--- a/tests/test_http_graphql.py
+++ b/tests/test_http_graphql.py
@@ -1756,6 +1756,47 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                 }
             """)
 
+    def test_graphql_functional_scalars_04(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'Cannot query field "p_array_json" on type "ScalarTest"',
+                _line=4, _col=25):
+            self.graphql_query(r"""
+                query {
+                    ScalarTest {
+                        p_array_json
+                    }
+                }
+            """)
+
+    def test_graphql_functional_scalars_05(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'Cannot query field "p_array_bytes" on type "ScalarTest"',
+                _line=4, _col=25):
+            self.graphql_query(r"""
+                query {
+                    ScalarTest {
+                        p_array_bytes
+                    }
+                }
+            """)
+
+    def test_graphql_functional_scalars_06(self):
+        # JSON is special since it has to be serialized into its
+        # string representation
+        self.assert_graphql_query_result(r"""
+            query {
+                ScalarTest {
+                    p_posint
+                }
+            }
+        """, {
+            "ScalarTest": [{
+                'p_posint': 42,
+            }]
+        })
+
     def test_graphql_functional_schema_01(self):
         self.assert_graphql_query_result(r"""
             query {


### PR DESCRIPTION
Tuples are not reflected.
Arrays are reflected as long as they are not of json or bytes.
Bytes are not reflected.
If a scalar is not even reconglized as being from the list of known
scalars (such as name changed in std, or a new scalar added to std) an
exception is raised.