### PR TITLE
docs: Rewrite type filter as an operator.

### DIFF
--- a/docs/edgeql/funcops/set.rst
+++ b/docs/edgeql/funcops/set.rst
@@ -167,6 +167,62 @@ Set
 ----------
 
 
+.. eql:operator:: ISFILTER: anytype [IS type] -> anytype
+
+    :index: is type filter
+
+    Filter the set based on type.
+
+    The type filter operator removes all elements from the input set
+    that aren't of the specified type. Additionally, since it
+    guarantees the type of the result set all the links and properties
+    associated with the specified type can now be used on the
+    resulting expression. This is especially useful in combination
+    with :ref:`backward links <ref_eql_expr_paths>`.
+
+    Consider the following types:
+
+    .. code-block:: sdl
+
+        type User {
+            required property name -> str;
+        }
+
+        abstract type Owned {
+            required link owner -> User;
+        }
+
+        type Issue extending Owned {
+            required property title -> str;
+        }
+
+        type Comment extending Owned {
+            required property body -> str;
+        }
+
+    The following expression will get all :eql:type:`Objects <Object>`
+    owned by all users (if there are any):
+
+    .. code-block:: edgeql
+
+        SELECT User.<owner;
+
+    By default backward links don't infer any type information beyond the
+    fact that it's an :eql:type:`Object`. To ensure that this path
+    specifically reaches ``Issue`` the type filter operator must be used:
+
+    .. code-block:: edgeql
+
+        SELECT User.<owner[IS Issue];
+
+        # With the use of type filter it's possible to refer to
+        # specific property of Issue now:
+        SELECT User.<owner[IS Issue].title;
+
+
+----------
+
+
 .. eql:function:: std::count(s: SET OF anytype) -> int64
 
     :index: aggregate

--- a/docs/edgeql/funcops/type.rst
+++ b/docs/edgeql/funcops/type.rst
@@ -71,11 +71,11 @@ Types
     satisfies the requirements of a target type. EdgeDB allows casting any
     scalar.
 
-    It is illegal to cast one :eql:type:`Object` into another. The only
-    way to construct a new :eql:type:`Object` is by using :ref:`INSERT
-    <ref_eql_statements_insert>`. However, the :ref:`target filter
-    <ref_eql_expr_paths_is>` can be used to achieve an effect similar to
-    casting for Objects.
+    It is illegal to cast one :eql:type:`Object` into another. The
+    only way to construct a new :eql:type:`Object` is by using
+    :ref:`INSERT <ref_eql_statements_insert>`. However, the
+    :eql:op:`type filter <ISFILTER>` can be used to achieve an
+    effect similar to casting for Objects.
 
     When a cast is applied to an expression of a known type, it represents a
     run-time type conversion. The cast will succeed only if a suitable type


### PR DESCRIPTION
Type filter `[IS ...]` is no longer path-specific.
Add type filter as a set operator.
Fix examples and references to type filter.