### PR TITLE
Use an environment variable to pass the address of test instance

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -212,18 +212,18 @@ def _init_cluster(data_dir=None, *, cleanup_atexit=True, init_settings={}):
     return cluster
 
 
-def _set_default_cluster(cluster):
-    global _default_cluster
-    _default_cluster = cluster
-
-
 def _start_cluster(*, cleanup_atexit=True):
     global _default_cluster
 
     if _default_cluster is None:
-        data_dir = os.environ.get('EDGEDB_TEST_DATA_DIR')
-        _default_cluster = _init_cluster(
-            data_dir=data_dir, cleanup_atexit=cleanup_atexit)
+        cluster_addr = os.environ.get('EDGEDB_TEST_CLUSTER_ADDR')
+        if cluster_addr:
+            conn_spec = json.loads(cluster_addr)
+            _default_cluster = edgedb_cluster.RunningCluster(**conn_spec)
+        else:
+            data_dir = os.environ.get('EDGEDB_TEST_DATA_DIR')
+            _default_cluster = _init_cluster(
+                data_dir=data_dir, cleanup_atexit=cleanup_atexit)
 
     return _default_cluster
 

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -23,6 +23,7 @@ import collections.abc
 import enum
 import io
 import itertools
+import json
 import multiprocessing
 import multiprocessing.reduction
 import multiprocessing.util
@@ -49,7 +50,6 @@ import edgedb
 
 from edb.common import devmode
 from edb.testbase import server as tb
-from edb.server import cluster as edgedb_cluster
 
 from . import styles
 
@@ -75,8 +75,7 @@ def init_worker(param_queue, result_queue):
         server_addr = param_queue.get()
 
         if server_addr is not None:
-            cluster = edgedb_cluster.RunningCluster(**server_addr)
-            tb._set_default_cluster(cluster)
+            os.environ['EDGEDB_TEST_CLUSTER_ADDR'] = json.dumps(server_addr)
 
     multiprocessing.util.Finalize(suite_cache, finalize_result_testcases,
                                   exitpriority=100)
@@ -282,8 +281,8 @@ class SequentialTestSuite(unittest.TestSuite):
         result = result_
 
         if self.server_conn:
-            cluster = edgedb_cluster.RunningCluster(**self.server_conn)
-            tb._set_default_cluster(cluster)
+            os.environ['EDGEDB_TEST_CLUSTER_ADDR'] = \
+                json.dumps(self.server_conn)
 
         for test in self.tests:
             _run_test(test)


### PR DESCRIPTION
This allows out-of-tree tests to use `edb test` without relying on
server's testbase infra.