### PR TITLE
Add an explicit dependency on edgedb-python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ RUNTIME_DEPS = [
 
     'graphql-core~=2.1.0',
     'promise~=2.2.0',
+
+    'edgedb~=0.6.1',
 ]
 
 CYTHON_DEPENDENCY = 'Cython==0.29.6'


### PR DESCRIPTION
Default to the PyPI version of EdgeDB-Python.  CI and dev can still use
the git version as necessary.