### PR TITLE
tests: Include code snippets from eql definitions into tests.

### DIFF
--- a/docs/edgeql/funcops/string.rst
+++ b/docs/edgeql/funcops/string.rst
@@ -171,7 +171,7 @@ String
         {true}
         db> SELECT 'abc' LIKE 'c';
         {false}
-        db> SELECT 'a%%c' NOT LIKE 'a\%c';
+        db> SELECT 'a%%c' NOT LIKE r'a\%c';
         {true}
 
 

--- a/docs/edgeql/funcops/type.rst
+++ b/docs/edgeql/funcops/type.rst
@@ -51,7 +51,7 @@ Types
         ... FILTER User.name = 'Alice';
         {true}
 
-        db> SELECT User IS (Text, Named);
+        db> SELECT User IS (Text | Named);
         {true, ..., true}  # one for every user instance
 
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -729,6 +729,13 @@ aa';
         SELECT (User IS (((SystemUser & Foo) | Bar) | (array<int>)));
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Unexpected ','", line=2, col=31)
+    def test_edgeql_syntax_ops_26(self):
+        """
+        SELECT (User IS (Named, Text));
+        """
+
     def test_edgeql_syntax_required_01(self):
         """
         SELECT REQUIRED (User.groups.description);


### PR DESCRIPTION
The code snippets appearing nested in type, funciton and constraint
definitions are now also subject to be parsed and tested.