### PR TITLE
tests: Error handling inside a transaction.

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1088,3 +1088,8 @@ class Compiler(BaseCompiler):
     async def interpret_backend_error(self, dbver, fields):
         db = await self._get_database(dbver)
         return errormech.interpret_backend_error(db.schema, fields)
+
+    async def interpret_backend_error_in_tx(self, txid, fields):
+        state = self._load_state(txid)
+        return errormech.interpret_backend_error(
+            state.current_tx().get_schema(), fields)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2429,7 +2429,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         The current docs for DDL have a *very* similar example to this
         one, but which works fine. The difference is in the
         CREATE/ALTER sequence of the PROPERTY and CONSTRAINT.
-
     ''')
     async def test_edgeql_ddl_constraint_alter_01(self):
         await self.con.execute(r"""


### PR DESCRIPTION
Error handling code should see all the changes inside the transaction in
order to correctly map the errors.