### PR TITLE
edgeql: Add a "session_only" attribute to functions.

### DIFF
--- a/docs/edgeql/ddl/functions.rst
+++ b/docs/edgeql/ddl/functions.rst
@@ -45,8 +45,9 @@ CREATE FUNCTION
 
     # where <subcommand> is one of
 
-      FROM <language> <functionbody>
+      SET session_only := {true | false}
       SET ANNOTATION <annotation-name> := <value>
+      FROM <language> <functionbody>
 
 
 Description
@@ -131,6 +132,16 @@ Subcommands
 
 ``CREATE FUNCTION`` allows specifying the following subcommands in its
 block:
+
+:eql:synopsis:`SET session_only := {true | false}`
+    If ``true``, the function is only valid in contexts where there is
+    a well-defined session. In particular, this function cannot be
+    used over an HTTP port, within the body of another
+    non-session-only function, as part of a view definition, or as a
+    default value in definitions. This field is ``false`` by default.
+    Examples of session-only functions: :eql:func:`sys::sleep`,
+    :eql:func:`sys::advisory_lock`, :eql:func:`sys::advisory_unlock`,
+    :eql:func:`sys::advisory_unlock_all`.
 
 :eql:synopsis:`SET ANNOTATION <annotation-name> := <value>`
     Set the function's :eql:synopsis:`<annotation-name>` to

--- a/docs/edgeql/sdl/functions.rst
+++ b/docs/edgeql/sdl/functions.rst
@@ -35,8 +35,9 @@ commands <ref_eql_ddl_functions>`.
 
     function <name> ([ <argspec> ] [, ... ]) -> <returnspec>
     "{"
-        from <language> <functionbody> ;
+        session_only := {true | false} ;
         [ <annotation-declarations> ]
+        from <language> <functionbody> ;
     "}" ;
 
     # where <argspec> is:

--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -128,7 +128,8 @@ def compile_ast_to_ir(tree,
                       implicit_tid_in_shapes=False,
                       schema_view_mode=False,
                       disable_constant_folding=False,
-                      json_parameters=False):
+                      json_parameters=False,
+                      session_mode=False):
     """Compile given EdgeQL AST into EdgeDB IR."""
 
     if debug.flags.edgeql_compile:
@@ -144,7 +145,8 @@ def compile_ast_to_ir(tree,
         implicit_tid_in_shapes=implicit_tid_in_shapes,
         schema_view_mode=schema_view_mode,
         disable_constant_folding=disable_constant_folding,
-        json_parameters=json_parameters)
+        json_parameters=json_parameters,
+        session_mode=session_mode)
 
     if path_prefix_anchor is not None:
         path_prefix = anchors[path_prefix_anchor]
@@ -252,7 +254,10 @@ def compile_func_to_ir(func, schema, *,
         tree, schema, anchors=anchors, func=func,
         security_context=security_context, modaliases=modaliases,
         implicit_id_in_shapes=implicit_id_in_shapes,
-        implicit_tid_in_shapes=implicit_tid_in_shapes)
+        implicit_tid_in_shapes=implicit_tid_in_shapes,
+        # the body of a session_only function can contain calls to
+        # other session_only functions
+        session_mode=func.get_session_only(schema))
 
     return ir
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -130,10 +130,14 @@ class Environment:
     json_parameters: bool
     """Force types of all parameters to std::json"""
 
+    session_mode: bool
+    """Whether there is a specific session."""
+
     def __init__(self, *, schema, path_scope,
                  schema_view_mode: bool=False,
                  constant_folding: bool=True,
-                 json_parameters: bool=False):
+                 json_parameters: bool=False,
+                 session_mode: bool=False):
         self.schema = schema
         self.path_scope = path_scope
         self.schema_view_cache = {}
@@ -148,6 +152,7 @@ class Environment:
         self.view_shapes_metadata = collections.defaultdict(
             irast.ViewShapeMetadata)
         self.json_parameters = json_parameters
+        self.session_mode = session_mode
 
 
 class ContextLevel(compiler.ContextLevel):

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -64,7 +64,8 @@ def init_context(
         disable_constant_folding: bool=False,
         implicit_id_in_shapes: bool=False,
         implicit_tid_in_shapes: bool=False,
-        json_parameters: bool=False) -> \
+        json_parameters: bool=False,
+        session_mode: bool=False) -> \
         context.ContextLevel:
     stack = context.CompilerContext()
     ctx = stack.current
@@ -75,7 +76,8 @@ def init_context(
         path_scope=irast.new_scope_tree(),
         constant_folding=not disable_constant_folding,
         schema_view_mode=schema_view_mode,
-        json_parameters=json_parameters)
+        json_parameters=json_parameters,
+        session_mode=session_mode)
 
     if singletons:
         # The caller wants us to treat these type references

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -517,6 +517,9 @@ class FunctionCall(Call):
     # (or None, if the function has no variadic parameters.)
     variadic_param_type: typing.Optional[TypeRef] = None
 
+    # True if function requires a session to be executed
+    session_only: bool = False
+
 
 class OperatorCall(Call):
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -243,7 +243,11 @@ ALTER TYPE schema::ObjectType {
 };
 
 
-CREATE TYPE schema::Function EXTENDING schema::CallableObject;
+CREATE TYPE schema::Function EXTENDING schema::CallableObject {
+    CREATE REQUIRED PROPERTY session_only -> std::bool {
+        SET default := false;
+    }
+};
 
 
 CREATE TYPE schema::Operator EXTENDING schema::CallableObject {

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -46,6 +46,7 @@ ALTER TYPE sys::Role {
 CREATE FUNCTION
 sys::sleep(duration: std::float64) -> std::bool
 {
+    SET session_only := True;
     FROM SQL $$
     SELECT pg_sleep("duration") IS NOT NULL;
     $$;
@@ -55,6 +56,7 @@ sys::sleep(duration: std::float64) -> std::bool
 CREATE FUNCTION
 sys::sleep(duration: std::duration) -> std::bool
 {
+    SET session_only := True;
     FROM SQL $$
     SELECT pg_sleep_for("duration") IS NOT NULL;
     $$;
@@ -64,6 +66,7 @@ sys::sleep(duration: std::duration) -> std::bool
 CREATE FUNCTION
 sys::advisory_lock(key: std::int64) -> std::bool
 {
+    SET session_only := True;
     FROM SQL $$
     SELECT CASE WHEN "key" < 0 THEN
         edgedb._raise_exception('lock key cannot be negative', NULL::bool)
@@ -77,6 +80,7 @@ sys::advisory_lock(key: std::int64) -> std::bool
 CREATE FUNCTION
 sys::advisory_unlock(key: std::int64) -> std::bool
 {
+    SET session_only := True;
     FROM SQL $$
     SELECT CASE WHEN "key" < 0 THEN
         edgedb._raise_exception('lock key cannot be negative', NULL::bool)
@@ -90,6 +94,7 @@ sys::advisory_unlock(key: std::int64) -> std::bool
 CREATE FUNCTION
 sys::advisory_unlock_all() -> std::bool
 {
+    SET session_only := True;
     FROM SQL $$
     SELECT pg_advisory_unlock_all() IS NOT NULL;
     $$;

--- a/edb/pgsql/datasources/schema/functions.py
+++ b/edb/pgsql/datasources/schema/functions.py
@@ -39,6 +39,7 @@ async def fetch(
                 f.sql_func_has_out_params,
                 f.error_on_null_result,
                 f.initial_value,
+                f.session_only,
                 f.return_type AS return_type,
                 edgedb._resolve_type_name(f.params) AS params
             FROM

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -404,8 +404,7 @@ def ptr_default_to_col_default(schema, ptr, expr):
     if not ir_utils.is_const(ir):
         return None
 
-    sql_expr = compiler.compile_ir_to_sql_tree(
-        ir, singleton_mode=True)
+    sql_expr = compiler.compile_ir_to_sql_tree(ir, singleton_mode=True)
     sql_text = codegen.SQLSourceGenerator.to_source(sql_expr)
 
     return sql_text

--- a/edb/server/baseport.py
+++ b/edb/server/baseport.py
@@ -75,7 +75,8 @@ class Port:
 
         self._compiler_manager = await procpool.create_manager(
             runstate_dir=self._internal_runstate_dir,
-            worker_args=(dict(host=self._pg_addr), self._pg_data_dir),
+            worker_args=(dict(host=self._pg_addr),
+                         self._pg_data_dir),
             worker_cls=self.get_compiler_worker_cls(),
             name=self.get_compiler_worker_name(),
         )

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -265,6 +265,10 @@ class Compiler(BaseCompiler):
             session_config,
             allow_unrecognized=True)
 
+        # the capability to execute transaction or session control
+        # commands indicates that session mode is available
+        session_mode = ctx.state.capability & (enums.Capability.TRANSACTION |
+                                               enums.Capability.SESSION)
         ir = ql_compiler.compile_ast_to_ir(
             ql,
             schema=current_tx.get_schema(),
@@ -272,7 +276,8 @@ class Compiler(BaseCompiler):
             implicit_tid_in_shapes=implicit_fields,
             implicit_id_in_shapes=implicit_fields,
             disable_constant_folding=disable_constant_folding,
-            json_parameters=ctx.json_parameters)
+            json_parameters=ctx.json_parameters,
+            session_mode=session_mode)
 
         if ir.cardinality is qltypes.Cardinality.ONE:
             result_cardinality = enums.ResultCardinality.ONE

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -637,6 +637,33 @@ class TestIntrospection(tb.QueryTestCase):
             ]
         )
 
+    @test.xfail('''
+        `session_only` is required and has a default, but still shows
+        up as `{}`.
+    ''')
+    async def test_edgeql_introspection_function_02(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE schema
+                SELECT `Function` {
+                    name,
+                    session_only
+                }
+                FILTER .name IN {'std::count', 'sys::advisory_lock'}
+                ORDER BY .name;
+            """,
+            [
+                {
+                    "name": "std::count",
+                    "session_only": False,
+                },
+                {
+                    "name": "sys::advisory_lock",
+                    "session_only": True,
+                }
+            ]
+        )
+
     async def test_edgeql_introspection_meta_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -173,3 +173,43 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
             """,
             [],
         )
+
+    def test_http_edgeql_session_func_01(self):
+        with self.assertRaisesRegex(edgedb.QueryError,
+                                    r'sys::advisory_lock\(\) cannot be '
+                                    r'called in a non-session context'):
+            self.edgeql_query(r"SELECT sys::advisory_lock(1);")
+
+    def test_http_edgeql_session_func_02(self):
+        with self.assertRaisesRegex(edgedb.QueryError,
+                                    r'sys::advisory_unlock\(\) cannot be '
+                                    r'called in a non-session context'):
+            self.edgeql_query(r"SELECT sys::advisory_unlock(1);")
+
+    def test_http_edgeql_session_func_03(self):
+        with self.assertRaisesRegex(edgedb.QueryError,
+                                    r'sys::advisory_unlock_all\(\) cannot be '
+                                    r'called in a non-session context'):
+            self.edgeql_query(r"SELECT sys::advisory_unlock_all();")
+
+    def test_http_edgeql_session_func_04(self):
+        with self.assertRaisesRegex(edgedb.QueryError,
+                                    r'sys::sleep\(\) cannot be '
+                                    r'called in a non-session context'):
+            self.edgeql_query(r"SELECT sys::sleep(0);")
+
+    def test_http_edgeql_session_func_05(self):
+        with self.assertRaisesRegex(edgedb.QueryError,
+                                    r'sys::sleep\(\) cannot be '
+                                    r'called in a non-session context'):
+            self.edgeql_query(r"SELECT sys::sleep(<duration>'0s');")
+
+    def test_http_edgeql_session_func_06(self):
+        with self.assertRaisesRegex(edgedb.QueryError,
+                                    r'sys::sleep\(\) cannot be '
+                                    r'called in a non-session context'):
+            self.edgeql_query(r"""
+                SELECT Object {
+                    bad := sys::sleep(0)
+                };
+            """)


### PR DESCRIPTION
If a function is marked as "session_only" it can't be executed over REST
protocol since that protocol doesn't provide any guarantees regarding
the session used.

Fixes #406.