### PR TITLE
Allow expressions to return generic types in certain scenarios

### DIFF
--- a/docs/edgeql/expressions/arrays.rst
+++ b/docs/edgeql/expressions/arrays.rst
@@ -23,13 +23,16 @@ For example:
 
 
 An empty array can also be created, but it must be used together with
-a type case, since EdgeDB cannot determine the type of an array without
+a type cast, since EdgeDB cannot determine the type of an array without
 having elements in it:
 
 .. code-block:: edgeql-repl
 
     db> SELECT [];
-    EdgeQLError: could not determine the type of empty array
+    QueryError: expression returns value of indeterminate type
+    Hint: Consider using an explicit type cast.
+    ### SELECT [];
+    ###        ^
 
     db> SELECT <array<int64>>[];
     {[]}

--- a/edb/edgeql/compiler/cast.py
+++ b/edb/edgeql/compiler/cast.py
@@ -59,7 +59,8 @@ def compile_cast(
         return setgen.new_empty_set(
             stype=new_stype,
             alias=ir_expr.path_id.target_name_hint.name,
-            ctx=ctx)
+            ctx=ctx,
+            srcctx=ir_expr.context)
 
     elif irutils.is_untyped_empty_array_expr(ir_expr):
         # Ditto for empty arrays.

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -103,6 +103,13 @@ class Environment:
     set_types: typing.Dict[irast.Set, s_types.Type]
     """A dictionary of all Set instances and their schema types."""
 
+    type_origins: typing.Dict[s_types.Type, parsing.ParserContext]
+    """A dictionary of notable types and their source origins.
+
+    This is used to trace where a particular type instance originated in
+    order to provide useful diagnostics for type errors.
+    """
+
     inferred_types: typing.Dict[irast.Base, s_types.Type]
     """A dictionary of all expressions and their inferred schema types."""
 
@@ -133,6 +140,7 @@ class Environment:
         self.query_parameters = {}
         self.schema_view_mode = schema_view_mode
         self.set_types = {}
+        self.type_origins = {}
         self.inferred_types = {}
         self.inferred_cardinality = {}
         self.constant_folding = constant_folding

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -139,7 +139,11 @@ def compile_Set(
                 )
             return dispatch.compile(bigunion, ctx=ctx)
     else:
-        return setgen.new_empty_set(alias=ctx.aliases.get('e'), ctx=ctx)
+        return setgen.new_empty_set(
+            alias=ctx.aliases.get('e'),
+            ctx=ctx,
+            srcctx=expr.context,
+        )
 
 
 @dispatch.compile.register(qlast.BaseConstant)
@@ -330,7 +334,7 @@ def compile_Array(
                 f'nested arrays are not supported',
                 context=expr_el.context)
 
-    return setgen.new_array_set(elements, ctx=ctx)
+    return setgen.new_array_set(elements, ctx=ctx, srcctx=expr.context)
 
 
 @dispatch.compile.register(qlast.IfElse)

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -282,6 +282,8 @@ def compile_operator(
             raise errors.QueryError(
                 f'operator {str(op_name)!r} cannot be applied to '
                 f'operands of type {types}',
+                hint='Consider using an explicit type cast or a conversion '
+                     'function.',
                 context=qlexpr.context)
         elif len(matched) > 1:
             detail = ', '.join(

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -187,12 +187,12 @@ def __infer_typecheckop(ir, env):
 
 @_infer_type.register(irast.AnyTypeRef)
 def __infer_anytyperef(ir, env):
-    return s_pseudo.Any.create()
+    return s_pseudo.Any.instance
 
 
 @_infer_type.register(irast.AnyTupleRef)
 def __infer_anytupleref(ir, env):
-    return s_pseudo.AnyTuple.create()
+    return s_pseudo.AnyTuple.instance
 
 
 @_infer_type.register(irast.TypeRef)
@@ -349,7 +349,7 @@ def __infer_index(ir, env):
                 node_type.get_name(env.schema) == 'std::anyscalar') and
             (index_type.implicitly_castable_to(int_t, env.schema) or
                 index_type.implicitly_castable_to(str_t, env.schema))):
-        result = s_pseudo.Any.create()
+        result = s_pseudo.Any.instance
 
     else:
         raise errors.QueryError(
@@ -370,9 +370,7 @@ def __infer_array(ir, env):
             raise errors.QueryError('could not determine array type',
                                     context=ir.context)
     else:
-        raise errors.QueryError(
-            'could not determine type of empty array',
-            context=ir.context)
+        element_type = s_pseudo.Any.instance
 
     return s_types.Array.create(env.schema, element_type=element_type)
 

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -54,9 +54,9 @@ def get_schema_object(
         module = name.module
         name = name.name
     elif isinstance(name, qlast.AnyType):
-        return s_pseudo.Any.create()
+        return s_pseudo.Any.instance
     elif isinstance(name, qlast.AnyTuple):
-        return s_pseudo.AnyTuple.create()
+        return s_pseudo.AnyTuple.instance
 
     if module:
         name = sn.Name(name=name, module=module)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -560,7 +560,9 @@ def compile_result_clause(
                 expr = setgen.new_empty_set(
                     stype=target_t,
                     alias=ctx.aliases.get('e'),
-                    ctx=sctx)
+                    ctx=sctx,
+                    srcctx=result_expr.context,
+                )
             else:
                 with sctx.new() as exprctx:
                     exprctx.empty_result_type_hint = target_t
@@ -572,7 +574,9 @@ def compile_result_clause(
                 expr = setgen.new_empty_set(
                     stype=sctx.empty_result_type_hint,
                     alias=ctx.aliases.get('e'),
-                    ctx=sctx)
+                    ctx=sctx,
+                    srcctx=result_expr.context,
+                )
             else:
                 expr = setgen.ensure_set(
                     dispatch.compile(result_expr, ctx=sctx), ctx=sctx)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -171,6 +171,14 @@ def fini_expression(
 
     expr_type = inference.infer_type(ir, ctx.env)
 
+    if ctx.func is None:
+        anytype = expr_type.find_any(ctx.env.schema)
+        if anytype is not None:
+            raise errors.QueryError(
+                'expression returns value of indeterminate type',
+                hint='Consider using an explicit type cast.',
+                context=ctx.env.type_origins.get(anytype))
+
     result = irast.Statement(
         expr=ir,
         params=ctx.env.query_parameters,

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -43,7 +43,11 @@ from . import setgen
 def type_to_ql_typeref(t: s_obj.Object, *,
                        _name=None,
                        ctx: context.ContextLevel) -> qlast.TypeName:
-    if not isinstance(t, s_abc.Collection):
+    if t.is_any():
+        result = qlast.TypeName(name=_name, maintype=qlast.AnyType())
+    elif t.is_anytuple():
+        result = qlast.TypeName(name=_name, maintype=qlast.AnyTuple())
+    elif not isinstance(t, s_abc.Collection):
         result = qlast.TypeName(
             name=_name,
             maintype=qlast.ObjectRef(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -392,6 +392,13 @@ def _normalize_view_ptr_expr(
         ptr_cardinality = None
         ptr_target = inference.infer_type(irexpr, ctx.env)
 
+        anytype = ptr_target.find_any(ctx.env.schema)
+        if anytype is not None:
+            raise errors.QueryError(
+                'expression returns value of indeterminate type',
+                context=ctx.env.type_origins.get(anytype),
+            )
+
         if (is_mutation and base_ptrcls is not None
                 and not ptr_target.assignment_castable_to(
                     base_ptrcls.get_target(ctx.env.schema),

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -631,7 +631,7 @@ class DeclarationLoader:
                     # This is a computable, but we cannot interpret
                     # the expression yet, so set the target to `any`
                     # temporarily.
-                    _targets = [s_pseudo.Any.create()]
+                    _targets = [s_pseudo.Any.instance]
 
                 else:
                     _targets = [self._get_ref_type(t) for t in linkdecl.target]

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -172,10 +172,10 @@ def type_to_typeref(schema, t: s_types.Type, *,
 
 def ir_typeref_to_type(schema, typeref: irast.TypeRef) -> s_types.Type:
     if is_anytuple(typeref):
-        return s_pseudo.AnyTuple.create()
+        return s_pseudo.AnyTuple.instance
 
     elif is_any(typeref):
-        return s_pseudo.Any.create()
+        return s_pseudo.Any.instance
 
     elif is_tuple(typeref):
         named = False

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -405,19 +405,7 @@ def compile_TypeCheckOp(
 def compile_Array(
         expr: irast.Base, *, ctx: context.CompilerContextLevel) -> pgast.Base:
     elements = [dispatch.compile(e, ctx=ctx) for e in expr.elements]
-    array = astutils.safe_array_expr(elements)
-
-    if irutils.is_empty_array_expr(expr):
-        serialized = output.in_serialization_ctx(ctx=ctx)
-        return pgast.TypeCast(
-            arg=array,
-            type_name=pgast.TypeName(
-                name=pg_types.pg_type_from_ir_typeref(
-                    expr.typeref, serialized=serialized)
-            )
-        )
-    else:
-        return array
+    return relgen.build_array_expr(expr, elements, ctx=ctx)
 
 
 @dispatch.compile.register(irast.TupleIndirection)

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -503,17 +503,17 @@ class IntrospectionMech:
             scls = coll_type.from_subtypes(schema, st, typemods=typemods)
 
         elif t['maintype'] == 'anytype':
-            scls = s_pseudo.Any.create()
+            scls = s_pseudo.Any.instance
 
         elif t['maintype'] == 'anytuple':
-            scls = s_pseudo.AnyTuple.create()
+            scls = s_pseudo.AnyTuple.instance
 
         else:
             type_id = t['maintype']
             if type_id == s_obj.get_known_type_id('anytype'):
-                scls = s_pseudo.Any.create()
+                scls = s_pseudo.Any.instance
             elif type_id == s_obj.get_known_type_id('anytuple'):
-                scls = s_pseudo.AnyTuple.create()
+                scls = s_pseudo.AnyTuple.instance
             else:
                 scls = schema.get_by_id(t['maintype'])
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -136,7 +136,7 @@ class Constraint(inheriting.InheritingObject, s_func.CallableObject,
     def _dummy_subject(cls, schema):
         # Point subject placeholder to a dummy pointer to make EdgeQL
         # pipeline happy.
-        return s_pseudo.Any.create()
+        return s_pseudo.Any.instance
 
     @classmethod
     def _normalize_constraint_expr(

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -60,15 +60,23 @@ class PseudoType(inheriting.InheritingObject, s_types.Type):
                 self.name == other.name)
 
 
-class Any(PseudoType):
+class AnyMeta(type(PseudoType)):
+
+    @property
+    def instance(cls):
+        if cls._instance is None:
+            cls._instance = cls.create()
+
+        return cls._instance
+
+
+class Any(PseudoType, metaclass=AnyMeta):
 
     _instance = None
 
     @classmethod
     def create(cls):
-        if cls._instance is None:
-            cls._instance = cls._create(None, name='anytype')
-        return cls._instance
+        return cls._create(None, name='anytype')
 
     def is_any(self):
         return True
@@ -111,18 +119,16 @@ class AnyObjectRef(so.ObjectRef):
         super().__init__(name=name)
 
     def _resolve_ref(self, schema):
-        return Any.create()
+        return Any.instance
 
 
-class AnyTuple(PseudoType):
+class AnyTuple(PseudoType, metaclass=AnyMeta):
 
     _instance = None
 
     @classmethod
     def create(cls):
-        if cls._instance is None:
-            cls._instance = cls._create(None, name='anytuple')
-        return cls._instance
+        return cls._create(None, name='anytuple')
 
     def is_anytuple(self):
         return True
@@ -153,4 +159,4 @@ class AnyTupleRef(so.ObjectRef):
         super().__init__(name=name)
 
     def _resolve_ref(self, schema):
-        return AnyTuple.create()
+        return AnyTuple.instance

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -86,6 +86,12 @@ class Type(so.Object, derivable.DerivableObjectBase, s_abc.Type):
     def is_anytuple(self):
         return False
 
+    def find_any(self, schema):
+        if self.is_any():
+            return self
+        else:
+            return None
+
     def contains_any(self, schema):
         return self.is_any()
 
@@ -132,7 +138,7 @@ class Type(so.Object, derivable.DerivableObjectBase, s_abc.Type):
             - `array<anytype>`.resolve_polymorphic(`array<int>`) -> `int`
             - `array<anytype>`.resolve_polymorphic(`tuple<int>`) -> None
         """
-        if not self.is_polymorphic(schema) or other.is_polymorphic(schema):
+        if not self.is_polymorphic(schema):
             return None
 
         return self._resolve_polymorphic(schema, other)
@@ -236,6 +242,12 @@ class Collection(Type, s_abc.Collection):
     def is_polymorphic(self, schema):
         return any(st.is_polymorphic(schema)
                    for st in self.get_subtypes(schema))
+
+    def find_any(self, schema):
+        for st in self.get_subtypes(schema):
+            any_t = st.find_any(schema)
+            if any_t is not None:
+                return any_t
 
     def contains_any(self, schema):
         return any(st.contains_any(schema) for st in self.get_subtypes(schema))

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -212,8 +212,9 @@ class TestExpressions(tb.QueryTestCase):
             [],
         )
 
-        with self.assertRaisesRegex(edgedb.QueryError,
-                                    r'could not determine expression type'):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'expression returns value of indeterminate type'):
 
             await self.con.execute("""
                 SELECT {};
@@ -230,12 +231,10 @@ class TestExpressions(tb.QueryTestCase):
             [0],
         )
 
-        with self.assertRaisesRegex(edgedb.QueryError,
-                                    r'could not determine expression type'):
-
-            await self.con.execute("""
-                SELECT count({});
-            """)
+        await self.assert_query_result(
+            r'''SELECT count({});''',
+            [0],
+        )
 
     async def test_edgeql_expr_idempotent_01(self):
         await self.assert_query_result(
@@ -2693,7 +2692,7 @@ class TestExpressions(tb.QueryTestCase):
     async def test_edgeql_expr_array_04(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'could not determine type of empty array'):
+                r'expression returns value of indeterminate type'):
 
             await self.con.fetchall_json("""
                 SELECT [];
@@ -2862,7 +2861,7 @@ class TestExpressions(tb.QueryTestCase):
         # it should be technically possible to infer the type of the array
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'could not determine type of empty array'):
+                r"operator 'UNION' cannot be applied to operands.*anytype.*"):
 
             await self.con.execute("""
                 SELECT {[1, 2], []};

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -160,7 +160,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_array_agg_05(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'could not determine expression type'):
+                r'expression returns value of indeterminate type'):
 
             await self.con.execute("""
                 SELECT array_agg({});
@@ -357,6 +357,20 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                 ]
             ]
         )
+
+    async def test_edgeql_functions_array_agg_17(self):
+        await self.assert_query_result(
+            '''SELECT count(array_agg({}))''',
+            [1],
+        )
+
+    async def test_edgeql_functions_array_agg_18(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'expression returns value of indeterminate type'):
+            await self.con.execute(
+                '''SELECT array_agg({})''',
+            )
 
     async def test_edgeql_functions_array_unpack_01(self):
         await self.assert_query_result(
@@ -2189,6 +2203,11 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_len_03(self):
         await self.assert_query_result(
             r'''SELECT len(<array<str>>[]);''',
+            [0],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT len([]);''',
             [0],
         )
 

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -3244,8 +3244,9 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         )
 
     async def test_edgeql_select_empty_05(self):
-        with self.assertRaisesRegex(edgedb.QueryError,
-                                    r'could not determine expression type'):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'expression returns value of indeterminate type'):
             await self.con.fetchall(r"""
                 WITH MODULE test
                 SELECT Issue {


### PR DESCRIPTION
Currently, a bare empty set constructor (`{}`) or a bare array
literal (`[]`) are illegal without an explicit type cast.  There are
cases, however, where the target type is now known, but the expression
still needs to be processed, such as the `initial_value` attribute of
a generic function.  Generic functions, such as `std::count` also don't
_need_ the input to be of a concrete type.

Thus, define `{}` as returning `anytype` and `[]` as returning
`array<anytype>`.  Operator and function resolution would naturally
prohibit using these, unless explicitly allowed.  It is also illegal for
a query to return a value of a generic type (this applies to computables
as well).