### PR TITLE
Implement schema object reference tracking in expressions

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -550,7 +550,7 @@ class ObjectDDL(CompositeDDL):
 
 
 class CreateObject(ObjectDDL):
-    pass
+    is_abstract: bool = False
 
 
 class AlterObject(ObjectDDL):
@@ -563,7 +563,6 @@ class DropObject(ObjectDDL):
 
 class CreateExtendingObject(CreateObject):
     bases: typing.List[TypeName]
-    is_abstract: bool = False
     is_final: bool = False
 
 

--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -129,7 +129,8 @@ def compile_ast_to_ir(tree,
                       schema_view_mode=False,
                       disable_constant_folding=False,
                       json_parameters=False,
-                      session_mode=False):
+                      session_mode=False,
+                      allow_abstract_opers=False):
     """Compile given EdgeQL AST into EdgeDB IR."""
 
     if debug.flags.edgeql_compile:
@@ -146,7 +147,8 @@ def compile_ast_to_ir(tree,
         schema_view_mode=schema_view_mode,
         disable_constant_folding=disable_constant_folding,
         json_parameters=json_parameters,
-        session_mode=session_mode)
+        session_mode=session_mode,
+        allow_abstract_opers=allow_abstract_opers)
 
     if path_prefix_anchor is not None:
         path_prefix = anchors[path_prefix_anchor]

--- a/edb/edgeql/compiler/cast.py
+++ b/edb/edgeql/compiler/cast.py
@@ -231,6 +231,9 @@ class CastCallableWrapper:
     def get_return_type(self, schema):
         return self._cast.get_to_type(schema)
 
+    def get_is_abstract(self, schema):
+        return False
+
 
 def _find_cast(
         orig_stype: s_types.Type,

--- a/edb/edgeql/compiler/cast.py
+++ b/edb/edgeql/compiler/cast.py
@@ -110,7 +110,7 @@ def compile_cast(
             ir_set, orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
 
     else:
-        json_t = ctx.env.schema.get('std::json')
+        json_t = ctx.env.get_track_schema_object('std::json')
 
         if (new_stype.issubclass(ctx.env.schema, json_t) and
                 ir_set.path_id.is_objtype_path()):

--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -49,7 +49,7 @@ def compile_where_clause(
             if subctx.stmt.parent_stmt is None:
                 subctx.toplevel_clause = subctx.clause
             ir_expr = dispatch.compile(where, ctx=subctx)
-            bool_t = ctx.env.schema.get('std::bool')
+            bool_t = ctx.env.get_track_schema_object('std::bool')
             ir_set = setgen.scoped_set(ir_expr, typehint=bool_t, ctx=subctx)
 
         ir_stmt.where = ir_set
@@ -133,7 +133,7 @@ def compile_limit_offset_clause(
         with ctx.newscope(fenced=True) as subctx:
             subctx.clause = 'offsetlimit'
             ir_expr = dispatch.compile(expr, ctx=subctx)
-            int_t = ctx.env.schema.get('std::int64')
+            int_t = ctx.env.get_track_schema_object('std::int64')
             ir_set = setgen.scoped_set(
                 ir_expr, force_reassign=True, typehint=int_t, ctx=subctx)
             ir_set.context = expr.context

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -133,8 +133,8 @@ def compile_ConfigInsert(
         )
 
     level = 'SYSTEM' if expr.system else 'SESSION'
-    schema = ctx.env.schema
-    subject = schema.get(f'cfg::{expr.name.name}', None)
+    subject = ctx.env.get_track_schema_object(
+        f'cfg::{expr.name.name}', default=None)
     if subject is None:
         raise errors.ConfigurationError(
             f'{expr.name.name!r} is not a valid configuration item',
@@ -233,7 +233,7 @@ def _validate_op(
         )
 
     name = expr.name.name
-    cfg_host_type = ctx.env.schema.get('cfg::Config')
+    cfg_host_type = ctx.env.get_track_schema_object('cfg::Config')
     cfg_type = None
 
     if isinstance(expr, (qlast.ConfigSet, qlast.ConfigReset)):
@@ -250,7 +250,8 @@ def _validate_op(
             )
 
         # expr.name is the name of the configuration type
-        cfg_type = ctx.env.schema.get(f'cfg::{name}', None)
+        cfg_type = ctx.env.get_track_schema_object(
+            f'cfg::{name}', default=None)
         if cfg_type is None:
             raise errors.ConfigurationError(
                 f'unrecognized configuration object {name!r}',

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -133,11 +133,15 @@ class Environment:
     session_mode: bool
     """Whether there is a specific session."""
 
+    allow_abstract_opers: bool
+    """Whether to allow the use of abstract operators."""
+
     def __init__(self, *, schema, path_scope,
                  schema_view_mode: bool=False,
                  constant_folding: bool=True,
                  json_parameters: bool=False,
-                 session_mode: bool=False):
+                 session_mode: bool=False,
+                 allow_abstract_opers: bool=True):
         self.schema = schema
         self.path_scope = path_scope
         self.schema_view_cache = {}
@@ -153,6 +157,7 @@ class Environment:
             irast.ViewShapeMetadata)
         self.json_parameters = json_parameters
         self.session_mode = session_mode
+        self.allow_abstract_opers = allow_abstract_opers
 
 
 class ContextLevel(compiler.ContextLevel):

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -267,6 +267,10 @@ def compile_operator(
     if matched is None:
         matched = polyres.find_callable(opers, args=args, kwargs={}, ctx=ctx)
 
+    if not env.allow_abstract_opers:
+        matched = [call for call in matched
+                   if not call.func.get_is_abstract(env.schema)]
+
     if len(matched) == 1:
         matched_call = matched[0]
     else:

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -232,7 +232,8 @@ def extract_filters(
                     if left_stype == result_stype:
                         ptr = left_stype.getptr(schema, 'id')
                     else:
-                        ptr = schema.get(left.rptr.ptrref.name)
+                        ptr = env.get_track_schema_object(
+                            left.rptr.ptrref.name)
 
                     ptr_filters.append((ptr, right))
 
@@ -242,7 +243,8 @@ def extract_filters(
                     if right_stype == result_stype:
                         ptr = right_stype.getptr(schema, 'id')
                     else:
-                        ptr = schema.get(right.rptr.ptrref.name)
+                        ptr = env.get_track_schema_object(
+                            right.rptr.ptrref.name)
 
                     ptr_filters.append((ptr, left))
 

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -188,8 +188,8 @@ def try_bind_call_args(
     schema = ctx.env.schema
 
     in_polymorphic_func = (
-        ctx.func is not None and
-        ctx.func.get_params(schema).has_polymorphic(schema)
+        ctx.env.func_params is not None and
+        ctx.env.func_params.has_polymorphic(schema)
     )
 
     has_empty_variadic = False
@@ -205,7 +205,7 @@ def try_bind_call_args(
             # being called with no arguments.
             args = []
             if has_inlined_defaults:
-                bytes_t = schema.get('std::bytes')
+                bytes_t = ctx.env.get_track_schema_object('std::bytes')
                 argval = setgen.ensure_set(
                     irast.BytesConstant(
                         value=b'\x00',
@@ -417,7 +417,7 @@ def try_bind_call_args(
     if has_inlined_defaults:
         # If we are compiling an EdgeQL function, inject the defaults
         # bit-mask as a first argument.
-        bytes_t = schema.get('std::bytes')
+        bytes_t = ctx.env.get_track_schema_object('std::bytes')
         bm = defaults_mask.to_bytes(nparams // 8 + 1, 'little')
         bm_set = setgen.ensure_set(
             irast.BytesConstant(

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -134,6 +134,7 @@ def try_bind_call_args(
         ctx: context.ContextLevel) -> BoundCall:
 
     return_type = func.get_return_type(ctx.env.schema)
+    is_abstract = func.get_is_abstract(ctx.env.schema)
 
     def _get_cast_distance(arg, arg_type, param_type) -> int:
         nonlocal resolved_poly_base_type
@@ -165,7 +166,7 @@ def try_bind_call_args(
                 resolved_poly_base_type = resolved
 
             if resolved_poly_base_type == resolved:
-                return 0
+                return s_types.MAX_TYPE_DISTANCE if is_abstract else 0
 
             ct = resolved_poly_base_type.find_common_implicitly_castable_type(
                 resolved, ctx.env.schema)
@@ -175,7 +176,7 @@ def try_bind_call_args(
                 # refine our resolved_poly_base_type to be that as the
                 # more general case.
                 resolved_poly_base_type = ct
-                return 0
+                return s_types.MAX_TYPE_DISTANCE if is_abstract else 0
             else:
                 return -1
 

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -67,9 +67,8 @@ def get_schema_object(
             return result
 
     try:
-        stype = ctx.env.schema.get(
-            name=name, module_aliases=ctx.modaliases,
-            type=item_types)
+        stype = ctx.env.get_track_schema_object(
+            name=name, modaliases=ctx.modaliases, type=item_types)
 
     except errors.QueryError as e:
         s_utils.enrich_schema_lookup_error(

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -190,12 +190,18 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
         if isinstance(step, qlast.Source):
             # 'self' can only appear as the starting path label
             # syntactically and is a known anchor
-            path_tip = anchors[step.__class__]
+            try:
+                path_tip = anchors[step.__class__]
+            except KeyError:
+                path_tip = anchors['__source__']
 
         elif isinstance(step, qlast.Subject):
             # '__subject__' can only appear as the starting path label
             # syntactically and is a known anchor
-            path_tip = anchors[step.__class__]
+            try:
+                path_tip = anchors[step.__class__]
+            except KeyError:
+                path_tip = anchors['__subject__']
 
         elif isinstance(step, qlast.ObjectRef):
             if i > 0:  # pragma: no cover

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -202,7 +202,7 @@ def compile_GroupQuery(
 
         typename = s_name.Name(
             module='__group__', name=ctx.aliases.get('Group'))
-        obj = ctx.env.schema.get('std::Object')
+        obj = ctx.env.get_track_schema_object('std::Object')
         stmt.group_path_id = pathctx.get_path_id(
             obj, typename=typename, ctx=ictx)
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -62,6 +62,7 @@ def init_context(
         result_view_name: typing.Optional[str]=None,
         schema_view_mode: bool=False,
         disable_constant_folding: bool=False,
+        allow_abstract_opers: bool=False,
         implicit_id_in_shapes: bool=False,
         implicit_tid_in_shapes: bool=False,
         json_parameters: bool=False,
@@ -77,7 +78,8 @@ def init_context(
         constant_folding=not disable_constant_folding,
         schema_view_mode=schema_view_mode,
         json_parameters=json_parameters,
-        session_mode=session_mode)
+        session_mode=session_mode,
+        allow_abstract_opers=allow_abstract_opers)
 
     if singletons:
         # The caller wants us to treat these type references

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -34,6 +34,7 @@ from edb.schema import types as s_types
 
 from edb.edgeql import ast as qlast
 
+from . import astutils
 from . import context
 from . import dispatch
 from . import schemactx
@@ -43,42 +44,8 @@ from . import setgen
 def type_to_ql_typeref(t: s_obj.Object, *,
                        _name=None,
                        ctx: context.ContextLevel) -> qlast.TypeName:
-    if t.is_any():
-        result = qlast.TypeName(name=_name, maintype=qlast.AnyType())
-    elif t.is_anytuple():
-        result = qlast.TypeName(name=_name, maintype=qlast.AnyTuple())
-    elif not isinstance(t, s_abc.Collection):
-        result = qlast.TypeName(
-            name=_name,
-            maintype=qlast.ObjectRef(
-                module=t.get_name(ctx.env.schema).module,
-                name=t.get_name(ctx.env.schema).name
-            )
-        )
-    elif isinstance(t, s_abc.Tuple) and t.named:
-        result = qlast.TypeName(
-            name=_name,
-            maintype=qlast.ObjectRef(
-                name=t.schema_name
-            ),
-            subtypes=[
-                type_to_ql_typeref(st, _name=sn, ctx=ctx)
-                for sn, st in t.iter_subtypes(ctx.env.schema)
-            ]
-        )
-    else:
-        result = qlast.TypeName(
-            name=_name,
-            maintype=qlast.ObjectRef(
-                name=t.schema_name
-            ),
-            subtypes=[
-                type_to_ql_typeref(st, ctx=ctx)
-                for st in t.get_subtypes(ctx.env.schema)
-            ]
-        )
 
-    return result
+    return astutils.type_to_ql_typeref(t, schema=ctx.env.schema)
 
 
 def ql_typeref_to_ir_typeref(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -447,9 +447,9 @@ def _normalize_view_ptr_expr(
                 path_id_name = None
 
             if ptr_target.is_object_type():
-                base = ctx.env.schema.get('std::link')
+                base = ctx.env.get_track_schema_object('std::link')
             else:
-                base = ctx.env.schema.get('std::property')
+                base = ctx.env.get_track_schema_object('std::property')
 
             if ptrcls is not None:
                 derive_from = ptrcls
@@ -526,9 +526,11 @@ def derive_ptrcls(
     if view_rptr.ptrcls is None:
         if view_rptr.base_ptrcls is None:
             if target_scls.is_object_type():
-                view_rptr.base_ptrcls = ctx.env.schema.get('std::link')
+                view_rptr.base_ptrcls = (
+                    ctx.env.get_track_schema_object('std::link'))
             else:
-                view_rptr.base_ptrcls = ctx.env.schema.get('std::property')
+                view_rptr.base_ptrcls = (
+                    ctx.env.get_track_schema_object('std::property'))
 
         derived_name = schemactx.derive_view_name(
             view_rptr.base_ptrcls,

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -142,6 +142,10 @@ class DeclarationLoader:
         for obj, decl in chain(t.items() for t in objects.values()):
             bases, enum_values = self._get_bases(obj, decl)
             self._schema = obj.set_field_value(self._schema, 'bases', bases)
+            self._schema = obj.set_field_value(
+                self._schema, 'ancestors',
+                s_inh.compute_mro(self._schema, obj)[1:])
+
             if enum_values:
                 enums[obj] = enum_values
 

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -21,7 +21,6 @@ import copy
 import itertools
 import typing
 
-from edb import errors
 from edb.common import ast
 
 from . import ast as qlast
@@ -46,10 +45,6 @@ class ParameterInliner(ast.NodeTransformer):
 
         arg = copy.deepcopy(arg)
         return arg
-
-    def visit_Parameter(self, node):
-        raise errors.InvalidConstraintDefinitionError(
-            f'dollar-prefixed "$parameters" are not supported in constraints')
 
 
 def inline_parameters(ql_expr: qlast.Base, args: typing.Dict[str, qlast.Base]):

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -344,6 +344,7 @@ class Statement(Command):
     view_shapes: typing.Dict[so.Object, typing.List[s_pointers.Pointer]]
     view_shapes_metadata: typing.Dict[so.Object, ViewShapeMetadata]
     schema: s_schema.Schema
+    schema_refs: typing.FrozenSet[so.Object]
     scope_tree: ScopeTreeNode
     source_map: typing.Dict[s_pointers.Pointer,
                             typing.Tuple[qlast.Expr,

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -253,6 +253,9 @@ CREATE TYPE schema::Function EXTENDING schema::CallableObject {
 CREATE TYPE schema::Operator EXTENDING schema::CallableObject {
     CREATE PROPERTY operator_kind -> schema::operator_kind_t;
     CREATE LINK commutator -> schema::Operator;
+    CREATE PROPERTY is_abstract -> std::bool {
+        SET default := false;
+    };
 };
 
 

--- a/edb/lib/std/12-abstractops.edgeql
+++ b/edb/lib/std/12-abstractops.edgeql
@@ -1,0 +1,46 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# All EdgeDB types support ordering and comparison.
+# The below definitions of abstract operators declare this fact
+# for the benefit of generic expressions (e.g. in abstract constraints).
+
+CREATE ABSTRACT INFIX OPERATOR
+std::`>=` (l: anytype, r: anytype) -> std::bool;
+
+CREATE ABSTRACT INFIX OPERATOR
+std::`>` (l: anytype, r: anytype) -> std::bool;
+
+CREATE ABSTRACT INFIX OPERATOR
+std::`<=` (l: anytype, r: anytype) -> std::bool;
+
+CREATE ABSTRACT INFIX OPERATOR
+std::`<` (l: anytype, r: anytype) -> std::bool;
+
+CREATE ABSTRACT INFIX OPERATOR
+std::`=` (l: anytype, r: anytype) -> std::bool;
+
+CREATE ABSTRACT INFIX OPERATOR
+std::`?=` (l: anytype, r: anytype) -> std::bool;
+
+CREATE ABSTRACT INFIX OPERATOR
+std::`!=` (l: anytype, r: anytype) -> std::bool;
+
+CREATE ABSTRACT INFIX OPERATOR
+std::`?!=` (l: anytype, r: anytype) -> std::bool;

--- a/edb/lib/std/50-constraints.edgeql
+++ b/edb/lib/std/50-constraints.edgeql
@@ -97,7 +97,7 @@ std::min_ex_value(min: anytype) EXTENDING std::min_value
 
 
 CREATE ABSTRACT CONSTRAINT
-std::regexp(pattern: anytype) EXTENDING std::constraint
+std::regexp(pattern: std::str) EXTENDING std::constraint
 {
     SET errmessage := 'invalid {__subject__}';
     SET expr := re_test(pattern, __subject__);

--- a/edb/pgsql/datasources/schema/operators.py
+++ b/edb/pgsql/datasources/schema/operators.py
@@ -30,6 +30,7 @@ async def fetch(
         SELECT
                 o.id AS id,
                 o.name AS name,
+                o.is_abstract AS is_abstract,
                 o.return_typemod,
                 o.language,
                 o.from_operator,

--- a/edb/pgsql/dbops/dml.py
+++ b/edb/pgsql/dbops/dml.py
@@ -85,8 +85,8 @@ class Insert(DMLOperation):
             rows = (', '.join('{}={!r}'.format(c, v) for c, v in row.items())
                     for row in self.records)
             vals = ', '.join('({})'.format(r) for r in rows)
-        return '<{} {} ({})>'.format(
-            self.__class__.__name__, self.table.name, vals)
+        return '<{} {} ({}) priority={}>'.format(
+            self.__class__.__name__, self.table.name, vals, self.priority)
 
 
 class Update(DMLOperation):
@@ -167,8 +167,9 @@ class Update(DMLOperation):
             '%s=%s' % (f, getattr(self.record, f)) for f in self.fields)
         where = ','.join('%s=%s' % (c[0], c[1])
                          for c in self.condition) if self.condition else ''
-        return '<%s %s %s (%s)>' % (
-            self.__class__.__name__, self.table.name, expr, where)
+        return '<%s %s %s (%s) priority=%s>' % (
+            self.__class__.__name__, self.table.name, expr, where,
+            self.priority)
 
 
 class Delete(DMLOperation):

--- a/edb/pgsql/dbops/tables.py
+++ b/edb/pgsql/dbops/tables.py
@@ -512,7 +512,7 @@ class AlterTableAlterColumnDefault(AlterTableFragment):
             return f'ALTER COLUMN {qi(self.column_name)} DROP DEFAULT'
         else:
             return (f'ALTER COLUMN {qi(self.column_name)} '
-                    f'SET DEFAULT {ql(str(self.default))}')
+                    f'SET DEFAULT {self.default}')
 
     def __repr__(self):
         return '<{}.{} "{}" {} DEFAULT{}>'.format(

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -624,6 +624,9 @@ class CreateOperator(OperatorCommand, CreateObject,
 
     def apply(self, schema, context):
         schema, oper = super().apply(schema, context)
+        if oper.get_is_abstract(schema):
+            return schema, oper
+
         oper_language = oper.get_language(schema)
         oper_fromop = oper.get_from_operator(schema)
         oper_fromfunc = oper.get_from_function(schema)
@@ -731,6 +734,10 @@ class DeleteOperator(
     def apply(self, schema, context):
         orig_schema = schema
         oper = schema.get(self.classname)
+
+        if oper.get_is_abstract(schema):
+            return super().apply(schema, context)
+
         name = self.get_pg_name(schema, oper)
         args = self.get_pg_operands(schema, oper)
 

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -307,6 +307,7 @@ class IntrospectionMech:
             oper_data = {
                 'id': row['id'],
                 'name': name,
+                'is_abstract': row['is_abstract'],
                 'operator_kind': row['operator_kind'],
                 'language': row['language'],
                 'params': params,

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -92,7 +92,7 @@ def get_scalar_base(schema, scalar):
     if base is not None:
         return base
 
-    for ancestor in scalar.compute_mro(schema)[1:]:
+    for ancestor in scalar.get_ancestors(schema).objects(schema):
         if not ancestor.get_is_abstract(schema):
             # Check if base is fundamental, if not, then it is
             # another domain.

--- a/edb/schema/abc.py
+++ b/edb/schema/abc.py
@@ -21,6 +21,10 @@ class Object:
     pass
 
 
+class ObjectContainer:
+    pass
+
+
 class Database(Object):
     pass
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -759,6 +759,12 @@ class CreateObject(CreateOrAlterObject):
             )
         )
 
+        if getattr(astnode, 'is_abstract', False):
+            cmd.add(AlterObjectProperty(
+                property='is_abstract',
+                new_value=True
+            ))
+
         return cmd
 
     def _create_begin(self, schema, context):

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -405,6 +405,9 @@ class CallableObject(annotations.AnnotationSubject):
     return_typemod = so.SchemaField(
         ft.TypeModifier, compcoef=0.4, coerce=True)
 
+    is_abstract = so.SchemaField(
+        bool, default=False, compcoef=0.909)
+
     @classmethod
     def delta(cls, old, new, *, context=None, old_schema, new_schema):
         context = context or so.ComparisonContext()

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -225,7 +225,7 @@ class RebaseInheritingObject(sd.ObjectCommand):
                         except KeyError:
                             schema, coll = coll.delete(schema, [ref_name])
 
-        props = self.get_struct_properties(schema)
+        schema, props = self._get_field_updates(schema, context)
         schema = scls.update(schema, props)
 
         for op in self.get_subcommands(type=sd.ObjectCommand):

--- a/edb/schema/nodes.py
+++ b/edb/schema/nodes.py
@@ -56,7 +56,7 @@ class Node(inheriting.InheritingObject, s_types.Type):
 
     def get_common_parent_type_distance(
             self, other: s_types.Type, schema) -> int:
-        if other.is_any():
+        if other.is_any() or self.is_any():
             return s_types.MAX_TYPE_DISTANCE
 
         if not isinstance(other, type(self)):

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -378,7 +378,8 @@ class ObjectMeta(type):
         if cls._object_fields is None:
             cls._object_fields = frozenset(
                 f for f in cls._fields.values()
-                if issubclass(f.type, (Object, ObjectCollection)))
+                if issubclass(f.type, s_abc.ObjectContainer)
+            )
         return cls._object_fields
 
     def get_field(cls, name):
@@ -419,7 +420,7 @@ class FieldValueNotFoundError(Exception):
     pass
 
 
-class Object(s_abc.Object, metaclass=ObjectMeta):
+class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
     """Base schema item class."""
 
     # Unique ID for this schema item.
@@ -1303,7 +1304,7 @@ class ObjectCollectionDuplicateNameError(Exception):
     pass
 
 
-class ObjectCollection:
+class ObjectCollection(s_abc.ObjectContainer):
 
     def __init_subclass__(cls, *, type=Object, container=None):
         cls._type = type

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -151,7 +151,7 @@ class CreateOperator(s_func.CreateCallableObject, OperatorCommand):
 
         fullname = self.classname
         shortname = sn.shortname_from_fullname(fullname)
-        cp = self._get_param_desc_from_delta(schema, self)
+        schema, cp = self._get_param_desc_from_delta(schema, context, self)
         signature = f'{shortname}({", ".join(p.as_str(schema) for p in cp)})'
 
         func = schema.get(fullname, None)

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -24,6 +24,7 @@ from edb.common import topological
 def get_global_dep_order():
     from . import annotations as s_anno
     from . import constraints as s_constr
+    from . import functions as s_func
     from . import lproperties as s_lprops
     from . import links as s_links
     from . import objtypes as s_objtypes
@@ -31,6 +32,7 @@ def get_global_dep_order():
 
     return (
         s_anno.Annotation,
+        s_func.Function,
         s_constr.Constraint,
         s_scalars.ScalarType,
         s_lprops.Property,

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -156,7 +156,7 @@ class ReferencedInheritingObjectCommand(
 
     def _create_begin(self, schema, context):
         referrer_ctx = self.get_referrer_context(context)
-        attrs = self.get_struct_properties(schema)
+        schema, attrs = self._get_create_fields(schema, context)
 
         if referrer_ctx is not None and not attrs.get('is_derived'):
             if attrs.get('inherited'):

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -26,6 +26,7 @@ import immutables as immu
 from edb import errors
 
 from . import casts as s_casts
+from . import expr as s_expr
 from . import functions as s_func
 from . import modules as s_mod
 from . import name as sn
@@ -289,6 +290,11 @@ class Schema:
                     else:
                         if isinstance(ref, so.ObjectCollection):
                             ids = frozenset(ref.ids(self))
+                        elif isinstance(ref, s_expr.Expression):
+                            if ref.refs:
+                                ids = frozenset(ref.refs.ids(self))
+                            else:
+                                ids = frozenset()
                         else:
                             ids = frozenset((ref.id,))
 
@@ -302,6 +308,11 @@ class Schema:
                     else:
                         if isinstance(ref, so.ObjectCollection):
                             orig_ids = frozenset(ref.ids(self))
+                        elif isinstance(ref, s_expr.Expression):
+                            if ref.refs:
+                                orig_ids = frozenset(ref.refs.ids(self))
+                            else:
+                                orig_ids = frozenset()
                         else:
                             orig_ids = frozenset((ref.id,))
 

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -258,6 +258,7 @@ class BaseSchemaTest(BaseDocTest):
                     f'unexpected {stmt!r} in compiler setup script')
 
             context = sd.CommandContext()
+            context.testmode = True
             current_schema, _ = ddl_plan.apply(current_schema, context)
 
         return current_schema

--- a/tests/test_deltas.py
+++ b/tests/test_deltas.py
@@ -407,9 +407,14 @@ a EXTENDING std::property -> array<std::int64>;
 -> std::str {
                     SET computable := true;
                     SET default := SELECT
-                        'foo'
+                        <std::str>{}
                     ;
                 };
+            };
+            ALTER TYPE test::Foo ALTER PROPERTY __typename {
+                SET default := SELECT
+                    'foo'
+                ;
             };
             '''
         )
@@ -437,12 +442,17 @@ a EXTENDING std::property -> array<std::int64>;
                 CREATE SINGLE PROPERTY __typename EXTENDING std::property \
 -> std::str {
                     SET computable := true;
-                    SET default := WITH
-                        MODULE test
-                    SELECT
-                        .__type__.name
+                    SET default := SELECT
+                        <std::str>{}
                     ;
                 };
+            };
+            ALTER TYPE test::Foo ALTER PROPERTY __typename {
+                SET default := WITH
+                    MODULE test
+                SELECT
+                    .__type__.name
+                ;
             };
             '''
         )

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2679,7 +2679,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute('''
                 CREATE SCALAR TYPE test::my_enum_3
                     EXTENDING enum<'foo', 'bar', 'baz'> {
-                    CREATE CONSTRAINT expression ON (__subject__ = 'bar')
+                    CREATE CONSTRAINT expression ON (EXISTS(__subject__))
                 };
             ''')
 

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -330,7 +330,7 @@ class TestIntrospection(tb.QueryTestCase):
                                 name
                             }
                         }
-                    }
+                    } FILTER .type IS schema::Array
                 } FILTER
                     .name LIKE '%my_one_of%' AND
                     NOT EXISTS .<constraints;
@@ -339,7 +339,7 @@ class TestIntrospection(tb.QueryTestCase):
                 'name': 'test::my_one_of',
                 'params': [
                     {
-                        'num': 0,
+                        'num': 1,
                         'type': {
                             'name': 'array',
                             'element_type': {
@@ -365,7 +365,7 @@ class TestIntrospection(tb.QueryTestCase):
                                 name
                             }
                         }
-                    }
+                    } FILTER .name != '__subject__'
                 } FILTER
                     .name LIKE '%my_one_of%' AND
                     NOT EXISTS .<constraints;
@@ -374,7 +374,7 @@ class TestIntrospection(tb.QueryTestCase):
                 'name': 'test::my_one_of',
                 'params': [
                     {
-                        'num': 0,
+                        'num': 1,
                         'type': {
                             'name': 'array',
                             'element_type': {
@@ -400,7 +400,7 @@ class TestIntrospection(tb.QueryTestCase):
                                 name
                             }
                         }
-                    }
+                    } ORDER BY .num
                 } FILTER
                     .name LIKE '%std::one_of%' AND
                     NOT EXISTS .<constraints;
@@ -410,6 +410,13 @@ class TestIntrospection(tb.QueryTestCase):
                 'params': [
                     {
                         'num': 0,
+                        'kind': 'POSITIONAL',
+                        'type': {
+                            'name': 'anytype',
+                        }
+                    },
+                    {
+                        'num': 1,
                         'kind': 'VARIADIC',
                         'type': {
                             'name': 'array',
@@ -442,7 +449,7 @@ class TestIntrospection(tb.QueryTestCase):
                     'name': 'test::body'
                 },
                 'args': [{
-                    'num': 0,
+                    'num': 1,
                     '@value': '10000'
                 }]
             }]
@@ -517,12 +524,6 @@ class TestIntrospection(tb.QueryTestCase):
             }]
         )
 
-    @test.xfail('''
-        The @value for the constraint variadic args only has 'ONE',
-        whereas the expectation is that it will be the full array of
-        options. Incidentally, the same array is mentioned in the
-        errmessage without any issues.
-    ''')
     async def test_edgeql_introspection_constraint_06(self):
         await self.assert_query_result(
             r"""
@@ -532,7 +533,7 @@ class TestIntrospection(tb.QueryTestCase):
                     constraints: {
                         name,
                         expr,
-                        attributes: { name, @value },
+                        annotations: { name, @value },
                         subject: { name },
                         args: { name, @value, type: { name } },
                         return_typemod,
@@ -549,7 +550,7 @@ class TestIntrospection(tb.QueryTestCase):
                     {
                         'name': 'std::one_of',
                         'expr': 'contains(vals, __subject__)',
-                        'attributes': {},
+                        'annotations': {},
                         'subject': {'name': 'schema::cardinality_t'},
                         'args': [
                             {


### PR DESCRIPTION
Currently any references to schema objects used in schema expressions do
not participate in reference tracking.  The fix is conceptually
simple--record all schema refs in an `ObjectSet` in every `Expression`
instance.

In practice this requires _all_ schema expressions to be compilable to IR,
which is especially tricky if the expression in question is part of some
generic construct, such as an abstract constraint.  So, the changes here
also include the necessary tweaks to the EdgeQL compiler, mostly around
callable resolution.  Another issue is potential object reference cycles
caused by expressions, so DDL generated by schema diffs now has to separate
operations involving expression attributes.