### PR TITLE
Fix constraint-checking during initialization.

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -893,8 +893,10 @@ class DeclarationLoader:
 
         if (not isinstance(expr_type, s_abc.Type) or
                 (ptr.get_target(self._schema) is not None and
-                 not expr_type.issubclass(
-                    self._schema, ptr.get_target(self._schema)))):
+                    # the default must be assignment-castable to the
+                    # target type
+                    not expr_type.assignment_castable_to(
+                        ptr.get_target(self._schema), self._schema))):
             raise errors.SchemaError(
                 'default value query must yield a single result of '
                 'type {!r}'.format(

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -170,9 +170,7 @@ class Constraint(inheriting.InheritingObject, s_func.CallableObject,
             raise errors.InvalidConstraintDefinitionError(
                 f'missing constraint expression in {name!r}')
 
-        expr_ql = expr.qlast
-        if expr_ql is None:
-            expr_ql = qlparser.parse(expr.text, module_aliases)
+        expr_ql = qlparser.parse(expr.text, module_aliases)
 
         if not args:
             args = constr_base.get_field_value(schema, 'args')

--- a/tests/schemas/constraints.esdl
+++ b/tests/schemas/constraints.esdl
@@ -55,8 +55,12 @@ scalar type constraint_enum extending str {
    constraint one_of('foo', 'bar');
 }
 
+scalar type constraint_enum2 extending str {
+   constraint one_of('notfoo', 'notbar');
+}
+
 scalar type constraint_my_enum extending str {
-   constraint my_one_of(['foo', 'bar']);
+   constraint my_one_of(['fuz', 'buz']);
 }
 
 
@@ -99,6 +103,9 @@ type Object {
     property c_minmax -> constraint_minmax;
     property c_strvalue -> constraint_strvalue;
     property c_enum -> constraint_enum;
+    property c_enum2 -> constraint_enum2 {
+        default := 'notfoo';
+    }
     property c_my_enum -> constraint_my_enum;
 }
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -124,9 +124,9 @@ class TestConstraintsSchema(tb.QueryTestCase):
 
     async def test_constraints_scalar_enum_02(self):
         data = {
-            ('foobar', 'invalid'),
-            ('bar', 'good'),
-            ('foo', 'good'),
+            ('foo', 'invalid'),
+            ('fuz', 'good'),
+            ('buz', 'good'),
         }
 
         await self._run_link_tests(data, 'test::Object', 'c_my_enum')


### PR DESCRIPTION
Default values for scalars with constraints should be validated as any
other assignemnt would have been.

Tests for initialization of scalars with constraints.