### PR TITLE
docs: Add explicit documentaion of available HTTP protocols.

### DIFF
--- a/docs/admin/installation.rst
+++ b/docs/admin/installation.rst
@@ -109,13 +109,16 @@ want to persist the data in):
 .. code-block:: bash
 
     docker run -it --rm -p 5656:5656 -p 8888:8888 \
-                --name=edgedb-server \
+                -p 8889:8889 --name=edgedb-server \
                 -v <datadir>:/var/lib/edgedb/data \
                 edgedb/edgedb
 
 When configuring extra :ref:`ports <ref_admin_config_connection>`, make
 sure to expose them on the host by adding a corresponding ``-p`` argument to
-the ``docker run`` command.
+the ``docker run`` command. The command above exposes the default ports used by
+:ref:`EdgeQL over binary protocol <ref_protocol_overview>` (5656),
+:ref:`EdgeQL over HTTP <ref_edgeql_index>` (8889), and
+:ref:`GraphQL over HTTP <ref_graphql_index>` (8888).
 
 
 Running EdgeDB shell in a linked container

--- a/docs/clients/90_edgeql/index.rst
+++ b/docs/clients/90_edgeql/index.rst
@@ -1,0 +1,36 @@
+.. _ref_edgeql_index:
+
+================
+EdgeQL over HTTP
+================
+
+EdgeDB can expose an HTTP endpoint for EdgeQL queries. Since HTTP is a
+stateless protocol, no :ref:`DDL <ref_eql_ddl>` or functions that
+require a session (such as :eql:func:`sys::advisory_lock`,
+:eql:func:`sys::advisory_unlock`, :eql:func:`sys::advisory_unlock_all`, and
+:eql:func:`sys::sleep`) can be executed using this endpoint. Only one
+query per request can be executed.
+
+Here's an example of configuration that will set up EdgeQL over HTTP
+access to the database:
+
+.. code-block:: edgeql-repl
+
+    tutorial> CONFIGURE SYSTEM INSERT Port {
+    .........     protocol := "edgeql+http",
+    .........     database := "your_database_name",
+    .........     address := "127.0.0.1",
+    .........     port := 8889,
+    .........     user := "http",
+    .........     concurrency := 4,
+    ......... };
+    CONFIGURE SYSTEM
+
+This will expose EdgeQL API on port 8889 (or any other port that was
+specified).
+
+.. toctree::
+    :maxdepth: 2
+    :hidden:
+
+    protocol

--- a/docs/clients/90_edgeql/protocol.rst
+++ b/docs/clients/90_edgeql/protocol.rst
@@ -1,0 +1,60 @@
+.. _ref_edgeqlql_protocol:
+
+
+Protocol
+========
+
+EdgeDB supports GET and POST methods for handling EdgeQL over HTTP
+protocol. Both GET and POST methods use the following fields:
+
+- ``query`` - contains the EdgeQL query string
+- ``variables`` - contains a JSON object where keys and values
+  correspond to the variable names and values. It is required if the
+  EdgeQL query has variables, otherwise it is optional.
+
+GET request
+-----------
+
+The HTTP GET request passes the fields as query parameters: ``query``
+and ``variables``.
+
+
+POST request
+------------
+
+The POST request should use ``application/json`` content type and
+submit the following JSON-encoded form with the necessary fields:
+
+.. code-block::
+
+    {
+      "query": "...",
+      "variables": { "varName": "varValue", ... }
+    }
+
+
+Response
+--------
+
+The response format is the same for both methods. The body of the
+response is JSON of the following form:
+
+.. code-block::
+
+    {
+      "data": [ ... ],
+      "error": {
+        "message": "Error message",
+        "type": "ErrorType",
+        "code": 123456
+      }
+    }
+
+The ``data`` response field will contain the response set serialized
+as a JSON array.
+
+Note that the ``error`` field will only be present if an error
+actually occurred. The ``error`` will further contain the ``message``
+field with the error message string, the ``type`` field with the name
+of the type of error and the ``code`` field with an integer
+:ref:`error code <ref_protocol_error_codes>`.

--- a/docs/clients/99_graphql/index.rst
+++ b/docs/clients/99_graphql/index.rst
@@ -1,8 +1,8 @@
 .. _ref_graphql_index:
 
-=======
-GraphQL
-=======
+=================
+GraphQL over HTTP
+=================
 
 EdgeBD supports `GraphQL queries`__ natively out of the box. Not
 everything that can be expressed in EdgeQL can easily be queried using
@@ -44,3 +44,4 @@ used to try out queries and explore the GraphQL capabilities.
 
     graphql
     introspection
+    protocol

--- a/docs/clients/99_graphql/protocol.rst
+++ b/docs/clients/99_graphql/protocol.rst
@@ -1,0 +1,56 @@
+.. _ref_graphql_protocol:
+
+
+Protocol
+========
+
+EdgeDB supports GET and POST methods for handling GraphQL over HTTP
+protocol. Both GET and POST methods use the following fields:
+
+- ``query`` - contains the GraphQL query string
+- ``operationName`` - contains the name of the operation that must be
+  executed. It is required if the GraphQL query contains several named
+  operations, otherwise it is optional.
+- ``variables`` - contains a JSON object where keys and values
+  correspond to the variable names and values. It is required if the
+  GraphQL query has variables, otherwise it is optional.
+
+GET request
+-----------
+
+The HTTP GET request passes the fields as query parameters: ``query``,
+``operationName``, and ``variables``.
+
+
+POST request
+------------
+
+The POST request should use ``application/json`` content type and
+submit the following JSON-encoded form with the necessary fields:
+
+.. code-block::
+
+    {
+      "query": "...",
+      "operationName": "...",
+      "variables": { "varName": "varValue", ... }
+    }
+
+
+Response
+--------
+
+The response format is the same for both methods. The body of the
+response is JSON of the following form:
+
+.. code-block::
+
+    {
+      "data": { ... },
+      "errors": [
+        { "message": "Error message"}, ...
+      ]
+    }
+
+Note that the ``errors`` field will only be present if some errors
+actually occurred.

--- a/docs/internals/protocol/overview.rst
+++ b/docs/internals/protocol/overview.rst
@@ -1,3 +1,5 @@
+.. _ref_protocol_overview:
+
 ========
 Overview
 ========

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -174,6 +174,15 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
             [],
         )
 
+    def test_http_edgeql_query_08(self):
+        with self.assertRaisesRegex(edgedb.ProtocolError,
+                                    r'expected one statement, got 2'):
+            self.edgeql_query(
+                r"""
+                    SELECT 1;
+                    SELECT 2;
+                """)
+
     def test_http_edgeql_session_func_01(self):
         with self.assertRaisesRegex(edgedb.QueryError,
                                     r'sys::advisory_lock\(\) cannot be '


### PR DESCRIPTION
Both EdgeQL and GraphQL are exposed over HTTP protocol. The fact that
EdgeQL can be exposed this way is documented and protocol details for
both EdgeQL and GraphQL are provided.