### PR TITLE
Fix a couple of protocol issues found when documenting it

### DIFF
--- a/.ci/travis-install.sh
+++ b/.ci/travis-install.sh
@@ -2,13 +2,14 @@
 
 set -e -x
 
+pip install --quiet -U setuptools wheel pip
+pip download --dest=/tmp/deps .[test,docs]
+pip install -U --no-index --find-links=/tmp/deps /tmp/deps/*
+
 git clone https://github.com/edgedb/edgedb-python.git edgedb
 cd edgedb
 git submodule update --init --depth 50
 pip install --verbose -e .
 cd ../
 
-pip install --quiet -U setuptools wheel pip
-pip download --dest=/tmp/deps .[test,docs]
-pip install -U --no-index --find-links=/tmp/deps /tmp/deps/*
-pip install --verbose -e .
+pip install --no-deps --verbose -e .

--- a/docs/internals/protocol/dataformats.rst
+++ b/docs/internals/protocol/dataformats.rst
@@ -21,7 +21,9 @@ The array values are represented as the following structure:
         // always be 1.
         int32       ndims;
         // Reserved.
-        int32       reserved;
+        int32       reserved0;
+        // Reserved.
+        int32       reserved1;
         // Dimension data.
         Dimension   dimensions[ndims];
         // Element data, the number of elements
@@ -64,6 +66,8 @@ The tuple values are represented as the following structure:
     };
 
     struct Element {
+        // Reserved.
+        int32       reserved;
         // Encoded element data length in bytes.
         int32       length;
         // Element data.

--- a/docs/internals/protocol/messages.rst
+++ b/docs/internals/protocol/messages.rst
@@ -84,6 +84,9 @@ Messages
     * - :ref:`ref_protocol_msg_sync`
       - Provide an explicit synchronization point.
 
+    * - :ref:`ref_protocol_msg_terminate`
+      - Terminate the connection.
+
 
 .. _ref_protocol_msg_error:
 
@@ -927,4 +930,25 @@ Format:
 
         // Mechanism-specific response data.
         bytes     sasl_data;
+    };
+
+
+.. _ref_protocol_msg_terminate:
+
+Terminate
+=========
+
+Sent by: client.
+
+Format:
+
+.. code-block:: c
+
+    struct Terminate {
+        // Message type ('X')
+        int8      mtype = 0x58;
+
+        // Length of message contents in bytes,
+        // including self.
+        int32     message_length;
     };

--- a/docs/internals/protocol/overview.rst
+++ b/docs/internals/protocol/overview.rst
@@ -273,3 +273,17 @@ ends if:
 * a :eql:stmt:`COMMIT` command is executed,
 * a :eql:stmt:`ROLLBACK` command is executed,
 * a :ref:`ref_protocol_msg_sync` message is received.
+
+
+Termination
+===========
+
+The normal termination procedure is that the client sends a
+:ref:`ref_protocol_msg_terminate` message and immediately closes the
+connection.  On receipt of this message, the server cleans up the
+connection resources and closes the connection.
+
+In some cases the server might disconnect without a client request to do so.
+In such cases the server will attempt to send an :ref:`ref_protocol_msg_error`
+or a :ref:`ref_protocol_msg_log` message to indicate the reason for the
+disconnection.

--- a/edb/pgsql/datasources/schema/scalars.py
+++ b/edb/pgsql/datasources/schema/scalars.py
@@ -41,7 +41,8 @@ async def fetch(
             edgedb._resolve_type_name(c.bases) AS bases,
             edgedb._resolve_type_name(c.ancestors) AS ancestors,
             c.default AS default,
-            c.inherited_fields AS inherited_fields
+            c.inherited_fields AS inherited_fields,
+            c.backend_id AS backend_id
         FROM
             edgedb.ScalarType c
         WHERE

--- a/edb/pgsql/dbops/types.py
+++ b/edb/pgsql/dbops/types.py
@@ -59,6 +59,28 @@ class TypeExists(base.Condition):
         ''')
 
 
+def type_oid(name):
+    if len(name) == 2:
+        typnamespace, typname = name
+    else:
+        typname = name[0]
+        typnamespace = 'pg_catalog'
+
+    qry = textwrap.dedent(f'''\
+        SELECT
+            typ.oid
+        FROM
+            pg_catalog.pg_type typ
+            INNER JOIN pg_catalog.pg_namespace nsp
+                ON nsp.oid = typ.typnamespace
+        WHERE
+            typ.typname = {ql(typname)}
+            AND nsp.nspname = {ql(typnamespace)}
+    ''')
+
+    return base.Query(qry)
+
+
 CompositeTypeExists = TypeExists
 
 

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -215,6 +215,7 @@ class IntrospectionMech:
                 'expr': (self.unpack_expr(row['expr'], schema)
                          if row['expr'] else None),
                 'enum_values': row['enum_values'],
+                'backend_id': row['backend_id'],
             }
 
             schema, scalar = s_scalars.ScalarType.create_in_schema(

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -43,11 +43,11 @@ from .common import quote_literal as ql
 
 base_type_name_map = {
     s_obj.get_known_type_id('std::str'): 'text',
-    s_obj.get_known_type_id('std::int64'): 'bigint',
-    s_obj.get_known_type_id('std::int32'): 'integer',
-    s_obj.get_known_type_id('std::int16'): 'smallint',
+    s_obj.get_known_type_id('std::int64'): 'int8',
+    s_obj.get_known_type_id('std::int32'): 'int4',
+    s_obj.get_known_type_id('std::int16'): 'int2',
     s_obj.get_known_type_id('std::decimal'): 'numeric',
-    s_obj.get_known_type_id('std::bool'): 'boolean',
+    s_obj.get_known_type_id('std::bool'): 'bool',
     s_obj.get_known_type_id('std::float64'): 'float8',
     s_obj.get_known_type_id('std::float32'): 'float4',
     s_obj.get_known_type_id('std::uuid'): 'uuid',
@@ -87,6 +87,10 @@ base_type_name_map_r = {
     'bytea': sn.Name('std::bytes'),
     'jsonb': sn.Name('std::json'),
 }
+
+
+def is_builtin_scalar(schema, scalar):
+    return scalar.id in base_type_name_map
 
 
 def get_scalar_base(schema, scalar):

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -83,6 +83,11 @@ class Type(so.InheritingObjectBase, derivable.DerivableObjectBase, s_abc.Type):
         weak_ref=True,
         default=None, compcoef=0.909)
 
+    # The OID by which the backend refers to the type.
+    backend_id = so.SchemaField(
+        int,
+        default=None, inheritable=False, introspectable=False)
+
     def is_blocking_ref(self, schema, reference):
         return reference is not self.get_rptr(schema)
 
@@ -1386,6 +1391,13 @@ class TypeCommand(sd.ObjectCommand):
         cmd.canonical = True
 
         return cmd
+
+    def _create_begin(self, schema, context):
+        schema = super()._create_begin(schema, context)
+        if not self.scls.is_view(schema):
+            delta_root = context.top().op
+            delta_root.new_types.add(self.scls.id)
+        return schema
 
 
 class CollectionTypeCommandContext(sd.ObjectCommandContext):

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -63,6 +63,9 @@ class Query(BaseQuery):
     out_type_id: bytes
     in_type_data: bytes
     in_type_id: bytes
+    in_array_backend_tids: typing.Optional[
+        typing.Mapping[int, int]
+    ] = None
 
     # Set only when a query is compiled with "json_parameters=True"
     in_type_args: typing.Optional[typing.Tuple[str, ...]] = None
@@ -85,7 +88,8 @@ class SessionStateQuery(BaseQuery):
 
 @dataclasses.dataclass(frozen=True)
 class DDLQuery(BaseQuery):
-    pass
+
+    new_types: typing.FrozenSet[str] = frozenset()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -121,6 +125,9 @@ class QueryUnit:
     # True if this unit contains DDL commands.
     has_ddl: bool = False
 
+    # A set of ids of types added by this unit.
+    new_types: typing.FrozenSet[str] = frozenset()
+
     # True if this unit contains SET commands.
     has_set: bool = False
 
@@ -155,6 +162,12 @@ class QueryUnit:
 
     # Set only when a query is compiled with "json_parameters=True"
     in_type_args: typing.Optional[typing.Tuple[str, ...]] = None
+
+    # A tuple of <index, element_backend_type_id> pairs for parameters
+    # that are of an array type.
+    in_array_backend_tids: typing.Optional[
+        typing.Mapping[int, int]
+    ] = None
 
     # Set only when this unit contains a CONFIGURE SYSTEM command.
     system_config: bool = False

--- a/edb/server/mng_port/edgecon.pxd
+++ b/edb/server/mng_port/edgecon.pxd
@@ -94,7 +94,7 @@ cdef class EdgeConnection:
 
     cdef pgcon_last_sync_status(self)
 
-    cdef WriteBuffer recode_bind_args(self, bytes bind_args)
+    cdef WriteBuffer recode_bind_args(self, bytes bind_args, dict array_tids)
 
     cdef WriteBuffer make_describe_msg(self, query_unit)
     cdef WriteBuffer make_command_complete_msg(self, query_unit)

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -1072,6 +1072,10 @@ cdef class EdgeConnection:
                     elif mtype == b'S':
                         await self.sync()
 
+                    elif mtype == b'X':
+                        self.abort()
+                        break
+
                     else:
                         self.fallthrough(False)
 

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -627,9 +627,6 @@ cdef class PGProto:
         buf.write_bytestring(b'client_encoding')
         buf.write_bytestring(b'utf-8')
 
-        buf.write_bytestring(b'edgedb_use_typeoids')
-        buf.write_bytestring(b'false')
-
         buf.write_bytestring(b'search_path')
         buf.write_bytestring(b'edgedb')
 

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2201,3 +2201,31 @@ class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):
 
         finally:
             await self.con.execute('ROLLBACK')
+
+    async def test_server_proto_backend_tid_propagation_01(self):
+        async with self._run_and_rollback():
+            await self.con.execute('''
+                CREATE SCALAR TYPE tid_prop_01 EXTENDING str;
+            ''')
+
+            result = await self.con.fetchone('''
+                SELECT (<array<tid_prop_01>>$input)[1]
+            ''', input=['a', 'b'])
+
+            self.assertEqual(result, 'b')
+
+    async def test_server_proto_backend_tid_propagation_02(self):
+        try:
+            await self.con.execute('''
+                CREATE SCALAR TYPE tid_prop_02 EXTENDING str;
+            ''')
+
+            result = await self.con.fetchone('''
+                SELECT (<array<tid_prop_02>>$input)[1]
+            ''', input=['a', 'b'])
+
+            self.assertEqual(result, 'b')
+        finally:
+            await self.con.execute('''
+                DROP SCALAR TYPE tid_prop_02;
+            ''')


### PR DESCRIPTION
The startup sequence has been shortened, the connection parameters are no
longer sent as a separate message, and are instead sent as part of the
initial `ClientHandshake` message.

The `ServerKeyData` message now contains a sequence of 32 bytes instead of
a 32-bit integer.

This is a breaking change, but no bump to the protocol version, since we're
in alpha.