### PR TITLE
edgeql: Allow str to be assigned to an enum or be used as default.

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -766,7 +766,19 @@ def computable_ptr_set(
             raise ValueError(
                 f'{ptrcls_sn!r} is not a computable pointer')
 
-        qlexpr = astutils.ensure_qlstmt(qlparser.parse(ptrcls_default.text))
+        qlexpr = qlparser.parse(ptrcls_default.text)
+        # NOTE: Validation of the expression type is not the concern
+        # of this function. For any non-object pointer target type,
+        # the default expression must be assignment-cast into that
+        # type.
+        target_scls = ptrcls.get_target(ctx.env.schema)
+        if not target_scls.is_object_type():
+            qlexpr = qlast.TypeCast(
+                type=astutils.type_to_ql_typeref(
+                    target_scls, schema=ctx.env.schema),
+                expr=qlexpr,
+            )
+        qlexpr = astutils.ensure_qlstmt(qlexpr)
         qlctx = None
         inner_source_path_id = None
         path_id_ns = None

--- a/edb/lib/std/25-enumoperators.edgeql
+++ b/edb/lib/std/25-enumoperators.edgeql
@@ -61,12 +61,17 @@ std::`<` (l: std::anyenum, r: std::anyenum) -> std::bool
     FROM SQL OPERATOR '<';
 
 
-## Boolean casts
-## -------------
+## Enum casts
+## ----------
 
-CREATE CAST FROM std::str TO std::anyenum
+# The only way to create an enum is to cast a str into it, so it makes
+# sense to create an implicit assignment cast.
+CREATE CAST FROM std::str TO std::anyenum {
     FROM SQL CAST;
+    ALLOW ASSIGNMENT;
+};
 
 
-CREATE CAST FROM std::anyenum TO std::str
+CREATE CAST FROM std::anyenum TO std::str {
     FROM SQL CAST;
+};

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -454,11 +454,6 @@ def insert_value_for_shape_element(
         else:
             insvalue = output.output_as_value(insvalue, env=ctx.env)
 
-    insvalue = pgast.TypeCast(
-        arg=insvalue,
-        type_name=pgast.TypeName(name=ptr_info.column_type),
-    )
-
     return insvalue
 
 

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -721,6 +721,13 @@ class InheritingObject(derivable.DerivableObject):
         raise errors.SchemaError(
             f'{self.get_verbosename(schema)} has no non-abstract ancestors')
 
+    def get_base_for_cast(self, schema):
+        if self.is_enum(schema):
+            # all enums have to use std::anyenum as base type for casts
+            return schema.get('std::anyenum')
+        else:
+            return self.get_topmost_concrete_base(schema)
+
     def compute_mro(self, schema):
         return compute_mro(schema, self)
 

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -123,8 +123,8 @@ class ScalarType(nodes.Node, constraints.ConsistencySubject,
             return self.issubclass(schema, other)
 
     def assignment_castable_to(self, other: s_types.Type, schema) -> bool:
-        left = self.get_topmost_concrete_base(schema)
-        right = other.get_topmost_concrete_base(schema)
+        left = self.get_base_for_cast(schema)
+        right = other.get_base_for_cast(schema)
         return s_casts.is_assignment_castable(schema, left, right)
 
     def implicitly_castable_to(self, other: s_types.Type, schema) -> bool:

--- a/edb/testbase/serutils.py
+++ b/edb/testbase/serutils.py
@@ -110,3 +110,8 @@ def _date(o: datetime.date):
 @serialize.register
 def _time(o: datetime.time):
     return o.isoformat()
+
+
+@serialize.register
+def _enum(o: edgedb.EnumValue):
+    return str(o)

--- a/tests/schemas/enums.esdl
+++ b/tests/schemas/enums.esdl
@@ -1,0 +1,31 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+scalar type color_enum_t extending enum<'RED', 'GREEN', 'BLUE'>;
+
+type Foo {
+    required property color -> color_enum_t;
+}
+
+
+type Bar {
+    required property color -> color_enum_t {
+        default := 'RED';
+    }
+}

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -366,6 +366,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             """)
 
+    # XXX: is this kind of default expression even valid (referring to
+    # another property of the same object)?
     @unittest.expectedFailure
     async def test_edgeql_ddl_14(self):
         await self.con.execute("""
@@ -679,6 +681,23 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 },
             ]
         )
+
+    @test.xfail('''
+        Currently default expressions are not validated, so they might
+        eventually fail in SQL, unless it so happens that the forces
+        assignment cast works (like in the below example).
+    ''')
+    async def test_edgeql_ddl_default_01(self):
+        # FIXME: need a specific error message
+        with self.assertRaises(edgedb.SchemaError):
+            await self.con.execute(r"""
+                CREATE TYPE test::TestDefault01 {
+                    CREATE PROPERTY def01 -> str {
+                        # int64 doesn't have an assignment cast into str
+                        SET default := 42;
+                    };
+                };
+            """)
 
     async def test_edgeql_ddl_bad_01(self):
         with self.assertRaisesRegex(

--- a/tests/test_edgeql_enums.py
+++ b/tests/test_edgeql_enums.py
@@ -1,0 +1,190 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os.path
+
+import edgedb
+
+from edb.testbase import server as tb
+
+
+class TestEdgeQLEnuma(tb.QueryTestCase):
+    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
+                          'enums.esdl')
+
+    async def test_edgeql_enums_cast_01(self):
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT <color_enum_t>{'RED', 'GREEN', 'BLUE'};
+            ''',
+            {'RED', 'GREEN', 'BLUE'},
+        )
+
+    async def test_edgeql_enums_cast_02(self):
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r'invalid input value for enum .+color_enum_t.+YELLOW'):
+            await self.con.execute(r'''
+                WITH MODULE test
+                SELECT <color_enum_t>'YELLOW';
+            ''')
+
+    async def test_edgeql_enums_cast_03(self):
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r'invalid input value for enum .+color_enum_t.+red'):
+            await self.con.execute(r'''
+                WITH MODULE test
+                SELECT <color_enum_t>'red';
+            ''')
+
+    async def test_edgeql_enums_cast_04(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r"operator '\+\+' cannot be applied to operands of type "
+                r"'std::str' and 'test::color_enum_t'"):
+            await self.con.execute(r'''
+                WITH MODULE test
+                INSERT Foo {
+                    color := 'BLUE'
+                };
+
+                WITH MODULE test
+                SELECT 'The test color is: ' ++ Foo.color;
+            ''')
+
+    async def test_edgeql_enums_cast_05(self):
+        await self.con.execute(
+            r'''
+                WITH MODULE test
+                INSERT Foo {
+                    color := 'BLUE'
+                };
+            ''')
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT 'The test color is: ' ++ <str>Foo.color;
+            ''',
+            ['The test color is: BLUE'],
+        )
+
+    async def test_edgeql_enums_assignment_01(self):
+        # testing the INSERT assignment cast
+        await self.con.execute(
+            r'''
+                WITH MODULE test
+                INSERT Foo {
+                    color := 'RED'
+                };
+            ''')
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT Foo {
+                    color
+                };
+            ''',
+            [{
+                'color': 'RED',
+            }],
+        )
+
+    async def test_edgeql_enums_assignment_02(self):
+        await self.con.execute(
+            r'''
+                WITH MODULE test
+                INSERT Foo {
+                    color := 'RED'
+                };
+            ''')
+
+        # testing the UPDATE assignment cast
+        await self.con.execute(
+            r'''
+                WITH MODULE test
+                UPDATE Foo
+                SET {
+                    color := 'GREEN'
+                };
+            ''')
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT Foo {
+                    color
+                };
+            ''',
+            [{
+                'color': 'GREEN',
+            }],
+        )
+
+    async def test_edgeql_enums_assignment_03(self):
+        # testing the INSERT assignment cast
+        await self.con.execute(
+            r'''
+                WITH MODULE test
+                INSERT Bar;
+            ''')
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT Bar {
+                    color
+                };
+            ''',
+            [{
+                'color': 'RED',
+            }],
+        )
+
+    async def test_edgeql_enums_assignment_04(self):
+        await self.con.execute(
+            r'''
+                WITH MODULE test
+                INSERT Bar;
+            ''')
+
+        # testing the UPDATE assignment cast
+        await self.con.execute(
+            r'''
+                WITH MODULE test
+                UPDATE Bar
+                SET {
+                    color := 'GREEN'
+                };
+            ''')
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT Bar {
+                    color
+                };
+            ''',
+            [{
+                'color': 'GREEN',
+            }],
+        )

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -451,10 +451,12 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 .>(test::deck_cost)[IS std::int64]": {
                         "FENCE": {
                             "FENCE": {
-                                "ns~2@@(test::User).>(test::friends)\
-[IS test::User].>(test::deck)[IS test::Card].>(test::cost)[IS std::int64]": {
+                                "FENCE": {
                                     "ns~2@@(test::User).>(test::friends)\
+[IS test::User].>(test::deck)[IS test::Card].>(test::cost)[IS std::int64]": {
+                                        "ns~2@@(test::User).>(test::friends)\
 [IS test::User].>(test::deck)[IS test::Card]"
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Enums themselves are not strings, but the only way to construct one is
by casting a str into it. In case of assignment, there's already no
ambiguity as to what the specific enum type is needed and the
convenience of not having to write the full cast every time is
desirable. Similarly, when a default value is specified for an enum
property, there's no need to have an explicit cast.

Assignment casts are now enforced at the EdgeQL->IR level.