### PR TITLE
tests: Fix expectedFailure test_constraints_ddl_04

### DIFF
--- a/docs/internals/dev.rst
+++ b/docs/internals/dev.rst
@@ -62,11 +62,13 @@ Python "venv" with all dependencies and commands installed into it.
    .. code-block:: bash
 
       $ cd ../edgedb
-      $ pip install -v -e .
+      $ pip install -v -e .[test,docs]
 
    In addition to compiling EdgeDB and all dependencies, this will also
    install ``edb`` and ``edgedb`` command line tools into the current
    Python virtual environment.
+
+   It will also install libraries used during development.
 
 #. Run tests:
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -18,7 +18,6 @@
 
 
 import os.path
-import unittest
 
 import edgedb
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -892,16 +892,12 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
                 };
             """)
 
-    @unittest.expectedFailure
-    # FIXME: the test fails because errmessage is an expression that's
-    #        not a simple string literal, but a concatenation of 2
-    #        string literals.
     async def test_constraints_ddl_04(self):
         # testing an issue with expressions used for 'errmessage'
         qry = r"""
             CREATE ABSTRACT CONSTRAINT test::mymax3(max: std::int64) {
                 SET errmessage :=
-                    '{__subject__} must be no longer ' +
+                    '{__subject__} must be no longer ' ++
                     'than {max} characters.';
                 SET expr := __subject__ <= max;
             };


### PR DESCRIPTION
Use correct operator for string concatenation, `++`.


Seems this test is failing just because it is using `+` instead `++`.  Or I am missing something?