### PR TITLE
Install "edgedb-server" script.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -301,8 +301,7 @@ class develop(setuptools_develop.develop):
         _compile_postgres_extensions(pathlib.Path('build').resolve())
 
         scripts = self.distribution.entry_points['console_scripts']
-        patched_scripts = [s + '_dev' for s in scripts
-                           if not s.startswith('edgedb-server')]
+        patched_scripts = [s + '_dev' for s in scripts]
         patched_scripts.append('edb = edb.tools.edb:edbcommands')
         self.distribution.entry_points['console_scripts'] = patched_scripts
 


### PR DESCRIPTION
Generic tools and tests would rely on running "edgedb-server" rather
than the development version "edb server". It should be possible to run
those from a dev environment.