### PR TITLE
Fix missing semi-colon in migrations example

### DIFF
--- a/docs/edgeql/ddl/migrations.rst
+++ b/docs/edgeql/ddl/migrations.rst
@@ -81,7 +81,7 @@ syntax:
 
     CREATE MIGRATION init TO {
         type User {
-            property username -> str
+            property username -> str;
         }
     };
 


### PR DESCRIPTION
Just learnt the hard way that property definitions should end with a semi-colon. 😄 They do in the rest of the migrations guide, at least, so I figured this was a typo.

https://edgedb.com/docs/edgeql/ddl/migrations#examples