### PR TITLE
edgeql: Improve error message for a common nested shape error.

### DIFF
--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -296,6 +296,16 @@ class OptAnySubShape(Nonterm):
         )]
         self.val += shape.elements
 
+    def reduce_LBRACE(self, *kids):
+        raise EdgeQLSyntaxError(
+            f"Missing ':' before '{{' in a sub-shape",
+            context=kids[0].context)
+
+    def reduce_Shape(self, *kids):
+        raise EdgeQLSyntaxError(
+            f"Missing ':' before '{{' in a sub-shape",
+            context=kids[0].context)
+
     def reduce_empty(self, *kids):
         self.val = None
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1360,6 +1360,26 @@ aa';
         };
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Missing ':' before '{'", line=3, col=17)
+    def test_edgeql_syntax_shape_45(self):
+        """
+        SELECT Foo {
+            foo {}
+        };
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Missing ':' before '{'", line=3, col=17)
+    def test_edgeql_syntax_shape_46(self):
+        """
+        SELECT Foo {
+            foo {
+                bar
+            }
+        };
+        """
+
     def test_edgeql_syntax_struct_01(self):
         """
         SELECT (


### PR DESCRIPTION
Instead of complaining of "Unexpected '{'", the error message should be:
"Missing ':' before '{' in a sub-shape".

Fixes #681.