### PR TITLE
Fix DDL for the modification of the link or property target type

### DIFF
--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -211,7 +211,7 @@ Change the definition of a :ref:`link <ref_datamodel_links>`.
       DROP REQUIRED
       SET SINGLE
       SET MULTI
-      ALTER TARGET <typename> [, ...]
+      SET TYPE <typename> [, ...]
       SET ANNOTATION <annotation-name> := <value>
       DROP ANNOTATION <annotation-name>
       CREATE PROPERTY <property-name> ...
@@ -280,7 +280,7 @@ The following subcommands are allowed in the ``ALTER LINK`` block:
     Change the maximum cardinality of the link set to *greater than one*.
     Only valid for concrete links;
 
-:eql:synopsis:`ALTER TARGET <typename> [, ...]`
+:eql:synopsis:`SET TYPE <typename> [, ...]`
     Change the target type of the link to the specified type or
     a union of types.  Only valid for concrete links.
 

--- a/docs/edgeql/ddl/props.rst
+++ b/docs/edgeql/ddl/props.rst
@@ -186,7 +186,7 @@ Change the definition of a :ref:`property <ref_datamodel_props>`.
       DROP REQUIRED
       SET SINGLE
       SET MULTI
-      ALTER TARGET <typename> [, ...]
+      SET TYPE <typename> [, ...]
       SET ANNOTATION <annotation-name> := <value>
       DROP ANNOTATION <annotation-name>
       CREATE CONSTRAINT <constraint-name> ...
@@ -262,7 +262,7 @@ The following subcommands are allowed in the ``ALTER LINK`` block:
     Change the maximum cardinality of the property set to
     *greater than one*.  Only valid for concrete properties;
 
-:eql:synopsis:`ALTER TARGET <typename> [, ...]`
+:eql:synopsis:`SET TYPE <typename> [, ...]`
     Change the target type of the property to the specified type or
     a union of types.  Only valid for concrete properties.
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -540,8 +540,16 @@ class AlterDropInherit(DDL):
     bases: typing.List[TypeName]
 
 
-class AlterTarget(DDL):
-    target: TypeExpr
+class SetPointerType(DDL):
+    type: TypeExpr
+
+
+class SetLinkType(SetPointerType):
+    pass
+
+
+class SetPropertyType(SetPointerType):
+    pass
 
 
 class OnTargetDelete(DDL):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1098,8 +1098,8 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
     def visit_DropConcreteLink(self, node):
         self._visit_DropObject(node, 'LINK', unqualified=True)
 
-    def visit_AlterTarget(self, node):
-        self.write('ALTER TYPE ')
+    def visit_SetType(self, node):
+        self.write('SET TYPE ')
         self.visit_list(node.target, newlines=False)
 
     def visit_OnTargetDelete(self, node):

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -877,9 +877,14 @@ class DropIndexStmt(Nonterm):
         )
 
 
-class AlterTargetStmt(Nonterm):
-    def reduce_ALTER_TYPE_FullTypeExpr(self, *kids):
-        self.val = qlast.AlterTarget(target=kids[2].val)
+class SetPropertyTypeStmt(Nonterm):
+    def reduce_SETTYPE_FullTypeExpr(self, *kids):
+        self.val = qlast.SetPropertyType(type=kids[1].val)
+
+
+class SetLinkTypeStmt(Nonterm):
+    def reduce_SETTYPE_FullTypeExpr(self, *kids):
+        self.val = qlast.SetLinkType(type=kids[1].val)
 
 
 #
@@ -1014,7 +1019,7 @@ commands_block(
     SetFieldStmt,
     SetAnnotationValueStmt,
     DropAnnotationValueStmt,
-    AlterTargetStmt,
+    SetPropertyTypeStmt,
     SetCardinalityStmt,
     SetRequiredStmt,
     CreateConcreteConstraintStmt,
@@ -1186,7 +1191,7 @@ commands_block(
     DropAnnotationValueStmt,
     SetCardinalityStmt,
     SetRequiredStmt,
-    AlterTargetStmt,
+    SetLinkTypeStmt,
     AlterSimpleExtending,
     CreateConcreteConstraintStmt,
     AlterConcreteConstraintStmt,

--- a/edb/edgeql/parser/grammar/lexer.py
+++ b/edb/edgeql/parser/grammar/lexer.py
@@ -53,7 +53,7 @@ class EdgeQLLexer(lexer.Lexer):
 
     start_state = STATE_BASE
 
-    MERGE_TOKENS = {('NAMED', 'ONLY'), ('SET', 'ANNOTATION')}
+    MERGE_TOKENS = {('NAMED', 'ONLY'), ('SET', 'ANNOTATION'), ('SET', 'TYPE')}
 
     NL = 'NL'
     MULTILINE_TOKENS = frozenset(('SCONST', 'BCONST', 'RSCONST'))

--- a/edb/edgeql/parser/grammar/tokens.py
+++ b/edb/edgeql/parser/grammar/tokens.py
@@ -181,6 +181,10 @@ class T_SETANNOTATION(Token):
     pass
 
 
+class T_SETTYPE(Token):
+    pass
+
+
 class T_ICONST(Token):
     pass
 

--- a/edb/pgsql/datasources/schema/links.py
+++ b/edb/pgsql/datasources/schema/links.py
@@ -31,7 +31,6 @@ async def fetch(
                 l.id,
                 edgedb._resolve_type_name(l.source) AS source,
                 l.target AS target,
-                edgedb._resolve_type_name(l.spectargets) AS spectargets,
                 l.name AS name,
                 edgedb._resolve_type_name(l.bases) AS bases,
                 edgedb._resolve_type_name(l.ancestors) AS ancestors,

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -625,11 +625,6 @@ class IntrospectionMech:
                 dermap[name] = r['derived_from']
 
             source = schema.get(r['source']) if r['source'] else None
-            if r['spectargets']:
-                spectargets = [schema.get(t) for t in r['spectargets']]
-            else:
-                spectargets = None
-
             target = self.unpack_typeref(r['target'], schema)
 
             required = r['required']
@@ -646,7 +641,6 @@ class IntrospectionMech:
                 name=name,
                 source=source,
                 target=target,
-                spectargets=spectargets,
                 cardinality=cardinality,
                 required=required,
                 is_derived=r['is_derived'],

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -300,6 +300,13 @@ class RebaseProperty(PropertyCommand, inheriting.RebaseInheritingObject):
     pass
 
 
+class SetPropertyType(pointers.SetPointerType,
+                      schema_metaclass=Property,
+                      referrer_context_class=PropertySourceContext):
+
+    astnode = qlast.SetPropertyType
+
+
 class AlterProperty(PropertyCommand,
                     referencing.AlterReferencedInheritingObject):
     astnode = [qlast.AlterConcreteProperty,
@@ -324,12 +331,11 @@ class AlterProperty(PropertyCommand,
     def _apply_field_ast(self, schema, context, node, op):
         if op.property == 'target':
             if op.new_value:
-                node.commands.append(qlast.AlterTarget(
-                    targets=[
-                        qlast.ObjectRef(
-                            name=op.new_value.classname.name,
-                            module=op.new_value.classname.module)
-                    ]
+                node.commands.append(qlast.SetType(
+                    type=qlast.ObjectRef(
+                        name=op.new_value.classname.name,
+                        module=op.new_value.classname.module
+                    )
                 ))
         elif op.property == 'source':
             pass

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2742,15 +2742,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 }
             """)
 
-    @test.xfail('''
-        The error is:
-
-        SchemaError: cannot derive <Link ...>(
-            std::std|link@@std|
-            Virtual_71a37e2cf26c98e5dad84176a6ffa910@test|Owner
-        )
-        from itself
-    ''')
     async def test_edgeql_ddl_inheritance_alter_03(self):
         await self.con.execute(r"""
             CREATE TYPE test::Owner;
@@ -2768,7 +2759,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result("""
             SELECT test::Owner.<owner;
-        """, [{}])
+        """, [])
 
     async def test_edgeql_ddl_inheritance_alter_04(self):
         await self.con.execute(r"""


### PR DESCRIPTION
`ALTER PROPERTY ... ALTER TYPE` is now spelled as `ALTER PROPERTY ... SET
TYPE`, and the validity of the operation is checked properly against the
inheritance structure and the use of the pointer in expressions.