### PR TITLE
Insert `from __future__ import annotations` to all Python files

### DIFF
--- a/edb/__init__.py
+++ b/edb/__init__.py
@@ -16,6 +16,9 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
+del annotations
 
 # DO NOT ADD ANYTHING TO THIS FILE:
 # we might want to make "edb" a namespace

--- a/edb/cli/__init__.py
+++ b/edb/cli/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import sys
 
 import click

--- a/edb/cli/mng.py
+++ b/edb/cli/mng.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import re
 import sys
 import textwrap

--- a/edb/common/adapter.py
+++ b/edb/common/adapter.py
@@ -17,6 +17,9 @@
 #
 
 
+from __future__ import annotations
+
+
 class AdapterError(Exception):
     pass
 

--- a/edb/common/ast/__init__.py
+++ b/edb/common/ast/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .base import *  # NOQA
 from .visitor import *  # NOQA
 from .transformer import *  # NOQA

--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import copy
 import collections.abc
 import functools

--- a/edb/common/ast/codegen.py
+++ b/edb/common/ast/codegen.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import itertools
 
 from .visitor import NodeVisitor

--- a/edb/common/ast/match.py
+++ b/edb/common/ast/match.py
@@ -19,6 +19,8 @@
 
 """Generic AST tree pattern matching."""
 
+from __future__ import annotations
+
 import collections.abc
 import types
 

--- a/edb/common/ast/transformer.py
+++ b/edb/common/ast/transformer.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common import typeutils
 
 from . import base

--- a/edb/common/ast/visitor.py
+++ b/edb/common/ast/visitor.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common import typeutils
 
 from . import base

--- a/edb/common/colorsys.py
+++ b/edb/common/colorsys.py
@@ -22,6 +22,8 @@
 Contains additional functions, with the most notable - :func:`rgb_distance`.
 """
 
+from __future__ import annotations
+
 from math import sqrt as _sqrt
 from colorsys import (
     rgb_to_yiq, yiq_to_rgb, rgb_to_hls, hls_to_rgb, rgb_to_hsv, hsv_to_rgb

--- a/edb/common/compiler.py
+++ b/edb/common/compiler.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections
 import re
 

--- a/edb/common/context.py
+++ b/edb/common/context.py
@@ -31,6 +31,8 @@ general approach is to infer context information by propagating known
 contexts through the AST structure.
 """
 
+from __future__ import annotations
+
 import bisect
 
 from edb.common import ast

--- a/edb/common/datetime.py
+++ b/edb/common/datetime.py
@@ -17,6 +17,9 @@
 #
 
 
+from __future__ import annotations
+
+
 def humanize_time_delta(t):
     f = 's'
     if t and not round(t):

--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -31,6 +31,8 @@ flexibility to redirect debug output if needed.
 """
 
 
+from __future__ import annotations
+
 import builtins
 import contextlib
 import os

--- a/edb/common/devmode.py
+++ b/edb/common/devmode.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import contextlib
 import hashlib
 import json

--- a/edb/common/enum.py
+++ b/edb/common/enum.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import enum
 
 

--- a/edb/common/exceptions.py
+++ b/edb/common/exceptions.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import sys
 
 

--- a/edb/common/levenshtein.py
+++ b/edb/common/levenshtein.py
@@ -17,6 +17,9 @@
 #
 
 
+from __future__ import annotations
+
+
 def distance(s, t):
     """Calculates Levenshtein distance between s and t."""
 

--- a/edb/common/lexer.py
+++ b/edb/common/lexer.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections
 import re
 import types

--- a/edb/common/lru.py
+++ b/edb/common/lru.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections.abc
 
 

--- a/edb/common/markup/__init__.py
+++ b/edb/common/markup/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import abc
 import sys
 

--- a/edb/common/markup/elements/__init__.py
+++ b/edb/common/markup/elements/__init__.py
@@ -17,4 +17,6 @@
 #
 
 
+from __future__ import annotations
+
 from . import base, lang, doc, code  # NOQA

--- a/edb/common/markup/elements/base.py
+++ b/edb/common/markup/elements/base.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common.struct import Struct, Field
 from edb.common import typed
 

--- a/edb/common/markup/elements/code.py
+++ b/edb/common/markup/elements/code.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common import struct, typed
 from . import base
 

--- a/edb/common/markup/elements/doc.py
+++ b/edb/common/markup/elements/doc.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import difflib
 
 from edb.common import typed

--- a/edb/common/markup/elements/lang.py
+++ b/edb/common/markup/elements/lang.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import linecache
 
 from edb.common.struct import Field

--- a/edb/common/markup/format.py
+++ b/edb/common/markup/format.py
@@ -17,6 +17,9 @@
 #
 
 
+from __future__ import annotations
+
+
 def xrepr(obj, *, max_len=None):
     """Extended ``builtins.repr`` function.
 

--- a/edb/common/markup/renderers/__init__.py
+++ b/edb/common/markup/renderers/__init__.py
@@ -17,4 +17,6 @@
 #
 
 
+from __future__ import annotations
+
 from . import terminal  # NOQA

--- a/edb/common/markup/renderers/styles.py
+++ b/edb/common/markup/renderers/styles.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common.term import Style16, Style256
 
 

--- a/edb/common/markup/renderers/terminal.py
+++ b/edb/common/markup/renderers/terminal.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import sys
 import contextlib
 

--- a/edb/common/markup/serializer/__init__.py
+++ b/edb/common/markup/serializer/__init__.py
@@ -17,6 +17,9 @@
 #
 
 
+from __future__ import annotations
+
+
 class settings:
     censor_sensitive_vars = True
     censor_list = ['secret', 'password']

--- a/edb/common/markup/serializer/base.py
+++ b/edb/common/markup/serializer/base.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections
 import collections.abc
 import decimal

--- a/edb/common/markup/serializer/code.py
+++ b/edb/common/markup/serializer/code.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common.markup.elements import code as code_el
 
 try:

--- a/edb/common/markup/serializer/logging.py
+++ b/edb/common/markup/serializer/logging.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import logging
 
 from . import base

--- a/edb/common/ordered.py
+++ b/edb/common/ordered.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections
 import collections.abc
 

--- a/edb/common/parsing.py
+++ b/edb/common/parsing.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import logging
 import os
 import sys

--- a/edb/common/struct.py
+++ b/edb/common/struct.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections
 
 from . import typed

--- a/edb/common/supervisor.py
+++ b/edb/common/supervisor.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncio
 import itertools
 

--- a/edb/common/taskgroup.py
+++ b/edb/common/taskgroup.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncio
 import functools
 import itertools

--- a/edb/common/term.py
+++ b/edb/common/term.py
@@ -19,6 +19,8 @@
 
 """A collection of functions and classes to simplify output to terminal."""
 
+from __future__ import annotations
+
 import os
 import sys
 import fcntl

--- a/edb/common/topological.py
+++ b/edb/common/topological.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from collections import defaultdict
 
 from edb.common.ordered import OrderedSet

--- a/edb/common/typed.py
+++ b/edb/common/typed.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import abc
 import builtins
 import collections

--- a/edb/common/typeutils.py
+++ b/edb/common/typeutils.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections.abc
 import functools
 

--- a/edb/common/uuidgen.py
+++ b/edb/common/uuidgen.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import os
 import uuid
 

--- a/edb/common/vendor/__init__.py
+++ b/edb/common/vendor/__init__.py
@@ -1,1 +1,3 @@
 # Vendored Dependencies
+
+from __future__ import annotations

--- a/edb/common/vendor/typing_inspect.py
+++ b/edb/common/vendor/typing_inspect.py
@@ -12,6 +12,8 @@ Example usage::
 
 # NOTE: This module must support Python 2.7 in addition to Python 3.x
 
+from __future__ import annotations
+
 import sys
 NEW_TYPING = sys.version_info[:3] >= (3, 7, 0)  # PEP 560
 if NEW_TYPING:

--- a/edb/edgeql/__init__.py
+++ b/edb/edgeql/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from . import ast  # NOQA
 from .codegen import generate_source  # NOQA
 from .parser import parse, parse_fragment, parse_block  # NOQA

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import decimal
 import typing
 

--- a/edb/edgeql/astmatch.py
+++ b/edb/edgeql/astmatch.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import sys
 
 from edb.common import ast

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import re
 
 from edb import errors

--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -20,6 +20,8 @@
 """EdgeQL to IR compiler."""
 
 
+from __future__ import annotations
+
 from edb import errors
 
 from edb.edgeql import parser as ql_parser

--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -20,6 +20,8 @@
 """EdgeQL compiler helpers for AST classification and basic transforms."""
 
 
+from __future__ import annotations
+
 from edb.edgeql import ast as qlast
 
 from edb.schema import abc as s_abc

--- a/edb/edgeql/compiler/cast.py
+++ b/edb/edgeql/compiler/cast.py
@@ -20,6 +20,8 @@
 """EdgeQL compiler routines for type casts."""
 
 
+from __future__ import annotations
+
 import typing
 
 from edb import errors

--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -20,6 +20,8 @@
 """EdgeQL compiler functions to process shared clauses."""
 
 
+from __future__ import annotations
+
 import typing
 
 from edb.edgeql import ast as qlast

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -20,6 +20,8 @@
 """CONFIGURE statement compilation functions."""
 
 
+from __future__ import annotations
+
 import json
 import typing
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -19,6 +19,8 @@
 
 """EdgeQL to IR compiler context."""
 
+from __future__ import annotations
+
 import collections
 import dataclasses
 import enum

--- a/edb/edgeql/compiler/dispatch.py
+++ b/edb/edgeql/compiler/dispatch.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import functools
 
 from edb.edgeql import ast as qlast

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -20,6 +20,8 @@
 """EdgeQL non-statement expression compilation functions."""
 
 
+from __future__ import annotations
+
 import ast
 import typing
 

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -20,6 +20,8 @@
 """EdgeQL compiler routines for function calls and operators."""
 
 
+from __future__ import annotations
+
 import typing
 
 from edb import errors

--- a/edb/edgeql/compiler/inference/__init__.py
+++ b/edb/edgeql/compiler/inference/__init__.py
@@ -17,5 +17,7 @@
 #
 
 
+from __future__ import annotations
+
 from .cardinality import infer_cardinality  # NOQA
 from .types import amend_empty_set_type, infer_type  # NOQA

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import functools
 import typing
 

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import functools
 import typing
 

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -20,6 +20,8 @@
 """EdgeQL compiler path scope helpers."""
 
 
+from __future__ import annotations
+
 import typing
 
 from edb import errors

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -20,6 +20,8 @@
 """EdgeQL compiler routines for polymorphic call resolution."""
 
 
+from __future__ import annotations
+
 import typing
 
 from edb import errors

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -20,6 +20,8 @@
 """EdgeQL compiler schema helpers."""
 
 
+from __future__ import annotations
+
 import typing
 
 from edb import errors

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -20,6 +20,8 @@
 """EdgeQL set compilation functions."""
 
 
+from __future__ import annotations
+
 import contextlib
 import typing
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -20,6 +20,8 @@
 """EdgeQL statement compilation routines."""
 
 
+from __future__ import annotations
+
 import typing
 
 from edb import errors

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -20,6 +20,8 @@
 """EdgeQL compiler statement-level context management."""
 
 
+from __future__ import annotations
+
 import functools
 import typing
 

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -20,6 +20,8 @@
 """EdgeQL compiler type-related helpers."""
 
 
+from __future__ import annotations
+
 import collections
 import typing
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -20,6 +20,8 @@
 """EdgeQL shape compilation functions."""
 
 
+from __future__ import annotations
+
 import functools
 import typing
 

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -28,6 +28,8 @@ In those cases we make a best-effort tracing using a rudimentary
 EdgeQL AST visitor.
 """
 
+from __future__ import annotations
+
 import copy
 import hashlib
 import functools

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from . import parser as ql_parser
 from .. import ast as qlast
 

--- a/edb/edgeql/parser/grammar/__init__.py
+++ b/edb/edgeql/parser/grammar/__init__.py
@@ -4,3 +4,5 @@
 #
 # See LICENSE for details.
 ##
+
+from __future__ import annotations

--- a/edb/edgeql/parser/grammar/block.py
+++ b/edb/edgeql/parser/grammar/block.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common import parsing
 
 from .expressions import Nonterm

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import sys
 import types
 

--- a/edb/edgeql/parser/grammar/config.py
+++ b/edb/edgeql/parser/grammar/config.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 from edb.edgeql import ast as qlast
 
 from .expressions import Nonterm

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections
 import re
 import typing

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections
 import re
 import typing

--- a/edb/edgeql/parser/grammar/keywords.py
+++ b/edb/edgeql/parser/grammar/keywords.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import re
 import typing
 

--- a/edb/edgeql/parser/grammar/lexer.py
+++ b/edb/edgeql/parser/grammar/lexer.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import re
 
 from edb.common import lexer

--- a/edb/edgeql/parser/grammar/lexutils.py
+++ b/edb/edgeql/parser/grammar/lexutils.py
@@ -19,6 +19,8 @@
 """Support utilities for lexical processing of literals."""
 
 
+from __future__ import annotations
+
 import re
 
 from . import lexer

--- a/edb/edgeql/parser/grammar/precedence.py
+++ b/edb/edgeql/parser/grammar/precedence.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common import parsing
 
 

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.edgeql import ast as qlast
 
 from edb.common import parsing

--- a/edb/edgeql/parser/grammar/sdldocument.py
+++ b/edb/edgeql/parser/grammar/sdldocument.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.edgeql import ast as esast
 
 from .expressions import Nonterm

--- a/edb/edgeql/parser/grammar/session.py
+++ b/edb/edgeql/parser/grammar/session.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 from edb.edgeql import ast as qlast
 
 from .expressions import Nonterm

--- a/edb/edgeql/parser/grammar/single.py
+++ b/edb/edgeql/parser/grammar/single.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .expressions import Nonterm
 from .precedence import *  # NOQA
 from .tokens import *  # NOQA

--- a/edb/edgeql/parser/grammar/statements.py
+++ b/edb/edgeql/parser/grammar/statements.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 from edb import errors
 
 from edb.common import parsing

--- a/edb/edgeql/parser/grammar/tokens.py
+++ b/edb/edgeql/parser/grammar/tokens.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import re
 import sys
 import types

--- a/edb/edgeql/parser/parser.py
+++ b/edb/edgeql/parser/parser.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 from edb import errors
 from edb.common import debug, parsing
 

--- a/edb/edgeql/pygments/__init__.py
+++ b/edb/edgeql/pygments/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from pygments.lexer import RegexLexer, include
 from pygments import token
 

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common import enum as s_enum
 
 

--- a/edb/edgeql/quote.py
+++ b/edb/edgeql/quote.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import re
 
 from .parser.grammar import keywords

--- a/edb/edgeql/rewriter.py
+++ b/edb/edgeql/rewriter.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common import ast
 
 from edb.schema import name as sn

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import functools
 import typing
 

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import copy
 import itertools
 import typing

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -5,6 +5,8 @@
 # flake8: noqa
 
 
+from __future__ import annotations
+
 from edb.errors.base import *
 
 

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import typing
 
 from edb.common import context as pctx

--- a/edb/graphql/__init__.py
+++ b/edb/graphql/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .translator import translate
 from .types import GQLCoreSchema
 

--- a/edb/graphql/_patch_core.py
+++ b/edb/graphql/_patch_core.py
@@ -17,6 +17,9 @@
 #
 
 
+from __future__ import annotations
+
+
 def patch_graphql_core():
     import graphql
     import graphql.utils.type_comparators as type_comparators

--- a/edb/graphql/codegen.py
+++ b/edb/graphql/codegen.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import json
 from edb.common.ast import codegen
 

--- a/edb/graphql/errors.py
+++ b/edb/graphql/errors.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 import typing
 
 from edb import errors

--- a/edb/graphql/pygments/__init__.py
+++ b/edb/graphql/pygments/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from pygments.lexer import RegexLexer, include
 from pygments import token
 

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import contextlib
 import json
 import re

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from collections import OrderedDict
 from functools import partial
 from graphql import (

--- a/edb/ir/__init__.py
+++ b/edb/ir/__init__.py
@@ -4,3 +4,5 @@
 #
 # See LICENSE for details.
 ##
+
+from __future__ import annotations

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import typing
 import uuid
 
@@ -71,16 +73,16 @@ class TypeRef(ImmutableBase):
     name_hint: str
     # The ref of the underlying material type, if this is a view type,
     # else None.
-    material_type: typing.Optional['TypeRef']
+    material_type: typing.Optional[TypeRef]
     # If this is a scalar type, base_type would be the highest
     # non-abstract base type.
-    base_type: typing.Optional['TypeRef']
+    base_type: typing.Optional[TypeRef]
     # If this is a union type, this would be a set of
     # union elements.
-    children: typing.FrozenSet['TypeRef']
+    children: typing.FrozenSet[TypeRef]
     # If this is a union type, this would be the nearest common
     # ancestor of the union members.
-    common_parent: typing.Optional['TypeRef']
+    common_parent: typing.Optional[TypeRef]
     # If this node is an element of a collection, and the
     # collection elements are named, this would be then
     # name of the element.
@@ -88,7 +90,7 @@ class TypeRef(ImmutableBase):
     # The kind of the collection type if this is a collection
     collection: str
     # Collection subtypes if this is a collection
-    subtypes: typing.Tuple['TypeRef', ...]
+    subtypes: typing.Tuple[TypeRef, ...]
     # True, if this describes a scalar type
     is_scalar: bool = False
     # True, if this describes a view
@@ -122,11 +124,11 @@ class BasePointerRef(ImmutableBase):
     out_source: TypeRef
     out_target: TypeRef
     direction: s_pointers.PointerDirection
-    parent_ptr: 'BasePointerRef'
-    material_ptr: 'BasePointerRef'
-    derived_from_ptr: 'BasePointerRef'
-    descendants: typing.Set['BasePointerRef']
-    union_components: typing.Set['BasePointerRef']
+    parent_ptr: BasePointerRef
+    material_ptr: BasePointerRef
+    derived_from_ptr: BasePointerRef
+    descendants: typing.Set[BasePointerRef]
+    union_components: typing.Set[BasePointerRef]
     has_properties: bool
     required: bool
     # Relation cardinality in the direction specified

--- a/edb/ir/astexpr.py
+++ b/edb/ir/astexpr.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common.ast import match as astmatch
 
 from . import astmatch as irastmatch

--- a/edb/ir/astmatch.py
+++ b/edb/ir/astmatch.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import sys
 
 from edb.common import ast

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -19,6 +19,8 @@
 
 """Query scope tree implementation."""
 
+from __future__ import annotations
+
 import textwrap
 import typing
 import weakref

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -20,6 +20,8 @@
 """Static evaluation of EdgeQL IR."""
 
 
+from __future__ import annotations
+
 import dataclasses
 import decimal
 import functools

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import json
 import typing
 

--- a/edb/lib/__init__.py
+++ b/edb/lib/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/edb/pgsql/__init__.py
+++ b/edb/pgsql/__init__.py
@@ -15,3 +15,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import annotations

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import enum
 import typing
 

--- a/edb/pgsql/astexpr.py
+++ b/edb/pgsql/astexpr.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common.ast import match as astmatch
 from . import ast as pgast  # NOQA
 from . import astmatch as pgastmatch

--- a/edb/pgsql/astmatch.py
+++ b/edb/pgsql/astmatch.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import sys
 
 from edb.common import ast

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import binascii
 
 from edb import errors

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import hashlib
 import base64
 import re

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import typing
 
 from edb import errors

--- a/edb/pgsql/compiler/aliases.py
+++ b/edb/pgsql/compiler/aliases.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common import compiler
 from edb.pgsql import common
 

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -20,6 +20,8 @@
 """Context-agnostic SQL AST utilities."""
 
 
+from __future__ import annotations
+
 import typing
 
 from edb.pgsql import ast as pgast

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import typing
 
 from edb.edgeql import qltypes

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb import errors
 from edb.ir import ast as irast
 

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -19,6 +19,8 @@
 
 """IR compiler context."""
 
+from __future__ import annotations
+
 import collections
 import enum
 

--- a/edb/pgsql/compiler/dispatch.py
+++ b/edb/pgsql/compiler/dispatch.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import functools
 
 from edb.ir import ast as irast

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -30,6 +30,8 @@
 #    depending on the link layout.
 #
 
+from __future__ import annotations
+
 import collections
 import typing
 

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -19,6 +19,8 @@
 
 """Compilation handlers for non-statement expressions."""
 
+from __future__ import annotations
+
 import typing
 
 from edb import errors

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -19,6 +19,8 @@
 
 """Compilation helpers for output formatting and serialization."""
 
+from __future__ import annotations
+
 import typing
 
 from edb.ir import ast as irast

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -20,6 +20,8 @@
 """Helpers to manage statement path contexts."""
 
 
+from __future__ import annotations
+
 import functools
 import typing
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -20,6 +20,8 @@
 """Compiler routines managing relation ranges and scope."""
 
 
+from __future__ import annotations
+
 import typing
 
 from edb.ir import ast as irast

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -20,6 +20,8 @@
 """Compiler functions to generate SQL relations for IR sets."""
 
 
+from __future__ import annotations
+
 import contextlib
 import typing
 

--- a/edb/pgsql/compiler/shapecomp.py
+++ b/edb/pgsql/compiler/shapecomp.py
@@ -19,6 +19,8 @@
 
 """Compilation helpers for shapes."""
 
+from __future__ import annotations
+
 import typing
 
 from edb.edgeql import qltypes

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.ir import ast as irast
 
 from edb.pgsql import ast as pgast

--- a/edb/pgsql/datasources/__init__.py
+++ b/edb/pgsql/datasources/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from . import introspection  # NOQA
 from . import schema  # NOQA
 from . import deltalog  # NOQA

--- a/edb/pgsql/datasources/deltalog.py
+++ b/edb/pgsql/datasources/deltalog.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/introspection/__init__.py
+++ b/edb/pgsql/datasources/introspection/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from . import domains  # NOQA
 from . import tables  # NOQA
 from . import schemas  # NOQA

--- a/edb/pgsql/datasources/introspection/constraints.py
+++ b/edb/pgsql/datasources/introspection/constraints.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/introspection/domains.py
+++ b/edb/pgsql/datasources/introspection/domains.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/introspection/schemas.py
+++ b/edb/pgsql/datasources/introspection/schemas.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/introspection/sequences.py
+++ b/edb/pgsql/datasources/introspection/sequences.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/introspection/tables.py
+++ b/edb/pgsql/datasources/introspection/tables.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/introspection/types.py
+++ b/edb/pgsql/datasources/introspection/types.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/schema/__init__.py
+++ b/edb/pgsql/datasources/schema/__init__.py
@@ -17,6 +17,10 @@
 #
 
 
+from __future__ import annotations
+
+del annotations  # There is a conflicting `annotations` module in this package.
+
 from . import annotations  # NOQA
 from . import casts  # NOQA
 from . import constraints  # NOQA

--- a/edb/pgsql/datasources/schema/annotations.py
+++ b/edb/pgsql/datasources/schema/annotations.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/schema/casts.py
+++ b/edb/pgsql/datasources/schema/casts.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/schema/constraints.py
+++ b/edb/pgsql/datasources/schema/constraints.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/schema/functions.py
+++ b/edb/pgsql/datasources/schema/functions.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/schema/indexes.py
+++ b/edb/pgsql/datasources/schema/indexes.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/schema/links.py
+++ b/edb/pgsql/datasources/schema/links.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/schema/modules.py
+++ b/edb/pgsql/datasources/schema/modules.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/schema/objtypes.py
+++ b/edb/pgsql/datasources/schema/objtypes.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/schema/operators.py
+++ b/edb/pgsql/datasources/schema/operators.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/schema/roles.py
+++ b/edb/pgsql/datasources/schema/roles.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/datasources/schema/scalars.py
+++ b/edb/pgsql/datasources/schema/scalars.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncpg
 import typing
 

--- a/edb/pgsql/dbops/__init__.py
+++ b/edb/pgsql/dbops/__init__.py
@@ -19,6 +19,8 @@
 
 """Abstractions for low-level database DDL and DML operations and data."""
 
+from __future__ import annotations
+
 from .base import *  # NOQA
 from .config import *  # NOQA
 from .ddl import *  # NOQA

--- a/edb/pgsql/dbops/base.py
+++ b/edb/pgsql/dbops/base.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import base64
 import collections
 import hashlib

--- a/edb/pgsql/dbops/catalogs.py
+++ b/edb/pgsql/dbops/catalogs.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from . import tables
 
 

--- a/edb/pgsql/dbops/composites.py
+++ b/edb/pgsql/dbops/composites.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common import ordered
 
 from .. import common

--- a/edb/pgsql/dbops/config.py
+++ b/edb/pgsql/dbops/config.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from ..common import quote_ident as qi
 from ..common import quote_literal as ql
 

--- a/edb/pgsql/dbops/constraints.py
+++ b/edb/pgsql/dbops/constraints.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .. import common
 from . import base
 

--- a/edb/pgsql/dbops/databases.py
+++ b/edb/pgsql/dbops/databases.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import textwrap
 
 from ..common import quote_ident as qi

--- a/edb/pgsql/dbops/ddl.py
+++ b/edb/pgsql/dbops/ddl.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import json
 import textwrap
 

--- a/edb/pgsql/dbops/dml.py
+++ b/edb/pgsql/dbops/dml.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import textwrap
 
 from ..common import qname as qn

--- a/edb/pgsql/dbops/domains.py
+++ b/edb/pgsql/dbops/domains.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import textwrap
 
 from ..common import qname as qn

--- a/edb/pgsql/dbops/enums.py
+++ b/edb/pgsql/dbops/enums.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import textwrap
 
 from ..common import qname as qn

--- a/edb/pgsql/dbops/extensions.py
+++ b/edb/pgsql/dbops/extensions.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from ..common import quote_ident as qi
 
 from . import base

--- a/edb/pgsql/dbops/functions.py
+++ b/edb/pgsql/dbops/functions.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import textwrap
 
 from ..common import qname as qn

--- a/edb/pgsql/dbops/indexes.py
+++ b/edb/pgsql/dbops/indexes.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import json
 import textwrap
 import typing

--- a/edb/pgsql/dbops/operators.py
+++ b/edb/pgsql/dbops/operators.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import textwrap
 
 from ..common import quote_ident as qi

--- a/edb/pgsql/dbops/roles.py
+++ b/edb/pgsql/dbops/roles.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import textwrap
 
 from ..common import quote_ident as qi

--- a/edb/pgsql/dbops/schemas.py
+++ b/edb/pgsql/dbops/schemas.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import textwrap
 
 from ..common import quote_ident as qi

--- a/edb/pgsql/dbops/sequences.py
+++ b/edb/pgsql/dbops/sequences.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from ..common import qname as qn
 from ..common import quote_ident as qi
 

--- a/edb/pgsql/dbops/tables.py
+++ b/edb/pgsql/dbops/tables.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections
 import textwrap
 

--- a/edb/pgsql/dbops/triggers.py
+++ b/edb/pgsql/dbops/triggers.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import json
 import textwrap
 import typing

--- a/edb/pgsql/dbops/types.py
+++ b/edb/pgsql/dbops/types.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import textwrap
 
 from edb.common import ordered

--- a/edb/pgsql/dbops/views.py
+++ b/edb/pgsql/dbops/views.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import textwrap
 
 from ..common import qname as qn

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections.abc
 import itertools
 import json

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -19,6 +19,8 @@
 
 """Abstractions for low-level database DDL and DML operations."""
 
+from __future__ import annotations
+
 from edb.schema import objects as s_obj
 from edb.common import adapter
 

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -18,6 +18,8 @@
 
 """Low level introspection of the schema."""
 
+from __future__ import annotations
+
 import json
 
 import immutables as immu

--- a/edb/pgsql/keywords.py
+++ b/edb/pgsql/keywords.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 keyword_types = range(1, 5)
 (UNRESERVED_KEYWORD, RESERVED_KEYWORD,
  TYPE_FUNC_NAME_KEYWORD, COL_NAME_KEYWORD) = keyword_types

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -19,6 +19,8 @@
 
 """Database structure and objects supporting EdgeDB metadata."""
 
+from __future__ import annotations
+
 import collections
 import re
 import textwrap

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import itertools
 
 from edb import errors

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections
 import functools
 import typing

--- a/edb/repl/__init__.py
+++ b/edb/repl/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import functools
 import io
 import os

--- a/edb/repl/context.py
+++ b/edb/repl/context.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import dataclasses
 import enum
 import typing

--- a/edb/repl/lexutils.py
+++ b/edb/repl/lexutils.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import functools
 
 from edb.edgeql.parser.grammar import lexer

--- a/edb/repl/render.py
+++ b/edb/repl/render.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import datetime
 import decimal
 import functools

--- a/edb/schema/__init__.py
+++ b/edb/schema/__init__.py
@@ -17,6 +17,10 @@
 #
 
 
+from __future__ import annotations
+
+del annotations  # There is a conflicting `annotations` module in this package.
+
 from .name import SchemaName  # NOQA
 
 from .objects import Object, ObjectMeta  # NOQA

--- a/edb/schema/_types.py
+++ b/edb/schema/_types.py
@@ -2,6 +2,8 @@
 #    $ edb gen-types
 
 
+from __future__ import annotations
+
 import uuid
 
 

--- a/edb/schema/abc.py
+++ b/edb/schema/abc.py
@@ -17,6 +17,9 @@
 #
 
 
+from __future__ import annotations
+
+
 class Object:
     pass
 

--- a/edb/schema/annotations.py
+++ b/edb/schema/annotations.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import typing
 
 from edb.edgeql import ast as qlast

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import functools
 import typing
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import hashlib
 
 from edb import errors

--- a/edb/schema/database.py
+++ b/edb/schema/database.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.edgeql import ast as qlast
 
 from . import abc as s_abc

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb import edgeql
 
 from edb.edgeql import declarative as s_decl

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import base64
 import collections
 import collections.abc

--- a/edb/schema/deltas.py
+++ b/edb/schema/deltas.py
@@ -20,6 +20,8 @@
 """Implementation of MIGRATION objects."""
 
 
+from __future__ import annotations
+
 from edb.edgeql import ast as qlast
 
 from . import abc as s_abc

--- a/edb/schema/derivable.py
+++ b/edb/schema/derivable.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from . import abc as s_abc
 from . import name as sn
 from . import objects as so

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import types
 import typing
 

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.edgeql import ast as qlast
 
 from . import abc as s_abc

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import contextlib
 
 import immutables as immu

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import typing
 
 from edb.edgeql import ast as qlast

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.edgeql import ast as qlast
 
 from . import annotations

--- a/edb/schema/name.py
+++ b/edb/schema/name.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import functools
 
 from edb import errors

--- a/edb/schema/nodes.py
+++ b/edb/schema/nodes.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb import errors
 
 from edb.edgeql import ast as qlast

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections
 import collections.abc
 import itertools

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import typing
 
 from edb.edgeql import ast as qlast

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import typing
 
 from edb import errors

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections
 
 from edb.common import topological

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import typing
 
 from . import inheriting

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.edgeql import ast as qlast
 
 from edb import errors

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edgedb import scram
 
 from edb.edgeql import ast as qlast

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import typing
 
 from edb import errors

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import functools
 import itertools
 import typing

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from . import indexes
 from . import name as sn
 from . import objects as so

--- a/edb/schema/std.py
+++ b/edb/schema/std.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import pathlib
 import typing
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections.abc
 import enum
 import types

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections
 import itertools
 import typing

--- a/edb/schema/views.py
+++ b/edb/schema/views.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.edgeql import ast as qlast
 
 from . import scalars as s_scalars

--- a/edb/server/__init__.py
+++ b/edb/server/__init__.py
@@ -4,3 +4,5 @@
 #
 # See LICENSE for details.
 ##
+
+from __future__ import annotations

--- a/edb/server/baseport.py
+++ b/edb/server/baseport.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections.abc
 import socket
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import json
 import logging
 import os.path

--- a/edb/server/buildmeta.py
+++ b/edb/server/buildmeta.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import enum
 import os
 import pathlib

--- a/edb/server/cache/__init__.py
+++ b/edb/server/cache/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .stmt_cache import StatementsCache
 
 

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncio
 import errno
 import os

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .compiler import Compiler, BaseCompiler, CompilerDatabaseState
 from .compiler import compile_bootstrap_script
 from .dbstate import QueryUnit

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections
 import dataclasses
 import hashlib

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import dataclasses
 import enum
 import time

--- a/edb/server/compiler/enums.py
+++ b/edb/server/compiler/enums.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import enum
 
 from edb.common import enum as strenum

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import enum
 import json
 import re

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import struct
 import uuid
 

--- a/edb/server/compiler/status.py
+++ b/edb/server/compiler/status.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import functools
 
 from edb.edgeql import ast as qlast

--- a/edb/server/compiler/stdschema.py
+++ b/edb/server/compiler/stdschema.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import pathlib
 import pickle
 

--- a/edb/server/config/__init__.py
+++ b/edb/server/config/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .ops import OpLevel, OpCode, Operation, lookup
 from .ops import spec_to_json, to_json, from_json
 from .ops import value_from_json

--- a/edb/server/config/spec.py
+++ b/edb/server/config/spec.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections.abc
 import dataclasses
 import json

--- a/edb/server/config/types.py
+++ b/edb/server/config/types.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import dataclasses
 
 from edb import errors

--- a/edb/server/daemon/__init__.py
+++ b/edb/server/daemon/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .pidfile import PidFile  # NOQA
 from .exceptions import DaemonError  # NOQA
 from .daemon import DaemonContext  # NOQA

--- a/edb/server/daemon/daemon.py
+++ b/edb/server/daemon/daemon.py
@@ -19,6 +19,8 @@
 
 """Implementation of PEP 3143."""
 
+from __future__ import annotations
+
 import atexit
 import io
 import signal

--- a/edb/server/daemon/exceptions.py
+++ b/edb/server/daemon/exceptions.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb import errors
 
 

--- a/edb/server/daemon/lib.py
+++ b/edb/server/daemon/lib.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import errno
 import io
 import os

--- a/edb/server/daemon/pidfile.py
+++ b/edb/server/daemon/pidfile.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import os
 import errno
 

--- a/edb/server/dbview/__init__.py
+++ b/edb/server/dbview/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .dbview import DatabaseIndex
 
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 EDGEDB_PORT = 5656
 EDGEDB_SUPERUSER = 'edgedb'
 EDGEDB_TEMPLATE_DB = 'edgedb0'

--- a/edb/server/http/__init__.py
+++ b/edb/server/http/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .port import BaseHttpPort
 
 

--- a/edb/server/http/port.py
+++ b/edb/server/http/port.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncio
 
 from edb.common import taskgroup

--- a/edb/server/http_edgeql_port/__init__.py
+++ b/edb/server/http_edgeql_port/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .port import HttpEdgeQLPort
 
 

--- a/edb/server/http_edgeql_port/port.py
+++ b/edb/server/http_edgeql_port/port.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.server import compiler
 from edb.server import http
 

--- a/edb/server/http_graphql_port/__init__.py
+++ b/edb/server/http_graphql_port/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .port import HttpGraphQLPort
 
 

--- a/edb/server/http_graphql_port/compiler.py
+++ b/edb/server/http_graphql_port/compiler.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import dataclasses
 import typing
 

--- a/edb/server/http_graphql_port/explore.py
+++ b/edb/server/http_graphql_port/explore.py
@@ -20,6 +20,8 @@
 # flake8: noqa
 
 
+from __future__ import annotations
+
 import base64
 
 

--- a/edb/server/http_graphql_port/port.py
+++ b/edb/server/http_graphql_port/port.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.server import http
 
 from . import compiler

--- a/edb/server/logsetup.py
+++ b/edb/server/logsetup.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import contextlib
 import copy
 import io

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import getpass

--- a/edb/server/mng_port/__init__.py
+++ b/edb/server/mng_port/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .port import ManagementPort
 
 

--- a/edb/server/mng_port/port.py
+++ b/edb/server/mng_port/port.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import logging
 import os
 import os.path

--- a/edb/server/pgcon/__init__.py
+++ b/edb/server/pgcon/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .pgcon import connect
 
 __all__ = ('connect',)

--- a/edb/server/pgcon/errors.py
+++ b/edb/server/pgcon/errors.py
@@ -17,6 +17,9 @@
 #
 
 
+from __future__ import annotations
+
+
 class BackendError(Exception):
 
     def __init__(self, *, fields):

--- a/edb/server/procpool/__init__.py
+++ b/edb/server/procpool/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 __all__ = 'create_manager',
 
 

--- a/edb/server/procpool/amsg.py
+++ b/edb/server/procpool/amsg.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncio
 import os
 import struct

--- a/edb/server/procpool/pool.py
+++ b/edb/server/procpool/pool.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncio
 import base64
 import collections

--- a/edb/server/procpool/worker.py
+++ b/edb/server/procpool/worker.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import argparse
 import asyncio
 import importlib

--- a/edb/server/render_dsn.py
+++ b/edb/server/render_dsn.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import urllib.parse
 
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import logging
 import os
 import urllib.parse

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import contextlib
 import http.client
 import json

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import functools
 import os
 import re

--- a/edb/testbase/serutils.py
+++ b/edb/testbase/serutils.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import datetime
 import decimal
 import functools

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import asyncio
 import atexit
 import collections

--- a/edb/tools/__init__.py
+++ b/edb/tools/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from .edb import edbcommands  # noqa
 from . import dflags  # noqa
 from . import gen_errors  # noqa

--- a/edb/tools/__main__.py
+++ b/edb/tools/__main__.py
@@ -19,6 +19,8 @@
 
 """Stub to allow invoking `edb` as `python -m edb.tools`."""
 
+from __future__ import annotations
+
 import sys
 
 from edb.tools import edbcommands

--- a/edb/tools/dflags.py
+++ b/edb/tools/dflags.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.common import debug
 from edb.tools.edb import edbcommands
 

--- a/edb/tools/docs/__init__.py
+++ b/edb/tools/docs/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from docutils import nodes as d_nodes
 from sphinx import transforms as s_transforms
 

--- a/edb/tools/docs/cli.py
+++ b/edb/tools/docs/cli.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.edgeql.pygments import EdgeQLLexer
 
 from sphinx import domains as s_domains

--- a/edb/tools/docs/eql.py
+++ b/edb/tools/docs/eql.py
@@ -198,6 +198,8 @@ To reference a keyword use a ":eql:kw:" role.  For instance:
 """
 
 
+from __future__ import annotations
+
 import io
 import re
 

--- a/edb/tools/docs/graphql.py
+++ b/edb/tools/docs/graphql.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.graphql.pygments import GraphQLLexer
 
 

--- a/edb/tools/docs/js.py
+++ b/edb/tools/docs/js.py
@@ -39,6 +39,8 @@ and function directives in the following ways:
   necessarily have a meaningful link).
 """
 
+from __future__ import annotations
+
 from docutils import nodes as d_nodes
 from docutils.parsers.rst import directives
 

--- a/edb/tools/docs/sdl.py
+++ b/edb/tools/docs/sdl.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from edb.edgeql.pygments import EdgeQLLexer
 
 from sphinx import domains as s_domains

--- a/edb/tools/docs/shared.py
+++ b/edb/tools/docs/shared.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 from docutils import nodes as d_nodes
 from docutils import utils as d_utils
 from docutils.parsers.rst import roles as d_roles

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import os
 
 import click

--- a/edb/tools/gen_errors.py
+++ b/edb/tools/gen_errors.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import builtins
 import json
 import pathlib

--- a/edb/tools/gen_types.py
+++ b/edb/tools/gen_types.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import pathlib
 import re
 import sys

--- a/edb/tools/inittestdb.py
+++ b/edb/tools/inittestdb.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import os.path
 import pathlib
 import shutil

--- a/edb/tools/test/__init__.py
+++ b/edb/tools/test/__init__.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import multiprocessing
 import os
 import platform

--- a/edb/tools/test/decorators.py
+++ b/edb/tools/test/decorators.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import unittest
 
 

--- a/edb/tools/test/loader.py
+++ b/edb/tools/test/loader.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import re
 import unittest
 

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import collections.abc
 import enum
 import io

--- a/edb/tools/test/styles.py
+++ b/edb/tools/test/styles.py
@@ -17,6 +17,8 @@
 #
 
 
+from __future__ import annotations
+
 import click
 
 


### PR DESCRIPTION
Includes using regular forward references to recursive types in `edb.ir.ast.BasePointerRef` and `edb.ir.ast.TypeRef`.

Fixes #692