### PR TITLE
Remove explicit index names

### DIFF
--- a/docs/datamodel/indexes.rst
+++ b/docs/datamodel/indexes.rst
@@ -22,7 +22,7 @@ or more properties directly:
 
     type User {
         property name -> str;
-        index name_idx on (__subject__.name);
+        index on (__subject__.name);
     }
 
 With the above, ``User`` lookups by the ``name`` property will be faster,
@@ -41,7 +41,7 @@ of the host object type:
     type User {
         property firstname -> str;
         property lastname -> str;
-        index name_idx on (str_lower(
+        index on (str_lower(
             __subject__.firstname + ' ' + __subject__.lastname));
     }
 
@@ -51,7 +51,7 @@ Similarly indexes may refer to the link properties if the *subject* is a link:
 
     abstract link friends_base {
         property nickname -> str;
-        index nickname_idx on (__subject__@nickname);
+        index on (__subject__@nickname);
     }
 
 The index expression must not reference any variables other than the

--- a/docs/edgeql/ddl/indexes.rst
+++ b/docs/edgeql/ddl/indexes.rst
@@ -19,23 +19,18 @@ type or link.
 
 .. eql:synopsis::
 
-    CREATE INDEX <index-name> ON ( <index-expr> );
+    CREATE INDEX ON ( <index-expr> );
 
 
 Description
 -----------
 
-``CREATE INDEX`` constructs a new index *index-name* for a given object
-type or link using *index-expr*.
+``CREATE INDEX`` constructs a new index for a given object type or
+link using *index-expr*.
 
 
 Parameters
 ----------
-
-:eql:synopsis:`<index-name>`
-    The name of the index to be created.  No module name can be specified,
-    indexes are always created in the same module as the parent type or
-    link.
 
 :sdl:synopsis:`ON ( <index-expr> )`
     The specific expression for which the index is made.  Note also
@@ -54,7 +49,7 @@ Create an object type ``User`` with an indexed ``title`` property:
             SET default := '';
         };
 
-        CREATE INDEX title_name ON (__subject__.title);
+        CREATE INDEX ON (.title);
     };
 
 
@@ -67,15 +62,15 @@ Remove an index from a given schema item.
 
 .. eql:synopsis::
 
-    DROP INDEX <index-name> ;
+    DROP INDEX ON ( <index-expr> );
 
 Description
 -----------
 
 ``DROP INDEX`` removes an index from a schema item.
 
-:eql:synopsis:`<index-name>`
-    Refers to the name of a defined index.
+:sdl:synopsis:`ON ( <index-expr> )`
+    The specific expression for which the index was made.
 
 This statement can only be used as a subdefinition in another
 DDL statement.
@@ -89,5 +84,5 @@ Drop the ``title`` index from the ``User`` object type:
 .. code-block:: edgeql
 
     ALTER TYPE User {
-        DROP INDEX title;
+        DROP INDEX ON (.title);
     };

--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -50,7 +50,7 @@ CREATE LINK
       CREATE PROPERTY <property-name> ...
       CREATE CONSTRAINT <constraint-name> ...
       ON TARGET DELETE <action>
-      CREATE INDEX <index-name> ON <index-expr>
+      CREATE INDEX ON <index-expr>
 
 
 Description
@@ -135,9 +135,9 @@ The following subcommands are allowed in the ``CREATE LINK`` block:
     what ``ON TARGET DELETE`` options mean are described in
     :ref:`this section <ref_datamodel_links>`.
 
-:eql:synopsis:`CREATE INDEX <index-name> ON <index-expr>`
-    Define a new :ref:`index <ref_datamodel_indexes>` named
-    *index-name* using *index-expr* for this link.  See
+:eql:synopsis:`CREATE INDEX ON <index-expr>`
+    Define a new :ref:`index <ref_datamodel_indexes>`
+    using *index-expr* for this link.  See
     :eql:stmt:`CREATE INDEX` for details.
 
 
@@ -221,8 +221,8 @@ Change the definition of a :ref:`link <ref_datamodel_links>`.
       ALTER CONSTRAINT <constraint-name> ...
       DROP CONSTRAINT <constraint-name> ...
       ON TARGET DELETE <action>
-      CREATE INDEX <index-name> ON <index-expr>
-      DROP INDEX <index-name>
+      CREATE INDEX ON <index-expr>
+      DROP INDEX ON <index-expr>
 
 Description
 -----------
@@ -304,8 +304,8 @@ The following subcommands are allowed in the ``ALTER LINK`` block:
     Remove a constraint from this link.  See
     :eql:stmt:`DROP CONSTRAINT` for details.
 
-:eql:synopsis:`DROP INDEX <index-name>`
-    Remove an :ref:`index <ref_datamodel_indexes>` named *index-name*
+:eql:synopsis:`DROP INDEX ON <index-expr>`
+    Remove an :ref:`index <ref_datamodel_indexes>` defined on *index-expr*
     from this link.  See :eql:stmt:`DROP INDEX` for details.
 
 All the subcommands allowed in the ``CREATE LINK`` block are also

--- a/docs/edgeql/ddl/objects.rst
+++ b/docs/edgeql/ddl/objects.rst
@@ -28,7 +28,7 @@ CREATE TYPE
       SET ANNOTATION <annotation-name> := <value>
       CREATE LINK <link-name> ...
       CREATE PROPERTY <property-name> ...
-      CREATE INDEX <index-name> ON <index-expr>
+      CREATE INDEX ON <index-expr>
 
 Description
 -----------
@@ -88,9 +88,9 @@ The following subcommands are allowed in the ``CREATE TYPE`` block:
     Define a new property for this object type.  See
     :eql:stmt:`CREATE PROPERTY` for details.
 
-:eql:synopsis:`CREATE INDEX <index-name> ON <index-expr>`
-    Define a new :ref:`index <ref_datamodel_indexes>` named
-    *index-name* using *index-expr* for this object type.  See
+:eql:synopsis:`CREATE INDEX ON <index-expr>`
+    Define a new :ref:`index <ref_datamodel_indexes>`
+    using *index-expr* for this object type.  See
     :eql:stmt:`CREATE INDEX` for details.
 
 Examples
@@ -138,8 +138,8 @@ Change the definition of an
       CREATE PROPERTY <property-name> ...
       ALTER PROPERTY <property-name> ...
       DROP PROPERTY <property-name> ...
-      CREATE INDEX <index-name> ON <index-expr>
-      DROP INDEX <index-name>
+      CREATE INDEX ON <index-expr>
+      DROP INDEX ON <index-expr>
 
 
 Description
@@ -207,8 +207,8 @@ The following subcommands are allowed in the ``ALTER TYPE`` block:
     Remove a property item from this object type.  See
     :eql:stmt:`DROP PROPERTY` for details.
 
-:eql:synopsis:`DROP INDEX <index-name>`
-    Remove an :ref:`index <ref_datamodel_indexes>` named *index-name*
+:eql:synopsis:`DROP INDEX ON <index-expr>`
+    Remove an :ref:`index <ref_datamodel_indexes>` defined as *index-expr*
     from this object type.  See :eql:stmt:`DROP INDEX` for details.
 
 All the subcommands allowed in the ``CREATE TYPE`` block are also

--- a/docs/edgeql/introspection/indexes.rst
+++ b/docs/edgeql/introspection/indexes.rst
@@ -49,23 +49,21 @@ Consider the following schema:
         multi link friends -> User;
 
         # define an index for User based on name
-        index user_name_idx on (__subject__.name);
+        index on (.name);
     }
 
-Introspection of ``user_name_idx``:
+Introspection of ``User.name`` index:
 
 .. code-block:: edgeql-repl
 
     db> WITH MODULE schema
     ... SELECT Index {
-    ...     name,
     ...     expr,
     ... }
-    ... FILTER .name LIKE '%user_name_idx';
+    ... FILTER .expr LIKE '%.name';
     {
         Object {
-            name: 'default::User.user_name_idx',
-            expr: 'default::User.name'
+            expr: '.name'
         }
     }
 

--- a/docs/edgeql/introspection/objects.rst
+++ b/docs/edgeql/introspection/objects.rst
@@ -60,7 +60,7 @@ Consider the following schema:
         multi link friends -> User;
 
         # define an index for User based on name
-        index user_name_idx on (__subject__.name);
+        index on (.name);
     }
 
 Introspection of ``User``:
@@ -88,7 +88,7 @@ Introspection of ``User``:
     ...         target: { name },
     ...     },
     ...     constraints: { name },
-    ...     indexes: { name, expr },
+    ...     indexes: { expr },
     ... }
     ... FILTER .name = 'default::User';
     {
@@ -139,8 +139,7 @@ Introspection of ``User``:
             constraints: {},
             indexes: {
                 Object {
-                    name: 'default::User.user_name_idx',
-                    expr: 'default::User.name'
+                    expr: '.name'
                 }
             }
         }

--- a/docs/edgeql/sdl/indexes.rst
+++ b/docs/edgeql/sdl/indexes.rst
@@ -22,7 +22,7 @@ Declare an index for a "User" based on the "name" property:
         multi link friends -> User;
 
         # define an index for User based on name
-        index user_name_idx on (__subject__.name);
+        index on (__subject__.name);
     }
 
 
@@ -34,7 +34,7 @@ commands <ref_eql_ddl_indexes>`.
 
 .. sdl:synopsis::
 
-    index <index-name> on ( <index-expr> ) ;
+    index on ( <index-expr> ) ;
 
 
 Description

--- a/docs/edgeql/sdl/links.rst
+++ b/docs/edgeql/sdl/links.rst
@@ -30,7 +30,7 @@ Declare a *concrete* link "friends" within a "User" type:
         # define a concrete link "friends"
         multi link friends extending friends_base-> User;
 
-        index user_name_idx on (__subject__.name);
+        index on (__subject__.name);
     }
 
 

--- a/docs/edgeql/sdl/objects.rst
+++ b/docs/edgeql/sdl/objects.rst
@@ -21,7 +21,7 @@ Example
         multi link friends -> User;
 
         # define an index for User based on name
-        index user_name_idx on (__subject__.name);
+        index on (__subject__.name);
     }
 
 

--- a/docs/edgeql/sdl/props.rst
+++ b/docs/edgeql/sdl/props.rst
@@ -31,7 +31,7 @@ Declare *concrete* properties "name" and "address" within a "User" type:
 
         multi link friends -> User;
 
-        index user_name_idx on (__subject__.name);
+        index on (__subject__.name);
     }
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -799,11 +799,15 @@ class DropConcreteConstraint(DropObject, ConstraintOp):
     pass
 
 
-class CreateIndex(CreateObject):
+class IndexOp(ObjectDDL):
     expr: Expr
 
 
-class DropIndex(DropObject):
+class CreateIndex(CreateObject, IndexOp):
+    pass
+
+
+class DropIndex(DropObject, IndexOp):
     pass
 
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -862,10 +862,10 @@ class DropAnnotationStmt(Nonterm):
 # CREATE INDEX
 #
 class CreateIndexStmt(Nonterm):
-    def reduce_CREATE_INDEX_NodeName_OnExpr(self, *kids):
+    def reduce_CREATE_INDEX_OnExpr(self, *kids):
         self.val = qlast.CreateIndex(
-            name=kids[2].val,
-            expr=kids[3].val
+            name=qlast.ObjectRef(name='idx'),
+            expr=kids[2].val,
         )
 
 
@@ -873,9 +873,10 @@ class CreateIndexStmt(Nonterm):
 # DROP INDEX
 #
 class DropIndexStmt(Nonterm):
-    def reduce_DROP_INDEX_NodeName(self, *kids):
+    def reduce_DROP_INDEX_OnExpr(self, *kids):
         self.val = qlast.DropIndex(
-            name=kids[2].val
+            name=qlast.ObjectRef(name='idx'),
+            expr=kids[2].val,
         )
 
 

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -474,10 +474,10 @@ class AnnotationDeclarationShort(Nonterm):
 # Indexes
 #
 class IndexDeclaration(Nonterm):
-    def reduce_INDEX_ShortNodeName_OnExpr(self, *kids):
+    def reduce_INDEX_OnExpr(self, *kids):
         self.val = qlast.CreateIndex(
-            name=kids[1].val,
-            expr=kids[2].val,
+            name=qlast.ObjectRef(name='idx'),
+            expr=kids[1].val,
         )
 
 

--- a/edb/pgsql/datasources/schema/indexes.py
+++ b/edb/pgsql/datasources/schema/indexes.py
@@ -31,8 +31,12 @@ async def fetch(
     return await conn.fetch("""
         SELECT
                 i.id            AS id,
+                i.bases         AS bases,
                 i.name          AS name,
                 i.expr          AS expr,
+                i.is_local      AS is_local,
+                i.is_final      AS is_final,
+                i.is_abstract   AS is_abstract,
                 edgedb._resolve_type_name(i.subject)
                                 AS subject_name
             FROM

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -576,20 +576,24 @@ class IntrospectionMech:
                 schema, subj, catenate=False)
             index_name = sn.Name(index_data['name'])
 
-            try:
-                pg_indexes.remove((subj_table_name, index_name))
-            except KeyError:
-                raise errors.SchemaError(
-                    'internal metadata inconsistency',
-                    details=f'Index {index_name} is defined in schema, but'
+            if index_data['is_local']:
+                try:
+                    pg_indexes.remove((subj_table_name, index_name))
+                except KeyError:
+                    raise errors.SchemaError(
+                        'internal metadata inconsistency',
+                        details=(
+                            f'Index {index_name} is defined in schema, but '
                             f'the corresponding PostgreSQL index is missing.'
-                ) from None
+                        )
+                    ) from None
 
             schema, index = s_indexes.Index.create_in_schema(
                 schema,
                 id=index_data['id'],
                 name=index_name,
                 subject=subj,
+                is_local=index_data['is_local'],
                 expr=self.unpack_expr(index_data['expr'], schema))
 
             schema = subj.add_index(schema, index)

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -19,8 +19,6 @@
 
 from __future__ import annotations
 
-import hashlib
-
 from edb import errors
 
 from edb import edgeql
@@ -88,13 +86,8 @@ class Constraint(referencing.ReferencedInheritingObject,
         else:
             finalexpr = self.get_field_value(schema, 'finalexpr')
 
-        return (self._name_qual_from_expr(schema, finalexpr.text),)
-
-    @classmethod
-    def _name_qual_from_expr(self, schema, expr):
-        m = hashlib.sha1()
-        m.update(expr.encode())
-        return m.hexdigest()
+        return (referencing.ReferencedObjectCommand._name_qual_from_expr(
+            schema, finalexpr.origtext),)
 
     @classmethod
     def _dummy_subject(cls, schema):
@@ -328,8 +321,8 @@ class ConstraintCommand(
             sourcectx=astnode.context,
             modaliases=context.modaliases, **props)
 
-        return (Constraint._name_qual_from_expr(
-            schema, attrs['finalexpr'].text),)
+        return (cls._name_qual_from_expr(
+            schema, attrs['finalexpr'].origtext),)
 
     @classmethod
     def _constraint_args_from_ast(cls, schema, astnode, context):

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -333,7 +333,11 @@ class CreateInheritingObject(InheritingObjectCommand, sd.CreateObject):
                 schema, 'ancestors', ancestors)
             self.set_attribute_value('ancestors', ancestors)
 
-            bases = self.get_attribute_value('bases').objects(schema)
+            bases_coll = self.get_attribute_value('bases')
+            if bases_coll:
+                bases = bases_coll.objects(schema)
+            else:
+                bases = ()
 
             if context.mark_derived and len(bases) == 1:
                 schema = self.scls.update(schema, {

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -174,6 +174,8 @@ def _trace_op(op, opstack, depgraph, renames, renames_r,
         tag = 'rebase'
     elif isinstance(op, sd.DeleteObject):
         tag = 'delete'
+    elif isinstance(op, sd.AlterObjectProperty):
+        return
     else:
         raise RuntimeError(
             f'unexpected delta command type at top level: {op!r}'

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -19,6 +19,8 @@
 
 from __future__ import annotations
 
+import hashlib
+
 from edb.edgeql import ast as qlast
 
 from edb import errors
@@ -100,6 +102,12 @@ class ReferencedObjectCommand(sd.ObjectCommand,
     def _classname_quals_from_ast(cls, schema, astnode, base_name,
                                   referrer_name, context):
         return ()
+
+    @classmethod
+    def _name_qual_from_expr(cls, schema, expr):
+        m = hashlib.sha1()
+        m.update(expr.encode())
+        return m.hexdigest()
 
     def _get_ast_node(self, context):
         subject_ctx = self.get_referrer_context(context)

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3559,13 +3559,13 @@ aa';
 
     def test_edgeql_syntax_ddl_index_01(self):
         """
-        CREATE INDEX title_name ON (Foo);
+        CREATE INDEX ON (Foo);
 
-        CREATE INDEX title_name ON (__subject__.title);
+        CREATE INDEX ON (.title);
 
-        CREATE INDEX title_name ON (SELECT __subject__.title);
+        CREATE INDEX ON (SELECT __subject__.title);
 
-        DROP INDEX title_name;
+        DROP INDEX ON (.title);
         """
 
     def test_edgeql_transaction_01(self):

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -468,7 +468,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
         type LogEntry extending OwnedObject, Text {
             required link owner -> User;
-            index test_index on (SELECT datetime::datetime_current());
+            index on (SELECT datetime::datetime_current());
         };
         """
 
@@ -478,7 +478,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
             property foo -> str {
                 title := 'Sample property';
             };
-            index prop on (__subject__@foo);
+            index on (__subject__@foo);
         };
         """
 


### PR DESCRIPTION
Like constraints, indexes are really defined by the *expression*, and
the need to specify a synthetic name is more of a hinderance, due to
possible inheritance conflicts, so remove the ability to specify index
names.

Also make indexes actually properly inheritable in the schema.