### PR TITLE
Fix buggy behavior of LIMIT inside a view

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -72,14 +72,12 @@ class ViewRPtr:
 @dataclasses.dataclass
 class StatementMetadata:
     is_unnest_fence: bool = False
-    ignore_offset_limit: bool = False
 
 
 class PendingCardinality(typing.NamedTuple):
 
     specified_cardinality: typing.Optional[qltypes.Cardinality]
     source_ctx: typing.Optional[parsing.ParserContext]
-    from_parent: bool
     callbacks: typing.List[typing.Callable]
 
 

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -43,6 +43,7 @@ from edb.schema import utils as s_utils
 from edb.edgeql import ast as qlast
 
 from . import context
+from . import stmtctx
 
 
 def get_schema_object(
@@ -187,6 +188,11 @@ def derive_view(
                 computable_data = ctx.source_map.get(src_ptr)
                 if computable_data is not None:
                     ctx.source_map[ptr] = computable_data
+
+                if src_ptr in ctx.pending_cardinality:
+                    ctx.pointer_derivation_map[src_ptr].append(ptr)
+                    stmtctx.pend_pointer_cardinality_inference(
+                        ptrcls=ptr, ctx=ctx)
 
     ctx.view_nodes[derived.get_name(ctx.env.schema)] = derived
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -907,7 +907,7 @@ def computable_ptr_set(
 
     comp_ir_set_copy = new_set_from_set(comp_ir_set, ctx=ctx)
     pending_cardinality = ctx.pending_cardinality.get(ptrcls)
-    if pending_cardinality is not None and not pending_cardinality.from_parent:
+    if pending_cardinality is not None:
         stmtctx.get_pointer_cardinality_later(
             ptrcls=ptrcls, irexpr=comp_ir_set_copy,
             specified_card=pending_cardinality.specified_cardinality,

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -117,30 +117,63 @@ class SimpleFor(Nonterm):
         r"%reduce FOR Identifier IN Set \
                   UNION OptionallyAliasedExpr \
                   OptFilterClause OptSortClause OptSelectLimit"
-        self.val = qlast.ForQuery(
-            iterator_alias=kids[1].val,
-            iterator=kids[3].val,
-            result=kids[5].val.expr,
-            result_alias=kids[5].val.alias,
-            where=kids[6].val,
-            orderby=kids[7].val,
-            offset=kids[8].val[0],
-            limit=kids[8].val[1],
-        )
+        offset, limit = kids[8].val
+
+        if offset is not None or limit is not None:
+            subj = qlast.ForQuery(
+                iterator_alias=kids[1].val,
+                iterator=kids[3].val,
+                result=kids[5].val.expr,
+                result_alias=kids[5].val.alias,
+                where=kids[6].val,
+                orderby=kids[7].val,
+                implicit=True,
+            )
+
+            self.val = qlast.SelectQuery(
+                result=subj,
+                offset=offset,
+                limit=limit,
+            )
+        else:
+            self.val = qlast.ForQuery(
+                iterator_alias=kids[1].val,
+                iterator=kids[3].val,
+                result=kids[5].val.expr,
+                result_alias=kids[5].val.alias,
+                where=kids[6].val,
+                orderby=kids[7].val,
+            )
 
 
 class SimpleSelect(Nonterm):
     def reduce_Select(self, *kids):
         r"%reduce SELECT OptionallyAliasedExpr \
                   OptFilterClause OptSortClause OptSelectLimit"
-        self.val = qlast.SelectQuery(
-            result=kids[1].val.expr,
-            result_alias=kids[1].val.alias,
-            where=kids[2].val,
-            orderby=kids[3].val,
-            offset=kids[4].val[0],
-            limit=kids[4].val[1],
-        )
+
+        offset, limit = kids[4].val
+
+        if offset is not None or limit is not None:
+            subj = qlast.SelectQuery(
+                result=kids[1].val.expr,
+                result_alias=kids[1].val.alias,
+                where=kids[2].val,
+                orderby=kids[3].val,
+                implicit=True,
+            )
+
+            self.val = qlast.SelectQuery(
+                result=subj,
+                offset=offset,
+                limit=limit,
+            )
+        else:
+            self.val = qlast.SelectQuery(
+                result=kids[1].val.expr,
+                result_alias=kids[1].val.alias,
+                where=kids[2].val,
+                orderby=kids[3].val,
+            )
 
 
 class SimpleGroup(Nonterm):

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -206,6 +206,21 @@ class TestEdgeQLFor(tb.QueryTestCase):
             }
         )
 
+    async def test_edgeql_for_limit_01(self):
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                FOR X IN {User.name}
+                UNION X
+                ORDER BY X
+                OFFSET 2
+                LIMIT 1
+            ''',
+            {
+                'Carol',
+            }
+        )
+
     async def test_edgeql_for_filter_02(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -469,6 +469,24 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             }]
         )
 
+    async def test_edgeql_select_computable_17(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r"possibly more than one element returned by an expression "
+                r"for a computable property 'foo' declared as 'single'",
+                _position=248):
+            await self.con.fetchall("""\
+                WITH
+                    MODULE test,
+                    V := (SELECT Issue {
+                        foo := {1, 2}
+                    } FILTER .number = '1')
+                SELECT
+                    V {
+                        single foo := .foo
+                    };
+            """)
+
     async def test_edgeql_select_match_01(self):
         await self.assert_query_result(
             r"""

--- a/tests/test_edgeql_views.py
+++ b/tests/test_edgeql_views.py
@@ -721,6 +721,33 @@ class TestEdgeQLViews(tb.QueryTestCase):
             res
         )
 
+    async def test_edgeql_views_limit_01(self):
+        # Test interaction of views and the LIMIT clause
+        await self.con.execute("""
+            WITH MODULE test
+            CREATE VIEW FirstUser := (
+                SELECT User {
+                    name_upper := str_upper(User.name)
+                }
+                ORDER BY .name
+                LIMIT 1
+            );
+        """)
+
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test
+                SELECT FirstUser {
+                    name_upper,
+                }
+            """,
+            [
+                {
+                    'name_upper': 'ALICE',
+                },
+            ],
+        )
+
     async def test_edgeql_views_ignore_alias(self):
         await self.con.execute('''
             SET MODULE test;


### PR DESCRIPTION
LIMIT and OFFSET currently have rather hacky implementation that breaks
down completely if the statement is used to define a view.  There is no
particular reason to juggle the scope to implement the necessary
`limit(SET OF subj, SET OF limit)` semantics, as a simple AST reorg with
an implicit `SELECT` wrapper in the left argument is entirely
sufficient.