### PR TITLE
Make nested views properly introspectable

### DIFF
--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -157,12 +157,6 @@ def fini_expression(
 
             view_own_pointers = view.get_pointers(ctx.env.schema)
             for vptr in view_own_pointers.objects(ctx.env.schema):
-                ctx.env.schema = vptr.set_field_value(
-                    ctx.env.schema,
-                    'target',
-                    vptr.get_target(ctx.env.schema).material_type(
-                        ctx.env.schema))
-
                 _elide_derived_ancestors(vptr, ctx=ctx)
 
                 if not hasattr(vptr, 'get_pointers'):
@@ -170,12 +164,6 @@ def fini_expression(
 
                 vptr_own_pointers = vptr.get_pointers(ctx.env.schema)
                 for vlprop in vptr_own_pointers.objects(ctx.env.schema):
-                    vlprop_target = vlprop.get_target(ctx.env.schema)
-                    ctx.env.schema = vlprop.set_field_value(
-                        ctx.env.schema,
-                        'target',
-                        vlprop_target.material_type(ctx.env.schema))
-
                     _elide_derived_ancestors(vlprop, ctx=ctx)
 
     expr_type = inference.infer_type(ir, ctx.env)

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -95,6 +95,39 @@ def _process_view(
         is_insert: bool=False,
         is_update: bool=False,
         ctx: context.ContextLevel) -> s_types.Type:
+
+    if (view_name is None and ctx.env.schema_view_mode
+            and view_rptr is not None):
+        # Make sure persistent schema views have properly formed
+        # names as opposed to the usual mangled form of the ephemeral
+        # views.  This is needed for introspection readability, as well
+        # as helps in maintaining proper type names for schema
+        # representations that require alphanumeric names, such as
+        # GraphQL.
+        #
+        # We use the name of the source together with the name
+        # of the inbound link to form the name, so in e.g.
+        #    CREATE VIEW V := (SELECT Foo { bar: { baz: { ... } })
+        # The name of the innermost view would be "__V__bar__baz".
+        source_name = view_rptr.source.get_name(ctx.env.schema).name
+        if not source_name.startswith('__'):
+            source_name = f'__{source_name}'
+        if view_rptr.ptrcls_name is not None:
+            ptr_name = view_rptr.ptrcls_name.name
+        elif view_rptr.ptrcls is not None:
+            ptr_name = view_rptr.ptrcls.get_shortname(ctx.env.schema).name
+        else:
+            raise errors.InternalServerError(
+                '_process_view in schema mode received view_rptr with '
+                'neither ptrcls_name, not ptrcls'
+            )
+
+        name = f'{source_name}__{ptr_name}'
+        view_name = sn.Name(
+            module=ctx.derived_target_module or '__derived__',
+            name=name,
+        )
+
     view_scls = schemactx.derive_view(
         stype, is_insert=is_insert, is_update=is_update,
         derived_name=view_name, ctx=ctx)

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -422,6 +422,26 @@ def _normalize_view_ptr_expr(
             shape_expr_ctx.path_scope.unnest_fence = True
             shape_expr_ctx.partial_path_prefix = setgen.class_set(
                 view_scls, path_id=path_id, ctx=shape_expr_ctx)
+            prefix_rptrref = path_id.rptr()
+            if prefix_rptrref is not None:
+                # Source path seems to contain multiple steps,
+                # so set up a rptr for abbreviated link property
+                # paths.
+                src_path_id = path_id.src_path()
+                prefix_rptr = irast.Pointer(
+                    source=setgen.class_set(
+                        irtyputils.ir_typeref_to_type(
+                            shape_expr_ctx.env.schema,
+                            src_path_id.target,
+                        ),
+                        path_id=src_path_id,
+                        ctx=shape_expr_ctx,
+                    ),
+                    target=shape_expr_ctx.partial_path_prefix,
+                    ptrref=prefix_rptrref,
+                    direction=s_pointers.PointerDirection.Outbound,
+                )
+                shape_expr_ctx.partial_path_prefix.rptr = prefix_rptr
 
             if is_mutation and ptrcls is not None:
                 shape_expr_ctx.expr_exposed = True

--- a/edb/pgsql/datasources/schema/objtypes.py
+++ b/edb/pgsql/datasources/schema/objtypes.py
@@ -38,6 +38,7 @@ async def fetch(
                 c.is_abstract AS is_abstract,
                 c.is_final AS is_final,
                 c.view_type AS view_type,
+                c.view_is_persistent AS view_is_persistent,
                 c.expr AS expr,
                 c.field_inh_map AS field_inh_map
 
@@ -65,6 +66,7 @@ async def fetch_derived(
                 c.is_abstract AS is_abstract,
                 c.is_final AS is_final,
                 c.view_type AS view_type,
+                c.view_is_persistent AS view_is_persistent,
                 c.expr AS expr,
                 c.field_inh_map AS field_inh_map
             FROM

--- a/edb/pgsql/datasources/schema/scalars.py
+++ b/edb/pgsql/datasources/schema/scalars.py
@@ -35,6 +35,7 @@ async def fetch(
             c.is_abstract AS is_abstract,
             c.is_final AS is_final,
             c.view_type AS view_type,
+            c.view_is_persistent AS view_is_persistent,
             c.expr AS expr,
             c.enum_values AS enum_values,
             edgedb._resolve_type_name(c.bases) AS bases,

--- a/edb/pgsql/datasources/schema/types.py
+++ b/edb/pgsql/datasources/schema/types.py
@@ -33,6 +33,7 @@ async def fetch_tuple_views(
             c.id AS id,
             c.name AS name,
             c.view_type AS view_type,
+            c.view_is_persistent AS view_is_persistent,
             c.expr AS expr,
             c.named AS named,
             c.element_types AS element_types
@@ -59,6 +60,7 @@ async def fetch_array_views(
             c.id AS id,
             c.name AS name,
             c.view_type AS view_type,
+            c.view_is_persistent AS view_is_persistent,
             c.expr AS expr,
             c.element_type AS element_type,
             c.dimensions AS dimensions

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -209,6 +209,7 @@ class IntrospectionMech:
                 'is_final': row['is_final'],
                 'view_type': (s_types.ViewType(row['view_type'])
                               if row['view_type'] else None),
+                'view_is_persistent': row['view_is_persistent'],
                 'default': (self.unpack_expr(row['default'], schema)
                             if row['default'] else None),
                 'expr': (self.unpack_expr(row['expr'], schema)
@@ -840,6 +841,7 @@ class IntrospectionMech:
                 'is_final': row['is_final'],
                 'view_type': (s_types.ViewType(row['view_type'])
                               if row['view_type'] else None),
+                'view_is_persistent': row['view_is_persistent'],
             }
 
             exprmap[name] = row['expr']
@@ -857,6 +859,7 @@ class IntrospectionMech:
                 union_of=union_of,
                 is_final=objtype['is_final'],
                 view_type=objtype['view_type'],
+                view_is_persistent=objtype['view_is_persistent'],
             )
 
             basemap[objtype] = (row['bases'], row['ancestors'])
@@ -893,6 +896,7 @@ class IntrospectionMech:
                 id=r['id'],
                 name=sn.Name(r['name']),
                 view_type=s_types.ViewType(r['view_type']),
+                view_is_persistent=r['view_is_persistent'],
                 named=r['named'],
                 expr=self.unpack_expr(r['expr'], schema),
                 element_types=s_obj.ObjectDict.create(
@@ -911,6 +915,7 @@ class IntrospectionMech:
                 id=r['id'],
                 name=sn.Name(r['name']),
                 view_type=s_types.ViewType(r['view_type']),
+                view_is_persistent=r['view_is_persistent'],
                 expr=self.unpack_expr(r['expr'], schema),
                 element_type=eltype,
                 dimensions=r['dimensions'],

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -492,7 +492,7 @@ class CallableObject(s_anno.AnnotationSubject):
     def has_inlined_defaults(self, schema):
         return False
 
-    def is_blocking_ref(self, schema, context, reference):
+    def is_blocking_ref(self, schema, reference):
         # Paramters cannot be deleted via DDL syntax,
         # so the only possible scenario is the deletion of
         # the host function.

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -121,7 +121,7 @@ class Property(pointers.Pointer, s_abc.Property):
     def get_default_base_name(self):
         return sn.Name('std::property')
 
-    def is_blocking_ref(self, schema, context, reference):
+    def is_blocking_ref(self, schema, reference):
         return not self.is_endpoint_pointer(schema)
 
 

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -62,7 +62,7 @@ class BaseObjectType(sources.Source,
         return True
 
     def get_displayname(self, schema):
-        if self.is_view(schema):
+        if self.is_view(schema) and not self.get_view_is_persistent(schema):
             mtype = self.material_type(schema)
         else:
             mtype = self
@@ -255,15 +255,15 @@ class ObjectTypeCommand(constraints.ConsistencySubjectCommand,
         else:
             super()._apply_field_ast(schema, context, node, op)
 
+
+class CreateObjectType(ObjectTypeCommand, inheriting.CreateInheritingObject):
+    astnode = qlast.CreateObjectType
+
     @classmethod
     def _cmd_tree_from_ast(cls, schema, astnode, context):
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
         cmd = cls._handle_view_op(schema, cmd, astnode, context)
         return cmd
-
-
-class CreateObjectType(ObjectTypeCommand, inheriting.CreateInheritingObject):
-    astnode = qlast.CreateObjectType
 
 
 class RenameObjectType(ObjectTypeCommand, sd.RenameObject):
@@ -276,6 +276,12 @@ class RebaseObjectType(ObjectTypeCommand, inheriting.RebaseInheritingObject):
 
 class AlterObjectType(ObjectTypeCommand, inheriting.AlterInheritingObject):
     astnode = qlast.AlterObjectType
+
+    @classmethod
+    def _cmd_tree_from_ast(cls, schema, astnode, context):
+        cmd = super()._cmd_tree_from_ast(schema, astnode, context)
+        cmd = cls._handle_view_op(schema, cmd, astnode, context)
+        return cmd
 
 
 class DeleteObjectType(ObjectTypeCommand, inheriting.DeleteInheritingObject):

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -259,7 +259,7 @@ class ReferencedObjectCommand(sd.ObjectCommand,
         reftype = referrer_class.get_field(refdict.attr).type
         refname = reftype.get_key_for(schema, self.scls)
 
-        if (not isinstance(referrer_ctx.op, sd.DeleteObject)
+        if (not context.in_deletion(offset=1)
                 and not context.disable_dep_verification):
             implicit_bases = set(self._get_implicit_ref_bases(
                 schema, context, referrer, refdict, refname))

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -60,6 +60,12 @@ class Type(so.InheritingObjectBase, derivable.DerivableObjectBase, s_abc.Type):
         ViewType,
         default=None, compcoef=0.909)
 
+    # True for views defined by CREATE VIEW, false for ephemeral
+    # views in queries.
+    view_is_persistent = so.SchemaField(
+        bool,
+        default=False, compcoef=None)
+
     # If this type is a view, expr may contain an expression that
     # defines the view set.
     expr = so.SchemaField(
@@ -71,7 +77,11 @@ class Type(so.InheritingObjectBase, derivable.DerivableObjectBase, s_abc.Type):
     # rptr will contain the inbound pointer class.
     rptr = so.SchemaField(
         so.Object,
+        weak_ref=True,
         default=None, compcoef=0.909)
+
+    def is_blocking_ref(self, schema, reference):
+        return reference is not self.get_rptr(schema)
 
     def derive_subtype(
             self, schema, *, name: str,
@@ -603,7 +613,7 @@ class BaseArray(Collection, s_abc.Array):
         else:
             return self
 
-    def as_create_delta(self, schema, *, view_name=None):
+    def as_create_delta(self, schema, *, view_name=None, attrs=None):
         cmd = sd.CommandGroup()
 
         if view_name is None:
@@ -625,6 +635,10 @@ class BaseArray(Collection, s_abc.Array):
         ca.set_attribute_value('name', name)
         ca.set_attribute_value('element_type', el)
         ca.set_attribute_value('dimensions', self.get_dimensions(schema))
+
+        if attrs:
+            for k, v in attrs.items():
+                ca.set_attribute_value(k, v)
 
         cmd.add(ca)
 
@@ -1040,7 +1054,7 @@ class BaseTuple(Collection, s_abc.Tuple):
         else:
             return self
 
-    def as_create_delta(self, schema, *, view_name=None):
+    def as_create_delta(self, schema, *, view_name=None, attrs=None):
         from . import delta as sd
 
         cmd = sd.CommandGroup()
@@ -1070,6 +1084,10 @@ class BaseTuple(Collection, s_abc.Tuple):
                 schema,
                 dict(self.iter_subtypes(schema)),
             ))
+
+        if attrs:
+            for k, v in attrs.items():
+                ct.set_attribute_value(k, v)
 
         cmd.add(ct)
 
@@ -1220,82 +1238,100 @@ class TypeCommand(sd.ObjectCommand):
 
     @classmethod
     def _handle_view_op(cls, schema, cmd, astnode, context):
+        from . import ordering as s_ordering
+
         view_expr = cls._maybe_get_view_expr(astnode)
-        if view_expr is not None:
-            classname = cmd.classname
-            if not s_name.Name.is_qualified(classname):
-                # Collection commands use unqualified names
-                # because they use the type id in the general case,
-                # but in the case of an explicit named view, we
-                # still want a properly qualified name.
-                classname = sd.ObjectCommand._classname_from_ast(
-                    schema, astnode, context)
-                cmd.classname = classname
+        if view_expr is None:
+            return cmd
 
-            expr = s_expr.Expression.from_ast(
-                view_expr, schema, context.modaliases)
+        classname = cmd.classname
+        if not s_name.Name.is_qualified(classname):
+            # Collection commands use unqualified names
+            # because they use the type id in the general case,
+            # but in the case of an explicit named view, we
+            # still want a properly qualified name.
+            classname = sd.ObjectCommand._classname_from_ast(
+                schema, astnode, context)
+            cmd.classname = classname
 
-            ir = cls._compile_view_expr(expr.qlast, classname,
-                                        schema, context)
+        expr = s_expr.Expression.from_ast(
+            view_expr, schema, context.modaliases)
 
-            expr = s_expr.Expression.from_ir(expr, ir, schema=schema)
+        ir = cls._compile_view_expr(expr.qlast, classname,
+                                    schema, context)
 
-            cmd.set_attribute_value('expr', expr)
+        new_schema = ir.schema
 
-            coll_view_types = []
-            prev_coll_view_types = []
-            view_types = []
-            prev_view_types = []
-            prev_ir = None
+        expr = s_expr.Expression.from_ir(expr, ir, schema=schema)
 
-            for vt in ir.views.values():
+        coll_view_types = []
+        prev_coll_view_types = []
+        view_types = []
+        prev_view_types = []
+        prev_ir = None
+        old_schema = None
+
+        for vt in ir.views.values():
+            if vt.is_collection():
+                coll_view_types.append(vt)
+            else:
+                new_schema = vt.set_field_value(
+                    new_schema, 'view_is_persistent', True)
+
+                view_types.append(vt)
+
+        if isinstance(astnode, qlast.AlterObject):
+            prev = schema.get(classname)
+            prev_ir = cls._compile_view_expr(
+                prev.get_expr(schema).qlast, classname, schema, context)
+            old_schema = prev_ir.schema
+            for vt in prev_ir.views.values():
                 if vt.is_collection():
-                    coll_view_types.append(vt)
+                    prev_coll_view_types.append(vt)
                 else:
-                    view_types.append(vt)
+                    prev_view_types.append(vt)
 
-            if isinstance(astnode, qlast.AlterObject):
-                prev = schema.get(classname)
-                prev_ir = cls._compile_view_expr(
-                    prev.expr, classname, schema, context)
-                for vt in prev_ir.views.values():
-                    if vt.is_collection():
-                        prev_coll_view_types.append(vt)
-                    else:
-                        prev_view_types.append(vt)
+        derived_delta = sd.DeltaRoot()
 
-            derived_delta = sd.DeltaRoot()
+        derived_delta.update(so.Object.delta_sets(
+            prev_view_types, view_types,
+            old_schema=old_schema, new_schema=new_schema))
 
-            new_schema = ir.schema
-            old_schema = prev_ir.schema if prev_ir is not None else None
+        for vt in prev_coll_view_types:
+            dt = vt.as_delete_delta(prev_ir.schema, view_name=classname)
+            derived_delta.prepend(dt)
 
-            derived_delta.update(so.Object.delta_sets(
-                prev_view_types, view_types,
-                old_schema=old_schema, new_schema=new_schema))
+        for vt in coll_view_types:
+            ct = vt.as_create_delta(
+                new_schema, view_name=classname,
+                attrs={
+                    'expr': expr,
+                    'view_is_persistent': True,
+                    'view_type': ViewType.Select,
+                })
+            new_schema, _ = ct.apply(new_schema, context)
+            derived_delta.add(ct)
 
-            for vt in prev_coll_view_types:
-                dt = vt.as_delete_delta(prev_ir.schema, view_name=classname)
-                derived_delta.prepend(dt)
+        derived_delta = s_ordering.linearize_delta(
+            derived_delta, old_schema=old_schema, new_schema=new_schema)
 
-            for vt in coll_view_types:
-                ct = vt.as_create_delta(ir.schema, view_name=classname)
-                derived_delta.add(ct)
+        real_cmd = None
+        for op in derived_delta.get_subcommands():
+            if op.classname == classname:
+                real_cmd = op
+                break
 
-            for op in list(derived_delta.get_subcommands()):
-                if op.classname == classname:
-                    for subop in op.get_subcommands():
-                        if isinstance(subop, sd.AlterObjectProperty):
-                            cmd.discard_attribute(subop.property)
-                        cmd.add(subop)
+        if real_cmd is None:
+            raise RuntimeError(
+                'view delta does not contain the expected '
+                'view Create/Alter command')
 
-                    derived_delta.discard(op)
+        real_cmd.set_attribute_value('expr', expr)
 
-            cmd.update(derived_delta.get_subcommands())
-            cmd.discard_attribute('view_type')
-            cmd.add(sd.AlterObjectProperty(
-                property='view_type', new_value=ViewType.Select))
+        cmd = sd.CommandGroup()
+        cmd.update(derived_delta.get_subcommands())
 
-            cmd.canonical = True
+        cmd.canonical = True
 
         return cmd
 

--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -45,6 +45,16 @@ type User extending NamedObject {
     link profile -> Profile;
 }
 
+view SettingView := Setting {
+    of_group := .<settings[IS UserGroup]
+};
+
+view SettingViewAugmented := Setting {
+    of_group := .<settings[IS UserGroup] {
+        name_upper := str_upper(.name)
+    }
+};
+
 type Person extending User;
 
 scalar type positive_int_t extending int64 {

--- a/tests/schemas/graphql_setup.edgeql
+++ b/tests/schemas/graphql_setup.edgeql
@@ -17,16 +17,6 @@
 #
 
 
-# FIXME: the computable in the view doesn't work without an explicit
-# abstract link
-CREATE ABSTRACT LINK default::of_group;
-# FIXME: currently a view cannot be defined via eschema
-CREATE VIEW SettingView := default::Setting {
-   # the settings link is exclusive, so this one is a singleton
-   of_group := default::Setting.<settings[IS default::UserGroup]
-};
-
-
 INSERT Setting {
     name := 'template',
     value := 'blue'

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -887,6 +887,30 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             }],
         )
 
+    async def test_edgeql_props_abbrev(self):
+        await self.assert_query_result(
+            r'''
+                WITH
+                    MODULE test
+                SELECT User {
+                    name,
+                    my_deck := (SELECT .deck {
+                        name,
+                        num_cards := @count
+                    } ORDER BY .name)
+                } FILTER .name = 'Alice';
+            ''',
+            [{
+                'name': 'Alice',
+                'my_deck': [
+                    {"name": "Bog monster", "num_cards": 3},
+                    {"name": "Dragon", "num_cards": 2},
+                    {"name": "Giant turtle", "num_cards": 3},
+                    {"name": "Imp", "num_cards": 2},
+                ],
+            }],
+        )
+
     async def test_edgeql_props_agg_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -574,6 +574,51 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             sort=lambda x: x['name']
         )
 
+    def test_graphql_functional_view_03(self):
+        self.assert_graphql_query_result(
+            r"""
+                {
+                    SettingViewAugmented {
+                        __typename
+                        name
+                        value
+                        of_group {
+                            __typename
+                            name
+                            name_upper
+                        }
+                    }
+                }
+            """,
+            {
+                "SettingViewAugmented": [
+                    {
+                        "__typename": "SettingViewAugmentedType",
+                        "name": "perks",
+                        "value": "full",
+                        "of_group": {
+                            "__typename":
+                                "__SettingViewAugmented__of_groupType",
+                            "name": "upgraded",
+                            "name_upper": "UPGRADED",
+                        }
+                    },
+                    {
+                        "__typename": "SettingViewAugmentedType",
+                        "name": "template",
+                        "value": "blue",
+                        "of_group": {
+                            "__typename":
+                                "__SettingViewAugmented__of_groupType",
+                            "name": "upgraded",
+                            "name_upper": "UPGRADED",
+                        }
+                    },
+                ],
+            },
+            sort=lambda x: x['name']
+        )
+
     def test_graphql_functional_arguments_01(self):
         result = self.graphql_query(r"""
             query {
@@ -3876,6 +3921,105 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                     {
                         "__typename": "__Type",
                         "kind": "OBJECT",
+                        "name": "SettingViewAugmentedType",
+                        "description": None,
+                        "fields": [
+                            {
+                                "__typename": "__Field",
+                                "name": "id",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "ID",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "name",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "String",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "of_group",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name":
+                                        "__SettingViewAugmented__of_group",
+                                    "kind": "INTERFACE",
+                                    "ofType": None
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "value",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "String",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            }
+                        ],
+                        "interfaces": [
+                            {
+                                "__typename": "__Type",
+                                "name": "NamedObject",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "Object",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "Setting",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "SettingViewAugmented",
+                                "kind": "INTERFACE"
+                            },
+                        ],
+                        "possibleTypes": None,
+                        "enumValues": None,
+                        "inputFields": None,
+                        "ofType": None
+                    },
+                    {
+                        "__typename": "__Type",
+                        "kind": "OBJECT",
                         "name": "SettingViewType",
                         "description": None,
                         "fields": [
@@ -4194,7 +4338,104 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                         "enumValues": None,
                         "inputFields": None,
                         "ofType": None
-                    }
+                    },
+                    {
+                        "__typename": "__Type",
+                        "kind": "OBJECT",
+                        "name": "__SettingViewAugmented__of_groupType",
+                        "description": None,
+                        "fields": [
+                            {
+                                "__typename": "__Field",
+                                "name": "id",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "ID",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "name",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "String",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "name_upper",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": "String",
+                                    "kind": "SCALAR"
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "settings",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "LIST",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": None,
+                                        "kind": "NON_NULL"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            }
+                        ],
+                        "interfaces": [
+                            {
+                                "__typename": "__Type",
+                                "name": "NamedObject",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "Object",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "UserGroup",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "__SettingViewAugmented__of_group",
+                                "kind": "INTERFACE"
+                            },
+                        ],
+                        "possibleTypes": None,
+                        "enumValues": None,
+                        "inputFields": None,
+                        "ofType": None
+                    },
                 ],
                 "enumValues": None,
                 "inputFields": None,


### PR DESCRIPTION
Currently, only the first level of a view is introspectable, which makes
nested views useless in contexts where proper introspection is
necessary, such as in GraphQL reflection.

Making schema views fully introspectable requires two changes: the names
of nested derived views must be unique and properly formed (i.e not use
the generic derived mangling), the target refs in of the derived
pointers in the view must be kept.

Also, `DROP VIEW` is currently broken when used on a view with nesting,
since it leaves behind the derived types created for nested views.  That
is also fixed by this commit.