### PR TITLE
edgeql: Update signature and error reporting of IF..ELSE.

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -361,7 +361,7 @@ def compile_IfElse(
 
     op_node = func.compile_operator(
         expr, op_name='std::IF',
-        qlargs=[expr.condition, expr.if_expr, expr.else_expr], ctx=ctx)
+        qlargs=[expr.if_expr, expr.condition, expr.else_expr], ctx=ctx)
 
     return setgen.ensure_set(op_node, ctx=ctx)
 

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -328,11 +328,18 @@ def compile_operator(
             )
 
         if not matched:
+            hint = ('Consider using an explicit type cast or a conversion '
+                    'function.')
+
+            if op_name == 'std::IF':
+                hint = (f"The IF and ELSE result clauses must be of "
+                        f"compatible types, while the condition clause must "
+                        f"be 'std::bool'. {hint}")
+
             raise errors.QueryError(
                 f'operator {str(op_name)!r} cannot be applied to '
                 f'operands of type {types}',
-                hint='Consider using an explicit type cast or a conversion '
-                     'function.',
+                hint=hint,
                 context=qlexpr.context)
         elif len(matched) > 1:
             if in_abstract_constraint:
@@ -364,7 +371,7 @@ def compile_operator(
         if oper_name == 'std::UNION':
             larg, rarg = (a.expr for a in final_args)
         else:
-            larg, rarg = (a.expr for a in final_args[1:])
+            larg, _, rarg = (a.expr for a in final_args)
 
         left_type = setgen.get_set_type(larg, ctx=ctx).material_type(
             ctx.env.schema)

--- a/edb/lib/std/25-setoperators.edgeql
+++ b/edb/lib/std/25-setoperators.edgeql
@@ -92,7 +92,7 @@ std::`??` (l: OPTIONAL anytype, r: SET OF anytype) -> SET OF anytype {
 
 
 CREATE TERNARY OPERATOR
-std::`IF` (condition: bool, if_true: SET OF anytype,
+std::`IF` (if_true: SET OF anytype, condition: bool,
            if_false: SET OF anytype) -> SET OF anytype {
     SET volatility := 'IMMUTABLE';
     FROM SQL EXPRESSION;

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -302,9 +302,9 @@ def compile_OperatorCall(
         ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
 
     if (expr.func_shortname == 'std::IF'
-            and expr.args[1].cardinality is ql_ft.Cardinality.ONE
+            and expr.args[0].cardinality is ql_ft.Cardinality.ONE
             and expr.args[2].cardinality is ql_ft.Cardinality.ONE):
-        condition, if_expr, else_expr = (a.expr for a in expr.args)
+        if_expr, condition, else_expr = (a.expr for a in expr.args)
         return pgast.CaseExpr(
             args=[
                 pgast.CaseWhen(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1097,8 +1097,8 @@ def process_set_as_ifelse(
     expr = ir_set.expr
     assert isinstance(expr, irast.OperatorCall)
 
-    condition, if_expr, else_expr = (a.expr for a in expr.args)
-    _, if_expr_card, else_expr_card = (a.cardinality for a in expr.args)
+    if_expr, condition, else_expr = (a.expr for a in expr.args)
+    if_expr_card, _, else_expr_card = (a.cardinality for a in expr.args)
 
     with ctx.new() as newctx:
         newctx.expr_exposed = False


### PR DESCRIPTION
Make the signature of the `std::IF` operator actually match the order of
the operands in EdgeQL (if_true, condition, if_false).

Provide a more specific error hint for the mismatched types of the IF
operator.

Clarifies the error message for #684.