### PR TITLE
Fix a bunch of bugs and omissions in migration DDL deparsing

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -712,11 +712,6 @@ class DropConcreteProperty(AlterObject):
     pass
 
 
-class SetSpecialField(DDL):
-    name: str
-    value: object
-
-
 class CreateObjectType(CreateExtendingObject):
     pass
 
@@ -818,6 +813,10 @@ class BaseSetField(DDL):
 
 class SetField(BaseSetField):
     pass
+
+
+class SetSpecialField(BaseSetField):
+    value: object
 
 
 class CreateAnnotationValue(CreateObject):

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -788,7 +788,7 @@ class ConstraintOp(ObjectDDL):
 
 
 class CreateConcreteConstraint(CreateObject, ConstraintOp):
-    is_abstract: bool = False
+    delegated: bool = False
 
 
 class AlterConcreteConstraint(AlterObject, ConstraintOp):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -971,7 +971,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 self.write(')')
 
         keywords = []
-        if node.is_abstract:
+        if node.delegated:
             keywords.append('DELEGATED')
         keywords.append('CONSTRAINT')
         self._visit_CreateObject(node, *keywords, after_name=after_name)

--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -24,9 +24,9 @@ from __future__ import annotations
 
 from edb.edgeql import ast as qlast
 
-from edb.schema import abc as s_abc
 from edb.schema import schema as s_schema
 from edb.schema import types as s_types
+from edb.schema import utils as s_utils
 
 
 def extend_qlbinop(binop, *exprs, op='AND'):
@@ -102,41 +102,5 @@ def is_degenerate_select(qlstmt):
 
 
 def type_to_ql_typeref(t: s_types.Type, *,
-                       _name=None,
                        schema: s_schema.Schema) -> qlast.TypeName:
-    if t.is_any():
-        result = qlast.TypeName(name=_name, maintype=qlast.AnyType())
-    elif t.is_anytuple():
-        result = qlast.TypeName(name=_name, maintype=qlast.AnyTuple())
-    elif not isinstance(t, s_abc.Collection):
-        result = qlast.TypeName(
-            name=_name,
-            maintype=qlast.ObjectRef(
-                module=t.get_name(schema).module,
-                name=t.get_name(schema).name
-            )
-        )
-    elif isinstance(t, s_abc.Tuple) and t.named:
-        result = qlast.TypeName(
-            name=_name,
-            maintype=qlast.ObjectRef(
-                name=t.schema_name
-            ),
-            subtypes=[
-                type_to_ql_typeref(st, _name=sn, schema=schema)
-                for sn, st in t.iter_subtypes(schema)
-            ]
-        )
-    else:
-        result = qlast.TypeName(
-            name=_name,
-            maintype=qlast.ObjectRef(
-                name=t.schema_name
-            ),
-            subtypes=[
-                type_to_ql_typeref(st, schema=schema)
-                for st in t.get_subtypes(schema)
-            ]
-        )
-
-    return result
+    return s_utils.typeref_to_ast(schema, t)

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -161,20 +161,15 @@ def derive_view(
             ctx.env.schema, name=derived_name)
 
     elif isinstance(stype, s_inh.InheritingObject):
-        qualifiers: typing.Tuple[str, ...] = ()
-        if stype.get_name(ctx.env.schema) == derived_name:
-            qualifiers = (ctx.aliases.get('d'),)
-
-        ctx.env.schema, derived = stype.derive(
+        ctx.env.schema, derived = stype.derive_subtype(
             ctx.env.schema,
-            stype,
-            *qualifiers,
             name=derived_name,
             inheritance_merge=inheritance_merge,
             refdict_whitelist={'pointers'},
             mark_derived=True,
             preserve_path_id=preserve_path_id,
-            attrs=attrs)
+            attrs=attrs,
+        )
 
         if (not stype.generic(ctx.env.schema)
                 and isinstance(derived, s_sources.Source)):
@@ -226,7 +221,7 @@ def derive_ptr(
     if ptr.get_name(ctx.env.schema) == derived_name:
         qualifiers = qualifiers + (ctx.aliases.get('d'),)
 
-    ctx.env.schema, derived = ptr.derive(
+    ctx.env.schema, derived = ptr.derive_ref(
         ctx.env.schema,
         source,
         target,

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -791,7 +791,7 @@ def computable_ptr_set(
     # in the form "self.linkname".  To prevent infinite recursion,
     # self must resolve to the parent type of the view NOT the view
     # type itself.  Similarly, when resolving computable link properties
-    # make sure that we use ptrcls.derived_from.
+    # make sure that we use the parent of derived ptrcls.
     if source_scls.is_view(ctx.env.schema):
         source_set_stype = source_scls.peel_view(ctx.env.schema)
         source_set = new_set_from_set(

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -157,12 +157,6 @@ def fini_expression(
 
             view_own_pointers = view.get_pointers(ctx.env.schema)
             for vptr in view_own_pointers.objects(ctx.env.schema):
-                ctx.env.schema = vptr.set_field_value(
-                    ctx.env.schema,
-                    'target',
-                    vptr.get_target(ctx.env.schema).material_type(
-                        ctx.env.schema))
-
                 _elide_derived_ancestors(vptr, ctx=ctx)
 
                 if not hasattr(vptr, 'get_pointers'):
@@ -170,12 +164,6 @@ def fini_expression(
 
                 vptr_own_pointers = vptr.get_pointers(ctx.env.schema)
                 for vlprop in vptr_own_pointers.objects(ctx.env.schema):
-                    vlprop_target = vlprop.get_target(ctx.env.schema)
-                    ctx.env.schema = vlprop.set_field_value(
-                        ctx.env.schema,
-                        'target',
-                        vlprop_target.material_type(ctx.env.schema))
-
                     _elide_derived_ancestors(vlprop, ctx=ctx)
 
     expr_type = inference.infer_type(ir, ctx.env)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -208,32 +208,9 @@ def _elide_derived_ancestors(
     present in the schema outside of the compilation context.
     """
 
-    derived_from = obj.get_derived_from(ctx.env.schema)
-    if derived_from is not None:
-        derived_from = typing.cast(
-            typing.Union[s_types.Type, s_pointers.Pointer],
-            derived_from,
-        )
-        if (derived_from.get_derived_from(ctx.env.schema)
-                is not None):
-            ctx.env.schema = obj.set_field_value(
-                ctx.env.schema,
-                'derived_from',
-                derived_from.get_nearest_non_derived_parent(
-                    ctx.env.schema,
-                )
-            )
-        elif derived_from.get_union_of(ctx.env.schema):
-            ctx.env.schema = obj.set_field_value(
-                ctx.env.schema,
-                'derived_from',
-                None,
-            )
-
     pbase = obj.get_bases(ctx.env.schema).first(ctx.env.schema)
-    if pbase.get_derived_from(ctx.env.schema) is not None:
-        pbase = pbase.get_nearest_non_derived_parent(
-            ctx.env.schema)
+    if pbase.get_is_derived(ctx.env.schema):
+        pbase = pbase.get_nearest_non_derived_parent(ctx.env.schema)
         ctx.env.schema = obj.set_field_value(
             ctx.env.schema,
             'bases',
@@ -253,15 +230,15 @@ def _derive_dummy_ptr(ptr, *, ctx: context.ContextLevel):
         ctx.env.schema, stdobj, module='__derived__')
     derived_obj = ctx.env.schema.get(derived_obj_name, None)
     if derived_obj is None:
-        ctx.env.schema, derived_obj = stdobj.derive(
-            ctx.env.schema, stdobj, name=derived_obj_name)
+        ctx.env.schema, derived_obj = stdobj.derive_subtype(
+            ctx.env.schema, name=derived_obj_name)
 
     derived_name = ptr.get_derived_name(
         ctx.env.schema, derived_obj)
 
     derived = ctx.env.schema.get(derived_name, None)
     if derived is None:
-        ctx.env.schema, derived = ptr.derive(
+        ctx.env.schema, derived = ptr.derive_ref(
             ctx.env.schema,
             derived_obj,
             derived_obj,

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -419,6 +419,26 @@ def _normalize_view_ptr_expr(
             shape_expr_ctx.path_scope.unnest_fence = True
             shape_expr_ctx.partial_path_prefix = setgen.class_set(
                 view_scls, path_id=path_id, ctx=shape_expr_ctx)
+            prefix_rptrref = path_id.rptr()
+            if prefix_rptrref is not None:
+                # Source path seems to contain multiple steps,
+                # so set up a rptr for abbreviated link property
+                # paths.
+                src_path_id = path_id.src_path()
+                prefix_rptr = irast.Pointer(
+                    source=setgen.class_set(
+                        irtyputils.ir_typeref_to_type(
+                            shape_expr_ctx.env.schema,
+                            src_path_id.target,
+                        ),
+                        path_id=src_path_id,
+                        ctx=shape_expr_ctx,
+                    ),
+                    target=shape_expr_ctx.partial_path_prefix,
+                    ptrref=prefix_rptrref,
+                    direction=s_pointers.PointerDirection.Outbound,
+                )
+                shape_expr_ctx.partial_path_prefix.rptr = prefix_rptr
 
             if is_mutation and ptrcls is not None:
                 shape_expr_ctx.expr_exposed = True

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -180,6 +180,13 @@ def trace_layout_CreateLink(
     _trace_item_layout(node, ctx=ctx)
 
 
+@trace_layout.register
+def trace_layout_CreateProperty(
+        node: qlast.CreateProperty, *, ctx: LayoutTraceContext):
+
+    _trace_item_layout(node, ctx=ctx)
+
+
 def _trace_item_layout(node: qlast.CreateObject, *,
                        obj=None, fq_name=None, ctx: LayoutTraceContext):
     if obj is None:

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -356,18 +356,22 @@ commands_block(
 
 class AlterAbstract(Nonterm):
     def reduce_DROP_ABSTRACT(self, *kids):
-        self.val = qlast.SetSpecialField(name='is_abstract', value=False)
+        self.val = qlast.SetSpecialField(
+            name=qlast.ObjectRef(name='is_abstract'), value=False)
 
     def reduce_SET_ABSTRACT(self, *kids):
-        self.val = qlast.SetSpecialField(name='is_abstract', value=True)
+        self.val = qlast.SetSpecialField(
+            name=qlast.ObjectRef(name='is_abstract'), value=True)
 
 
 class AlterFinal(Nonterm):
     def reduce_DROP_FINAL(self, *kids):
-        self.val = qlast.SetSpecialField(name='is_final', value=False)
+        self.val = qlast.SetSpecialField(
+            name=qlast.ObjectRef(name='is_final'), value=False)
 
     def reduce_SET_FINAL(self, *kids):
-        self.val = qlast.SetSpecialField(name='is_final', value=True)
+        self.val = qlast.SetSpecialField(
+            name=qlast.ObjectRef(name='is_final'), value=True)
 
 
 class OptInheritPosition(Nonterm):
@@ -702,10 +706,26 @@ class CreateConcreteConstraintStmt(Nonterm):
         )
 
 
+class SetDelegatedStmt(Nonterm):
+
+    def reduce_SET_DELEGATED(self, *kids):
+        self.val = qlast.SetSpecialField(
+            name=qlast.ObjectRef(name='delegated'),
+            value=True,
+        )
+
+    def reduce_DROP_DELEGATED(self, *kids):
+        self.val = qlast.SetSpecialField(
+            name=qlast.ObjectRef(name='delegated'),
+            value=False,
+        )
+
+
 commands_block(
     'AlterConcreteConstraint',
     RenameStmt,
     SetFieldStmt,
+    SetDelegatedStmt,
     SetAnnotationValueStmt,
     DropAnnotationValueStmt,
     AlterAbstract,
@@ -990,13 +1010,13 @@ class SetCardinalityStmt(Nonterm):
 
     def reduce_SET_SINGLE(self, *kids):
         self.val = qlast.SetSpecialField(
-            name='cardinality',
+            name=qlast.ObjectRef(name='cardinality'),
             value=qltypes.Cardinality.ONE,
         )
 
     def reduce_SET_MULTI(self, *kids):
         self.val = qlast.SetSpecialField(
-            name='cardinality',
+            name=qlast.ObjectRef(name='cardinality'),
             value=qltypes.Cardinality.MANY,
         )
 
@@ -1005,13 +1025,13 @@ class SetRequiredStmt(Nonterm):
 
     def reduce_SET_REQUIRED(self, *kids):
         self.val = qlast.SetSpecialField(
-            name='required',
+            name=qlast.ObjectRef(name='required'),
             value=True,
         )
 
     def reduce_DROP_REQUIRED(self, *kids):
         self.val = qlast.SetSpecialField(
-            name='required',
+            name=qlast.ObjectRef(name='required'),
             value=False,
         )
 
@@ -1025,6 +1045,7 @@ commands_block(
     SetPropertyTypeStmt,
     SetCardinalityStmt,
     SetRequiredStmt,
+    AlterSimpleExtending,
     CreateConcreteConstraintStmt,
     AlterConcreteConstraintStmt,
     DropConcreteConstraintStmt,

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -694,7 +694,7 @@ class CreateConcreteConstraintStmt(Nonterm):
                     NodeName OptConcreteConstraintArgList OptOnExpr \
                     OptCreateCommandsBlock"""
         self.val = qlast.CreateConcreteConstraint(
-            is_abstract=kids[1].val,
+            delegated=kids[1].val,
             name=kids[3].val,
             args=kids[4].val,
             subjectexpr=kids[5].val,

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -309,7 +309,7 @@ class ConcreteConstraintBlock(Nonterm):
                     NodeName OptConcreteConstraintArgList OptOnExpr \
                     CreateSDLCommandsBlock"""
         self.val = qlast.CreateConcreteConstraint(
-            is_abstract=True,
+            delegated=True,
             name=kids[2].val,
             args=kids[3].val,
             subjectexpr=kids[4].val,
@@ -331,7 +331,7 @@ class ConcreteConstraintShort(Nonterm):
         r"""%reduce DELEGATED CONSTRAINT \
                     NodeName OptConcreteConstraintArgList OptOnExpr"""
         self.val = qlast.CreateConcreteConstraint(
-            is_abstract=True,
+            delegated=True,
             name=kids[2].val,
             args=kids[3].val,
             subjectexpr=kids[4].val,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -126,11 +126,11 @@ class BasePointerRef(ImmutableBase):
     direction: s_pointers.PointerDirection
     parent_ptr: PointerRef
     material_ptr: BasePointerRef
-    derived_from_ptr: BasePointerRef
     descendants: typing.Set[BasePointerRef]
     union_components: typing.Set[BasePointerRef]
     has_properties: bool
     required: bool
+    is_derived: bool
     # Relation cardinality in the direction specified
     # by *direction*.
     dir_cardinality: qltypes.Cardinality

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -258,18 +258,6 @@ def ptrref_from_ptrcls(
     else:
         material_ptr = None
 
-    if ptrcls.get_derived_from(schema) is not None:
-        derived_ptrcls = ptrcls.get_nearest_non_derived_parent(schema)
-        derived_from_ptr = ptrref_from_ptrcls(
-            source_ref=source_ref,
-            target_ref=target_ref,
-            ptrcls=derived_ptrcls,
-            direction=direction,
-            parent_ptr=parent_ptr,
-            schema=schema)
-    else:
-        derived_from_ptr = None
-
     union_components = set()
     union_of = ptrcls.get_union_of(schema)
     if union_of:
@@ -285,7 +273,7 @@ def ptrref_from_ptrcls(
                     schema=schema,
                 )
             )
-    elif (derived_from_ptr is None
+    elif (material_ptr is None
             and not ptrcls.generic(schema)
             and not ptrcls.get_is_local(schema)):
         for base in ptrcls.as_locally_defined(schema):
@@ -344,7 +332,7 @@ def ptrref_from_ptrcls(
         direction=direction,
         parent_ptr=parent_ptr,
         material_ptr=material_ptr,
-        derived_from_ptr=derived_from_ptr,
+        is_derived=ptrcls.get_is_derived(schema),
         descendants=descendants,
         union_components=union_components,
         has_properties=ptrcls.has_user_defined_properties(schema),
@@ -396,4 +384,4 @@ def is_inbound_ptrref(
 
 def is_computable_ptrref(
         ptrref: irast.BasePointerRef):
-    return ptrref.derived_from_ptr is not None
+    return ptrref.is_derived

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -161,6 +161,7 @@ CREATE TYPE schema::Constraint
     CREATE PROPERTY subjectexpr -> std::str;
     CREATE PROPERTY finalexpr -> std::str;
     CREATE PROPERTY errmessage -> std::str;
+    CREATE PROPERTY delegated -> std::bool;
 };
 
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -951,8 +951,8 @@ def range_for_pointer(
         dml_source: typing.Optional[irast.MutatingStmt]=None,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
     ptrref = pointer.ptrref
-    if ptrref.derived_from_ptr is not None:
-        ptrref = ptrref.derived_from_ptr
+    if ptrref.material_ptr is not None:
+        ptrref = ptrref.material_ptr
 
     return range_for_ptrref(ptrref, dml_source=dml_source, ctx=ctx)
 

--- a/edb/pgsql/datasources/schema/constraints.py
+++ b/edb/pgsql/datasources/schema/constraints.py
@@ -36,6 +36,7 @@ async def fetch(
                 a.is_abstract           AS is_abstract,
                 a.is_final              AS is_final,
                 a.is_local              AS is_local,
+                a.delegated             AS delegated,
                 edgedb._resolve_type_name(a.bases)
                                         AS bases,
                 edgedb._resolve_type_name(a.ancestors)

--- a/edb/pgsql/datasources/schema/links.py
+++ b/edb/pgsql/datasources/schema/links.py
@@ -36,7 +36,6 @@ async def fetch(
                 l.name AS name,
                 edgedb._resolve_type_name(l.bases) AS bases,
                 edgedb._resolve_type_name(l.ancestors) AS ancestors,
-                edgedb._resolve_type_name(l.derived_from) AS derived_from,
                 l.cardinality,
                 l.required,
                 l.expr,
@@ -72,8 +71,6 @@ async def fetch_properties(
                                         AS bases,
                 edgedb._resolve_type_name(p.ancestors)
                                         AS ancestors,
-                edgedb._resolve_type_name(p.derived_from)
-                                        AS derived_from,
                 p.cardinality           AS cardinality,
                 p.required              AS required,
                 p.expr                  AS expr,

--- a/edb/pgsql/datasources/schema/objtypes.py
+++ b/edb/pgsql/datasources/schema/objtypes.py
@@ -38,6 +38,7 @@ async def fetch(
                 c.is_abstract AS is_abstract,
                 c.is_final AS is_final,
                 c.view_type AS view_type,
+                c.view_is_persistent AS view_is_persistent,
                 c.expr AS expr,
                 c.field_inh_map AS field_inh_map
 
@@ -65,6 +66,7 @@ async def fetch_derived(
                 c.is_abstract AS is_abstract,
                 c.is_final AS is_final,
                 c.view_type AS view_type,
+                c.view_is_persistent AS view_is_persistent,
                 c.expr AS expr,
                 c.field_inh_map AS field_inh_map
             FROM

--- a/edb/pgsql/datasources/schema/scalars.py
+++ b/edb/pgsql/datasources/schema/scalars.py
@@ -35,6 +35,7 @@ async def fetch(
             c.is_abstract AS is_abstract,
             c.is_final AS is_final,
             c.view_type AS view_type,
+            c.view_is_persistent AS view_is_persistent,
             c.expr AS expr,
             c.enum_values AS enum_values,
             edgedb._resolve_type_name(c.bases) AS bases,

--- a/edb/pgsql/datasources/schema/types.py
+++ b/edb/pgsql/datasources/schema/types.py
@@ -33,6 +33,7 @@ async def fetch_tuple_views(
             c.id AS id,
             c.name AS name,
             c.view_type AS view_type,
+            c.view_is_persistent AS view_is_persistent,
             c.expr AS expr,
             c.named AS named,
             c.element_types AS element_types
@@ -59,6 +60,7 @@ async def fetch_array_views(
             c.id AS id,
             c.name AS name,
             c.view_type AS view_type,
+            c.view_is_persistent AS view_is_persistent,
             c.expr AS expr,
             c.element_type AS element_type,
             c.dimensions AS dimensions

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -440,7 +440,9 @@ class DeleteArrayView(
     pass
 
 
-class ParameterCommand:
+class ParameterCommand(sd.ObjectCommand,
+                       metaclass=ReferencedObjectCommandMeta):
+
     _table = metaschema.get_metaclass_table(s_funcs.Parameter)
 
     def get_table(self, schema):

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -44,7 +44,7 @@ class ConstraintCommon:
     def __init__(self, constraint, schema):
         self._constr_id = constraint.id
         self._schema_constr_name = constraint.get_name(schema)
-        self._schema_constr_is_delegated = constraint.get_is_abstract(schema)
+        self._schema_constr_is_delegated = constraint.get_delegated(schema)
         self._schema = schema
         self._constraint = constraint
 
@@ -66,7 +66,7 @@ class ConstraintCommon:
         cmd.generate(block)
 
     @property
-    def is_abstract(self):
+    def delegated(self):
         return self._schema_constr_is_delegated
 
 
@@ -518,15 +518,15 @@ class AlterTableInheritableConstraintBase(
             self.add_commands(mv_trigger)
 
     def alter_constraint(self, old_constraint, new_constraint):
-        if old_constraint.is_abstract and not new_constraint.is_abstract:
+        if old_constraint.delegated and not new_constraint.delegated:
             # No longer delegated, create db structures
             self.create_constraint(new_constraint)
 
-        elif not old_constraint.is_abstract and new_constraint.is_abstract:
+        elif not old_constraint.delegated and new_constraint.delegated:
             # Now delegated, drop db structures
             self.drop_constraint(old_constraint)
 
-        elif not new_constraint.is_abstract:
+        elif not new_constraint.delegated:
             # Some other modification, drop/create
             self.drop_constraint(old_constraint)
             self.create_constraint(new_constraint)
@@ -557,7 +557,7 @@ class AlterTableAddInheritableConstraint(AlterTableInheritableConstraintBase):
             self._constraint)
 
     def generate(self, block):
-        if not self._constraint.is_abstract:
+        if not self._constraint.delegated:
             self.create_constraint(self._constraint)
         super().generate(block)
 
@@ -574,7 +574,7 @@ class AlterTableRenameInheritableConstraint(
             self._constraint)
 
     def generate(self, block):
-        if not self._constraint.is_abstract:
+        if not self._constraint.delegated:
             self.rename_constraint(self._constraint, self._new_constraint)
         super().generate(block)
 
@@ -602,6 +602,6 @@ class AlterTableDropInheritableConstraint(AlterTableInheritableConstraintBase):
             self._constraint)
 
     def generate(self, block):
-        if not self._constraint.is_abstract:
+        if not self._constraint.delegated:
             self.drop_constraint(self._constraint)
         super().generate(block)

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -620,7 +620,6 @@ class IntrospectionMech:
         links_list = {sn.Name(r['name']): r for r in links_list}
 
         basemap = {}
-        dermap = {}
         exprmap = {}
 
         for name, r in links_list.items():
@@ -630,9 +629,6 @@ class IntrospectionMech:
                 bases = tuple(sn.Name(b) for b in r['bases'])
             elif name != 'std::link':
                 bases = (sn.Name('std::link'), )
-
-            if r['derived_from']:
-                dermap[name] = r['derived_from']
 
             source = schema.get(r['source']) if r['source'] else None
             target = self.unpack_typeref(r['target'], schema)
@@ -675,16 +671,6 @@ class IntrospectionMech:
         for scls, (basenames, ancestors) in basemap.items():
             schema = self._set_reflist(schema, scls, 'bases', basenames)
             schema = self._set_reflist(schema, scls, 'ancestors', ancestors)
-
-            try:
-                derived_from = dermap[scls.get_name(schema)]
-            except KeyError:
-                pass
-            else:
-                schema = scls.set_field_value(
-                    schema,
-                    'derived_from',
-                    schema.get(derived_from))
 
         return schema, exprmap
 
@@ -739,7 +725,7 @@ class IntrospectionMech:
                 is_local=r['is_local'],
                 is_abstract=r['is_abstract'], is_final=r['is_final'])
 
-            basemap[prop] = (bases, r['ancestors'], r['derived_from'])
+            basemap[prop] = (bases, r['ancestors'])
 
             if r['default']:
                 exprmap[prop] = r['default']
@@ -755,12 +741,9 @@ class IntrospectionMech:
             if source:
                 schema = source.add_pointer(schema, prop)
 
-        for scls, (basenames, ancestors, derived) in basemap.items():
+        for scls, (basenames, ancestors) in basemap.items():
             schema = self._set_reflist(schema, scls, 'bases', basenames)
             schema = self._set_reflist(schema, scls, 'ancestors', ancestors)
-            if derived is not None:
-                schema = scls.set_field_value(
-                    schema, 'derived_from', schema.get(derived))
 
         return schema, exprmap
 

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -448,6 +448,7 @@ class IntrospectionMech:
                 is_abstract=r['is_abstract'],
                 is_final=r['is_final'],
                 is_local=r['is_local'],
+                delegated=r['delegated'],
                 expr=(self.unpack_expr(r['expr'], schema)
                       if r['expr'] else None),
                 subjectexpr=(self.unpack_expr(r['subjectexpr'], schema)

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -209,6 +209,7 @@ class IntrospectionMech:
                 'is_final': row['is_final'],
                 'view_type': (s_types.ViewType(row['view_type'])
                               if row['view_type'] else None),
+                'view_is_persistent': row['view_is_persistent'],
                 'default': (self.unpack_expr(row['default'], schema)
                             if row['default'] else None),
                 'expr': (self.unpack_expr(row['expr'], schema)
@@ -840,6 +841,7 @@ class IntrospectionMech:
                 'is_final': row['is_final'],
                 'view_type': (s_types.ViewType(row['view_type'])
                               if row['view_type'] else None),
+                'view_is_persistent': row['view_is_persistent'],
             }
 
             exprmap[name] = row['expr']
@@ -857,6 +859,7 @@ class IntrospectionMech:
                 union_of=union_of,
                 is_final=objtype['is_final'],
                 view_type=objtype['view_type'],
+                view_is_persistent=objtype['view_is_persistent'],
             )
 
             basemap[objtype] = (row['bases'], row['ancestors'])
@@ -893,6 +896,7 @@ class IntrospectionMech:
                 id=r['id'],
                 name=sn.Name(r['name']),
                 view_type=s_types.ViewType(r['view_type']),
+                view_is_persistent=r['view_is_persistent'],
                 named=r['named'],
                 expr=self.unpack_expr(r['expr'], schema),
                 element_types=s_obj.ObjectDict.create(
@@ -911,6 +915,7 @@ class IntrospectionMech:
                 id=r['id'],
                 name=sn.Name(r['name']),
                 view_type=s_types.ViewType(r['view_type']),
+                view_is_persistent=r['view_is_persistent'],
                 expr=self.unpack_expr(r['expr'], schema),
                 element_type=eltype,
                 dimensions=r['dimensions'],

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -136,12 +136,8 @@ class CreateAnnotation(AnnotationCommand, sd.CreateObject):
     @classmethod
     def _cmd_tree_from_ast(cls, schema, astnode, context):
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
-        cmd.update((
-            sd.AlterObjectProperty(
-                property='inheritable',
-                new_value=astnode.inheritable,
-            ),
-        ))
+        cmd.set_attribute_value('inheritable', astnode.inheritable)
+        cmd.set_attribute_value('is_abstract', True)
 
         return cmd
 
@@ -204,15 +200,9 @@ class CreateAnnotationValue(AnnotationValueCommand,
             raise ValueError(
                 f'unexpected value type in AnnotationValue: {value!r}')
 
-        parent_ctx = context.get(AnnotationSubjectCommandContext)
-        subject_name = parent_ctx.op.classname
         attr = schema.get(propname)
 
         cmd.update((
-            sd.AlterObjectProperty(
-                property='subject',
-                new_value=so.ObjectRef(name=subject_name),
-            ),
             sd.AlterObjectProperty(
                 property='annotation',
                 new_value=utils.reduce_to_typeref(schema, attr)
@@ -236,14 +226,6 @@ class CreateAnnotationValue(AnnotationValueCommand,
     def _apply_field_ast(self, schema, context, node, op):
         if op.property == 'value':
             node.value = qlast.BaseConstant.from_python(op.new_value)
-        elif op.property == 'is_derived':
-            pass
-        elif op.property == 'annotation':
-            pass
-        elif op.property == 'subject':
-            pass
-        elif op.property == 'inheritable':
-            pass
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -53,6 +53,8 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer):
 
     @property
     def qlast(self):
+        if self._qlast is None:
+            self._qlast = qlparser.parse_fragment(self.text)
         return self._qlast
 
     @property
@@ -98,12 +100,8 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer):
 
         from edb.edgeql import compiler as qlcompiler
 
-        qltree = expr.qlast
-        if qltree is None:
-            qltree = qlparser.parse(expr.text)
-
         ir = qlcompiler.compile_ast_to_ir(
-            qltree,
+            expr.qlast,
             schema=schema,
             modaliases=modaliases,
             anchors=anchors,
@@ -118,7 +116,7 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer):
             text=expr.text,
             origtext=expr.origtext,
             refs=so.ObjectSet.create(schema, ir.schema_refs),
-            _qlast=qltree,
+            _qlast=expr.qlast,
             _irast=ir,
         )
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -492,7 +492,7 @@ class CallableObject(s_anno.AnnotationSubject):
     def has_inlined_defaults(self, schema):
         return False
 
-    def is_blocking_ref(self, schema, context, reference):
+    def is_blocking_ref(self, schema, reference):
         # Paramters cannot be deleted via DDL syntax,
         # so the only possible scenario is the deletion of
         # the host function.

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -168,17 +168,9 @@ class CreateIndex(IndexCommand, referencing.CreateReferencedInheritingObject):
             expr=expr_ql,
         )
 
-    def _apply_fields_ast(self, schema, context, node):
-        super()._apply_fields_ast(schema, context, node)
-        node.name.module = ''
-
     def _apply_field_ast(self, schema, context, node, op):
         if op.property == 'expr':
-            node.expr = op.new_value
-        elif op.property == 'is_derived':
-            pass
-        elif op.property == 'subject':
-            pass
+            node.expr = op.new_value.qlast
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -121,7 +121,7 @@ class Property(pointers.Pointer, s_abc.Property):
     def get_default_base_name(self):
         return sn.Name('std::property')
 
-    def is_blocking_ref(self, schema, context, reference):
+    def is_blocking_ref(self, schema, reference):
         return not self.is_endpoint_pointer(schema)
 
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1623,10 +1623,6 @@ class InheritingObjectBase(Object):
         bool,
         default=False, compcoef=0.909)
 
-    derived_from = SchemaField(
-        Object,
-        default=None, compcoef=0.909, inheritable=False)
-
     is_abstract = SchemaField(
         bool,
         default=False,
@@ -1668,8 +1664,8 @@ class InheritingObjectBase(Object):
 
     def get_nearest_non_derived_parent(self, schema):
         obj = self
-        while obj.get_derived_from(schema) is not None:
-            obj = obj.get_derived_from(schema)
+        while obj.get_is_derived(schema):
+            obj = obj.get_bases(schema).first(schema)
         return obj
 
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -119,12 +119,13 @@ class Field(struct.ProtoField):  # derived from ProtoField for validation
 
     __slots__ = ('name', 'type', 'coerce',
                  'compcoef', 'inheritable', 'simpledelta',
-                 'merge_fn', 'ephemeral', 'introspectable', 'allow_ddl_set')
+                 'merge_fn', 'ephemeral', 'introspectable',
+                 'allow_ddl_set', 'weak_ref')
 
     def __init__(self, type_, *, coerce=False,
                  compcoef=None, inheritable=True,
                  simpledelta=True, merge_fn=None, ephemeral=False,
-                 introspectable=True, **kwargs):
+                 introspectable=True, weak_ref=False, **kwargs):
         """Schema item core attribute definition.
 
         """
@@ -139,6 +140,7 @@ class Field(struct.ProtoField):  # derived from ProtoField for validation
         self.inheritable = inheritable
         self.simpledelta = simpledelta
         self.introspectable = introspectable
+        self.weak_ref = weak_ref
 
         if merge_fn is not None:
             self.merge_fn = merge_fn
@@ -742,7 +744,7 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
 
         return similarity
 
-    def is_blocking_ref(self, schema, context, reference):
+    def is_blocking_ref(self, schema, reference):
         return True
 
     @classmethod
@@ -789,7 +791,7 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
             context = ComparisonContext()
 
         with context(old, new):
-            command_args = {}
+            command_args = {'canonical': True}
 
             if old and new:
                 try:

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -62,7 +62,7 @@ class BaseObjectType(sources.Source,
         return True
 
     def get_displayname(self, schema):
-        if self.is_view(schema):
+        if self.is_view(schema) and not self.get_view_is_persistent(schema):
             mtype = self.material_type(schema)
         else:
             mtype = self
@@ -255,15 +255,15 @@ class ObjectTypeCommand(constraints.ConsistencySubjectCommand,
         else:
             super()._apply_field_ast(schema, context, node, op)
 
+
+class CreateObjectType(ObjectTypeCommand, inheriting.CreateInheritingObject):
+    astnode = qlast.CreateObjectType
+
     @classmethod
     def _cmd_tree_from_ast(cls, schema, astnode, context):
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
         cmd = cls._handle_view_op(schema, cmd, astnode, context)
         return cmd
-
-
-class CreateObjectType(ObjectTypeCommand, inheriting.CreateInheritingObject):
-    astnode = qlast.CreateObjectType
 
 
 class RenameObjectType(ObjectTypeCommand, sd.RenameObject):
@@ -276,6 +276,12 @@ class RebaseObjectType(ObjectTypeCommand, inheriting.RebaseInheritingObject):
 
 class AlterObjectType(ObjectTypeCommand, inheriting.AlterInheritingObject):
     astnode = qlast.AlterObjectType
+
+    @classmethod
+    def _cmd_tree_from_ast(cls, schema, astnode, context):
+        cmd = super()._cmd_tree_from_ast(schema, astnode, context)
+        cmd = cls._handle_view_op(schema, cmd, astnode, context)
+        return cmd
 
 
 class DeleteObjectType(ObjectTypeCommand, inheriting.DeleteInheritingObject):

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -191,8 +191,9 @@ def get_or_create_union_type(
 
         std_object = schema.get('std::Object')
 
-        schema, objtype = std_object.derive(
-            schema, std_object, name=name,
+        schema, objtype = std_object.derive_subtype(
+            schema,
+            name=name,
             attrs=dict(
                 id=type_id,
                 union_of=so.ObjectSet.create(schema, components),
@@ -249,11 +250,7 @@ class ObjectTypeCommand(constraints.ConsistencySubjectCommand,
                         s_types.TypeCommand,
                         schema_metaclass=ObjectType,
                         context_class=ObjectTypeCommandContext):
-    def _apply_field_ast(self, schema, context, node, op):
-        if op.property == 'is_derived':
-            pass
-        else:
-            super()._apply_field_ast(schema, context, node, op)
+    pass
 
 
 class CreateObjectType(ObjectTypeCommand, inheriting.CreateInheritingObject):

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -259,7 +259,7 @@ class ReferencedObjectCommand(sd.ObjectCommand,
         reftype = referrer_class.get_field(refdict.attr).type
         refname = reftype.get_key_for(schema, self.scls)
 
-        if (not isinstance(referrer_ctx.op, sd.DeleteObject)
+        if (not context.in_deletion(offset=1)
                 and not context.disable_dep_verification):
             implicit_bases = set(self._get_implicit_ref_bases(
                 schema, context, referrer, refdict, refname))

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -244,6 +244,23 @@ class CreateScalarType(ScalarTypeCommand, inheriting.CreateInheritingObject):
             if op.new_value:
                 op.new_value = op.new_value[0]
                 super()._apply_field_ast(schema, context, node, op)
+
+        elif op.property == 'bases':
+            enum_values = self.get_attribute_value('enum_values')
+            if enum_values:
+                node.bases = [
+                    qlast.TypeName(
+                        maintype=qlast.ObjectRef(name='enum'),
+                        subtypes=[
+                            qlast.TypeExprLiteral(
+                                val=qlast.BaseConstant.from_python(v)
+                            )
+                            for v in enum_values
+                        ]
+                    )
+                ]
+            else:
+                super()._apply_field_ast(schema, context, node, op)
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -45,6 +45,16 @@ type User extending NamedObject {
     link profile -> Profile;
 }
 
+view SettingView := Setting {
+    of_group := .<settings[IS UserGroup]
+};
+
+view SettingViewAugmented := Setting {
+    of_group := .<settings[IS UserGroup] {
+        name_upper := str_upper(.name)
+    }
+};
+
 type Person extending User;
 
 scalar type positive_int_t extending int64 {

--- a/tests/schemas/graphql_setup.edgeql
+++ b/tests/schemas/graphql_setup.edgeql
@@ -17,16 +17,6 @@
 #
 
 
-# FIXME: the computable in the view doesn't work without an explicit
-# abstract link
-CREATE ABSTRACT LINK default::of_group;
-# FIXME: currently a view cannot be defined via eschema
-CREATE VIEW SettingView := default::Setting {
-   # the settings link is exclusive, so this one is a singleton
-   of_group := default::Setting.<settings[IS default::UserGroup]
-};
-
-
 INSERT Setting {
     name := 'template',
     value := 'blue'

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -216,9 +216,9 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     };
                 """)
 
-    async def test_constraints_exclusive_abstract(self):
+    async def test_constraints_exclusive_delegation(self):
         async with self._run_and_rollback():
-            # This is OK, the name exclusivity constraint is abstract
+            # This is OK, the name exclusivity constraint is delegating
             await self.con.execute("""
                 INSERT test::AbstractConstraintParent {
                     name := 'exclusive_name_ap'

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -887,6 +887,30 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             }],
         )
 
+    async def test_edgeql_props_abbrev(self):
+        await self.assert_query_result(
+            r'''
+                WITH
+                    MODULE test
+                SELECT User {
+                    name,
+                    my_deck := (SELECT .deck {
+                        name,
+                        num_cards := @count
+                    } ORDER BY .name)
+                } FILTER .name = 'Alice';
+            ''',
+            [{
+                'name': 'Alice',
+                'my_deck': [
+                    {"name": "Bog monster", "num_cards": 3},
+                    {"name": "Dragon", "num_cards": 2},
+                    {"name": "Giant turtle", "num_cards": 3},
+                    {"name": "Imp", "num_cards": 2},
+                ],
+            }],
+        )
+
     async def test_edgeql_props_agg_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3552,7 +3552,7 @@ aa';
         CREATE VIEW Foo := (SELECT User);
 
         ALTER VIEW Foo
-            SET expr := SELECT Person;
+            SET expr := (SELECT Person);
 
         DROP VIEW Foo;
         """

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -550,6 +550,51 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             sort=lambda x: x['name']
         )
 
+    def test_graphql_functional_view_03(self):
+        self.assert_graphql_query_result(
+            r"""
+                {
+                    SettingViewAugmented {
+                        __typename
+                        name
+                        value
+                        of_group {
+                            __typename
+                            name
+                            name_upper
+                        }
+                    }
+                }
+            """,
+            {
+                "SettingViewAugmented": [
+                    {
+                        "__typename": "SettingViewAugmentedType",
+                        "name": "perks",
+                        "value": "full",
+                        "of_group": {
+                            "__typename":
+                                "__SettingViewAugmented__of_groupType",
+                            "name": "upgraded",
+                            "name_upper": "UPGRADED",
+                        }
+                    },
+                    {
+                        "__typename": "SettingViewAugmentedType",
+                        "name": "template",
+                        "value": "blue",
+                        "of_group": {
+                            "__typename":
+                                "__SettingViewAugmented__of_groupType",
+                            "name": "upgraded",
+                            "name_upper": "UPGRADED",
+                        }
+                    },
+                ],
+            },
+            sort=lambda x: x['name']
+        )
+
     def test_graphql_functional_arguments_01(self):
         result = self.graphql_query(r"""
             query {
@@ -3852,6 +3897,105 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                     {
                         "__typename": "__Type",
                         "kind": "OBJECT",
+                        "name": "SettingViewAugmentedType",
+                        "description": None,
+                        "fields": [
+                            {
+                                "__typename": "__Field",
+                                "name": "id",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "ID",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "name",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "String",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "of_group",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name":
+                                        "__SettingViewAugmented__of_group",
+                                    "kind": "INTERFACE",
+                                    "ofType": None
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "value",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "String",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            }
+                        ],
+                        "interfaces": [
+                            {
+                                "__typename": "__Type",
+                                "name": "NamedObject",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "Object",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "Setting",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "SettingViewAugmented",
+                                "kind": "INTERFACE"
+                            },
+                        ],
+                        "possibleTypes": None,
+                        "enumValues": None,
+                        "inputFields": None,
+                        "ofType": None
+                    },
+                    {
+                        "__typename": "__Type",
+                        "kind": "OBJECT",
                         "name": "SettingViewType",
                         "description": None,
                         "fields": [
@@ -4170,7 +4314,104 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                         "enumValues": None,
                         "inputFields": None,
                         "ofType": None
-                    }
+                    },
+                    {
+                        "__typename": "__Type",
+                        "kind": "OBJECT",
+                        "name": "__SettingViewAugmented__of_groupType",
+                        "description": None,
+                        "fields": [
+                            {
+                                "__typename": "__Field",
+                                "name": "id",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "ID",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "name",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "String",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "name_upper",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": "String",
+                                    "kind": "SCALAR"
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "settings",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "LIST",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": None,
+                                        "kind": "NON_NULL"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            }
+                        ],
+                        "interfaces": [
+                            {
+                                "__typename": "__Type",
+                                "name": "NamedObject",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "Object",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "UserGroup",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "__SettingViewAugmented__of_group",
+                                "kind": "INTERFACE"
+                            },
+                        ],
+                        "possibleTypes": None,
+                        "enumValues": None,
+                        "inputFields": None,
+                        "ofType": None
+                    },
                 ],
                 "enumValues": None,
                 "inputFields": None,


### PR DESCRIPTION
Current implementation of `GET MIGRATION` is rusty and poorly tested, and
this brings things to a much saner state.  There is a new rudimentaty test
suite here intended to check that DDL obtained from
`GET MIGRATION` produces the exact same result as `COMMIT MIGRATION` on the
same migration.  This is a prerequisite of making sure that schema dumps
are produced correctly.