### PR TITLE
Expose schema object attribute inheritance in introspection

### DIFF
--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -108,6 +108,7 @@ CREATE ABSTRACT TYPE schema::AnnotationSubject EXTENDING schema::Object {
 CREATE ABSTRACT TYPE schema::InheritingObject EXTENDING schema::Object {
     CREATE MULTI LINK bases -> schema::InheritingObject;
     CREATE MULTI LINK ancestors -> schema::InheritingObject;
+    CREATE PROPERTY inherited_fields -> array<std::str>;
 
     CREATE REQUIRED PROPERTY is_abstract -> std::bool {
         SET default := false;

--- a/edb/pgsql/datasources/schema/annos.py
+++ b/edb/pgsql/datasources/schema/annos.py
@@ -33,7 +33,7 @@ async def fetch(
                 a.id                    AS id,
                 a.name                  AS name,
                 a.inheritable           AS inheritable,
-                a.field_inh_map         AS field_inh_map
+                a.inherited_fields           AS inherited_fields
             FROM
                 edgedb.annotation a
             WHERE
@@ -64,7 +64,7 @@ async def fetch_values(
                                             AS annotation_name,
                 a.value                     AS value,
                 a.inheritable               AS inheritable,
-                a.field_inh_map             AS field_inh_map
+                a.inherited_fields               AS inherited_fields
             FROM
                 edgedb.AnnotationValue a
             WHERE

--- a/edb/pgsql/datasources/schema/constraints.py
+++ b/edb/pgsql/datasources/schema/constraints.py
@@ -52,7 +52,7 @@ async def fetch(
                                         AS params,
                 a.return_type           AS return_type,
                 a.return_typemod        AS return_typemod,
-                a.field_inh_map         AS field_inh_map
+                a.inherited_fields           AS inherited_fields
 
             FROM
                 edgedb.constraint a

--- a/edb/pgsql/datasources/schema/links.py
+++ b/edb/pgsql/datasources/schema/links.py
@@ -45,7 +45,7 @@ async def fetch(
                 l.is_derived,
                 l.readonly,
                 l.default,
-                l.field_inh_map
+                l.inherited_fields
             FROM
                 edgedb.link l
             WHERE
@@ -83,7 +83,7 @@ async def fetch_properties(
                 p.is_final              AS is_final,
                 p.is_local              AS is_local,
                 p.is_derived            AS is_derived,
-                p.field_inh_map         AS field_inh_map
+                p.inherited_fields           AS inherited_fields
             FROM
                 edgedb.Property p
             WHERE

--- a/edb/pgsql/datasources/schema/objtypes.py
+++ b/edb/pgsql/datasources/schema/objtypes.py
@@ -40,7 +40,7 @@ async def fetch(
                 c.view_type AS view_type,
                 c.view_is_persistent AS view_is_persistent,
                 c.expr AS expr,
-                c.field_inh_map AS field_inh_map
+                c.inherited_fields AS inherited_fields
 
             FROM
                 edgedb.BaseObjectType c
@@ -68,7 +68,7 @@ async def fetch_derived(
                 c.view_type AS view_type,
                 c.view_is_persistent AS view_is_persistent,
                 c.expr AS expr,
-                c.field_inh_map AS field_inh_map
+                c.inherited_fields AS inherited_fields
             FROM
                 edgedb.DerivedObjectType c
             WHERE

--- a/edb/pgsql/datasources/schema/scalars.py
+++ b/edb/pgsql/datasources/schema/scalars.py
@@ -41,7 +41,7 @@ async def fetch(
             edgedb._resolve_type_name(c.bases) AS bases,
             edgedb._resolve_type_name(c.ancestors) AS ancestors,
             c.default AS default,
-            c.field_inh_map AS field_inh_map
+            c.inherited_fields AS inherited_fields
         FROM
             edgedb.ScalarType c
         WHERE

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -209,9 +209,9 @@ class ObjectMetaCommand(MetaCommand, sd.ObjectCommand,
         else:
             schema, fields = self._get_field_updates(schema, context)
 
-        inh_map = self.get_inheritance_map(schema, context)
-        if inh_map:
-            fields['field_inh_map'] = inh_map
+        inherited_fields = self.compute_inherited_fields(schema, context)
+        if inherited_fields:
+            fields['inherited_fields'] = inherited_fields
 
         return schema, fields
 

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -202,8 +202,8 @@ class IntrospectionMech:
 
             scalar_data = {
                 'id': row['id'],
-                'field_inh_map': self._unpack_field_inh_map(
-                    row['field_inh_map']),
+                'inherited_fields': self._unpack_inherited_fields(
+                    row['inherited_fields']),
                 'name': name,
                 'is_abstract': row['is_abstract'],
                 'is_final': row['is_final'],
@@ -441,7 +441,8 @@ class IntrospectionMech:
             schema, constraint = s_constr.Constraint.create_in_schema(
                 schema,
                 id=r['id'],
-                field_inh_map=self._unpack_field_inh_map(r['field_inh_map']),
+                inherited_fields=self._unpack_inherited_fields(
+                    r['inherited_fields']),
                 name=name,
                 subject=subject,
                 params=params,
@@ -473,7 +474,7 @@ class IntrospectionMech:
 
         return schema
 
-    def _unpack_field_inh_map(self, value):
+    def _unpack_inherited_fields(self, value):
         if value is None:
             return immu.Map()
         else:
@@ -643,7 +644,8 @@ class IntrospectionMech:
             schema, link = s_links.Link.create_in_schema(
                 schema,
                 id=r['id'],
-                field_inh_map=self._unpack_field_inh_map(r['field_inh_map']),
+                inherited_fields=self._unpack_inherited_fields(
+                    r['inherited_fields']),
                 name=name,
                 source=source,
                 target=target,
@@ -715,7 +717,8 @@ class IntrospectionMech:
             schema, prop = s_props.Property.create_in_schema(
                 schema,
                 id=r['id'],
-                field_inh_map=self._unpack_field_inh_map(r['field_inh_map']),
+                inherited_fields=self._unpack_inherited_fields(
+                    r['inherited_fields']),
                 name=name, source=source, target=target, required=required,
                 readonly=r['readonly'],
                 expr=(self.unpack_expr(r['expr'], schema)
@@ -764,7 +767,8 @@ class IntrospectionMech:
             schema, _ = s_anno.Annotation.create_in_schema(
                 schema,
                 id=r['id'],
-                field_inh_map=self._unpack_field_inh_map(r['field_inh_map']),
+                inherited_fields=self._unpack_inherited_fields(
+                    r['inherited_fields']),
                 name=name,
                 inheritable=r['inheritable'],
             )
@@ -788,7 +792,8 @@ class IntrospectionMech:
             schema, anno = s_anno.AnnotationValue.create_in_schema(
                 schema,
                 id=r['id'],
-                field_inh_map=self._unpack_field_inh_map(r['field_inh_map']),
+                inherited_fields=self._unpack_inherited_fields(
+                    r['inherited_fields']),
                 name=name,
                 subject=subject,
                 annotation=anno,
@@ -818,8 +823,8 @@ class IntrospectionMech:
         for name, row in objtype_list.items():
             objtype = {
                 'id': row['id'],
-                'field_inh_map': self._unpack_field_inh_map(
-                    row['field_inh_map']),
+                'inherited_fields': self._unpack_inherited_fields(
+                    row['inherited_fields']),
                 'name': name,
                 'is_abstract': row['is_abstract'],
                 'is_final': row['is_final'],

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -24,6 +24,8 @@ import collections
 import collections.abc
 import typing
 
+import immutables as immu
+
 from edb import errors
 
 from edb.common import adapter
@@ -777,13 +779,12 @@ class ObjectCommand(Command, metaclass=ObjectCommandMeta):
         metaclass = self.get_schema_metaclass()
         return schema.get(name, type=metaclass)
 
-    def get_inheritance_map(self, schema, context):
+    def compute_inherited_fields(self, schema, context):
         result = {}
         for op in self.get_subcommands(type=AlterObjectProperty):
-            if op.source == 'inheritance':
-                result[op.property] = True
+            result[op.property] = op.source == 'inheritance'
 
-        return result
+        return immu.Map(result)
 
     def _prepare_field_updates(self, schema, context):
         result = {}

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -417,7 +417,7 @@ class CallableObject(s_anno.AnnotationSubject):
     params = so.SchemaField(
         FuncParameterList,
         coerce=True, compcoef=0.4, default=FuncParameterList,
-        simpledelta=False)
+        inheritable=False, simpledelta=False)
 
     return_type = so.SchemaField(
         s_types.Type, compcoef=0.2)

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -674,8 +674,8 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
 
     def get_explicit_local_field_value(self, schema, field_name,
                                        default=NoDefault):
-        field_inh_map = self.get_field_inh_map(schema)
-        if not field_inh_map.get(field_name):
+        inherited_fields = self.get_inherited_fields(schema)
+        if not inherited_fields.get(field_name):
             return self.get_explicit_field_value(schema, field_name, default)
         elif default is not NoDefault:
             return default
@@ -1648,11 +1648,11 @@ class InheritingObjectBase(Object):
         hashable=False,
     )
 
-    field_inh_map = SchemaField(
+    # Attributes that have been set locally as opposed to inherited.
+    inherited_fields = SchemaField(
         immu.Map,
         default=immu.Map(),
         inheritable=False,
-        introspectable=False,
         hashable=False,
     )
 

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -314,6 +314,40 @@ class TestIntrospection(tb.QueryTestCase):
             }]
         )
 
+    async def test_edgeql_introspection_locality(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE schema
+                SELECT ObjectType {
+                    properties: {
+                        name,
+                        @is_local,
+                        inherited_fields,
+                    } ORDER BY .name
+                }
+                FILTER
+                    .name = 'test::URL'
+            """,
+            [{
+                'properties': [{
+                    "name": "address",
+                    "inherited_fields": [],
+                    "@is_local": True
+                }, {
+                    "name": "id",
+                    "inherited_fields": {
+                        "default", "readonly",
+                        "required", "cardinality"
+                    },
+                    "@is_local": False
+                }, {
+                    "name": "name",
+                    "inherited_fields": {"required", "cardinality"},
+                    "@is_local": False
+                }]
+            }]
+        )
+
     async def test_edgeql_introspection_constraint_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
Every inheriting schema object introspection now has an
`inherited_attrs` property containing an array of names of attributes
that were inherited from a parent as opposed to defined locally.