### PR TITLE
graphql: Fix an issue with having no mutations.

### DIFF
--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -132,10 +132,19 @@ class GQLCoreSchema:
             fields=self.get_fields('Query'),
         )
 
-        mutation = self._gql_objtypes['Mutation'] = GraphQLObjectType(
-            name='Mutation',
-            fields=self.get_fields('Mutation'),
-        )
+        # If a database only has abstract types and scalars, no
+        # mutations will be possible (such as in a blank database),
+        # but we would still want the reflection to work without
+        # error, even if all that can be discovered through GraphQL
+        # then is the schema.
+        fields = self.get_fields('Mutation')
+        if fields:
+            mutation = self._gql_objtypes['Mutation'] = GraphQLObjectType(
+                name='Mutation',
+                fields=fields,
+            )
+        else:
+            mutation = None
 
         # get a sorted list of types relevant for the Schema
         types = [

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -5094,3 +5094,28 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                 ]
             }
         })
+
+
+class TestGraphQLInit(tb.GraphQLTestCase):
+    """Test GraphQL initialization on an empty database."""
+
+    # GraphQL queries cannot run in a transaction
+    ISOLATED_METHODS = False
+
+    def test_graphql_init_type_01(self):
+        # An empty database should still have an "Object" interface.
+        self.assert_graphql_query_result(r"""
+            query {
+                __type(name: "Object") {
+                    __typename
+                    name
+                    kind
+                }
+            }
+        """, {
+            "__type": {
+                "kind": "INTERFACE",
+                "name": "Object",
+                "__typename": "__Type"
+            }
+        })


### PR DESCRIPTION
If a database only has abstract types and scalars, no
mutations will be possible (such as in a blank database),
but we would still want the reflection to work without
error, even if all that can be discovered through GraphQL
then is the schema.

Closes #708.