### PR TITLE
tests: Add data migration tests.

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -31,6 +31,7 @@ import os
 import pprint
 import re
 import unittest
+import uuid
 
 import click.testing
 
@@ -455,6 +456,10 @@ class ConnectedTestCaseMixin:
             elif isinstance(shape, float):
                 if not math.isclose(data, shape, rel_tol=1e-04):
                     self.fail(f'{message}: not isclose({data}, {shape})')
+            elif isinstance(shape, uuid.UUID):
+                # since the data comes from JSON, it will only have a str
+                if data != str(shape):
+                    self.fail(f'{message}: {data!r} != {shape!r}')
             elif isinstance(shape, (str, int)):
                 if data != shape:
                     self.fail(f'{message}: {data!r} != {shape!r}')

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -39,6 +39,10 @@ type User extending Named {
     multi link awards -> Award {
         constraint exclusive;
     }
+
+    link avatar -> Card {
+        property text -> str;
+    }
 }
 
 type Card extending Named {

--- a/tests/schemas/cards_setup.edgeql
+++ b/tests/schemas/cards_setup.edgeql
@@ -102,6 +102,9 @@ INSERT User {
         FILTER .element IN {'Fire', 'Water'}
     ),
     awards := Award,
+    avatar := (
+        SELECT Card {@text := 'Best'} FILTER .name = 'Dragon'
+    ),
 };
 
 WITH MODULE test

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -31,7 +31,12 @@ type InsertTest {
     multi link subordinates -> Subordinate {
         property comment -> str;
     }
+    link sub -> Subordinate {
+        property note -> str;
+    }
 }
+
+type DerivedTest extending InsertTest;
 
 type Note {
     required property name -> str;

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -1211,3 +1211,37 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                         SELECT [(a,)]
                     $$;
             ''')
+
+    @test.xfail('''
+        We have other examples of function definitions using defaults
+        successfully, but not this innocuous-looking one.
+
+        edgedb.errors.InternalServerError: column "__defaults_mask__"
+        does not exist
+    ''')
+    async def test_edgeql_calls_35(self):
+        # define a function with positional arguments with defaults
+        await self.con.execute('''
+            CREATE FUNCTION test::call35(
+                a: int64 = 1,
+                b: int64 = 2
+            ) -> int64
+                FROM EdgeQL $$
+                    SELECT a + b
+                $$;
+        ''')
+
+        await self.assert_query_result(
+            r'''SELECT test::call35();''',
+            [3],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT test::call35(2);''',
+            [4],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT test::call35(2, 3);''',
+            [5],
+        )

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1437,6 +1437,73 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             DROP FUNCTION test::ddlf_21(str: std::str);
         """)
 
+    @test.xfail('''
+        InvalidFunctionDefinitionError not raised
+
+        Currently we implicitly cast the function result into the
+        declared type. This *might* be useful for SQL functions, but
+        gets really weird for EdgeQL functions. As this implicit
+        casting is by no means obvious and is error-prone in "user
+        land".
+    ''')
+    async def test_edgeql_ddl_function_22(self):
+        with self.assertRaisesRegex(edgedb.InvalidFunctionDefinitionError,
+                                    # FIXME: add specific wording
+                                    r''):
+            await self.con.execute(r"""
+                CREATE FUNCTION test::broken_edgeql_func22(
+                    a: std::str) -> std::int64
+                # This cast sometimes fails in runtime.
+                FROM EdgeQL $$
+                    SELECT a
+                $$;
+            """)
+
+    @test.xfail('''
+        edgedb.errors.InternalServerError: cannot cast type text[] to
+        bigint
+
+        At least this fails at compile time, but the SQL error is leaking.
+    ''')
+    async def test_edgeql_ddl_function_23(self):
+        with self.assertRaisesRegex(edgedb.InvalidFunctionDefinitionError,
+                                    # FIXME: add specific wording
+                                    r''):
+            await self.con.execute(r"""
+                CREATE FUNCTION test::broken_edgeql_func23(
+                    a: std::str) -> std::int64
+                # This cast is invalid.
+                FROM EdgeQL $$
+                    SELECT [a]
+                $$;
+            """)
+
+    @test.xfail('''
+        InvalidFunctionDefinitionError not raised
+
+        Currently we implicitly cast the function result into the
+        declared type. This *might* be useful for SQL functions, but
+        gets really weird for EdgeQL functions. As this implicit
+        casting is by no means obvious and is error-prone in "user
+        land".
+    ''')
+    async def test_edgeql_ddl_function_24(self):
+        with self.assertRaisesRegex(edgedb.InvalidFunctionDefinitionError,
+                                    # FIXME: add specific wording
+                                    r''):
+            await self.con.execute(r"""
+                CREATE FUNCTION test::broken_edgeql_func24(
+                    a: std::str) -> std::str
+                # This never fails, because everything is castable to str,
+                # but it results in an utterly unexpected result:
+                #
+                # edgeqb> SELECT test::broken_edgeql_func24('q');
+                # {'{q}'}
+                FROM EdgeQL $$
+                    SELECT [a]
+                $$;
+            """)
+
     async def test_edgeql_ddl_module_01(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaError,

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -18,9 +18,9 @@
 
 
 import os.path
-import unittest  # NOQA
 
 from edb.testbase import server as tb
+from edb.tools import test
 
 
 class TestEdgeQLLinkproperties(tb.QueryTestCase):
@@ -389,6 +389,35 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
                         {'name': 'Dave', '@nickname': 'Grumpy'},
                     ]
                 }
+            ]
+        )
+
+    @test.xfail('''
+        edgedb.errors.InternalServerError: column avatar~1.avatar does
+        not exist
+    ''')
+    async def test_edgeql_props_basic_06(self):
+        await self.assert_query_result(
+            r'''
+                SELECT test::User.avatar@text;
+            ''',
+            [
+                'Best'
+            ]
+        )
+
+    async def test_edgeql_props_basic_07(self):
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT User {
+                    avatar: {
+                        @text
+                    }
+                } FILTER EXISTS .avatar@text;
+            ''',
+            [
+                {'avatar': {'@text': 'Best'}},
             ]
         )
 


### PR DESCRIPTION
An important feature of migrations is that data is supposed to be
preserved when possible (renaming, adding constraints, etc.). In
addition to tests verifying that multiple SDL migrations create the same
schema as a single SDL migration, data integrity tests make sure that
those migrations don't destroy data unexpectedly.