### PR TITLE
Remove SELECT-like clauses from FOR statement

### DIFF
--- a/docs/edgeql/statements/for.rst
+++ b/docs/edgeql/statements/for.rst
@@ -19,14 +19,6 @@ FOR
 
     UNION <output-expr>
 
-    [ FILTER <filter-expr> ]
-
-    [ ORDER BY <order-expr> [direction] [THEN ...] ]
-
-    [ OFFSET <offset-expr> ]
-
-    [ LIMIT  <limit-expr> ] ;
-
 :eql:synopsis:`FOR <variable> IN "{" <iterator-set> [, ...]  "}"`
     The ``FOR`` clause has this general form:
 
@@ -53,9 +45,6 @@ FOR
     is an arbitrary expression that is evaluated for
     every element in a set produced by evaluating the ``FOR`` clause.
     The results of the evaluation are appended into the result set.
-
-For details about ``FILTER``, ``ORDER BY``, ``OFFSET``, and ``LIMIT``
-clauses see the documentation of the :eql:stmt:`SELECT` statement.
 
 
 .. _ref_eql_forstatement:

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -72,6 +72,7 @@ class ViewRPtr:
 @dataclasses.dataclass
 class StatementMetadata:
     is_unnest_fence: bool = False
+    iterator_target: bool = False
 
 
 class PendingCardinality(typing.NamedTuple):
@@ -323,6 +324,9 @@ class ContextLevel(compiler.ContextLevel):
     path_scope_map: typing.Dict[irast.Set, irast.ScopeTreeNode]
     """A forest of scope trees used for views."""
 
+    iterator_ctx: typing.Optional[ContextLevel]
+    """The context of the statement where all iterators should be placed."""
+
     scope_id_ctr: compiler.Counter
     """Path scope id counter."""
 
@@ -386,6 +390,7 @@ class ContextLevel(compiler.ContextLevel):
             self.view_map = collections.ChainMap()
             self.path_scope = None
             self.path_scope_map = {}
+            self.iterator_ctx = None
             self.scope_id_ctr = compiler.Counter()
             self.view_scls = None
             self.expr_exposed = False
@@ -415,6 +420,7 @@ class ContextLevel(compiler.ContextLevel):
             self.expr_view_cache = prevlevel.expr_view_cache
             self.shape_type_cache = prevlevel.shape_type_cache
 
+            self.iterator_ctx = prevlevel.iterator_ctx
             self.path_id_namespace = prevlevel.path_id_namespace
             self.pending_stmt_own_path_id_namespace = \
                 prevlevel.pending_stmt_own_path_id_namespace
@@ -469,6 +475,8 @@ class ContextLevel(compiler.ContextLevel):
                 self.pending_stmt_own_path_id_namespace = frozenset()
                 self.pending_stmt_full_path_id_namespace = frozenset()
                 self.banned_paths = set()
+
+                self.iterator_ctx = None
 
                 self.view_rptr = None
                 self.view_scls = None

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -531,6 +531,7 @@ def extend_path(
         target: typing.Optional[s_types.Type]=None, *,
         ignore_computable: bool=False,
         is_mut_assign: bool=False,
+        hoist_iterators: bool=False,
         unnest_fence: bool=False,
         same_computable_scope: bool=False,
         ctx: context.ContextLevel) -> irast.Set:
@@ -572,6 +573,7 @@ def extend_path(
         target_set = computable_ptr_set(
             ptr,
             unnest_fence=unnest_fence,
+            hoist_iterators=hoist_iterators,
             from_default_expr=is_mut_assign,
             same_computable_scope=same_computable_scope,
             ctx=ctx,
@@ -780,6 +782,7 @@ def ensure_stmt(expr: irast.Base, *, ctx: context.ContextLevel) -> irast.Stmt:
 def computable_ptr_set(
         rptr: irast.Pointer, *,
         unnest_fence: bool=False,
+        hoist_iterators: bool=False,
         same_computable_scope: bool=False,
         from_default_expr: bool=False,
         ctx: context.ContextLevel) -> irast.Set:
@@ -898,9 +901,11 @@ def computable_ptr_set(
         subctx.empty_result_type_hint = ptrcls.get_target(ctx.env.schema)
         subctx.partial_path_prefix = source_set
 
-        if isinstance(qlexpr, qlast.Statement) and unnest_fence:
+        if isinstance(qlexpr, qlast.Statement):
             subctx.stmt_metadata[qlexpr] = context.StatementMetadata(
-                is_unnest_fence=True)
+                is_unnest_fence=unnest_fence,
+                iterator_target=True,
+            )
 
         comp_ir_set = ensure_set(
             dispatch.compile(qlexpr, ctx=subctx), ctx=subctx)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -108,12 +108,6 @@ def compile_ForQuery(
         stmt = irast.SelectStmt()
         init_stmt(stmt, qlstmt, ctx=sctx, parent_ctx=ctx)
 
-        if qlstmt.offset is not None or qlstmt.limit is not None:
-            # LIMIT and OFFSET are infix operators with both
-            # operands being SET OF, so we need to compile
-            # the body of the statement behind a fence.
-            sctx.path_scope = sctx.path_scope.attach_fence()
-
         with sctx.newscope(fenced=True) as scopectx:
             iterator = qlstmt.iterator
             if isinstance(iterator, qlast.Set) and len(iterator.elements) == 1:
@@ -131,29 +125,14 @@ def compile_ForQuery(
         node = sctx.path_scope.find_descendant(stmt.iterator_stmt.path_id)
         node.attach_subtree(iterator_scope)
 
+        output = astutils.ensure_qlstmt(qlstmt.result)
         stmt.result = compile_result_clause(
-            qlstmt.result,
+            output,
             view_scls=ctx.view_scls,
             view_rptr=ctx.view_rptr,
-            result_alias=qlstmt.result_alias,
             view_name=ctx.toplevel_result_view_name,
             forward_rptr=True,
             ctx=sctx)
-
-        clauses.compile_where_clause(
-            stmt, qlstmt.where, ctx=sctx)
-
-        stmt.orderby = clauses.compile_orderby_clause(
-            qlstmt.orderby, ctx=sctx)
-
-        if qlstmt.offset is not None or qlstmt.limit is not None:
-            sctx.path_scope = sctx.path_scope.parent
-
-            stmt.offset = clauses.compile_limit_offset_clause(
-                qlstmt.offset, ctx=sctx)
-
-            stmt.limit = clauses.compile_limit_offset_clause(
-                qlstmt.limit, ctx=sctx)
 
         result = fini_stmt(stmt, qlstmt, ctx=sctx, parent_ctx=ctx)
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -448,6 +448,9 @@ def _normalize_view_ptr_expr(
                 shape_expr_ctx.empty_result_type_hint = \
                     ptrcls.get_target(ctx.env.schema)
 
+            shape_expr_ctx.stmt_metadata[qlexpr] = context.StatementMetadata(
+                iterator_target=True,
+            )
             irexpr = dispatch.compile(qlexpr, ctx=shape_expr_ctx)
 
             irexpr.context = compexpr.context
@@ -867,7 +870,8 @@ def _compile_view_shapes_in_set(
         for path_tip, ptr in shape_ptrs:
             element = setgen.extend_path(
                 path_tip, ptr, is_mut_assign=is_mutation,
-                unnest_fence=True, same_computable_scope=True, ctx=ctx)
+                unnest_fence=True, same_computable_scope=True,
+                hoist_iterators=True, ctx=ctx)
 
             element_scope = pathctx.get_set_scope(element, ctx=ctx)
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -114,36 +114,12 @@ class ByExprList(ListNonterm, element=ByExpr, separator=tokens.T_COMMA):
 
 class SimpleFor(Nonterm):
     def reduce_For(self, *kids):
-        r"%reduce FOR Identifier IN Set \
-                  UNION OptionallyAliasedExpr \
-                  OptFilterClause OptSortClause OptSelectLimit"
-        offset, limit = kids[8].val
-
-        if offset is not None or limit is not None:
-            subj = qlast.ForQuery(
-                iterator_alias=kids[1].val,
-                iterator=kids[3].val,
-                result=kids[5].val.expr,
-                result_alias=kids[5].val.alias,
-                where=kids[6].val,
-                orderby=kids[7].val,
-                implicit=True,
-            )
-
-            self.val = qlast.SelectQuery(
-                result=subj,
-                offset=offset,
-                limit=limit,
-            )
-        else:
-            self.val = qlast.ForQuery(
-                iterator_alias=kids[1].val,
-                iterator=kids[3].val,
-                result=kids[5].val.expr,
-                result_alias=kids[5].val.alias,
-                where=kids[6].val,
-                orderby=kids[7].val,
-            )
+        r"%reduce FOR Identifier IN Set UNION Expr"
+        self.val = qlast.ForQuery(
+            iterator_alias=kids[1].val,
+            iterator=kids[3].val,
+            result=kids[5].val,
+        )
 
 
 class SimpleSelect(Nonterm):

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -530,6 +530,7 @@ class Stmt(Base):
     cardinality: qltypes.Cardinality
     parent_stmt: Stmt
     iterator_stmt: Set
+    hoisted_iterators: typing.List[Set]
 
 
 class FilteredStmt(Stmt):

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -262,3 +262,13 @@ def get_nearest_dml_stmt(ir_set) -> typing.Optional[irast.MutatingStmt]:
             ir_set = ir_set.rptr.source
         else:
             ir_set = None
+
+
+def get_iterator_sets(stmt: irast.Stmt) -> typing.Sequence[irast.Set]:
+    iterators = []
+    if stmt.iterator_stmt is not None:
+        iterators.append(stmt.iterator_stmt)
+    if stmt.hoisted_iterators:
+        iterators.extend(stmt.hoisted_iterators)
+
+    return iterators

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -591,16 +591,17 @@ def update_scope(
     ctx.path_scope = ctx.path_scope.new_child()
     ctx.path_scope.update({p.path_id: stmt for p in scope_tree.path_children})
 
-    iter_path_id = None
-    if (isinstance(ir_set.expr, irast.Stmt) and
-            ir_set.expr.iterator_stmt is not None):
-        iter_path_id = ir_set.expr.iterator_stmt.path_id
+    if isinstance(ir_set.expr, irast.Stmt):
+        iterators = irutils.get_iterator_sets(ir_set.expr)
+        iter_paths = {it.path_id for it in iterators}
+    else:
+        iter_paths = set()
 
     for child_path in scope_tree.get_all_paths():
         parent_scope = scope_tree.parent
         if ((parent_scope is None or
                 not parent_scope.is_visible(child_path)) and
-                child_path != iter_path_id):
+                child_path not in iter_paths):
             stmt.path_id_mask.add(child_path)
 
 

--- a/edb/pgsql/compiler/shapecomp.py
+++ b/edb/pgsql/compiler/shapecomp.py
@@ -45,8 +45,8 @@ def compile_shape(
     with ctx.newscope() as shapectx:
         shapectx.disable_semi_join.add(ir_set.path_id)
 
-        if (isinstance(ir_set.expr, irast.Stmt) and
-                ir_set.expr.iterator_stmt is not None):
+        if isinstance(ir_set.expr, irast.Stmt):
+            iterators = irutils.get_iterator_sets(ir_set.expr)
             # The source set for this shape is a FOR statement,
             # which is special in that besides set path_id it
             # should also expose the path_id of the FOR iterator
@@ -60,8 +60,9 @@ def compile_shape(
             #
             # the path scope when processing the shape of Bar.foo
             # should be {'Bar.foo', 'x'}.
-            iter_path_id = ir_set.expr.iterator_stmt.path_id
-            shapectx.path_scope[iter_path_id] = ctx.rel
+            if iterators:
+                for iterator in iterators:
+                    shapectx.path_scope[iterator.path_id] = ctx.rel
 
         for el in shape:
             rptr = el.rptr

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import typing
 
 from edb.ir import ast as irast
+from edb.ir import utils as irutils
 
 from edb.pgsql import ast as pgast
 
@@ -49,11 +50,11 @@ def compile_SelectStmt(
 
         query = ctx.stmt
 
-        iterator_set = stmt.iterator_stmt
-        if (iterator_set is not None and
-                not isinstance(stmt.result.expr, irast.MutatingStmt)):
-            # Process FOR clause.
-            clauses.compile_iterator_expr(query, iterator_set, ctx=ctx)
+        if not isinstance(stmt.result.expr, irast.MutatingStmt):
+            iterators = irutils.get_iterator_sets(stmt)
+            for iterator_set in iterators:
+                # Process FOR clause.
+                clauses.compile_iterator_expr(query, iterator_set, ctx=ctx)
 
         # Process the result expression;
         outvar = clauses.compile_output(stmt.result, ctx=ctx)

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2151,24 +2151,6 @@ class TestExpressions(tb.QueryTestCase):
                 };
             """)
 
-    @unittest.expectedFailure
-    async def test_edgeql_expr_paths_07(self):
-        # `Issue.number` in FILTER is illegal because it shares a
-        # prefix `Issue` with `Issue.owner` which is defined in an
-        # outer scope.
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r"'Issue.number' changes the interpretation of 'Issue'"):
-            await self.con.execute(r"""
-                WITH MODULE test
-                FOR x IN {'Elvis', 'Yury'}
-                UNION (
-                    SELECT Issue.owner
-                    FILTER Issue.owner.name = x
-                )
-                FILTER Issue.number > '2';
-            """)
-
     async def test_edgeql_expr_paths_08(self):
         # `Issue.number` in FILTER is illegal because it shares a
         # prefix `Issue` with `Issue.owner` which is defined in an
@@ -4267,19 +4249,17 @@ class TestExpressions(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 FOR x IN {1, 3, 5, 7}
-                UNION x
-                ORDER BY x;
+                UNION x;
             """,
-            [1, 3, 5, 7],
+            {1, 3, 5, 7},
         )
 
         await self.assert_query_result(
             r"""
                 FOR x IN {1, 3, 5, 7}
-                UNION x + 1
-                ORDER BY x;
+                UNION x + 1;
             """,
-            [2, 4, 6, 8],
+            {2, 4, 6, 8},
         )
 
     async def test_edgeql_expr_for_02(self):

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -639,7 +639,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         SELECT User {
             select_deck := (
                 FOR letter IN {'I', 'B'}
-                UNION foo := (
+                UNION (
                     SELECT User.deck {
                         name,
                         @letter := letter
@@ -653,17 +653,14 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(__derived__::__derived__|foo@@w~2)": {
-                    "FENCE": {
-                        "(test::User).>deck[IS test::Card]",
-                        "FENCE": {
-                            "(test::User).>deck[IS test::Card]\
-.>name[IS std::str]"
-                        }
-                    }
-                },
                 "(__derived__::__derived__|letter@@w~1)",
-                "(test::User).>select_deck[IS test::Card]"
+                "(test::User).>select_deck[IS test::Card]",
+                "FENCE": {
+                    "(test::User).>deck[IS test::Card]",
+                    "FENCE": {
+                        "(test::User).>deck[IS test::Card].>name[IS std::str]"
+                    }
+                }
             },
             "FENCE": {
                 "(test::User).>name[IS std::str]"

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -4857,39 +4857,22 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             }]
         )
 
-    async def test_edgeql_select_for_01(self):
-        await self.assert_query_result(
-            r'''
-            WITH MODULE test
-            FOR x IN {1, 4}
-            UNION Issue {
-                name
-            }
-            FILTER
-                Issue.number = <str>x
-            ORDER BY
-                Issue.number;
-            ''',
-            [
-                {'name': 'Release EdgeDB'},
-                {'name': 'Regression.'},
-            ]
-        )
-
     async def test_edgeql_select_for_02(self):
         await self.assert_query_result(
             r'''
             WITH MODULE test
-            FOR x IN {1, 3, 4}
-            UNION I := (
-                SELECT Issue {
-                    name,
-                    number,
-                }
-                FILTER
-                    Issue.number > <str>x
-                ORDER BY
-                    Issue.number
+            SELECT I := (
+                FOR x IN {1, 3, 4}
+                UNION (
+                    SELECT Issue {
+                        name,
+                        number,
+                    }
+                    FILTER
+                        Issue.number > <str>x
+                    ORDER BY
+                        Issue.number
+                )
             )
             ORDER BY I.number;
             ''',


### PR DESCRIPTION
Currently, the `FOR` statement accepts the `FILTER`, `ORDER BY`,
`OFFSET` and `LIMIT` clauses that apply to the *result* of the `UNION`. In
essense, `FOR x IN <expr> UNION <expr> FILTER <flt>` is equivalent to
`SELECT <implicit_alias> := (FOR x IN <expr> UNION <expr>) FILTER <flt>`

The problem is that the above transformation is arguably not intuitive, 
since it is possible to *also* assume that the `FILTER` clause etc. apply
to the expression in the `UNION` clause.  The current implementation is
also incorrect, since it doesn't hide the iterator variable from the
followup clauses, and doing that would also be an exception from all other
statements.

For those reasons, remove the clause sugar support from the `FOR` statement
until we figure out an intuitive way of reintroducing them.