### PR TITLE
Fix dropping of subrefs in inherited objects

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1218,19 +1218,11 @@ class DeleteObject(ObjectCommand):
 
         self._validate_legal_command(schema, context)
 
-        if not context.canonical and self._is_top_deletion(schema, context):
+        if not context.canonical:
             self._canonicalize(schema, context, scls)
             ordering.linearize_delta(self, schema, schema)
 
         return schema
-
-    def _is_top_deletion(self, schema, context):
-        for ctx in context.stack:
-            if isinstance(ctx.op, DeleteObject):
-                del_op = ctx.op
-                break
-
-        return del_op is self
 
     def _canonicalize(self, schema, context, scls):
         mcls = self.get_schema_metaclass()

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2901,6 +2901,21 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             }
         ])
 
+    async def test_edgeql_ddl_drop_inherited_link(self):
+        await self.con.execute(r"""
+            CREATE TYPE test::Target;
+            CREATE TYPE test::Parent {
+                CREATE LINK dil_foo -> test::Target;
+            };
+
+            CREATE TYPE test::Child EXTENDING test::Parent;
+            CREATE TYPE test::GrandChild EXTENDING test::Child;
+       """)
+
+        await self.con.execute("""
+            ALTER TYPE test::Parent DROP LINK dil_foo;
+        """)
+
     async def test_edgeql_ddl_tuple_properties(self):
         await self.con.execute(r"""
             CREATE TYPE test::TupProp01 {


### PR DESCRIPTION
When a ref is being dropped from an ancestor type, make sure the
ref deletion propagation in descendants cleans up their own refs.  This
is actually happening by default, but there was a no-longer-necessary
kludge that prevented this from happening properly.