### PR TITLE
tests: Add a test of self-incrementing property.

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -163,6 +163,13 @@ def _process_view(
             if not ptrcls.get_default(ctx.env.schema):
                 if ptrcls.get_required(ctx.env.schema):
                     if ptrcls.is_property(ctx.env.schema):
+                        # If the target is a sequence, there's no need
+                        # for an explicit value.
+                        if ptrcls.get_target(ctx.env.schema).issubclass(
+                                ctx.env.schema,
+                                ctx.env.schema.get('std::sequence')):
+                            continue
+
                         what = 'property'
                     else:
                         what = 'link'

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -113,6 +113,18 @@ type DefaultTest7 {
     }
 }
 
+# self incrementing integer sequence
+scalar type int_seq8_t extending sequence;
+
+type DefaultTest8 {
+    required property number -> int_seq8_t {
+        # The number values are automatically
+        # generated, and are not supposed to be
+        # directly writable.
+        readonly := true;
+    }
+}
+
 # types to test some inheritance issues
 type InputValue {
     property val -> str;

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1024,6 +1024,24 @@ class TestInsert(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_insert_default_05(self):
+        # Issue #730
+        await self.con.execute(r'''
+            # The 'number' property is supposed to be
+            # self-incrementing and read-only.
+            INSERT test::DefaultTest8;
+            INSERT test::DefaultTest8;
+            INSERT test::DefaultTest8;
+        ''')
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT DefaultTest8.number;
+            ''',
+            {1, 2, 3}
+        )
+
     @unittest.expectedFailure
     async def test_edgeql_insert_as_expr_01(self):
         await self.con.execute(r'''


### PR DESCRIPTION
It should be legal to omit a required self-incrementing property when
inserting a new object.

Issue: #730