### PR TITLE
Fix handling of arg defaults in functions without named params

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -356,7 +356,7 @@ class ConstraintCommand(
                 params = self.scls.get_params(schema)
             anchors, _ = (
                 qlcompiler.get_param_anchors_for_callable(
-                    params, schema)
+                    params, schema, inlined_defaults=False)
             )
             referrer_ctx = self.get_referrer_context(context)
             if referrer_ctx is not None:

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -1212,13 +1212,6 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                     $$;
             ''')
 
-    @test.xfail('''
-        We have other examples of function definitions using defaults
-        successfully, but not this innocuous-looking one.
-
-        edgedb.errors.InternalServerError: column "__defaults_mask__"
-        does not exist
-    ''')
     async def test_edgeql_calls_35(self):
         # define a function with positional arguments with defaults
         await self.con.execute('''

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -1617,10 +1617,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             ],
         )
 
-    @test.xfail('''
-        See `test_edgeql_calls_35` and
-        `test_migrations_equivalence_function_01` first.
-    ''')
     async def test_edgeql_migration_function_01(self):
         await self.con.execute("""
             SET MODULE test;
@@ -1656,10 +1652,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             ['hello3'],
         )
 
-    @test.xfail('''
-        See `test_edgeql_calls_35` and
-        `test_migrations_equivalence_function_01` first.
-    ''')
     async def test_edgeql_migration_function_02(self):
         await self.con.execute("""
             SET MODULE test;


### PR DESCRIPTION
An oversight in function compilation code leads to a crash when a
function has defaults in positional arguments and not a single named
argument.