### PR TITLE
When replacing functions in migrations perform deletions first

### DIFF
--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -24,7 +24,9 @@ import collections
 from edb.common import topological
 
 from . import delta as sd
+from . import functions as s_func
 from . import inheriting
+from . import name as sn
 from . import objects as so
 from . import referencing
 
@@ -293,6 +295,13 @@ def _trace_op(op, opstack, depgraph, renames, renames_r, strongrefs,
             # In a delete/create cycle, deletion must obviously
             # happen first.
             deps.add(('delete', op.classname))
+
+            if isinstance(obj, s_func.Function):
+                old_funcs = old_schema.get_functions(
+                    sn.shortname_from_fullname(op.classname),
+                    default=[])
+                for old_func in old_funcs:
+                    deps.add(('delete', old_func.get_name(old_schema)))
 
         if tag == 'alter':
             # Alteration must happen after creation, if any.

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -1687,10 +1687,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             ['hello3'],
         )
 
-    @test.xfail('''
-        See `test_edgeql_calls_35` and
-        `test_migrations_equivalence_function_01` first.
-    ''')
     async def test_edgeql_migration_function_03(self):
         await self.con.execute("""
             SET MODULE test;


### PR DESCRIPTION
When a function is replaced in a migration with a function of the same
name, but different signature, make sure the old function is dropped
before the new function is created, otherwise the polymorphic checker
might not be happy.