### PR TITLE
Use Expression for representation of func argument defaults

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -483,11 +483,16 @@ class FunctionCommand:
                 f'of function {func.get_shortname(schema)}',
                 context=self.source_context) from None
 
-    def compile_default(self, func: s_funcs.Function, default: str, schema):
+    def compile_default(self, func: s_funcs.Function,
+                        default: s_expr.Expression, schema):
         try:
-            ir = ql_compiler.compile_fragment_to_ir(
-                default, schema, location='parameter-default')
+            comp = s_expr.Expression.compiled(
+                default,
+                schema=schema,
+                as_fragment=True,
+            )
 
+            ir = comp.irast
             if not irutils.is_const(ir.expr):
                 raise ValueError('expression not constant')
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1450,15 +1450,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             # empty schema
         """])
 
-    @test.xfail('''
-        Fails on `_assert_migration_consistency` step:
-
-        ...
-        File "/home/victor/dev/magicstack/edgedb/edb/schema/functions.py",
-            line 908, in _apply_fields_ast default=default.qlast if
-            default is not None else None,
-        AttributeError: 'str' object has no attribute 'qlast'
-    ''')
     def test_migrations_equivalence_function_01(self):
         self._assert_migration_equivalence([r"""
             function hello01(a: int64) -> str


### PR DESCRIPTION
Function argument defaults are currently represented as EdgeQL strings,
which is incosistent with other schema fields that house expressions.
An `Expression` should be used instead.