### PR TITLE
Fix alteration of property type with inheritance

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2908,18 +2908,6 @@ class AlterProperty(
                         column_name=ptr_stor_info.column_name,
                         null=not prop.get_required(schema)))
 
-            new_type = None
-            for op in self.get_subcommands(type=sd.AlterObjectProperty):
-                if (op.property == 'target' and
-                        not prop.is_endpoint_pointer(schema)):
-                    new_type = op.new_value.name \
-                        if op.new_value is not None else None
-                    break
-
-            if new_type:
-                self.alter_host_table_column(
-                    prop, schema, orig_schema, context)
-
             self.alter_pointer_default(prop, schema, context)
 
             if not prop.generic(schema):

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -288,14 +288,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        edgedb.errors.InternalServerError: cannot alter inherited
-        column "foo"
-
-        Oddly enough, when prop was changing from str to int64, the
-        error was about casting. And the pure schema migration test
-        works just fine either way see (`test_migrations_equivalence_06`).
-    ''')
     async def test_edgeql_migration_06(self):
         await self.con.execute("""
             SET MODULE test;


### PR DESCRIPTION
An unnecessary cludge was breaking the alteration of the type of
properties with inheritance descendants.