### PR TITLE
Fix an issue with incorrect deltas for functions.

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -338,6 +338,18 @@ def trace_View(
 
 
 @trace_dependencies.register
+def trace_Function(node: qlast.CreateFunction, *, ctx: DepTraceContext):
+    # Functions are defined by their name + call signature, so we need
+    # to add that to the "extra_name".
+    params = f'({qlcodegen.generate_source(node.params)})'
+    m = hashlib.sha1()
+    m.update(params.encode())
+    extra_name = m.hexdigest()
+
+    _register_item(node, ctx=ctx, extra_name=extra_name)
+
+
+@trace_dependencies.register
 def trace_default(node: qlast.CreateObject, *, ctx: DepTraceContext):
     # Generic DDL catchall
     _register_item(node, ctx=ctx)

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -2624,12 +2624,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 r"""SELECT hello11(1);"""
             )
 
-    @test.xfail('''
-        edgedb.errors.QueryError: could not find a function variant hello12
-
-        After the migration only one version of the function exists,
-        instead of two.
-    ''')
     async def test_edgeql_migration_function_12(self):
         await self.con.execute("""
             SET MODULE test;
@@ -2670,12 +2664,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             ['hello1'],
         )
 
-    @test.xfail('''
-        edgedb.errors.QueryError: could not find a function variant hello13
-
-        The first migration ostensibly succeeds, but there's only one
-        version of the function instead of two.
-    ''')
     async def test_edgeql_migration_function_13(self):
         # this is the inverse of test_edgeql_migration_function_12
         await self.con.execute("""
@@ -2721,7 +2709,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 edgedb.QueryError,
                 r'could not find a function variant hello13'):
             await self.con.execute(
-                r"""SELECT hello11(' world');"""
+                r"""SELECT hello13(' world');"""
             )
 
     async def test_edgeql_migration_linkprops_01(self):


### PR DESCRIPTION
Functions are defined by their name and their call signatures. Both need
to be taken into account when producing a delta from SDL, otherwise
polymorphic functions end up with only one version.

Fixes #746.