### PR TITLE
Prevent incorrect inheritance of non-inheritable annotations

### DIFF
--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -234,19 +234,15 @@ class CreateAnnotationValue(AnnotationValueCommand,
         assert attrsubj, "Annotation commands must be run in " + \
                          "AnnotationSubject context"
 
-        with context(AnnotationValueCommandContext(schema, self, None)):
-            name = sn.shortname_from_fullname(self.classname)
-            attrs = attrsubj.scls.get_annotations(schema)
-            annotation = attrs.get(schema, name, None)
-            if annotation is None:
-                schema, annotation = super().apply(schema, context)
-                schema = self.add_annotation(
-                    schema, annotation, attrsubj.scls)
-            else:
-                schema, annotation = sd.AlterObject.apply(
-                    self, schema, context)
+        name = sn.shortname_from_fullname(self.classname)
+        attrs = attrsubj.scls.get_annotations(schema)
+        annotation = attrs.get(schema, name, None)
+        if annotation is None:
+            schema, annotation = super().apply(schema, context)
+        else:
+            schema, annotation = sd.AlterObject.apply(self, schema, context)
 
-            return schema, annotation
+        return schema, annotation
 
 
 class AlterAnnotationValue(AnnotationValueCommand, sd.AlterObject):

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -258,7 +258,8 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase):
 
         schema = referrer.add_classref(schema, refdict.attr, self.scls)
 
-        if isinstance(referrer, inheriting.InheritingObject):
+        if (not self.scls.get_is_final(schema)
+                and isinstance(referrer, inheriting.InheritingObject)):
             if not context.canonical:
                 # Propagate the creation of a new ref to descendants.
                 alter_cmd = sd.ObjectCommandMeta.get_command_class_or_die(


### PR DESCRIPTION
When propagating annotations down the inheritance chain, make sure
the annotation is actually inheritable, otherwise the schema will
end up with a partially-inherited annotation in a descendant object.
This really isn't specific to annotations, it's just that only the
annotations may be declared as non-inheritable currently.

Fixes: #755