### PR TITLE
Index

### DIFF
--- a/docs/datamodel/annotations.rst
+++ b/docs/datamodel/annotations.rst
@@ -19,6 +19,9 @@ The following are the annotations which can be set on any schema item:
 - ``title``
 - ``description``
 
+There's also a special ``schema::system`` annotation that should never
+be altered directly by the user, but can be useful in introspection.
+
 For example, consider the following declaration:
 
 .. code-block:: sdl

--- a/docs/datamodel/indexes.rst
+++ b/docs/datamodel/indexes.rst
@@ -58,6 +58,18 @@ The index expression must not reference any variables other than the
 properties of the index *subject*.  All functions used in the
 expression must not be set-returning.
 
+Typically the explicit ``__subject__`` can be omitted in favor of a
+short-form expression, since the index always appears nested inside
+its *subject*:
+
+.. code-block:: sdl
+
+    type User {
+        property name -> str;
+        index on (.name);
+    }
+
+
 .. note::
 
     While being beneficial to the speed of queries, indexes increase

--- a/docs/edgeql/ddl/indexes.rst
+++ b/docs/edgeql/ddl/indexes.rst
@@ -19,7 +19,12 @@ type or link.
 
 .. eql:synopsis::
 
-    CREATE INDEX ON ( <index-expr> );
+    CREATE INDEX ON ( <index-expr> )
+    [ "{" <subcommand>; [...] "}" ] ;
+
+    # where <subcommand> is one of
+
+      SET ANNOTATION <annotation-name> := <value>
 
 
 Description
@@ -36,20 +41,90 @@ Parameters
     The specific expression for which the index is made.  Note also
     that ``<index-expr>`` itself has to be parenthesized.
 
+The only subcommand that is allowed in the ``CREATE INDEX`` block:
+
+:eql:synopsis:`SET ANNOTATION <annotation-name> := <value>`
+    Set object type :eql:synopsis:`<annotation-name>` to
+    :eql:synopsis:`<value>`.
+
+    See :eql:stmt:`SET ANNOTATION` for details.
+
 
 Example
 -------
 
-Create an object type ``User`` with an indexed ``title`` property:
+Create an object type ``User`` with an indexed ``name`` property:
 
 .. code-block:: edgeql
 
     CREATE TYPE User {
-        CREATE PROPERTY title -> str {
+        CREATE PROPERTY name -> str {
             SET default := '';
         };
 
-        CREATE INDEX ON (.title);
+        CREATE INDEX ON (.name);
+    };
+
+
+ALTER INDEX
+===========
+
+:eql-statement:
+
+
+Alter the definition of an :ref:`index <ref_eql_sdl_indexes>`.
+
+.. eql:synopsis::
+
+    ALTER INDEX ON ( <index-expr> )
+    [ "{" <subcommand>; [...] "}" ] ;
+
+    # where <subcommand> is one of
+
+      SET ANNOTATION <annotation-name> := <value>
+      DROP ANNOTATION <annotation-name>
+
+
+Description
+-----------
+
+``ALTER INDEX`` is used to change the :ref:`annotations
+<ref_datamodel_annotations>` of an index. The *index-expr* is used to
+identify the index to be altered.
+
+
+Parameters
+----------
+
+:sdl:synopsis:`ON ( <index-expr> )`
+    The specific expression for which the index is made.  Note also
+    that ``<index-expr>`` itself has to be parenthesized.
+
+The following subcommands are allowed in the ``ALTER INDEX`` block:
+
+:eql:synopsis:`SET ANNOTATION <annotation-name> := <value>`
+    Set object type :eql:synopsis:`<annotation-name>` to
+    :eql:synopsis:`<value>`.
+
+    See :eql:stmt:`SET ANNOTATION` for details.
+
+:eql:synopsis:`DROP ANNOTATION <annotation-name>;`
+    Remove constraint :eql:synopsis:`<annotation-name>`.
+    See :eql:stmt:`DROP ANNOTATION <DROP ANNOTATION>` for details.
+
+
+Example
+-------
+
+Add an annotation to the index on the ``name`` property of object type
+``User``:
+
+.. code-block:: edgeql
+
+    ALTER TYPE User {
+        ALTER INDEX ON (.name) {
+            SET ANNOTATION title := "User name index";
+        };
     };
 
 
@@ -79,10 +154,10 @@ DDL statement.
 Example
 -------
 
-Drop the ``title`` index from the ``User`` object type:
+Drop the ``name`` index from the ``User`` object type:
 
 .. code-block:: edgeql
 
     ALTER TYPE User {
-        DROP INDEX ON (.title);
+        DROP INDEX ON (.name);
     };

--- a/docs/edgeql/sdl/indexes.rst
+++ b/docs/edgeql/sdl/indexes.rst
@@ -22,7 +22,9 @@ Declare an index for a "User" based on the "name" property:
         multi link friends -> User;
 
         # define an index for User based on name
-        index on (__subject__.name);
+        index on (.name) {
+            annotation title := 'User name index';
+        }
     }
 
 
@@ -34,7 +36,8 @@ commands <ref_eql_ddl_indexes>`.
 
 .. sdl:synopsis::
 
-    index on ( <index-expr> ) ;
+    index on ( <index-expr> )
+    [ "{" <annotation-declarations> "}" ] ;
 
 
 Description

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -802,6 +802,10 @@ class CreateIndex(CreateObject, IndexOp):
     pass
 
 
+class AlterIndex(CreateObject, IndexOp):
+    pass
+
+
 class DropIndex(DropObject, IndexOp):
     pass
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -737,14 +737,15 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self.write('}')
 
     def _visit_AlterObject(self, node, *object_keywords, allow_short=True,
-                           after_name=None, unqualified=False):
+                           after_name=None, unqualified=False, named=True):
         self._visit_aliases(node)
         self.write('ALTER', *object_keywords, delimiter=' ')
-        self.write(' ')
-        if unqualified:
-            self.write(ident_to_str(node.name.name))
-        else:
-            self.visit(node.name)
+        if named:
+            self.write(' ')
+            if unqualified:
+                self.write(ident_to_str(node.name.name))
+            else:
+                self.visit(node.name)
         if after_name:
             after_name()
         if node.commands:
@@ -1138,15 +1139,26 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_CreateIndex(self, node):
         def after_name():
-            self.write(' ON (')
+            self._write_keywords(' ON ')
+            self.write('(')
             self.visit(node.expr)
             self.write(')')
         self._visit_CreateObject(
             node, 'INDEX', after_name=after_name, named=False)
 
+    def visit_AlterIndex(self, node):
+        def after_name():
+            self._write_keywords(' ON ')
+            self.write('(')
+            self.visit(node.expr)
+            self.write(')')
+        self._visit_AlterObject(
+            node, 'INDEX', after_name=after_name, named=False)
+
     def visit_DropIndex(self, node):
         def after_name():
-            self.write(' ON (')
+            self._write_keywords(' ON ')
+            self.write('(')
             self.visit(node.expr)
             self.write(')')
         self._visit_DropObject(

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -200,12 +200,6 @@ class InnerDDLStmt(Nonterm):
     def reduce_DropCastStmt(self, *kids):
         self.val = kids[0].val
 
-    def reduce_CreateIndexStmt(self, *kids):
-        self.val = kids[0].val
-
-    def reduce_DropIndexStmt(self, *kids):
-        self.val = kids[0].val
-
 
 class InnerDDLStmtBlock(ListNonterm, element=InnerDDLStmt,
                         separator=Semicolons):
@@ -878,14 +872,39 @@ class DropAnnotationStmt(Nonterm):
         )
 
 
+commands_block(
+    'CreateIndex',
+    SetAnnotationValueStmt)
+
+
+commands_block(
+    'AlterIndex',
+    SetAnnotationValueStmt,
+    DropAnnotationValueStmt,
+    opt=False)
+
+
 #
 # CREATE INDEX
 #
 class CreateIndexStmt(Nonterm):
-    def reduce_CREATE_INDEX_OnExpr(self, *kids):
+    def reduce_CREATE_INDEX_OnExpr_OptCreateIndexCommandsBlock(self, *kids):
         self.val = qlast.CreateIndex(
             name=qlast.ObjectRef(name='idx'),
             expr=kids[2].val,
+            commands=kids[3].val,
+        )
+
+
+#
+# ALTER INDEX
+#
+class AlterIndexStmt(Nonterm):
+    def reduce_ALTER_INDEX_OnExpr_AlterIndexCommandsBlock(self, *kids):
+        self.val = qlast.AlterIndex(
+            name=qlast.ObjectRef(name='idx'),
+            expr=kids[2].val,
+            commands=kids[3].val,
         )
 
 
@@ -1124,6 +1143,7 @@ commands_block(
     AlterConcretePropertyStmt,
     DropConcretePropertyStmt,
     CreateIndexStmt,
+    AlterIndexStmt,
     DropIndexStmt,
     opt=False
 )
@@ -1269,7 +1289,8 @@ commands_block(
     AlterConcretePropertyStmt,
     CreateConcreteLinkStmt,
     AlterConcreteLinkStmt,
-    CreateIndexStmt
+    CreateIndexStmt,
+    AlterIndexStmt,
 )
 
 
@@ -1317,6 +1338,7 @@ commands_block(
     AlterConcreteLinkStmt,
     DropConcreteLinkStmt,
     CreateIndexStmt,
+    AlterIndexStmt,
     DropIndexStmt,
     opt=False
 )

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -116,9 +116,6 @@ class SDLShortStatement(Nonterm):
     def reduce_FunctionDeclarationShort(self, *kids):
         self.val = kids[0].val
 
-    def reduce_IndexDeclaration(self, *kids):
-        self.val = kids[0].val
-
 
 class DotName(Nonterm):
     def reduce_ModuleName(self, *kids):
@@ -473,7 +470,21 @@ class AnnotationDeclarationShort(Nonterm):
 #
 # Indexes
 #
-class IndexDeclaration(Nonterm):
+sdl_commands_block(
+    'CreateIndex',
+    SetAnnotation)
+
+
+class IndexDeclarationBlock(Nonterm):
+    def reduce_INDEX_OnExpr_CreateIndexSDLCommandsBlock(self, *kids):
+        self.val = qlast.CreateIndex(
+            name=qlast.ObjectRef(name='idx'),
+            expr=kids[1].val,
+            commands=kids[2].val,
+        )
+
+
+class IndexDeclarationShort(Nonterm):
     def reduce_INDEX_OnExpr(self, *kids):
         self.val = qlast.CreateIndex(
             name=qlast.ObjectRef(name='idx'),
@@ -603,7 +614,8 @@ sdl_commands_block(
     ConcreteConstraintShort,
     ConcretePropertyBlock,
     ConcretePropertyShort,
-    IndexDeclaration,
+    IndexDeclarationBlock,
+    IndexDeclarationShort,
 )
 
 
@@ -743,7 +755,8 @@ sdl_commands_block(
     ConcretePropertyShort,
     ConcreteLinkBlock,
     ConcreteLinkShort,
-    IndexDeclaration,
+    IndexDeclarationBlock,
+    IndexDeclarationShort,
 )
 
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -22,6 +22,8 @@
 
 CREATE MODULE schema;
 
+CREATE ABSTRACT ANNOTATION schema::system;
+
 CREATE SCALAR TYPE schema::cardinality_t EXTENDING std::str {
     CREATE CONSTRAINT std::one_of ('ONE', 'MANY');
 };

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -957,6 +957,12 @@ class DeleteAnnotationValue(
     pass
 
 
+class RebaseAnnotationValue(
+        AnnotationValueCommand, RebaseObject,
+        adapts=s_anno.RebaseAnnotationValue):
+    pass
+
+
 class ConstraintCommand(sd.ObjectCommand,
                         metaclass=ReferencedObjectCommandMeta):
     _table = metaschema.get_metaclass_table(s_constr.Constraint)
@@ -1722,11 +1728,7 @@ class RenameIndex(IndexCommand, RenameObject, adapts=s_indexes.RenameIndex):
 
 
 class AlterIndex(IndexCommand, AlterObject, adapts=s_indexes.AlterIndex):
-    def apply(self, schema, context=None):
-        schema, result = s_indexes.AlterIndex.apply(
-            self, schema, context)
-        schema, _ = AlterObject.apply(self, schema, context)
-        return schema, result
+    pass
 
 
 class DeleteIndex(IndexCommand, DeleteObject, adapts=s_indexes.DeleteIndex):

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -252,11 +252,7 @@ class AlterAnnotationValue(AnnotationValueCommand, sd.AlterObject):
 class DeleteAnnotationValue(AnnotationValueCommand, sd.DeleteObject):
     astnode = qlast.DropAnnotationValue
 
-    def apply(self, schema, context):
-        attrsubj = context.get(AnnotationSubjectCommandContext)
-        assert attrsubj, "Annotation commands must be run in " + \
-                         "AnnotationSubject context"
 
-        schema = self.del_annotation(schema, self.classname, attrsubj.scls)
-
-        return super().apply(schema, context)
+class RebaseAnnotationValue(AnnotationValueCommand,
+                            inheriting.RebaseInheritingObject):
+    pass

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -3937,6 +3937,10 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
     @test.xfail('''
         Fails on the last migration that attempts to rename the
         property being indexed.
+
+        This is an example of a general problem that any renaming
+        needs to be done in such a way so that the existing
+        expressions are still valid.
     ''')
     async def test_edgeql_migration_index_01(self):
         await self.con.execute("""

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3559,13 +3559,51 @@ aa';
 
     def test_edgeql_syntax_ddl_index_01(self):
         """
-        CREATE INDEX ON (Foo);
+        CREATE TYPE Foo {
+            CREATE INDEX ON (.title);
 
-        CREATE INDEX ON (.title);
+            CREATE INDEX ON (SELECT __subject__.title);
+        };
+        """
 
-        CREATE INDEX ON (SELECT __subject__.title);
+    def test_edgeql_syntax_ddl_index_02(self):
+        """
+        ALTER TYPE Foo {
+            DROP INDEX ON (.title);
 
-        DROP INDEX ON (.title);
+            CREATE INDEX ON (.title) {
+                SET ANNOTATION system := 'Foo';
+            };
+
+            ALTER INDEX ON (.title)
+                SET ANNOTATION system := 'Foo';
+
+            ALTER INDEX ON (.title)
+                DROP ANNOTATION system;
+        };
+        """
+
+    def test_edgeql_syntax_ddl_index_03(self):
+        """
+        ALTER TYPE Foo {
+            ALTER INDEX ON (.title) {
+                SET ANNOTATION system := 'Foo'
+            };
+
+            ALTER INDEX ON (.title) {
+                DROP ANNOTATION system
+            };
+        };
+
+% OK %
+
+        ALTER TYPE Foo {
+            ALTER INDEX ON (.title)
+                SET ANNOTATION system := 'Foo';
+
+            ALTER INDEX ON (.title)
+                DROP ANNOTATION system;
+        };
         """
 
     def test_edgeql_transaction_01(self):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2149,10 +2149,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             type Derived extending Base;
         """])
 
-    @test.xfail('''
-        The `_assert_migration_consistency` of the final state fails,
-        never getting to the equivalence.
-    ''')
     def test_migrations_equivalence_index_01(self):
         self._assert_migration_equivalence([r"""
             type Base {
@@ -2185,10 +2181,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
-    @test.xfail('''
-        The `_assert_migration_consistency` of the final state fails,
-        never getting to the equivalence.
-    ''')
     def test_migrations_equivalence_index_03(self):
         self._assert_migration_equivalence([r"""
             type Base {
@@ -2208,10 +2200,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
-    @test.xfail('''
-        The `_assert_migration_consistency` of the final state fails,
-        never getting to the equivalence.
-    ''')
     def test_migrations_equivalence_index_04(self):
         self._assert_migration_equivalence([r"""
             type Base {

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -492,6 +492,25 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         };
         """
 
+    def test_eschema_syntax_index_04(self):
+        """
+        type User {
+            property name -> str;
+            index on (.name);
+        };
+        """
+
+    def test_eschema_syntax_index_05(self):
+        """
+        type User {
+            property name -> str;
+
+            index on (.name) {
+                annotation title := 'User name index';
+            };
+        };
+        """
+
     def test_eschema_syntax_ws_01(self):
         """
 type LogEntry extending    OwnedObject,    Text {


### PR DESCRIPTION
Add a new ANNOTATION `schema::system` for storing details used by
EdgeDB. Users should not change this annotation directly.

Record the original INDEX expression text in the `system` annotation for
that index. This way it is possible to use that to display a more
human-friendly expression during introspection as well. It is also used
to identify the INDEX itself in SDL and DDL.

Update the syntax so that index annotations are allowed. Also, disallow
indexes as top-level statements in DDL or SDL. They must be nested
inside a type or a link statement.
Also update the docs.

Fixes: #758