### PR TITLE
edgeql: Store original index expression in a special field.

### DIFF
--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -882,10 +882,11 @@ class DropAnnotationStmt(Nonterm):
 # CREATE INDEX
 #
 class CreateIndexStmt(Nonterm):
-    def reduce_CREATE_INDEX_OnExpr(self, *kids):
+    def reduce_CREATE_INDEX_OnExpr_OptCreateCommandsBlock(self, *kids):
         self.val = qlast.CreateIndex(
             name=qlast.ObjectRef(name='idx'),
             expr=kids[2].val,
+            commands=kids[3].val,
         )
 
 

--- a/edb/pgsql/datasources/schema/indexes.py
+++ b/edb/pgsql/datasources/schema/indexes.py
@@ -34,11 +34,13 @@ async def fetch(
                 i.bases         AS bases,
                 i.name          AS name,
                 i.expr          AS expr,
+                i.origexpr      AS origexpr,
                 i.is_local      AS is_local,
                 i.is_final      AS is_final,
                 i.is_abstract   AS is_abstract,
                 edgedb._resolve_type_name(i.subject)
-                                AS subject_name
+                                AS subject_name,
+                i.inherited_fields  AS inherited_fields
             FROM
                 edgedb.Index i
             WHERE

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1760,6 +1760,12 @@ class DeleteIndex(IndexCommand, DeleteObject, adapts=s_indexes.DeleteIndex):
         return schema, index
 
 
+class RebaseIndex(
+        IndexCommand, RebaseObject,
+        adapts=s_indexes.RebaseIndex):
+    pass
+
+
 class ObjectTypeMetaCommand(ViewCapableObjectMetaCommand,
                             CompositeObjectMetaCommand):
     def get_table(self, schema):

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -603,6 +603,9 @@ class IntrospectionMech:
                 name=index_name,
                 subject=subj,
                 is_local=index_data['is_local'],
+                origexpr=index_data['origexpr'],
+                inherited_fields=self._unpack_inherited_fields(
+                    index_data['inherited_fields']),
                 expr=self.unpack_expr(index_data['expr'], schema))
 
             schema = subj.add_index(schema, index)

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1371,11 +1371,6 @@ class AlterObjectProperty(Command):
             (value is None or
                 (isinstance(value, collections.abc.Container) and not value))
 
-        old_value_empty = \
-            (self.old_value is None or
-                (isinstance(self.old_value, collections.abc.Container) and
-                    not self.old_value))
-
         parent_ctx = context.current()
         parent_op = parent_ctx.op
         field = parent_op.get_schema_metaclass().get_field(self.property)
@@ -1390,7 +1385,7 @@ class AlterObjectProperty(Command):
         if self.source == 'inheritance':
             return
 
-        if new_value_empty and old_value_empty:
+        if new_value_empty:
             return
 
         if isinstance(value, s_expr.Expression):

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -3959,6 +3959,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         This is an example of a general problem that any renaming
         needs to be done in such a way so that the existing
         expressions are still valid.
+
+        See test_migrations_equivalence_index_01 first.
     ''')
     async def test_edgeql_migration_index_01(self):
         await self.con.execute("""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2148,8 +2148,12 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         """])
 
     @test.xfail('''
-        The `_assert_migration_consistency` of the final state fails,
-        never getting to the equivalence.
+        Fails on the last migration that attempts to rename the
+        property being indexed.
+
+        This is an example of a general problem that any renaming
+        needs to be done in such a way so that the existing
+        expressions are still valid.
     ''')
     def test_migrations_equivalence_index_01(self):
         self._assert_migration_equivalence([r"""
@@ -2183,10 +2187,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
-    @test.xfail('''
-        The `_assert_migration_consistency` of the final state fails,
-        never getting to the equivalence.
-    ''')
     def test_migrations_equivalence_index_03(self):
         self._assert_migration_equivalence([r"""
             type Base {
@@ -2206,10 +2206,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
-    @test.xfail('''
-        The `_assert_migration_consistency` of the final state fails,
-        never getting to the equivalence.
-    ''')
     def test_migrations_equivalence_index_04(self):
         self._assert_migration_equivalence([r"""
             type Base {


### PR DESCRIPTION
Record the original INDEX expression text in the "origexpr" field for
that index. This way it is possible to use that to display a more
human-friendly expression during introspection as well. It is also used
to identify the INDEX itself in SDL and DDL.

Fixes: #758