### PR TITLE
edgeql: Fix constraint SDL migrations.

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -435,6 +435,13 @@ def _register_item(
                     if isinstance(sub, qlast.CreateIndex):
                         alter_cmd.expr = sub.expr
                         break
+            # constraints need to preserve their "on" expression
+            elif alter_name == 'AlterConcreteConstraint':
+                # find the original expr, which will be in non-normalized form
+                for sub in op.commands:
+                    if isinstance(sub, qlast.CreateConcreteConstraint):
+                        alter_cmd.subjectexpr = sub.subjectexpr
+                        break
 
             if not ctx.depstack:
                 alter_cmd.aliases = [

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -591,6 +591,11 @@ class CreateConstraint(ConstraintCommand,
         return cmd
 
     def _apply_field_ast(self, schema, context, node, op):
+        subjectexpr = self.get_attribute_value('subjectexpr')
+        if subjectexpr is not None:
+            # add subjectexpr to the node
+            node.subjectexpr = subjectexpr.qlast
+
         if op.property == 'delegated':
             if isinstance(node, qlast.CreateConcreteConstraint):
                 node.delegated = op.new_value

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1800,11 +1800,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
-    @test.xfail('''
-        edb.errors.InvalidConstraintDefinitionError: std::expression
-        constraint expression expected to return a bool value, got
-        'int64'
-    ''')
     def test_migrations_equivalence_function_10(self):
         self._assert_migration_equivalence([r"""
             function hello10(a: int64) -> str


### PR DESCRIPTION
The case where a constraint has an explicit "on expr" clause is now
handled correctly w.r.t. preserving the `subjectexpr` when producing DDL
from SDL in a migration.