### PR TITLE
Validate that we can trace all the expression AST nodes.

### DIFF
--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -54,6 +54,8 @@ class MetaAST(type):
     def __new__(mcls, name, bases, dct):
         cls = super().__new__(mcls, name, bases, dct)
 
+        cls.__abstract_node__ = bool(dct.get('__abstract_node__'))
+
         if '__annotations__' not in dct:
             return cls
 
@@ -184,6 +186,11 @@ class AST(object, metaclass=MetaAST):
     __ast_frozen_fields__ = frozenset()
 
     def __init__(self, **kwargs):
+        if type(self).__abstract_node__:
+            raise ASTError(
+                f'cannot instantiate abstract AST node '
+                f'{self.__class__.__name__!r}')
+
         object.__setattr__(self, 'parent', None)
         self._init_fields(kwargs)
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -312,20 +312,6 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         if parenthesise:
             self.write(')')
 
-    def visit_GroupExpr(self, node):
-        # GROUP expression is always parenthesised
-        self.write('(')
-        self._block_ws(1)
-        self.write('GROUP ')
-        if node.subject_alias:
-            self.write(node.subject_alias, ' := ')
-        self.visit(node.subject)
-        self.write(' BY ')
-        self._block_ws(1)
-        self.visit_list(node.by)
-        self._block_ws(-2)
-        self.write(')')
-
     def visit_ByExpr(self, node):
         if node.each is not None:
             if node.each:

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -45,7 +45,7 @@ def append_module_aliases(tree, aliases):
 def parse(expr, module_aliases=None):
     tree = parse_fragment(expr)
 
-    if not isinstance(tree, qlast.Statement):
+    if not isinstance(tree, qlast.Command):
         tree = qlast.SelectQuery(result=tree)
 
     if module_aliases:

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -218,7 +218,7 @@ def imprint_expr_context(qltree, modaliases):
         # Leave constants alone.
         return qltree
 
-    if not isinstance(qltree, qlast.Statement):
+    if not isinstance(qltree, qlast.Command):
         qltree = qlast.SelectQuery(result=qltree, implicit=True)
     else:
         qltree = copy.copy(qltree)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -751,6 +751,46 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_get_migration_04(self):
+        # validate that we can trace DETACHED
+        schema = r'''
+            type Foo {
+                property bar -> int64;
+            };
+
+            view X := (SELECT Foo FILTER .bar > count(DETACHED Foo));
+        '''
+
+        self._assert_migration_consistency(schema)
+
+    def test_get_migration_05(self):
+        # validate that we can trace INTROSPECT
+        schema = r'''
+            type Foo;
+
+            view X := (SELECT INTROSPECT Foo);
+        '''
+
+        self._assert_migration_consistency(schema)
+
+    def test_get_migration_06(self):
+        # validate that we can trace DELETE
+        schema = r'''
+            type Bar {
+                property data -> str;
+            }
+
+            type Foo {
+                required property bar -> str {
+                    # if bar is not specified, grab it from Bar and
+                    # delete the object
+                    default := (DELETE Bar LIMIT 1).data
+                }
+            };
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_migrations_equivalence_01(self):
         self._assert_migration_equivalence([r"""
             type Base;

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,0 +1,44 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import inspect
+import unittest
+
+from edb.edgeql import ast as qlast
+from edb.edgeql import tracer
+
+
+class TestTracer(unittest.TestCase):
+
+    def test_tracer(self):
+        not_implemented = tracer.trace.registry[object]
+
+        for name, astcls in inspect.getmembers(qlast, inspect.isclass):
+            if (issubclass(astcls, qlast.Expr)
+                    # ignore these abstract AST nodes
+                    and not astcls.__abstract_node__
+                    # ignore special internal class
+                    and astcls is not qlast._Optional
+                    # ignore query parameters
+                    and not issubclass(astcls, qlast.Parameter)
+                    # ignore all config operations
+                    and not issubclass(astcls, qlast.ConfigOp)):
+
+                if tracer.trace.dispatch(astcls) is not_implemented:
+                    self.fail(f'trace for {name} is not implemented')

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -164,7 +164,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 12.73)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 15.76)
 
     def test_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 56.96)


### PR DESCRIPTION
Edgeql AST nodes now have a `__abstract_node__` field which marks nodes
that should never be instantiated.

Refactor EdgeQL AST nodes hierarchy so that things that aren't valid expressions
no longer inherit from Expr. Introduce a base class `Command` from which
all EdgeQL commands inherit. `Statement` is a `Command` that is also valid
expression (i.e. EdgeQL query). Clean up a few unused AST nodes.

Add a test that checks that all eligible expression AST nodes are
traceable. Add tracing for several missing AST nodes.

Add return type annotations to tracer.py and adjust the coverage
percentage.