### PR TITLE
Use typing.Any instead of "object"

### DIFF
--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -393,6 +393,9 @@ def _check_annotation(f_type, f_fullname, f_default):
                 f'{f_type!r} is not supported')
 
     elif f_type is not None:
+        if f_type is typing.Any:
+            f_type = object
+
         if not isinstance(f_type, type):
             raise RuntimeError(
                 f'invalid type annotation on {f_fullname}: '
@@ -488,6 +491,6 @@ def _check_type(type_, value, raise_error):
         elif ot is not None:
             raise TypeError(f'unsupported typing type: {type_!r}')
 
-    else:
+    elif type_ is not typing.Any:
         if value is not None and not isinstance(value, type_):
             raise_error(type_.__name__, value)

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -207,7 +207,7 @@ class BaseConstant(Expr):
     value: str
 
     @classmethod
-    def from_python(cls, val: object) -> 'BaseConstant':
+    def from_python(cls, val: typing.Any) -> 'BaseConstant':
         if isinstance(val, str):
             return StringConstant.from_python(val)
         elif isinstance(val, bool):
@@ -599,7 +599,7 @@ class Delta:
 class CreateDelta(CreateObject, Delta):
     parents: typing.List[ObjectRef]
     language: str
-    target: object
+    target: typing.Any
 
 
 class GetDelta(ObjectDDL, Delta):
@@ -820,7 +820,7 @@ class SetField(BaseSetField):
 
 
 class SetSpecialField(BaseSetField):
-    value: object
+    value: typing.Any
 
 
 class CreateAnnotationValue(CreateObject):

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -75,27 +75,27 @@ class GraphQLTranslatorContext:
 
 
 class Step(typing.NamedTuple):
-    name: object
-    type: object
+    name: typing.Any
+    type: typing.Any
     eql_alias: str
 
 
 class Field(typing.NamedTuple):
-    name: object
-    value: object
+    name: typing.Any
+    value: typing.Any
 
 
 class Var(typing.NamedTuple):
-    val: object
+    val: typing.Any
     defn: gql_ast.VariableDefinition
     critical: bool
 
 
 class Operation(typing.NamedTuple):
-    name: object
-    stmt: object
-    critvars: object
-    vars: object
+    name: typing.Any
+    stmt: typing.Any
+    critvars: typing.Any
+    vars: typing.Any
 
 
 class TranspiledOperation(typing.NamedTuple):
@@ -1445,7 +1445,7 @@ class GraphQLTranslator:
             return results
 
 
-def value_node_from_pyvalue(val: object):
+def value_node_from_pyvalue(val: typing.Any):
     if isinstance(val, str):
         val = val.replace('\\', '\\\\')
         value = eql_quote.quote_literal(val)

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -312,7 +312,7 @@ class ConstExpr(Expr):
 
 class BaseConstant(ConstExpr):
 
-    value: object
+    value: typing.Any
 
     def __init__(self, *args, typeref, **kwargs):
         super().__init__(*args, typeref=typeref, **kwargs)

--- a/edb/pgsql/dbops/base.py
+++ b/edb/pgsql/dbops/base.py
@@ -36,7 +36,7 @@ from ..common import quote_type as qt
 from ..common import qname as qn
 
 
-def encode_value(val: object) -> str:
+def encode_value(val: typing.Any) -> str:
     """Encode value into an appropriate SQL expression."""
     if hasattr(val, 'to_sql_expr'):
         val = val.to_sql_expr()

--- a/edb/server/buildmeta.py
+++ b/edb/server/buildmeta.py
@@ -114,7 +114,7 @@ class Version(typing.NamedTuple):
         return ver
 
 
-def parse_version(ver: object) -> Version:
+def parse_version(ver: typing.Any) -> Version:
     v = ver._version
     local = []
     if v.pre:

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -206,7 +206,7 @@ def spec_to_json(spec: spec.Spec):
     return json.dumps(dct)
 
 
-def value_to_json_value(setting: spec.Setting, value: object):
+def value_to_json_value(setting: spec.Setting, value: typing.Any):
     if setting.set_of:
         if issubclass(setting.type, types.ConfigType):
             return [v.to_json_value() for v in value]
@@ -219,7 +219,7 @@ def value_to_json_value(setting: spec.Setting, value: object):
             return value
 
 
-def value_from_json_value(setting: spec.Setting, value: object):
+def value_from_json_value(setting: spec.Setting, value: typing.Any):
     if setting.set_of:
         if issubclass(setting.type, types.ConfigType):
             return frozenset(setting.type.from_json_value(v) for v in value)

--- a/edb/server/config/spec.py
+++ b/edb/server/config/spec.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import collections.abc
 import dataclasses
 import json
+import typing
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import codegen as qlcodegen
@@ -37,7 +38,7 @@ class Setting:
 
     name: str
     type: type
-    default: object
+    default: typing.Any
     set_of: bool = False
     system: bool = False
     internal: bool = False

--- a/tests/common/test_ast.py
+++ b/tests/common/test_ast.py
@@ -163,9 +163,9 @@ class ASTBaseTests(unittest.TestCase):
         self.assertEqual(Node().field3, 123)
 
     def test_common_ast_type_anno(self):
-        with self.assertRaisesRegex(RuntimeError, r"Any is not a type"):
+        with self.assertRaisesRegex(RuntimeError, r"1 is not a type"):
             class Node1(ast.AST):
-                field: typing.Any  # We don't want to use/support it.
+                field: 1
 
         with self.assertRaisesRegex(RuntimeError,
                                     r"Mapping.*is not supported"):


### PR DESCRIPTION
Using "object" looks equivalent but it's not.

Saying "object" informs the type checker that only operations which are valid on "object" instances should be considered valid by the type checker.

Using "Any" instead informs the type checker that all operations should be considered valid on those instances.