### PR TITLE
Fix some inconsistencies in ir.ast

### DIFF
--- a/edb/edgeql/compiler/dispatch.py
+++ b/edb/edgeql/compiler/dispatch.py
@@ -19,6 +19,8 @@
 
 from __future__ import annotations
 
+from typing import *  # noqa
+
 import functools
 
 from edb.edgeql import ast as qlast
@@ -28,6 +30,9 @@ from . import context
 
 
 @functools.singledispatch
-def compile(node: qlast.Base, *, ctx: context.ContextLevel) -> irast.Base:
+def compile(
+    node: qlast.Base, *,
+    ctx: context.ContextLevel
+) -> Union[irast.Expr, irast.Set]:
     raise NotImplementedError(
         f'no EdgeQL compiler handler for {node.__class__}')

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -55,7 +55,7 @@ from . import typegen
 
 @dispatch.compile.register(qlast.FunctionCall)
 def compile_FunctionCall(
-        expr: qlast.FunctionCall, *, ctx: context.ContextLevel) -> irast.Base:
+        expr: qlast.FunctionCall, *, ctx: context.ContextLevel) -> irast.Set:
 
     env = ctx.env
 

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -57,7 +57,7 @@ class MissingArg(typing.NamedTuple):
 
 class BoundCall(typing.NamedTuple):
 
-    func: s_func.CallableObject
+    func: s_func.CallableLike
     args: typing.List[BoundArg]
     null_args: typing.Set[str]
     return_type: s_types.Type
@@ -74,7 +74,7 @@ _SINGLETON = ft.TypeModifier.SINGLETON
 
 
 def find_callable(
-        candidates: typing.Iterable[s_func.CallableObject], *,
+        candidates: typing.Iterable[s_func.CallableLike], *,
         args: typing.Sequence[typing.Tuple[s_types.Type, irast.Set]],
         kwargs: typing.Mapping[str, typing.Tuple[s_types.Type, irast.Set]],
         ctx: context.ContextLevel) -> typing.List[BoundCall]:
@@ -136,7 +136,7 @@ def find_callable(
 def try_bind_call_args(
         args: typing.Sequence[typing.Tuple[s_types.Type, irast.Set]],
         kwargs: typing.Mapping[str, typing.Tuple[s_types.Type, irast.Set]],
-        func: s_func.CallableObject, *,
+        func: s_func.CallableLike, *,
         ctx: context.ContextLevel) -> typing.Optional[BoundCall]:
 
     return_type = func.get_return_type(ctx.env.schema)

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -152,7 +152,7 @@ def new_tuple_set(
 
 
 def new_array_set(
-        elements: typing.List[irast.Base], *,
+        elements: typing.Sequence[irast.Base], *,
         ctx: context.ContextLevel,
         srcctx: typing.Optional[parsing.ParserContext]=None) -> irast.Set:
 
@@ -665,7 +665,7 @@ def class_set(
 
 
 def expression_set(
-        expr: irast.Base,
+        expr: irast.Expr,
         path_id: typing.Optional[irast.PathId]=None, *,
         type_override: typing.Optional[s_types.Type]=None,
         ctx: context.ContextLevel) -> irast.Set:
@@ -693,7 +693,7 @@ def expression_set(
 
 
 def scoped_set(
-        expr: irast.Base, *,
+        expr: typing.Union[irast.Set, irast.Expr], *,
         type_override: typing.Optional[s_types.Type]=None,
         typehint: typing.Optional[s_types.Type]=None,
         path_id: typing.Optional[irast.PathId]=None,
@@ -729,7 +729,7 @@ def scoped_set(
 
 
 def ensure_set(
-        expr: irast.Base, *,
+        expr: typing.Union[irast.Set, irast.Expr], *,
         type_override: typing.Optional[s_types.Type]=None,
         typehint: typing.Optional[s_types.Type]=None,
         path_id: typing.Optional[irast.PathId]=None,
@@ -768,7 +768,10 @@ def ensure_set(
     return ir_set
 
 
-def ensure_stmt(expr: irast.Base, *, ctx: context.ContextLevel) -> irast.Stmt:
+def ensure_stmt(
+    expr: typing.Union[irast.Set, irast.Expr], *,
+    ctx: context.ContextLevel
+) -> irast.Stmt:
     if not isinstance(expr, irast.Stmt):
         expr = irast.SelectStmt(
             result=ensure_set(expr, ctx=ctx),

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -50,7 +50,7 @@ from . import stmtctx
 
 @dispatch.compile.register(qlast.SelectQuery)
 def compile_SelectQuery(
-        expr: qlast.SelectQuery, *, ctx: context.ContextLevel) -> irast.Base:
+        expr: qlast.SelectQuery, *, ctx: context.ContextLevel) -> irast.Set:
     if astutils.is_degenerate_select(expr) and ctx.toplevel_stmt is not None:
         # Compile implicit "SELECT Path" as "Path"
         with ctx.new() as sctx:
@@ -103,7 +103,7 @@ def compile_SelectQuery(
 
 @dispatch.compile.register(qlast.ForQuery)
 def compile_ForQuery(
-        qlstmt: qlast.ForQuery, *, ctx: context.ContextLevel) -> irast.Base:
+        qlstmt: qlast.ForQuery, *, ctx: context.ContextLevel) -> irast.Set:
     with ctx.subquery() as sctx:
         stmt = irast.SelectStmt()
         init_stmt(stmt, qlstmt, ctx=sctx, parent_ctx=ctx)
@@ -162,7 +162,7 @@ def compile_ForQuery(
 
 @dispatch.compile.register(qlast.GroupQuery)
 def compile_GroupQuery(
-        expr: qlast.Base, *, ctx: context.ContextLevel) -> irast.Base:
+        expr: qlast.Base, *, ctx: context.ContextLevel) -> irast.Set:
 
     raise errors.UnsupportedFeatureError(
         "'GROUP' statement is not currently implemented",
@@ -226,7 +226,7 @@ def compile_GroupQuery(
 
 @dispatch.compile.register(qlast.InsertQuery)
 def compile_InsertQuery(
-        expr: qlast.InsertQuery, *, ctx: context.ContextLevel) -> irast.Base:
+        expr: qlast.InsertQuery, *, ctx: context.ContextLevel) -> irast.Set:
     with ctx.subquery() as ictx:
         ictx.implicit_id_in_shapes = False
         ictx.implicit_tid_in_shapes = False
@@ -282,7 +282,7 @@ def compile_InsertQuery(
 
 @dispatch.compile.register(qlast.UpdateQuery)
 def compile_UpdateQuery(
-        expr: qlast.UpdateQuery, *, ctx: context.ContextLevel) -> irast.Base:
+        expr: qlast.UpdateQuery, *, ctx: context.ContextLevel) -> irast.Set:
     with ctx.subquery() as ictx:
         ictx.implicit_id_in_shapes = False
         ictx.implicit_tid_in_shapes = False
@@ -334,7 +334,7 @@ def compile_UpdateQuery(
 
 @dispatch.compile.register(qlast.DeleteQuery)
 def compile_DeleteQuery(
-        expr: qlast.DeleteQuery, *, ctx: context.ContextLevel) -> irast.Base:
+        expr: qlast.DeleteQuery, *, ctx: context.ContextLevel) -> irast.Set:
     with ctx.subquery() as ictx:
         ictx.implicit_id_in_shapes = False
         ictx.implicit_tid_in_shapes = False
@@ -409,7 +409,7 @@ def compile_DeleteQuery(
 
 @dispatch.compile.register(qlast.Shape)
 def compile_Shape(
-        shape: qlast.Shape, *, ctx: context.ContextLevel) -> irast.Base:
+        shape: qlast.Shape, *, ctx: context.ContextLevel) -> irast.Set:
     expr = setgen.ensure_set(dispatch.compile(shape.expr, ctx=ctx), ctx=ctx)
     expr_stype = setgen.get_set_type(expr, ctx=ctx)
     view_type = viewgen.process_view(
@@ -449,7 +449,8 @@ def init_stmt(
 
 
 def fini_stmt(
-        irstmt: irast.Base, qlstmt: qlast.Statement, *,
+        irstmt: typing.Union[irast.Stmt, irast.Set],
+        qlstmt: qlast.Statement, *,
         ctx: context.ContextLevel,
         parent_ctx: context.ContextLevel) -> irast.Set:
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -252,9 +252,12 @@ class TypeIndirectionPointer(Pointer):
     optional: bool
 
 
-class TypeIntrospection(ImmutableBase):
+class Expr(Base):
+    pass
 
-    typeref: TypeRef
+
+class ImmutableExpr(Expr, ImmutableBase):
+    pass
 
 
 class Set(Base):
@@ -264,7 +267,7 @@ class Set(Base):
     path_id: PathId
     path_scope_id: typing.Optional[int]
     typeref: TypeRef
-    expr: Base
+    expr: Expr
     rptr: Pointer
     anchor: typing.Union[str, ast.MetaAST]
     show_as_anchor: typing.Union[str, ast.MetaAST]
@@ -301,11 +304,12 @@ class Statement(Command):
                                          typing.Optional[WeakNamespace]]]
 
 
-class Expr(ImmutableBase):
-    pass
+class TypeIntrospection(ImmutableExpr):
+
+    typeref: TypeRef
 
 
-class ConstExpr(Expr):
+class ConstExpr(ImmutableExpr):
 
     typeref: TypeRef
 
@@ -361,7 +365,7 @@ class ConstantSet(ConstExpr):
     elements: typing.Tuple[BaseConstant, ...]
 
 
-class Parameter(Expr):
+class Parameter(ImmutableExpr):
 
     name: str
     typeref: TypeRef
@@ -374,20 +378,20 @@ class TupleElement(ImmutableBase):
     path_id: PathId
 
 
-class Tuple(Expr):
+class Tuple(ImmutableExpr):
 
     named: bool = False
     elements: typing.List[TupleElement]
     typeref: TypeRef
 
 
-class Array(Expr):
+class Array(ImmutableExpr):
 
     elements: typing.List[Set]
     typeref: TypeRef
 
 
-class TypeCheckOp(Expr):
+class TypeCheckOp(ImmutableExpr):
 
     left: Set
     right: TypeRef
@@ -412,7 +416,7 @@ class CallArg(ImmutableBase):
     cardinality: qltypes.Cardinality = qltypes.Cardinality.ONE
 
 
-class Call(Expr):
+class Call(ImmutableExpr):
     """Operator or a function call."""
 
     # Bound callable has polymorphic parameters and
@@ -489,20 +493,20 @@ class OperatorCall(Call):
     sql_operator: typing.Optional[typing.Tuple[str, ...]] = None
 
 
-class TupleIndirection(Expr):
+class TupleIndirection(ImmutableExpr):
 
     expr: Set
     name: str
     path_id: PathId
 
 
-class IndexIndirection(Expr):
+class IndexIndirection(ImmutableExpr):
 
     expr: Base
     index: Base
 
 
-class SliceIndirection(Expr):
+class SliceIndirection(ImmutableExpr):
 
     expr: Base
     start: Base
@@ -510,8 +514,8 @@ class SliceIndirection(Expr):
     step: Base
 
 
-class TypeCast(Expr):
-    """<Type>Expr"""
+class TypeCast(ImmutableExpr):
+    """<Type>ImmutableExpr"""
 
     expr: Set
     cast_module_id: uuid.UUID
@@ -523,7 +527,7 @@ class TypeCast(Expr):
     sql_expr: bool
 
 
-class Stmt(Base):
+class Stmt(Expr):
 
     name: str
     result: Set
@@ -601,6 +605,6 @@ class ConfigReset(ConfigCommand):
     selector: typing.Optional[Set] = None
 
 
-class ConfigInsert(ConfigCommand):
+class ConfigInsert(ConfigCommand, Expr):
 
     expr: Set

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -62,7 +62,7 @@ def param_as_str(schema, param):
 
 
 # Non-schema description of a parameter.
-class ParameterDesc(typing.NamedTuple):
+class ParameterDesc(typing.NamedTuple, s_abc.Parameter):
 
     num: int
     name: str
@@ -406,7 +406,29 @@ class VolatilitySubject(so.Object):
         compcoef=0.4, coerce=True, allow_ddl_set=True)
 
 
-class CallableObject(s_anno.AnnotationSubject):
+class CallableLike:
+    """A minimal callable object interface required by multidispatch."""
+
+    def has_inlined_defaults(self, schema) -> bool:
+        raise NotImplementedError
+
+    def get_params(self, schema) -> FuncParameterList:
+        raise NotImplementedError
+
+    def get_return_type(self, schema) -> s_types.Type:
+        raise NotImplementedError
+
+    def get_return_typemod(self, schema) -> ft.TypeModifier:
+        raise NotImplementedError
+
+    def get_verbosename(self, schema) -> str:
+        raise NotImplementedError
+
+    def get_is_abstract(self, schema) -> bool:
+        raise NotImplementedError
+
+
+class CallableObject(s_anno.AnnotationSubject, CallableLike):
 
     params = so.SchemaField(
         FuncParameterList,

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,3 +9,7 @@ ignore_errors = True
 # [mypy-some.package.*]
 # follow_imports = True
 # ignore_errors = False
+
+[mypy-edb.edgeql.compiler.*]
+follow_imports = True
+ignore_errors = False

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -164,10 +164,10 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 15.76)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 15.74)
 
     def test_type_coverage_edgeql_compiler(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 56.96)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 56.47)
 
     def test_type_coverage_edgeql_parser(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "parser", 0)


### PR DESCRIPTION
`ir.ast.Set.expr` is defined as `ir.ast.Base`, which is wrong, since it
must always be an instance of `ir.ast.Expr`.  Fix this, and the
relevant typing annotations in the EdgeQL frontend.

This also fixes a couple of remaining typing errors in
`edb.edgeql.compiler`, so enable mypy checks on it.