### PR TITLE
Add schema.ddl.ddl_text_from_schema(schema)

### DIFF
--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 0)
 
     def test_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 1.87)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 2.10)
 
     def test_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 6.68)


### PR DESCRIPTION
The new `ddl_text_from_schema()` helper returns valid DDL text
for a specified schema, and is, essentially, an implementation of a
schema dump.  It is now used as another check for the migration
unit tests.