### PR TITLE
Fix problems with test teardown when running `edb test`

### DIFF
--- a/edb/tools/test/mproc_fixes.py
+++ b/edb/tools/test/mproc_fixes.py
@@ -1,0 +1,105 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+from typing import *  # NoQA
+
+import logging
+import multiprocessing.pool
+import multiprocessing.process
+import multiprocessing.util
+import platform
+
+
+_orig_pool_worker = None
+_orig_pool_worker_handler = None
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerScope:
+
+    def __init__(self, initializer, destructor):
+        self.initializer = initializer
+        self.destructor = destructor
+
+    def __call__(self, *args, **kwargs):
+        # Make multiprocessing.Pool happy
+        return self.initializer(*args, **kwargs)
+
+
+def multiprocessing_pool_worker(inqueue, outqueue, initializer=None,
+                                *args, **kwargs):
+    destructor = None
+    if isinstance(initializer, WorkerScope):
+        destructor = initializer.destructor
+
+    _orig_pool_worker(inqueue, outqueue, initializer, *args, **kwargs)
+
+    if destructor is not None:
+        destructor()
+
+
+def multiprocessing_worker_handler(*args):
+    _orig_pool_worker_handler(*args)
+
+    if len(args) == 1:
+        # In some pythons this is a static method with
+        # a single argument...
+        workers = args[0]._pool
+    else:
+        # ... and in others it's a staticmethod or a classmethod taking
+        # 12-14 positional arguments.
+        for arg in args:
+            if (isinstance(arg, list) and arg
+                    and isinstance(
+                        arg[0],
+                        multiprocessing.process.BaseProcess)):
+                workers = arg
+                break
+        else:
+            logger.error(
+                'unable to patch multiprocessing.Pool._handle_workers')
+            return
+
+    for worker_process in workers:
+        # Give workers ample time to shutdown, and
+        # if they don't, the pool will terminate them.
+        worker_process.join(timeout=10)
+
+
+def patch_multiprocessing(debug: bool):
+    global _orig_pool_worker
+    global _orig_pool_worker_handler
+
+    if debug:
+        multiprocessing.util.log_to_stderr(logging.DEBUG)
+
+    if platform.system().lower() == 'darwin':
+        # A "fork" without "exec" is broken on macOS since 10.14:
+        # https://www.wefearchange.org/2018/11/forkmacos.rst.html
+        multiprocessing.set_start_method('spawn')
+
+    # Add the ability to do clean shutdown of the worker.
+    _orig_pool_worker = multiprocessing.pool.worker
+    multiprocessing.pool.worker = multiprocessing_pool_worker
+
+    # Allow workers some time to shut down gracefully.
+    _orig_pool_worker_handler = multiprocessing.pool.Pool._handle_workers
+    multiprocessing.pool.Pool._handle_workers = multiprocessing_worker_handler

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -292,7 +292,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "testbase", 0)
 
     def test_type_coverage_tools(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "tools", 6.98)
+        self.assertFunctionCoverage(EDB_DIR / "tools", 8.43)
 
     def test_type_coverage_tools_docs(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "tools" / "docs", 0)
@@ -301,7 +301,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "tools" / "mypy", 36.36)
 
     def test_type_coverage_tools_test(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "tools" / "test", 0)
+        self.assertFunctionCoverage(EDB_DIR / "tools" / "test", 4.23)
 
     def test_type_coverage_tests(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "tests", 0)


### PR DESCRIPTION
This is yet another *attempt* to convince our multiprocessed
unittest to actually do final test teardown properly.

Both `unittest` and `multiprocessing` are at fault here, with
multiple issues to address.

Problem ONE: same `tearDownClass` called multiple times.  This is
a result of misunderstanding of what `unittest.TestSuite` actually
is.  Our current teardown fix iterates over the registered
`TestSuite` instances and calls `_tearDownPreviousClass` on them.
This is wrong, because `TestSuite` is essentially just a bunch
of methods that mutate a *single result instance*, so they're really
basically static methods of `TestResult`, and so must be called
**once**, and not per `TestSuite` instance as is now.

Problem TWO: `multiprocessing.Pool` worker finalization does not
work.  When running with `-jN`, where `N` is greater than one,
we use the standard process pool to run tests in parallel.
Currently, the teardown portion is implemented via
`multiprocessing.util.Finalize`, which is a complicated proxy
for `atexit()`.  Using `atexit()` for finalization is a fraught
undertaking, since there's no guarantee if any object would be
alive at this point (hence the `Finalize` hacks with its
`weakref` use).

A sane approach is to actually provide a counterpart of
the `initialize` argument to the Pool constructor to ensure
correct worker cleanup and call it just after the worker
loop concludes.  The only way to do this currently is to
monkeypatch `multiprocessing.pool.worker()`.

But this is not all.  Since `multiprocessing` does not actually
care about correct worker funalization, it basically just
calls `Process.terminate()` on them as soon as `Pool.terminate()`
is called, without trying to be nice and `join()` them properly.
Hence another monkeypatch to convince it to do so.