### PR TITLE
Annotate edb.common.ordered

### DIFF
--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -923,17 +923,19 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
         def _delta_subdict(attr):
             if old:
                 oldcoll = old.get_field_value(old_schema, attr)
-                oldcoll_idx = ordered.OrderedIndex(
-                    oldcoll.objects(old_schema), key=old_idx_key)
+                oldcoll_idx = sorted(
+                    set(oldcoll.objects(old_schema)), key=old_idx_key
+                )
             else:
-                oldcoll_idx = {}
+                oldcoll_idx = []
 
             if new:
                 newcoll = new.get_field_value(new_schema, attr)
-                newcoll_idx = ordered.OrderedIndex(
-                    newcoll.objects(new_schema), key=new_idx_key)
+                newcoll_idx = sorted(
+                    set(newcoll.objects(new_schema)), key=new_idx_key
+                )
             else:
-                newcoll_idx = {}
+                newcoll_idx = []
 
             delta.update(cls.delta_sets(
                 oldcoll_idx, newcoll_idx, context,

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,8 @@ plugins = edb.tools.mypy.plugin
 follow_imports = False
 ignore_missing_imports = True
 ignore_errors = True
+warn_redundant_casts = True
+warn_unused_configs = True
 
 # To enable type checks on some package, add a section like:
 # [mypy-some.package.*]
@@ -13,3 +15,19 @@ ignore_errors = True
 [mypy-edb.edgeql.compiler.*]
 follow_imports = True
 ignore_errors = False
+
+[mypy-edb.common.ordered]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -197,7 +197,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "cli", 0)
 
     def test_type_coverage_common(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "common", 1.24)
+        self.assertFunctionCoverage(EDB_DIR / "common", 3.78)
 
     def test_type_coverage_common_ast(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "common" / "ast", 0)


### PR DESCRIPTION
As @elprans suggested, OrderedIndex was removed since it was only used in one
place.