### PR TITLE
Track original constraint subject expression to ensure consistent names

### DIFF
--- a/edb/pgsql/datasources/schema/constraints.py
+++ b/edb/pgsql/datasources/schema/constraints.py
@@ -43,6 +43,7 @@ async def fetch(
                                         AS ancestors,
                 a.expr                  AS expr,
                 a.subjectexpr           AS subjectexpr,
+                a.orig_subjectexpr      AS orig_subjectexpr,
                 a.finalexpr             AS finalexpr,
                 a.errmessage            AS errmessage,
                 a.args                  AS args,

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -460,6 +460,7 @@ class IntrospectionMech:
                       if r['expr'] else None),
                 subjectexpr=(self.unpack_expr(r['subjectexpr'], schema)
                              if r['subjectexpr'] else None),
+                orig_subjectexpr=r['orig_subjectexpr'],
                 finalexpr=(self.unpack_expr(r['finalexpr'], schema)
                            if r['finalexpr'] else None),
                 errmessage=r['errmessage'],

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -189,6 +189,14 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
         else:
             return None
 
+    def get_local_attribute_value(self, attr_name):
+        """Return the new value of field, if not inherited."""
+        op = self.get_attribute_set_cmd(attr_name)
+        if op is not None and op.source != 'inheritance':
+            return op.new_value
+        else:
+            return None
+
     def set_attribute_value(self, attr_name, value, *, inherited=False):
         for op in self.get_subcommands(type=AlterObjectProperty):
             if op.property == attr_name:

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -136,7 +136,7 @@ class IndexCommand(referencing.ReferencedInheritingObjectCommand,
                 astnode.expr, schema, context.modaliases)
             expr_text = expr.origtext
 
-        name = (cls._name_qual_from_expr(schema, expr_text),)
+        name = (cls._name_qual_from_exprs(schema, (expr_text,)),)
 
         return name
 

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -222,9 +222,10 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase):
         return ()
 
     @classmethod
-    def _name_qual_from_expr(cls, schema, expr):
+    def _name_qual_from_exprs(cls, schema, exprs):
         m = hashlib.sha1()
-        m.update(expr.encode())
+        for expr in exprs:
+            m.update(expr.encode())
         return m.hexdigest()
 
     def _get_ast_node(self, schema, context):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -807,6 +807,17 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_get_migration_07(self):
+        schema = r'''
+            type Bar {
+                property data -> str {
+                    constraint min_value(10) on (len(<str>__subject__))
+                }
+            }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_migrations_equivalence_01(self):
         self._assert_migration_equivalence([r"""
             type Base;


### PR DESCRIPTION
Like indexes (which were treated in faf52c0763930c), constraints derive
their internal name from the expressions used to define them, so
tracking the original expressions is necessary.  This also simplifies
the relevant code.