### PR TITLE
Postpone interpretation of schema refs in pointer definitions

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -197,17 +197,29 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
         else:
             return None
 
-    def set_attribute_value(self, attr_name, value, *, inherited=False):
+    def get_attribute_source_context(self, attr_name):
+        op = self.get_attribute_set_cmd(attr_name)
+        if op is not None:
+            return op.source_context
+        else:
+            return None
+
+    def set_attribute_value(self, attr_name, value, *, inherited=False,
+                            source_context=None):
         for op in self.get_subcommands(type=AlterObjectProperty):
             if op.property == attr_name:
                 op.new_value = value
                 if inherited:
                     op.source = 'inheritance'
+                if source_context is not None:
+                    op.source_context = source_context
                 break
         else:
             op = AlterObjectProperty(property=attr_name, new_value=value)
             if inherited:
                 op.source = 'inheritance'
+            if source_context is not None:
+                op.source_context = source_context
 
             self.add(op)
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1265,9 +1265,19 @@ class GlobalObject(UnqualifiedObject):
 
 class ObjectRef(Object):
 
-    def __init__(self, *, name: str):
+    def __init__(
+        self,
+        *,
+        name: str,
+        origname: Optional[str]=None,
+        schemaclass: Optional[ObjectMeta]=None,
+        sourcectx=None,
+    ) -> None:
         super().__init__(_private_init=True)
         self.__dict__['_name'] = name
+        self.__dict__['_origname'] = origname
+        self.__dict__['_sourcectx'] = sourcectx
+        self.__dict__['_schemaclass'] = schemaclass
 
     @property
     def name(self):
@@ -1275,6 +1285,12 @@ class ObjectRef(Object):
 
     def get_name(self, schema):
         return self._name
+
+    def get_refname(self, schema):
+        return self._origname if self._origname is not None else self._name
+
+    def get_sourcectx(self, schema):
+        return self._sourcectx
 
     def __repr__(self):
         return '<ObjectRef "{}" at 0x{:x}>'.format(self._name, id(self))
@@ -1291,7 +1307,12 @@ class ObjectRef(Object):
         return self, self.get_name(schema)
 
     def _resolve_ref(self, schema):
-        return schema.get(self.get_name(schema))
+        return schema.get(
+            self.get_name(schema),
+            type=self._schemaclass,
+            refname=self._origname,
+            sourcectx=self.get_sourcectx(schema),
+        )
 
 
 class ObjectCollectionDuplicateNameError(Exception):

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -61,6 +61,9 @@ class BaseObjectType(sources.Source,
     def is_object_type(self):
         return True
 
+    def is_union_type(self, schema) -> bool:
+        return bool(self.get_union_of(schema))
+
     def get_displayname(self, schema):
         if self.is_view(schema) and not self.get_view_is_persistent(schema):
             mtype = self.material_type(schema)

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -596,8 +596,10 @@ class Schema(s_abc.Schema):
                 f'{desc} {name!r} does not exist')
 
     def get(self, name, default=_void, *,
+            refname=None,
             module_aliases=None, type=None,
-            condition=None, label=None):
+            condition=None, label=None,
+            sourcectx=None):
         def getter(schema, name):
             obj = schema._get_by_name(name, type=type)
             if obj is not None and condition is not None:
@@ -623,8 +625,12 @@ class Schema(s_abc.Schema):
             else:
                 label = 'schema item'
 
+        if refname is None:
+            refname = name
+
         raise errors.InvalidReferenceError(
-            f'{label} {name!r} does not exist')
+            f'{label} {refname!r} does not exist',
+            context=sourcectx)
 
     def has_module(self, module):
         return self.get_global(s_mod.Module, module, None) is not None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -77,7 +77,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
         """
 
     @tb.must_fail(errors.InvalidLinkTargetError,
-                  'invalid link target, expected object type, got ScalarType',
+                  'invalid link target, expected object type, got scalar type',
                   position=55)
     def test_schema_bad_link_01(self):
         """
@@ -87,7 +87,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
         """
 
     @tb.must_fail(errors.InvalidLinkTargetError,
-                  'invalid link target, expected object type, got ScalarType',
+                  'invalid link target, expected object type, got scalar type',
                   position=55)
     def test_schema_bad_link_02(self):
         """
@@ -109,7 +109,7 @@ _123456789_123456789_123456789 -> Object
 
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "invalid property type: expected a scalar type, "
-                  "or a scalar collection, got 'test::Object'",
+                  "or a scalar collection, got object type 'test::Object'",
                   position=59)
     def test_schema_bad_prop_01(self):
         """
@@ -120,7 +120,7 @@ _123456789_123456789_123456789 -> Object
 
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "invalid property type: expected a scalar type, "
-                  "or a scalar collection, got 'test::Object'",
+                  "or a scalar collection, got object type 'test::Object'",
                   position=59)
     def test_schema_bad_prop_02(self):
         """
@@ -153,7 +153,7 @@ _123456789_123456789_123456789 -> str
 
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "expected a scalar type, or a scalar collection, "
-                  "got 'array<test::Foo>'",
+                  "got collection 'array<test::Foo>'",
                   position=80)
     def test_schema_bad_type_02(self):
         """
@@ -166,7 +166,7 @@ _123456789_123456789_123456789 -> str
 
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "expected a scalar type, or a scalar collection, "
-                  "got 'tuple<test::Foo>'",
+                  "got collection 'tuple<test::Foo>'",
                   position=80)
     def test_schema_bad_type_03(self):
         """
@@ -179,7 +179,7 @@ _123456789_123456789_123456789 -> str
 
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "expected a scalar type, or a scalar collection, "
-                  "got 'tuple<std::str, array<test::Foo>>'",
+                  "got collection 'tuple<std::str, array<test::Foo>>'",
                   position=80)
     def test_schema_bad_type_04(self):
         """
@@ -2464,7 +2464,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         with self.assertRaisesRegex(
                 errors.InvalidPropertyTargetError,
                 "expected a scalar type, or a scalar collection, "
-                "got 'array<default::Foo>'"):
+                "got collection 'array<default::Foo>'"):
             self._assert_migration_equivalence([r"""
                 type Base;
 
@@ -2485,7 +2485,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         with self.assertRaisesRegex(
                 errors.InvalidPropertyTargetError,
                 "expected a scalar type, or a scalar collection, "
-                "got 'tuple<std::str, default::Foo>'"):
+                "got collection 'tuple<std::str, default::Foo>'"):
 
             self._assert_migration_equivalence([r"""
                 type Base;
@@ -2507,7 +2507,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         with self.assertRaisesRegex(
                 errors.InvalidPropertyTargetError,
                 "expected a scalar type, or a scalar collection, "
-                "got 'array<default::Foo>'"):
+                "got collection 'array<default::Foo>'"):
 
             self._assert_migration_equivalence([r"""
             type Base {

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 0)
 
     def test_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 2.30)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 2.49)
 
     def test_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 6.68)


### PR DESCRIPTION
Currently, we attempt to do too much at the AST->DDL IR stage for links and
properties: we validate the target type and the computable expression in
the context where we might not have all the necessary types yet. Most
importantly, this breaks tight loop cases like this:

    create type Category {
        create link parent -> Category
    };

As a general rule, any assumption about the schema state at the AST->IR 
stage of DDL processing is invalid, and only the checks that don't rely on
the schema can be safely made.  Schema-dependent checks must be made during
the DDL canonicalization pass.