### PR TITLE
Introduce edb.common.checked

### DIFF
--- a/edb/common/checked.py
+++ b/edb/common/checked.py
@@ -1,0 +1,619 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2011-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+from typing import *  # NoQA
+
+import collections.abc
+import functools
+import itertools
+import types
+
+
+__all__ = [
+    "CheckedList",
+    "CheckedDict",
+    "CheckedSet",
+    "FrozenCheckedList",
+    "FrozenCheckedSet",
+]
+
+
+T = TypeVar("T")
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class ParametricType:
+    types: Optional[Tuple[type, ...]] = None
+
+    def __init__(self) -> None:
+        if self.types is None:
+            raise TypeError(
+                f"{type(self)!r} must be parametrized to instantiate"
+            )
+
+        super().__init__()
+
+    @classmethod
+    @functools.lru_cache()
+    def __class_getitem__(
+        cls, params: Union[type, Tuple[type, ...]]
+    ) -> Type[ParametricType]:
+        """Return a dynamic subclass parametrized with `params`.
+
+        We cannot use `_GenericAlias` provided by `Generic[T]` because the
+        default `__class_getitem__` on `_GenericAlias` is not a real type and
+        so it doesn't retain information on generics on the class.  Even on
+        the object, it adds the relevant `__orig_class__` link too late, after
+        `__init__()` is called.  That means we wouldn't be able to type-check
+        in the initializer using built-in `Generic[T]`.
+        """
+        if cls.types is not None:
+            raise TypeError(f"{cls!r} is already parametrized")
+
+        if not isinstance(params, tuple):
+            params = (params,)
+        params_str = ", ".join(_type_repr(a) for a in params)
+        name = f"{cls.__name__}[{params_str}]"
+        bases = (cls,)
+        type_dict = {"types": params, "__module__": cls.__module__}
+        for param in params:
+            if not isinstance(param, type):
+                raise TypeError(f"{cls!r} expects types as type parameters")
+        if issubclass(cls, SingleParameter):
+            if len(params) != 1:
+                raise TypeError(f"{cls!r} expects one type parameter")
+            type_dict["type"] = params[0]
+        elif issubclass(cls, KeyValueParameter):
+            if len(params) != 2:
+                raise TypeError(f"{cls!r} expects two type parameters")
+            type_dict["keytype"] = params[0]
+            type_dict["valuetype"] = params[1]
+        return type(name, bases, type_dict)
+
+    def __reduce__(self) -> Tuple[Any, ...]:
+        assert self.types is not None
+        base: Type[ParametricType] = self.__class__.__bases__[0]
+        container = getattr(self, "_container", ())
+        args = self.types[0] if len(self.types) == 1 else self.types
+        return base.__restore__, (args, container)
+
+    @classmethod
+    def __restore__(
+        cls, params: Tuple[type, ...], data: Iterable[Any]
+    ) -> ParametricType:
+        return cls[params](data)  # type: ignore
+
+
+class SingleParameter:
+    type: type
+
+
+class KeyValueParameter:
+    keytype: type
+    valuetype: type
+
+
+class AbstractCheckedList(Generic[T]):
+    type: type
+    _container: List[T]
+
+    def _check_type(self, value: Any) -> T:
+        """Ensure `value` is of type T and return it."""
+        if not isinstance(value, self.type):
+            raise ValueError(
+                f"{type(self)!r} accepts only values of type {self.type!r}, "
+                f"got {type(value)!r}"
+            )
+        return cast(T, value)
+
+    def __lt__(self, other: List[T]) -> bool:
+        return self._container < self._cast(other)
+
+    def __le__(self, other: List[T]) -> bool:
+        return self._container <= self._cast(other)
+
+    def __gt__(self, other: List[T]) -> bool:
+        return self._container > self._cast(other)
+
+    def __ge__(self, other: List[T]) -> bool:
+        return self._container >= self._cast(other)
+
+    def _cast(self, other: List[T]) -> List[T]:
+        if isinstance(other, (CheckedList, FrozenCheckedList)):
+            return other._container
+
+        return other
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (CheckedList, FrozenCheckedList)):
+            other = other._container
+        return self._container == other
+
+    def __str__(self) -> str:
+        return repr(self._container)
+
+    def __repr__(self) -> str:
+        return f"{_type_repr(type(self))}({repr(self._container)})"
+
+
+class FrozenCheckedList(
+    ParametricType, SingleParameter, AbstractCheckedList[T], Sequence[T]
+):
+    def __init__(self, iterable: Iterable[T] = ()) -> None:
+        super().__init__()
+        self._container = [self._check_type(element) for element in iterable]
+
+    #
+    # Sequence
+    #
+
+    @overload
+    def __getitem__(self, index: int) -> T:
+        ...
+
+    @overload  # NoQA: F811
+    def __getitem__(self, index: slice) -> FrozenCheckedList[T]:
+        ...
+
+    def __getitem__(self, index):  # NoQA: F811
+        if isinstance(index, slice):
+            return self.__class__(self._container[index])
+
+        return self._container[index]
+
+    def __len__(self) -> int:
+        return len(self._container)
+
+    #
+    # List-specific
+    #
+
+    def __add__(self, other: Iterable[T]) -> FrozenCheckedList[T]:
+        return self.__class__(itertools.chain(self, other))
+
+    def __radd__(self, other: Iterable[T]) -> FrozenCheckedList[T]:
+        return self.__class__(itertools.chain(other, self))
+
+    def __mul__(self, n: int) -> FrozenCheckedList[T]:
+        return self.__class__(self._container * n)
+
+    __rmul__ = __mul__
+
+
+class CheckedList(
+    ParametricType, SingleParameter, AbstractCheckedList[T], MutableSequence[T]
+):
+    def __init__(self, iterable: Iterable[T] = ()) -> None:
+        super().__init__()
+        self._container = [self._check_type(element) for element in iterable]
+
+    #
+    # Sequence
+    #
+
+    @overload
+    def __getitem__(self, index: int) -> T:
+        ...
+
+    @overload  # NoQA: F811
+    def __getitem__(self, index: slice) -> CheckedList[T]:
+        ...
+
+    def __getitem__(self, index):  # NoQA: F811
+        if isinstance(index, slice):
+            return self.__class__(self._container[index])
+
+        return self._container[index]
+
+    #
+    # MutableSequence
+    #
+
+    @overload
+    def __setitem__(self, index: int, value: T) -> None:
+        ...
+
+    @overload  # NoQA: F811
+    def __setitem__(self, index: slice, value: Iterable[T]) -> None:
+        ...
+
+    def __setitem__(self, index, value):  # NoQA: F811
+        if isinstance(index, int):
+            self._container[index] = self._check_type(value)
+            return
+
+        _slice = index
+        self._container[_slice] = filter(self._check_type, value)
+
+    @overload
+    def __delitem__(self, index: int) -> None:
+        ...
+
+    @overload  # NoQA: F811
+    def __delitem__(self, index: slice) -> None:
+        ...
+
+    def __delitem__(self, index):  # NoQA: F811
+        del self._container[index]
+
+    def insert(self, index: int, value: T) -> None:
+        self._container.insert(index, self._check_type(value))
+
+    def __len__(self) -> int:
+        return len(self._container)
+
+    #
+    # List-specific
+    #
+
+    def __add__(self, other: Iterable[T]) -> CheckedList[T]:
+        return self.__class__(itertools.chain(self, other))
+
+    def __radd__(self, other: Iterable[T]) -> CheckedList[T]:
+        return self.__class__(itertools.chain(other, self))
+
+    def __iadd__(self, other: Iterable[T]) -> CheckedList[T]:
+        self._container.extend(filter(self._check_type, other))
+        return self
+
+    def __mul__(self, n: int) -> CheckedList[T]:
+        return self.__class__(self._container * n)
+
+    __rmul__ = __mul__
+
+    def __imul__(self, n: int) -> CheckedList[T]:
+        self._container *= n
+        return self
+
+    def sort(self, *, key: Any = None, reverse: bool = False) -> None:
+        self._container.sort(key=key, reverse=reverse)
+
+
+class AbstractCheckedSet(AbstractSet[T]):
+    type: type
+    _container: Set[T]
+
+    def _check_type(self, value: Any) -> T:
+        """Ensure `value` is of type T and return it."""
+        if not isinstance(value, self.type):
+            raise ValueError(
+                f"{type(self)!r} accepts only values of type {self.type!r}, "
+                f"got {type(value)!r}"
+            )
+        return cast(T, value)
+
+    def _cast(self, other: Any) -> AbstractSet[T]:
+        if isinstance(other, (FrozenCheckedSet, CheckedSet)):
+            return other._container
+
+        if isinstance(other, collections.abc.Set):
+            return other
+
+        return set(other)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (CheckedSet, FrozenCheckedSet)):
+            other = other._container
+        return self._container == other
+
+    def __str__(self) -> str:
+        return repr(self._container)
+
+    def __repr__(self) -> str:
+        return f"{_type_repr(type(self))}({repr(self._container)})"
+
+    #
+    # collections.abc.Set aka typing.AbstractSet
+    #
+
+    def __contains__(self, value: Any) -> bool:
+        return value in self._container
+
+    def __iter__(self) -> Iterator[T]:
+        return iter(self._container)
+
+    def __len__(self) -> int:
+        return len(self._container)
+
+    #
+    # Specific to set() and frozenset()
+    #
+
+    def issubset(self, other: AbstractSet[Any]) -> bool:
+        return self.__le__(other)
+
+    def issuperset(self, other: AbstractSet[Any]) -> bool:
+        return self.__ge__(other)
+
+
+class FrozenCheckedSet(ParametricType, SingleParameter, AbstractCheckedSet[T]):
+    def __init__(self, iterable: Iterable[T] = ()) -> None:
+        super().__init__()
+        self._container = {self._check_type(element) for element in iterable}
+
+    #
+    # Replaced mixins of collections.abc.Set
+    #
+
+    # NOTE: The type ignores on function signatures below are because we are
+    # deliberately breaking the Liskov Substitute Principle: we want the type
+    # checker to warn the user if a checked set of a type is __or__'d, or
+    # __and__'d  with a set of an incompatible type.  If the user wanted this,
+    # they should convert the checked set into a regular set or a differently
+    # typed checked set first.
+
+    def __and__(self, other: AbstractSet[T]) -> FrozenCheckedSet[T]:
+        other_set = self._cast(other)
+        for elem in other_set:
+            # We need the explicit type check to reject nonsensical
+            # & operations that must always result in an empty new set.
+            self._check_type(elem)
+        return self.__class__(other_set & self._container)
+
+    __rand__ = __and__
+
+    def __or__(  # type: ignore
+        self, other: AbstractSet[T]
+    ) -> FrozenCheckedSet[T]:
+        other_set = self._cast(other)
+        return self.__class__(other_set | self._container)
+
+    __ror__ = __or__
+
+    def __sub__(self, other: AbstractSet[T]) -> FrozenCheckedSet[T]:
+        other_set = self._cast(other)
+        for elem in other_set:
+            # We need the explicit type check to reject nonsensical
+            # - operations that always return the original checked set.
+            self._check_type(elem)
+        return self.__class__(self._container - other_set)
+
+    def __rsub__(self, other: AbstractSet[T]) -> FrozenCheckedSet[T]:
+        other_set = self._cast(other)
+        return self.__class__(other_set - self._container)
+
+    def __xor__(  # type: ignore
+        self, other: AbstractSet[T]
+    ) -> FrozenCheckedSet[T]:
+        other_set = self._cast(other)
+        return self.__class__(self._container ^ other_set)
+
+    __rxor__ = __xor__
+
+    #
+    # Specific to set() and frozenset()
+    #
+
+    union = __and__
+    intersection = __or__
+    difference = __sub__
+    symmetric_difference = __xor__
+
+
+class CheckedSet(
+    ParametricType, SingleParameter, AbstractCheckedSet[T], MutableSet[T]
+):
+    def __init__(self, iterable: Iterable[T] = ()) -> None:
+        super().__init__()
+        self._container = {self._check_type(element) for element in iterable}
+
+    #
+    # Replaced mixins of collections.abc.Set
+    #
+
+    # NOTE: The type ignores on function signatures below are because we are
+    # deliberately breaking the Liskov Substitute Principle: we want the type
+    # checker to warn the user if a checked set of a type is __or__'d, or
+    # __and__'d  with a set of an incompatible type.  If the user wanted this,
+    # they should convert the checked set into a regular set or a differently
+    # typed checked set first.
+
+    def __and__(self, other: AbstractSet[T]) -> CheckedSet[T]:
+        other_set = self._cast(other)
+        for elem in other_set:
+            # We need the explicit type check to reject nonsensical
+            # & operations that must always result in an empty new set.
+            self._check_type(elem)
+        return self.__class__(other_set & self._container)
+
+    __rand__ = __and__
+
+    def __or__(self, other: AbstractSet[T]) -> CheckedSet[T]:  # type: ignore
+        other_set = self._cast(other)
+        return self.__class__(other_set | self._container)
+
+    __ror__ = __or__
+
+    def __sub__(self, other: AbstractSet[T]) -> CheckedSet[T]:
+        other_set = self._cast(other)
+        for elem in other_set:
+            # We need the explicit type check to reject nonsensical
+            # - operations that always return the original checked set.
+            self._check_type(elem)
+        return self.__class__(self._container - other_set)
+
+    def __rsub__(self, other: AbstractSet[T]) -> CheckedSet[T]:
+        other_set = self._cast(other)
+        return self.__class__(other_set - self._container)
+
+    def __xor__(self, other: AbstractSet[T]) -> CheckedSet[T]:  # type: ignore
+        other_set = self._cast(other)
+        return self.__class__(self._container ^ other_set)
+
+    __rxor__ = __xor__
+
+    #
+    # MutableSet
+    #
+
+    def add(self, value: T) -> None:
+        self._container.add(self._check_type(value))
+
+    def discard(self, value: T) -> None:
+        self._container.discard(self._check_type(value))
+
+    #
+    # Replaced mixins of collections.abc.MutableSet
+    #
+
+    def __ior__(self, other: AbstractSet[T]) -> CheckedSet[T]:  # type: ignore
+        self._container |= set(filter(self._check_type, other))
+        return self
+
+    def __iand__(self, other: AbstractSet[T]) -> CheckedSet[T]:
+        # We do the type check here to reject nonsensical
+        # & operations that always clear the checked set.
+        self._container &= set(filter(self._check_type, other))
+        return self
+
+    def __ixor__(self, other: AbstractSet[T]) -> CheckedSet[T]:  # type: ignore
+        self._container ^= set(filter(self._check_type, other))
+        return self
+
+    def __isub__(self, other: AbstractSet[T]) -> CheckedSet[T]:
+        # We do the type check here to reject nonsensical
+        # - operations that could never affect the checked set.
+        self._container -= set(filter(self._check_type, other))
+        return self
+
+    #
+    # Specific to set() and frozenset()
+    #
+
+    union = __and__
+    intersection = __or__
+    difference = __sub__
+    symmetric_difference = __xor__
+
+    #
+    # Specific to set()
+    #
+
+    update = __ior__
+    intersection_update = __iand__
+    difference_update = __isub__
+    symmetric_difference_update = __ixor__
+
+
+def _type_repr(obj: Any) -> str:
+    if isinstance(obj, type):
+        if obj.__module__ == "builtins":
+            return obj.__qualname__
+        return f"{obj.__module__}.{obj.__qualname__}"
+    if isinstance(obj, types.FunctionType):
+        return obj.__name__
+    return repr(obj)
+
+
+class AbstractCheckedDict(Generic[K, V]):
+    keytype: type
+    valuetype: type
+    _container: Dict[K, V]
+
+    @classmethod
+    def _check_key_type(cls, key: Any) -> K:
+        """Ensure `key` is of type K and return it."""
+        if not isinstance(key, cls.keytype):
+            raise KeyError(
+                f"{cls!r} accepts only keys of type {cls.keytype!r}, "
+                f"got {type(key)!r}"
+            )
+        return cast(K, key)
+
+    @classmethod
+    def _check_value_type(cls, value: Any) -> V:
+        """Ensure `value` is of type V and return it."""
+        if not isinstance(value, cls.valuetype):
+            raise ValueError(
+                f"{cls!r} accepts only values of type "
+                "{cls.valuetype!r}, got {type(value)!r}"
+            )
+        return cast(V, value)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, CheckedDict):
+            other = other._container
+        return self._container == other
+
+    def __str__(self) -> str:
+        return repr(self._container)
+
+    def __repr__(self) -> str:
+        return f"{_type_repr(type(self))}({repr(self._container)})"
+
+
+class CheckedDict(
+    ParametricType,
+    KeyValueParameter,
+    AbstractCheckedDict[K, V],
+    MutableMapping[K, V],
+):
+    def __init__(self, *args: Any, **kwargs: V) -> None:
+        super().__init__()
+        self._container = {}
+        if len(args) == 1:
+            self.update(args[0])
+        if len(args) > 1:
+            raise ValueError(
+                f"{type(self)!r} expected at most 1 argument, got {len(args)}"
+            )
+
+        if len(kwargs):
+            # Mypy is right below that the type of kwargs is Dict[str, V]
+            # but we are deliberately letting this through for it to blow up
+            # on runtime type checking if K is not a string.
+            self.update(kwargs)  # type: ignore
+
+    #
+    # collections.abc.Mapping
+    #
+
+    def __getitem__(self, key: K) -> V:
+        return self._container[key]
+
+    def __iter__(self) -> Iterator[K]:
+        return iter(self._container)
+
+    def __len__(self) -> int:
+        return len(self._container)
+
+    #
+    # collections.abc.MutableMapping
+    #
+
+    def __setitem__(self, key: K, value: V) -> None:
+        self._check_key_type(key)
+        self._container[key] = self._check_value_type(value)
+
+    def __delitem__(self, key: K) -> None:
+        del self._container[key]
+
+    #
+    # Dict-specific
+    #
+
+    @classmethod
+    def fromkeys(
+        cls, iterable: Iterable[K], value: Optional[V] = None
+    ) -> CheckedDict[K, V]:
+        new: CheckedDict[K, V] = cls()
+        for key in iterable:
+            new[cls._check_key_type(key)] = cls._check_value_type(value)
+        return new

--- a/mypy.ini
+++ b/mypy.ini
@@ -16,6 +16,22 @@ warn_unused_configs = True
 follow_imports = True
 ignore_errors = False
 
+[mypy-edb.common.checked]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+disallow_untyped_calls = True
+# disallow_untyped_defs = True  # disabled due to @overload
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+
 [mypy-edb.common.ordered]
 follow_imports = True
 ignore_errors = False

--- a/tests/common/test_checked.py
+++ b/tests/common/test_checked.py
@@ -1,0 +1,370 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2011-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+from typing import *  # NoQA
+
+import pickle
+import unittest
+
+from edb.common.checked import CheckedDict
+from edb.common.checked import CheckedList
+from edb.common.checked import CheckedSet
+from edb.common.checked import FrozenCheckedList
+from edb.common.checked import FrozenCheckedSet
+
+
+class CheckedDictTests(unittest.TestCase):
+    def test_common_checked_checkeddict_basics(self) -> None:
+        StrDict = CheckedDict[str, int]
+        assert StrDict({"1": 2})["1"] == 2
+        assert StrDict(foo=1, initdict=2)["initdict"] == 2
+
+        sd = StrDict(**{"1": 2})
+        assert sd["1"] == 2
+
+        assert dict(sd) == {"1": 2}
+
+        sd["foo"] = 42
+
+        with self.assertRaises(KeyError):
+            sd[0] = 0
+        with self.assertRaises(ValueError):
+            sd["foo"] = "bar"
+        assert sd["foo"] == 42
+
+        with self.assertRaises(ValueError):
+            sd.update({"spam": "ham"})
+
+        sd.update({"spam": 12})
+        assert sd["spam"] == 12
+
+        with self.assertRaises(ValueError):
+            StrDict(**{"foo": "bar"})
+
+        with self.assertRaisesRegex(TypeError, "expects two type parameters"):
+            # no value type given
+            CheckedDict[int]
+
+        class Foo:
+            def __repr__(self):
+                return self.__class__.__name__
+
+        class Bar(Foo):
+            pass
+
+        FooDict = CheckedDict[str, Foo]
+
+        td = FooDict(bar=Bar(), foo=Foo())
+        expected = (
+            f"edb.common.checked.CheckedDict[str, common.test_checked."
+            "CheckedDictTests.test_common_checked_checkeddict_basics."
+            "<locals>.Foo]({'bar': Bar, 'foo': Foo})"
+        )
+        assert repr(td) == expected
+        expected = "{'bar': Bar, 'foo': Foo}"
+        assert str(td) == expected
+
+        with self.assertRaisesRegex(ValueError, "expected at most 1"):
+            FooDict(Foo(), Bar())
+
+        td = FooDict.fromkeys("abc", value=Bar())
+        assert len(td) == 3
+        del td["b"]
+        assert "b" not in td
+        assert len(td) == 2
+        assert str(td) == "{'a': Bar, 'c': Bar}"
+
+    def test_common_checked_checkeddict_pickling(self) -> None:
+        StrDict = CheckedDict[str, int]
+        sd = StrDict()
+        sd["foo"] = 123
+        sd["bar"] = 456
+
+        assert sd.keytype is str and sd.valuetype is int
+        assert type(sd) is StrDict
+        assert sd["foo"] == 123
+        assert sd["bar"] == 456
+
+        sd2 = pickle.loads(pickle.dumps(sd))
+
+        assert sd2.keytype is str and sd2.valuetype is int
+        assert type(sd2) is StrDict
+        assert sd2["foo"] == 123
+        assert sd2["bar"] == 456
+        assert sd is not sd2
+        assert sd == sd2
+
+
+class BaseCheckedListTests(unittest.TestCase):
+    BaseList = FrozenCheckedList
+
+    def test_common_checked_shared_list_basics(self) -> None:
+        IntList = self.BaseList[int]
+        StrList = self.BaseList[str]
+
+        with self.assertRaises(ValueError):
+            IntList(("1", "2"))
+
+        with self.assertRaises(ValueError):
+            StrList([1])
+
+        with self.assertRaises(ValueError):
+            StrList([None])
+
+        sl = StrList(["Some", "strings", "here"])
+        assert sl == ["Some", "strings", "here"]
+        assert list(sl) == ["Some", "strings", "here"]
+        assert sl > ["Some", "strings"]
+        assert sl < ["Some", "strings", "here", "too"]
+        assert sl >= ["Some", "strings"]
+        assert sl <= ["Some", "strings", "here", "too"]
+        assert sl >= ["Some", "strings", "here"]
+        assert sl <= StrList(["Some", "strings", "here"])
+        assert sl + ["too"] == ["Some", "strings", "here", "too"]
+        assert ["Hey"] + sl == ["Hey", "Some", "strings", "here"]
+        assert type(sl + ["too"]) is StrList
+        assert type(["Hey"] + sl) is StrList
+        assert sl[0] == "Some"
+        assert type(sl[:2]) is StrList
+        assert sl[:2] == StrList(["Some", "strings"])
+        assert len(sl) == 3
+        assert sl[1:2] * 3 == ["strings", "strings", "strings"]
+        assert 3 * sl[1:2] == ["strings", "strings", "strings"]
+        assert type(3 * sl[1:2]) is StrList
+
+        class Foo:
+            def __repr__(self):
+                return self.__class__.__name__
+
+        class Bar(Foo):
+            pass
+
+        FooList = self.BaseList[Foo]
+
+        tl = FooList([Bar(), Foo()])
+        cls_name = self.BaseList.__name__
+        expected = (
+            f"edb.common.checked.{cls_name}[common.test_checked."
+            "BaseCheckedListTests.test_common_checked_shared_list_basics."
+            "<locals>.Foo]([Bar, Foo])"
+        )
+        assert repr(tl) == expected, repr(tl)
+        expected = "[Bar, Foo]"
+        assert str(tl) == expected
+
+    def test_common_checked_shared_list_pickling(self):
+        StrList = self.BaseList[str]
+        sd = StrList(["123", "456"])
+
+        assert sd.type is str
+        assert type(sd) is StrList
+        assert sd[0] == "123"
+        assert sd[1] == "456"
+
+        sd = pickle.loads(pickle.dumps(sd))
+
+        assert sd.type is str
+        assert type(sd) is StrList
+        assert sd[0] == "123"
+        assert sd[1] == "456"
+
+    def test_common_checked_shared_list_invalid_parameters(self):
+        with self.assertRaisesRegex(TypeError, "must be parametrized"):
+            self.BaseList()
+
+        with self.assertRaisesRegex(TypeError, "expects one type parameter"):
+            self.BaseList[int, int]()
+
+        with self.assertRaisesRegex(TypeError, "expects types"):
+            self.BaseList[1]()
+
+        with self.assertRaisesRegex(TypeError, "already parametrized"):
+            self.BaseList[int][int]
+
+
+class FrozenCheckedListTests(BaseCheckedListTests):
+    BaseList = FrozenCheckedList
+
+    def test_common_checked_frozenlist_basics(self) -> None:
+        StrList = self.BaseList[str]
+        sl = StrList(["1", "2"])
+        with self.assertRaises(AttributeError):
+            sl.append("3")
+
+
+class CheckedListTests(BaseCheckedListTests):
+    BaseList = CheckedList
+
+    def test_common_checked_checkedlist_basics(self) -> None:
+        StrList = self.BaseList[str]
+        tl = StrList()
+        tl.append("1")
+        tl.extend(("2", "3"))
+        tl += ["4"]
+        tl += ("5",)
+        tl = tl + ("6",)
+        tl = ("0",) + tl
+        tl.insert(0, "-1")
+        assert tl == ["-1", "0", "1", "2", "3", "4", "5", "6"]
+        del tl[1]
+        assert tl == ["-1", "1", "2", "3", "4", "5", "6"]
+        del tl[1:3]
+        assert tl == ["-1", "3", "4", "5", "6"]
+        tl[2] = "X"
+        assert tl == ["-1", "3", "X", "5", "6"]
+        tl[1:4] = ("A", "B", "C")
+        assert tl == ["-1", "A", "B", "C", "6"]
+        tl *= 2
+        assert tl == ["-1", "A", "B", "C", "6", "-1", "A", "B", "C", "6"]
+        tl.sort()
+        assert tl == ["-1", "-1", "6", "6", "A", "A", "B", "B", "C", "C"]
+
+        with self.assertRaises(ValueError):
+            tl.append(42)
+
+        with self.assertRaises(ValueError):
+            tl.extend((42,))
+
+        with self.assertRaises(ValueError):
+            tl.insert(0, 42)
+
+        with self.assertRaises(ValueError):
+            tl += (42,)
+
+        with self.assertRaises(ValueError):
+            tl = tl + (42,)
+
+        with self.assertRaises(ValueError):
+            tl = (42,) + tl
+
+
+class BaseCheckedSetTests(unittest.TestCase):
+    BaseSet = FrozenCheckedSet
+
+    def test_common_checked_shared_set_basics(self) -> None:
+        StrSet = self.BaseSet[str]
+        s1 = StrSet("sphinx of black quartz judge my vow")
+        assert s1 == set("abcdefghijklmnopqrstuvwxyz ")
+        s2 = StrSet("hunter2")
+        assert (s1 & s2) == StrSet("hunter")
+        assert type(s1 & s2) is StrSet
+        assert (s1 | s2) == set("abcdefghijklmnopqrstuvwxyz 2")
+        assert type(s1 | s2) is StrSet
+        assert (s1 - s2) == set("abcdfgijklmopqsvwxyz ")
+        assert type(s1 - s2) is StrSet
+        assert (set("hunter2") - s1) == StrSet("2")
+        assert type(set("hunter2") - s1) is StrSet
+
+        class Foo:
+            def __repr__(self):
+                return self.__class__.__name__
+
+        class Bar(Foo):
+            def __eq__(self, other):
+                return isinstance(other, Bar)
+
+            def __hash__(self):
+                return 1
+
+        FooSet = self.BaseSet[Foo]
+
+        tl = FooSet([Bar(), Foo(), Bar()])
+        tl2 = FooSet(tl | {Foo()})
+        assert len(tl) == 2
+        assert len(tl ^ tl2) == 1
+        assert tl.issuperset({Bar()})
+        assert tl.issubset(tl2)
+        # We have to do some gymnastics due to sets being unordered.
+        expected = {"{Bar, Foo}", "{Foo, Bar}"}
+        assert str(tl) in expected
+        cls_name = self.BaseSet.__name__
+        expected_template = (
+            f"edb.common.checked.{cls_name}[common.test_checked."
+            "BaseCheckedSetTests.test_common_checked_shared_set_basics."
+            "<locals>.Foo]({})"
+        )
+        assert repr(tl) in {expected_template.format(e) for e in expected}
+
+
+class FrozenCheckedSetTests(BaseCheckedSetTests):
+    BaseSet = FrozenCheckedSet
+
+
+class CheckedSetTests(BaseCheckedSetTests):
+    BaseSet = CheckedSet
+
+    def test_common_checked_checkedset_basics(self) -> None:
+        StrSet = self.BaseSet[str]
+        tl = StrSet()
+        tl.add("1")
+        tl.update(("2", "3"))
+        tl |= ["4"]
+        tl |= ("5",)
+        tl = tl | StrSet(["6"])
+        tl = {"0"} | tl
+        assert set(tl) == {"0", "1", "2", "3", "4", "5", "6"}
+
+        tl = "67896789" - tl  # sic, TypedSet used to coerce arguments, too.
+        assert tl == {"7", "8", "9"}
+        assert set(tl - {"8", "9"}) == {"7"}
+
+        assert set(tl ^ {"8", "9", "10"}) == {"7", "10"}
+        assert set({"8", "9", "10"} ^ tl) == {"7", "10"}
+        tl -= {"8"}
+        assert tl == StrSet("79")
+
+        with self.assertRaises(ValueError):
+            tl.add(42)
+
+        with self.assertRaises(ValueError):
+            tl.update((42,))
+
+        with self.assertRaises(ValueError):
+            tl |= {42}
+
+        with self.assertRaises(ValueError):
+            tl = tl | {42}
+
+        with self.assertRaises(ValueError):
+            tl = {42} | tl
+
+        with self.assertRaises(ValueError):
+            tl = {42} ^ tl
+
+        with self.assertRaises(ValueError):
+            tl &= {42}
+
+        with self.assertRaises(ValueError):
+            tl ^= {42}
+
+    def test_common_checkedset_pickling(self):
+        StrSet = self.BaseSet[str]
+        sd = StrSet({"123", "456"})
+
+        assert sd.type is str
+        assert type(sd) is StrSet
+        assert "123" in sd
+        assert "456" in sd
+
+        sd = pickle.loads(pickle.dumps(sd))
+
+        assert sd.type is str
+        assert type(sd) is StrSet
+        assert "123" in sd
+        assert "456" in sd

--- a/tests/common/test_checked.py
+++ b/tests/common/test_checked.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import *  # NoQA
 
 import pickle
+import sys
 import unittest
 
 from edb.common.checked import CheckedDict
@@ -111,7 +112,7 @@ class CheckedDictTests(unittest.TestCase):
         assert sd == sd2
 
 
-class BaseCheckedListTests(unittest.TestCase):
+class CheckedListTestBase:
     BaseList = FrozenCheckedList
 
     def test_common_checked_shared_list_basics(self) -> None:
@@ -161,7 +162,7 @@ class BaseCheckedListTests(unittest.TestCase):
         cls_name = self.BaseList.__name__
         expected = (
             f"edb.common.checked.{cls_name}[common.test_checked."
-            "BaseCheckedListTests.test_common_checked_shared_list_basics."
+            "CheckedListTestBase.test_common_checked_shared_list_basics."
             "<locals>.Foo]([Bar, Foo])"
         )
         assert repr(tl) == expected, repr(tl)
@@ -191,14 +192,16 @@ class BaseCheckedListTests(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "expects one type parameter"):
             self.BaseList[int, int]()
 
-        with self.assertRaisesRegex(TypeError, "expects types"):
-            self.BaseList[1]()
-
         with self.assertRaisesRegex(TypeError, "already parametrized"):
             self.BaseList[int][int]
 
+    @unittest.skipUnless(sys.version_info >= (3, 7, 3), "BPO-35992")
+    def test_common_checked_shared_list_non_type_parameter(self):
+        with self.assertRaisesRegex(TypeError, "expects types"):
+            self.BaseList[1]()
 
-class FrozenCheckedListTests(BaseCheckedListTests):
+
+class FrozenCheckedListTests(CheckedListTestBase, unittest.TestCase):
     BaseList = FrozenCheckedList
 
     def test_common_checked_frozenlist_basics(self) -> None:
@@ -208,7 +211,7 @@ class FrozenCheckedListTests(BaseCheckedListTests):
             sl.append("3")
 
 
-class CheckedListTests(BaseCheckedListTests):
+class CheckedListTests(CheckedListTestBase, unittest.TestCase):
     BaseList = CheckedList
 
     def test_common_checked_checkedlist_basics(self) -> None:
@@ -254,7 +257,7 @@ class CheckedListTests(BaseCheckedListTests):
             tl = (42,) + tl
 
 
-class BaseCheckedSetTests(unittest.TestCase):
+class CheckedSetTestBase:
     BaseSet = FrozenCheckedSet
 
     def test_common_checked_shared_set_basics(self) -> None:
@@ -296,17 +299,17 @@ class BaseCheckedSetTests(unittest.TestCase):
         cls_name = self.BaseSet.__name__
         expected_template = (
             f"edb.common.checked.{cls_name}[common.test_checked."
-            "BaseCheckedSetTests.test_common_checked_shared_set_basics."
+            "CheckedSetTestBase.test_common_checked_shared_set_basics."
             "<locals>.Foo]({})"
         )
         assert repr(tl) in {expected_template.format(e) for e in expected}
 
 
-class FrozenCheckedSetTests(BaseCheckedSetTests):
+class FrozenCheckedSetTests(CheckedSetTestBase, unittest.TestCase):
     BaseSet = FrozenCheckedSet
 
 
-class CheckedSetTests(BaseCheckedSetTests):
+class CheckedSetTests(CheckedSetTestBase, unittest.TestCase):
     BaseSet = CheckedSet
 
     def test_common_checked_checkedset_basics(self) -> None:

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -197,7 +197,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "cli", 0)
 
     def test_type_coverage_common(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "common", 3.78)
+        self.assertFunctionCoverage(EDB_DIR / "common", 16.91)
 
     def test_type_coverage_common_ast(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "common" / "ast", 0)


### PR DESCRIPTION
Those data structures are supposed to replace edb.common.typed.  These are the main selling points:
* they're fully type-annotated themselves;
* they are generic data structures enabling better annotating of other code; 
* they use *that same generic syntax* to perform runtime checking; and
* the parametrized types don't have to be pre-declared on module level for the type to be picklable.

Example usage:
```pycon
>>> from edb.common.checked import CheckedList
>>> cl = CheckedList[int]((1, 2, 3))
>>> cl.append(4)
>>> cl
edb.common.checked.CheckedList[int]([1, 2, 3, 4])
>>> cl.append("s")
Traceback (most recent call last):
...
ValueError: <class 'edb.common.checked.CheckedList[int]'> accepts only values of type <class 'int'>, got <class 'str'>
```

Other remarks:
* CheckedSet and FrozenCheckedSet implement all methods on the builtin data structures, unlike TypedSet and FrozenTypedSet.
* There is no separate OrderedCheckedDict since CheckedDict is ordered already.
* Just like in edb.common.typed there is no FrozenCheckedDict, we might add that later if needed. 
* edb.common.checked has a 50% test coverage whereas edb.common.typed had 36%.  In both cases the coverage is underreported because the test module is pre-imported before
coverage started.
* There is no need for separate parametrized classes like `StrList`, `IntSet` anymore. We can just use the generic types.
* Tests were copied from `test_typed` and extended to cover frozen collections as well.
* `edb.common.checked` collections have reprs that don't hide their true nature. For a compact representation use `str(collection)` instead of `repr(collection)`. I hope that's OK.
* Coercion isn't implemented in `edb.common.typed` but in `edb.common.struct` and `edb.schema.objects` (it looks like they share some design). I think it would be cleaner to move this functionality to the checked collections in form of an alternative constructor called simply `CheckedSet[int].coerce(iterable)`.
* Since they need to perform runtime type checks, `edb.common.checked` collections don't accept type variables, unions, and other special types. Parametrization needs to use concrete or abstract builtin types, user classes, or extension types.
* Type annotations on edb.common.checked classes are not covariant for simplicity. If we ever need that, it's relatively easy to change but they might be more verbose.
* Since this was not used anywhere, `edb.common.checked` doesn't implement "accept None" variants. This could be re-added by supporting `Optional[X]` as a type parameter but looks like we don't need it.
* The implementation doesn't depend on runtime type parametrization provided by `typing.Generic[T]` because this one is inadequate for pickling, coercion and type checks at `__init__` time. Instead, we're building picklable parametrized subclasses at runtime with `ParametricType.__class_getitem__`.
* The implementation has *some* code duplication due to type annotations being sometimes different between mutable and frozen variants of the same data structure. `ParametricType` itself cannot be generic because it implements `__class_getitem__` for our collections. I tried to minimize the duplication and think the result is fine. Mypy is very happy with those types.
* The implementation does not allow for customizing the underlying container type.  This ability of edb.common.typed was not used anywhere.
