### PR TITLE
Fix coverage integration in tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = False
 plugins = Cython.Coverage
+parallel = True
 
 [report]
 exclude_lines =

--- a/edb/common/devmode.py
+++ b/edb/common/devmode.py
@@ -80,6 +80,16 @@ class CoverageConfig(NamedTuple):
         )
 
     @classmethod
+    def start_coverage_if_requested(cls):
+        cov_config = cls.from_environ()
+        if cov_config is not None:
+            cov = cov_config.new_coverage_object()
+            cov.start()
+            return cov
+        else:
+            return None
+
+    @classmethod
     @contextlib.contextmanager
     def enable_coverage_if_requested(cls):
         cov_config = cls.from_environ()

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -197,7 +197,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "cli", 0)
 
     def test_type_coverage_common(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "common", 16.91)
+        self.assertFunctionCoverage(EDB_DIR / "common", 16.88)
 
     def test_type_coverage_common_ast(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "common" / "ast", 0)
@@ -292,7 +292,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "testbase", 0)
 
     def test_type_coverage_tools(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "tools", 8.43)
+        self.assertFunctionCoverage(EDB_DIR / "tools", 8.38)
 
     def test_type_coverage_tools_docs(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "tools" / "docs", 0)
@@ -301,7 +301,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "tools" / "mypy", 36.36)
 
     def test_type_coverage_tools_test(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "tools" / "test", 4.23)
+        self.assertFunctionCoverage(EDB_DIR / "tools" / "test", 4.17)
 
     def test_type_coverage_tests(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "tests", 0)


### PR DESCRIPTION
Current coverage integration is buggy in two ways:

First, in `-j1` mode, the test discovery is ran in the same process
as tests, so coverage might report module-level statements as uncovered,
since they've been executed before coverage started.  The fix is to
start coverage _before_ any test discovery.

Second, in `-jN` mode, any code that isn't part of the server process
isn't covered at all.  The fix here is to explicitly start coverage in
the test worker, and not just in the server process entrypoints.

I also added a check that the argument to `--cov` is not a file path,
since it's now possible to get very confused by
`edb test --cov test/file.py` by thinking you've enabled coverage for
everything and are testing `test/file.py`, whereas in fact you've
enabled coverage for `test/file.py` and are testing everything.