### PR TITLE
Replace TypedDict usage with CheckedDict

### DIFF
--- a/edb/common/markup/elements/base.py
+++ b/edb/common/markup/elements/base.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 from edb.common.struct import Struct, Field
+from edb.common import checked
 from edb.common import typed
 
 
@@ -71,8 +72,7 @@ class MarkupList(typed.TypedList, type=Markup):
     """List of BaseMarkup elements."""
 
 
-class MarkupMapping(typed.OrderedTypedDict, keytype=str, valuetype=Markup):
-    """Mapping ``str -> BaseMarkup``."""
+MarkupMapping = checked.CheckedDict[str, Markup]
 
 
 class OverflowBarier(Markup):

--- a/edb/common/struct.py
+++ b/edb/common/struct.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import collections
 
+from . import checked
 from . import typed
 
 
@@ -352,7 +353,7 @@ class Struct(metaclass=StructMeta):
                             v = ftype.type(v)
                         casted_value.append(v)
                     value = casted_value
-                elif issubclass(ftype, typed.AbstractTypedMapping):
+                elif issubclass(ftype, checked.CheckedDict):
                     casted_value = {}
                     for k, v in value.items():
                         if k is not None and not isinstance(k, ftype.keytype):

--- a/edb/common/typed.py
+++ b/edb/common/typed.py
@@ -24,7 +24,7 @@ import builtins
 import collections
 import collections.abc
 
-__all__ = 'TypedList', 'TypedDict', 'OrderedTypedDict'
+__all__ = ['TypedList']
 
 
 class TypedCollectionMeta(abc.ABCMeta):
@@ -103,75 +103,6 @@ class AbstractTypedSet(AbstractTypedCollection, type=None):
 
         for item in set:
             self._check_item(item)
-
-
-class AbstractTypedMapping(
-        AbstractTypedCollection, keytype=None, valuetype=None):
-    _TYPE_ARGS = ('keytype', 'valuetype')
-
-    def _check_key(self, key):
-        AbstractTypedCollection._check_type(self, key, self.keytype, 'keys')
-
-    def _check_value(self, value):
-        AbstractTypedCollection._check_type(
-            self, value, self.valuetype, 'values')
-
-    def _check_values(self, dct):
-        for key, value in dct.items():
-            self._check_key(key)
-            self._check_value(value)
-
-
-class _AbstractTypedDict(AbstractTypedMapping, keytype=None, valuetype=None):
-    _base_dict_cls = None
-
-    def __init__(self, *args, **kwargs):
-        """
-        :param kwargs: Initial values.
-        """
-
-        AbstractTypedCollection.__init__(self)
-        self.__class__._base_dict_cls.__init__(self)
-
-        if len(args) == 1:
-            self.update(args[0])
-        elif len(args) > 1:
-            msg = 'TypedDict expected at most 1 arguments, got {}'
-            raise TypeError(msg.format(len(args)))
-
-        if kwargs:
-            self.update(kwargs)
-
-    def __setitem__(self, key, value):
-        self._check_key(key)
-        self._check_value(value)
-        super().__setitem__(key, value)
-
-
-class TypedDict(
-        _AbstractTypedDict, collections.UserDict, keytype=None,
-        valuetype=None):
-    """Dict-like mapping with typed keys and values.
-
-    .. code-block:: pycon
-
-        >>> class StrIntMapping(TypedDict, keytype=str, valuetype=int):
-        ...    pass
-
-        >>> dct = StrIntMapping()
-        >>> dct['foo'] = 42
-
-        >>> dct['foo'] = 'spam'
-        ValueError
-    """
-
-    _base_dict_cls = collections.UserDict
-
-
-class OrderedTypedDict(
-        _AbstractTypedDict, collections.OrderedDict, keytype=None,
-        valuetype=None):
-    _base_dict_cls = collections.OrderedDict
 
 
 class FrozenTypedList(AbstractTypedSequence, collections.UserList, type=None):

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -31,7 +31,7 @@ from edb import errors
 from edb.common import adapter
 from edb.edgeql import ast as qlast
 
-from edb.common import markup, ordered, struct, typed
+from edb.common import checked, markup, ordered, struct, typed
 
 from . import expr as s_expr
 from . import name as sn
@@ -115,7 +115,7 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
         if isinstance(ftype, so.ObjectMeta):
             value = self._resolve_type_ref(value, schema)
 
-        elif issubclass(ftype, typed.AbstractTypedMapping):
+        elif issubclass(ftype, checked.CheckedDict):
             if issubclass(ftype.valuetype, so.Object):
                 vals = {}
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -29,6 +29,7 @@ import immutables as immu
 
 from edb import errors
 
+from edb.common import checked
 from edb.common import markup
 from edb.common import ordered
 from edb.common import parsing
@@ -202,7 +203,7 @@ class Field(struct.ProtoField):  # derived from ProtoField for validation
                 casted_value.append(v)
             return ftype(casted_value)
 
-        if issubclass(ftype, typed.AbstractTypedMapping):
+        if issubclass(ftype, checked.CheckedDict):
             casted_value = {}
             for k, v in value.items():
                 if k is not None and not isinstance(k, ftype.keytype):

--- a/tests/common/test_typed.py
+++ b/tests/common/test_typed.py
@@ -20,57 +20,10 @@
 import pickle
 import unittest
 
-from edb.common.typed import TypedDict, TypedList, StrList, TypedSet
-
-
-# StrDict and StrList are declared here (not in tests that use them)
-# to test pickling support (classes have to be accessible from the module
-# where declared)
-#
-class StrDict(TypedDict, keytype=str, valuetype=int):
-    pass
+from edb.common.typed import TypedList, StrList, TypedSet
 
 
 class TypedTests(unittest.TestCase):
-
-    def test_common_typeddict_basics(self):
-        assert StrDict({'1': 2})['1'] == 2
-        assert StrDict(foo=1, initdict=2)['initdict'] == 2
-
-        sd = StrDict(**{'1': 2})
-        assert sd['1'] == 2
-
-        assert dict(sd) == {'1': 2}
-
-        sd['foo'] = 42
-
-        with self.assertRaises(ValueError):
-            sd['foo'] = 'bar'
-        assert sd['foo'] == 42
-
-        with self.assertRaises(ValueError):
-            sd.update({'spam': 'ham'})
-
-        sd.update({'spam': 12})
-        assert sd['spam'] == 12
-
-        with self.assertRaises(ValueError):
-            StrDict(**{'foo': 'bar'})
-
-        with self.assertRaisesRegex(TypeError, "'valuetype'"):
-
-            class InvalidTypedDict(TypedDict, keytype=int):
-                """no 'valuetype' arg -- this class cannot be instantiated."""
-
-    def test_common_typeddict_pickling(self):
-        sd = StrDict()
-        sd['foo'] = 123
-
-        sd = pickle.loads(pickle.dumps(sd))
-
-        assert sd.keytype is str and sd.valuetype is int
-        assert type(sd) is StrDict
-        assert sd['foo'] == 123
 
     def test_common_typedlist_basics(self):
         tl = StrList()

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -197,7 +197,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "cli", 0)
 
     def test_type_coverage_common(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "common", 16.88)
+        self.assertFunctionCoverage(EDB_DIR / "common", 17.03)
 
     def test_type_coverage_common_ast(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "common" / "ast", 0)


### PR DESCRIPTION
Also removed TypedDict from the codebase.

## Note on perf
I didn't do any rigorous benchmarks but running the test suites 3X before and 3X after, the best of three for each looks like this:

### Before
SUCCESS
  tests ran: 2651
  expected failures: 67
  not implemented: 42

Running times:
  bootstrap: 00:00:57.6
  tests: 00:04:46.1
  total: 00:05:43.7

### After
SUCCESS
  tests ran: 2651
  expected failures: 67
  not implemented: 42

Running times:
  bootstrap: 00:00:57.6
  tests: 00:04:47.4
  total: 00:05:45.1

Note, the "After" runs were done before I removed the TypedDict code and tests.

Anyway, looks like there's two seconds lost there but I'd have to look why that would be. Maybe it's as simple as the extra imports in common.struct, schema.delta, and schema.objects. I'll look at what we can do about speeding this up when I'm doing profiling.