### PR TITLE
Allow ommitting target type in overloaded links and properties in SDL

### DIFF
--- a/edb/common/context.py
+++ b/edb/common/context.py
@@ -254,7 +254,10 @@ def has_context(func):
                     obj.val.context = obj.context
                 return result
 
-        obj.context = get_context(*args)
+        # Avoid mangling any existing context.
+        if getattr(obj, 'context', None) is None:
+            obj.context = get_context(*args)
+
         # we have the context for the nonterminal, but now we need to
         # enforce context in the obj.val, recursively, in case it was
         # a complex production with nested AST nodes

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -697,7 +697,7 @@ class CreateConcretePointer(CreateObject):
     bases: typing.List[TypeName]
     is_required: bool = False
     declared_inherited: bool = False
-    target: typing.Union[Expr, TypeExpr]
+    target: typing.Optional[typing.Union[Expr, TypeExpr]]
     cardinality: qltypes.Cardinality
 
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1039,8 +1039,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
         def after_name():
             self._ddl_visit_bases(node)
-            self.write(' -> ')
-            self.visit(node.target)
+            if node.target is not None:
+                self.write(' -> ')
+                self.visit(node.target)
         self._visit_CreateObject(
             node, *keywords, after_name=after_name, unqualified=True)
 
@@ -1076,14 +1077,15 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
         def after_name():
             self._ddl_visit_bases(node)
-            if isinstance(node.target, qlast.TypeExpr):
-                self.write(' -> ')
-                self.visit(node.target)
-            else:
-                # computable
-                self.write(' := (')
-                self.visit(node.target)
-                self.write(')')
+            if node.target is not None:
+                if isinstance(node.target, qlast.TypeExpr):
+                    self.write(' -> ')
+                    self.visit(node.target)
+                else:
+                    # computable
+                    self.write(' := (')
+                    self.visit(node.target)
+                    self.write(')')
         self._visit_CreateObject(
             node, *keywords, after_name=after_name, unqualified=True)
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -439,7 +439,6 @@ class ShapePointer(Nonterm):
 
 
 class PtrQualsSpec(typing.NamedTuple):
-    inherited: typing.Optional[bool] = None
     required: typing.Optional[bool] = None
     cardinality: typing.Optional[qltypes.Cardinality] = None
 
@@ -461,29 +460,6 @@ class PtrQuals(Nonterm):
     def reduce_REQUIRED_MULTI(self, *kids):
         self.val = PtrQualsSpec(
             required=True, cardinality=qltypes.Cardinality.MANY)
-
-    def reduce_INHERITED(self, *kids):
-        self.val = PtrQualsSpec(inherited=True)
-
-    def reduce_INHERITED_REQUIRED(self, *kids):
-        self.val = PtrQualsSpec(inherited=True, required=True)
-
-    def reduce_INHERITED_SINGLE(self, *kids):
-        self.val = PtrQualsSpec(
-            inherited=True, cardinality=qltypes.Cardinality.ONE)
-
-    def reduce_INHERITED_MULTI(self, *kids):
-        self.val = PtrQualsSpec(
-            inherited=True, cardinality=qltypes.Cardinality.MANY)
-
-    def reduce_INHERITED_REQUIRED_SINGLE(self, *kids):
-        self.val = PtrQualsSpec(
-            inherited=True, required=True, cardinality=qltypes.Cardinality.ONE)
-
-    def reduce_INHERITED_REQUIRED_MULTI(self, *kids):
-        self.val = PtrQualsSpec(
-            inherited=True, required=True,
-            cardinality=qltypes.Cardinality.MANY)
 
 
 class OptPtrQuals(Nonterm):

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -737,7 +737,7 @@ class PointerCommand(constraints.ConsistencySubjectCommand,
 
             target_ref = s_types.UnionTypeRef(
                 new_targets, module=source_name.module)
-        else:
+        elif targets:
             target_expr = targets[0]
             if isinstance(target_expr, qlast.TypeName):
                 target_ref = utils.ast_to_typeref(
@@ -751,6 +751,9 @@ class PointerCommand(constraints.ConsistencySubjectCommand,
                         context.modaliases,
                     )
                 )
+        else:
+            # Target is inherited.
+            target_ref = None
 
         if isinstance(self, sd.CreateObject):
             self.set_attribute_value(
@@ -763,7 +766,7 @@ class PointerCommand(constraints.ConsistencySubjectCommand,
             if self.get_attribute_value('required') is None:
                 self.set_attribute_value(
                     'required', False)
-        else:
+        elif target_ref is not None:
             self._set_pointer_type(schema, astnode, context, target_ref)
 
     @classmethod

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -856,6 +856,25 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_get_migration_08(self):
+        schema = r'''
+            type Foo;
+            type Spam {
+                link foo -> Foo;
+                property name -> str;
+            };
+            type Ham extending Spam {
+                inherited link foo {
+                    constraint exclusive;
+                };
+                inherited property name {
+                    constraint exclusive;
+                };
+            };
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_migrations_equivalence_01(self):
         self._assert_migration_equivalence([r"""
             type Base;

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -349,6 +349,14 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
             required multi link spam -> Spam;
             inherited required single link ham -> Ham;
             inherited required multi link eggs -> Egg;
+            inherited link knight;
+            inherited link clinic {
+                property argument -> int64;
+            };
+            inherited property castle;
+            inherited property tower {
+                constraint exclusive;
+            };
         };
         """
 

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 15.81)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 15.80)
 
     def test_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 56.47)


### PR DESCRIPTION
Currently, the SDL syntax requires one to re-state the target type when
overloading a link or a property in a subtype:

    type Foo {
        link spam -> <complicated type expr>
    }

    type Bar extending Foo {
        inherited link spam -> <complicated type expr> {
            <overloads>
        }
    }

This is both pointless and error-prone, so amend the syntax to allow the
type to be elided in an overloaded link or property:

    type Bar extending Foo {
        inherited link spam {
            <overloads>
        }
    }