### PR TITLE
An assortment of fixes for DESCRIBE infidelities

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -180,8 +180,11 @@ class Constraint(referencing.ReferencedInheritingObject,
                         for name, val in args_map.items()}
 
             args_map['__subject__'] = '{__subject__}'
-            attrs['errmessage'] = attrs['errmessage'].format(**args_map)
-            inherited.pop('errmessage', None)
+            message_template = attrs['errmessage']
+            formatted_message = message_template.format(**args_map)
+            if message_template != formatted_message:
+                attrs['errmessage'] = formatted_message
+                inherited['errmessage'] = False
 
         attrs['args'] = args
 

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -165,41 +165,46 @@ def delta_schemas(
 
     objects = sd.DeltaRoot(canonical=True)
 
-    for type in get_global_dep_order():
-        if issubclass(type, so.UnqualifiedObject):
+    for sclass in get_global_dep_order():
+        filters = []
+
+        if issubclass(sclass, derivable.DerivableObject):
+            filters.append(lambda schema, obj: obj.generic(schema))
+
+        if issubclass(sclass, so.UnqualifiedObject):
             # UnqualifiedObjects (like anonymous tuples and arrays)
             # should not use an included_modules filter.
             new = schema1.get_objects(
-                type=type,
+                type=sclass,
                 excluded_modules=excluded_modules,
                 included_items=included_items,
                 excluded_items=excluded_items,
+                extra_filters=filters,
             )
             old = schema2.get_objects(
-                type=type,
+                type=sclass,
                 excluded_modules=excluded_modules,
                 included_items=included_items,
                 excluded_items=excluded_items,
+                extra_filters=filters,
             )
         else:
             new = schema1.get_objects(
-                type=type,
+                type=sclass,
                 included_modules=included_modules,
                 excluded_modules=excluded_modules,
                 included_items=included_items,
                 excluded_items=excluded_items,
+                extra_filters=filters,
             )
             old = schema2.get_objects(
-                type=type,
+                type=sclass,
                 included_modules=included_modules,
                 excluded_modules=excluded_modules,
                 included_items=included_items,
                 excluded_items=excluded_items,
+                extra_filters=filters,
             )
-
-        if issubclass(type, derivable.DerivableObject):
-            new = filter(lambda i: i.generic(schema1), new)
-            old = filter(lambda i: i.generic(schema2), old)
 
         objects.update(so.Object.delta_sets(
             old, new, old_schema=schema2, new_schema=schema1))

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -232,8 +232,12 @@ class CreateLink(LinkCommand, referencing.CreateReferencedInheritingObject):
         elif op.property == 'target' and objtype:
             if isinstance(node, qlast.CreateConcreteLink):
                 if not node.target:
-                    t = op.new_value
-                    node.target = utils.typeref_to_ast(schema, t)
+                    expr = self.get_attribute_value('expr')
+                    if expr is not None:
+                        node.target = expr.qlast
+                    else:
+                        t = op.new_value
+                        node.target = utils.typeref_to_ast(schema, t)
             else:
                 node.commands.append(
                     qlast.SetLinkType(

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -229,7 +229,12 @@ class CreateProperty(PropertyCommand,
             node.cardinality = op.new_value
         elif op.property == 'target' and link:
             if isinstance(node, qlast.CreateConcreteProperty):
-                node.target = utils.typeref_to_ast(schema, op.new_value)
+                expr = self.get_attribute_value('expr')
+                if expr is not None:
+                    node.target = expr.qlast
+                else:
+                    t = op.new_value
+                    node.target = utils.typeref_to_ast(schema, t)
             else:
                 node.commands.append(
                     qlast.SetPropertyType(

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1249,7 +1249,6 @@ class ObjectRef(Object):
         schemaclass: Optional[ObjectMeta]=None,
         sourcectx=None,
     ) -> None:
-        super().__init__(_private_init=True)
         self.__dict__['_name'] = name
         self.__dict__['_origname'] = origname
         self.__dict__['_sourcectx'] = sourcectx

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -283,6 +283,12 @@ class CreateObjectType(ObjectTypeCommand, inheriting.CreateInheritingObject):
         cmd = cls._handle_view_op(schema, cmd, astnode, context)
         return cmd
 
+    def _get_ast_node(self, schema, context):
+        if self.get_attribute_value('expr'):
+            return qlast.CreateView
+        else:
+            return super()._get_ast_node(schema, context)
+
 
 class RenameObjectType(ObjectTypeCommand, sd.RenameObject):
     pass

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -147,6 +147,23 @@ class BaseObjectType(sources.Source,
             return all(c._issubclass(schema, parent)
                        for c in my_vchildren.objects(schema))
 
+    def _reduce_to_ref(self, schema):
+        union_of = self.get_union_of(schema)
+        if union_of:
+            my_name = self.get_name(schema)
+            return (
+                s_types.ExistingUnionTypeRef(
+                    components=[
+                        c._reduce_to_ref(schema)[0]
+                        for c in union_of.objects(schema)
+                    ],
+                    name=my_name,
+                ),
+                my_name,
+            )
+        else:
+            return super()._reduce_to_ref(schema)
+
 
 class ObjectType(BaseObjectType, qlkind=qltypes.SchemaObjectClass.TYPE):
     pass

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -241,6 +241,12 @@ class CreateScalarType(ScalarTypeCommand, inheriting.CreateInheritingObject):
 
         return cmd
 
+    def _get_ast_node(self, schema, context):
+        if self.get_attribute_value('expr'):
+            return qlast.CreateView
+        else:
+            return super()._get_ast_node(schema, context)
+
     def _apply_field_ast(self, schema, context, node, op):
         if op.property == 'default':
             if op.new_value:

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -347,12 +347,14 @@ class UnionTypeRef(so.Object):
         components: Iterable[so.ObjectRef], *,
         module: str,
     ) -> None:
-        super().__init__(_private_init=True)
         self.__dict__['_components'] = tuple(components)
         self.__dict__['module'] = module
 
     def resolve_components(self, schema) -> typing.Tuple[Type, ...]:
         return tuple(c._resolve_ref(schema) for c in self._components)
+
+    def get_union_of(self, schema) -> typing.Tuple[so.ObjectRef, ...]:
+        return self._components
 
     def __repr__(self) -> str:
         return f'<UnionTypeRef {self._components!r} at 0x{id(self):x}>'
@@ -369,6 +371,26 @@ class UnionTypeRef(so.Object):
         self, schema: s_schema.Schema
     ) -> typing.Tuple[UnionTypeRef, typing.Tuple[so.ObjectRef, ...]]:
         return self, self._components
+
+
+class ExistingUnionTypeRef(so.ObjectRef, UnionTypeRef):
+
+    def __init__(
+        self,
+        *,
+        name: s_name.Name,
+        components: Iterable[so.ObjectRef],
+        origname: Optional[str]=None,
+        schemaclass: Optional[so.ObjectMeta]=None,
+        sourcectx=None,
+    ) -> None:
+
+        so.ObjectRef.__init__(
+            self, name=name, origname=origname,
+            schemaclass=schemaclass, sourcectx=sourcectx)
+
+        UnionTypeRef.__init__(
+            self, components=components, module=name.module)
 
 
 class Collection(Type, s_abc.Collection):

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -145,9 +145,11 @@ class BaseDocTest(unittest.TestCase, metaclass=DocTestMeta):
             expected_stripped = expected.lower()
             result_stripped = result.lower()
 
-        assert expected_stripped == result_stripped, \
-            '[test]expected: {}\n[test] != returned: {}'.format(
-                expected, result)
+        self.assertEqual(
+            expected_stripped,
+            result_stripped,
+            f'\nexpected:\n{expected}\nreturned:\n{result}'
+        )
 
 
 class BaseSyntaxTest(BaseDocTest):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2936,3 +2936,26 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             };
             """
         )
+
+    def test_describe_04(self):
+        self._assert_describe(
+            """
+            abstract constraint my_one_of(one_of: array<anytype>) {
+                expr := contains(one_of, __subject__);
+            }
+            """,
+
+            'DESCRIBE SCHEMA',
+
+            """
+            CREATE MODULE test;
+
+            CREATE ABSTRACT CONSTRAINT test::my_one_of(one_of: array<anytype>){
+                SET expr := (WITH
+                    MODULE test
+                SELECT
+                    contains(one_of, __subject__)
+                );
+            };
+            """
+        )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2917,3 +2917,22 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 """,
             ]
         )
+
+    def test_describe_03(self):
+        self._assert_describe(
+            """
+            scalar type custom_str_t extending str {
+                constraint regexp('[A-Z]+');
+            }
+            """,
+
+            'DESCRIBE SCHEMA',
+
+            """
+            CREATE MODULE test;
+
+            CREATE SCALAR TYPE test::custom_str_t EXTENDING std::str {
+                CREATE CONSTRAINT std::regexp('[A-Z]+');
+            };
+            """
+        )

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 0)
 
     def test_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 15.45)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 15.34)
 
     def test_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 6.67)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 0)
 
     def test_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 15.27)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 15.24)
 
     def test_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 6.67)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 0)
 
     def test_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 15.29)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 15.27)
 
     def test_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 6.67)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 0)
 
     def test_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 15.34)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 15.29)
 
     def test_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 6.67)


### PR DESCRIPTION
* Fix rendering of view and computables

  Use the correct `CREATE VIEW` syntax for views and prefer the shorthand 
  syntax for computable links and properties.

* Emit abstract constraint parameters correctly

  The parameter definitions of abstract constraints are currently not emitted
  altogether.  Fix this.

* Stop marking Constraint.errmessage as non-inherited if interpolated

  In abstract constraints `errmessage` is usually a string template, which
  may contain references to constraint arguments, in which case argument
  values are interpolated into the error message, and it is marked as
  non-inherited.  The last bit is actually not necessary, since the
  interpolation is reproducible.

* Render union types correctly in description of link targets

  This ensures that the original type union expression is rendered instead of
  an internal name for the generated union type.

* Omit derived types (such as unions) from DESCRIBE output

  Derived types are a result of some DDL construct, such as a union type 
  declaration, as should not appear as full types.

Props to @1st1 for noticing these.