### PR TITLE
Several fixes for the handling of views in schema

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -147,6 +147,9 @@ class Environment:
     schema_refs: Set[s_obj.Object]
     """A set of all schema objects referenced by an expression."""
 
+    created_schema_objects: Set[s_obj.Object]
+    """A set of all schema objects derived by this compilation."""
+
     allow_generic_type_output: bool
     """Whether to allow the expression to be of a generic type."""
 
@@ -177,6 +180,7 @@ class Environment:
         self.allow_abstract_operators = allow_abstract_operators
         self.allow_generic_type_output = allow_generic_type_output
         self.schema_refs = set()
+        self.created_schema_objects = set()
         self.func_params = func_params
         self.parent_object_type = parent_object_type
 

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -36,7 +36,6 @@ from edb.schema import modules as s_mod
 from edb.schema import name as sn
 from edb.schema import operators as s_oper
 from edb.schema import types as s_types
-from edb.schema import utils as s_utils
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes as ft
@@ -48,6 +47,7 @@ from . import dispatch
 from . import inference
 from . import pathctx
 from . import polyres
+from . import schemactx
 from . import setgen
 from . import stmtctx
 from . import typegen
@@ -383,8 +383,7 @@ def compile_operator(
         elif right_type.issubclass(env.schema, left_type):
             rtype = left_type
         else:
-            env.schema, rtype = s_utils.get_union_type(
-                env.schema, [left_type, right_type])
+            rtype = schemactx.get_union_type([left_type, right_type], ctx=ctx)
 
     is_polymorphic = (
         any(p.get_type(env.schema).is_polymorphic(env.schema)

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -234,8 +234,7 @@ def extract_filters(
                     if left_stype == result_stype:
                         ptr = left_stype.getptr(schema, 'id')
                     else:
-                        ptr = env.get_track_schema_object(
-                            left.rptr.ptrref.name)
+                        ptr = env.schema.get(left.rptr.ptrref.name)
 
                     ptr_filters.append((ptr, right))
 
@@ -245,8 +244,7 @@ def extract_filters(
                     if right_stype == result_stype:
                         ptr = right_stype.getptr(schema, 'id')
                     else:
-                        ptr = env.get_track_schema_object(
-                            right.rptr.ptrref.name)
+                        ptr = env.schema.get(right.rptr.ptrref.name)
 
                     ptr_filters.append((ptr, left))
 

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -31,7 +31,6 @@ from edb.ir import typeutils as irtyputils
 
 from edb.schema import abc as s_abc
 from edb.schema import types as s_types
-from edb.schema import utils as s_utils
 
 from edb.edgeql import ast as qlast
 
@@ -63,9 +62,7 @@ def ql_typeexpr_to_type(
 
     types = _ql_typeexpr_to_type(ql_t, ctx=ctx)
     if len(types) > 1:
-        ctx.env.schema, uniontype = s_utils.get_union_type(
-            ctx.env.schema, types)
-        return uniontype
+        return schemactx.get_union_type(types, ctx=ctx)
     else:
         return types[0]
 

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -244,6 +244,11 @@ def trace_Path(node: qlast.Path, *,
                     return
 
             if step.type == 'property':
+                if ptr is None:
+                    # This is either a computable def, or
+                    # unknown link, bail.
+                    return
+
                 lprop = ptr.getptr(ctx.schema, step.ptr.name)
                 if lprop is None:
                     # Invalid link property reference, bail.

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -207,6 +207,7 @@ def get_or_create_union_type(
 
     type_id = s_types.generate_type_id(name)
     objtype = schema.get_by_id(type_id, None)
+    created = objtype is None
     if objtype is None:
         components = list(components)
 
@@ -255,7 +256,7 @@ def get_or_create_union_type(
                     if objtype.getptr(schema, pn) is None:
                         schema = objtype.add_pointer(schema, ptr)
 
-    return schema, objtype
+    return schema, objtype, created
 
 
 class ObjectTypeCommandContext(sd.ObjectCommandContext,

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -38,6 +38,9 @@ from . import sources
 from . import types as s_types
 from . import utils
 
+if TYPE_CHECKING:
+    from . import schema as s_schema
+
 
 class BaseObjectType(sources.Source,
                      s_types.Type,
@@ -284,8 +287,22 @@ class CreateObjectType(ObjectTypeCommand, inheriting.CreateInheritingObject):
         cmd = cls._handle_view_op(schema, cmd, astnode, context)
         return cmd
 
+    def _get_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> Optional[qlast.Base]:
+        if (self.get_attribute_value('view_type')
+                and not self.get_attribute_value('expr')):
+            # This is a nested view type, e.g
+            # __FooView_bar produced by  FooView := (SELECT Foo { bar: ... })
+            # and should obviously not appear as a top level definition.
+            return None
+        else:
+            return super()._get_ast(schema, context)
+
     def _get_ast_node(self, schema, context):
-        if self.get_attribute_value('expr'):
+        if self.get_attribute_value('view_type'):
             return qlast.CreateView
         else:
             return super()._get_ast_node(schema, context)

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -305,8 +305,13 @@ class Pointer(referencing.ReferencedInheritingObject,
                         f'{t1.get_displayname(schema)!r}.'))
 
             if len(new_targets) > 1:
-                schema, current_target = s_objtypes.get_or_create_union_type(
-                    schema, new_targets, module=source.get_name(schema).module)
+                schema, current_target, _ = (
+                    s_objtypes.get_or_create_union_type(
+                        schema,
+                        new_targets,
+                        module=source.get_name(schema).module,
+                    )
+                )
             else:
                 current_target = new_targets[0]
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1798,10 +1798,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             )
         """])
 
-    @test.xfail('''
-        Eventually `trace_Path` fails with:
-        AttributeError: 'NoneType' object has no attribute 'getptr'
-    ''')
     def test_migrations_equivalence_41(self):
         # testing schema views
         self._assert_migration_equivalence([r"""
@@ -1844,10 +1840,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             )
         """])
 
-    @test.xfail('''
-        Eventually `trace_Path` fails with:
-        AttributeError: 'NoneType' object has no attribute 'getptr'
-    ''')
     def test_migrations_equivalence_42(self):
         # testing schema views
         self._assert_migration_equivalence([r"""

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,10 +206,10 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 15.81)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 15.89)
 
     def test_type_coverage_edgeql_compiler(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 56.65)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 56.84)
 
     def test_type_coverage_edgeql_parser(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "parser", 0)
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 0)
 
     def test_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 15.24)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 15.22)
 
     def test_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 6.67)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 0)
 
     def test_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 15.22)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 15.32)
 
     def test_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 6.67)


### PR DESCRIPTION
* Make sure types created for nested views do not appear at top level

  View types produced as a result of a view definition that contains nested
  shapes should not appear as top level definitions.

* Ensure objects derived during compilation don't end up as expr refs

  When computing the set of schema object references for an expression, make
  sure to exclude any objects produced during compilation.

* Fix SDL deptracer crash on link property computables

  Computable link properties will usually have no parent link context when 
  traced, and they're new objects and cannot be a dependency.