### PR TITLE
Fix implicit id and __tid__ injection in DML statements

### DIFF
--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -246,13 +246,14 @@ class TestDelete(tb.QueryTestCase):
             }],
         )
 
-        await self.assert_query_result(
+        deleted = await self.con.fetchall(
             r"""
                 WITH MODULE test
-                SELECT (DELETE DeleteTest2) { name };
+                DELETE DeleteTest2;
             """,
-            [{}, {}],
         )
+
+        self.assertTrue(hasattr(deleted[0], '__tid__'))
 
     async def test_edgeql_delete_returning_04(self):
         await self.con.execute(r"""

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -542,10 +542,10 @@ class TestInsert(tb.QueryTestCase):
         await self.assert_query_result(
             '''
                 WITH MODULE test
-                SELECT (INSERT DefaultTest1 {
+                INSERT DefaultTest1 {
                     foo := 'ret1',
                     num := 1,
-                });
+                };
             ''',
             [{
                 'id': uuid.UUID,
@@ -575,6 +575,19 @@ class TestInsert(tb.QueryTestCase):
             ''',
             [3],
         )
+
+        obj = await self.con.fetchone(
+            '''
+                WITH MODULE test
+                INSERT DefaultTest1 {
+                    foo := 'ret1',
+                    num := 1,
+                };
+            ''',
+        )
+
+        self.assertTrue(hasattr(obj, 'id'))
+        self.assertTrue(hasattr(obj, '__tid__'))
 
     async def test_edgeql_insert_returning_03(self):
         await self.con.execute('''

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -438,6 +438,20 @@ class TestUpdate(tb.QueryTestCase):
                     }
                 ],
             )
+
+            objs = await self.con.fetchall(
+                r"""
+                    WITH MODULE test
+                    UPDATE UpdateTest
+                    FILTER UpdateTest.name LIKE '%ret5._'
+                    SET {
+                        name := 'new ' ++ UpdateTest.name
+                    };
+                """
+            )
+
+            self.assertTrue(hasattr(objs[0], '__tid__'))
+
         finally:
             await self.con.execute(r"""
                 DELETE (


### PR DESCRIPTION
The current coding inhibits implicit id/tid in subject shapes of
DML statements, which is correct, but it _also_ erroneously affects the
return shape of the statement.  Fix this.

Fixes: #664.