### PR TITLE
edgeql: Change `FROM` to `USING` keyword.

### DIFF
--- a/docs/edgeql/ddl/functions.rst
+++ b/docs/edgeql/ddl/functions.rst
@@ -21,7 +21,7 @@ CREATE FUNCTION
 
     [ WITH <with-item> [, ...] ]
     CREATE FUNCTION <name> ([ <argspec> ] [, ... ]) -> <returnspec>
-    FROM <language> <functionbody> ;
+    USING <language> <functionbody> ;
 
     [ WITH <with-item> [, ...] ]
     CREATE FUNCTION <name> ([ <argspec> ] [, ... ]) -> <returnspec>
@@ -47,7 +47,7 @@ CREATE FUNCTION
 
       SET session_only := {true | false}
       SET ANNOTATION <annotation-name> := <value>
-      FROM <language> <functionbody>
+      USING <language> <functionbody>
 
 
 Description
@@ -149,7 +149,7 @@ block:
 
     See :eql:stmt:`SET ANNOTATION` for details.
 
-:eql:synopsis:`FROM <language> <functionbody>`
+:eql:synopsis:`USING <language> <functionbody>`
     See the meaning of *language* and *functionbody* above.
 
 
@@ -161,7 +161,7 @@ Define a function returning the sum of its arguments:
 .. code-block:: edgeql
 
     CREATE FUNCTION mysum(a: int64, b: int64) -> int64
-    FROM edgeql $$
+    USING edgeql $$
         SELECT a + b;
     $$;
 
@@ -170,7 +170,7 @@ The same, but using a variadic argument:
 .. code-block:: edgeql
 
     CREATE FUNCTION mysum(VARIADIC argv: int64) -> int64
-    FROM edgeql $$
+    USING edgeql $$
         SELECT sum(array_unpack(argv));
     $$;
 
@@ -179,7 +179,7 @@ Define a function using the block syntax:
 .. code-block:: edgeql
 
     CREATE FUNCTION mysum(a: int64, b: int64) -> int64 {
-        FROM edgeql $$
+        USING edgeql $$
             SELECT a + b;
         $$;
         SET ANNOTATION title := "My sum function.";

--- a/docs/edgeql/sdl/functions.rst
+++ b/docs/edgeql/sdl/functions.rst
@@ -17,7 +17,7 @@ the end of the that string:
 .. code-block:: sdl
 
     function foo(s: str) -> str
-        from EdgeQL $$
+        using EdgeQL $$
             SELECT s ++ <str>len(a)
         $$;
 
@@ -31,13 +31,13 @@ commands <ref_eql_ddl_functions>`.
 .. sdl:synopsis::
 
     function <name> ([ <argspec> ] [, ... ]) -> <returnspec>
-    from <language> <functionbody> ;
+    using <language> <functionbody> ;
 
     function <name> ([ <argspec> ] [, ... ]) -> <returnspec>
     "{"
         session_only := {true | false} ;
         [ <annotation-declarations> ]
-        from <language> <functionbody> ;
+        using <language> <functionbody> ;
     "}" ;
 
     # where <argspec> is:

--- a/edb/common/ast/codegen.py
+++ b/edb/common/ast/codegen.py
@@ -18,18 +18,25 @@
 
 
 from __future__ import annotations
+from typing import *  # NoQA
 
 import itertools
 
+from . import base
 from .visitor import NodeVisitor
 
 
 class SourceGenerator(NodeVisitor):
     """Generate source code from an AST tree."""
 
+    result: List[str]
+
     def __init__(
-            self, indent_with=' ' * 4, add_line_information=False,
-            pretty=True):
+        self,
+        indent_with: str = ' ' * 4,
+        add_line_information: bool = False,
+        pretty: bool = True
+    ) -> None:
         self.result = []
         self.indent_with = indent_with
         self.add_line_information = add_line_information
@@ -39,12 +46,16 @@ class SourceGenerator(NodeVisitor):
         self.current_line = 1
         self.pretty = pretty
 
-    def node_visit(self, node):
+    def node_visit(self, node: base.AST) -> None:
         method = 'visit_' + node.__class__.__name__
         visitor = getattr(self, method, self.generic_visit)
         return visitor(node)
 
-    def write(self, *x, delimiter=None):
+    def write(
+        self,
+        *x: str,
+        delimiter: Optional[str] = None
+    ) -> None:
         if self.new_lines:
             if self.result and self.pretty:
                 self.current_line += self.new_lines
@@ -69,8 +80,14 @@ class SourceGenerator(NodeVisitor):
             self.result.append(chunk)
 
     def visit_list(
-            self, items, *,
-            separator=',', terminator=None, newlines=True, **kwargs):
+        self,
+        items: Sequence[base.AST],
+        *,
+        separator: str = ',',
+        terminator: Optional[str] = None,
+        newlines: bool = True,
+        **kwargs: Any
+    ) -> None:
         # terminator overrides separator setting
         #
         separator = terminator if terminator is not None else separator
@@ -92,8 +109,13 @@ class SourceGenerator(NodeVisitor):
 
     @classmethod
     def to_source(
-            cls, node, indent_with=' ' * 4, add_line_information=False,
-            pretty=True, **kwargs):
+        cls,
+        node: Union[base.AST, Sequence[base.AST]],
+        indent_with: str = ' ' * 4,
+        add_line_information: bool = False,
+        pretty: bool = True,
+        **kwargs: Any
+    ) -> str:
         generator = cls(indent_with, add_line_information,
                         pretty=pretty, **kwargs)
         generator.visit(node)

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1342,13 +1342,13 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 self.write(' ')
 
             if node.code.from_function:
-                from_clause = f'FROM {node.code.language} FUNCTION '
+                from_clause = f'USING {node.code.language} FUNCTION '
                 if self.sdlmode:
                     from_clause = from_clause.lower()
                 self.write(from_clause)
                 self.write(f'{node.code.from_function!r}')
             else:
-                from_clause = f'FROM {node.code.language} '
+                from_clause = f'USING {node.code.language} '
                 if self.sdlmode:
                     from_clause = from_clause.lower()
                 self.write(from_clause)

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -327,7 +327,7 @@ def trace_View(
     hard_dep_exprs = []
 
     for cmd in node.commands:
-        if isinstance(cmd, qlast.SetField) and cmd.name.name == "expr":
+        if isinstance(cmd, qlast.SetField) and cmd.name == "expr":
             hard_dep_exprs.append(cmd.value)
             break
 
@@ -362,6 +362,8 @@ def _register_item(
 
     if isinstance(decl, qlast.CreateConcretePointer):
         name = decl.name.name
+    elif isinstance(decl, qlast.BaseSetField):
+        name = decl.name
     else:
         name = ctx.get_local_name(decl.name)
 

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -284,26 +284,26 @@ class FunctionType(Nonterm):
 
 
 class FromFunction(Nonterm):
-    def reduce_FROM_Identifier_BaseStringConstant(self, *kids):
+    def reduce_USING_Identifier_BaseStringConstant(self, *kids):
         lang = _parse_language(kids[1])
         code = kids[2].val.value
         self.val = qlast.FunctionCode(language=lang, code=code)
 
-    def reduce_FROM_Identifier_FUNCTION_BaseStringConstant(self, *kids):
+    def reduce_USING_Identifier_FUNCTION_BaseStringConstant(self, *kids):
         lang = _parse_language(kids[1])
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
-                f'{lang} language is not supported in FROM FUNCTION clause',
+                f'{lang} language is not supported in USING FUNCTION clause',
                 context=kids[1].context) from None
 
         self.val = qlast.FunctionCode(language=lang,
                                       from_function=kids[3].val.value)
 
-    def reduce_FROM_Identifier_EXPRESSION(self, *kids):
+    def reduce_USING_Identifier_EXPRESSION(self, *kids):
         lang = _parse_language(kids[1])
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
-                f'{lang} language is not supported in FROM clause',
+                f'{lang} language is not supported in USING clause',
                 context=kids[1].context) from None
 
         self.val = qlast.FunctionCode(language=lang)
@@ -324,34 +324,34 @@ class ProcessFunctionBlockMixin:
                 if node.from_function:
                     if from_function is not None:
                         raise EdgeQLSyntaxError(
-                            'more than one FROM FUNCTION clause',
+                            'more than one USING FUNCTION clause',
                             context=node.context)
                     from_function = node.from_function
 
                 elif node.code:
                     if code is not None:
                         raise EdgeQLSyntaxError(
-                            'more than one FROM <code> clause',
+                            'more than one USING <code> clause',
                             context=node.context)
                     code = node.code
                     language = node.language
 
                 else:
-                    # FROM SQL EXPRESSION
+                    # USING SQL EXPRESSION
                     from_expr = True
             else:
                 commands.append(node)
 
         if (code is None and from_function is None and not from_expr):
             raise EdgeQLSyntaxError(
-                'CREATE FUNCTION requires at least one FROM clause',
+                'CREATE FUNCTION requires at least one USING clause',
                 context=block.context)
 
         else:
             if from_expr and (from_function or code):
                 raise EdgeQLSyntaxError(
-                    'FROM SQL EXPRESSION is mutually exclusive with other '
-                    'FROM variants',
+                    'USING SQL EXPRESSION is mutually exclusive with other '
+                    'USING variants',
                     context=block.context)
 
             props['code'] = qlast.FunctionCode(

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1533,18 +1533,18 @@ class OperatorKind(Nonterm):
 
 class OperatorCode(Nonterm):
 
-    def reduce_FROM_Identifier_OPERATOR_BaseStringConstant(self, *kids):
+    def reduce_USING_Identifier_OPERATOR_BaseStringConstant(self, *kids):
         lang = commondl._parse_language(kids[1])
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
-                f'{lang} language is not supported in FROM OPERATOR clause',
+                f'{lang} language is not supported in USING OPERATOR clause',
                 context=kids[1].context) from None
 
         sql_operator = kids[3].val.value
         m = re.match(r'([^(]+)(?:\((\w*(?:,\s*\w*)*)\))?', sql_operator)
         if not m:
             raise EdgeQLSyntaxError(
-                f'invalid syntax for FROM OPERATOR clause',
+                f'invalid syntax for USING OPERATOR clause',
                 context=kids[3].context) from None
 
         sql_operator = (m.group(1),)
@@ -1555,31 +1555,31 @@ class OperatorCode(Nonterm):
         self.val = qlast.OperatorCode(
             language=lang, from_operator=sql_operator)
 
-    def reduce_FROM_Identifier_FUNCTION_BaseStringConstant(self, *kids):
+    def reduce_USING_Identifier_FUNCTION_BaseStringConstant(self, *kids):
         lang = commondl._parse_language(kids[1])
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
-                f'{lang} language is not supported in FROM FUNCTION clause',
+                f'{lang} language is not supported in USING FUNCTION clause',
                 context=kids[1].context) from None
 
         self.val = qlast.OperatorCode(language=lang,
                                       from_function=kids[3].val.value)
 
-    def reduce_FROM_Identifier_BaseStringConstant(self, *kids):
+    def reduce_USING_Identifier_BaseStringConstant(self, *kids):
         lang = commondl._parse_language(kids[1])
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
-                f'{lang} language is not supported in FROM clause',
+                f'{lang} language is not supported in USING clause',
                 context=kids[1].context) from None
 
         self.val = qlast.OperatorCode(language=lang,
                                       code=kids[2].val.value)
 
-    def reduce_FROM_Identifier_EXPRESSION(self, *kids):
+    def reduce_USING_Identifier_EXPRESSION(self, *kids):
         lang = commondl._parse_language(kids[1])
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
-                f'{lang} language is not supported in FROM clause',
+                f'{lang} language is not supported in USING clause',
                 context=kids[1].context) from None
 
         self.val = qlast.OperatorCode(language=lang)
@@ -1649,7 +1649,7 @@ class CreateOperatorStmt(Nonterm):
             if isinstance(node, qlast.OperatorCode):
                 if abstract:
                     raise errors.InvalidOperatorDefinitionError(
-                        'unexpected FROM clause in abstract '
+                        'unexpected USING clause in abstract '
                         'operator definition',
                         context=node.context,
                     )
@@ -1657,26 +1657,26 @@ class CreateOperatorStmt(Nonterm):
                 if node.from_function:
                     if from_function is not None:
                         raise errors.InvalidOperatorDefinitionError(
-                            'more than one FROM FUNCTION clause',
+                            'more than one USING FUNCTION clause',
                             context=node.context)
                     from_function = node.from_function
 
                 elif node.from_operator:
                     if from_operator is not None:
                         raise errors.InvalidOperatorDefinitionError(
-                            'more than one FROM OPERATOR clause',
+                            'more than one USING OPERATOR clause',
                             context=node.context)
                     from_operator = node.from_operator
 
                 elif node.code:
                     if code is not None:
                         raise errors.InvalidOperatorDefinitionError(
-                            'more than one FROM <code> clause',
+                            'more than one USING <code> clause',
                             context=node.context)
                     code = node.code
 
                 else:
-                    # FROM SQL EXPRESSION
+                    # USING SQL EXPRESSION
                     from_expr = True
             else:
                 commands.append(node)
@@ -1686,14 +1686,14 @@ class CreateOperatorStmt(Nonterm):
                     and from_function is None
                     and not from_expr):
                 raise errors.InvalidOperatorDefinitionError(
-                    'CREATE OPERATOR requires at least one FROM clause',
+                    'CREATE OPERATOR requires at least one USING clause',
                     context=block.context)
 
             else:
                 if from_expr and (from_operator or from_function or code):
                     raise errors.InvalidOperatorDefinitionError(
-                        'FROM SQL EXPRESSION is mutually exclusive with other '
-                        'FROM variants',
+                        'USING SQL EXPRESSION is mutually exclusive with '
+                        'other USING variants',
                         context=block.context)
 
                 props['code'] = qlast.OperatorCode(
@@ -1774,40 +1774,40 @@ class CastAllowedUse(Nonterm):
 
 class CastCode(Nonterm):
 
-    def reduce_FROM_Identifier_FUNCTION_BaseStringConstant(self, *kids):
+    def reduce_USING_Identifier_FUNCTION_BaseStringConstant(self, *kids):
         lang = commondl._parse_language(kids[1])
         if lang not in {qlast.Language.SQL, qlast.Language.EdgeQL}:
             raise EdgeQLSyntaxError(
-                f'{lang} language is not supported in FROM FUNCTION clause',
+                f'{lang} language is not supported in USING FUNCTION clause',
                 context=kids[1].context) from None
 
         self.val = qlast.CastCode(language=lang,
                                   from_function=kids[3].val.value)
 
-    def reduce_FROM_Identifier_BaseStringConstant(self, *kids):
+    def reduce_USING_Identifier_BaseStringConstant(self, *kids):
         lang = commondl._parse_language(kids[1])
         if lang not in {qlast.Language.SQL, qlast.Language.EdgeQL}:
             raise EdgeQLSyntaxError(
-                f'{lang} language is not supported in FROM clause',
+                f'{lang} language is not supported in USING clause',
                 context=kids[1].context) from None
 
         self.val = qlast.CastCode(language=lang,
                                   code=kids[2].val.value)
 
-    def reduce_FROM_Identifier_CAST(self, *kids):
+    def reduce_USING_Identifier_CAST(self, *kids):
         lang = commondl._parse_language(kids[1])
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
-                f'{lang} language is not supported in FROM CAST clause',
+                f'{lang} language is not supported in USING CAST clause',
                 context=kids[1].context) from None
 
         self.val = qlast.CastCode(language=lang, from_cast=True)
 
-    def reduce_FROM_Identifier_EXPRESSION(self, *kids):
+    def reduce_USING_Identifier_EXPRESSION(self, *kids):
         lang = commondl._parse_language(kids[1])
         if lang != qlast.Language.SQL:
             raise EdgeQLSyntaxError(
-                f'{lang} language is not supported in FROM EXPRESSION clause',
+                f'{lang} language is not supported in USING EXPRESSION clause',
                 context=kids[1].context) from None
 
         self.val = qlast.CastCode(language=lang)
@@ -1852,33 +1852,33 @@ class CreateCastStmt(Nonterm):
                 if node.from_function:
                     if from_function is not None:
                         raise EdgeQLSyntaxError(
-                            'more than one FROM FUNCTION clause',
+                            'more than one USING FUNCTION clause',
                             context=node.context)
                     from_function = node.from_function
 
                 elif node.code:
                     if code is not None:
                         raise EdgeQLSyntaxError(
-                            'more than one FROM <code> clause',
+                            'more than one USING <code> clause',
                             context=node.context)
                     code = node.code
 
                 elif node.from_cast:
-                    # FROM SQL CAST
+                    # USING SQL CAST
 
                     if from_cast:
                         raise EdgeQLSyntaxError(
-                            'more than one FROM CAST clause',
+                            'more than one USING CAST clause',
                             context=node.context)
 
                     from_cast = True
 
                 else:
-                    # FROM SQL EXPRESSION
+                    # USING SQL EXPRESSION
 
                     if from_expr:
                         raise EdgeQLSyntaxError(
-                            'more than one FROM EXPRESSION clause',
+                            'more than one USING EXPRESSION clause',
                             context=node.context)
 
                     from_expr = True
@@ -1900,20 +1900,20 @@ class CreateCastStmt(Nonterm):
         if (code is None and from_function is None
                 and not from_expr and not from_cast):
             raise EdgeQLSyntaxError(
-                'CREATE CAST requires at least one FROM clause',
+                'CREATE CAST requires at least one USING clause',
                 context=block.context)
 
         else:
             if from_expr and (from_function or code or from_cast):
                 raise EdgeQLSyntaxError(
-                    'FROM SQL EXPRESSION is mutually exclusive with other '
-                    'FROM variants',
+                    'USING SQL EXPRESSION is mutually exclusive with other '
+                    'USING variants',
                     context=block.context)
 
             if from_cast and (from_function or code or from_expr):
                 raise EdgeQLSyntaxError(
-                    'FROM SQL CAST is mutually exclusive with other '
-                    'FROM variants',
+                    'USING SQL CAST is mutually exclusive with other '
+                    'USING variants',
                     context=block.context)
 
             props['code'] = qlast.CastCode(

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -286,17 +286,17 @@ def commands_block(parent, *commands, opt=True):
 
 class SetFieldStmt(Nonterm):
     # field := <expr>
-    def reduce_SET_NodeName_ASSIGN_Expr(self, *kids):
+    def reduce_SET_Identifier_ASSIGN_Expr(self, *kids):
         self.val = qlast.SetField(
             name=kids[1].val,
             value=kids[3].val,
         )
 
-    def reduce_SET_NodeName_AS_SchemaItem(self, *kids):
-        self.val = qlast.SetField(
-            name=kids[1].val,
-            value=kids[3].val,
-        )
+    # def reduce_SET_NodeName_AS_SchemaItem(self, *kids):
+    #     self.val = qlast.SetField(
+    #         name=kids[1].val,
+    #         value=kids[3].val,
+    #     )
 
 
 class SetAnnotationValueStmt(Nonterm):
@@ -337,21 +337,21 @@ commands_block(
 class AlterAbstract(Nonterm):
     def reduce_DROP_ABSTRACT(self, *kids):
         self.val = qlast.SetSpecialField(
-            name=qlast.ObjectRef(name='is_abstract'), value=False)
+            name='is_abstract', value=False)
 
     def reduce_SET_ABSTRACT(self, *kids):
         self.val = qlast.SetSpecialField(
-            name=qlast.ObjectRef(name='is_abstract'), value=True)
+            name='is_abstract', value=True)
 
 
 class AlterFinal(Nonterm):
     def reduce_DROP_FINAL(self, *kids):
         self.val = qlast.SetSpecialField(
-            name=qlast.ObjectRef(name='is_final'), value=False)
+            name='is_final', value=False)
 
     def reduce_SET_FINAL(self, *kids):
         self.val = qlast.SetSpecialField(
-            name=qlast.ObjectRef(name='is_final'), value=True)
+            name='is_final', value=True)
 
 
 class OptInheritPosition(Nonterm):
@@ -690,13 +690,13 @@ class SetDelegatedStmt(Nonterm):
 
     def reduce_SET_DELEGATED(self, *kids):
         self.val = qlast.SetSpecialField(
-            name=qlast.ObjectRef(name='delegated'),
+            name='delegated',
             value=True,
         )
 
     def reduce_DROP_DELEGATED(self, *kids):
         self.val = qlast.SetSpecialField(
-            name=qlast.ObjectRef(name='delegated'),
+            name='delegated',
             value=False,
         )
 
@@ -1011,13 +1011,13 @@ class SetCardinalityStmt(Nonterm):
 
     def reduce_SET_SINGLE(self, *kids):
         self.val = qlast.SetSpecialField(
-            name=qlast.ObjectRef(name='cardinality'),
+            name='cardinality',
             value=qltypes.Cardinality.ONE,
         )
 
     def reduce_SET_MULTI(self, *kids):
         self.val = qlast.SetSpecialField(
-            name=qlast.ObjectRef(name='cardinality'),
+            name='cardinality',
             value=qltypes.Cardinality.MANY,
         )
 
@@ -1026,13 +1026,13 @@ class SetRequiredStmt(Nonterm):
 
     def reduce_SET_REQUIRED(self, *kids):
         self.val = qlast.SetSpecialField(
-            name=qlast.ObjectRef(name='required'),
+            name='required',
             value=True,
         )
 
     def reduce_DROP_REQUIRED(self, *kids):
         self.val = qlast.SetSpecialField(
-            name=qlast.ObjectRef(name='required'),
+            name='required',
             value=False,
         )
 
@@ -1384,7 +1384,7 @@ class CreateViewStmt(Nonterm):
             name=kids[2].val,
             commands=[
                 qlast.SetField(
-                    name=qlast.ObjectRef(name='expr'),
+                    name='expr',
                     value=kids[4].val,
                 )
             ]

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -226,7 +226,7 @@ def sdl_commands_block(parent, *commands, opt=True):
 
 class SetField(Nonterm):
     # field := <expr>
-    def reduce_ShortNodeName_ASSIGN_Expr(self, *kids):
+    def reduce_Identifier_ASSIGN_Expr(self, *kids):
         self.val = qlast.SetField(name=kids[0].val, value=kids[2].val)
 
 
@@ -905,7 +905,7 @@ class ViewDeclarationShort(Nonterm):
             name=kids[1].val,
             commands=[
                 qlast.SetField(
-                    name=qlast.ObjectRef(name='expr'),
+                    name='expr',
                     value=kids[3].val,
                 )
             ]

--- a/edb/edgeql/quote.py
+++ b/edb/edgeql/quote.py
@@ -31,7 +31,7 @@ _re_ident = re.compile(r'''(?x)
 ''')
 
 
-def escape_string(s):
+def escape_string(s: str) -> str:
     split = re.split(r"(\n|\\\\|\\')", s)
 
     if len(split) == 1:
@@ -41,11 +41,11 @@ def escape_string(s):
                    for i, r in enumerate(split))
 
 
-def quote_literal(string):
+def quote_literal(string: str) -> str:
     return "'" + escape_string(string) + "'"
 
 
-def dollar_quote_literal(text):
+def dollar_quote_literal(text: str) -> str:
     quote = '$$'
     qq = 0
 
@@ -59,7 +59,7 @@ def dollar_quote_literal(text):
     return quote + text + quote
 
 
-def needs_quoting(string, allow_reserved):
+def needs_quoting(string: str, allow_reserved: bool) -> bool:
     if not string or string.startswith('@') or '::' in string:
         # some strings are illegal as identifiers and as such don't
         # require quoting
@@ -80,11 +80,12 @@ def needs_quoting(string, allow_reserved):
     )
 
 
-def _quote_ident(string):
+def _quote_ident(string: str) -> str:
     return '`' + string.replace('`', '``') + '`'
 
 
-def quote_ident(string, *, force=False, allow_reserved=False):
+def quote_ident(string: str, *,
+                force: bool = False, allow_reserved: bool = False) -> str:
     if force or needs_quoting(string, allow_reserved):
         return _quote_ident(string)
     else:

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -431,7 +431,7 @@ class Call(ImmutableExpr):
     # The id of the module in which the callable is defined.
     func_module_id: uuid.UUID
 
-    # If the bound callable is a "FROM SQL" callable, this
+    # If the bound callable is a "USING SQL" callable, this
     # attribute will be set to the name of the SQL function.
     func_sql_function: typing.Optional[str]
 

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -145,7 +145,7 @@ CREATE TYPE cfg::Config {
 CREATE FUNCTION
 cfg::get_config_json() -> std::json
 {
-    FROM SQL $$
+    USING SQL $$
     SELECT jsonb_object_agg(cfg.name, cfg)
     FROM edgedb._read_sys_config() AS cfg
     $$;

--- a/edb/lib/math.edgeql
+++ b/edb/lib/math.edgeql
@@ -23,7 +23,7 @@ CREATE FUNCTION
 math::abs(x: std::anyreal) -> std::anyreal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'abs';
+    USING SQL FUNCTION 'abs';
 };
 
 
@@ -31,7 +31,7 @@ CREATE FUNCTION
 math::ceil(x: std::int64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'ceil';
+    USING SQL FUNCTION 'ceil';
 };
 
 
@@ -39,7 +39,7 @@ CREATE FUNCTION
 math::ceil(x: std::float64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'ceil';
+    USING SQL FUNCTION 'ceil';
 };
 
 
@@ -47,7 +47,7 @@ CREATE FUNCTION
 math::ceil(x: std::decimal) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'ceil';
+    USING SQL FUNCTION 'ceil';
 };
 
 
@@ -55,7 +55,7 @@ CREATE FUNCTION
 math::floor(x: std::int64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'floor';
+    USING SQL FUNCTION 'floor';
 };
 
 
@@ -63,7 +63,7 @@ CREATE FUNCTION
 math::floor(x: std::float64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'floor';
+    USING SQL FUNCTION 'floor';
 };
 
 
@@ -71,7 +71,7 @@ CREATE FUNCTION
 math::floor(x: std::decimal) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'floor';
+    USING SQL FUNCTION 'floor';
 };
 
 
@@ -79,7 +79,7 @@ CREATE FUNCTION
 math::ln(x: std::int64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'ln';
+    USING SQL FUNCTION 'ln';
 };
 
 
@@ -87,7 +87,7 @@ CREATE FUNCTION
 math::ln(x: std::float64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'ln';
+    USING SQL FUNCTION 'ln';
 };
 
 
@@ -95,7 +95,7 @@ CREATE FUNCTION
 math::ln(x: std::decimal) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'ln';
+    USING SQL FUNCTION 'ln';
 };
 
 
@@ -103,7 +103,7 @@ CREATE FUNCTION
 math::lg(x: std::int64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'log';
+    USING SQL FUNCTION 'log';
 };
 
 
@@ -111,7 +111,7 @@ CREATE FUNCTION
 math::lg(x: std::float64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'log';
+    USING SQL FUNCTION 'log';
 };
 
 
@@ -119,7 +119,7 @@ CREATE FUNCTION
 math::lg(x: std::decimal) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'log';
+    USING SQL FUNCTION 'log';
 };
 
 
@@ -127,7 +127,7 @@ CREATE FUNCTION
 math::log(x: std::decimal, NAMED ONLY base: std::decimal) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT log("base", "x")
     $$;
 };
@@ -141,7 +141,7 @@ CREATE FUNCTION
 math::mean(vals: SET OF std::decimal) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'avg';
+    USING SQL FUNCTION 'avg';
     SET error_on_null_result := 'invalid input to mean(): not ' ++
                                 'enough elements in input set';
 };
@@ -151,7 +151,7 @@ CREATE FUNCTION
 math::mean(vals: SET OF std::int64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'avg';
+    USING SQL FUNCTION 'avg';
     # SQL 'avg' returns numeric on integer inputs.
     SET force_return_cast := true;
     SET error_on_null_result := 'invalid input to mean(): not ' ++
@@ -163,7 +163,7 @@ CREATE FUNCTION
 math::mean(vals: SET OF std::float64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'avg';
+    USING SQL FUNCTION 'avg';
     SET error_on_null_result := 'invalid input to mean(): not ' ++
                                 'enough elements in input set';
 };
@@ -175,7 +175,7 @@ CREATE FUNCTION
 math::stddev(vals: SET OF std::decimal) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'stddev';
+    USING SQL FUNCTION 'stddev';
     SET error_on_null_result := 'invalid input to stddev(): not ' ++
                                 'enough elements in input set';
 };
@@ -185,7 +185,7 @@ CREATE FUNCTION
 math::stddev(vals: SET OF std::int64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'stddev';
+    USING SQL FUNCTION 'stddev';
     # SQL 'stddev' returns numeric on integer inputs.
     SET force_return_cast := true;
     SET error_on_null_result := 'invalid input to stddev(): not ' ++
@@ -197,7 +197,7 @@ CREATE FUNCTION
 math::stddev(vals: SET OF std::float64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'stddev';
+    USING SQL FUNCTION 'stddev';
     SET error_on_null_result := 'invalid input to stddev(): not ' ++
                                 'enough elements in input set';
 };
@@ -209,7 +209,7 @@ CREATE FUNCTION
 math::stddev_pop(vals: SET OF std::decimal) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'stddev_pop';
+    USING SQL FUNCTION 'stddev_pop';
     SET error_on_null_result := 'invalid input to stddev_pop(): not ' ++
                                 'enough elements in input set';
 };
@@ -219,7 +219,7 @@ CREATE FUNCTION
 math::stddev_pop(vals: SET OF std::int64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'stddev_pop';
+    USING SQL FUNCTION 'stddev_pop';
     # SQL 'stddev_pop' returns numeric on integer inputs.
     SET force_return_cast := true;
     SET error_on_null_result := 'invalid input to stddev_pop(): not ' ++
@@ -231,7 +231,7 @@ CREATE FUNCTION
 math::stddev_pop(vals: SET OF std::float64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'stddev_pop';
+    USING SQL FUNCTION 'stddev_pop';
     SET error_on_null_result := 'invalid input to stddev_pop(): not ' ++
                                 'enough elements in input set';
 };
@@ -243,7 +243,7 @@ CREATE FUNCTION
 math::var(vals: SET OF std::decimal) -> OPTIONAL std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'variance';
+    USING SQL FUNCTION 'variance';
     SET error_on_null_result := 'invalid input to var(): not ' ++
                                 'enough elements in input set';
 };
@@ -253,7 +253,7 @@ CREATE FUNCTION
 math::var(vals: SET OF std::int64) -> OPTIONAL std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'variance';
+    USING SQL FUNCTION 'variance';
     # SQL 'var' returns numeric on integer inputs.
     SET force_return_cast := true;
     SET error_on_null_result := 'invalid input to var(): not ' ++
@@ -265,7 +265,7 @@ CREATE FUNCTION
 math::var(vals: SET OF std::float64) -> OPTIONAL std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'variance';
+    USING SQL FUNCTION 'variance';
     SET error_on_null_result := 'invalid input to var(): not ' ++
                                 'enough elements in input set';
 };
@@ -277,7 +277,7 @@ CREATE FUNCTION
 math::var_pop(vals: SET OF std::decimal) -> OPTIONAL std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'var_pop';
+    USING SQL FUNCTION 'var_pop';
     SET error_on_null_result := 'invalid input to var_pop(): not ' ++
                                 'enough elements in input set';
 };
@@ -287,7 +287,7 @@ CREATE FUNCTION
 math::var_pop(vals: SET OF std::int64) -> OPTIONAL std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'var_pop';
+    USING SQL FUNCTION 'var_pop';
     # SQL 'var_pop' returns numeric on integer inputs.
     SET force_return_cast := true;
     SET error_on_null_result := 'invalid input to var_pop(): not ' ++
@@ -299,7 +299,7 @@ CREATE FUNCTION
 math::var_pop(vals: SET OF std::float64) -> OPTIONAL std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'var_pop';
+    USING SQL FUNCTION 'var_pop';
     SET error_on_null_result := 'invalid input to var_pop(): not ' ++
                                 'enough elements in input set';
 };

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -26,7 +26,7 @@ CREATE FUNCTION
 std::len(str: std::str) -> std::int64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT char_length("str")::bigint
     $$;
 };
@@ -36,7 +36,7 @@ CREATE FUNCTION
 std::len(bytes: std::bytes) -> std::int64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT length("bytes")::bigint
     $$;
 };
@@ -46,7 +46,7 @@ CREATE FUNCTION
 std::len(array: array<anytype>) -> std::int64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT cardinality("array")::bigint
     $$;
 };
@@ -60,7 +60,7 @@ std::sum(s: SET OF std::decimal) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
     SET initial_value := 0;
-    FROM SQL FUNCTION 'sum';
+    USING SQL FUNCTION 'sum';
 };
 
 
@@ -70,7 +70,7 @@ std::sum(s: SET OF std::int32) -> std::int64
     SET volatility := 'IMMUTABLE';
     SET initial_value := 0;
     SET force_return_cast := true;
-    FROM SQL FUNCTION 'sum';
+    USING SQL FUNCTION 'sum';
 };
 
 
@@ -80,7 +80,7 @@ std::sum(s: SET OF std::int64) -> std::int64
     SET volatility := 'IMMUTABLE';
     SET initial_value := 0;
     SET force_return_cast := true;
-    FROM SQL FUNCTION 'sum';
+    USING SQL FUNCTION 'sum';
 };
 
 
@@ -89,7 +89,7 @@ std::sum(s: SET OF std::float32) -> std::float32
 {
     SET volatility := 'IMMUTABLE';
     SET initial_value := 0;
-    FROM SQL FUNCTION 'sum';
+    USING SQL FUNCTION 'sum';
 };
 
 
@@ -98,7 +98,7 @@ std::sum(s: SET OF std::float64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
     SET initial_value := 0;
-    FROM SQL FUNCTION 'sum';
+    USING SQL FUNCTION 'sum';
 };
 
 
@@ -110,7 +110,7 @@ std::count(s: SET OF anytype) -> std::int64
 {
     SET volatility := 'IMMUTABLE';
     SET initial_value := 0;
-    FROM SQL FUNCTION 'count';
+    USING SQL FUNCTION 'count';
 };
 
 
@@ -121,7 +121,7 @@ CREATE FUNCTION
 std::random() -> std::float64
 {
     SET volatility := 'VOLATILE';
-    FROM SQL FUNCTION 'random';
+    USING SQL FUNCTION 'random';
 };
 
 
@@ -132,7 +132,7 @@ CREATE FUNCTION
 std::min(vals: SET OF anytype) -> OPTIONAL anytype
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'min';
+    USING SQL FUNCTION 'min';
 };
 
 
@@ -143,7 +143,7 @@ CREATE FUNCTION
 std::max(vals: SET OF anytype) -> OPTIONAL anytype
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'max';
+    USING SQL FUNCTION 'max';
 };
 
 
@@ -155,7 +155,7 @@ std::all(vals: SET OF std::bool) -> std::bool
 {
     SET volatility := 'IMMUTABLE';
     SET initial_value := True;
-    FROM SQL FUNCTION 'bool_and';
+    USING SQL FUNCTION 'bool_and';
 };
 
 
@@ -167,7 +167,7 @@ std::any(vals: SET OF std::bool) -> std::bool
 {
     SET volatility := 'IMMUTABLE';
     SET initial_value := False;
-    FROM SQL FUNCTION 'bool_or';
+    USING SQL FUNCTION 'bool_or';
 };
 
 
@@ -180,7 +180,7 @@ std::enumerate(
 ) -> SET OF tuple<std::int64, anytype>
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
@@ -191,7 +191,7 @@ CREATE FUNCTION
 std::round(val: std::int64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT round("val")
     $$;
 };
@@ -201,7 +201,7 @@ CREATE FUNCTION
 std::round(val: std::float64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT round("val")
     $$;
 };
@@ -211,7 +211,7 @@ CREATE FUNCTION
 std::round(val: std::decimal) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT round("val")
     $$;
 };
@@ -221,7 +221,7 @@ CREATE FUNCTION
 std::round(val: std::decimal, d: std::int64) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT round("val", "d"::int4)
     $$;
 };
@@ -234,7 +234,7 @@ CREATE FUNCTION
 std::contains(haystack: std::str, needle: std::str) -> std::bool
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         -- There was a regression in 12.0 (fixed in 12.1): strpos
         -- started to report 0 for empty search strings:
@@ -254,7 +254,7 @@ CREATE FUNCTION
 std::contains(haystack: std::bytes, needle: std::bytes) -> std::bool
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT position("needle" in "haystack") != 0
     $$;
 };
@@ -264,7 +264,7 @@ CREATE FUNCTION
 std::contains(haystack: array<anytype>, needle: anytype) -> std::bool
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT
         CASE
             WHEN "needle" IS NULL THEN NULL
@@ -281,7 +281,7 @@ CREATE FUNCTION
 std::find(haystack: std::str, needle: std::str) -> std::int64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         -- There was a regression in 12.0 (fixed in 12.1): strpos
         -- started to report 0 for empty search strings:
@@ -301,7 +301,7 @@ CREATE FUNCTION
 std::find(haystack: std::bytes, needle: std::bytes) -> std::int64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (position("needle" in "haystack") - 1)::int8
     $$;
 };
@@ -312,7 +312,7 @@ std::find(haystack: array<anytype>, needle: anytype,
           from_pos: std::int64=0) -> std::int64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT COALESCE(
         array_position("haystack", "needle", ("from_pos"::int4 + 1)::int4) - 1,
         -1)::int8
@@ -326,7 +326,7 @@ std::find(haystack: array<anytype>, needle: anytype,
 CREATE INFIX OPERATOR
 std::`=` (l: anytuple, r: anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '=';
+    USING SQL OPERATOR '=';
     SET recursive := true;
 };
 
@@ -334,7 +334,7 @@ std::`=` (l: anytuple, r: anytuple) -> std::bool {
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL anytuple, r: OPTIONAL anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
     SET recursive := true;
 };
 
@@ -342,7 +342,7 @@ std::`?=` (l: OPTIONAL anytuple, r: OPTIONAL anytuple) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: anytuple, r: anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<>';
+    USING SQL OPERATOR '<>';
     SET recursive := true;
 };
 
@@ -350,7 +350,7 @@ std::`!=` (l: anytuple, r: anytuple) -> std::bool {
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL anytuple, r: OPTIONAL anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
     SET recursive := true;
 };
 
@@ -358,7 +358,7 @@ std::`?!=` (l: OPTIONAL anytuple, r: OPTIONAL anytuple) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: anytuple, r: anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>=';
+    USING SQL OPERATOR '>=';
     SET recursive := true;
 };
 
@@ -366,7 +366,7 @@ std::`>=` (l: anytuple, r: anytuple) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: anytuple, r: anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>';
+    USING SQL OPERATOR '>';
     SET recursive := true;
 };
 
@@ -374,7 +374,7 @@ std::`>` (l: anytuple, r: anytuple) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: anytuple, r: anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<=';
+    USING SQL OPERATOR '<=';
     SET recursive := true;
 };
 
@@ -382,6 +382,6 @@ std::`<=` (l: anytuple, r: anytuple) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: anytuple, r: anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<';
+    USING SQL OPERATOR '<';
     SET recursive := true;
 };

--- a/edb/lib/std/25-booloperators.edgeql
+++ b/edb/lib/std/25-booloperators.edgeql
@@ -36,81 +36,81 @@
 CREATE INFIX OPERATOR
 std::`OR` (a: std::bool, b: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT ("a" OR "b") AND ("a"::int | "b"::int)::bool
     $$;
 };
 
 
-# `FROM SQL EXPRESSION` means that the operator is translated
+# `USING SQL EXPRESSION` means that the operator is translated
 # by the compiler into some SQL expression.
 CREATE INFIX OPERATOR
 std::`AND` (a: std::bool, b: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE PREFIX OPERATOR
 std::`NOT` (v: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::bool, r: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::bool, r: OPTIONAL std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::bool, r: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::bool, r: OPTIONAL std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::bool, r: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>=';
+    USING SQL OPERATOR '>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::bool, r: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>';
+    USING SQL OPERATOR '>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::bool, r: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<=';
+    USING SQL OPERATOR '<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::bool, r: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<';
+    USING SQL OPERATOR '<';
 };
 
 
@@ -119,11 +119,11 @@ std::`<` (l: std::bool, r: std::bool) -> std::bool {
 
 CREATE CAST FROM std::str TO std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'edgedb.str_to_bool';
+    USING SQL FUNCTION 'edgedb.str_to_bool';
 };
 
 
 CREATE CAST FROM std::bool TO std::str {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };

--- a/edb/lib/std/25-enumoperators.edgeql
+++ b/edb/lib/std/25-enumoperators.edgeql
@@ -24,56 +24,56 @@
 CREATE INFIX OPERATOR
 std::`=` (l: std::anyenum, r: std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::anyenum, r: OPTIONAL std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::anyenum, r: std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::anyenum, r: OPTIONAL std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::anyenum, r: std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>=';
+    USING SQL OPERATOR '>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::anyenum, r: std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>';
+    USING SQL OPERATOR '>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::anyenum, r: std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<=';
+    USING SQL OPERATOR '<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::anyenum, r: std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<';
+    USING SQL OPERATOR '<';
 };
 
 
@@ -84,12 +84,12 @@ std::`<` (l: std::anyenum, r: std::anyenum) -> std::bool {
 # sense to create an implicit assignment cast.
 CREATE CAST FROM std::str TO std::anyenum {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
     ALLOW ASSIGNMENT;
 };
 
 
 CREATE CAST FROM std::anyenum TO std::str {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };

--- a/edb/lib/std/25-numoperators.edgeql
+++ b/edb/lib/std/25-numoperators.edgeql
@@ -52,224 +52,224 @@
 CREATE INFIX OPERATOR
 std::`=` (l: std::int16, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int16, r: OPTIONAL std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int16, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int16, r: OPTIONAL std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int16, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int16, r: OPTIONAL std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int32, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int32, r: OPTIONAL std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int32, r: OPTIONAL std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int32, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int32, r: OPTIONAL std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int64, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int64, r: OPTIONAL std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int64, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int64, r: OPTIONAL std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int64, r: OPTIONAL std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::float32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::float32, r: OPTIONAL std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::float32, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::float32, r: OPTIONAL std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::float64, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::float64, r: OPTIONAL std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::float64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::float64, r: OPTIONAL std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::decimal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::decimal, r: std::anyreal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::decimal, r: OPTIONAL std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::decimal, r: OPTIONAL std::anyreal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::anyreal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::anyreal, r: OPTIONAL std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
@@ -278,224 +278,224 @@ std::`?=` (l: OPTIONAL std::anyreal, r: OPTIONAL std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int16, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int16, r: OPTIONAL std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int16, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int16, r: OPTIONAL std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int16, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int16, r: OPTIONAL std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int32, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int32, r: OPTIONAL std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int32, r: OPTIONAL std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int32, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int32, r: OPTIONAL std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int64, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int64, r: OPTIONAL std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int64, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int64, r: OPTIONAL std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int64, r: OPTIONAL std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::float32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::float32, r: OPTIONAL std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::float32, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::float32, r: OPTIONAL std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::float64, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::float64, r: OPTIONAL std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::float64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::float64, r: OPTIONAL std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::decimal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::decimal, r: std::anyreal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::decimal, r: OPTIONAL std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::decimal, r: OPTIONAL std::anyreal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::anyreal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::anyreal, r: OPTIONAL std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
@@ -505,140 +505,140 @@ std::`?!=` (l: OPTIONAL std::anyreal, r: OPTIONAL std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::int16, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int16, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int16, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int32, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int32, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>(float8,float8)';
+    USING SQL OPERATOR '>(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int64, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int64, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>(float8,float8)';
+    USING SQL OPERATOR r'>(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::float32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::float32, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::float32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>(float8,float8)';
+    USING SQL OPERATOR '>(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::float64, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::float64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::float64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>(float8,float8)';
+    USING SQL OPERATOR r'>(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::decimal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::anyreal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::decimal, r: std::anyreal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
@@ -647,140 +647,140 @@ std::`>` (l: std::decimal, r: std::anyreal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int16, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int16, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int16, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int32, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int32, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>=(float8,float8)';
+    USING SQL OPERATOR '>=(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int64, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int64, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=(float8,float8)';
+    USING SQL OPERATOR r'>=(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float32, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>=(float8,float8)';
+    USING SQL OPERATOR '>=(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float64, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=(float8,float8)';
+    USING SQL OPERATOR r'>=(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::decimal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::anyreal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::decimal, r: std::anyreal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
@@ -789,140 +789,140 @@ std::`>=` (l: std::decimal, r: std::anyreal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::int16, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int16, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int16, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int32, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int32, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<(float8,float8)';
+    USING SQL OPERATOR '<(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int64, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int64, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<(float8,float8)';
+    USING SQL OPERATOR r'<(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::float32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::float32, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::float32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<(float8,float8)';
+    USING SQL OPERATOR '<(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::float64, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::float64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::float64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<(float8,float8)';
+    USING SQL OPERATOR r'<(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::decimal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::anyreal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::decimal, r: std::anyreal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
@@ -931,140 +931,140 @@ std::`<` (l: std::decimal, r: std::anyreal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int16, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int16, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int16, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int32, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int32, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<=(float8,float8)';
+    USING SQL OPERATOR '<=(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int64, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int64, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=(float8,float8)';
+    USING SQL OPERATOR r'<=(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float32, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<=(float8,float8)';
+    USING SQL OPERATOR '<=(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float64, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=(float8,float8)';
+    USING SQL OPERATOR r'<=(float8,float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::decimal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::anyreal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::decimal, r: std::anyreal) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
@@ -1073,42 +1073,42 @@ std::`<=` (l: std::decimal, r: std::anyreal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`+` (l: std::int16, r: std::int16) -> std::int16 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::int32, r: std::int32) -> std::int32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::int64, r: std::int64) -> std::int64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::float32, r: std::float32) -> std::float32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::float64, r: std::float64) -> std::float64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::decimal, r: std::decimal) -> std::decimal {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
@@ -1117,42 +1117,42 @@ std::`+` (l: std::decimal, r: std::decimal) -> std::decimal {
 CREATE PREFIX OPERATOR
 std::`+` (l: std::int16) -> std::int16 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`+` (l: std::int32) -> std::int32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`+` (l: std::int64) -> std::int64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`+` (l: std::float32) -> std::float32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`+` (l: std::float64) -> std::float64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`+` (l: std::decimal) -> std::decimal {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
@@ -1162,42 +1162,42 @@ std::`+` (l: std::decimal) -> std::decimal {
 CREATE INFIX OPERATOR
 std::`-` (l: std::int16, r: std::int16) -> std::int16 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::int32, r: std::int32) -> std::int32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::int64, r: std::int64) -> std::int64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::float32, r: std::float32) -> std::float32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::float64, r: std::float64) -> std::float64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::decimal, r: std::decimal) -> std::decimal {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
@@ -1206,42 +1206,42 @@ std::`-` (l: std::decimal, r: std::decimal) -> std::decimal {
 CREATE PREFIX OPERATOR
 std::`-` (l: std::int16) -> std::int16 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (l: std::int32) -> std::int32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (l: std::int64) -> std::int64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (l: std::float32) -> std::float32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (l: std::float64) -> std::float64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (l: std::decimal) -> std::decimal {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
@@ -1250,42 +1250,42 @@ std::`-` (l: std::decimal) -> std::decimal {
 CREATE INFIX OPERATOR
 std::`*` (l: std::int16, r: std::int16) -> std::int16 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'*';
+    USING SQL OPERATOR r'*';
 };
 
 
 CREATE INFIX OPERATOR
 std::`*` (l: std::int32, r: std::int32) -> std::int32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'*';
+    USING SQL OPERATOR r'*';
 };
 
 
 CREATE INFIX OPERATOR
 std::`*` (l: std::int64, r: std::int64) -> std::int64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'*';
+    USING SQL OPERATOR r'*';
 };
 
 
 CREATE INFIX OPERATOR
 std::`*` (l: std::float32, r: std::float32) -> std::float32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'*';
+    USING SQL OPERATOR r'*';
 };
 
 
 CREATE INFIX OPERATOR
 std::`*` (l: std::float64, r: std::float64) -> std::float64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'*';
+    USING SQL OPERATOR r'*';
 };
 
 
 CREATE INFIX OPERATOR
 std::`*` (l: std::decimal, r: std::decimal) -> std::decimal {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'*';
+    USING SQL OPERATOR r'*';
 };
 
 
@@ -1295,32 +1295,32 @@ CREATE INFIX OPERATOR
 std::`/` (l: std::int64, r: std::int64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    # We need both FROM SQL OPERATOR and FROM SQL to copy
+    # We need both USING SQL OPERATOR and USING SQL to copy
     # the common attributes of the SQL division operator while
     # overriding the main operator function.
-    FROM SQL OPERATOR r'/';
-    FROM SQL 'SELECT "l" / ("r"::float8)';
+    USING SQL OPERATOR r'/';
+    USING SQL 'SELECT "l" / ("r"::float8)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`/` (l: std::float32, r: std::float32) -> std::float32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'/';
+    USING SQL OPERATOR r'/';
 };
 
 
 CREATE INFIX OPERATOR
 std::`/` (l: std::float64, r: std::float64) -> std::float64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'/';
+    USING SQL OPERATOR r'/';
 };
 
 
 CREATE INFIX OPERATOR
 std::`/` (l: std::decimal, r: std::decimal) -> std::decimal {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'/';
+    USING SQL OPERATOR r'/';
 };
 
 
@@ -1336,11 +1336,11 @@ CREATE INFIX OPERATOR
 std::`//` (n: std::int16, d: std::int16) -> std::int16
 {
     SET volatility := 'IMMUTABLE';
-    # We need both FROM SQL OPERATOR and FROM SQL FUNCTION to copy
+    # We need both USING SQL OPERATOR and USING SQL FUNCTION to copy
     # the common attributes of the SQL division operator while
     # overriding the main operator function.
-    FROM SQL OPERATOR r'/';
-    FROM SQL 'SELECT floor("n"::numeric / "d"::numeric)::int2';
+    USING SQL OPERATOR r'/';
+    USING SQL 'SELECT floor("n"::numeric / "d"::numeric)::int2';
 };
 
 
@@ -1348,8 +1348,8 @@ CREATE INFIX OPERATOR
 std::`//` (n: std::int32, d: std::int32) -> std::int32
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'/';
-    FROM SQL 'SELECT floor("n"::numeric / "d"::numeric)::int4';
+    USING SQL OPERATOR r'/';
+    USING SQL 'SELECT floor("n"::numeric / "d"::numeric)::int4';
 };
 
 
@@ -1357,8 +1357,8 @@ CREATE INFIX OPERATOR
 std::`//` (n: std::int64, d: std::int64) -> std::int64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'/';
-    FROM SQL 'SELECT floor("n"::numeric / "d"::numeric)::int8';
+    USING SQL OPERATOR r'/';
+    USING SQL 'SELECT floor("n"::numeric / "d"::numeric)::int8';
 };
 
 
@@ -1366,8 +1366,8 @@ CREATE INFIX OPERATOR
 std::`//` (n: std::float32, d: std::float32) -> std::float32
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'/';
-    FROM SQL 'SELECT floor("n" / "d")::float4';
+    USING SQL OPERATOR r'/';
+    USING SQL 'SELECT floor("n" / "d")::float4';
 };
 
 
@@ -1375,8 +1375,8 @@ CREATE INFIX OPERATOR
 std::`//` (n: std::float64, d: std::float64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'/';
-    FROM SQL 'SELECT floor("n" / "d")';
+    USING SQL OPERATOR r'/';
+    USING SQL 'SELECT floor("n" / "d")';
 };
 
 
@@ -1384,8 +1384,8 @@ CREATE INFIX OPERATOR
 std::`//` (n: std::decimal, d: std::decimal) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'/';
-    FROM SQL 'SELECT floor("n" / "d")';
+    USING SQL OPERATOR r'/';
+    USING SQL 'SELECT floor("n" / "d")';
 };
 
 
@@ -1395,8 +1395,8 @@ CREATE INFIX OPERATOR
 std::`%` (n: std::int16, d: std::int16) -> std::int16
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'%';
-    FROM SQL $$
+    USING SQL OPERATOR r'%';
+    USING SQL $$
         SELECT ((n % d) + d) % d;
     $$;
 };
@@ -1406,8 +1406,8 @@ CREATE INFIX OPERATOR
 std::`%` (n: std::int32, d: std::int32) -> std::int32
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'%';
-    FROM SQL $$
+    USING SQL OPERATOR r'%';
+    USING SQL $$
         SELECT ((n % d) + d) % d;
     $$;
 };
@@ -1417,8 +1417,8 @@ CREATE INFIX OPERATOR
 std::`%` (n: std::int64, d: std::int64) -> std::int64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'%';
-    FROM SQL $$
+    USING SQL OPERATOR r'%';
+    USING SQL $$
         SELECT ((n % d) + d) % d;
     $$;
 };
@@ -1430,8 +1430,8 @@ std::`%` (n: std::float32, d: std::float32) -> std::float32
     SET volatility := 'IMMUTABLE';
     # We cheat here a bit by copying most of SQL operator metadata
     # from the `/` operator, since there is no float % in Postgres.
-    FROM SQL OPERATOR r'/';
-    FROM SQL $$
+    USING SQL OPERATOR r'/';
+    USING SQL $$
         SELECT n - floor(n / d)::float4 * d;
     $$;
 };
@@ -1441,8 +1441,8 @@ CREATE INFIX OPERATOR
 std::`%` (n: std::float64, d: std::float64) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'/';
-    FROM SQL $$
+    USING SQL OPERATOR r'/';
+    USING SQL $$
         SELECT n - floor(n / d) * d;
     $$;
 };
@@ -1452,8 +1452,8 @@ CREATE INFIX OPERATOR
 std::`%` (n: std::decimal, d: std::decimal) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'%';
-    FROM SQL $$
+    USING SQL OPERATOR r'%';
+    USING SQL $$
         SELECT ((n % d) + d) % d;
     $$;
 };
@@ -1471,8 +1471,8 @@ std::`^` (n: std::int64, p: std::int64) -> std::float64
     # therefore it should have the same basic properties w.r.t. types,
     # etc. We don't use an explicit cast of the result because
     # Postgres will treat this as float8 already.
-    FROM SQL OPERATOR r'/';
-    FROM SQL 'SELECT ("n" ^ "p")';
+    USING SQL OPERATOR r'/';
+    USING SQL 'SELECT ("n" ^ "p")';
 };
 
 
@@ -1485,22 +1485,22 @@ std::`^` (n: std::float32, p: std::float32) -> std::float32
     # The power operator can behave like a division (negative power),
     # therefore it should have the same basic properties w.r.t. types,
     # etc.
-    FROM SQL OPERATOR '/';
-    FROM SQL 'SELECT ("n" ^ "p")::float4';
+    USING SQL OPERATOR '/';
+    USING SQL 'SELECT ("n" ^ "p")::float4';
 };
 
 
 CREATE INFIX OPERATOR
 std::`^` (n: std::float64, p: std::float64) -> std::float64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '^';
+    USING SQL OPERATOR '^';
 };
 
 
 CREATE INFIX OPERATOR
 std::`^` (n: std::decimal, p: std::decimal) -> std::decimal {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '^';
+    USING SQL OPERATOR '^';
 };
 
 
@@ -1512,42 +1512,42 @@ std::`^` (n: std::decimal, p: std::decimal) -> std::decimal {
 
 CREATE CAST FROM std::int16 TO std::int32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
     ALLOW IMPLICIT;
 };
 
 
 CREATE CAST FROM std::int32 TO std::int64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
     ALLOW IMPLICIT;
 };
 
 
 CREATE CAST FROM std::int16 TO std::float32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
     ALLOW IMPLICIT;
 };
 
 
 CREATE CAST FROM std::int64 TO std::float64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
     ALLOW IMPLICIT;
 };
 
 
 CREATE CAST FROM std::int64 TO std::decimal {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
     ALLOW IMPLICIT;
 };
 
 
 CREATE CAST FROM std::float32 TO std::float64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
     ALLOW IMPLICIT;
 };
 
@@ -1556,113 +1556,113 @@ CREATE CAST FROM std::float32 TO std::float64 {
 
 CREATE CAST FROM std::int32 TO std::int16 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::int64 TO std::int32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
     ALLOW ASSIGNMENT;
 };
 
 
 CREATE CAST FROM std::int64 TO std::int16 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
     ALLOW ASSIGNMENT;
 };
 
 
 CREATE CAST FROM std::int64 TO std::float32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
     ALLOW ASSIGNMENT;
 };
 
 
 CREATE CAST FROM std::float64 TO std::float32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
     ALLOW ASSIGNMENT;
 };
 
 
 CREATE CAST FROM std::decimal TO std::int16 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::decimal TO std::int32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::decimal TO std::int64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::decimal TO std::float64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::decimal TO std::float32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float32 TO std::int16 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float32 TO std::int32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float32 TO std::int64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float32 TO std::decimal {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float64 TO std::int16 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float64 TO std::int32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float64 TO std::int64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float64 TO std::decimal {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
@@ -1670,71 +1670,71 @@ CREATE CAST FROM std::float64 TO std::decimal {
 
 CREATE CAST FROM std::str TO std::int16 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::str TO std::int32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::str TO std::int64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::str TO std::float32 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::str TO std::float64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::str TO std::decimal {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::int16 TO std::str {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::int32 TO std::str {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::int64 TO std::str {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float32 TO std::str {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float64 TO std::str {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::decimal TO std::str {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };

--- a/edb/lib/std/25-setoperators.edgeql
+++ b/edb/lib/std/25-setoperators.edgeql
@@ -27,7 +27,7 @@
 CREATE INFIX OPERATOR
 std::`IN` (e: anytype, s: SET OF anytype) -> std::bool
 {
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
     SET volatility := 'IMMUTABLE';
     SET derivative_of := 'std::=';
 };
@@ -36,7 +36,7 @@ std::`IN` (e: anytype, s: SET OF anytype) -> std::bool
 CREATE INFIX OPERATOR
 std::`NOT IN` (e: anytype, s: SET OF anytype) -> std::bool
 {
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
     SET volatility := 'IMMUTABLE';
     SET derivative_of := 'std::!=';
 };
@@ -45,28 +45,28 @@ std::`NOT IN` (e: anytype, s: SET OF anytype) -> std::bool
 CREATE PREFIX OPERATOR
 std::`EXISTS` (s: SET OF anytype) -> bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE PREFIX OPERATOR
 std::`DISTINCT` (s: SET OF anytype) -> SET OF anytype {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`UNION` (s1: SET OF anytype, s2: SET OF anytype) -> SET OF anytype {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`??` (l: OPTIONAL anytype, r: SET OF anytype) -> SET OF anytype {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
@@ -74,5 +74,5 @@ CREATE TERNARY OPERATOR
 std::`IF` (if_true: SET OF anytype, condition: bool,
            if_false: SET OF anytype) -> SET OF anytype {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };

--- a/edb/lib/std/30-arrayfuncs.edgeql
+++ b/edb/lib/std/30-arrayfuncs.edgeql
@@ -25,7 +25,7 @@ std::array_agg(s: SET OF anytype) -> array<anytype>
 {
     SET volatility := 'IMMUTABLE';
     SET initial_value := [];
-    FROM SQL FUNCTION 'array_agg';
+    USING SQL FUNCTION 'array_agg';
 };
 
 
@@ -33,7 +33,7 @@ CREATE FUNCTION
 std::array_unpack(array: array<anytype>) -> SET OF anytype
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'unnest';
+    USING SQL FUNCTION 'unnest';
 };
 
 
@@ -45,7 +45,7 @@ std::array_get(
 ) -> OPTIONAL anytype
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT COALESCE(
         "array"[
             edgedb._normalize_array_index(
@@ -63,7 +63,7 @@ std::array_get(
 CREATE INFIX OPERATOR
 std::`=` (l: array<anytype>, r: array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '=';
+    USING SQL OPERATOR '=';
     SET recursive := true;
 };
 
@@ -72,7 +72,7 @@ CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL array<anytype>,
            r: OPTIONAL array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
     SET recursive := true;
 };
 
@@ -80,7 +80,7 @@ std::`?=` (l: OPTIONAL array<anytype>,
 CREATE INFIX OPERATOR
 std::`!=` (l: array<anytype>, r: array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<>';
+    USING SQL OPERATOR '<>';
     SET recursive := true;
 };
 
@@ -89,35 +89,35 @@ CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL array<anytype>,
             r: OPTIONAL array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
     SET recursive := true;
 };
 
 CREATE INFIX OPERATOR
 std::`>=` (l: array<anytype>, r: array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>=';
+    USING SQL OPERATOR '>=';
     SET recursive := true;
 };
 
 CREATE INFIX OPERATOR
 std::`>` (l: array<anytype>, r: array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>';
+    USING SQL OPERATOR '>';
     SET recursive := true;
 };
 
 CREATE INFIX OPERATOR
 std::`<=` (l: array<anytype>, r: array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<=';
+    USING SQL OPERATOR '<=';
     SET recursive := true;
 };
 
 CREATE INFIX OPERATOR
 std::`<` (l: array<anytype>, r: array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<';
+    USING SQL OPERATOR '<';
     SET recursive := true;
 };
 
@@ -125,5 +125,5 @@ std::`<` (l: array<anytype>, r: array<anytype>) -> std::bool {
 CREATE INFIX OPERATOR
 std::`++` (l: array<anytype>, r: array<anytype>) -> array<anytype> {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '||';
+    USING SQL OPERATOR '||';
 };

--- a/edb/lib/std/30-bytesfuncs.edgeql
+++ b/edb/lib/std/30-bytesfuncs.edgeql
@@ -24,7 +24,7 @@ CREATE FUNCTION
 std::bytes_get_bit(bytes: std::bytes, num: int64) -> std::int64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT get_bit("bytes", "num"::int)::bigint
     $$;
 };
@@ -37,61 +37,61 @@ std::bytes_get_bit(bytes: std::bytes, num: int64) -> std::int64
 CREATE INFIX OPERATOR
 std::`=` (l: std::bytes, r: std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::bytes, r: OPTIONAL std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::bytes, r: std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::bytes, r: OPTIONAL std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`++` (l: std::bytes, r: std::bytes) -> std::bytes {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'||';
+    USING SQL OPERATOR r'||';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::bytes, r: std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>=';
+    USING SQL OPERATOR '>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::bytes, r: std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>';
+    USING SQL OPERATOR '>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::bytes, r: std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<=';
+    USING SQL OPERATOR '<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::bytes, r: std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<';
+    USING SQL OPERATOR '<';
 };

--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -24,7 +24,7 @@ CREATE FUNCTION
 std::datetime_current() -> std::datetime
 {
     SET volatility := 'VOLATILE';
-    FROM SQL FUNCTION 'clock_timestamp';
+    USING SQL FUNCTION 'clock_timestamp';
 };
 
 
@@ -32,7 +32,7 @@ CREATE FUNCTION
 std::datetime_of_transaction() -> std::datetime
 {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'transaction_timestamp';
+    USING SQL FUNCTION 'transaction_timestamp';
 };
 
 
@@ -40,7 +40,7 @@ CREATE FUNCTION
 std::datetime_of_statement() -> std::datetime
 {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'statement_timestamp';
+    USING SQL FUNCTION 'statement_timestamp';
 };
 
 
@@ -49,7 +49,7 @@ std::datetime_get(dt: std::datetime, el: std::str) -> std::float64
 {
     # date_part of timestamptz is STABLE in PostgreSQL
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT date_part("el", "dt")
     $$;
 };
@@ -59,7 +59,7 @@ CREATE FUNCTION
 std::datetime_get(dt: std::local_datetime, el: std::str) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT date_part("el", "dt")
     $$;
 };
@@ -69,7 +69,7 @@ CREATE FUNCTION
 std::time_get(dt: std::local_time, el: std::str) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT date_part("el", "dt")
     $$;
 };
@@ -79,7 +79,7 @@ CREATE FUNCTION
 std::date_get(dt: std::local_date, el: std::str) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT date_part("el", "dt")
     $$;
 };
@@ -89,7 +89,7 @@ CREATE FUNCTION
 std::duration_get(dt: std::duration, el: std::str) -> std::float64
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT date_part("el", "dt")
     $$;
 };
@@ -100,7 +100,7 @@ std::datetime_trunc(dt: std::datetime, unit: std::str) -> std::datetime
 {
     # date_trunc of timestamptz is STABLE in PostgreSQL
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT date_trunc("unit", "dt")
     $$;
 };
@@ -110,7 +110,7 @@ CREATE FUNCTION
 std::duration_trunc(dt: std::duration, unit: std::str) -> std::duration
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT date_trunc("unit", "dt")
     $$;
 };
@@ -124,56 +124,56 @@ std::duration_trunc(dt: std::duration, unit: std::str) -> std::duration
 CREATE INFIX OPERATOR
 std::`=` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::datetime, r: OPTIONAL std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::datetime, r: OPTIONAL std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
@@ -181,7 +181,7 @@ CREATE INFIX OPERATOR
 std::`+` (l: std::datetime, r: std::duration) -> std::datetime {
     # operators on timestamptz are STABLE in PostgreSQL
     SET volatility := 'STABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
@@ -189,7 +189,7 @@ CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: std::datetime) -> std::datetime {
     # operators on timestamptz are STABLE in PostgreSQL
     SET volatility := 'STABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
@@ -197,14 +197,14 @@ CREATE INFIX OPERATOR
 std::`-` (l: std::datetime, r: std::duration) -> std::datetime {
     # operators on timestamptz are STABLE in PostgreSQL
     SET volatility := 'STABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::datetime, r: std::datetime) -> std::duration {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
@@ -213,7 +213,7 @@ std::`-` (l: std::datetime, r: std::datetime) -> std::duration {
 CREATE INFIX OPERATOR
 std::`=` (l: std::local_datetime, r: std::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
@@ -221,14 +221,14 @@ CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::local_datetime,
            r: OPTIONAL std::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::local_datetime, r: std::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
@@ -236,63 +236,63 @@ CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::local_datetime,
             r: OPTIONAL std::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::local_datetime, r: std::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::local_datetime, r: std::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::local_datetime, r: std::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::local_datetime, r: std::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::local_datetime, r: std::duration) -> std::local_datetime {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: std::local_datetime) -> std::local_datetime {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::local_datetime, r: std::duration) -> std::local_datetime {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::local_datetime, r: std::local_datetime) -> std::duration {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
@@ -301,7 +301,7 @@ std::`-` (l: std::local_datetime, r: std::local_datetime) -> std::duration {
 CREATE INFIX OPERATOR
 std::`=` (l: std::local_date, r: std::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
@@ -309,14 +309,14 @@ CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::local_date,
            r: OPTIONAL std::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::local_date, r: std::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
@@ -324,35 +324,35 @@ CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::local_date,
             r: OPTIONAL std::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::local_date, r: std::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::local_date, r: std::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::local_date, r: std::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::local_date, r: std::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
@@ -360,7 +360,7 @@ CREATE INFIX OPERATOR
 std::`+` (l: std::local_date, r: std::duration) -> std::local_date
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '+';
+    USING SQL OPERATOR '+';
     SET force_return_cast := true;
 };
 
@@ -369,7 +369,7 @@ CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: std::local_date) -> std::local_date
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '+';
+    USING SQL OPERATOR '+';
     SET force_return_cast := true;
 };
 
@@ -378,7 +378,7 @@ CREATE INFIX OPERATOR
 std::`-` (l: std::local_date, r: std::duration) -> std::local_date
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '-';
+    USING SQL OPERATOR '-';
     SET force_return_cast := true;
 };
 
@@ -386,7 +386,7 @@ std::`-` (l: std::local_date, r: std::duration) -> std::local_date
 CREATE INFIX OPERATOR
 std::`-` (l: std::local_date, r: std::local_date) -> std::duration {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT make_interval(days => "l" - "r")
     $$;
 };
@@ -397,7 +397,7 @@ std::`-` (l: std::local_date, r: std::local_date) -> std::duration {
 CREATE INFIX OPERATOR
 std::`=` (l: std::local_time, r: std::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
@@ -405,14 +405,14 @@ CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::local_time,
            r: OPTIONAL std::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::local_time, r: std::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
@@ -420,63 +420,63 @@ CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::local_time,
             r: OPTIONAL std::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::local_time, r: std::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::local_time, r: std::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::local_time, r: std::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::local_time, r: std::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::local_time, r: std::duration) -> std::local_time {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: std::local_time) -> std::local_time {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::local_time, r: std::duration) -> std::local_time {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::local_time, r: std::local_time) -> std::duration {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
@@ -485,21 +485,21 @@ std::`-` (l: std::local_time, r: std::local_time) -> std::duration {
 CREATE INFIX OPERATOR
 std::`=` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::duration, r: OPTIONAL std::duration) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
@@ -509,56 +509,56 @@ std::`?!=` (
         r: OPTIONAL std::duration
 ) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: std::duration) -> std::duration {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::duration, r: std::duration) -> std::duration {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (v: std::duration) -> std::duration {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-';
 };
 
 
@@ -567,19 +567,19 @@ std::`-` (v: std::duration) -> std::duration {
 
 CREATE CAST FROM std::local_datetime TO std::local_date {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::local_datetime TO std::local_time {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::local_date TO std::local_datetime {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
@@ -591,31 +591,31 @@ CREATE CAST FROM std::local_date TO std::local_datetime {
 # IMMUTABLE (as the corresponding casts from those types to text).
 CREATE CAST FROM std::str TO std::datetime {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'edgedb.datetime_in';
+    USING SQL FUNCTION 'edgedb.datetime_in';
 };
 
 
 CREATE CAST FROM std::str TO std::local_datetime {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'edgedb.local_datetime_in';
+    USING SQL FUNCTION 'edgedb.local_datetime_in';
 };
 
 
 CREATE CAST FROM std::str TO std::local_date {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'edgedb.local_date_in';
+    USING SQL FUNCTION 'edgedb.local_date_in';
 };
 
 
 CREATE CAST FROM std::str TO std::local_time {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'edgedb.local_time_in';
+    USING SQL FUNCTION 'edgedb.local_time_in';
 };
 
 
 CREATE CAST FROM std::str TO std::duration {
     SET volatility := 'STABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
@@ -626,7 +626,7 @@ CREATE CAST FROM std::str TO std::duration {
 # and time.
 CREATE CAST FROM std::datetime TO std::str {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT trim(to_json(val)::text, '"');
     $$;
 };
@@ -634,7 +634,7 @@ CREATE CAST FROM std::datetime TO std::str {
 
 CREATE CAST FROM std::local_datetime TO std::str {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT trim(to_json(val)::text, '"');
     $$;
 };
@@ -642,19 +642,19 @@ CREATE CAST FROM std::local_datetime TO std::str {
 
 CREATE CAST FROM std::local_date TO std::str {
     SET volatility := 'STABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::local_time TO std::str {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::duration TO std::str {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT regexp_replace(val::text, '[[:<:]]mon(?=s?[[:>:]])', 'month');
     $$;
 };

--- a/edb/lib/std/30-jsonfuncs.edgeql
+++ b/edb/lib/std/30-jsonfuncs.edgeql
@@ -24,7 +24,7 @@ CREATE FUNCTION
 std::json_typeof(json: std::json) -> std::str
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'jsonb_typeof';
+    USING SQL FUNCTION 'jsonb_typeof';
 };
 
 
@@ -32,7 +32,7 @@ CREATE FUNCTION
 std::json_array_unpack(array: std::json) -> SET OF std::json
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'jsonb_array_elements';
+    USING SQL FUNCTION 'jsonb_array_elements';
 };
 
 
@@ -40,7 +40,7 @@ CREATE FUNCTION
 std::json_object_unpack(obj: std::json) -> SET OF tuple<std::str, std::json>
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'jsonb_each';
+    USING SQL FUNCTION 'jsonb_each';
     # jsonb_each is defined as (jsonb, OUT key text, OUT value jsonb),
     # and, quite perprexingly, would reject a column definition list
     # with `a column definition list is only allowed for functions
@@ -58,7 +58,7 @@ std::json_get(
     NAMED ONLY default: OPTIONAL std::json={}) -> OPTIONAL std::json
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT COALESCE(
         jsonb_extract_path("json", VARIADIC "path"),
         "default"
@@ -70,56 +70,56 @@ std::json_get(
 CREATE INFIX OPERATOR
 std::`=` (l: std::json, r: std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::json, r: OPTIONAL std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::json, r: std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::json, r: OPTIONAL std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::json, r: std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>=';
+    USING SQL OPERATOR '>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::json, r: std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>';
+    USING SQL OPERATOR '>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::json, r: std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<=';
+    USING SQL OPERATOR '<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::json, r: std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<';
+    USING SQL OPERATOR '<';
 };
 
 
@@ -129,7 +129,7 @@ std::`<` (l: std::json, r: std::json) -> std::bool {
 # availability.
 CREATE CAST FROM array<anytype> TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
@@ -137,13 +137,13 @@ CREATE CAST FROM array<anytype> TO std::json {
 # availability.
 CREATE CAST FROM anytuple TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE CAST FROM std::json TO array<json> {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
         SELECT array_agg(j)
         FROM jsonb_array_elements(val) AS j
     $$;
@@ -154,91 +154,91 @@ CREATE CAST FROM std::json TO array<json> {
 # generic and STABLE volatility may be an overestimation in many cases.
 CREATE CAST FROM std::bool TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::uuid TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::str TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::datetime TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::local_datetime TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::local_date TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::local_time TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::duration TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::int16 TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::int32 TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::int64 TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::float32 TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::float64 TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::decimal TO std::json {
     SET volatility := 'STABLE';
-    FROM SQL FUNCTION 'to_jsonb';
+    USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::json TO std::bool  {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'boolean')::bool;
     $$;
 };
@@ -246,7 +246,7 @@ CREATE CAST FROM std::json TO std::bool  {
 
 CREATE CAST FROM std::json TO std::uuid {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'string')::uuid;
     $$;
 };
@@ -254,7 +254,7 @@ CREATE CAST FROM std::json TO std::uuid {
 
 CREATE CAST FROM std::json TO std::str {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'string');
     $$;
 };
@@ -262,7 +262,7 @@ CREATE CAST FROM std::json TO std::str {
 
 CREATE CAST FROM std::json TO std::datetime {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.datetime_in(edgedb.jsonb_extract_scalar(val, 'string'));
     $$;
 };
@@ -270,7 +270,7 @@ CREATE CAST FROM std::json TO std::datetime {
 
 CREATE CAST FROM std::json TO std::local_datetime {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.local_datetime_in(
         edgedb.jsonb_extract_scalar(val, 'string'));
     $$;
@@ -279,7 +279,7 @@ CREATE CAST FROM std::json TO std::local_datetime {
 
 CREATE CAST FROM std::json TO std::local_date {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.local_date_in(edgedb.jsonb_extract_scalar(val, 'string'));
     $$;
 };
@@ -287,7 +287,7 @@ CREATE CAST FROM std::json TO std::local_date {
 
 CREATE CAST FROM std::json TO std::local_time {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.local_time_in(edgedb.jsonb_extract_scalar(val, 'string'));
     $$;
 };
@@ -295,7 +295,7 @@ CREATE CAST FROM std::json TO std::local_time {
 
 CREATE CAST FROM std::json TO std::duration {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'string')::interval;
     $$;
 };
@@ -303,7 +303,7 @@ CREATE CAST FROM std::json TO std::duration {
 
 CREATE CAST FROM std::json TO std::int16 {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'number')::int2;
     $$;
 };
@@ -311,7 +311,7 @@ CREATE CAST FROM std::json TO std::int16 {
 
 CREATE CAST FROM std::json TO std::int32 {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'number')::int4;
     $$;
 };
@@ -319,7 +319,7 @@ CREATE CAST FROM std::json TO std::int32 {
 
 CREATE CAST FROM std::json TO std::int64 {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'number')::int8;
     $$;
 };
@@ -327,7 +327,7 @@ CREATE CAST FROM std::json TO std::int64 {
 
 CREATE CAST FROM std::json TO std::float32 {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'number')::float4;
     $$;
 };
@@ -335,7 +335,7 @@ CREATE CAST FROM std::json TO std::float32 {
 
 CREATE CAST FROM std::json TO std::float64 {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'number')::float8;
     $$;
 };
@@ -343,7 +343,7 @@ CREATE CAST FROM std::json TO std::float64 {
 
 CREATE CAST FROM std::json TO std::decimal {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'number')::numeric;
     $$;
 };

--- a/edb/lib/std/30-regexpfuncs.edgeql
+++ b/edb/lib/std/30-regexpfuncs.edgeql
@@ -24,7 +24,7 @@ CREATE FUNCTION
 std::re_match(pattern: std::str, str: std::str) -> array<std::str>
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT regexp_matches("str", "pattern");
     $$;
 };
@@ -34,7 +34,7 @@ CREATE FUNCTION
 std::re_match_all(pattern: std::str, str: std::str) -> SET OF array<std::str>
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT regexp_matches("str", "pattern", 'g');
     $$;
 };
@@ -44,7 +44,7 @@ CREATE FUNCTION
 std::re_test(pattern: std::str, str: std::str) -> std::bool
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT "str" ~ "pattern";
     $$;
 };
@@ -58,7 +58,7 @@ std::re_replace(
     NAMED ONLY flags: std::str = '') -> std::str
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT regexp_replace("str", "pattern", "sub", "flags");
     $$;
 };

--- a/edb/lib/std/30-strfuncs.edgeql
+++ b/edb/lib/std/30-strfuncs.edgeql
@@ -22,28 +22,28 @@
 CREATE INFIX OPERATOR
 std::`=` (l: std::str, r: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::str, r: OPTIONAL std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::str, r: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::str, r: OPTIONAL std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
@@ -51,63 +51,63 @@ std::`?!=` (l: OPTIONAL std::str, r: OPTIONAL std::str) -> std::bool {
 CREATE INFIX OPERATOR
 std::`++` (l: std::str, r: std::str) -> std::str {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '||';
+    USING SQL OPERATOR '||';
 };
 
 
 CREATE INFIX OPERATOR
 std::`LIKE` (string: std::str, pattern: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`ILIKE` (string: std::str, pattern: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`NOT LIKE` (string: std::str, pattern: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`NOT ILIKE` (string: std::str, pattern: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::str, r: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::str, r: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::str, r: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::str, r: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=';
 };
 
 
@@ -118,7 +118,7 @@ CREATE FUNCTION
 std::str_repeat(s: std::str, n: std::int64) -> std::str
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT repeat("s", "n"::int4)
     $$;
 };
@@ -128,7 +128,7 @@ CREATE FUNCTION
 std::str_lower(s: std::str) -> std::str
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'lower';
+    USING SQL FUNCTION 'lower';
 };
 
 
@@ -136,7 +136,7 @@ CREATE FUNCTION
 std::str_upper(s: std::str) -> std::str
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'upper';
+    USING SQL FUNCTION 'upper';
 };
 
 
@@ -144,7 +144,7 @@ CREATE FUNCTION
 std::str_title(s: std::str) -> std::str
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'initcap';
+    USING SQL FUNCTION 'initcap';
 };
 
 
@@ -152,7 +152,7 @@ CREATE FUNCTION
 std::str_lpad(s: std::str, n: std::int64, fill: std::str=' ') -> std::str
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT lpad("s", "n"::int4, "fill")
     $$;
 };
@@ -162,7 +162,7 @@ CREATE FUNCTION
 std::str_rpad(s: std::str, n: std::int64, fill: std::str=' ') -> std::str
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT rpad("s", "n"::int4, "fill")
     $$;
 };
@@ -172,7 +172,7 @@ CREATE FUNCTION
 std::str_ltrim(s: std::str, tr: std::str=' ') -> std::str
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'ltrim';
+    USING SQL FUNCTION 'ltrim';
 };
 
 
@@ -180,7 +180,7 @@ CREATE FUNCTION
 std::str_rtrim(s: std::str, tr: std::str=' ') -> std::str
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'rtrim';
+    USING SQL FUNCTION 'rtrim';
 };
 
 
@@ -188,5 +188,5 @@ CREATE FUNCTION
 std::str_trim(s: std::str, tr: std::str=' ') -> std::str
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL FUNCTION 'btrim';
+    USING SQL FUNCTION 'btrim';
 };

--- a/edb/lib/std/30-uuidfuncs.edgeql
+++ b/edb/lib/std/30-uuidfuncs.edgeql
@@ -23,7 +23,7 @@
 CREATE FUNCTION
 std::uuid_generate_v1mc() -> std::uuid {
     SET volatility := 'VOLATILE';
-    FROM SQL $$
+    USING SQL $$
     SELECT edgedb.uuid_generate_v1mc()
     $$;
 };
@@ -32,56 +32,56 @@ std::uuid_generate_v1mc() -> std::uuid {
 CREATE INFIX OPERATOR
 std::`=` (l: std::uuid, r: std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::uuid, r: OPTIONAL std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::uuid, r: std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::uuid, r: OPTIONAL std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::uuid, r: std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>=';
+    USING SQL OPERATOR '>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::uuid, r: std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '>';
+    USING SQL OPERATOR '>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::uuid, r: std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<=';
+    USING SQL OPERATOR '<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::uuid, r: std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL OPERATOR '<';
+    USING SQL OPERATOR '<';
 };
 
 
@@ -89,11 +89,11 @@ std::`<` (l: std::uuid, r: std::uuid) -> std::bool {
 
 CREATE CAST FROM std::str TO std::uuid {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::uuid TO std::str {
     SET volatility := 'IMMUTABLE';
-    FROM SQL CAST;
+    USING SQL CAST;
 };

--- a/edb/lib/std/50-constraints.edgeql
+++ b/edb/lib/std/50-constraints.edgeql
@@ -25,7 +25,7 @@ std::_is_exclusive(s: SET OF anytype) -> std::bool
 {
     SET volatility := 'IMMUTABLE';
     SET initial_value := True;
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 

--- a/edb/lib/std/60-baseobject.edgeql
+++ b/edb/lib/std/60-baseobject.edgeql
@@ -39,78 +39,78 @@ CREATE ABSTRACT TYPE std::Object {
 };
 
 
-# 'FROM SQL EXPRESSION' creates an EdgeDB Operator for purposes of
+# 'USING SQL EXPRESSION' creates an EdgeDB Operator for purposes of
 # introspection and validation by the EdgeQL compiler. However, no
 # object is created in Postgres and the EdgeQL->SQL compiler is expected
 # to produce some expression that will be valid.
 #
-# 'FROM SQL OPERATOR' does all of the above and it also creates an
+# 'USING SQL OPERATOR' does all of the above and it also creates an
 # actual Postgres operator. It is expected that the EdgeQL->SQL compiler
 # will specifically use that operator.
 
-# HACK: We use 'FROM SQL EXPRESSION' instead of 'FROM SQL OPERATOR'
+# HACK: We use 'USING SQL EXPRESSION' instead of 'USING SQL OPERATOR'
 # here because in actuality Objects will be resolved as their uuids
 # and in the end it's the uuid operators that will be called in SQL.
-# On the other hand, if we use "FROM SQL OPERATOR", we will end up
+# On the other hand, if we use "USING SQL OPERATOR", we will end up
 # clashing with the operators for uuid in Postgres.
 CREATE INFIX OPERATOR
 std::`=` (l: std::Object, r: std::Object) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::Object, r: OPTIONAL std::Object) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::Object, r: std::Object) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::Object, r: OPTIONAL std::Object) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::Object, r: std::Object) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::Object, r: std::Object) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::Object, r: std::Object) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::Object, r: std::Object) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };
 
 
 # The only possible Object cast is into json.
 CREATE CAST FROM std::Object TO std::json {
     SET volatility := 'IMMUTABLE';
-    FROM SQL EXPRESSION;
+    USING SQL EXPRESSION;
 };

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -35,7 +35,7 @@ std::to_str(dt: std::datetime, fmt: OPTIONAL str={}) -> std::str
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             trim(to_json("dt")::text, '"')
@@ -63,7 +63,7 @@ std::to_str(td: std::duration, fmt: OPTIONAL str={}) -> std::str
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             trim(to_json("td")::text, '"')
@@ -91,7 +91,7 @@ std::to_str(dt: std::local_datetime, fmt: OPTIONAL str={}) -> std::str
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             trim(to_json("dt")::text, '"')
@@ -119,7 +119,7 @@ std::to_str(d: std::local_date, fmt: OPTIONAL str={}) -> std::str
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             "d"::text
@@ -153,7 +153,7 @@ std::to_str(nt: std::local_time, fmt: OPTIONAL str={}) -> std::str
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             "nt"::text
@@ -186,7 +186,7 @@ std::to_str(i: std::int64, fmt: OPTIONAL str={}) -> std::str
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             "i"::text
@@ -214,7 +214,7 @@ std::to_str(f: std::float64, fmt: OPTIONAL str={}) -> std::str
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             "f"::text
@@ -242,7 +242,7 @@ std::to_str(d: std::decimal, fmt: OPTIONAL str={}) -> std::str
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             "d"::text
@@ -274,7 +274,7 @@ std::to_str(json: std::json, fmt: OPTIONAL str={}) -> std::str
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             "json"::text
@@ -303,7 +303,7 @@ CREATE FUNCTION
 std::to_str(array: array<std::str>, delimiter: std::str) -> std::str
 {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT array_to_string("array", "delimiter");
     $$;
 };
@@ -314,7 +314,7 @@ std::to_json(str: std::str) -> std::json
 {
     # Casting of jsonb to and from text in PostgreSQL is IMMUTABLE.
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT "str"::jsonb
     $$;
 };
@@ -325,7 +325,7 @@ std::to_datetime(s: std::str, fmt: OPTIONAL str={}) -> std::datetime
 {
     # Helper function to_datetime is VOLATILE.
     SET volatility := 'VOLATILE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             edgedb.datetime_in("s")
@@ -354,7 +354,7 @@ std::to_datetime(local: std::local_datetime, zone: std::str)
 {
     # The version of timezone with these arguments is IMMUTABLE.
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT timezone("zone", "local");
     $$;
 };
@@ -368,7 +368,7 @@ std::to_datetime(year: std::int64, month: std::int64, day: std::int64,
 {
     # make_timestamptz is STABLE
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT make_timestamptz(
         "year"::int, "month"::int, "day"::int,
         "hour"::int, "min"::int, "sec", "timezone"
@@ -383,7 +383,7 @@ std::to_local_datetime(s: std::str, fmt: OPTIONAL str={})
 {
     # Helper function to_local_datetime is VOLATILE.
     SET volatility := 'VOLATILE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             edgedb.local_datetime_in("s")
@@ -412,7 +412,7 @@ std::to_local_datetime(year: std::int64, month: std::int64, day: std::int64,
     -> std::local_datetime
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT make_timestamp(
         "year"::int, "month"::int, "day"::int,
         "hour"::int, "min"::int, "sec"
@@ -427,7 +427,7 @@ std::to_local_datetime(dt: std::datetime, zone: std::str)
 {
     # The version of timezone with these arguments is IMMUTABLE.
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT timezone("zone", "dt");
     $$;
 };
@@ -438,7 +438,7 @@ std::to_local_date(s: std::str, fmt: OPTIONAL str={}) -> std::local_date
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             edgedb.local_date_in("s")
@@ -467,7 +467,7 @@ std::to_local_date(dt: std::datetime, zone: std::str)
 {
     # The version of timezone with these arguments is IMMUTABLE.
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT timezone("zone", "dt")::date;
     $$;
 };
@@ -478,7 +478,7 @@ std::to_local_date(year: std::int64, month: std::int64, day: std::int64)
     -> std::local_date
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT make_date("year"::int, "month"::int, "day"::int)
     $$;
 };
@@ -489,7 +489,7 @@ std::to_local_time(s: std::str, fmt: OPTIONAL str={}) -> std::local_time
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             edgedb.local_time_in("s")
@@ -519,7 +519,7 @@ std::to_local_time(dt: std::datetime, zone: std::str)
     # The version of timezone with these arguments is IMMUTABLE and so
     # is the cast.
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT timezone("zone", "dt")::time;
     $$;
 };
@@ -530,7 +530,7 @@ std::to_local_time(hour: std::int64, min: std::int64, sec: std::float64)
     -> std::local_time
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT make_time("hour"::int, "min"::int, "sec")
     $$;
 };
@@ -548,7 +548,7 @@ std::to_duration(
     ) -> std::duration
 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT make_interval(
         "years"::int,
         "months"::int,
@@ -567,7 +567,7 @@ std::to_decimal(s: std::str, fmt: OPTIONAL str={}) -> std::decimal
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             "s"::numeric
@@ -595,7 +595,7 @@ std::to_int64(s: std::str, fmt: OPTIONAL str={}) -> std::int64
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             "s"::bigint
@@ -623,7 +623,7 @@ std::to_int32(s: std::str, fmt: OPTIONAL str={}) -> std::int32
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             "s"::int
@@ -651,7 +651,7 @@ std::to_int16(s: std::str, fmt: OPTIONAL str={}) -> std::int16
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             "s"::smallint
@@ -679,7 +679,7 @@ std::to_float64(s: std::str, fmt: OPTIONAL str={}) -> std::float64
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             "s"::float8
@@ -707,7 +707,7 @@ std::to_float32(s: std::str, fmt: OPTIONAL str={}) -> std::float32
 {
     # Helper functions raising exceptions are STABLE.
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
             "s"::float4

--- a/edb/lib/stdgraphql.edgeql
+++ b/edb/lib/stdgraphql.edgeql
@@ -35,7 +35,7 @@ ALTER TYPE stdgraphql::Mutation {
 
 CREATE FUNCTION stdgraphql::short_name(name: str) -> str {
     SET volatility := 'IMMUTABLE';
-    FROM EdgeQL $$
+    USING EdgeQL $$
         SELECT (
             name[5:] IF name LIKE 'std::%' ELSE
             name[9:] IF name LIKE 'default::%' ELSE

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -53,7 +53,7 @@ sys::sleep(duration: std::float64) -> std::bool
     # This function has side-effect.
     SET volatility := 'VOLATILE';
     SET session_only := True;
-    FROM SQL $$
+    USING SQL $$
     SELECT pg_sleep("duration") IS NOT NULL;
     $$;
 };
@@ -65,7 +65,7 @@ sys::sleep(duration: std::duration) -> std::bool
     # This function has side-effect.
     SET volatility := 'VOLATILE';
     SET session_only := True;
-    FROM SQL $$
+    USING SQL $$
     SELECT pg_sleep_for("duration") IS NOT NULL;
     $$;
 };
@@ -77,7 +77,7 @@ sys::advisory_lock(key: std::int64) -> std::bool
     # This function has side-effect.
     SET volatility := 'VOLATILE';
     SET session_only := True;
-    FROM SQL $$
+    USING SQL $$
     SELECT CASE WHEN "key" < 0 THEN
         edgedb._raise_exception('lock key cannot be negative', NULL::bool)
     ELSE
@@ -93,7 +93,7 @@ sys::advisory_unlock(key: std::int64) -> std::bool
     # This function has side-effect.
     SET volatility := 'VOLATILE';
     SET session_only := True;
-    FROM SQL $$
+    USING SQL $$
     SELECT CASE WHEN "key" < 0 THEN
         edgedb._raise_exception('lock key cannot be negative', NULL::bool)
     ELSE
@@ -109,7 +109,7 @@ sys::advisory_unlock_all() -> std::bool
     # This function has side-effect.
     SET volatility := 'VOLATILE';
     SET session_only := True;
-    FROM SQL $$
+    USING SQL $$
     SELECT pg_advisory_unlock_all() IS NOT NULL;
     $$;
 };
@@ -130,7 +130,7 @@ sys::__version_internal() -> tuple<major: std::int64,
 {
     # This function reads external data.
     SET volatility := 'VOLATILE';
-    FROM SQL $$
+    USING SQL $$
     SELECT
         (v ->> 'major')::int8,
         (v ->> 'minor')::int8,
@@ -153,7 +153,7 @@ sys::get_version() -> tuple<major: std::int64,
 {
     # This function reads external data.
     SET volatility := 'VOLATILE';
-    FROM EdgeQL $$
+    using EdgeQL $$
     SELECT <tuple<major: std::int64,
                   minor: std::int64,
                   stage: sys::version_stage,
@@ -168,7 +168,7 @@ sys::get_version_as_str() -> std::str
 {
     # This function reads external data.
     SET volatility := 'VOLATILE';
-    FROM EdgeQL $$
+    using EdgeQL $$
     WITH v := sys::get_version()
     SELECT
         <str>v.major
@@ -188,5 +188,5 @@ sys::get_transaction_isolation() -> sys::transaction_isolation_t
     # This function only reads from a table.
     SET volatility := 'STABLE';
     SET force_return_cast := true;
-    FROM SQL FUNCTION 'edgedb._get_transaction_isolation';
+    USING SQL FUNCTION 'edgedb._get_transaction_isolation';
 };

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -301,16 +301,10 @@ class ConstraintCommand(
         # check that 'subject' and 'subjectexpr' are not set as annotations
         for command in astnode.commands:
             cname = command.name
-            if cls._is_special_name(cname):
+            if cname in {'subject', 'subjectexpr'}:
                 raise errors.InvalidConstraintDefinitionError(
-                    f'{cname.name} is not a valid constraint annotation',
+                    f'{cname} is not a valid constraint annotation',
                     context=command.context)
-
-    @classmethod
-    def _is_special_name(cls, astnode):
-        # check that 'subject' and 'subjectexpr' are not set as annotations
-        return (astnode.name in {'subject', 'subjectexpr'} and
-                not astnode.module)
 
     @classmethod
     def _classname_quals_from_ast(cls, schema, astnode, base_name,
@@ -328,8 +322,7 @@ class ConstraintCommand(
         # check if "orig_subjectexpr" field is set
         for node in astnode.commands:
             if isinstance(node, qlast.SetField):
-                if (node.name.module is None and
-                        node.name.name == 'orig_subjectexpr'):
+                if node.name == 'orig_subjectexpr':
                     subjexpr_text = node.value.value
                     break
 
@@ -606,7 +599,7 @@ class CreateConstraint(ConstraintCommand,
             else:
                 node.commands.append(
                     qlast.SetSpecialField(
-                        name=qlast.ObjectRef(name='delegated'),
+                        name='delegated',
                         value=op.new_value,
                     )
                 )

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -442,9 +442,10 @@ def _text_from_delta(
         with context(sd.DeltaRootContext(schema=schema, op=delta)):
             delta_ast = command.get_ast(schema, context)
             if delta_ast:
-                ql_classes = [
+                ql_classes_src = {
                     scls.get_ql_class() for scls in limit_ref_classes
-                ]
+                }
+                ql_classes = {q for q in ql_classes_src if q is not None}
 
                 stmt_text = edgeql.generate_source(
                     delta_ast, sdlmode=sdlmode,

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1194,7 +1194,7 @@ class AlterObject(ObjectCommand):
         if op.property in {'is_abstract', 'is_final'}:
             node.commands.append(
                 qlast.SetSpecialField(
-                    name=qlast.ObjectRef(name=op.property),
+                    name=op.property,
                     value=op.new_value
                 )
             )
@@ -1338,7 +1338,7 @@ class AlterSpecialObjectProperty(Command):
     @classmethod
     def _cmd_tree_from_ast(cls, schema, astnode, context):
         return AlterObjectProperty(
-            property=astnode.name.name,
+            property=astnode.name,
             new_value=astnode.value
         )
 
@@ -1355,7 +1355,7 @@ class AlterObjectProperty(Command):
     def _cmd_tree_from_ast(cls, schema, astnode, context):
         from edb.edgeql import compiler as qlcompiler
 
-        propname = astnode.name.name
+        propname = astnode.name
 
         parent_ctx = context.current()
         parent_op = parent_ctx.op
@@ -1453,9 +1453,7 @@ class AlterObjectProperty(Command):
         else:
             value = qlast.BaseConstant.from_python(value)
 
-        op = qlast.SetField(
-            name=qlast.ObjectRef(module='', name=self.property),
-            value=value)
+        op = qlast.SetField(name=self.property, value=value)
         return op
 
     def __repr__(self):

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -764,13 +764,13 @@ class CreateFunction(CreateCallableObject, FunctionCommand):
             elif from_function:
                 raise errors.InvalidFunctionDefinitionError(
                     f'cannot create `{signature}` function: '
-                    f'"FROM SQL FUNCTION" is not supported in '
+                    f'"USING SQL FUNCTION" is not supported in '
                     f'user-defined functions',
                     context=self.source_context)
             elif language != qlast.Language.EdgeQL:
                 raise errors.InvalidFunctionDefinitionError(
                     f'cannot create `{signature}` function: '
-                    f'"FROM {language}" is not supported in '
+                    f'"USING {language}" is not supported in '
                     f'user-defined functions',
                     context=self.source_context)
 
@@ -827,7 +827,7 @@ class CreateFunction(CreateCallableObject, FunctionCommand):
                         for f in overloaded_funcs)):
                 raise errors.InvalidFunctionDefinitionError(
                     f'cannot create the `{signature}` function: '
-                    f'overloading "FROM SQL FUNCTION" functions is '
+                    f'overloading "USING SQL FUNCTION" functions is '
                     f'allowed only when all functions point to the same '
                     f'SQL function',
                     context=self.source_context)

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -125,8 +125,7 @@ class IndexCommand(referencing.ReferencedInheritingObjectCommand,
         # check if "origexpr" field is already set
         for node in astnode.commands:
             if isinstance(node, qlast.SetField):
-                if (node.name.module is None and
-                        node.name.name == 'origexpr'):
+                if node.name == 'origexpr':
                     expr_text = node.value.value
                     break
 

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -223,7 +223,7 @@ class CreateLink(LinkCommand, referencing.CreateReferencedInheritingObject):
             else:
                 node.commands.append(
                     qlast.SetSpecialField(
-                        name=qlast.ObjectRef(name='required'),
+                        name='required',
                         value=op.new_value,
                     )
                 )

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -221,7 +221,7 @@ class CreateProperty(PropertyCommand,
             else:
                 node.commands.append(
                     qlast.SetSpecialField(
-                        name=qlast.ObjectRef(name='required'),
+                        name='required',
                         value=op.new_value,
                     ),
                 )

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1577,7 +1577,7 @@ class TypeCommand(sd.ObjectCommand):
     ) -> Optional[qlast.Expr]:
         for subcmd in astnode.commands:
             if (isinstance(subcmd, qlast.SetField) and
-                    subcmd.name.name == 'expr'):
+                    subcmd.name == 'expr'):
                 return subcmd.value
 
         return None

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -532,7 +532,7 @@ class DatabaseTestCase(ClusterTestCase, ConnectedTestCaseMixin):
     # in which case ISOLATED_METHODS will be False.
     ISOLATED_METHODS = True
     # Turns on "EdgeDB developer" mode which allows using restricted
-    # syntax like FROM SQL and similar. It allows modifying standard
+    # syntax like USING SQL and similar. It allows modifying standard
     # library (e.g. declaring casts).
     INTERNAL_TESTMODE = True
 

--- a/edb/tools/docs/eql.py
+++ b/edb/tools/docs/eql.py
@@ -665,7 +665,7 @@ class EQLFunctionDirective(BaseEQLDirective):
         parser = edgeql_parser.EdgeQLBlockParser()
         try:
             astnode = parser.parse(
-                f'CREATE FUNCTION {sig} FROM SQL FUNCTION "xxx";')[0]
+                f'CREATE FUNCTION {sig} USING SQL FUNCTION "xxx";')[0]
         except Exception as ex:
             raise shared.DirectiveParseError(
                 self, f'could not parse function signature {sig!r}',
@@ -687,7 +687,7 @@ class EQLFunctionDirective(BaseEQLDirective):
             ^
             CREATE\sFUNCTION\s
             (?P<f>.*?)
-            \sFROM\sSQL\sFUNCTION
+            \sUSING\sSQL\sFUNCTION
             .*$
         ''', func_repr)
         if not m or not m.group('f'):

--- a/mypy.ini
+++ b/mypy.ini
@@ -16,6 +16,23 @@ warn_unused_configs = True
 follow_imports = True
 ignore_errors = False
 
+[mypy-edb.edgeql.codegen]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+
+
 [mypy-edb.pgsql.compiler.*]
 follow_imports = True
 ignore_errors = False

--- a/tests/schemas/volatility_setup.edgeql
+++ b/tests/schemas/volatility_setup.edgeql
@@ -19,42 +19,42 @@
 
 CREATE FUNCTION test::vol_immutable() -> float64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
         SELECT random();
     $$;
 };
 
 CREATE FUNCTION test::vol_stable() -> float64 {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
         SELECT random();
     $$;
 };
 
 CREATE FUNCTION test::vol_volatile() -> float64 {
     SET volatility := 'VOLATILE';
-    FROM SQL $$
+    USING SQL $$
         SELECT random();
     $$;
 };
 
 CREATE FUNCTION test::err_immutable() -> float64 {
     SET volatility := 'IMMUTABLE';
-    FROM SQL $$
+    USING SQL $$
         SELECT random()/0;
     $$;
 };
 
 CREATE FUNCTION test::err_stable() -> float64 {
     SET volatility := 'STABLE';
-    FROM SQL $$
+    USING SQL $$
         SELECT random()/0;
     $$;
 };
 
 CREATE FUNCTION test::err_volatile() -> float64 {
     SET volatility := 'VOLATILE';
-    FROM SQL $$
+    USING SQL $$
         SELECT random()/0;
     $$;
 };

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -926,7 +926,7 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
 
         await self.con.execute(r"""
             CREATE FUNCTION con05(a: int64) -> str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT <str>a
                 $$;
         """)
@@ -966,7 +966,7 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
 
         await self.con.execute(r"""
             CREATE FUNCTION con06(a: int64) -> array<int64>
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT [a]
                 $$;
         """)

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -34,7 +34,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 NAMED ONLY suffix: str = '-suf',
                 NAMED ONLY prefix: str = 'pref-'
             ) -> std::str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT prefix ++ s ++ <str>sum(array_unpack(a)) ++ suffix;
                 $$;
         ''')
@@ -102,7 +102,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call2(
                 VARIADIC a: anytype
             ) -> std::str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT '=' ++ <str>len(a) ++ '='
                 $$;
         ''')
@@ -122,7 +122,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 a: int32,
                 NAMED ONLY b: int32
             ) -> int32
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a + b
                 $$;
         ''')
@@ -150,7 +150,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 a: int32,
                 NAMED ONLY b: array<anytype> = []
             ) -> int32
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a + len(b)
                 $$;
         ''')
@@ -180,7 +180,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 a: int64,
                 NAMED ONLY b: OPTIONAL int64 = <int64>{}
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a + b ?? -100
                 $$;
         ''')
@@ -210,7 +210,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call6(
                 VARIADIC a: int64
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT <int64>sum(array_unpack(a));;
                 $$;
         ''')
@@ -239,7 +239,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 NAMED ONLY d: int64 = 4,
                 NAMED ONLY e: int64 = 5
             ) -> array<int64>
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT [a, b, c, d, e]
                 $$;
         ''')
@@ -297,7 +297,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 a: int64 = 1,
                 NAMED ONLY b: int64 = 2
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a + b
                 $$;
 
@@ -305,7 +305,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 a: float64 = 1.0,
                 NAMED ONLY b: int64 = 2
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT 1000 + <int64>a + b
                 $$;
         ''')
@@ -442,7 +442,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call11(
                 a: array<int32>
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT sum(array_unpack(a))
                 $$;
         ''')
@@ -484,14 +484,14 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call12(
                 a: anyint
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT <int64>a + 100
                 $$;
 
             CREATE FUNCTION test::call12(
                 a: int64
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT <int64>a + 1
                 $$;
         ''')
@@ -511,14 +511,14 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::inner(
                 a: anytype
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT 1;
                 $$;
 
             CREATE FUNCTION test::call13(
                 a: anytype
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT test::inner(a)
                 $$;
         ''')
@@ -547,14 +547,14 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::inner(
                 a: str
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT 2;
                 $$;
 
             CREATE FUNCTION test::call13_2(
                 a: anytype
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT test::inner(a)
                 $$;
         ''')
@@ -584,7 +584,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call14(
                 a: anytype
             ) -> array<anytype>
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT [a]
                 $$;
         ''')
@@ -609,7 +609,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call15(
                 a: anytype
             ) -> array<anytype>
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT [a, a, a]
                 $$;
         ''')
@@ -630,7 +630,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 a: array<anytype>,
                 idx: int64
             ) -> anytype
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a[idx]
                 $$;
 
@@ -638,7 +638,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 a: array<anytype>,
                 idx: str
             ) -> anytype
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a[<int64>idx + 1]
                 $$;
 
@@ -646,7 +646,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 a: anyscalar,
                 idx: int64
             ) -> anytype
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a[idx]
                 $$;
         ''')
@@ -681,14 +681,14 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call17(
                 a: anytype
             ) -> array<anytype>
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT [a, a, a]
                 $$;
 
             CREATE FUNCTION test::call17(
                 a: str
             ) -> array<str>
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT ['!!!!', a, '!!!!']
                 $$;
         ''')
@@ -708,7 +708,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call18(
                 VARIADIC a: anytype
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT len(a)
                 $$;
         ''')
@@ -745,7 +745,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call19(
                 a: anytype
             ) -> array<anytype>
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT [a]
                 $$;
         ''')
@@ -761,14 +761,14 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call20_1(
                 a: anyreal, b: anyreal
             ) -> anyreal
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a + b
                 $$;
 
             CREATE FUNCTION test::call20_2(
                 a: anyscalar, b: anyscalar
             ) -> bool
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a < b
                 $$;
         ''')
@@ -799,7 +799,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call21(
                 a: array<anytype>
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT len(a)
                 $$;
         ''')
@@ -829,14 +829,14 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call22(
                 a: str, b: str
             ) -> str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a ++ b
                 $$;
 
             CREATE FUNCTION test::call22(
                 a: array<anytype>, b: array<anytype>
             ) -> array<anytype>
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a ++ b
                 $$;
         ''')
@@ -859,7 +859,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 a: anytype,
                 idx: int64
             ) -> anytype
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a[idx]
                 $$;
 
@@ -867,7 +867,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 a: anytype,
                 idx: int32
             ) -> anytype
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a[-idx:]
                 $$;
         ''')
@@ -894,14 +894,14 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
     async def test_edgeql_calls_24(self):
         await self.con.execute('''
             CREATE FUNCTION test::call24() -> str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT 'ab' ++ 'cd'
                 $$;
 
             CREATE FUNCTION test::call24(
                 a: str
             ) -> str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a ++ '!'
                 $$;
         ''')
@@ -921,7 +921,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call26(
                 a: array<anyscalar>
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT len(a)
                 $$;
         ''')
@@ -947,7 +947,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call27(
                 a: array<anyint>
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT len(a)
                 $$;
         ''')
@@ -983,14 +983,14 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call28(
                 a: array<anyint>
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT len(a)
                 $$;
 
             CREATE FUNCTION test::call28(
                 a: array<anyscalar>
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT len(a) + 1000
                 $$;
         ''')
@@ -1015,7 +1015,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call29(
                 a: anyint
             ) -> anyint
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a + 1
                 $$;
         ''')
@@ -1030,7 +1030,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call30(
                 a: anyint
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT <int64>a + 100
                 $$;
         ''')
@@ -1050,7 +1050,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call31(
                 a: anytype
             ) -> anytype
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a
                 $$;
         ''')
@@ -1130,7 +1130,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call32(
                 a: anytype, b: anytype
             ) -> anytype
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a ++ b
                 $$;
         ''')
@@ -1150,7 +1150,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 a: tuple<int64, tuple<int64>>,
                 b: tuple<foo: int64, bar: str>
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a.0 + b.foo
                 $$;
         ''')
@@ -1169,7 +1169,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 CREATE FUNCTION test::call33_2(
                     a: array<tuple<int64, int64>>
                 ) -> int64
-                    FROM EdgeQL $$
+                    USING EdgeQL $$
                         SELECT a[0].0
                     $$;
             ''')
@@ -1181,7 +1181,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::call34(
                 a: int64
             ) -> tuple<int64, tuple<foo: int64>>
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT (a, ((a + 1),))
                 $$;
         ''')
@@ -1207,7 +1207,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 CREATE FUNCTION test::call34_2(
                     a: int64
                 ) -> array<tuple<int64>>
-                    FROM EdgeQL $$
+                    USING EdgeQL $$
                         SELECT [(a,)]
                     $$;
             ''')
@@ -1219,7 +1219,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 a: int64 = 1,
                 b: int64 = 2
             ) -> int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a + b
                 $$;
         ''')

--- a/tests/test_edgeql_coalesce.py
+++ b/tests/test_edgeql_coalesce.py
@@ -1220,7 +1220,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             r'''
                 CREATE FUNCTION test::optfunc(
                         a: std::str, b: OPTIONAL std::str) -> std::str
-                    FROM EdgeQL $$
+                    USING EdgeQL $$
                         SELECT b IF a = 'foo' ELSE a
                     $$;
             '''

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -2494,7 +2494,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello01(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$
         """)
@@ -2508,7 +2508,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # in principle)
         await self._migrate(r"""
             function hello01(a: int64, b: int64=42) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>(a + b)
                 $$
         """)
@@ -2529,7 +2529,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello02(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$
         """)
@@ -2543,7 +2543,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # in principle)
         await self._migrate(r"""
             function hello02(a: int64, b: OPTIONAL int64=42) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>(a + b)
                 $$
         """)
@@ -2564,7 +2564,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello03(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$
         """)
@@ -2578,7 +2578,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # in principle)
         await self._migrate(r"""
             function hello03(a: int64, NAMED ONLY b: int64=42) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>(a + b)
                 $$
         """)
@@ -2599,7 +2599,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello04(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$
         """)
@@ -2612,7 +2612,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # same parameters, different return type
         await self._migrate(r"""
             function hello04(a: int64) -> int64
-                from edgeql $$
+                using edgeql $$
                     SELECT -a
                 $$
         """)
@@ -2628,7 +2628,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello05(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT <str>a
                 $$
         """)
@@ -2641,7 +2641,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # same parameters, different return type (array)
         await self._migrate(r"""
             function hello05(a: int64) -> array<int64>
-                from edgeql $$
+                using edgeql $$
                     SELECT [a]
                 $$
         """)
@@ -2672,7 +2672,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello06(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT <str>a
                 $$;
 
@@ -2695,7 +2695,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # same parameters, different return type (array)
         await self._migrate(r"""
             function hello06(a: int64) -> array<int64>
-                from edgeql $$
+                using edgeql $$
                     SELECT [a]
                 $$;
 
@@ -2721,7 +2721,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello07(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT <str>a
                 $$;
 
@@ -2742,7 +2742,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # same parameters, different return type (array)
         await self._migrate(r"""
             function hello07(a: int64) -> array<int64>
-                from edgeql $$
+                using edgeql $$
                     SELECT [a]
                 $$;
 
@@ -2763,7 +2763,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello08(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT <str>a
                 $$;
 
@@ -2779,7 +2779,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # same parameters, different return type (array)
         await self._migrate(r"""
             function hello08(a: int64) -> array<int64>
-                from edgeql $$
+                using edgeql $$
                     SELECT [a]
                 $$;
 
@@ -2798,7 +2798,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello09(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT <str>a
                 $$;
 
@@ -2823,7 +2823,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # same parameters, different return type (array)
         await self._migrate(r"""
             function hello09(a: int64) -> array<int64>
-                from edgeql $$
+                using edgeql $$
                     SELECT [a]
                 $$;
 
@@ -2860,7 +2860,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello10(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT <str>a
                 $$;
 
@@ -2883,7 +2883,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # same parameters, different return type (array)
         await self._migrate(r"""
             function hello10(a: int64) -> array<int64>
-                from edgeql $$
+                using edgeql $$
                     SELECT [a]
                 $$;
 
@@ -2906,7 +2906,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello11(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$
         """)
@@ -2919,7 +2919,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         await self._migrate(r"""
             # replace the function with a new one by the same name
             function hello11(a: str) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ a
                 $$
         """)
@@ -2943,7 +2943,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello12(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$;
         """)
@@ -2955,13 +2955,13 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self._migrate(r"""
             function hello12(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$;
 
             # make the function polymorphic
             function hello12(a: str) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ a
                 $$;
         """)
@@ -2985,12 +2985,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         await self._migrate(r"""
             # start with a polymorphic function
             function hello13(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$;
 
             function hello13(a: str) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ a
                 $$;
         """)
@@ -3007,7 +3007,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         await self._migrate(r"""
             # remove one of the 2 versions
             function hello13(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$;
         """)
@@ -3031,7 +3031,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello14(a: str, b: str) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT a ++ b
                 $$
         """)
@@ -3045,7 +3045,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             # Replace the function with a new one by the same name,
             # but working with arrays.
             function hello14(a: array<str>, b: array<str>) -> array<str>
-                from edgeql $$
+                using edgeql $$
                     SELECT a ++ b
                 $$
         """)
@@ -3070,7 +3070,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self._migrate(r"""
             function hello15(a: str, b: str) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT a ++ b
                 $$
         """)
@@ -3084,7 +3084,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             # Replace the function with a new one by the same name,
             # but working with arrays.
             function hello15(a: tuple<str, str>) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT a.0 ++ a.1
                 $$
         """)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -923,7 +923,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_function_01(self):
         await self.con.execute("""
             CREATE FUNCTION test::my_lower(s: std::str) -> std::str
-                FROM SQL FUNCTION 'lower';
+                USING SQL FUNCTION 'lower';
         """)
 
         with self.assertRaisesRegex(edgedb.DuplicateFunctionDefinitionError,
@@ -934,7 +934,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     CREATE FUNCTION test::my_lower(s: SET OF std::str)
                         -> std::str {
                         SET initial_value := '';
-                        FROM SQL FUNCTION 'count';
+                        USING SQL FUNCTION 'count';
                     };
                 """)
 
@@ -945,7 +945,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.con.execute("""
             CREATE FUNCTION test::my_lower(s: SET OF anytype)
                 -> std::str {
-                FROM SQL FUNCTION 'count';
+                USING SQL FUNCTION 'count';
                 SET initial_value := '';
             };
         """)
@@ -956,7 +956,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             async with self.con.transaction():
                 await self.con.execute("""
                     CREATE FUNCTION test::my_lower(s: anytype) -> std::str
-                        FROM SQL FUNCTION 'lower';
+                        USING SQL FUNCTION 'lower';
                 """)
 
         await self.con.execute("""
@@ -969,37 +969,37 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.con.execute(f"""
             CREATE FUNCTION test::my_sql_func1()
                 -> std::str
-                FROM SQL $$
+                USING SQL $$
                     SELECT 'spam'::text
                 $$;
 
             CREATE FUNCTION test::my_sql_func2(foo: std::str)
                 -> std::str
-                FROM SQL $$
+                USING SQL $$
                     SELECT "foo"::text
                 $$;
 
             CREATE FUNCTION test::my_sql_func4(VARIADIC s: std::str)
                 -> std::str
-                FROM SQL $$
+                USING SQL $$
                     SELECT array_to_string(s, '-')
                 $$;
 
             CREATE FUNCTION test::{long_func_name}()
                 -> std::str
-                FROM SQL $$
+                USING SQL $$
                     SELECT '{long_func_name}'::text
                 $$;
 
             CREATE FUNCTION test::my_sql_func6(a: std::str='a' ++ 'b')
                 -> std::str
-                FROM SQL $$
+                USING SQL $$
                     SELECT $1 || 'c'
                 $$;
 
             CREATE FUNCTION test::my_sql_func7(s: array<std::int64>)
                 -> std::int64
-                FROM SQL $$
+                USING SQL $$
                     SELECT sum(s)::bigint FROM UNNEST($1) AS s
                 $$;
         """)
@@ -1063,7 +1063,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 CREATE FUNCTION test::broken_sql_func1(
                     a: std::int64=(SELECT schema::ObjectType))
                 -> std::str
-                FROM SQL $$
+                USING SQL $$
                     SELECT 'spam'::text
                 $$;
             """)
@@ -1072,13 +1072,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.con.execute(f"""
             CREATE FUNCTION test::my_edgeql_func1()
                 -> std::str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT 'sp' ++ 'am'
                 $$;
 
             CREATE FUNCTION test::my_edgeql_func2(s: std::str)
                 -> schema::ObjectType
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT
                         schema::ObjectType
                     FILTER schema::ObjectType.name = s
@@ -1087,13 +1087,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             CREATE FUNCTION test::my_edgeql_func3(s: std::int64)
                 -> std::int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT s + 10
                 $$;
 
             CREATE FUNCTION test::my_edgeql_func4(i: std::int64)
                 -> array<std::int64>
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT [i, 1, 2, 3]
                 $$;
         """)
@@ -1134,7 +1134,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.con.execute("""
             CREATE FUNCTION test::attr_func_1() -> std::str {
                 SET ANNOTATION description := 'hello';
-                FROM EdgeQL "SELECT '1'";
+                USING EdgeQL "SELECT '1'";
             };
         """)
 
@@ -1160,7 +1160,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_function_06(self):
         await self.con.execute("""
             CREATE FUNCTION test::int_func_1() -> std::int64 {
-                FROM EdgeQL "SELECT 1";
+                USING EdgeQL "SELECT 1";
             };
         """)
 
@@ -1179,7 +1179,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute(r"""
                 CREATE FUNCTION test::my_agg(
                         s: anytype = [1]) -> array<anytype>
-                    FROM SQL FUNCTION "my_agg";
+                    USING SQL FUNCTION "my_agg";
             """)
 
     async def test_edgeql_ddl_function_08(self):
@@ -1189,7 +1189,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             await self.con.execute("""
                 CREATE FUNCTION test::ddlf_08(s: std::str = 1) -> std::str
-                    FROM EdgeQL $$ SELECT "1" $$;
+                    USING EdgeQL $$ SELECT "1" $$;
             """)
 
     async def test_edgeql_ddl_function_09(self):
@@ -1198,7 +1198,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 NAMED ONLY a: int64,
                 NAMED ONLY b: int64
             ) -> std::str
-                FROM EdgeQL $$ SELECT "1" $$;
+                USING EdgeQL $$ SELECT "1" $$;
         """)
 
         with self.assertRaisesRegex(
@@ -1211,7 +1211,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         NAMED ONLY b: int64,
                         NAMED ONLY a: int64 = 1
                     ) -> std::str
-                        FROM EdgeQL $$ SELECT "1" $$;
+                        USING EdgeQL $$ SELECT "1" $$;
                 """)
 
         await self.con.execute("""
@@ -1219,7 +1219,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 NAMED ONLY b: str,
                 NAMED ONLY a: int64
             ) -> std::str
-                FROM EdgeQL $$ SELECT "2" $$;
+                USING EdgeQL $$ SELECT "2" $$;
         """)
 
         await self.assert_query_result(
@@ -1244,7 +1244,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 CREATE FUNCTION test::ddlf_10(
                     sum: int64
                 ) -> int64
-                    FROM EdgeQL $$
+                    USING EdgeQL $$
                         SELECT <int64>sum(sum)
                     $$;
             ''')
@@ -1252,17 +1252,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_function_11(self):
         await self.con.execute(r'''
             CREATE FUNCTION test::ddlf_11_1() -> str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT '\u0062'
                 $$;
 
             CREATE FUNCTION test::ddlf_11_2() -> str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT r'\u0062'
                 $$;
 
             CREATE FUNCTION test::ddlf_11_3() -> str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT $a$\u0062$a$
                 $$;
         ''')
@@ -1301,10 +1301,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             await self.con.execute(r'''
                 CREATE FUNCTION test::ddlf_12(a: int64) -> int64
-                    FROM EdgeQL $$ SELECT 11 $$;
+                    USING EdgeQL $$ SELECT 11 $$;
 
                 CREATE FUNCTION test::ddlf_12(a: int64) -> float64
-                    FROM EdgeQL $$ SELECT 11 $$;
+                    USING EdgeQL $$ SELECT 11 $$;
             ''')
 
     async def test_edgeql_ddl_function_13(self):
@@ -1317,7 +1317,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             async with self.con.transaction():
                 await self.con.execute(r'''
                     CREATE FUNCTION test::ddlf_13(a: SET OF int64) -> int64
-                        FROM EdgeQL $$ SELECT 11 $$;
+                        USING EdgeQL $$ SELECT 11 $$;
                 ''')
 
         with self.assertRaises(edgedb.InvalidReferenceError):
@@ -1329,11 +1329,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.con.execute(r'''
             CREATE FUNCTION test::ddlf_14(
                     a: int64, NAMED ONLY f: int64) -> int64
-                FROM EdgeQL $$ SELECT 11 $$;
+                USING EdgeQL $$ SELECT 11 $$;
 
             CREATE FUNCTION test::ddlf_14(
                     a: int32, NAMED ONLY f: str) -> int64
-                FROM EdgeQL $$ SELECT 12 $$;
+                USING EdgeQL $$ SELECT 12 $$;
         ''')
 
         try:
@@ -1364,11 +1364,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute(r'''
                 CREATE FUNCTION test::ddlf_15(
                         a: int64, NAMED ONLY f: int64) -> int64
-                    FROM EdgeQL $$ SELECT 11 $$;
+                    USING EdgeQL $$ SELECT 11 $$;
 
                 CREATE FUNCTION test::ddlf_15(
                         a: int32, NAMED ONLY h: str) -> int64
-                    FROM EdgeQL $$ SELECT 12 $$;
+                    USING EdgeQL $$ SELECT 12 $$;
             ''')
 
     async def test_edgeql_ddl_function_16(self):
@@ -1380,27 +1380,27 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute(r'''
                 CREATE FUNCTION test::ddlf_16(
                         a: anytype, b: int64) -> OPTIONAL int64
-                    FROM EdgeQL $$ SELECT 11 $$;
+                    USING EdgeQL $$ SELECT 11 $$;
 
                 CREATE FUNCTION test::ddlf_16(a: anytype, b: float64) -> str
-                    FROM EdgeQL $$ SELECT '12' $$;
+                    USING EdgeQL $$ SELECT '12' $$;
             ''')
 
     async def test_edgeql_ddl_function_17(self):
         await self.con.execute(r'''
             CREATE FUNCTION test::ddlf_17(str: std::str) -> int64
-                FROM SQL FUNCTION 'whatever';
+                USING SQL FUNCTION 'whatever';
         ''')
 
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
                 r'cannot create.*test::ddlf_17.*'
-                r'overloading "FROM SQL FUNCTION"'):
+                r'overloading "USING SQL FUNCTION"'):
 
             async with self.con.transaction():
                 await self.con.execute(r'''
                     CREATE FUNCTION test::ddlf_17(str: std::int64) -> int64
-                        FROM SQL FUNCTION 'whatever2';
+                        USING SQL FUNCTION 'whatever2';
                 ''')
 
         await self.con.execute("""
@@ -1416,7 +1416,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             await self.con.execute(r'''
                 CREATE FUNCTION test::ddlf_18(str: std::str) -> anytype
-                    FROM EdgeQL $$ SELECT 1 $$;
+                    USING EdgeQL $$ SELECT 1 $$;
             ''')
 
     async def test_edgeql_ddl_function_19(self):
@@ -1426,7 +1426,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             await self.con.execute(r'''
                 CREATE FUNCTION test::ddlf_19(f: std::anytype) -> int64
-                    FROM EdgeQL $$ SELECT 1 $$;
+                    USING EdgeQL $$ SELECT 1 $$;
             ''')
 
     async def test_edgeql_ddl_function_20(self):
@@ -1436,13 +1436,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             await self.con.execute(r'''
                 CREATE FUNCTION test::ddlf_20(f: int64) -> int64
-                    FROM EdgeQL $$ SELECT 1; SELECT f; $$;
+                    USING EdgeQL $$ SELECT 1; SELECT f; $$;
             ''')
 
     async def test_edgeql_ddl_function_21(self):
         await self.con.execute(r'''
             CREATE FUNCTION test::ddlf_21(str: str) -> int64
-                FROM EdgeQL $$ SELECT 1$$;
+                USING EdgeQL $$ SELECT 1$$;
         ''')
 
         with self.assertRaisesRegex(
@@ -1454,7 +1454,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 await self.con.execute(r'''
                     CREATE FUNCTION test::ddlf_21(str: int64) -> int64 {
                         SET session_only := true;
-                        FROM EdgeQL $$ SELECT 1$$;
+                        USING EdgeQL $$ SELECT 1$$;
                     };
                 ''')
 
@@ -1470,7 +1470,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute(r"""
                 CREATE FUNCTION test::broken_edgeql_func22(
                     a: std::str) -> std::int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT a
                 $$;
             """)
@@ -1483,7 +1483,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute(r"""
                 CREATE FUNCTION test::broken_edgeql_func23(
                     a: std::str) -> std::int64
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT [a]
                 $$;
             """)
@@ -1496,7 +1496,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute(r"""
                 CREATE FUNCTION test::broken_edgeql_func24(
                     a: std::str) -> std::str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT [a]
                 $$;
             """)
@@ -1509,7 +1509,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute(r"""
                 CREATE FUNCTION test::broken_edgeql_func25(
                     a: std::str) -> std::str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT {a, a}
                 $$;
             """)
@@ -1528,7 +1528,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.con.execute('''
             CREATE INFIX OPERATOR test::`+++`
                 (left: int64, right: int64) -> int64
-                FROM SQL OPERATOR r'+';
+                USING SQL OPERATOR r'+';
         ''')
 
         await self.assert_query_result(
@@ -1623,11 +1623,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute('''
                 CREATE POSTFIX OPERATOR test::`!`
                     (operand: int64) -> int64
-                    FROM SQL OPERATOR r'!';
+                    USING SQL OPERATOR r'!';
 
                 CREATE PREFIX OPERATOR test::`!`
                     (operand: int64) -> int64
-                    FROM SQL OPERATOR r'!!';
+                    USING SQL OPERATOR r'!!';
             ''')
 
             await self.assert_query_result(
@@ -1670,7 +1670,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r'an operator must have operands'):
             await self.con.execute('''
                 CREATE PREFIX OPERATOR test::`NOT`() -> bool
-                    FROM SQL EXPRESSION;
+                    USING SQL EXPRESSION;
             ''')
 
     async def test_edgeql_ddl_operator_04(self):
@@ -1683,7 +1683,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute('''
                 CREATE INFIX OPERATOR
                 test::`=` (l: array<anytype>, r: str) -> std::bool {
-                    FROM SQL EXPRESSION;
+                    USING SQL EXPRESSION;
                     SET recursive := true;
                 };
             ''')
@@ -1698,7 +1698,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute('''
                 CREATE INFIX OPERATOR
                 test::`=` (l: array<anytype>, r: anytuple) -> std::bool {
-                    FROM SQL EXPRESSION;
+                    USING SQL EXPRESSION;
                     SET recursive := true;
                 };
             ''')
@@ -1717,7 +1717,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute('''
                 CREATE INFIX OPERATOR
                 std::`=` (l: array<int64>, r: array<int64>) -> std::bool {
-                    FROM SQL EXPRESSION;
+                    USING SQL EXPRESSION;
                 };
             ''')
 
@@ -1735,12 +1735,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute('''
                 CREATE INFIX OPERATOR
                 test::`=` (l: array<anytype>, r: array<anytype>) -> std::bool {
-                    FROM SQL EXPRESSION;
+                    USING SQL EXPRESSION;
                 };
 
                 CREATE INFIX OPERATOR
                 test::`=` (l: array<int64>, r: array<int64>) -> std::bool {
-                    FROM SQL EXPRESSION;
+                    USING SQL EXPRESSION;
                     SET recursive := true;
                 };
             ''')
@@ -1779,11 +1779,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_operator_09(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidOperatorDefinitionError,
-                r'unexpected FROM clause in abstract operator definition'):
+                r'unexpected USING clause in abstract operator definition'):
             await self.con.execute('''
                 CREATE ABSTRACT INFIX OPERATOR
                 test::`=` (l: array<anytype>, r: array<anytype>) -> std::bool {
-                    FROM SQL EXPRESSION;
+                    USING SQL EXPRESSION;
                 };
             ''')
 
@@ -1798,13 +1798,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute('''
                 CREATE INFIX OPERATOR
                 test::`IN` (l: std::float64, r: std::float64) -> std::bool {
-                    FROM SQL EXPRESSION;
+                    USING SQL EXPRESSION;
                     SET derivative_of := 'std::=';
                 };
 
                 CREATE INFIX OPERATOR
                 test::`IN` (l: std::int64, r: std::int64) -> std::bool {
-                    FROM SQL EXPRESSION;
+                    USING SQL EXPRESSION;
                 };
             ''')
 
@@ -1820,12 +1820,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute('''
                 CREATE INFIX OPERATOR
                 test::`IN` (l: std::float64, r: std::float64) -> std::bool {
-                    FROM SQL EXPRESSION;
+                    USING SQL EXPRESSION;
                 };
 
                 CREATE INFIX OPERATOR
                 test::`IN` (l: std::int64, r: std::int64) -> std::bool {
-                    FROM SQL EXPRESSION;
+                    USING SQL EXPRESSION;
                     SET derivative_of := 'std::=';
                 };
             ''')
@@ -1837,12 +1837,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             CREATE SCALAR TYPE test::type_c EXTENDING std::datetime;
 
             CREATE CAST FROM test::type_a TO test::type_b {
-                FROM SQL CAST;
+                USING SQL CAST;
                 ALLOW IMPLICIT;
             };
 
             CREATE CAST FROM test::type_a TO test::type_c {
-                FROM SQL CAST;
+                USING SQL CAST;
                 ALLOW ASSIGNMENT;
             };
         ''')
@@ -3593,7 +3593,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             };
             CREATE SCALAR TYPE test::dropint EXTENDING int64;
             CREATE FUNCTION test::dropfunc(a: test::dropint) -> int64
-                FROM EdgeQL $$ SELECT a; $$;
+                USING EdgeQL $$ SELECT a; $$;
         """)
 
         async with self.assertRaisesRegexTx(

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -1283,7 +1283,7 @@ class TestIntrospection(tb.QueryTestCase):
         async with self.con.transaction():
             await self.con.execute(r'''
                 CREATE FUNCTION bad() -> str
-                    FROM EdgeQL $$ SELECT r'\1' $$;
+                    USING EdgeQL $$ SELECT r'\1' $$;
             ''')
 
             desc = await self.con.fetchone('''
@@ -1293,5 +1293,5 @@ class TestIntrospection(tb.QueryTestCase):
         self.assertEqual(
             desc,
             r"function default::bad() ->  std::str "
-            r"from edgeql $$ SELECT r'\1' $$;"
+            r"using edgeql $$ SELECT r'\1' $$;"
         )

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -2154,7 +2154,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_func_05(self):
         await self.con.execute(r'''
             CREATE FUNCTION test::concat1(VARIADIC s: anytype) -> std::str
-                FROM SQL FUNCTION 'concat';
+                USING SQL FUNCTION 'concat';
         ''')
 
         await self.assert_query_result(
@@ -2193,7 +2193,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_func_06(self):
         await self.con.execute(r'''
             CREATE FUNCTION test::concat2(VARIADIC s: std::str) -> std::str
-                FROM SQL FUNCTION 'concat';
+                USING SQL FUNCTION 'concat';
         ''')
 
         with self.assertRaisesRegex(edgedb.QueryError,
@@ -2205,7 +2205,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             CREATE FUNCTION test::concat3(sep: OPTIONAL std::str,
                                           VARIADIC s: std::str)
                     -> std::str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     # poor man concat
                     SELECT (array_get(s, 0) ?? '') ++
                            (sep ?? '::') ++

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2790,7 +2790,7 @@ aa';
         """
         CREATE FUNCTION std::sum(v: SET OF std::int64)
             -> std::int64
-            FROM SQL FUNCTION 'sum';
+            USING SQL FUNCTION 'sum';
         """
 
     def test_edgeql_syntax_ddl_aggregate_01(self):
@@ -2798,7 +2798,7 @@ aa';
         CREATE FUNCTION std::sum(v: SET OF std::int64)
             -> std::int64 {
             SET initial_value := 0;
-            FROM SQL FUNCTION 'test';
+            USING SQL FUNCTION 'test';
         };
         """
 
@@ -2807,7 +2807,7 @@ aa';
         CREATE FUNCTION std::sum(arg: SET OF std::int64)
             -> std::int64 {
             SET initial_value := 0;
-            FROM SQL FUNCTION 'sum';
+            USING SQL FUNCTION 'sum';
         };
         """
 
@@ -2816,7 +2816,7 @@ aa';
         CREATE FUNCTION std::sum(integer: SET OF std::int64)
             -> std::int64 {
             SET initial_value := 0;
-            FROM SQL FUNCTION 'sum';
+            USING SQL FUNCTION 'sum';
         };
         """
 
@@ -2825,7 +2825,7 @@ aa';
         CREATE FUNCTION std::sum(integer: SET OF std::int64)
             -> std::int64 {
             SET initial_value := 0;
-            FROM SQL FUNCTION 'sum';
+            USING SQL FUNCTION 'sum';
         };
         """
 
@@ -2836,7 +2836,7 @@ aa';
         CREATE FUNCTION foo(string: SET OF std::str)
             -> std::int64 {
             SET initial_value := 0;
-            FROM AAA FUNCTION 'foo';
+            USING AAA FUNCTION 'foo';
         };
         """
 
@@ -2845,7 +2845,7 @@ aa';
         CREATE FUNCTION std::count(expression: SET OF anytype)
             -> std::int64 {
             SET initial_value := 0;
-            FROM SQL FUNCTION 'count';
+            USING SQL FUNCTION 'count';
         };
         """
 
@@ -3010,40 +3010,40 @@ aa';
     def test_edgeql_syntax_ddl_function_01(self):
         """
         CREATE FUNCTION std::strlen(string: std::str) -> std::int64
-            FROM SQL FUNCTION 'strlen';
+            USING SQL FUNCTION 'strlen';
         """
 
     def test_edgeql_syntax_ddl_function_02(self):
         """
         CREATE FUNCTION std::strlen(a: std::str) -> std::int64
-            FROM SQL FUNCTION 'strlen';
+            USING SQL FUNCTION 'strlen';
         """
 
     def test_edgeql_syntax_ddl_function_03(self):
         """
         CREATE FUNCTION std::strlen(string: std::str) -> std::int64
-            FROM SQL FUNCTION 'strlen';
+            USING SQL FUNCTION 'strlen';
         """
 
     def test_edgeql_syntax_ddl_function_04(self):
         """
         CREATE FUNCTION std::strlen(string: std::str, integer: std::int64)
             -> std::int64
-            FROM SQL FUNCTION 'strlen';
+            USING SQL FUNCTION 'strlen';
         """
 
     def test_edgeql_syntax_ddl_function_05(self):
         """
         CREATE FUNCTION std::strlen(string: std::str, a: std::int64)
             -> std::int64
-            FROM SQL FUNCTION 'strlen';
+            USING SQL FUNCTION 'strlen';
         """
 
     def test_edgeql_syntax_ddl_function_06(self):
         """
         CREATE FUNCTION std::strlen(string: std::str = '1')
             -> std::int64
-            FROM SQL FUNCTION 'strlen';
+            USING SQL FUNCTION 'strlen';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -3078,19 +3078,19 @@ aa';
         """
         CREATE FUNCTION std::strlen(a: std::str = '1', VARIADIC b: std::str)
             -> std::int64
-            FROM SQL FUNCTION 'strlen';
+            USING SQL FUNCTION 'strlen';
         """
 
     def test_edgeql_syntax_ddl_function_11(self):
         """
         CREATE FUNCTION no_params() -> std::int64
-        FROM EdgeQL $$ SELECT 1 $$;
+        USING EdgeQL $$ SELECT 1 $$;
         """
 
     def test_edgeql_syntax_ddl_function_13(self):
         """
         CREATE FUNCTION foo(string: std::str) -> tuple<bar: std::int64>
-        FROM EDGEQL $$ SELECT (bar := 123) $$;
+        USING EDGEQL $$ SELECT (bar := 123) $$;
         """
 
     def test_edgeql_syntax_ddl_function_14(self):
@@ -3099,14 +3099,14 @@ aa';
         -> tuple<
             bar: std::int64,
             baz: std::str
-        > FROM EdgeQL $$ SELECT smth() $$;
+        > USING EdgeQL $$ SELECT smth() $$;
         """
     @tb.must_fail(errors.EdgeQLSyntaxError,
                   "AAA is not a valid language", line=3)
     def test_edgeql_syntax_ddl_function_16(self):
         """
         CREATE FUNCTION foo(string: std::str)
-        -> std::int64 FROM AAA FUNCTION 'foo';
+        -> std::int64 USING AAA FUNCTION 'foo';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -3114,33 +3114,33 @@ aa';
     def test_edgeql_syntax_ddl_function_19(self):
         """
         CREATE FUNCTION foo(string: std::str)
-        -> std::int64 FROM AAA 'code';
+        -> std::int64 USING AAA 'code';
         """
 
     def test_edgeql_syntax_ddl_function_20(self):
         """
-        CREATE FUNCTION foo() -> std::int64 FROM SQL 'SELECT 1';
+        CREATE FUNCTION foo() -> std::int64 USING SQL 'SELECT 1';
 
 % OK %
 
-        CREATE FUNCTION foo() -> std::int64 FROM SQL $$SELECT 1$$;
+        CREATE FUNCTION foo() -> std::int64 USING SQL $$SELECT 1$$;
         """
 
     def test_edgeql_syntax_ddl_function_21(self):
         """
-        CREATE FUNCTION foo() -> std::int64 FROM SQL FUNCTION 'aaa';
+        CREATE FUNCTION foo() -> std::int64 USING SQL FUNCTION 'aaa';
         """
 
     def test_edgeql_syntax_ddl_function_24(self):
         """
-        CREATE FUNCTION foo() -> std::str FROM SQL $a$SELECT $$foo$$$a$;
+        CREATE FUNCTION foo() -> std::str USING SQL $a$SELECT $$foo$$$a$;
         """
 
     def test_edgeql_syntax_ddl_function_25(self):
         """
         CREATE FUNCTION foo() -> std::str {
             SET ANNOTATION description := 'aaaa';
-            FROM SQL $a$SELECT $$foo$$$a$;
+            USING SQL $a$SELECT $$foo$$$a$;
         };
         """
 
@@ -3149,12 +3149,12 @@ aa';
         CREATE FUNCTION foo() -> std::str {
             SET volatility := 'VOLATILE';
             SET ANNOTATION description := 'aaaa';
-            FROM SQL $a$SELECT $$foo$$$a$;
+            USING SQL $a$SELECT $$foo$$$a$;
         };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "CREATE FUNCTION requires at least one FROM clause", line=2)
+                  "CREATE FUNCTION requires at least one USING clause", line=2)
     def test_edgeql_syntax_ddl_function_27(self):
         """
         CREATE FUNCTION foo() -> std::str {
@@ -3163,13 +3163,13 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "more than one FROM <code> clause", line=5)
+                  "more than one USING <code> clause", line=5)
     def test_edgeql_syntax_ddl_function_28(self):
         """
         CREATE FUNCTION foo() -> std::str {
-            FROM SQL 'SELECT 1';
+            USING SQL 'SELECT 1';
             SET ANNOTATION description := 'aaaa';
-            FROM SQL 'SELECT 2';
+            USING SQL 'SELECT 2';
         };
         """
 
@@ -3181,7 +3181,7 @@ aa';
         CREATE FUNCTION std::foobar(arg1: str, arg2: str = 'DEFAULT',
                                     VARIADIC arg3)
             -> std::int64
-            FROM EdgeQL $$$$;
+            USING EdgeQL $$$$;
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -3209,7 +3209,7 @@ aa';
     def test_edgeql_syntax_ddl_function_34(self):
         """
         CREATE FUNCTION foo(a: OPTIONAL std::str) ->
-            std::int64 FROM SQL FUNCTION 'aaa';
+            std::int64 USING SQL FUNCTION 'aaa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -3217,7 +3217,7 @@ aa';
     def test_edgeql_syntax_ddl_function_35(self):
         """
         CREATE FUNCTION std::foo(a: SET OF std::str) -> VARIADIC std::int64
-            FROM SQL $a$SELECT $$foo$$$a$;
+            USING SQL $a$SELECT $$foo$$$a$;
         """
 
     def test_edgeql_syntax_ddl_function_36(self):
@@ -3228,7 +3228,7 @@ aa';
             NAMED ONLY c: OPTIONAL std::str = '1',
             NAMED ONLY d: OPTIONAL std::str
         ) ->
-            std::int64 FROM SQL FUNCTION 'aaa';
+            std::int64 USING SQL FUNCTION 'aaa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -3242,7 +3242,7 @@ aa';
             NAMED ONLY c: OPTIONAL std::str,
             d: OPTIONAL std::str
         ) ->
-            std::int64 FROM SQL FUNCTION 'aaa';
+            std::int64 USING SQL FUNCTION 'aaa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -3256,7 +3256,7 @@ aa';
             NAMED ONLY s1: OPTIONAL std::str = '1',
             VARIADIC v: OPTIONAL std::str = '1'
         ) ->
-            std::int64 FROM SQL FUNCTION 'aaa';
+            std::int64 USING SQL FUNCTION 'aaa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -3270,7 +3270,7 @@ aa';
             VARIADIC v: OPTIONAL std::str = '1',
             NAMED ONLY s1: OPTIONAL std::str = '1'
         ) ->
-            std::int64 FROM SQL FUNCTION 'aaa';
+            std::int64 USING SQL FUNCTION 'aaa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -3283,7 +3283,7 @@ aa';
             VARIADIC `variadic`: OPTIONAL std::str,
             `select`: OPTIONAL std::str = '1'
         ) ->
-            std::int64 FROM SQL FUNCTION 'aaa';
+            std::int64 USING SQL FUNCTION 'aaa';
         """
 
     def test_edgeql_syntax_ddl_function_41(self):
@@ -3294,7 +3294,7 @@ aa';
             NAMED ONLY `create`: OPTIONAL std::str,
             NAMED ONLY `select`: OPTIONAL std::str = '1'
         ) ->
-            std::int64 FROM SQL FUNCTION 'aaa';
+            std::int64 USING SQL FUNCTION 'aaa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -3304,7 +3304,7 @@ aa';
         """
         CREATE FUNCTION std::strlen(VARIADIC b: std::str = '1')
             -> std::int64
-            FROM SQL FUNCTION 'strlen';
+            USING SQL FUNCTION 'strlen';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -3313,7 +3313,7 @@ aa';
     def test_edgeql_syntax_ddl_function_43(self):
         """
         CREATE FUNCTION std::strlen($1: int32) -> int64
-            FROM EdgeQL $$ SELECT 1 $$;
+            USING EdgeQL $$ SELECT 1 $$;
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -3322,7 +3322,7 @@ aa';
     def test_edgeql_syntax_ddl_function_44(self):
         """
         CREATE FUNCTION std::strlen(a: int16, b: str, a: int16) -> int64
-            FROM EdgeQL $$ SELECT 1 $$;
+            USING EdgeQL $$ SELECT 1 $$;
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -3332,7 +3332,7 @@ aa';
         """
         CREATE FUNCTION std::strlen(aa: int16, b: str,
                                     NAMED ONLY aa: int16) -> int64
-            FROM EdgeQL $$ SELECT 1 $$;
+            USING EdgeQL $$ SELECT 1 $$;
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -3342,7 +3342,7 @@ aa';
         """
         CREATE FUNCTION std::strlen(aa: int16, b: str,
                                     VARIADIC aa: int16) -> int64
-            FROM EdgeQL $$ SELECT 1 $$;
+            USING EdgeQL $$ SELECT 1 $$;
         """
 
     def test_edgeql_syntax_ddl_function_47(self):
@@ -3352,7 +3352,7 @@ aa';
             named only foo: OPTIONAL std::str,
             nameD onlY bar: OPTIONAL std::str = '1'
         ) ->
-            std::int64 FROM SQL FUNCTION 'aaa';
+            std::int64 USING SQL FUNCTION 'aaa';
         """
 
     def test_edgeql_syntax_ddl_property_01(self):

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -36,7 +36,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 CREATE FUNCTION test::func_01(
                     a: anytype
                 ) -> bool
-                    FROM EdgeQL $$
+                    USING EdgeQL $$
                         SELECT a IS float32
                     $$;
             ''')
@@ -52,7 +52,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 CREATE FUNCTION test::func_02(
                     a: anyreal
                 ) -> bool
-                    FROM EdgeQL $$
+                    USING EdgeQL $$
                         SELECT a IS float32
                     $$;
             ''')
@@ -68,7 +68,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 CREATE FUNCTION test::func_03(
                     a: str
                 ) -> anytype
-                    FROM EdgeQL $$
+                    USING EdgeQL $$
                         SELECT a
                     $$;
             ''')
@@ -84,7 +84,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 CREATE FUNCTION test::func_04(
                     a: str
                 ) -> anyscalar
-                    FROM EdgeQL $$
+                    USING EdgeQL $$
                         SELECT a
                     $$;
             ''')
@@ -93,26 +93,26 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
                 r'cannot create.*test::func_05.*'
-                r'FROM SQL FUNCTION.*not supported in '
+                r'USING SQL FUNCTION.*not supported in '
                 r'user-defined functions'):
             await self.con.execute('''
                 CREATE FUNCTION test::func_05(
                     a: str
                 ) -> str
-                    FROM SQL FUNCTION 'lower';
+                    USING SQL FUNCTION 'lower';
             ''')
 
     async def test_edgeql_userddl_06(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
                 r'cannot create.*test::func_06.*'
-                r'FROM SQL.*not supported in '
+                r'USING SQL.*not supported in '
                 r'user-defined functions'):
             await self.con.execute('''
                 CREATE FUNCTION test::func_06(
                     a: str
                 ) -> str
-                    FROM SQL $$ SELECT "a" $$;
+                    USING SQL $$ SELECT "a" $$;
             ''')
 
     async def test_edgeql_userddl_07(self):
@@ -122,7 +122,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
             await self.con.execute('''
                 CREATE INFIX OPERATOR
                 std::`+` (l: std::str, r: std::str) -> std::str
-                    FROM SQL OPERATOR r'||';
+                    USING SQL OPERATOR r'||';
             ''')
 
     async def test_edgeql_userddl_08(self):
@@ -131,7 +131,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 r'user-defined casts are not supported'):
             await self.con.execute('''
                 CREATE CAST FROM std::int64 TO std::duration {
-                    FROM SQL CAST;
+                    USING SQL CAST;
                     ALLOW ASSIGNMENT;
                 };
             ''')
@@ -144,7 +144,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 CREATE FUNCTION std::func_09(
                     a: str
                 ) -> str
-                    FROM EdgeQL $$
+                    USING EdgeQL $$
                         SELECT a
                     $$;
             ''')
@@ -157,7 +157,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 CREATE FUNCTION math::func_10(
                     a: str
                 ) -> str
-                    FROM EdgeQL $$
+                    USING EdgeQL $$
                         SELECT a
                     $$;
             ''')
@@ -240,7 +240,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 CREATE FUNCTION test::func_19(
                     a: SET OF str
                 ) -> bool
-                    FROM EdgeQL $$
+                    USING EdgeQL $$
                         SELECT EXISTS a
                     $$;
             ''')
@@ -250,7 +250,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
             CREATE FUNCTION test::func_20(
                 a: str
             ) -> SET OF str
-                FROM EdgeQL $$
+                USING EdgeQL $$
                     SELECT {a, 'a'}
                 $$;
         ''')
@@ -278,7 +278,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                     a: str
                 ) -> bool
                 {
-                    FROM EdgeQL $$
+                    USING EdgeQL $$
                         SELECT True;
                     $$;
                     SET force_return_cast := true;

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -323,7 +323,7 @@ _123456789_123456789_123456789 -> str
         schema = self.run_ddl(schema, '''
             CREATE FUNCTION
             test::my_contains(arr: array<anytype>, val: anytype) -> bool {
-                FROM edgeql $$
+                USING edgeql $$
                     SELECT contains(arr, val);
                 $$;
             };
@@ -498,7 +498,7 @@ _123456789_123456789_123456789 -> str
 
         schema = self.run_ddl(schema, '''
             CREATE FUNCTION test::foo (a: int64) -> int64
-            FROM EdgeQL $$ SELECT a; $$;
+            USING EdgeQL $$ SELECT a; $$;
         ''')
 
         self.assertEqual(
@@ -797,7 +797,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             function get_ingredients(
                 recipe: Recipe
             ) -> tuple<name: str, quantity: decimal> {
-                from edgeql $$
+                using edgeql $$
                     SELECT (
                         name := recipe.ingredients.name,
                         quantity := recipe.ingredients.quantity,
@@ -1882,12 +1882,12 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
     def test_migrations_equivalence_function_01(self):
         self._assert_migration_equivalence([r"""
             function hello01(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$
         """, r"""
             function hello01(a: int64, b: int64=42) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>(a + b)
                 $$
         """])
@@ -1895,7 +1895,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
     def test_migrations_equivalence_function_06(self):
         self._assert_migration_equivalence([r"""
             function hello06(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT <str>a
                 $$;
 
@@ -1907,7 +1907,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """, r"""
             function hello06(a: int64) -> array<int64>
-                from edgeql $$
+                using edgeql $$
                     SELECT [a]
                 $$;
 
@@ -1922,7 +1922,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
     def test_migrations_equivalence_function_10(self):
         self._assert_migration_equivalence([r"""
             function hello10(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT <str>a
                 $$;
 
@@ -1934,7 +1934,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """, r"""
             function hello10(a: int64) -> array<int64>
-                from edgeql $$
+                using edgeql $$
                     SELECT [a]
                 $$;
 
@@ -1949,13 +1949,13 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
     def test_migrations_equivalence_function_11(self):
         self._assert_migration_equivalence([r"""
             function hello11(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$
         """, r"""
             # replace the function with a new one by the same name
             function hello11(a: str) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ a
                 $$
         """])
@@ -1963,18 +1963,18 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
     def test_migrations_equivalence_function_12(self):
         self._assert_migration_equivalence([r"""
             function hello12(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$;
         """, r"""
             function hello12(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$;
 
             # make the function polymorphic
             function hello12(a: str) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ a
                 $$;
         """])
@@ -1984,18 +1984,18 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         self._assert_migration_equivalence([r"""
             # start with a polymorphic function
             function hello13(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$;
 
             function hello13(a: str) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ a
                 $$;
         """, r"""
             # remove one of the 2 versions
             function hello13(a: int64) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT 'hello' ++ <str>a
                 $$;
         """])
@@ -2003,14 +2003,14 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
     def test_migrations_equivalence_function_14(self):
         self._assert_migration_equivalence([r"""
             function hello14(a: str, b: str) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT a ++ b
                 $$
         """, r"""
             # Replace the function with a new one by the same name,
             # but working with arrays.
             function hello14(a: array<str>, b: array<str>) -> array<str>
-                from edgeql $$
+                using edgeql $$
                     SELECT a ++ b
                 $$
         """])
@@ -2018,14 +2018,14 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
     def test_migrations_equivalence_function_15(self):
         self._assert_migration_equivalence([r"""
             function hello15(a: str, b: str) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT a ++ b
                 $$
         """, r"""
             # Replace the function with a new one by the same name,
             # but working with arrays.
             function hello15(a: tuple<str, str>) -> str
-                from edgeql $$
+                using edgeql $$
                     SELECT a.0 ++ a.1
                 $$
         """])
@@ -2886,7 +2886,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             """
             function std::array_agg(s: SET OF anytype) ->  array<anytype> {
                 volatility := 'IMMUTABLE';
-                from sql;
+                using sql;
             };
             """,
 
@@ -2895,7 +2895,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             r"""
             function stdgraphql::short_name(name: std::str) -> std::str {
                 volatility := 'IMMUTABLE';
-                from edgeql $$
+                using edgeql $$
                     SELECT (
                         name[5:] IF name LIKE 'std::%' ELSE
                         name[9:] IF name LIKE 'default::%' ELSE

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -878,6 +878,21 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    # def test_get_migration_09(self):
+    #     # validate that we can trace DETACHED
+    #     schema = r'''
+    #         type Foo {
+    #             property bar -> int64;
+    #         };
+
+    #         view X {
+    #             using (SELECT Foo FILTER .bar > count(DETACHED Foo));
+    #             annotation title := 'A Foo view';
+    #         }
+    #     '''
+
+    #     self._assert_migration_consistency(schema)
+
     def test_migrations_equivalence_01(self):
         self._assert_migration_equivalence([r"""
             type Base;

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -941,20 +941,20 @@ abstract property foo {
     def test_eschema_syntax_function_01(self):
         """
         function len() -> std::int64
-            from sql function 'length';
+            using sql function 'length';
         """
 
     def test_eschema_syntax_function_02(self):
         r"""
         function some_func(foo: std::int64 = 42) -> std::str
-            from sql $$
+            using sql $$
                 SELECT 'life';
             $$;
 
 % OK %
 
         function some_func(foo: std::int64 = 42) -> std::str
-            from sql $$
+            using sql $$
                 SELECT 'life';
             $$;
         """
@@ -962,7 +962,7 @@ abstract property foo {
     def test_eschema_syntax_function_03(self):
         r"""
         function some_func(foo: std::int64 = 42) -> std::str
-            from edgeql $$
+            using edgeql $$
                 SELECT 'life';
             $$;
         """
@@ -972,7 +972,7 @@ abstract property foo {
         function myfunc(arg1: str, arg2: str = 'DEFAULT',
                         variadic arg3: std::int64) -> set of int {
             annotation description := 'myfunc sample';
-            from sql
+            using sql
                 $$SELECT blarg;$$;
         };
         """
@@ -984,7 +984,7 @@ abstract property foo {
                         variadic arg3: std::int64,
                         named only arg4: std::int64,
                         named only arg5: std::int64) -> set of int
-            from edgeql $$
+            using edgeql $$
                 SELECT blarg
             $$;
         """
@@ -993,7 +993,7 @@ abstract property foo {
         """
         function some_func(foo: std::int64 = 42) -> std::str {
             initial_value := 'bad';
-            from edgeql $$
+            using edgeql $$
                 SELECT 'life'
             $$;
         };
@@ -1002,31 +1002,31 @@ abstract property foo {
     def test_eschema_syntax_function_07(self):
         """
         function some_func(foo: std::int64 = bar(42)) -> std::str
-            from sql function 'some_other_func';
+            using sql function 'some_other_func';
         """
 
     def test_eschema_syntax_function_08(self):
         """
         function some_func(foo: str = ')') -> std::str
-            from sql function 'some_other_func';
+            using sql function 'some_other_func';
         """
 
     def test_eschema_syntax_function_09(self):
         """
         function some_func(foo: str = $$)$$) -> std::str
-            from sql function 'some_other_func';
+            using sql function 'some_other_func';
         """
 
     def test_eschema_syntax_function_10(self):
         """
         function some_func(foo: str = $a1$)$a1$) -> std::str
-            from sql function 'some_other_func';
+            using sql function 'some_other_func';
         """
 
     def test_eschema_syntax_function_11(self):
         """
         function some_func(`(`: str = ')') -> std::str
-            from sql function 'some_other_func';
+            using sql function 'some_other_func';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -1035,7 +1035,7 @@ abstract property foo {
     def test_eschema_syntax_function_12(self):
         """
         function some_func($`(`: str = ) ) -> std::str {
-            from edgeql function 'some_other_func';
+            using edgeql function 'some_other_func';
         }
         """
 
@@ -1044,7 +1044,7 @@ abstract property foo {
         function some_func(`(`:
                 str = ')',
                 bar: int = bar()) -> std::str
-            from sql function 'some_other_func';
+            using sql function 'some_other_func';
         """
 
     def test_eschema_syntax_function_15(self):
@@ -1053,7 +1053,7 @@ abstract property foo {
                     str,
                     array<tuple<int, str>>
                 >
-            from sql function 'some_other_func';
+            using sql function 'some_other_func';
         """
 
     def test_eschema_syntax_function_16(self):
@@ -1062,7 +1062,7 @@ abstract property foo {
                     str,
                     array<tuple<int, `Foo:>`>>
                 >
-            from sql function 'some_other_func';
+            using sql function 'some_other_func';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError, r"Unexpected '>'",
@@ -1073,89 +1073,89 @@ abstract property foo {
                     str,
                     array<tuple<int, Foo>>>
                 > {
-            from sql function 'some_other_func';
+            using sql function 'some_other_func';
         };
         """
 
     def test_eschema_syntax_function_18(self):
         """
         function len1() -> std::int64
-            from sql function 'length1';
+            using sql function 'length1';
 
         function len2() -> std::int64
-            from sql function 'length2';
+            using sql function 'length2';
 
         function len3() -> std::int64
-            from sql function 'length3';
+            using sql function 'length3';
 
         function len4() -> std::int64
-            from sql function 'length4';
+            using sql function 'length4';
 
 % OK %
 
         function len1() ->  std::int64
-            from SQL function 'length1';
+            using SQL function 'length1';
         function len2() ->  std::int64
-            from SQL function 'length2';
+            using SQL function 'length2';
         function len3() ->  std::int64
-            from SQL function 'length3';
+            using SQL function 'length3';
         function len4() ->  std::int64
-            from SQL function 'length4';
+            using SQL function 'length4';
         """
 
     def test_eschema_syntax_function_19(self):
         """
         function len1() ->  std::int64 {
-            from SQL function 'length1'
+            using SQL function 'length1'
         }
         function len2() ->  std::int64 {
-            from SQL function 'length2'
+            using SQL function 'length2'
         }
         function len3() ->  std::int64 {
-            from SQL function 'length3'
+            using SQL function 'length3'
         }
         function len4() ->  std::int64 {
-            from SQL function 'length4'
+            using SQL function 'length4'
         }
 
 
 % OK %
 
         function len1() ->  std::int64
-            from SQL function 'length1';
+            using SQL function 'length1';
         function len2() ->  std::int64
-            from SQL function 'length2';
+            using SQL function 'length2';
         function len3() ->  std::int64
-            from SQL function 'length3';
+            using SQL function 'length3';
         function len4() ->  std::int64
-            from SQL function 'length4';
+            using SQL function 'length4';
         """
 
     def test_eschema_syntax_function_20(self):
         """
         function len1() ->  std::int64 {
-            from SQL function 'length1'
+            using SQL function 'length1'
         }
         function len2() ->  std::int64
-            from SQL function 'length2';
+            using SQL function 'length2';
 
         function len3() ->  std::int64 {
-            from SQL function 'length3'
+            using SQL function 'length3'
         }
         function len4() ->  std::int64
-            from SQL function 'length4';
+            using SQL function 'length4';
 
 
 % OK %
 
         function len1() ->  std::int64
-            from SQL function 'length1';
+            using SQL function 'length1';
         function len2() ->  std::int64
-            from SQL function 'length2';
+            using SQL function 'length2';
         function len3() ->  std::int64
-            from SQL function 'length3';
+            using SQL function 'length3';
         function len4() ->  std::int64
-            from SQL function 'length4';
+            using SQL function 'length4';
         """
 
     def test_eschema_syntax_view_01(self):

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -56,7 +56,7 @@ class TestServerProto(tb.QueryTestCase):
         try:
             await self.con.execute('''
                 CREATE FUNCTION test::testconf() -> bool
-                    FROM SQL $$ SELECT true; $$;
+                    USING SQL $$ SELECT true; $$;
                 DROP FUNCTION test::testconf();
             ''')
         except edgedb.InvalidFunctionDefinitionError:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -258,7 +258,7 @@ class TestSession(tb.QueryTestCase):
                                     r'called in a non-session context'):
             await self.con.execute(r"""
                 CREATE FUNCTION bad() -> bool
-                    FROM EdgeQL $$ SELECT sys::sleep(0) $$;
+                    USING EdgeQL $$ SELECT sys::sleep(0) $$;
             """)
 
     async def test_session_only_function_06(self):
@@ -266,7 +266,7 @@ class TestSession(tb.QueryTestCase):
             await self.con.execute(r"""
                 CREATE FUNCTION ok() -> bool {
                     SET session_only := true;
-                    FROM EdgeQL $$ SELECT sys::sleep(0) $$;
+                    USING EdgeQL $$ SELECT sys::sleep(0) $$;
                 };
             """)
 

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -197,16 +197,16 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "cli", 0)
 
     def test_cqa_type_coverage_common(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "common", 22.33)
+        self.assertFunctionCoverage(EDB_DIR / "common", 23.34)
 
     def test_cqa_type_coverage_common_ast(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "common" / "ast", 0)
+        self.assertFunctionCoverage(EDB_DIR / "common" / "ast", 7.25)
 
     def test_cqa_type_coverage_common_markup(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 15.98)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 31.08)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 56.84)
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 9.86)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 30.57)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 30.61)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 6.63)


### PR DESCRIPTION
In contexts where `FROM` appears to indicate the language or original
used change the syntax to use `USING` keyword. This primarily affects
function, cast and operator bodies.

In contexts where `FROM` indicates some initial state, the keyword
remains unchanged. This concernes migrations and cast signatures.