### PR TITLE
edgeql: Remove SELECT-like clauses from FOR.

### DIFF
--- a/docs/edgeql/statements/for.rst
+++ b/docs/edgeql/statements/for.rst
@@ -17,15 +17,7 @@ FOR
 
     FOR <variable> IN "{" <iterator-set> [, ...]  "}"
 
-    UNION <output-expr>
-
-    [ FILTER <filter-expr> ]
-
-    [ ORDER BY <order-expr> [direction] [THEN ...] ]
-
-    [ OFFSET <offset-expr> ]
-
-    [ LIMIT  <limit-expr> ] ;
+    UNION <output-expr> ;
 
 :eql:synopsis:`FOR <variable> IN "{" <iterator-set> [, ...]  "}"`
     The ``FOR`` clause has this general form:
@@ -53,9 +45,6 @@ FOR
     is an arbitrary expression that is evaluated for
     every element in a set produced by evaluating the ``FOR`` clause.
     The results of the evaluation are appended into the result set.
-
-For details about ``FILTER``, ``ORDER BY``, ``OFFSET``, and ``LIMIT``
-clauses see the documentation of the :eql:stmt:`SELECT` statement.
 
 
 .. _ref_eql_forstatement:

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -504,7 +504,7 @@ class DeleteQuery(Statement, SubjectMixin, SelectClauseMixin):
     pass
 
 
-class ForQuery(SelectQuery):
+class ForQuery(Statement, ReturningMixin):
     iterator: Expr
     iterator_alias: str
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -273,10 +273,6 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self.visit(node.result)
         self.indentation -= 1
 
-        self._visit_filter(node)
-        self._visit_order(node)
-        self._visit_offset_limit(node)
-
         if parenthesise:
             self.write(')')
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -115,35 +115,13 @@ class ByExprList(ListNonterm, element=ByExpr, separator=tokens.T_COMMA):
 class SimpleFor(Nonterm):
     def reduce_For(self, *kids):
         r"%reduce FOR Identifier IN Set \
-                  UNION OptionallyAliasedExpr \
-                  OptFilterClause OptSortClause OptSelectLimit"
-        offset, limit = kids[8].val
-
-        if offset is not None or limit is not None:
-            subj = qlast.ForQuery(
-                iterator_alias=kids[1].val,
-                iterator=kids[3].val,
-                result=kids[5].val.expr,
-                result_alias=kids[5].val.alias,
-                where=kids[6].val,
-                orderby=kids[7].val,
-                implicit=True,
-            )
-
-            self.val = qlast.SelectQuery(
-                result=subj,
-                offset=offset,
-                limit=limit,
-            )
-        else:
-            self.val = qlast.ForQuery(
-                iterator_alias=kids[1].val,
-                iterator=kids[3].val,
-                result=kids[5].val.expr,
-                result_alias=kids[5].val.alias,
-                where=kids[6].val,
-                orderby=kids[7].val,
-            )
+                  UNION OptionallyAliasedExpr"
+        self.val = qlast.ForQuery(
+            iterator_alias=kids[1].val,
+            iterator=kids[3].val,
+            result=kids[5].val.expr,
+            result_alias=kids[5].val.alias,
+        )
 
 
 class SimpleSelect(Nonterm):

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -493,6 +493,15 @@ def trace_DeleteQuery(node: qlast.DeleteQuery, *, ctx: TracerContext) -> None:
 
 
 @trace.register
+def trace_For(node: qlast.ForQuery, *, ctx: TracerContext) -> None:
+    for alias in node.aliases:
+        if isinstance(alias, qlast.AliasedExpr):
+            trace(alias.expr, ctx=ctx)
+
+    trace(node.result, ctx=ctx)
+
+
+@trace.register
 def trace_DescribeStmt(
     node: qlast.DescribeStmt, *,
     ctx: TracerContext,

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4288,8 +4288,10 @@ class TestExpressions(tb.QueryTestCase):
     async def test_edgeql_expr_for_01(self):
         await self.assert_query_result(
             r"""
-                FOR x IN {1, 3, 5, 7}
-                UNION x
+                SELECT x := (
+                    FOR x IN {1, 3, 5, 7}
+                    UNION x
+                )
                 ORDER BY x;
             """,
             [1, 3, 5, 7],
@@ -4297,8 +4299,10 @@ class TestExpressions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                FOR x IN {1, 3, 5, 7}
-                UNION x + 1
+                SELECT x := (
+                    FOR x IN {1, 3, 5, 7}
+                    UNION x + 1
+                )
                 ORDER BY x;
             """,
             [2, 4, 6, 8],

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -4861,14 +4861,18 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH MODULE test
-            FOR x IN {1, 4}
-            UNION Issue {
-                name
-            }
-            FILTER
-                Issue.number = <str>x
+            SELECT Issue := (
+                FOR x IN {1, 4}
+                UNION (
+                    SELECT Issue {
+                        name
+                    }
+                    FILTER
+                        .number = <str>x
+                )
+            )
             ORDER BY
-                Issue.number;
+                .number;
             ''',
             [
                 {'name': 'Release EdgeDB'},
@@ -4880,18 +4884,18 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH MODULE test
-            FOR x IN {1, 3, 4}
-            UNION I := (
-                SELECT Issue {
-                    name,
-                    number,
-                }
-                FILTER
-                    Issue.number > <str>x
-                ORDER BY
-                    Issue.number
+            SELECT I := (
+                FOR x IN {1, 3, 4}
+                UNION (
+                    SELECT Issue {
+                        name,
+                        number,
+                    }
+                    FILTER
+                        .number > <str>x
+                )
             )
-            ORDER BY I.number;
+            ORDER BY .number;
             ''',
             [
                 {

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 15.89)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 15.96)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 56.84)


### PR DESCRIPTION
The `FOR` statement now only has the basic form of:

    FOR x IN {iterexpr} UNION expr;

All the `FILTER`, `ORDER BY`, `LIMIT` and `OFFSET` clauses have been
removed due to the potential ambiguity of their meaning (as evidenced by
even some tests with incorrect semantics).

If those clauses are necessary, then the correct procedure is to wrap
the whole `FOR ...` expression into a `SELECT`.

When rewriting the tests to move the SELECT-like clauses some potential
scoping issues were dicovered.

Fixes #743.