### PR TITLE
edgeql: Update backtick quoting.

### DIFF
--- a/docs/edgeql/lexical.rst
+++ b/docs/edgeql/lexical.rst
@@ -26,7 +26,10 @@ The plain identifiers are similar to many other languages, they are
 alphanumeric with underscores and cannot start with a digit. The
 quoted identifiers start and end with a *backtick*
 ```quoted.identifier``` and can contain any characters inside, but
-must not start with an ampersand (``@``).
+must not start with an ampersand (``@``). If there's a need to include
+a backtick character as part of the identifier name a double-backtick
+sequence (``````) should be used: ```quoted``identifier``` will result
+in the actual identifier being ``quoted`identifier``.
 
 .. productionlist:: edgeql
     identifier: `plain_ident` | `quoted_ident`

--- a/edb/common/lexer.py
+++ b/edb/common/lexer.py
@@ -219,10 +219,15 @@ class Lexer:
         if eof_tok is not None:
             yield eof_tok
 
-    def handle_error(self, txt, *, exc_type=UnknownTokenError):
+    def handle_error(self, txt, *,
+                     exact_message=False, exc_type=UnknownTokenError):
+        if exact_message:
+            msg = txt
+        else:
+            msg = f"Unexpected '{txt}'"
+
         raise exc_type(
-            f"Unexpected '{txt}'",
-            line=self.lineno, col=self.column, filename=self.filename)
+            msg, line=self.lineno, col=self.column, filename=self.filename)
 
     def token(self):
         """Return the next token produced by the lexer.

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -41,11 +41,11 @@ def any_ident_to_str(ident):
 
 
 def ident_to_str(ident):
-    return edgeql_quote.disambiguate_identifier(ident)
+    return edgeql_quote.quote_ident(ident)
 
 
 def param_to_str(ident):
-    return '$' + edgeql_quote.disambiguate_identifier(
+    return '$' + edgeql_quote.quote_ident(
         ident, allow_reserved=True)
 
 

--- a/edb/edgeql/quote.py
+++ b/edb/edgeql/quote.py
@@ -59,21 +59,8 @@ def dollar_quote_literal(text):
     return quote + text + quote
 
 
-def disambiguate_identifier(text, *, allow_reserved=False):
-    reserved = keywords.by_type[keywords.RESERVED_KEYWORD]
-    if (text.lower() != '__type__' and
-            ((not allow_reserved and reserved.get(text.lower())) or
-                not _re_ident.fullmatch(text))):
-        return '`{}`'.format(text)
-    else:
-        return text
-
-
 def needs_quoting(string, allow_reserved):
-    isalnum = (
-        string and not string[0].isdecimal()
-        and string.replace('_', 'a').isalnum()
-    )
+    isalnum = _re_ident.fullmatch(string)
 
     string = string.lower()
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3794,3 +3794,35 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     SET id := <uuid>'00000000-0000-0000-0000-0000feedbeef'
                 }
             ''')
+
+    async def test_edgeql_ddl_quoting_01(self):
+        await self.con.execute("""
+            CREATE TYPE test::`U S``E R` {
+                CREATE PROPERTY `n ame` -> str;
+            };
+        """)
+
+        await self.con.execute("""
+            INSERT test::`U S``E R` {
+                `n ame` := 'quoting_01'
+            };
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT test::`U S``E R` {
+                    __type__: {
+                        name
+                    },
+                    `n ame`
+                };
+            """,
+            [{
+                '__type__': {'name': 'test::U S`E R'},
+                'n ame': 'quoting_01'
+            }],
+        )
+
+        await self.con.execute("""
+            DROP TYPE test::`U S``E R`;
+        """)

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -759,6 +759,9 @@ aa';
         SELECT foo::`bar`;
         SELECT `foo`::bar;
         SELECT `foo`::`bar`;
+        SELECT `foo``bar`;
+        SELECT `foo`::`bar```;
+        SELECT `foo::bar`;
 
 % OK %
 
@@ -768,6 +771,9 @@ aa';
         SELECT foo::bar;
         SELECT foo::bar;
         SELECT foo::bar;
+        SELECT `foo``bar`;
+        SELECT foo::`bar```;
+        SELECT `foo::bar`;
         """
 
     def test_edgeql_syntax_name_02(self):

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 15.96)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 15.98)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 56.84)


### PR DESCRIPTION
Add the ability to use a backtick inside a backtick-quoted identifier by
using a double-backtick "``". Primarily the double-backtick is chosen
over backslash-quoting "\`" because the latter could be misleading. No
other backslash-escape sequence is interpreted inside backticks so
using, say "\n", in an identifier would be accepted, but not result in a
newline character.

Update the error message for identifiers starting with "@" to be more
specific.

Fixes: #632.