### PR TITLE
edgeql: Ban "::" from being used inside quoted identifiers.

### DIFF
--- a/docs/edgeql/lexical.rst
+++ b/docs/edgeql/lexical.rst
@@ -25,11 +25,12 @@ There are two ways of writing identifiers in EdgeQL: plain and quoted.
 The plain identifiers are similar to many other languages, they are
 alphanumeric with underscores and cannot start with a digit. The
 quoted identifiers start and end with a *backtick*
-```quoted.identifier``` and can contain any characters inside, but
-must not start with an ampersand (``@``). If there's a need to include
-a backtick character as part of the identifier name a double-backtick
-sequence (``````) should be used: ```quoted``identifier``` will result
-in the actual identifier being ``quoted`identifier``.
+```quoted.identifier``` and can contain any characters inside with a
+few exceptions. They must not start with an ampersand (``@``) or
+contain double-colon (``::``). If there's a need to include a backtick
+character as part of the identifier name a double-backtick sequence
+(``````) should be used: ```quoted``identifier``` will result in the
+actual identifier being ``quoted`identifier``.
 
 .. productionlist:: edgeql
     identifier: `plain_ident` | `quoted_ident`

--- a/edb/edgeql/parser/grammar/lexer.py
+++ b/edb/edgeql/parser/grammar/lexer.py
@@ -278,9 +278,13 @@ class EdgeQLLexer(lexer.Lexer):
         elif rule_token == 'BADIDENT':
             self.handle_error(txt)
 
-        elif rule_token == 'QIDENT' and txt[1] == '@':
-            self.handle_error(f'Identifiers cannot start with "@"',
-                              exact_message=True)
+        elif rule_token == 'QIDENT':
+            if txt[1] == '@':
+                self.handle_error(f'Identifiers cannot start with "@"',
+                                  exact_message=True)
+            elif '::' in txt:
+                self.handle_error(f'Identifiers cannot contain "::"',
+                                  exact_message=True)
 
         tok = super().token_from_text(rule_token, txt)
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -761,7 +761,6 @@ aa';
         SELECT `foo`::`bar`;
         SELECT `foo``bar`;
         SELECT `foo`::`bar```;
-        SELECT `foo::bar`;
 
 % OK %
 
@@ -773,7 +772,6 @@ aa';
         SELECT foo::bar;
         SELECT `foo``bar`;
         SELECT foo::`bar```;
-        SELECT `foo::bar`;
         """
 
     def test_edgeql_syntax_name_02(self):
@@ -947,6 +945,13 @@ aa';
     def test_edgeql_syntax_name_22(self):
         """
         SELECT mod::Foo.bar.baz.boo;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Identifiers cannot contain "::"', line=2, col=16)
+    def test_edgeql_syntax_name_23(self):
+        """
+        SELECT `foo::bar`;
         """
 
     def test_edgeql_syntax_shape_01(self):


### PR DESCRIPTION
Using "::" inside a quoted identifier leads to ambiguity in some
representations so it is illegal.

Fixes #840.