### PR TITLE
edgeql: Make date/time converters without format more strict.

### DIFF
--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -386,7 +386,7 @@ std::to_local_datetime(s: std::str, fmt: OPTIONAL str={})
     FROM SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
-            "s"::timestamp
+            edgedb.local_datetime_in("s")
         WHEN "fmt" = '' THEN
             edgedb._raise_specific_exception(
                 'invalid_parameter_value',
@@ -441,7 +441,7 @@ std::to_local_date(s: std::str, fmt: OPTIONAL str={}) -> std::local_date
     FROM SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
-            "s"::date
+            edgedb.local_date_in("s")
         WHEN "fmt" = '' THEN
             edgedb._raise_specific_exception(
                 'invalid_parameter_value',
@@ -492,7 +492,7 @@ std::to_local_time(s: std::str, fmt: OPTIONAL str={}) -> std::local_time
     FROM SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
-            "s"::time
+            edgedb.local_time_in("s")
         WHEN "fmt" = '' THEN
             edgedb._raise_specific_exception(
                 'invalid_parameter_value',

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -1371,6 +1371,16 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                                     'YYYY/MM/DD H24:MI:SS "NOPE"TZHTZM');
                 ''')
 
+    async def test_edgeql_functions_to_datetime_05(self):
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
+                                    'invalid input syntax'):
+            async with self.con.transaction():
+                # omitting time zone
+                await self.con.fetchall(r'''
+                    SELECT
+                        to_datetime('2019/01/01 00:00:00');
+                ''')
+
     async def test_edgeql_functions_to_local_datetime_01(self):
         await self.assert_query_result(
             r'''
@@ -1441,6 +1451,16 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
               '2019-02-01T00:00:00']],
         )
 
+    async def test_edgeql_functions_to_local_datetime_06(self):
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
+                                    'invalid input syntax'):
+            async with self.con.transaction():
+                # including time zone
+                await self.con.fetchall(r'''
+                    SELECT
+                        to_local_datetime('2019/01/01 00:00:00 0715');
+                ''')
+
     async def test_edgeql_functions_to_local_date_01(self):
         await self.assert_query_result(
             r'''
@@ -1477,6 +1497,16 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                             <local_date>'2019-01-01';
                     ''')
 
+    async def test_edgeql_functions_to_local_date_04(self):
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
+                                    'invalid input syntax'):
+            async with self.con.transaction():
+                # including too much
+                await self.con.fetchall(r'''
+                    SELECT
+                        to_local_datetime('2019/01/01 00:00:00 0715');
+                ''')
+
     async def test_edgeql_functions_to_local_time_01(self):
         await self.assert_query_result(
             r'''
@@ -1511,6 +1541,16 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                                           'H24:MI:SS TZH') =
                             <local_time>'00:00:00';
                     ''')
+
+    async def test_edgeql_functions_to_local_time_04(self):
+        with self.assertRaisesRegex(edgedb.InvalidValueError,
+                                    'invalid input syntax'):
+            async with self.con.transaction():
+                # including time zone
+                await self.con.fetchall(r'''
+                    SELECT
+                        to_local_datetime('00:00:00 0715');
+                ''')
 
     async def test_edgeql_functions_to_duration_01(self):
         await self.assert_query_result(


### PR DESCRIPTION
Converters without format string should not allow input that would not
be a valid cast for date/time values. Mainly this is so that we can
treat presence or absence of time zone in input consistently.