### PR TITLE
Adjust function volatility deoptimization guard for Postgres 12

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1757,11 +1757,13 @@ def _compile_func_epilogue(
             expr.volatility is qltypes.Volatility.VOLATILE):
         # Apply the volatility reference.
         # See the comment in process_set_as_subquery().
-        volatility_source = pgast.SelectStmt(
-            values=[pgast.ImplicitRowExpr(args=[ctx.volatility_ref])]
+        func_rel.where_clause = astutils.extend_binop(
+            func_rel.where_clause,
+            pgast.NullTest(
+                arg=ctx.volatility_ref,
+                negated=True,
+            )
         )
-        volatility_rvar = relctx.rvar_for_rel(volatility_source, ctx=ctx)
-        relctx.rel_join(func_rel, volatility_rvar, ctx=ctx)
 
     pathctx.put_path_var_if_not_exists(
         func_rel, ir_set.path_id, set_expr, aspect='value', env=ctx.env)

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -22,7 +22,6 @@ import os.path
 import edgedb
 
 from edb.testbase import server as tb
-from edb.tools import test
 
 
 class TestEdgeQLVolatility(tb.QueryTestCase):
@@ -66,7 +65,6 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             'more than one value for the same vol_stable() call'
         )
 
-    @test.xfail('regression with Postgres 12; see issue #830')
     async def test_edgeql_volatility_function_03(self):
         result = await self.con.fetchall(
             r"""


### PR DESCRIPTION
In PostgreSQL 12 the query planner got smart enough to optimize away trivial `VALUES` clauses in the from list, so the current deoptimization guard we use no longer works.  Replace it with an explicit `WHERE` condition referencing the correlated var.  See upstream [#16121](https://postgr.es/m/16121-b8e8dc82e608b89d@postgresql.org) for some discussion.

Fixes: #830