### PR TITLE
edgeql: Add an enum for transaction isolation modes.

### DIFF
--- a/docs/edgeql/funcops/sys.rst
+++ b/docs/edgeql/funcops/sys.rst
@@ -135,14 +135,29 @@ System
         {'1.0-alpha.1'}
 
 
-.. eql:function:: sys::get_transaction_isolation() -> str
+.. eql:function:: sys::get_transaction_isolation() -> \
+                        sys::transaction_isolation_t
 
     Return the isolation level of the current transaction.
 
-    Possible return values: ``"repeatable read"``,
-    ``"serialized"``.
+    Possible return values are given by
+    :eql:type:`sys::transaction_isolation_t`.
 
     .. code-block:: edgeql-repl
 
         db> SELECT sys::get_transaction_isolation();
-        {'repeatable read'}
+        {<enum>'REPEATABLE READ'}
+
+
+-----------
+
+
+.. eql:type:: sys::transaction_isolation_t
+
+    :index: enum transaction isolation
+
+    :eql:type:`Enum <enum>` indicating the possible transaction
+    isolation modes.
+
+    This enum takes the following values: ``REPEATABLE READ``,
+    ``SERIALIZABLE``.

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -20,6 +20,10 @@
 CREATE MODULE sys;
 
 
+CREATE SCALAR TYPE sys::transaction_isolation_t
+    EXTENDING enum<'REPEATABLE READ', 'SERIALIZABLE'>;
+
+
 CREATE TYPE sys::Database {
     CREATE REQUIRED PROPERTY name -> std::str {
         SET readonly := True;
@@ -179,11 +183,10 @@ sys::get_version_as_str() -> std::str
 
 
 CREATE FUNCTION
-sys::get_transaction_isolation() -> std::str
+sys::get_transaction_isolation() -> sys::transaction_isolation_t
 {
     # This function only reads from a table.
     SET volatility := 'STABLE';
-    FROM SQL $$
-        SELECT setting FROM pg_settings WHERE name = 'transaction_isolation'
-    $$;
+    SET force_return_cast := true;
+    FROM SQL FUNCTION 'edgedb._get_transaction_isolation';
 };

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -504,7 +504,9 @@ def compile_FunctionCall(
         args.append(pgast.VariadicArgument(expr=var))
 
     if expr.func_sql_function:
-        name = (expr.func_sql_function,)
+        # The name might contain a "." if it's one of our
+        # metaschema helpers.
+        name = tuple(expr.func_sql_function.split('.', 1))
     else:
         name = common.get_function_backend_name(expr.func_shortname,
                                                 expr.func_module_id)

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1830,7 +1830,9 @@ def process_set_as_func_enumerate(
         args = _compile_func_args(inner_func_set, ctx=newctx)
 
         if inner_func.func_sql_function:
-            func_name = (inner_func.func_sql_function,)
+            # The name might contain a "." if it's one of our
+            # metaschema helpers.
+            func_name = tuple(inner_func.func_sql_function.split('.', 1))
         else:
             func_name = common.get_function_backend_name(
                 inner_func.func_shortname, inner_func.func_module_id)
@@ -1859,7 +1861,9 @@ def process_set_as_func_expr(
         args = _compile_func_args(ir_set, ctx=newctx)
 
         if expr.func_sql_function:
-            name = (expr.func_sql_function,)
+            # The name might contain a "." if it's one of our
+            # metaschema helpers.
+            name = tuple(expr.func_sql_function.split('.', 1))
         else:
             name = common.get_function_backend_name(
                 expr.func_shortname, expr.func_module_id)
@@ -2023,7 +2027,9 @@ def process_set_as_agg_expr(
                 args.append(arg_ref)
 
         if expr.func_sql_function:
-            name = (expr.func_sql_function,)
+            # The name might contain a "." if it's one of our
+            # metaschema helpers.
+            name = tuple(expr.func_sql_function.split('.', 1))
         else:
             name = common.get_function_backend_name(expr.func_shortname,
                                                     expr.func_module_id)

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -1804,6 +1804,24 @@ class SysConfigFunction(dbops.Function):
         )
 
 
+class SysGetTransactionIsolation(dbops.Function):
+    "Get transaction isolation value as text compatible with EdgeDB's enum."
+    text = r'''
+        SELECT upper(setting)
+        FROM pg_settings
+        WHERE name = 'transaction_isolation'
+    '''
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', '_get_transaction_isolation'),
+            args=[],
+            returns=('text',),
+            # This function only reads from a table.
+            volatility='stable',
+            text=self.text)
+
+
 def _field_to_column(field):
     ftype = field.type
     coltype = None
@@ -2030,6 +2048,7 @@ async def bootstrap(conn):
         dbops.CreateFunction(BytesIndexWithBoundsFunction()),
         dbops.CreateCompositeType(SysConfigValueType()),
         dbops.CreateFunction(SysConfigFunction()),
+        dbops.CreateFunction(SysGetTransactionIsolation()),
     ])
 
     # Register "any" pseudo-type.

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1665,16 +1665,18 @@ class TestServerProto(tb.QueryTestCase):
 
                 if isol:
                     stmt += f' ISOLATION {isol}'
-                    expected = isol.lower()
+                    expected = isol
                 else:
-                    expected = 'repeatable read'
+                    expected = 'REPEATABLE READ'
 
                 await self.con.execute(stmt)
-                self.assertEqual(
-                    await self.con.fetchone(
-                        'SELECT sys::get_transaction_isolation()'),
-                    expected,
-                )
+                result = await self.con.fetchone(
+                    'SELECT sys::get_transaction_isolation()')
+                # Check that it's an enum and that the value is as
+                # expected without explicitly listing all the possible
+                # enum values for this.
+                self.assertIsInstance(result, edgedb.EnumValue)
+                self.assertEqual(str(result), expected)
                 await self.con.execute('ROLLBACK')
         finally:
             await self.con.execute('ROLLBACK')

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 36.07)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 40.86)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 40.91)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)


### PR DESCRIPTION
Add `sys::transaction_isolation_t` enum to denote possible transaction
isolation modes. The `sys::get_transaction_isolation` function now
returns that enum.

Fixes: #640.