### PR TITLE
Disable runtime checks in production by default

### DIFF
--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -28,6 +28,7 @@ from typing import *  # NoQA
 
 import typing_inspect
 
+from edb.common import debug
 from edb.common import markup
 from edb.common import typeutils
 
@@ -462,7 +463,11 @@ def _check_mapping_type(type_, value, raise_error, instance_type):
         _check_type(vtype, v, raise_error)
 
 
-def _check_type(type_, value, raise_error):
+def _check_type_passthrough(type_, value, raise_error):
+    pass
+
+
+def _check_type_real(type_, value, raise_error):
     if type_ is None:
         return
 
@@ -501,3 +506,9 @@ def _check_type(type_, value, raise_error):
     elif type_ is not Any:
         if value is not None and not isinstance(value, type_):
             raise_error(type_.__name__, value)
+
+
+if debug.flags.typecheck:
+    _check_type = _check_type_real
+else:
+    _check_type = _check_type_passthrough

--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -108,6 +108,9 @@ class flags(metaclass=FlagsMeta):
     disable_qcache = Flag(
         doc="Disable server query cache. Parse/Execute will always recompile.")
 
+    typecheck = Flag(
+        doc="Perform runtime type checking.")
+
 
 @contextlib.contextmanager
 def timeit(title='block'):

--- a/tests/common/test_ast.py
+++ b/tests/common/test_ast.py
@@ -20,6 +20,7 @@
 import copy
 import typing
 import unittest
+import unittest.mock
 
 from edb.common import ast
 from edb.common.ast import match
@@ -83,6 +84,10 @@ class ASTBaseTests(unittest.TestCase):
         assert ctree22.left.args[0].node['lconst'] is not lconst
         assert ctree22.left.args[0].node['lconst'].value == lconst.value
 
+    @unittest.mock.patch(
+        'edb.common.ast.base._check_type',
+        ast.base._check_type_real,
+    )
     def test_common_ast_typing(self):
         class Base(ast.AST):
             pass

--- a/tests/common/test_checked.py
+++ b/tests/common/test_checked.py
@@ -28,9 +28,21 @@ from edb.common.checked import CheckedList
 from edb.common.checked import CheckedSet
 from edb.common.checked import FrozenCheckedList
 from edb.common.checked import FrozenCheckedSet
+from edb.common.checked import enable_typechecks, disable_typechecks
+from edb.common import debug
 
 
-class CheckedDictTests(unittest.TestCase):
+class EnsureTypeChecking:
+    def setUp(self):
+        if not debug.flags.typecheck:
+            enable_typechecks()
+
+    def tearDown(self):
+        if not debug.flags.typecheck:
+            disable_typechecks()
+
+
+class CheckedDictTests(EnsureTypeChecking, unittest.TestCase):
     def test_common_checked_checkeddict_basics(self) -> None:
         StrDict = CheckedDict[str, int]
         assert StrDict({"1": 2})["1"] == 2
@@ -113,7 +125,7 @@ class CheckedDictTests(unittest.TestCase):
         assert sd == sd2
 
 
-class CheckedListTestBase:
+class CheckedListTestBase(EnsureTypeChecking):
     BaseList = FrozenCheckedList
 
     def test_common_checked_shared_list_basics(self) -> None:
@@ -266,7 +278,7 @@ class CheckedListTests(CheckedListTestBase, unittest.TestCase):
             tl = (42,) + tl
 
 
-class CheckedSetTestBase:
+class CheckedSetTestBase(EnsureTypeChecking):
     BaseSet = FrozenCheckedSet
 
     def test_common_checked_shared_set_basics(self) -> None:
@@ -406,7 +418,7 @@ class GenericFrozenCheckedSetSubclass(FrozenCheckedSet[T]):
 ConcreteFrozenCheckedSetSubclass2 = GenericFrozenCheckedSetSubclass[int]
 
 
-class CheckedSubclassingTestBase:
+class CheckedSubclassingTestBase(EnsureTypeChecking):
     BaseSet = GenericFrozenCheckedSetSubclass
 
     def test_common_checked_checkedset_subclass_pickling(self):

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -197,10 +197,10 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "cli", 0)
 
     def test_cqa_type_coverage_common(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "common", 24.00)
+        self.assertFunctionCoverage(EDB_DIR / "common", 24.40)
 
     def test_cqa_type_coverage_common_ast(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "common" / "ast", 7.25)
+        self.assertFunctionCoverage(EDB_DIR / "common" / "ast", 7.14)
 
     def test_cqa_type_coverage_common_markup(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)


### PR DESCRIPTION
Runtime type checks in edb.common.ast and edb.common.checked are taking up to
15% of the compilation cost based on profiling done as part of #694.

This change disables runtime type checks  by default unless an
EDGEDB_DEBUG_TYPECHECK=1 flag is passed in the environment.  Note: this is also
true for tests with the exception of tests of the runtime typechecking
capability itself.

In the case of edb.common.checked, disabling type checks cannot unfortunately
be done by replacing the data structures with builtin untyped versions due to
picklability.  Instead, we're shadowing the type checking classmethods from the
abstract classes with identity functions on the concrete types.

Benchmarks to follow.