### PR TITLE
Implement support for describing functions

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -18,6 +18,8 @@
 
 
 from __future__ import annotations
+# Do not import "from typing *"; this module contains
+# AST classes that name-clash with classes from the typing module.
 
 import decimal
 import typing
@@ -875,8 +877,8 @@ class Language(s_enum.StrEnum):
 
 class FunctionCode(Clause):
     language: Language
-    code: str
-    from_function: str
+    code: typing.Optional[str]
+    from_function: typing.Optional[str]
     from_expr: bool
 
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1338,20 +1338,23 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 self._block_ws(1)
                 self.visit_list(node.commands, terminator=';')
                 self.new_lines = 1
+            else:
+                self.write(' ')
 
             if node.code.from_function:
-                from_clause = f' FROM {node.code.language} FUNCTION '
+                from_clause = f'FROM {node.code.language} FUNCTION '
                 if self.sdlmode:
                     from_clause = from_clause.lower()
                 self.write(from_clause)
                 self.write(f'{node.code.from_function!r}')
             else:
-                from_clause = f' FROM {node.code.language} '
+                from_clause = f'FROM {node.code.language} '
                 if self.sdlmode:
                     from_clause = from_clause.lower()
                 self.write(from_clause)
-                self.write(edgeql_quote.dollar_quote_literal(
-                    node.code.code))
+                if node.code.code:
+                    self.write(edgeql_quote.dollar_quote_literal(
+                        node.code.code))
 
             self._block_ws(-1)
             if node.commands:

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -933,21 +933,30 @@ class CreateFunction(CreateCallableObject, FunctionCommand):
     def _apply_field_ast(self, schema, context, node, op):
         if op.property == 'return_type':
             node.returning = utils.typeref_to_ast(schema, op.new_value)
+
         elif op.property == 'return_typemod':
             node.returning_typemod = op.new_value
+
         elif op.property == 'code':
-            node.code = qlast.FunctionCode(
-                language=self.get_attribute_value('language'),
-                code=op.new_value,
-            )
+            if node.code is None:
+                node.code = qlast.FunctionCode()
+            node.code.code = op.new_value
+
+        elif op.property == 'language':
+            if node.code is None:
+                node.code = qlast.FunctionCode()
+            node.code.language = op.new_value
+
         elif op.property == 'from_function' and op.new_value:
-            node.code = qlast.FunctionCode(
-                from_function=op.new_value,
-            )
+            if node.code is None:
+                node.code = qlast.FunctionCode()
+            node.code.from_function = op.new_value
+
         elif op.property == 'from_expr' and op.new_value:
-            node.code = qlast.FunctionCode(
-                from_expr=op.new_value,
-            )
+            if node.code is None:
+                node.code = qlast.FunctionCode()
+            node.code.from_expr = op.new_value
+
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2879,7 +2879,31 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                                    for {__subject__} is 15.';
                 };
             };
+            """,
+
+            'DESCRIBE OBJECT array_agg AS TEXT',
+
             """
+            function std::array_agg(s: SET OF anytype) ->  array<anytype> {
+                volatility := 'IMMUTABLE';
+                from sql;
+            };
+            """,
+
+            'DESCRIBE FUNCTION stdgraphql::short_name AS SDL',
+
+            r"""
+            function stdgraphql::short_name(name: std::str) -> std::str {
+                volatility := 'IMMUTABLE';
+                from edgeql $$
+                    SELECT (
+                        name[5:] IF name LIKE 'std::%' ELSE
+                        name[9:] IF name LIKE 'default::%' ELSE
+                        re_replace(r'(.+?)::(.+$)', r'\1__\2', name)
+                    ) ++ 'Type'
+                $$
+            ;};
+            """,
         )
 
     def test_describe_02(self):


### PR DESCRIPTION
The following commands are now supported:

* `DESCRIBE OBJECT <funcname>`;
* `DESCRIBE FUNCTION <funcname>`.

Also fix the way the DESCRIBE command outputs its result -- it
should be as if it selects a raw string literal.