### PR TITLE
It looks like string's length prefix is 32bit

### DIFF
--- a/docs/internals/protocol/overview.rst
+++ b/docs/internals/protocol/overview.rst
@@ -35,9 +35,9 @@ The following data types are used in the descriptions:
     * - ``byte``
       - 8-bit unsigned integer
     * - ``string``
-      - a UTF-8 encoded text string prefixed with its byte length as ``int16``
+      - a UTF-8 encoded text string prefixed with its byte length as ``int32``
     * - ``bytes``
-      - a byte string prefixed with its length as ``int16``
+      - a byte string prefixed with its length as ``int32``
     * - ``Headers``
       - a key-value structure with the following layout:
 


### PR DESCRIPTION
Implementations:
* Python [write](https://github.com/MagicStack/py-pgproto/blob/master/buffer.pyx#L164)
* Python [read](https://github.com/MagicStack/py-pgproto/blob/master/buffer.pyx#L408)
* JS [write](https://github.com/edgedb/edgedb-js/blob/master/src/buffer.ts#L78)
* JS [read](https://github.com/edgedb/edgedb-js/blob/master/src/buffer.ts#L537)