### PR TITLE
Add basic `\d` command to REPL.

### DIFF
--- a/edb/edgeql/parser/grammar/lexer.py
+++ b/edb/edgeql/parser/grammar/lexer.py
@@ -229,7 +229,7 @@ class EdgeQLLexer(lexer.Lexer):
              regexp=r'''
                     __[^\W\d]\w*__
                     |
-                    `__.*?__`
+                    `__([^`]|``)*__`(?!`)
                 '''),
 
         Rule(token='IDENT',
@@ -279,7 +279,10 @@ class EdgeQLLexer(lexer.Lexer):
             self.handle_error(txt)
 
         elif rule_token == 'QIDENT':
-            if txt[1] == '@':
+            if txt == '``':
+                self.handle_error(f'Identifiers cannot be empty',
+                                  exact_message=True)
+            elif txt[1] == '@':
                 self.handle_error(f'Identifiers cannot start with "@"',
                                   exact_message=True)
             elif '::' in txt:

--- a/edb/edgeql/pygments/__init__.py
+++ b/edb/edgeql/pygments/__init__.py
@@ -81,10 +81,15 @@ class EdgeQLLexer(RegexLexer):
 
             (fr'''(?ix)
                 \b(?<![:\.<>@])(
-                    {' | '.join(unreserved_keywords)}
-                    |
                     {' | '.join(reserved_keywords)}
                 )\b''', token.Keyword.Reserved),
+
+            # Unreserved keywords should lose their special meaning
+            # when part of a path or fully-qualified name.
+            (fr'''(?ix)
+                \b(?<![:\.<>@])(
+                    {' | '.join(unreserved_keywords)}
+                )\b(?![:\.<>@])''', token.Keyword.Reserved),
 
             (fr'''(?x)
                 \b(?<!\.)(

--- a/edb/edgeql/quote.py
+++ b/edb/edgeql/quote.py
@@ -60,6 +60,11 @@ def dollar_quote_literal(text):
 
 
 def needs_quoting(string, allow_reserved):
+    if not string or string.startswith('@') or '::' in string:
+        # some strings are illegal as identifiers and as such don't
+        # require quoting
+        return False
+
     isalnum = _re_ident.fullmatch(string)
 
     string = string.lower()

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -954,6 +954,27 @@ aa';
         SELECT `foo::bar`;
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Identifiers cannot be empty', line=2, col=16)
+    def test_edgeql_syntax_name_24(self):
+        """
+        SELECT ``;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Identifiers cannot be empty', line=2, col=21)
+    def test_edgeql_syntax_name_25(self):
+        """
+        SELECT foo::``;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Identifiers cannot be empty', line=2, col=16)
+    def test_edgeql_syntax_name_26(self):
+        """
+        SELECT ``::Bar;
+        """
+
     def test_edgeql_syntax_shape_01(self):
         """
         SELECT Foo {bar};

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -19,32 +19,32 @@
 
 import unittest
 
-from edb.repl import lexutils
+from edb.repl import utils
 
 
-class TestReplLexutils(unittest.TestCase):
+class TestReplUtils(unittest.TestCase):
 
     def test_split_edgeql_01(self):
         # test regular complete statements
         self.assertEqual(
-            lexutils.split_edgeql('select +  - 1;', script_mode=False),
+            utils.split_edgeql('select +  - 1;', script_mode=False),
             (['select +  - 1;'], None))
 
         self.assertEqual(
-            lexutils.split_edgeql('select +  - 1;  ', script_mode=False),
+            utils.split_edgeql('select +  - 1;  ', script_mode=False),
             (['select +  - 1;'], None))
 
         self.assertEqual(
-            lexutils.split_edgeql(
+            utils.split_edgeql(
                 '  select +  - 1;  select ;;', script_mode=False),
             (['select +  - 1;', 'select ;'], None))
 
         self.assertEqual(
-            lexutils.split_edgeql(';;;', script_mode=False),
+            utils.split_edgeql(';;;', script_mode=False),
             ([], None))
 
         self.assertEqual(
-            lexutils.split_edgeql('''\
+            utils.split_edgeql('''\
                     CREATE TYPE blah {
                         set ;
                         blah ;
@@ -65,84 +65,84 @@ class TestReplLexutils(unittest.TestCase):
     def test_split_edgeql_02(self):
         # test multiline statements
         self.assertEqual(
-            lexutils.split_edgeql('', script_mode=False),
+            utils.split_edgeql('', script_mode=False),
             ([], ''))
         self.assertEqual(
-            lexutils.split_edgeql(' ', script_mode=False),
+            utils.split_edgeql(' ', script_mode=False),
             ([], ' '))
         self.assertEqual(
-            lexutils.split_edgeql(' \n ', script_mode=False),
+            utils.split_edgeql(' \n ', script_mode=False),
             ([], ' \n '))
-        self.assertEqual(lexutils.split_edgeql(
+        self.assertEqual(utils.split_edgeql(
             ' \n sel \n ', script_mode=False),
             ([], ' \n sel \n '))
 
         self.assertEqual(
-            lexutils.split_edgeql('select +  - 1;  select 1',
-                                  script_mode=False),
+            utils.split_edgeql('select +  - 1;  select 1',
+                               script_mode=False),
             (['select +  - 1;'], '  select 1'))
 
         self.assertEqual(
-            lexutils.split_edgeql('select +  - 1;  select {;}',
-                                  script_mode=False),
+            utils.split_edgeql('select +  - 1;  select {;}',
+                               script_mode=False),
             (['select +  - 1;'], '  select {;}'))
 
         self.assertEqual(
-            lexutils.split_edgeql('select +  - 1;  select {;;;;}}}}',
-                                  script_mode=False),
+            utils.split_edgeql('select +  - 1;  select {;;;;}}}}',
+                               script_mode=False),
             (['select +  - 1;'], '  select {;;;;}}}}'))
 
     def test_split_edgeql_03(self):
         # test multiline statements where the string is unterminated
         self.assertEqual(
-            lexutils.split_edgeql('SELECT "aaa', script_mode=False),
+            utils.split_edgeql('SELECT "aaa', script_mode=False),
             ([], 'SELECT "aaa'))
 
         self.assertEqual(
-            lexutils.split_edgeql('SELECT "as', script_mode=False),
+            utils.split_edgeql('SELECT "as', script_mode=False),
             ([], 'SELECT "as'))
 
         self.assertEqual(
-            lexutils.split_edgeql('SELECT "as\n', script_mode=False),
+            utils.split_edgeql('SELECT "as\n', script_mode=False),
             ([], 'SELECT "as\n'))
 
     def test_split_edgeql_04(self):
         # test multiline statements where the ';' is not a separator
         self.assertEqual(
-            lexutils.split_edgeql('SELECT "aaa;', script_mode=False),
+            utils.split_edgeql('SELECT "aaa;', script_mode=False),
             ([], 'SELECT "aaa;'))
 
         self.assertEqual(
-            lexutils.split_edgeql('SELECT 1 #;', script_mode=False),
+            utils.split_edgeql('SELECT 1 #;', script_mode=False),
             ([], 'SELECT 1 #;'))
 
     def test_split_edgeql_05(self):
         # test invalid tokens
         self.assertEqual(
-            lexutils.split_edgeql('SELECT 1 ~ 2;', script_mode=False),
+            utils.split_edgeql('SELECT 1 ~ 2;', script_mode=False),
             (['SELECT 1 ~ 2;'], None))
 
         self.assertEqual(
-            lexutils.split_edgeql('SELECT 1 ~ 2', script_mode=False),
+            utils.split_edgeql('SELECT 1 ~ 2', script_mode=False),
             ([], 'SELECT 1 ~ 2'))
 
     def test_split_edgeql_06(self):
         # test regular script mode
         self.assertEqual(
-            lexutils.split_edgeql('select +  - 1;', script_mode=True),
+            utils.split_edgeql('select +  - 1;', script_mode=True),
             (['select +  - 1;'], None))
 
         self.assertEqual(
-            lexutils.split_edgeql('select +  - 1;  ', script_mode=True),
+            utils.split_edgeql('select +  - 1;  ', script_mode=True),
             (['select +  - 1;'], None))
 
         self.assertEqual(
-            lexutils.split_edgeql('  select +  - 1;  select ;;',
-                                  script_mode=True),
+            utils.split_edgeql('  select +  - 1;  select ;;',
+                               script_mode=True),
             (['select +  - 1;', 'select ;'], None))
 
         self.assertEqual(
-            lexutils.split_edgeql('''\
+            utils.split_edgeql('''\
                 CREATE TYPE blah {
                     set ;
                     blah ;
@@ -160,28 +160,111 @@ class TestReplLexutils(unittest.TestCase):
     def test_split_edgeql_07(self):
         # test script mode with various incomplete parts
         self.assertEqual(
-            lexutils.split_edgeql('', script_mode=True), ([], None))
+            utils.split_edgeql('', script_mode=True), ([], None))
         self.assertEqual(
-            lexutils.split_edgeql(' ', script_mode=True), ([], None))
+            utils.split_edgeql(' ', script_mode=True), ([], None))
         self.assertEqual(
-            lexutils.split_edgeql(' \n ', script_mode=True), ([], None))
+            utils.split_edgeql(' \n ', script_mode=True), ([], None))
 
         self.assertEqual(
-            lexutils.split_edgeql('select +  - 1;  select 1',
-                                  script_mode=True),
+            utils.split_edgeql('select +  - 1;  select 1',
+                               script_mode=True),
             (['select +  - 1;', 'select 1'], None))
 
         self.assertEqual(
-            lexutils.split_edgeql('select +  - 1;  select {;}',
-                                  script_mode=True),
+            utils.split_edgeql('select +  - 1;  select {;}',
+                               script_mode=True),
             (['select +  - 1;', 'select {;}'], None))
 
         self.assertEqual(
-            lexutils.split_edgeql('select +  - 1;  select {;;;;}}}} select',
-                                  script_mode=True),
+            utils.split_edgeql('select +  - 1;  select {;;;;}}}} select',
+                               script_mode=True),
             (['select +  - 1;', 'select {;;;;}}}} select'], None))
 
         self.assertEqual(
-            lexutils.split_edgeql('select +  - 1;  select {;;;;}}}}; select',
-                                  script_mode=True),
+            utils.split_edgeql('select +  - 1;  select {;;;;}}}}; select',
+                               script_mode=True),
             (['select +  - 1;', 'select {;;;;}}}};', 'select'], None))
+
+    def test_normalize_name_01(self):
+        # test REPL name normalization
+        self.assertEqual(
+            utils.normalize_name('Object'), 'Object')
+        self.assertEqual(
+            utils.normalize_name('`Object`'), 'Object')
+        self.assertEqual(
+            utils.normalize_name('std::Object'), 'std::Object')
+        self.assertEqual(
+            utils.normalize_name('`std`::`Object`'), 'std::Object')
+        self.assertEqual(
+            utils.normalize_name('std::Ob je`ct'), 'std::`Ob je``ct`')
+        self.assertEqual(
+            utils.normalize_name('std::`Ob je``ct`'), 'std::`Ob je``ct`')
+        self.assertEqual(
+            utils.normalize_name('foo::Group'), 'foo::`Group`')
+        self.assertEqual(
+            utils.normalize_name('foo::`Group`'), 'foo::`Group`')
+        self.assertEqual(
+            utils.normalize_name('select::Group'), '`select`::`Group`')
+        self.assertEqual(
+            utils.normalize_name('`select`::Group'), '`select`::`Group`')
+        self.assertEqual(
+            utils.normalize_name('`select`::`Group`'), '`select`::`Group`')
+
+    def test_normalize_name_02(self):
+        # The empty string quote is not a valid identifier,
+        # therefore it's treated as plain text "``".
+        self.assertEqual(
+            utils.normalize_name('Obj``ect'), '`Obj````ect`')
+        # valid, albeit odd name
+        self.assertEqual(
+            utils.normalize_name('`'), '````')
+        self.assertEqual(
+            utils.normalize_name('````'), '````')
+        # empty quoted identifier is illegal, so it must be
+        # interpreted literally as 2 "`"
+        self.assertEqual(
+            utils.normalize_name('``'), '``````')
+        # "```" is not a valid quoted identifier, therefore it's
+        # treated as plain text, so the quoted version consists of
+        # 3*2+2=8 "`"
+        self.assertEqual(
+            utils.normalize_name('```'), '````````')
+        self.assertEqual(
+            utils.normalize_name('````````'), '````````')
+
+    def test_normalize_name_03(self):
+        # The normalization allows some unusual quoting that would not
+        # be legal in EdgeQL, but since \d command is not bound by the
+        # same rules for valid identifiers, these are allowed here.
+        self.assertEqual(
+            # quoting embedded into a name
+            utils.normalize_name('Ob`je`ct'), 'Object')
+        self.assertEqual(
+            # "correct" identifier that actually contains 2 "`"
+            utils.normalize_name('`Ob``je``ct`'), '`Ob``je``ct`')
+        self.assertEqual(
+            # identifier that actually contains 2 "`", where only the
+            # first "`" is quoted
+            utils.normalize_name('`Ob```je`ct'), '`Ob``je``ct`')
+        self.assertEqual(
+            # identifier that actually contains 2 "`", where only the
+            # "`" are quoted
+            utils.normalize_name('Ob````je````ct'), '`Ob``je``ct`')
+        self.assertEqual(
+            # quoting that encompasses "::", which would be illegal in EdgeQL
+            utils.normalize_name('`std::Object`'), 'std::Object')
+
+    def test_normalize_name_04(self):
+        # this results in an illegal (empty) name
+        self.assertEqual(
+            utils.normalize_name(''), '')
+        # this results in an illegal name with empty module
+        self.assertEqual(
+            utils.normalize_name('::Foo'), '')
+        # this results in an illegal name with empty short name
+        self.assertEqual(
+            utils.normalize_name('foo::'), '')
+        # this results in an illegal name starting with "@"
+        self.assertEqual(
+            utils.normalize_name('@foo'), '')

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -242,7 +242,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 34.40)
 
     def test_cqa_type_coverage_repl(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "repl", 0)
+        self.assertFunctionCoverage(EDB_DIR / "repl", 10.00)
 
     def test_cqa_type_coverage_schema(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "schema", 30.57)


### PR DESCRIPTION
Add `\d NAME` command to REPL. It is a shortcut for `DESCRIBE OBJECT`
where the `NAME` is plain text name of the concept that needs to be
described. No backtick name quoting is needed, but it can be used.

For example, the following are equivalent:

    \d O bje`ct
    \d `O bje``ct`

Largely the backticks are optional so that when keywords are used as
names no quoting is necessary. For example, describing a user-created
type `Commit` could be done like this:

    \d Commit
    \d default::Commit
    \d default::`Commit`

Issue: #179