### PR TITLE
Add more \l REPL commands.

### DIFF
--- a/edb/repl/utils.py
+++ b/edb/repl/utils.py
@@ -124,3 +124,20 @@ def normalize_name(name: str) -> str:
         return ''
 
     return name
+
+
+def get_filter_based_on_pattern(pattern: str,
+                                field: str = '.name',
+                                flag: str = '') -> Tuple[str, Dict[str, str]]:
+    if flag:
+        flag = f'(?{flag})'
+
+    qkw = {}
+
+    if pattern:
+        qkw[f're_{field}'] = flag + pattern
+        return f'FILTER re_test(<str>$`re_{field}`, {field})', qkw
+
+    else:
+        # no FILTER clause necessary
+        return '', qkw

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -242,7 +242,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 34.40)
 
     def test_cqa_type_coverage_repl(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "repl", 9.86)
+        self.assertFunctionCoverage(EDB_DIR / "repl", 22.08)
 
     def test_cqa_type_coverage_schema(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "schema", 30.57)


### PR DESCRIPTION
Add `\lm [PATTERN]` command for listing modules, optionally filtered by
name using the specified regexp pattern.
Add `\lmI [PATTERN]` command for case-sensitive pattern matching.

Add `\lr [PATTERN]` command for listing roles, also with option to
filter by name using regexp.
Add `\lrI [PATTERN]` command for case-sensitive pattern matching.

The PATTERN is purely regexp, it should not be quoted in any way, but
instead will be treated as a raw string for a regexp search.

Issue: #179.

Co-authored-by: Eduardo Schettino <schettino72@gmail.com>