### PR TITLE
doc: Add "message" field to ErrorResponse structure

### DIFF
--- a/docs/internals/protocol/messages.rst
+++ b/docs/internals/protocol/messages.rst
@@ -113,6 +113,9 @@ Format:
         // Error code.
         int32               code;
 
+        // Error message
+        string              message;
+
         // Other error attributes.
         Headers             attributes;
     };


### PR DESCRIPTION
As exists in [javascript](https://github.com/edgedb/edgedb-js/blob/b24717d8f002d51829684314c24ac236c8cad312/src/client.ts#L280) version.