### PR TITLE
Draw a flame graph SVG during profile data aggregation

### DIFF
--- a/edb/tools/profiling.py
+++ b/edb/tools/profiling.py
@@ -186,7 +186,7 @@ class profile:
             # Mypy is wrong below, `stats` is there on all pstats.Stats objects
             render_svg(ps.stats, svg_path)  # type: ignore
         except ValueError as ve:
-            print("Cannot display flame graph: {ve}", file=sys.stderr)
+            print(f"Cannot display flame graph: {ve}", file=sys.stderr)
         print(
             f"Processed {success + failure} files, {failure} failed.",
             file=sys.stderr,

--- a/edb/tools/profiling.py
+++ b/edb/tools/profiling.py
@@ -21,11 +21,13 @@ from typing import *  # NoQA
 
 import atexit
 import cProfile
+import dataclasses
 import functools
 import pathlib
 import pstats
 import sys
 import tempfile
+from xml.sax import saxutils
 
 import click
 
@@ -34,10 +36,40 @@ import click
 # edgedb/edb/tools/profiling.py, leaving just edgedb/
 EDGEDB_DIR = pathlib.Path(__file__).resolve().parent.parent.parent
 PREFIX = "edgedb_"
-SUFFIX = ".pstats"
+STAT_SUFFIX = ".pstats"
+PROF_SUFFIX = ".prof"
+SVG_SUFFIX = ".svg"
 
 
 T = TypeVar("T", bound=Callable[..., Any])
+
+
+if TYPE_CHECKING:
+    ModulePath = str
+    LineNo = int
+    FunctionName = str
+    FunctionID = Tuple[ModulePath, LineNo, FunctionName]
+    # cc, nc, tt, ct, callers
+    PrimitiveCallCount = int  # without recursion
+    CallCount = int  # with recursion
+    TotalTime = float
+    CumulativeTime = float
+    StatWithCallers = Tuple[
+        PrimitiveCallCount,
+        CallCount,
+        TotalTime,
+        CumulativeTime,
+        # values below are also StatWithCallers but Mypy does not support
+        # recursive definitions
+        Dict[FunctionID, Any],
+    ]
+    Stats = Dict[FunctionID, StatWithCallers]
+    Stat = Tuple[
+        PrimitiveCallCount, CallCount, TotalTime, CumulativeTime,
+    ]
+    Caller = FunctionID
+    Callee = FunctionID
+    Call = Tuple[Caller, Optional[Callee]]
 
 
 class profile:
@@ -47,7 +79,7 @@ class profile:
         self,
         *,
         prefix: str = PREFIX,
-        suffix: str = SUFFIX,
+        suffix: str = PROF_SUFFIX,
         dir: Optional[str] = None,
         reuse: bool = True,
     ):
@@ -125,12 +157,17 @@ class profile:
                 directory = pathlib.Path(tmp.name).parent
         else:
             directory = pathlib.Path(self.dir)
+        if out_path.is_dir():
+            out_path = out_path / "profile_analysis"
+        prof_path = out_path.with_suffix(PROF_SUFFIX)
+        pstats_path = out_path.with_suffix(STAT_SUFFIX)
+        svg_path = out_path.with_suffix(SVG_SUFFIX)
         files = list(
             str(f) for f in directory.glob(self.prefix + "*" + self.suffix)
         )
         success = 0
         failure = 0
-        with open(out_path, "w") as out:
+        with open(pstats_path, "w") as out:
             ps = pstats.Stats(stream=out)
             for file in files:
                 try:
@@ -141,9 +178,15 @@ class profile:
                     failure += 1
                 else:
                     success += 1
+            ps.dump_stats(str(prof_path))
             if sort_by:
                 ps.sort_stats(sort_by)
             ps.print_stats()
+        try:
+            # Mypy is wrong below, `stats` is there on all pstats.Stats objects
+            render_svg(ps.stats, svg_path)  # type: ignore
+        except ValueError as ve:
+            print("Cannot display flame graph: {ve}", file=sys.stderr)
         print(
             f"Processed {success + failure} files, {failure} failed.",
             file=sys.stderr,
@@ -151,11 +194,399 @@ class profile:
         return success, failure
 
 
+@dataclasses.dataclass
+class Function:
+    id: FunctionID
+    calls: List
+    calledby: List
+    stat: Stat
+
+
+ROOT_ID: FunctionID = ("<root>", 0, "<root>")
+
+
+class RGB(NamedTuple):
+    r: int
+    g: int
+    b: int
+
+
+def gen_colors(s: RGB, e: RGB, size: int) -> Iterator[RGB]:
+    """Generate a gradient of `size` colors between `s` and `e`."""
+    for i in range(size):
+        yield RGB(
+            s.r + (e.r - s.r) * i // size,
+            s.g + (e.g - s.g) * i // size,
+            s.b + (e.b - s.b) * i // size,
+        )
+
+
+COLORS = list(gen_colors(RGB(255, 240, 141), RGB(255, 65, 34), 7))
+CCOLORS = list(gen_colors(RGB(44, 255, 210), RGB(113, 194, 0), 5))
+ECOLORS = list(gen_colors(RGB(230, 230, 255), RGB(150, 150, 255), 5))
+DCOLORS = list(gen_colors(RGB(190, 190, 190), RGB(240, 240, 240), 7))
+
+
+import hashlib
+
+
+def gradient_from_name(name: str) -> float:
+    v = int(hashlib.sha1(name.encode("utf8")).hexdigest()[:8], base=16)
+    return v / (0xFFFFFFFF + 1.0)
+
+
+def calc_callers(
+    stats: Stats,
+    threshold: float,
+) -> Tuple[Dict[FunctionID, Function], Dict[Call, Stat]]:
+    """Calculate flattened stats of calls between functions."""
+    roots: List[FunctionID] = []
+    funcs: Dict[FunctionID, Function] = {}
+    calls: Dict[Call, Stat] = {}
+    for func, (cc, nc, tt, ct, callers) in stats.items():
+        funcs[func] = Function(
+            id=func, calls=[], calledby=[], stat=(cc, nc, tt, ct)
+        )
+        if not callers:
+            roots.append(func)
+            calls[ROOT_ID, func] = funcs[func].stat
+
+    for func, (_, _, _, _, callers) in stats.items():
+        for caller, t in callers.items():
+            assert (caller, func) not in calls
+            funcs[caller].calls.append(func)
+            funcs[func].calledby.append(caller)
+            calls[caller, func] = t
+
+    total = sum(funcs[r].stat[3] for r in roots)
+    ttotal = sum(funcs[r].stat[2] for r in funcs)
+    if total < threshold or ttotal < threshold:
+        raise ValueError(
+            f"Not enough profiling data to draw a meaningful graph"
+        )
+
+    if not (0.8 < total / ttotal < 1.2):
+        raise ValueError(
+            f"invalid data: root cumulative time is {total} but the sum of "
+            f"total time is {ttotal}"
+        )
+
+    # Try to find suitable root
+    newroot = max(
+        (r for r in funcs if r not in roots), key=lambda r: funcs[r].stat[3]
+    )
+    nstat = funcs[newroot].stat
+    ntotal = total + nstat[3]
+    if 0.8 < ntotal / ttotal < 1.2:
+        roots.append(newroot)
+        calls[ROOT_ID, newroot] = nstat
+        total = ntotal
+    else:
+        total = ttotal
+
+    funcs[ROOT_ID] = Function(
+        id=ROOT_ID, calls=roots, calledby=[], stat=(1, 1, 0, total),
+    )
+    return funcs, calls
+
+
+@dataclasses.dataclass
+class Block:
+    func: FunctionID
+    call_stack: Tuple[FunctionID, ...]
+    color: int
+    level: int
+    tooltip: str
+    w: float
+    x: float
+
+    @property
+    def id(self) -> str:
+        return repr(self.func)
+
+    @property
+    def name(self) -> FunctionName:
+        return self.func[2]
+
+
+def count_calls(funcs: Dict[FunctionID, Function]) -> Counter[Call]:
+    call_counter: Counter[Call] = Counter()
+
+    def _counts(
+        caller: FunctionID, visited: Set[Call], level: int = 0
+    ) -> None:
+        for callee in funcs[caller].calls:
+            call = caller, callee
+            call_counter[call] += 1
+            if call_counter[call] < 2 and call not in visited:
+                _counts(callee, visited | {call}, level + 1)
+
+    _counts(ROOT_ID, set())
+    return call_counter
+
+
+def build_svg_blocks(
+    funcs: Dict[FunctionID, Function],
+    calls: Dict[Call, Stat],
+    threshold: float,
+) -> Tuple[List[Block], List[Block], float]:
+    call_stack_blocks: List[Block] = []
+    usage_blocks: List[Block] = []
+    counts: Counter[Call] = count_calls(funcs)
+
+    def _build_blocks_by_call_stack(
+        func: FunctionID,
+        scaled_timings: Stat,
+        *,
+        visited: AbstractSet[Call] = frozenset(),
+        level: int = 0,
+        origin: float = 0,
+        call_stack: Tuple[FunctionID, ...] = (),
+        parent_call_count: int = 1,
+        parent_block: Optional[Block] = None,
+    ) -> None:
+        _, _, func_tt, func_tc = scaled_timings
+        pcc = parent_call_count
+        fchildren = [
+            (f, funcs[f], calls[func, f], max(counts[func, f], pcc))
+            for f in funcs[func].calls
+        ]
+        fchildren.sort(key=lambda elem: elem[0])
+        gchildren = [elem for elem in fchildren if elem[3] == 1]
+        bchildren = [elem for elem in fchildren if elem[3] > 1]
+        if bchildren:
+            gchildren_tc_sum = sum(r[2][3] for r in gchildren)
+            bchildren_tc_sum = sum(r[2][3] for r in bchildren)
+            rest = func_tc - func_tt - gchildren_tc_sum
+            if bchildren_tc_sum > 0:
+                factor = rest / bchildren_tc_sum
+            else:
+                factor = 1
+            # Round up and scale times and call counts.
+            bchildren = [
+                (
+                    f,
+                    ff,
+                    (
+                        round(cc * factor),
+                        round(nc * factor),
+                        tt * factor,
+                        tc * factor,
+                    ),
+                    ccnt,
+                )
+                for f, ff, (cc, nc, tt, tc), ccnt in bchildren
+            ]
+
+        for child, _, (cc, nc, tt, tc), call_count in gchildren + bchildren:
+            if tc / maxw < threshold:
+                origin += tc
+                continue
+
+            child_call_stack = call_stack + (child,)
+            tooltip = "{0[0]}:{0[1]}:{0[2]} {5:.2%} ({1} {2} {3} {4})".format(
+                child, cc, nc, tt, tc, tc / maxw
+            )
+            block = Block(
+                func=child,
+                call_stack=child_call_stack,
+                color=(parent_call_count == 1 and call_count > 1),
+                level=level,
+                tooltip=tooltip,
+                w=tc,
+                x=origin,
+            )
+            call_stack_blocks.append(block)
+            call = func, child
+            if call not in visited:
+                _build_blocks_by_call_stack(
+                    child,
+                    (cc, nc, tt, tc),
+                    level=level + 1,
+                    origin=origin,
+                    visited=visited | {call},
+                    call_stack=child_call_stack,
+                    parent_call_count=call_count,
+                    parent_block=block,
+                )
+            origin += tc
+
+    def _build_blocks_by_usage(
+        ids: Sequence[FunctionID],
+        *,
+        level: int = 0,
+        to: Optional[FunctionID] = None,
+        origin: float = 0,
+        visited: AbstractSet[Call] = frozenset(),
+        parent_width: float = 0,
+    ) -> None:
+        if ids and to is not None:
+            factor = parent_width / sum(calls[fid, to][3] for fid in ids)
+        else:
+            factor = 1.0
+
+        for fid in sorted(ids):
+            call = fid, to
+            if to is not None:
+                cc, nc, tt, tc = calls[call]  # type: ignore
+                ttt = tc * factor
+            else:
+                cc, nc, tt, tc = funcs[fid].stat
+                ttt = tt * factor
+
+            if ttt / maxw < threshold:
+                origin += ttt
+                continue
+
+            tooltip = "{0[0]}:{0[1]}:{0[2]} {5:.2%} ({1} {2} {3} {4})".format(
+                fid, cc, nc, tt, tc, tt / maxw
+            )
+            block = Block(
+                func=fid,
+                call_stack=(),
+                color=2 if level > 0 else not funcs[fid].calls,
+                level=level,
+                tooltip=tooltip,
+                w=ttt,
+                x=origin,
+            )
+            usage_blocks.append(block)
+            if call not in visited:
+                _build_blocks_by_usage(
+                    funcs[fid].calledby,
+                    level=level + 1,
+                    to=fid,
+                    origin=origin,
+                    visited=visited | {call},
+                    parent_width=ttt,
+                )
+            origin += ttt
+
+    maxw = float(funcs[ROOT_ID].stat[3])
+    _build_blocks_by_call_stack(ROOT_ID, scaled_timings=(1, 1, maxw, maxw))
+    _build_blocks_by_usage([fid for fid in funcs if fid != ROOT_ID])
+    return call_stack_blocks, usage_blocks, maxw
+
+
+def render_svg_section(
+    blocks: List[Block],
+    maxw: float,
+    colors: List[List[RGB]],
+    block_height: int,
+    font_size: int,
+    width: int,
+    top: int,
+    invert: bool = False,
+) -> Tuple[List[str], int]:
+    maxlevel = max(r.level for r in blocks)
+    height = (maxlevel + 1) * block_height
+    content = []
+    for b in blocks:
+        x = b.x * width / maxw
+        tx = block_height / 6
+        y = b.level
+        if invert:
+            y = maxlevel - y
+        y = top + height - y * block_height - block_height
+        ty = block_height / 2
+        w = max(1, b.w * width / maxw - 1)
+        bcolors = colors[b.color]
+        fill = bcolors[int(len(bcolors) * gradient_from_name(b.id))]
+        content.append(
+            ELEM.format(
+                w=w,
+                x=x,
+                y=y,
+                tx=tx,
+                ty=ty,
+                name=saxutils.escape(b.name),
+                full_name=saxutils.escape(b.tooltip),
+                font_size=font_size,
+                h=block_height - 1,
+                fill=fill,
+            )
+        )
+
+    return content, top + height
+
+
+def render_svg(
+    stats: Stats,
+    out: Union[pathlib.Path, str],
+    threshold: float = 0.1 / 100,
+    width: int = 1920,  # in pixels
+    block_height: int = 24,  # in pixels
+    font_size: int = 9,
+    log_mult: int = 1000000,
+) -> None:
+    """Render an SVG file to `out`.
+
+    Raises ValueError if rendering cannot be done with the given `stats`.
+    """
+    funcs, calls = calc_callers(stats, threshold)
+    call_blocks, usage_blocks, maxw = build_svg_blocks(
+        funcs, calls, threshold=threshold
+    )
+    lines1: List[str] = []
+    lines2: List[str] = []
+    current_height = 0
+    if call_blocks:
+        lines1, current_height = render_svg_section(
+            call_blocks,
+            maxw,
+            [COLORS, CCOLORS],
+            block_height=block_height,
+            font_size=font_size,
+            width=width,
+            top=0,
+        )
+        # a visual distinction between the call graph and the usage graph
+        current_height += block_height
+    if usage_blocks:
+        lines2, current_height = render_svg_section(
+            usage_blocks,
+            maxw,
+            [COLORS, ECOLORS, DCOLORS],
+            block_height=block_height,
+            font_size=font_size,
+            width=width,
+            top=current_height,
+            invert=True,
+        )
+    with open(out, "w") as outf:
+        content = "\n".join(lines1 + lines2)
+        outf.write(SVG.format(content, width=width, height=current_height))
+
+
+SVG = """\
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" \
+"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" width="{width}" height="{height}"
+     xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink">
+<style type="text/css">
+    .func_g {{ font-family: arial }}
+    .func_g:hover {{ stroke:black; stroke-width:0.5; cursor:pointer; }}
+</style>
+{}
+</svg>"""
+
+ELEM = """\
+<svg class="func_g" x="{x}" y="{y}" width="{w}" height="{h}"><g>
+    <title>{full_name}</title>
+    <rect height="100%" width="100%" fill="rgb({fill.r},{fill.g},{fill.b})"
+     rx="2" ry="2" />
+    <text alignment-baseline="central" x="{tx}" y="{ty}"
+     font-size="{font_size}px" fill="rgb(0,0,0)">{name}</text>
+</g></svg>"""
+
+
 @click.command()
 @click.option("--prefix", default=PREFIX)
-@click.option("--suffix", default=SUFFIX)
+@click.option("--suffix", default=PROF_SUFFIX)
 @click.option("--sort-by", default="cumulative")
-@click.option("--out", default=EDGEDB_DIR / "profile_analysis.out")
+@click.option("--out", default=EDGEDB_DIR)
 @click.argument("dirs", nargs=-1)
 def cli(
     dirs: List[str],
@@ -168,7 +599,7 @@ def cli(
         raise click.UsageError("Specify at most one directory")
 
     dir: Optional[str] = dirs[0] if dirs else None
-    prof = profile(dir=dir, prefix=prefix, suffix=suffix)
+    prof = profile(dir=dir, prefix=prefix, suffix=suffix, reuse=False)
     prof.aggregate(pathlib.Path(out), sort_by=sort_by)
 
 

--- a/edb/tools/profiling_svg_helpers.js
+++ b/edb/tools/profiling_svg_helpers.js
@@ -1,0 +1,256 @@
+/*
+The contents of this file are subject to the terms of the
+Common Development and Distribution License (the "License").
+You may not use this file except in compliance with the License.
+
+You can obtain a copy of the license at docs/cddl1.txt or
+http://opensource.org/licenses/CDDL-1.0.
+See the License for the specific language governing permissions
+and limitations under the License.
+
+When distributing Covered Code, include this CDDL HEADER in each
+file and include the License file at docs/cddl1.txt.
+
+Portions Copyright 2019 EdgeDB Inc.
+Copyright 2016 Netflix, Inc.
+Copyright 2011 Joyent, Inc.  All rights reserved.
+Copyright 2011 Brendan Gregg.  All rights reserved.
+*/
+
+var details, searchbtn, svg, searching;
+function init(evt) {
+    details = document.getElementById("details").firstChild;
+    searchbtn = document.getElementById("search");
+    svg = document.getElementsByTagName("svg")[0];
+    searching = 0;
+}
+
+// mouse-over for info
+function s(node) {
+    value = "";
+    if (node !== undefined) {
+        title = node.getElementsByTagName("title");
+        if (title.length == 1) {
+            value = "Function: " + title[0].textContent;
+        }
+    }
+    details.nodeValue = value;
+}
+
+// ctrl-F for search
+window.addEventListener("keydown",function (e) {
+    if (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)) {
+        e.preventDefault();
+        search_prompt();
+    }
+})
+
+// functions
+function find_child(parent, name, attr) {
+    var children = parent.childNodes;
+    for (var i=0; i<children.length;i++) {
+        if (children[i].tagName == name)
+            return (attr != undefined) ? children[i].attributes[attr].value : children[i];
+    }
+    return;
+}
+function orig_save(e, attr, val) {
+    if (e.attributes["_orig_"+attr] != undefined) return;
+    if (e.attributes[attr] == undefined) return;
+    if (val == undefined) val = e.attributes[attr].value;
+    e.setAttribute("_orig_"+attr, val);
+}
+function orig_load(e, attr) {
+    if (e.attributes["_orig_"+attr] == undefined) return;
+    e.attributes[attr].value = e.attributes["_orig_"+attr].value;
+    e.removeAttribute("_orig_"+attr);
+}
+function g_to_text(e) {
+    var text = find_child(e, "title").firstChild.nodeValue;
+    return (text)
+}
+function g_to_func(e) {
+    var func = g_to_text(e);
+    if (func != null)
+        func = func.replace(/ .*/, "");
+    return (func);
+}
+
+// zoom
+function zoom_reset(e) {
+    if (e.attributes != undefined) {
+        orig_load(e, "x");
+        orig_load(e, "width");
+    }
+    if (e.childNodes == undefined) return;
+    for(var i=0, c=e.childNodes; i<c.length; i++) {
+        zoom_reset(c[i]);
+    }
+}
+function zoom_child(e, x, ratio) {
+    if(e.tagName != "svg")  {
+        return;
+    }
+    if (e.attributes != undefined) {
+        if (e.attributes["x"] != undefined) {
+            orig_save(e, "x");
+            e.attributes["x"].value = (parseFloat(e.attributes["x"].value) - x) * ratio;
+        }
+        if (e.attributes["width"] != undefined) {
+            orig_save(e, "width");
+            e.attributes["width"].value = parseFloat(e.attributes["width"].value) * ratio;
+        }
+    }
+
+    if (e.childNodes == undefined) return;
+    for(var i=0, c=e.childNodes; i<c.length; i++) {
+        zoom_child(c[i], x, ratio);
+    }
+}
+function zoom_parent(e) {
+    if(e.tagName != "svg")  {
+        return;
+    }
+    if (e.attributes) {
+        if (e.attributes["x"] != undefined) {
+            orig_save(e, "x");
+            e.attributes["x"].value = 0;
+        }
+        if (e.attributes["width"] != undefined) {
+            orig_save(e, "width");
+            e.attributes["width"].value = parseInt(svg.width.baseVal.value);
+        }
+    }
+    if (e.childNodes == undefined) return;
+    for(var i=0, c=e.childNodes; i<c.length; i++) {
+        zoom_parent(c[i]);
+    }
+}
+function zoom(node, upsidedown) {
+    var attr = node.attributes;
+    var width = parseFloat(attr["width"].value);
+    var xmin = parseFloat(attr["x"].value);
+    var xmax = parseFloat(xmin + width);
+    var ymin = parseFloat(attr["y"].value);
+    var ratio = (svg.width.baseVal.value) / width;
+
+    // XXX: Workaround for JavaScript float issues (fix me)
+    var fudge = 0.0001;
+
+    var unzoombtn = document.getElementById("unzoom");
+    unzoombtn.style["opacity"] = "1.0";
+
+    var el = document.getElementsByTagName("svg");
+    for(var i=0;i<el.length;i++){
+        var e = el[i];
+        var a = e.attributes;
+        if (a["class"].value !== "func_g")
+            continue;
+
+        var ex = parseFloat(a["x"].value);
+        var ew = parseFloat(a["width"].value);
+
+        // Is it an ancestor
+        if (upsidedown === true) {
+            var upstack = parseFloat(a["y"].value) < ymin;
+        } else {
+            var upstack = parseFloat(a["y"].value) > ymin;
+        }
+        if (upstack) {
+            // Direct ancestor
+            if (ex <= xmin && (ex+ew+fudge) >= xmax) {
+                e.style["opacity"] = "0.5";
+                zoom_parent(e);
+                e.onclick = function(e){unzoom(); zoom(this, upsidedown);};
+                //#update_text(e);
+            }
+            // not in current path
+            else
+                e.style["display"] = "none";
+        }
+        // Children maybe
+        else {
+            // no common path
+            if (ex < xmin || ex + fudge >= xmax) {
+                e.style["display"] = "none";
+            }
+            else {
+                zoom_child(e, xmin, ratio);
+                e.onclick = function(e){zoom(this, upsidedown);};
+                //#update_text(e);
+            }
+        }
+    }
+}
+function unzoom() {
+    var unzoombtn = document.getElementById("unzoom");
+    unzoombtn.style["opacity"] = "0.0";
+
+    var el = document.getElementsByTagName("svg");
+    for(i=0;i<el.length;i++) {
+        var e = el[i];
+        if (e.attributes["class"].value !== "func_g")
+            continue;
+        e.style["display"] = "block";
+        e.style["opacity"] = "1";
+        zoom_reset(e);
+        //#update_text(e);
+    }
+}
+
+// search
+function reset_search() {
+    var el = document.getElementsByTagName("rect");
+    for (var i=0; i < el.length; i++){
+        orig_load(el[i], "fill")
+    }
+}
+function search_prompt() {
+    if (!searching) {
+        var term = prompt("Enter a search term (regexp " +
+            "allowed, eg: ^compile_)", "");
+        if (term != null) {
+            search(term)
+        }
+    } else {
+        reset_search();
+        searching = 0;
+        searchbtn.style["opacity"] = "0.1";
+        searchbtn.firstChild.nodeValue = "Search"
+    }
+}
+function search(term) {
+    var re = new RegExp(term);
+    var el = document.getElementsByTagName("svg");
+    for (var i = 0; i < el.length; i++) {
+        var e = el[i];
+        if (e.attributes["class"].value != "func_g")
+            continue;
+        var func = g_to_func(e);
+        var rect = find_child(e, "rect");
+        if (func == null || rect == null)
+            continue;
+
+        if (func.match(re)) {
+            // highlight
+            orig_save(rect, "fill");
+            rect.attributes["fill"].value = "rgb(230,0,230)";
+            searching = 1;
+        }
+    }
+    if (!searching)
+        return;
+
+    searchbtn.style["opacity"] = "1.0";
+    searchbtn.firstChild.nodeValue = "Reset Search"
+}
+function searchover(e) {
+    searchbtn.style["opacity"] = "1.0";
+}
+function searchout(e) {
+    if (searching) {
+        searchbtn.style["opacity"] = "1.0";
+    } else {
+        searchbtn.style["opacity"] = "0.1";
+    }
+}

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -73,7 +73,7 @@ class ProfilingTestCase(unittest.TestCase):
         self.assertEqual(len(ptest_files), 1)
 
         # aggregate the results
-        out_file = ptest_files[0].with_suffix(".out")
+        out_file = ptest_files[0].with_suffix(".pstats")
         success, failure = profiler.aggregate(out_file, sort_by="cumulative")
 
         self.assertEqual(success, 1)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -292,7 +292,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "testbase", 0)
 
     def test_cqa_type_coverage_tools(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "tools", 10.70)
+        self.assertFunctionCoverage(EDB_DIR / "tools", 16.08)
 
     def test_cqa_type_coverage_tools_docs(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "tools" / "docs", 0)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -292,7 +292,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "testbase", 0)
 
     def test_cqa_type_coverage_tools(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "tools", 16.08)
+        self.assertFunctionCoverage(EDB_DIR / "tools", 16.92)
 
     def test_cqa_type_coverage_tools_docs(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "tools" / "docs", 0)


### PR DESCRIPTION
Now when running `python -m edb.tools.profiling` to aggregate results from
profiling, it will generate three files instead of one:

- a single aggregate .prof file for future use (it's faster to load a single
file);

- a classic pstats text profile Top Calls listing; and

- an SVG flame graph.

The flame graph goes both up and down.  The upper one shows the call stack so
there's relative scaling effects in play.  If that makes it hard to see at
first glance which leaf functions run for the longest, the lower graph shows
the usage graph (reverse call stack).  That presents the relative timing of
a given function, plus percentage-wise which callers call it most often.

Example result:
<img width="1920" alt="Screenshot 2019-11-22 17 40 09" src="https://user-images.githubusercontent.com/55281/69445206-2eb03280-0d52-11ea-85d7-51cc869f2079.png">
