### PR TITLE
Add \lT command listing scalar types.

### DIFF
--- a/edb/repl/__init__.py
+++ b/edb/repl/__init__.py
@@ -48,8 +48,9 @@ from edb.edgeql import quote as eql_quote
 from edb.server import buildmeta
 
 from . import context
-from . import utils
 from . import render
+from . import table
+from . import utils
 
 
 STATUSES_WITH_OUTPUT = frozenset({
@@ -360,6 +361,80 @@ class Cli:
                 print(f'No {item_name} found matching '
                       f'{eql_quote.quote_literal(pattern)}')
 
+    @_command('lT', R'\lT [PATTERN]', 'list scalar types')
+    def command_list_scalar_types(self, args: str, *,
+                                  case_sensitive: bool = False) -> None:
+        self._list_scalar_types(args.strip(), case_sensitive=case_sensitive)
+
+    @_command('lTI', R'\lTI [PATTERN]',
+              'list scalar types (case sensitive pattern match)')
+    def command_list_scalar_types_i(self, args: str) -> None:
+        self.command_list_scalar_types(args, case_sensitive=True)
+
+    def _list_scalar_types(
+        self,
+        pattern: str,
+        case_sensitive: bool = False
+    ) -> None:
+        if case_sensitive:
+            flag = ''
+        else:
+            flag = 'i'
+
+        filter_clause, qkw = utils.get_filter_based_on_pattern(
+            pattern, flag=flag)
+
+        base_query = r'''
+            WITH MODULE schema
+            SELECT ScalarType {
+                name,
+                is_abstract,
+                `extending` := to_str(array_agg(.bases.name), ', '),
+                kind := (
+                    'enum' IF 'std::anyenum' IN .ancestors.name ELSE
+                    'sequence' IF 'std::sequence' IN .ancestors.name ELSE
+                    'normal'
+                ),
+            }
+        '''
+
+        try:
+            result, _ = self.fetch(
+                f'''
+                    {base_query}
+                    {filter_clause}
+                    ORDER BY .is_abstract THEN .name;
+                ''',
+                json=False,
+                **qkw
+            )
+        except edgedb.EdgeDBError as exc:
+            render.render_exception(self.context, exc)
+        else:
+            if result:
+                print(f'List of scalar types:')
+                max_width = self.prompt.output.get_size().columns
+                render.render_table(
+                    self.context,
+                    title='Scalar Types',
+                    columns=[
+                        table.ColumnSpec(field='name', title='Name',
+                                         width=2, align='left'),
+                        table.ColumnSpec(field='extending', title='Extending',
+                                         width=2, align='left'),
+                        table.ColumnSpec(field='is_abstract', title='Abstract',
+                                         width=1, align='left'),
+                        table.ColumnSpec(field='kind', title='Kind',
+                                         width=1, align='left'),
+                    ],
+                    data=result,
+                    max_width=min(max_width, 120),
+                )
+
+            else:
+                print(f'No scalar types found matching '
+                      f'{eql_quote.quote_literal(pattern)}')
+
     @_command('d', R'\d NAME', 'describe schema object')
     def command_describe_object(self, args: str, *, verbose=False) -> None:
         name = utils.normalize_name(args.strip())
@@ -379,16 +454,19 @@ class Cli:
         except edgedb.EdgeDBError as exc:
             render.render_exception(self.context, exc)
         else:
-            desc_doc = pt_document.Document(result[0])
-            lexer = pt_lexers.PygmentsLexer(eql_pygments.EdgeQLLexer)
-            formatter = lexer.lex_document(desc_doc)
+            self._render_sdl(result[0])
 
-            for line in range(desc_doc.line_count):
-                pt_shortcuts.print_formatted_text(
-                    pt_formatted_text.FormattedText(formatter(line)),
-                    style=self.style
-                )
-            print()
+    def _render_sdl(self, sdl):
+        desc_doc = pt_document.Document(sdl)
+        lexer = pt_lexers.PygmentsLexer(eql_pygments.EdgeQLLexer)
+        formatter = lexer.lex_document(desc_doc)
+
+        for line in range(desc_doc.line_count):
+            pt_shortcuts.print_formatted_text(
+                pt_formatted_text.FormattedText(formatter(line)),
+                style=self.style
+            )
+        print()
 
     @_command('d+', R'\d+ NAME', 'describe schema object in a verbose mode')
     def command_describe_object_verbose(self, args: str) -> None:

--- a/edb/repl/render.py
+++ b/edb/repl/render.py
@@ -34,7 +34,9 @@ from edb.errors import base as base_errors
 from edb.common.markup.renderers import terminal
 from edb.common.markup.renderers import styles
 
+from typing import *  # NoQA
 from . import context
+from . import table
 
 
 style = styles.Dark256
@@ -375,3 +377,15 @@ def render_exception(repl_ctx: context.ReplContext, exc, *, query=None):
                     print('###', line)
                     if lineno == exc_line:
                         print('###', ' ' * (exc_col - 1) + '^')
+
+
+def render_table(
+    repl_ctx: context.ReplContext,
+    *,
+    title: str,
+    columns: Sequence[table.ColumnSpec],
+    data: Iterable[edgedb.Object],
+    max_width=None,
+) -> None:
+    table.render_table(
+        title=title, columns=columns, data=data, max_width=max_width)

--- a/edb/repl/table.py
+++ b/edb/repl/table.py
@@ -1,0 +1,173 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+from typing import *  # NoQA
+from typing_extensions import Literal
+
+import math
+import sys
+import textwrap
+import typing  # needed for linting TextIO
+
+import edgedb
+
+
+class ColumnSpec(NamedTuple):
+    field: str
+    title: str
+    width: int
+    align: Union[Literal['left'], Literal['center'], Literal['right']]
+
+
+def render_table(
+    *,
+    title: str,
+    columns: List[ColumnSpec],
+    data: Iterable[edgedb.Object],
+    max_width: int = 0,
+    file: typing.TextIO = sys.stdout,
+) -> None:
+    if max_width == 0:
+        return
+
+    # Find the amount of space available for text. Every column needs
+    # whitespace padding of 2 (1 on each side) and 1 "|" column
+    # separator (except for last column).
+    avail_width = max(0, max_width - (3 * len(columns) - 1))
+    total_flex = sum(col[2] for col in columns)
+
+    # setup header row and separator
+    hline_list: List[str] = []
+    widths: List[int] = []
+    # Look at columns backwards to calculate the column widths and to
+    # pad the first column with all the extra width left over. The
+    # assumption is that the first column probably contains highly
+    # relevant information so it deserves a few extra characters if
+    # they are available.
+    for col in reversed(columns):
+        width = math.floor(avail_width * (col.width / total_flex)) + 2
+        # actual text needs to accommodate a space on each side and be
+        # a minimum of 1
+        width = max(3, width)
+        widths.append(width - 2)
+        hline_list.append('-' * width)
+
+    # reverse things back
+    widths.reverse()
+    hline_list.reverse()
+
+    # pad the first column if possible
+    pad = avail_width - sum(widths)
+    if pad > 0:
+        widths[0] += pad
+        hline_list[0] += '-' * pad
+
+    # generate the horizontal separator line
+    hline = '+'.join(hline_list)
+    # merge the title and hline
+    print(merge_centered_title(title, hline), file=file)
+
+    # create the header row(s)
+    headers = {col.field: col.title for col in columns}
+    rows = get_table_row(headers, columns, widths)
+    for row in rows:
+        print(row, file=file)
+
+    print(hline, file=file)
+
+    # process data
+    for item in data:
+        rows = get_table_row(item, columns, widths)
+        for row in rows:
+            print(row, file=file)
+
+    print(file=file)
+
+
+def merge_centered_title(title: str, background: str) -> str:
+    '''Embed the title in the center of the background string.'''
+    bg_len = len(background)
+    pos = max(0, (bg_len - len(title)) // 2)
+    if pos == 0:
+        # the title is expected to completely obscure the background
+        result = title.ljust(bg_len)
+
+    else:
+        result = (background[:pos - 1] + f' {title} ' +
+                  background[pos + 1 + len(title):])
+
+    return result
+
+
+def get_table_row(
+    item: Any,
+    columns: List[ColumnSpec],
+    widths: List[int]
+) -> List[str]:
+    # a single logical row may be split across multiple actual rows
+    multirow: List[str] = []
+    # first pass converts all column data into text that is
+    # wrapped according to the column widths
+    rdata: List[List[str]] = []
+    numrows = 1
+    for i, col in enumerate(columns):
+        width = widths[i]
+        # item could be either an object with attributes or a dict
+        if isinstance(item, dict):
+            text = str(item[col.field])
+        else:
+            text = str(getattr(item, col.field))
+
+        rdata.append(textwrap.wrap(text, width))
+        numrows = max(numrows, len(rdata[-1]))
+
+    # iterate over the potentially multiple rows per logical row
+    for r in range(numrows):
+        row = []
+        # build up each row from the respective pieces from each column
+        for i, cdata in enumerate(rdata):
+            width = widths[i]
+            data = cdata[r:r + 1]
+            if data:
+                text = data[0]
+            else:
+                text = ''
+
+            # determine if line continuation symbol is needed
+            col_len = len(cdata)
+            # if there are multiple rows in this column and the
+            # current one is not the last
+            if col_len > 1 and r < col_len - 1:
+                cont = '+'
+            else:
+                cont = ' '
+
+            # align the content
+            if columns[i].align == 'right':
+                text = text.rjust(width)
+            elif columns[i].align == 'center':
+                text = text.center(width)
+            else:
+                text = text.ljust(width)
+
+            row.append(f' {text}{cont}')
+        multirow.append('|'.join(row))
+
+    return multirow

--- a/edb/repl/utils.py
+++ b/edb/repl/utils.py
@@ -30,7 +30,7 @@ from edb.edgeql.parser.grammar import lexer
 @functools.lru_cache(100)
 def split_edgeql(
     script: str, *,
-    script_mode=True
+    script_mode: bool = True
 ) -> Tuple[List[str], Optional[str]]:
     '''\
     Split the input string into a list of possible EdgeQL statements.

--- a/mypy.ini
+++ b/mypy.ini
@@ -168,3 +168,35 @@ ignore_errors = False
 [mypy-edb.tools.profiling]
 follow_imports = True
 ignore_errors = False
+
+[mypy-edb.repl.table]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+
+[mypy-edb.repl.utils]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -242,7 +242,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 34.40)
 
     def test_cqa_type_coverage_repl(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "repl", 21.05)
+        self.assertFunctionCoverage(EDB_DIR / "repl", 27.38)
 
     def test_cqa_type_coverage_schema(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "schema", 36.78)


### PR DESCRIPTION
Add `\lT [PATTERN]` command for listing scalar types, optionally
filtered by name using the specified regexp pattern.
Add `\lTI [PATTERN]` command for case-sensitive pattern matching.

Issue #179