### PR TITLE
server: Only set rlimit nofile on macos

### DIFF
--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -30,7 +30,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 # By default, at least on macOS, the max number of open FDs
 # is 256, which is low and can cause 'edb test' to hang.
 # We try to bump the rlimit on server start if pemitted.
-EDGEDB_RLIMIT_NOFILE = 2048
+EDGEDB_MIN_RLIMIT_NOFILE = 2048
 
 
 _MAX_QUERIES_CACHE = 1000

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -248,7 +248,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "schema", 35.36)
 
     def test_cqa_type_coverage_server(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server", 6.63)
+        self.assertFunctionCoverage(EDB_DIR / "server", 6.86)
 
     def test_cqa_type_coverage_server_cache(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "cache", 0)


### PR DESCRIPTION
Setting it on Linux seems to be prohibited anyways.