### PR TITLE
Detect script mode by using isatty (fixes #859)

### DIFF
--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -242,7 +242,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 34.40)
 
     def test_cqa_type_coverage_repl(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "repl", 22.08)
+        self.assertFunctionCoverage(EDB_DIR / "repl", 21.05)
 
     def test_cqa_type_coverage_schema(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "schema", 35.36)


### PR DESCRIPTION
This kinda fixes #859 but I can't make a test. I've spent ~2 hours trying to convince repl running on pseudo-tty and there are still issues here and there (and forcing interactive mode doesn't work either, because a lot of code assumes that interactive mode is running on a tty).

It would be easier if repl is run as a subprocess. But this needs another copy of CLITestCaseMixin.

At the end of the day, I'm not sure I need to spend another chunk of time on this instead of continuing rust work (which eventually replaces whole repl).

Note: having this without the test also implies that I can't test #857 because that fails in interactive mode too.