### PR TITLE
Enable strict typing checks for edb.edgeql.compiler

### DIFF
--- a/edb/common/compiler.py
+++ b/edb/common/compiler.py
@@ -34,7 +34,10 @@ class ContextLevel:
     def __init__(self, prevlevel: Optional[ContextLevel], mode: Any) -> None:
         pass
 
-    def on_pop(self, prevlevel: Optional[ContextLevel]) -> None:
+    def on_pop(
+        self: ContextLevel_T,
+        prevlevel: Optional[ContextLevel_T],
+    ) -> None:
         pass
 
     def new(
@@ -45,7 +48,7 @@ class ContextLevel:
         return stack.new(mode, self)
 
 
-class CompilerContextManager(Generic[ContextLevel_T]):
+class CompilerContextManager(ContextManager[ContextLevel_T]):
     def __init__(
         self,
         context: CompilerContext[ContextLevel_T],
@@ -68,9 +71,9 @@ class CompilerContext(Generic[ContextLevel_T]):
     ContextLevelClass: Type[ContextLevel_T]
     default_mode: Any
 
-    def __init__(self) -> None:
+    def __init__(self, initial: ContextLevel_T) -> None:
         self.stack = []
-        self._push(None, initial=True)
+        self._push(None, initial=initial)
 
     def push(
         self,
@@ -84,11 +87,13 @@ class CompilerContext(Generic[ContextLevel_T]):
         mode: Any,
         prevlevel: Optional[ContextLevel_T] = None,
         *,
-        initial: bool = False,
+        initial: Optional[ContextLevel_T] = None,
     ) -> ContextLevel_T:
-        if prevlevel is None and not initial:
+        if initial is not None:
+            level = initial
+        else:
             prevlevel = self.current
-        level = self.ContextLevelClass(prevlevel, mode)
+            level = self.ContextLevelClass(prevlevel, mode)
         # XXX: typing fu
         level._stack = cast(CompilerContext[ContextLevel], self)
         self.stack.append(level)

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -214,6 +214,9 @@ class SpecialAnchor(Expr):
     __abstract_node__ = True
 
 
+SpecialAnchorT = typing.Type[SpecialAnchor]
+
+
 class Source(SpecialAnchor):  # __source__
     pass
 

--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -48,8 +48,6 @@ def compile_where_clause(
     with ctx.newscope(fenced=True) as subctx:
         subctx.path_scope.unnest_fence = True
         subctx.clause = 'where'
-        if subctx.stmt.parent_stmt is None:
-            subctx.toplevel_clause = subctx.clause
         ir_expr = dispatch.compile(where, ctx=subctx)
         bool_t = ctx.env.get_track_schema_type('std::bool')
         ir_set = setgen.scoped_set(ir_expr, typehint=bool_t, ctx=subctx)
@@ -70,8 +68,6 @@ def compile_orderby_clause(
 
     with ctx.new() as subctx:
         subctx.clause = 'orderby'
-        if subctx.stmt.parent_stmt is None:
-            subctx.toplevel_clause = subctx.clause
 
         for sortexpr in sortexprs:
             with subctx.newscope(fenced=True) as exprctx:

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -41,7 +41,7 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes as ft
 from edb.edgeql import parser as qlparser
 
-from . import cast
+from . import casts
 from . import context
 from . import dispatch
 from . import inference
@@ -624,7 +624,7 @@ def finalize_args(
             # cast the arguments so that the backend has no
             # wiggle room to apply its own (potentially different)
             # casting.
-            arg = cast.compile_cast(
+            arg = casts.compile_cast(
                 arg, paramtype, srcctx=None, ctx=ctx)
 
         if param_mod is not ft.TypeModifier.SET_OF:

--- a/edb/edgeql/compiler/inference/__init__.py
+++ b/edb/edgeql/compiler/inference/__init__.py
@@ -19,5 +19,7 @@
 
 from __future__ import annotations
 
+__all__ = ('amend_empty_set_type', 'infer_cardinality', 'infer_type',)
+
 from .cardinality import infer_cardinality  # NOQA
 from .types import amend_empty_set_type, infer_type  # NOQA

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -30,7 +30,6 @@ from edb.edgeql import qltypes
 from edb.ir import ast as irast
 
 from edb.schema import name as s_name
-from edb.schema import objects as s_obj
 from edb.schema import pointers as s_pointers
 from edb.schema import types as s_types
 
@@ -38,7 +37,7 @@ from . import context
 from . import stmtctx
 
 
-def get_path_id(stype: s_obj.Object, *,
+def get_path_id(stype: s_types.Type, *,
                 typename: Optional[str]=None,
                 ctx: context.ContextLevel) -> irast.PathId:
     return irast.PathId.from_type(
@@ -129,9 +128,15 @@ def mark_path_as_optional(
 
 
 def extend_path_id(
-        path_id: irast.PathId, *,
-        ptrcls, direction=None, target=None, ns=None,
-        ctx: context.ContextLevel) -> irast.PathId:
+    path_id: irast.PathId,
+    *,
+    ptrcls: s_pointers.PointerLike,
+    direction: s_pointers.PointerDirection = (
+        s_pointers.PointerDirection.Outbound),
+    target: Union[None, s_types.Type, irast.TypeRef] = None,
+    ns: AbstractSet[str] = frozenset(),
+    ctx: context.ContextLevel,
+) -> irast.PathId:
 
     result = path_id.extend(ptrcls=ptrcls, direction=direction, target=target,
                             ns=ns, schema=ctx.env.schema)

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -143,7 +143,11 @@ def try_bind_call_args(
     is_abstract = func.get_is_abstract(ctx.env.schema)
     resolved_poly_base_type: Optional[s_types.Type] = None
 
-    def _get_cast_distance(arg, arg_type, param_type) -> int:
+    def _get_cast_distance(
+        arg: irast.Set,
+        arg_type: s_types.Type,
+        param_type: s_types.Type,
+    ) -> int:
         nonlocal resolved_poly_base_type
 
         if in_polymorphic_func:

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -41,9 +41,12 @@ from . import schemactx
 from . import setgen
 
 
-def type_to_ql_typeref(t: s_types.Type, *,
-                       _name=None,
-                       ctx: context.ContextLevel) -> qlast.TypeName:
+def type_to_ql_typeref(
+    t: s_types.Type,
+    *,
+    _name: Optional[str] = None,
+    ctx: context.ContextLevel,
+) -> qlast.TypeName:
 
     return astutils.type_to_ql_typeref(t, schema=ctx.env.schema)
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -540,8 +540,8 @@ class Stmt(Expr):
     name: str
     result: Set
     cardinality: qltypes.Cardinality
-    parent_stmt: Stmt
-    iterator_stmt: Set
+    parent_stmt: typing.Optional[Stmt]
+    iterator_stmt: typing.Optional[Set]
 
 
 class FilteredStmt(Stmt):

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -36,7 +36,7 @@ from . import relgen
 def init_stmt(
         stmt: irast.Stmt, ctx: context.CompilerContextLevel,
         parent_ctx: context.CompilerContextLevel) -> None:
-    if ctx.toplevel_stmt is None:
+    if ctx.toplevel_stmt is context.NO_STMT:
         parent_ctx.toplevel_stmt = ctx.toplevel_stmt = ctx.stmt
 
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -187,7 +187,7 @@ def get_dml_stmt_stack(
         ir_stmt: irast.MutatingStmt, *,
         ctx: context.CompilerContextLevel) -> List[irast.MutatingStmt]:
     stack = []
-    stmt: irast.Stmt = ir_stmt
+    stmt: Optional[irast.Stmt] = ir_stmt
     while stmt is not None:
         if isinstance(stmt, irast.MutatingStmt):
             stack.append(stmt)
@@ -292,6 +292,9 @@ def process_insert_body(
     else:
         iterator_set = None
 
+    iterator_cte: Optional[pgast.CommonTableExpr]
+    iterator_id: Optional[pgast.BaseExpr]
+
     if iterator_set is not None:
         with ctx.substmt() as ictx:
             ictx.path_scope = ictx.path_scope.new_child()
@@ -376,7 +379,7 @@ def process_insert_body(
             if ptr_info and ptr_info.table_type == 'link':
                 external_inserts.append((shape_el, props_only))
 
-        if iterator_cte is not None:
+        if iterator_set is not None:
             cols.append(pgast.ColumnRef(name=['__edb_token']))
 
             values.append(pgast.ResTarget(val=iterator_id))
@@ -426,7 +429,7 @@ def compile_insert_shape_element(
         wrapper: pgast.Query,
         ir_stmt: irast.MutatingStmt,
         shape_el: irast.Set,
-        iterator_id: pgast.BaseExpr, *,
+        iterator_id: Optional[pgast.BaseExpr], *,
         ctx: context.CompilerContextLevel) -> pgast.Query:
 
     with ctx.newscope() as insvalctx:
@@ -450,7 +453,7 @@ def insert_value_for_shape_element(
         wrapper: pgast.Query,
         ir_stmt: irast.MutatingStmt,
         shape_el: irast.Set,
-        iterator_id: pgast.BaseExpr, *,
+        iterator_id: Optional[pgast.BaseExpr], *,
         ptr_info: pg_types.PointerStorageInfo,
         ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
 

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -54,7 +54,7 @@ def compile_Set(
     if ctx.singleton_mode:
         return _compile_set_in_singleton_mode(ir_set, ctx=ctx)
 
-    is_toplevel = ctx.toplevel_stmt is None
+    is_toplevel = ctx.toplevel_stmt is context.NO_STMT
 
     _compile_set_impl(ir_set, ctx=ctx)
 
@@ -86,14 +86,14 @@ def _compile_set_impl(
         ir_set: irast.Set, *,
         ctx: context.CompilerContextLevel) -> None:
 
-    is_toplevel = ctx.toplevel_stmt is None
+    is_toplevel = ctx.toplevel_stmt is context.NO_STMT
 
     if isinstance(ir_set.expr, irast.BaseConstant):
         # Avoid creating needlessly complicated constructs for
         # constant expressions.  Besides being an optimization,
         # this helps in GROUP BY queries.
         value = dispatch.compile(ir_set.expr, ctx=ctx)
-        if ctx.rel is None:
+        if is_toplevel:
             ctx.rel = ctx.toplevel_stmt = pgast.SelectStmt()
         pathctx.put_path_value_var(ctx.rel, ir_set.path_id, value, env=ctx.env)
         if (output.in_serialization_ctx(ctx) and ir_set.shape

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -119,7 +119,7 @@ def get_set_rvar(
     if rvar is not None:
         return rvar
 
-    if ctx.toplevel_stmt is None:
+    if ctx.toplevel_stmt is context.NO_STMT:
         # Top level query
         return _process_toplevel_query(ir_set, ctx=ctx)
 

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -209,10 +209,11 @@ class ConstraintMech:
             cls, subject, constraint, schema):
         assert constraint.get_subject(schema) is not None
 
-        ir = ql_compiler.compile_to_ir(
-            constraint.get_finalexpr(schema).text,
+        ir = ql_compiler.compile_ast_to_ir(
+            constraint.get_finalexpr(schema).qlast,
             schema,
-            anchors={qlast.Subject: subject})
+            anchors={qlast.Subject: subject},
+        )
 
         terminal_refs = ir_utils.get_terminal_references(ir.expr.expr.result)
         ref_tables = cls._get_ref_storage_info(ir.schema, terminal_refs)

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -278,7 +278,8 @@ def delta_schemas(
                 else:
                     relevant_schema = schema_b
 
-                obj = relevant_schema.get(cmd.classname)
+                obj = cast(objtypes.ObjectType,
+                           relevant_schema.get(cmd.classname))
                 if obj.is_union_type(relevant_schema):
                     continue
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -818,7 +818,7 @@ class ObjectCommand(Command, metaclass=ObjectCommandMeta):
             if rename is not None:
                 name = rename
         metaclass = self.get_schema_metaclass()
-        return schema.get(name, type=metaclass)
+        return schema.get(name, type=(metaclass,))
 
     def compute_inherited_fields(self, schema, context):
         result = {}

--- a/edb/schema/derivable.py
+++ b/edb/schema/derivable.py
@@ -18,6 +18,7 @@
 
 
 from __future__ import annotations
+from typing import *  # NoQA
 
 from . import abc as s_abc
 from . import name as sn
@@ -86,8 +87,13 @@ class DerivableObject(so.InheritingObjectBase, DerivableObjectBase):
         inheritable=False)
 
 
-def derive_name(schema, *qualifiers,
-                module, parent=None, derived_name_base=None):
+def derive_name(
+    schema,
+    *qualifiers: str,
+    module: str,
+    parent: Optional[DerivableObjectBase] = None,
+    derived_name_base: Optional[str] = None,
+) -> sn.Name:
     if derived_name_base is None:
         derived_name_base = parent.get_derived_name_base(schema)
 

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -19,6 +19,8 @@
 
 from __future__ import annotations
 
+from typing import *  # NoQA
+
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
@@ -34,11 +36,23 @@ from . import referencing
 from . import sources
 from . import utils
 
+if TYPE_CHECKING:
+    from . import schema as s_schema
+    from . import sources as s_sources
+    from . import types as s_types
+
 
 class Property(pointers.Pointer, s_abc.Property,
                qlkind=qltypes.SchemaObjectClass.PROPERTY):
 
-    def derive_ref(self, schema, source, target=None, attrs=None, **kwargs):
+    def derive_ref(
+        self: referencing.ReferencedT,
+        schema: s_schema.Schema,
+        source: s_sources.Source,
+        target: Optional[s_types.Type] = None,
+        attrs: Optional[Mapping[str, Any]] = None,
+        **kwargs: Any,
+    ) -> Tuple[s_schema.Schema, referencing.ReferencedT]:
         if target is None:
             target = self.get_target(schema)
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1419,6 +1419,9 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
 
                     new_class = new_schema.get(new_name)
 
+                    assert isinstance(old_class, s_inh.InheritingObject)
+                    assert isinstance(new_class, s_inh.InheritingObject)
+
                     old_bases = \
                         old_class.get_bases(old_schema).objects(old_schema)
                     new_bases = \
@@ -1532,9 +1535,14 @@ class ObjectRef(Object):
         return self, self.get_name(schema)
 
     def _resolve_ref(self, schema: s_schema.Schema) -> Object:
+        type_filter: Tuple[ObjectMeta, ...]
+        if self._schemaclass is not None:
+            type_filter = (self._schemaclass,)
+        else:
+            type_filter = tuple()
         return schema.get(
             self.get_name(schema),
-            type=self._schemaclass,
+            type=type_filter,
             refname=self._origname,
             sourcectx=self.get_sourcectx(schema),
         )

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 from typing import *  # NoQA
 
 import collections
-import uuid
 
 from edb.common import topological
 
@@ -45,7 +44,7 @@ def linearize_delta(
     """Sort delta operations to dependency order."""
 
     opmap: Dict[sd.ObjectCommand, List[sd.ObjectCommand]] = {}
-    strongrefs: Dict[uuid.UUID, so.Object] = {}
+    strongrefs: Dict[str, str] = {}
 
     for op in delta.get_subcommands():
         _break_down(opmap, strongrefs, [delta, op])
@@ -194,7 +193,7 @@ def _trace_op(
     depgraph: Dict[Tuple[str, sn.Name], Dict[str, Any]],
     renames: Dict[sn.Name, sn.Name],
     renames_r: Dict[sn.Name, sn.Name],
-    strongrefs: Dict[uuid.UUID, so.Object],
+    strongrefs: Dict[str, str],
     old_schema: Optional[s_schema.Schema],
     new_schema: s_schema.Schema,
 ) -> None:
@@ -364,7 +363,7 @@ def get_object(
 def _get_referrers(
     schema: s_schema.Schema,
     obj: so.Object,
-    strongrefs: Dict[uuid.UUID, so.Object],
+    strongrefs: Dict[str, str],
 ) -> Set[so.Object]:
     refs = schema.get_referrers(obj)
     result = set()

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -40,6 +40,10 @@ from . import types as s_types
 from . import utils
 
 
+if TYPE_CHECKING:
+    from . import sources as s_sources
+
+
 class PointerDirection(enum.StrEnum):
     Outbound = '>'
     Inbound = '<'
@@ -338,12 +342,17 @@ class Pointer(referencing.ReferencedInheritingObject,
         shortname = self.get_shortname(schema)
         return sn.Name(module='__', name=shortname.name)
 
-    def derive_ref(self, schema, source,
-                   target=None,
-                   *qualifiers,
-                   mark_derived=False,
-                   attrs=None,
-                   dctx=None, **kwargs):
+    def derive_ref(
+        self: referencing.ReferencedT,
+        schema: s_schema.Schema,
+        source: s_sources.Source,
+        target: Optional[s_types.Type] = None,
+        *qualifiers: str,
+        mark_derived: bool = False,
+        attrs: Optional[Mapping[str, Any]] = None,
+        dctx: Optional[sd.CommandContext] = None,
+        **kwargs: Any,
+    ) -> Tuple[s_schema.Schema, referencing.ReferencedT]:
 
         if target is None:
             if attrs and 'target' in attrs:

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -70,10 +70,13 @@ class PseudoType(inheriting.InheritingObject, s_types.Type):
                 self.name == other.name)
 
 
+AnyT = typing.TypeVar('AnyT', bound='Any')
+
+
 class AnyMeta(type(PseudoType)):
 
     @property
-    def instance(cls):
+    def instance(cls: typing.Type[AnyT]) -> AnyT:
         if cls._instance is None:
             cls._instance = cls.create()
 

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -18,11 +18,15 @@
 
 
 from __future__ import annotations
+from typing import *  # NoQA
 
 from . import indexes
 from . import name as sn
 from . import objects as so
 from . import pointers
+
+if TYPE_CHECKING:
+    from . import schema as s_schema
 
 
 class SourceCommandContext(indexes.IndexSourceCommandContext):
@@ -46,7 +50,11 @@ class Source(indexes.IndexableSubject):
         inheritable=False, ephemeral=True, coerce=True, compcoef=0.857,
         default=so.ObjectIndexByUnqualifiedName)
 
-    def getptr(self, schema, name):
+    def getptr(
+        self,
+        schema: s_schema.Schema,
+        name: str,
+    ) -> Optional[pointers.Pointer]:
         if sn.Name.is_qualified(name):
             raise ValueError(
                 'references to concrete pointers must not be qualified')

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -157,7 +157,7 @@ class Type(so.InheritingObjectBase, derivable.DerivableObjectBase, s_abc.Type):
             delta.add(cmd)
             schema, _ = delta.apply(schema, context)
 
-        derived = schema.get(name)
+        derived = typing.cast(TypeT, schema.get(name))
 
         return schema, derived
 
@@ -1664,9 +1664,11 @@ class TypeCommand(sd.ObjectCommand):
                 view_types.append(vt)
 
         if isinstance(astnode, qlast.AlterObject):
-            prev = schema.get(classname)
+            prev = typing.cast(Type, schema.get(classname))
+            prev_expr = prev.get_expr(schema)
+            assert prev_expr is not None
             prev_ir = cls._compile_view_expr(
-                prev.get_expr(schema).qlast, classname, schema, context)
+                prev_expr.qlast, classname, schema, context)
             old_schema = prev_ir.schema
             for vt in prev_ir.views.values():
                 if isinstance(vt, Collection):

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -295,7 +295,7 @@ def get_nq_name(schema, item) -> str:
 
 
 def find_item_suggestions(
-        name, modaliases, schema, *, item_types=None, limit=3,
+        name, modaliases, schema, *, item_types=(), limit=3,
         collection=None, condition=None):
     from . import functions as s_func
     from . import modules as s_mod

--- a/edb/tools/flake8/typing.py
+++ b/edb/tools/flake8/typing.py
@@ -55,6 +55,7 @@ def __init__(self, tree, filename='(none)', builtins=None, *args, **kwargs):
         typing_all.add("ChainMap")  # added: 3.5.4; in __all__ since 3.7.4
         typing_all.add("ForwardRef")  # added: 3.7.0; in __all__ since 3.7.4
         typing_all.add("OrderedDict")  # added: 3.7.2
+        typing_all.add("Protocol")  # added: 3.8.0
         if typing_star_import_re.search(source):
             if builtins:
                 builtins = set(builtins) | typing_all

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,6 +15,18 @@ warn_unused_configs = True
 [mypy-edb.edgeql.compiler.*]
 follow_imports = True
 ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
 
 [mypy-edb.edgeql.codegen]
 follow_imports = True

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -24,6 +24,7 @@ from edb.testbase import lang as tb
 
 from edb.edgeql import compiler
 from edb.edgeql import qltypes
+from edb.edgeql import parser as qlparser
 
 
 class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
@@ -33,7 +34,8 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
                           'cards.esdl')
 
     def run_test(self, *, source, spec, expected):
-        ir = compiler.compile_to_ir(source, self.schema)
+        qltree = qlparser.parse(source)
+        ir = compiler.compile_ast_to_ir(qltree, self.schema)
         expected_cardinality = qltypes.Cardinality(
             textwrap.dedent(expected).strip(' \n'))
         self.assertEqual(ir.cardinality, expected_cardinality,

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -26,6 +26,7 @@ from edb import errors
 from edb.testbase import lang as tb
 
 from edb.edgeql import compiler
+from edb.edgeql import parser as qlparser
 
 
 class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
@@ -35,7 +36,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                           'cards.esdl')
 
     def run_test(self, *, source, spec, expected):
-        ir = compiler.compile_to_ir(source, self.schema)
+        qltree = qlparser.parse(source)
+        ir = compiler.compile_ast_to_ir(qltree, self.schema)
 
         path_scope = textwrap.indent(ir.scope_tree.pformat(), '    ')
         expected_scope = textwrap.indent(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -26,6 +26,7 @@ from edb.testbase import lang as tb
 
 from edb import edgeql
 from edb.edgeql import compiler as qlcompiler
+from edb.edgeql import parser as qlparser
 from edb.edgeql import qltypes
 
 from edb.schema import delta as s_delta
@@ -2766,8 +2767,9 @@ class TestDescribe(tb.BaseSchemaLoadTest):
         tests = [iter(tests)] * 2
 
         for stmt_text, expected_output in zip(*tests):
-            stmt = qlcompiler.compile_to_ir(
-                stmt_text,
+            qltree = qlparser.parse(stmt_text, {None: 'test'})
+            stmt = qlcompiler.compile_ast_to_ir(
+                qltree,
                 schema,
                 modaliases={None: 'test'},
             )

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,10 +206,10 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 31.92)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.16)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 58.12)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)
 
     def test_cqa_type_coverage_edgeql_parser(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "parser", 0)
@@ -227,7 +227,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "graphql" / "pygments", 0)
 
     def test_cqa_type_coverage_ir(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "ir", 36.07)
+        self.assertFunctionCoverage(EDB_DIR / "ir", 42.62)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql", 40.96)
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 22.08)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 35.36)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 36.78)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 6.86)


### PR DESCRIPTION
Some adjacent areas are now properly typed as well and minor refactoring
to accomodate some of the typing as well.