### PR TITLE
Add more \l commands.

### DIFF
--- a/edb/repl/utils.py
+++ b/edb/repl/utils.py
@@ -127,17 +127,20 @@ def normalize_name(name: str) -> str:
 
 
 def get_filter_based_on_pattern(pattern: str,
-                                field: str = '.name',
+                                fields: Sequence[str] = ('.name',),
                                 flag: str = '') -> Tuple[str, Dict[str, str]]:
     if flag:
         flag = f'(?{flag})'
 
-    qkw = {}
-
-    if pattern:
-        qkw[f're_{field}'] = flag + pattern
-        return f'FILTER re_test(<str>$`re_{field}`, {field})', qkw
+    if pattern and fields:
+        # the pattern is the same for all fields, so we only use one
+        # variable
+        qkw = {'re_filter': flag + pattern}
+        filters = []
+        for field in fields:
+            filters.append(f're_test(<str>$re_filter, {field})')
+        return f'FILTER {" OR ".join(filters)}', qkw
 
     else:
         # no FILTER clause necessary
-        return '', qkw
+        return '', {}

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -279,30 +279,40 @@ class TestReplUtils(unittest.TestCase):
         self.assertEqual(clause, '')
         self.assertEqual(qkw, {})
 
-        clause, qkw = utils.get_filter_based_on_pattern('', 'name')
+        clause, qkw = utils.get_filter_based_on_pattern('', ['name'])
         self.assertEqual(clause, '')
         self.assertEqual(qkw, {})
 
-        clause, qkw = utils.get_filter_based_on_pattern('', 'name', 'i')
+        clause, qkw = utils.get_filter_based_on_pattern('', ['name'], 'i')
         self.assertEqual(clause, '')
         self.assertEqual(qkw, {})
 
         # actual filters
         clause, qkw = utils.get_filter_based_on_pattern(r'std')
-        self.assertEqual(clause, r'FILTER re_test(<str>$`re_.name`, .name)')
-        self.assertEqual(qkw, {'re_.name': 'std'})
+        self.assertEqual(clause, r'FILTER re_test(<str>$re_filter, .name)')
+        self.assertEqual(qkw, {'re_filter': 'std'})
 
-        clause, qkw = utils.get_filter_based_on_pattern(r'std', 'foo')
-        self.assertEqual(clause, r'FILTER re_test(<str>$`re_foo`, foo)')
-        self.assertEqual(qkw, {'re_foo': 'std'})
+        clause, qkw = utils.get_filter_based_on_pattern(r'std', ['foo'])
+        self.assertEqual(clause, r'FILTER re_test(<str>$re_filter, foo)')
+        self.assertEqual(qkw, {'re_filter': 'std'})
 
-        clause, qkw = utils.get_filter_based_on_pattern(r'std', 'foo', 'i')
-        self.assertEqual(clause, r'FILTER re_test(<str>$`re_foo`, foo)')
-        self.assertEqual(qkw, {'re_foo': '(?i)std'})
+        clause, qkw = utils.get_filter_based_on_pattern(r'std', ['foo'], 'i')
+        self.assertEqual(clause, r'FILTER re_test(<str>$re_filter, foo)')
+        self.assertEqual(qkw, {'re_filter': '(?i)std'})
 
         clause, qkw = utils.get_filter_based_on_pattern(r'\s*\'\w+\'')
-        self.assertEqual(clause, r'FILTER re_test(<str>$`re_.name`, .name)')
-        self.assertEqual(qkw, {'re_.name': r'\s*\'\w+\''})
+        self.assertEqual(clause, r'FILTER re_test(<str>$re_filter, .name)')
+        self.assertEqual(qkw, {'re_filter': r'\s*\'\w+\''})
+
+    def test_repl_filter_pattern_02(self):
+        # no pattern - no filter
+        clause, qkw = utils.get_filter_based_on_pattern(
+            r'foo', ['first_name', 'last_name'])
+        self.assertEqual(
+            clause,
+            r'FILTER re_test(<str>$re_filter, first_name) OR '
+            r're_test(<str>$re_filter, last_name)')
+        self.assertEqual(qkw, {'re_filter': 'foo'})
 
     def _compare_tables(self, tab1: str, tab2: str, max_width: int) -> None:
         # trailing whitespace for each line is ignored in this comparison

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -242,7 +242,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 34.40)
 
     def test_cqa_type_coverage_repl(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "repl", 27.38)
+        self.assertFunctionCoverage(EDB_DIR / "repl", 32.22)
 
     def test_cqa_type_coverage_schema(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "schema", 36.78)


### PR DESCRIPTION
Add `\lc [PATTERN]` command for listing casts, optionally filtered by
affected type names using the specified regexp pattern.
Add `\lcI [PATTERN]` command for case-sensitive pattern matching.

Add `\lt [PATTERN]` command for listing object types, optionally filtered by
name using the specified regexp pattern.
Add `\ltI [PATTERN]` command for case-sensitive pattern matching.

Issue: #179