### PR TITLE
Implement short form of the USING syntax for CREATE FUNCTION

### DIFF
--- a/docs/edgeql/ddl/functions.rst
+++ b/docs/edgeql/ddl/functions.rst
@@ -21,6 +21,10 @@ CREATE FUNCTION
 
     [ WITH <with-item> [, ...] ]
     CREATE FUNCTION <name> ([ <argspec> ] [, ... ]) -> <returnspec>
+    USING ( <expr> );
+
+    [ WITH <with-item> [, ...] ]
+    CREATE FUNCTION <name> ([ <argspec> ] [, ... ]) -> <returnspec>
     USING <language> <functionbody> ;
 
     [ WITH <with-item> [, ...] ]
@@ -45,9 +49,10 @@ CREATE FUNCTION
 
     # where <subcommand> is one of
 
-      SET session_only := {true | false}
-      SET ANNOTATION <annotation-name> := <value>
-      USING <language> <functionbody>
+      SET session_only := {true | false} ;
+      SET ANNOTATION <annotation-name> := <value> ;
+      USING ( <expr> ) ;
+      USING <language> <functionbody> ;
 
 
 Description
@@ -117,14 +122,21 @@ Parameters
     The ``OPTIONAL`` qualifier indicates that the function may return
     an empty set.
 
-:eql:synopsis:`<language>`
-    The name of the language that the function is implemented in.
-    Currently it can only be ``edgeql``.
+:eql:synopsis:`USING ( <expr> )`
+    Specified the body of the function.  :eql:synopsis:`<expr>` is an
+    arbitrary EdgeQL expression.
 
-:eql:synopsis:`<functionbody>`
-    A string constant defining the function.  It is often helpful
-    to use :ref:`dollar quoting <ref_eql_lexical_dollar_quoting>`
-    to write the function definition string.
+:eql:synopsis:`USING <language> <functionbody>`
+    A verbose version of the :eql:synopsis:`USING` clause that allows
+    to specify the language of the function body.
+
+    * :eql:synopsis:`<language>` is the name of the language that
+      the function is implemented in.  Currently can only be ``edgeql``.
+
+    * :eql:synopsis:`<functionbody>` isa  string constant defining
+      the function.  It is often helpful to use
+      :ref:`dollar quoting <ref_eql_lexical_dollar_quoting>`
+      to write the function definition string.
 
 
 Subcommands
@@ -161,17 +173,17 @@ Define a function returning the sum of its arguments:
 .. code-block:: edgeql
 
     CREATE FUNCTION mysum(a: int64, b: int64) -> int64
-    USING edgeql $$
-        SELECT a + b;
-    $$;
+    USING (
+        SELECT a + b
+    );
 
-The same, but using a variadic argument:
+The same, but using a variadic argument and an explicit language:
 
 .. code-block:: edgeql
 
     CREATE FUNCTION mysum(VARIADIC argv: int64) -> int64
     USING edgeql $$
-        SELECT sum(array_unpack(argv));
+        SELECT sum(array_unpack(argv))
     $$;
 
 Define a function using the block syntax:
@@ -179,9 +191,9 @@ Define a function using the block syntax:
 .. code-block:: edgeql
 
     CREATE FUNCTION mysum(a: int64, b: int64) -> int64 {
-        USING edgeql $$
-            SELECT a + b;
-        $$;
+        USING (
+            SELECT a + b
+        );
         SET ANNOTATION title := "My sum function.";
     };
 

--- a/docs/edgeql/sdl/functions.rst
+++ b/docs/edgeql/sdl/functions.rst
@@ -31,12 +31,16 @@ commands <ref_eql_ddl_functions>`.
 .. sdl:synopsis::
 
     function <name> ([ <argspec> ] [, ... ]) -> <returnspec>
+    using ( <edgeql> );
+
+    function <name> ([ <argspec> ] [, ... ]) -> <returnspec>
     using <language> <functionbody> ;
 
     function <name> ([ <argspec> ] [, ... ]) -> <returnspec>
     "{"
         session_only := {true | false} ;
         [ <annotation-declarations> ]
+        using ( <expr> ) ;
         using <language> <functionbody> ;
     "}" ;
 

--- a/edb/common/devmode.py
+++ b/edb/common/devmode.py
@@ -169,7 +169,7 @@ def hash_dirs(dirs: Tuple[str, str]) -> bytes:
     for dirname, ext in dirs:
         hash_dir(dirname, ext, paths)
 
-    h = hashlib.md5()
+    h = hashlib.sha1()  # sha1 is the fastest one.
     for path in sorted(paths):
         with open(path, 'rb') as f:
             h.update(f.read())

--- a/edb/common/uuidgen.py
+++ b/edb/common/uuidgen.py
@@ -42,12 +42,6 @@ def uuid1mc() -> uuid.UUID:
 # called `hex` which is not something that pgproto.UUID supports.
 
 
-def uuid3(namespace: uuid.UUID, name: str) -> uuid.UUID:
-    """Generate a UUID from the MD5 hash of a namespace UUID and a name."""
-    hash = hashlib.md5(namespace.bytes + bytes(name, "utf-8")).digest()
-    return UUID(hash[:16])  # type: ignore
-
-
 def uuid4() -> uuid.UUID:
     """Generate a random UUID."""
     return UUID(os.urandom(16))  # type: ignore

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1437,6 +1437,10 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                     from_clause = from_clause.lower()
                 self.write(from_clause)
                 self.write(f'{node.code.from_function!r}')
+            elif node.code.language is qlast.Language.EdgeQL:
+                assert node.code.code
+                self._write_keywords('USING')
+                self.write(f' ({node.code.code})')
             else:
                 from_clause = f'USING {node.code.language} '
                 if self.sdlmode:

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -284,6 +284,20 @@ class FunctionType(Nonterm):
 
 
 class FromFunction(Nonterm):
+    def reduce_USING_ParenExpr(self, *kids):
+        lang = qlast.Language.EdgeQL
+
+        # Now that we know that we were able to parse the expression
+        # inside "USING (...)", we want to get the original text of it.
+        # Sadly we have to discard the parsed AST as there's no way we
+        # can pass it to the schema constructor yet.
+        ctx = kids[1].context
+        code = ctx.buffer[ctx.start.pointer + 1:ctx.end.pointer - 1]
+
+        self.val = qlast.FunctionCode(
+            language=lang,
+            code=code)
+
     def reduce_USING_Identifier_BaseStringConstant(self, *kids):
         lang = _parse_language(kids[1])
         code = kids[2].val.value

--- a/edb/lib/stdgraphql.edgeql
+++ b/edb/lib/stdgraphql.edgeql
@@ -35,11 +35,11 @@ ALTER TYPE stdgraphql::Mutation {
 
 CREATE FUNCTION stdgraphql::short_name(name: str) -> str {
     SET volatility := 'IMMUTABLE';
-    USING EdgeQL $$
+    USING (
         SELECT (
             name[5:] IF name LIKE 'std::%' ELSE
             name[9:] IF name LIKE 'default::%' ELSE
             re_replace(r'(.+?)::(.+$)', r'\1__\2', name)
         ) ++ 'Type'
-    $$;
+    );
 };

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -153,13 +153,13 @@ sys::get_version() -> tuple<major: std::int64,
 {
     # This function reads external data.
     SET volatility := 'VOLATILE';
-    using EdgeQL $$
-    SELECT <tuple<major: std::int64,
-                  minor: std::int64,
-                  stage: sys::version_stage,
-                  stage_no: std::int64,
-                  local: array<std::str>>>sys::__version_internal()
-    $$;
+    USING (
+        SELECT <tuple<major: std::int64,
+                    minor: std::int64,
+                    stage: sys::version_stage,
+                    stage_no: std::int64,
+                    local: array<std::str>>>sys::__version_internal()
+    );
 };
 
 
@@ -168,17 +168,17 @@ sys::get_version_as_str() -> std::str
 {
     # This function reads external data.
     SET volatility := 'VOLATILE';
-    using EdgeQL $$
-    WITH v := sys::get_version()
-    SELECT
-        <str>v.major
-        ++ '.' ++ <str>v.minor
-        ++ ('-' ++ <str>v.stage
-            ++ '.' ++ <str>v.stage_no
-            ++ ('+' ++ std::to_str(v.local, '.')
-                IF len(v.local) > 0 ELSE '')
-        ) IF v.stage != <sys::version_stage>'final' ELSE ''
-    $$;
+    USING (
+        WITH v := sys::get_version()
+        SELECT
+            <str>v.major
+            ++ '.' ++ <str>v.minor
+            ++ ('-' ++ <str>v.stage
+                ++ '.' ++ <str>v.stage_no
+                ++ ('+' ++ std::to_str(v.local, '.')
+                    IF len(v.local) > 0 ELSE '')
+            ) IF v.stage != <sys::version_stage>'final' ELSE ''
+    );
 };
 
 

--- a/edb/pgsql/dbops/base.py
+++ b/edb/pgsql/dbops/base.py
@@ -19,9 +19,7 @@
 
 from __future__ import annotations
 
-import base64
 import collections
-import hashlib
 import numbers
 import textwrap
 from typing import *  # NoQA
@@ -59,17 +57,6 @@ def encode_value(val: Any) -> str:
         val = str(val)
 
     return val
-
-
-def pack_name(name, prefix_length=0):
-    """Pack a potentially long name into Postgres' 63 char limit."""
-    name = str(name)
-    if len(name) > 63 - prefix_length:
-        hash = base64.b64encode(hashlib.md5(name.encode()).digest()).decode(
-        ).rstrip('=')
-        name = name[:prefix_length] + hash + ':' + name[-(
-            63 - prefix_length - 1 - len(hash)):]
-    return name
 
 
 class PLExpression(str):

--- a/edb/pgsql/dbops/indexes.py
+++ b/edb/pgsql/dbops/indexes.py
@@ -26,6 +26,7 @@ from typing import *  # NoQA
 from edb.common import ordered
 from edb.server import defines
 
+from .. import common
 from ..common import qname as qn
 from ..common import quote_ident as qi
 from ..common import quote_literal as ql
@@ -82,7 +83,8 @@ class Index(tables.InheritableTableObject):
 
     @property
     def name_in_catalog(self):
-        return base.pack_name(self.table_name[1] + '__' + self.name)
+        return common.edgedb_name_to_pg_name(
+            self.table_name[1] + '__' + self.name)
 
     def add_columns(self, columns):
         for col in columns:

--- a/edb/schema/std.py
+++ b/edb/schema/std.py
@@ -28,6 +28,7 @@ from edb import errors
 from edb import edgeql
 from edb import schema
 from edb.edgeql import compiler as qlcompiler
+from edb.edgeql import parser as qlparser
 from edb.schema import delta as s_delta
 
 from . import ddl as s_ddl
@@ -37,10 +38,12 @@ from . import schema as s_schema
 SCHEMA_ROOT = pathlib.Path(schema.__path__[0])
 LIB_ROOT = pathlib.Path(stdlib.__path__[0])
 QL_COMPILER_ROOT = pathlib.Path(qlcompiler.__path__[0])
+QL_PARSER_ROOT = pathlib.Path(qlparser.__path__[0])
 
 CACHE_SRC_DIRS = (
     (SCHEMA_ROOT, '.py'),
     (QL_COMPILER_ROOT, '.py'),
+    (QL_PARSER_ROOT, '.py'),
     (LIB_ROOT, '.edgeql'),
 )
 

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -34,9 +34,9 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 NAMED ONLY suffix: str = '-suf',
                 NAMED ONLY prefix: str = 'pref-'
             ) -> std::str
-                USING EdgeQL $$
-                    SELECT prefix ++ s ++ <str>sum(array_unpack(a)) ++ suffix;
-                $$;
+                USING (
+                    SELECT prefix ++ s ++ <str>sum(array_unpack(a)) ++ suffix
+                );
         ''')
 
         await self.assert_query_result(
@@ -101,10 +101,11 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
         await self.con.execute('''
             CREATE FUNCTION test::call2(
                 VARIADIC a: anytype
-            ) -> std::str
-                USING EdgeQL $$
+            ) -> std::str {
+                USING (
                     SELECT '=' ++ <str>len(a) ++ '='
-                $$;
+                );
+            }
         ''')
 
         await self.assert_query_result(

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -1283,7 +1283,7 @@ class TestIntrospection(tb.QueryTestCase):
         async with self.con.transaction():
             await self.con.execute(r'''
                 CREATE FUNCTION bad() -> str
-                    USING EdgeQL $$ SELECT r'\1' $$;
+                    USING ( SELECT r'\1' );
             ''')
 
             desc = await self.con.fetchone('''
@@ -1293,5 +1293,5 @@ class TestIntrospection(tb.QueryTestCase):
         self.assertEqual(
             desc,
             r"function default::bad() ->  std::str "
-            r"using edgeql $$ SELECT r'\1' $$;"
+            r"using ( SELECT r'\1' );"
         )

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3091,13 +3091,13 @@ aa';
     def test_edgeql_syntax_ddl_function_11(self):
         """
         CREATE FUNCTION no_params() -> std::int64
-        USING EdgeQL $$ SELECT 1 $$;
+        USING ( SELECT 1 );
         """
 
     def test_edgeql_syntax_ddl_function_13(self):
         """
         CREATE FUNCTION foo(string: std::str) -> tuple<bar: std::int64>
-        USING EDGEQL $$ SELECT (bar := 123) $$;
+        USING (SELECT (bar := 123));
         """
 
     def test_edgeql_syntax_ddl_function_14(self):
@@ -3106,7 +3106,7 @@ aa';
         -> tuple<
             bar: std::int64,
             baz: std::str
-        > USING EdgeQL $$ SELECT smth() $$;
+        > USING (SELECT smth());
         """
     @tb.must_fail(errors.EdgeQLSyntaxError,
                   "AAA is not a valid language", line=3)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -324,9 +324,9 @@ _123456789_123456789_123456789 -> str
         schema = self.run_ddl(schema, '''
             CREATE FUNCTION
             test::my_contains(arr: array<anytype>, val: anytype) -> bool {
-                USING edgeql $$
-                    SELECT contains(arr, val);
-                $$;
+                USING (
+                    SELECT contains(arr, val)
+                );
             };
 
             CREATE ABSTRACT CONSTRAINT
@@ -798,12 +798,12 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             function get_ingredients(
                 recipe: Recipe
             ) -> tuple<name: str, quantity: decimal> {
-                using edgeql $$
+                using (
                     SELECT (
                         name := recipe.ingredients.name,
                         quantity := recipe.ingredients.quantity,
-                    );
-                $$
+                    )
+                )
             }
         '''
 
@@ -1898,14 +1898,14 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
     def test_migrations_equivalence_function_01(self):
         self._assert_migration_equivalence([r"""
             function hello01(a: int64) -> str
-                using edgeql $$
+                using (
                     SELECT 'hello' ++ <str>a
-                $$
+                )
         """, r"""
             function hello01(a: int64, b: int64=42) -> str
-                using edgeql $$
+                using (
                     SELECT 'hello' ++ <str>(a + b)
-                $$
+                )
         """])
 
     def test_migrations_equivalence_function_06(self):
@@ -1923,9 +1923,9 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """, r"""
             function hello06(a: int64) -> array<int64>
-                using edgeql $$
+                using (
                     SELECT [a]
-                $$;
+                );
 
             type Base {
                 property foo -> int64 {
@@ -1950,9 +1950,9 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """, r"""
             function hello10(a: int64) -> array<int64>
-                using edgeql $$
+                using (
                     SELECT [a]
-                $$;
+                );
 
             type Base {
                 required property foo -> int64 {
@@ -1971,9 +1971,9 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         """, r"""
             # replace the function with a new one by the same name
             function hello11(a: str) -> str
-                using edgeql $$
+                using (
                     SELECT 'hello' ++ a
-                $$
+                )
         """])
 
     def test_migrations_equivalence_function_12(self):
@@ -1984,15 +1984,15 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                 $$;
         """, r"""
             function hello12(a: int64) -> str
-                using edgeql $$
+                using (
                     SELECT 'hello' ++ <str>a
-                $$;
+                );
 
             # make the function polymorphic
             function hello12(a: str) -> str
-                using edgeql $$
+                using (
                     SELECT 'hello' ++ a
-                $$;
+                );
         """])
 
     def test_migrations_equivalence_function_13(self):
@@ -2011,39 +2011,39 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         """, r"""
             # remove one of the 2 versions
             function hello13(a: int64) -> str
-                using edgeql $$
+                using (
                     SELECT 'hello' ++ <str>a
-                $$;
+                );
         """])
 
     def test_migrations_equivalence_function_14(self):
         self._assert_migration_equivalence([r"""
             function hello14(a: str, b: str) -> str
-                using edgeql $$
+                using (
                     SELECT a ++ b
-                $$
+                )
         """, r"""
             # Replace the function with a new one by the same name,
             # but working with arrays.
             function hello14(a: array<str>, b: array<str>) -> array<str>
-                using edgeql $$
+                using (
                     SELECT a ++ b
-                $$
+                )
         """])
 
     def test_migrations_equivalence_function_15(self):
         self._assert_migration_equivalence([r"""
             function hello15(a: str, b: str) -> str
-                using edgeql $$
+                using (
                     SELECT a ++ b
-                $$
+                )
         """, r"""
             # Replace the function with a new one by the same name,
             # but working with arrays.
             function hello15(a: tuple<str, str>) -> str
-                using edgeql $$
+                using (
                     SELECT a.0 ++ a.1
-                $$
+                )
         """])
 
     def test_migrations_equivalence_linkprops_03(self):
@@ -2912,13 +2912,13 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             r"""
             function stdgraphql::short_name(name: std::str) -> std::str {
                 volatility := 'IMMUTABLE';
-                using edgeql $$
+                using (
                     SELECT (
                         name[5:] IF name LIKE 'std::%' ELSE
                         name[9:] IF name LIKE 'default::%' ELSE
                         re_replace(r'(.+?)::(.+$)', r'\1__\2', name)
                     ) ++ 'Type'
-                $$
+                )
             ;};
             """,
         )

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -962,9 +962,9 @@ abstract property foo {
     def test_eschema_syntax_function_03(self):
         r"""
         function some_func(foo: std::int64 = 42) -> std::str
-            using edgeql $$
-                SELECT 'life';
-            $$;
+            using (
+                SELECT 'life'
+            );
         """
 
     def test_eschema_syntax_function_04(self):
@@ -984,18 +984,18 @@ abstract property foo {
                         variadic arg3: std::int64,
                         named only arg4: std::int64,
                         named only arg5: std::int64) -> set of int
-            using edgeql $$
+            using (
                 SELECT blarg
-            $$;
+            );
         """
 
     def test_eschema_syntax_function_06(self):
         """
         function some_func(foo: std::int64 = 42) -> std::str {
             initial_value := 'bad';
-            using edgeql $$
+            using (
                 SELECT 'life'
-            $$;
+            );
         };
         """
 

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -197,7 +197,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "cli", 0)
 
     def test_cqa_type_coverage_common(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "common", 23.80)
+        self.assertFunctionCoverage(EDB_DIR / "common", 23.65)
 
     def test_cqa_type_coverage_common_ast(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "common" / "ast", 7.25)
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 42.62)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 40.96)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.05)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)
@@ -239,7 +239,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "datasources", 48.39)
 
     def test_cqa_type_coverage_pgsql_dbops(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 34.40)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 34.48)
 
     def test_cqa_type_coverage_repl(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "repl", 21.05)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.16)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.12)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
Now functions can be defined in the same syntax as constraints.

A longer form of the USING syntax is also implemented in anticipation of
EdgePL.