### PR TITLE
Make profiling tests quiet

### DIFF
--- a/edb/tools/profiling.py
+++ b/edb/tools/profiling.py
@@ -149,6 +149,7 @@ class profile:
         sort_by: str = "",
         width: int = 1920,
         threshold: float = 0.0001,  # 1.0 is 100%
+        quiet: bool = False,
     ) -> Tuple[int, int]:
         """Read all pstats in `self.dir` and write a summary to `out_path`.
 
@@ -163,6 +164,9 @@ class profile:
         Returns a tuple with number of successfully and unsucessfully
         aggregated files.
         """
+        if quiet:
+            print = lambda *args, **kwargs: None
+
         if not self.dir:
             with tempfile.NamedTemporaryFile() as tmp:
                 directory = pathlib.Path(tmp.name).parent

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -74,7 +74,9 @@ class ProfilingTestCase(unittest.TestCase):
 
         # aggregate the results
         out_file = ptest_files[0].with_suffix(".pstats")
-        success, failure = profiler.aggregate(out_file, sort_by="cumulative")
+        success, failure = profiler.aggregate(
+            out_file, sort_by="cumulative", quiet=True
+        )
 
         self.assertEqual(success, 1)
         self.assertEqual(failure, 0)


### PR DESCRIPTION
This is a trivial change. Some output was visible during tests when `--output-format=simple` was used. This is no longer the case after this change.

Fixes #874