### PR TITLE
doc: Fixes Map -> Headers, byte[16] -> uuid

### DIFF
--- a/docs/internals/protocol/messages.rst
+++ b/docs/internals/protocol/messages.rst
@@ -229,7 +229,7 @@ Format:
         int32   message_length;
 
         // A set of message headers.
-        Map     headers;
+        Headers     headers;
 
         // Command status.
         bytes   status_data;
@@ -371,13 +371,13 @@ Format:
         int8<Cardinality> result_cardinality;
 
         // Argument data descriptor ID.
-        byte              input_typedesc_id[16];
+        uuid              input_typedesc_id;
 
         // Argument data descriptor.
         bytes             input_typedesc;
 
         // Output data descriptor ID.
-        byte              output_typedesc_id[16];
+        uuid              output_typedesc_id;
 
         // Output data descriptor.
         bytes             output_typedesc;
@@ -497,10 +497,10 @@ Format:
         string              command_text;
 
         // Argument data descriptor ID.
-        byte                input_typedesc_id[16];
+        uuid                input_typedesc_id;
 
         // Output data descriptor ID.
-        byte                output_typedesc_id[16];
+        uuid                output_typedesc_id;
 
         // Encoded argument data.
         bytes               arguments;
@@ -614,16 +614,16 @@ Format:
         int32               message_length;
 
         // A set of message headers.
-        Map                 headers;
+        Headers             headers;
 
         // Result cardinality
         int8<Cardinality>   cardinality;
 
         // Argument data descriptor ID.
-        byte                input_typedesc_id[16];
+        uuid                input_typedesc_id;
 
         // Output data descriptor ID.
-        byte                output_typedesc_id[16];
+        uuid                output_typedesc_id;
     };
 
     enum Cardinality {

--- a/docs/internals/protocol/overview.rst
+++ b/docs/internals/protocol/overview.rst
@@ -52,6 +52,10 @@ The following data types are used in the descriptions:
                int16  key;
                bytes  value;
            };
+    * - ``uuid``
+      - a simple array of 16 bytes with no length prefix, equivalent to
+        ``byte[16]``
+
 
 
 Message Format


### PR DESCRIPTION
`Map` is probably some legacy it isn't defined anywhere.

`byte[16]` where used as type descriptor id makes it more clear that it
refers to a type in type description array (or list of blocks). We use
uuid in type descriptor docs anyway.