### PR TITLE
Raise an error if a view defined in WITH is unused

### DIFF
--- a/docs/edgeql/statements/with.rst
+++ b/docs/edgeql/statements/with.rst
@@ -3,13 +3,11 @@
 WITH block
 ==========
 
-:index: cardinality alias module view detached
+:index: alias module view detached
 
 .. eql:keyword:: WITH
 
     The ``WITH`` block in EdgeQL is used to define aliases.
-
-    .. XXX: not just for aliases! e.g. WITH CARDINALITY
 
     In case of aliased expressions, those expressions are evaluated in
     the lexical scope they appear in, not the scope where their alias
@@ -85,20 +83,24 @@ Another use case is for giving short aliases to long module names
     FILTER .name = fbz::Baz.name;
 
 
-Expressions
-+++++++++++
+Ad-hoc Views
+++++++++++++
 
-It is possible to define an alias for some expression. The aliased set
-behaves as a completely independent set of a given name. The contents
-of the set are determined by the expression at the point where the
-alias is defined. In terms of scope, the aliased expression in the
-``WITH`` block is in a sibling scope to the rest of the query.
+It is possible to define an ad-hoc view for some expression. The result
+set of a view expression behaves as a completely independent set of a
+given name. The contents of the set are determined by the expression
+at the point where the view is defined. In terms of scope, the view
+expression in the ``WITH`` block is in a sibling scope to the rest
+of the query.
 
 It may be useful to factor out a common sub-expression from a larger
 complex query. This can be done by assigning the sub-expression a new
 symbol in the ``WITH`` block. However, care must be taken to ensure
 that this refactoring doesn't alter the meaning of the expression due
 to scope change.
+
+All views defined in a ``WITH`` block must be referenced in the main
+part of the query.
 
 .. code-block:: edgeql
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -306,6 +306,9 @@ class ContextLevel(compiler.ContextLevel):
     aliased_views: ChainMap[str, Optional[s_types.Type]]
     """A dictionary of views aliased in a statement body."""
 
+    must_use_views: Dict[s_types.Type, Tuple[str, parsing.ParserContext]]
+    """A set of views that *must* be used in an expression."""
+
     expr_view_cache: Dict[Tuple[qlast.Base, str], irast.Set]
     """Type cache used by expression-level views."""
 
@@ -424,6 +427,7 @@ class ContextLevel(compiler.ContextLevel):
             self.view_nodes = {}
             self.view_sets = {}
             self.aliased_views = collections.ChainMap()
+            self.must_use_views = {}
             self.expr_view_cache = {}
             self.shape_type_cache = {}
             self.class_view_overrides = {}
@@ -465,6 +469,7 @@ class ContextLevel(compiler.ContextLevel):
             self.source_map = prevlevel.source_map
             self.view_nodes = prevlevel.view_nodes
             self.view_sets = prevlevel.view_sets
+            self.must_use_views = prevlevel.must_use_views
             self.expr_view_cache = prevlevel.expr_view_cache
             self.shape_type_cache = prevlevel.shape_type_cache
 

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -75,6 +75,7 @@ def get_schema_object(
     elif isinstance(name, str):
         view = ctx.aliased_views.get(name)
         if view is not None:
+            ctx.must_use_views.pop(view, None)
             return view
 
     try:
@@ -92,6 +93,7 @@ def get_schema_object(
 
     view = ctx.aliased_views.get(stype.get_name(ctx.env.schema))
     if view is not None:
+        ctx.must_use_views.pop(view, None)
         return view
     else:
         return stype

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -611,7 +611,10 @@ def process_with_block(
             with ctx.new() as scopectx:
                 scopectx.expr_exposed = False
                 stmtctx.declare_view(
-                    with_entry.expr, with_entry.alias, ctx=scopectx)
+                    with_entry.expr,
+                    with_entry.alias,
+                    must_be_used=True,
+                    ctx=scopectx)
 
         else:
             raise RuntimeError(

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -39,6 +39,7 @@ class ParameterInliner(ast.NodeTransformer):
     def visit_Path(self, node: qlast.Path) -> qlast.Base:
         if (len(node.steps) != 1 or
                 not isinstance(node.steps[0], qlast.ObjectRef)):
+            self.visit(node.steps[0])
             return node
 
         ref: qlast.ObjectRef = node.steps[0]

--- a/tests/test_edgeql_linkatoms.py
+++ b/tests/test_edgeql_linkatoms.py
@@ -695,8 +695,7 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             r'''
                 # just a simple unpack
                 WITH
-                    MODULE test,
-                    I2 := Item
+                    MODULE test
                 SELECT Item {
                     name,
                     unpack := (SELECT array_unpack(Item.tag_array))
@@ -737,8 +736,7 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             r'''
                 # just a simple unpack
                 WITH
-                    MODULE test,
-                    I2 := Item
+                    MODULE test
                 SELECT Item {
                     name,
                     unpack := array_unpack(Item.tag_array)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -332,8 +332,10 @@ _123456789_123456789_123456789 -> str
             CREATE ABSTRACT CONSTRAINT
             test::my_one_of(one_of: array<anytype>) {
                 USING (
-                    WITH foo := test::Object1
-                    SELECT test::my_contains(one_of, __subject__)
+                    SELECT (
+                        test::my_contains(one_of, __subject__),
+                        test::Object1,
+                    ).0
                 );
             };
 


### PR DESCRIPTION
The `WITH` block contains pure definitions, i.e. the expressions there
are not actually executed unless referenced in the main part of the
query.  To avoid possible confusion, especially when DML is involved,
require all defined views to actually be referenced.

Fixes: #871.