### PR TITLE
Fix DESCRIBE command bug.

### DIFF
--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -258,8 +258,8 @@ ALTER TYPE schema::Link {
 
 
 ALTER TYPE schema::ObjectType {
-    CREATE LINK links := .pointers[IS schema::Link];
-    CREATE LINK properties := .pointers[IS schema::Property];
+    CREATE MULTI LINK links := .pointers[IS schema::Link];
+    CREATE MULTI LINK properties := .pointers[IS schema::Property];
 };
 
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -423,6 +423,16 @@ class Pointer(referencing.ReferencedInheritingObject,
         else:
             return self.is_exclusive(schema)
 
+    def get_implicit_bases(self, schema: s_schema.Schema) -> List[Pointer]:
+        bases = super().get_implicit_bases(schema)
+
+        # True implicit bases for pointers will have a different source.
+        my_source = self.get_source(schema)
+        return [
+            b for b in bases
+            if b.get_source(schema) != my_source
+        ]
+
 
 class PseudoPointer(s_abc.Pointer):
     # An abstract base class for pointer-like objects, i.e.

--- a/edb/schema/std.py
+++ b/edb/schema/std.py
@@ -78,9 +78,6 @@ def load_std_module(
         schema: s_schema.Schema, modname: str) -> s_schema.Schema:
 
     modaliases = {}
-    if modname == 'std':
-        modaliases[None] = 'std'
-
     context = s_delta.CommandContext()
     context.stdmode = True
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -256,7 +256,7 @@ async def _make_stdlib(testmode: bool):
 
     for ddl_cmd in edgeql.parse_block(ddl_text):
         delta_command = s_ddl.delta_from_ddl(
-            ddl_cmd, schema=schema, modaliases={None: 'std'}, stdmode=True)
+            ddl_cmd, modaliases={}, schema=schema, stdmode=True)
 
         if debug.flags.delta_plan_input:
             debug.header('Delta Plan Input')

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 32.22)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 36.78)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 36.85)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 6.86)


### PR DESCRIPTION
Fix a bug with `DESCRIBE` of `schema::ObjectType` where
`links` and `properties` computable links were incorrectly displayed.