### PR TITLE
Work around atexit not running in workers

### DIFF
--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -48,7 +48,7 @@ class ProfilingTestCase(unittest.TestCase):
 
     def _inner_basic(self, dir: str, atexit: FakeAtexit) -> None:
         profiler = profiling.profile(
-            dir=dir, prefix="test_", suffix=".ptest", reuse=True
+            dir=dir, prefix="test_", suffix=".ptest", save_every_n_calls=100
         )
 
         @profiler

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -292,7 +292,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "testbase", 0)
 
     def test_cqa_type_coverage_tools(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "tools", 16.92)
+        self.assertFunctionCoverage(EDB_DIR / "tools", 17.41)
 
     def test_cqa_type_coverage_tools_docs(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "tools" / "docs", 0)


### PR DESCRIPTION
Workers are often closed with `proc.kill()` or `proc.terminate()` which
prevents them from running atexit handlers.  Profiling in those circumstances
when `reuse=True` was used was missing a significant chunks of traces.

The workaround is to always use the same profiler object and file, and to save
every n-th call (those saves significantly slow down responsiveness otherwise).