### PR TITLE
Add an explicit database instance compatibility check

### DIFF
--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -26,6 +26,9 @@ EDGEDB_SUPERUSER_DB = 'edgedb'
 EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
+# Increment this whenever the database layout or stdlib changes.
+EDGEDB_CATALOG_VERSION = 20191127
+
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs
 # is 256, which is low and can cause 'edb test' to hang.

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -248,7 +248,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "schema", 36.85)
 
     def test_cqa_type_coverage_server(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server", 6.86)
+        self.assertFunctionCoverage(EDB_DIR / "server", 7.09)
 
     def test_cqa_type_coverage_server_cache(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "cache", 0)


### PR DESCRIPTION
EdgeDB now checks whether a given database instance is compatible with
the currently running version of the server.  There are two checks:
major version (which is implied to be incompatible), and an additional
"format version" check which is intended to protect from incompatible
changes happening during development.

Fixes: #884.