### PR TITLE
A couple of fixes

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -195,7 +195,7 @@ class BaseObjectRef(Base):
 class ObjectRef(BaseObjectRef):
     name: str
     module: str
-    itemclass: qltypes.SchemaObjectClass
+    itemclass: typing.Optional[qltypes.SchemaObjectClass]
 
 
 class PseudoObjectRef(BaseObjectRef):

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -426,7 +426,7 @@ def compile_DescribeStmt(
             if itemclass is qltypes.SchemaObjectClass.MODULE:
                 modules.append(objref.name)
             else:
-                itemtypes = None
+                itemtypes: Tuple[s_obj.ObjectMeta, ...] = ()
                 found = False
 
                 name: str

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -34,7 +34,6 @@ from . import constraints
 from . import delta as sd
 from . import expr
 from . import inheriting
-from . import name as sn
 from . import objects as so
 from . import types as s_types
 
@@ -56,41 +55,6 @@ class ScalarType(s_types.Type, constraints.ConsistencySubject,
     @classmethod
     def get_schema_class_displayname(cls):
         return 'scalar type'
-
-    def _get_deps(self, schema):
-        deps = super()._get_deps(schema)
-
-        consts = self.get_constraints(schema)
-        if consts:
-            N = sn.Name
-
-            # Add dependency on all built-in scalars unconditionally
-            deps.add(N(module='std', name='str'))
-            deps.add(N(module='std', name='bytes'))
-            deps.add(N(module='std', name='int16'))
-            deps.add(N(module='std', name='int32'))
-            deps.add(N(module='std', name='int64'))
-            deps.add(N(module='std', name='float32'))
-            deps.add(N(module='std', name='float64'))
-            deps.add(N(module='std', name='decimal'))
-            deps.add(N(module='std', name='bool'))
-            deps.add(N(module='std', name='uuid'))
-
-            for constraint in consts.objects(schema):
-                c_params = constraint.get_params(schema).objects(schema)
-                ptypes = [p.get_type(schema) for p in c_params]
-                if ptypes:
-                    for ptype in ptypes:
-                        if isinstance(ptype, s_abc.Collection):
-                            subtypes = ptype.get_subtypes(schema)
-                        else:
-                            subtypes = [ptype]
-
-                        for subtype in subtypes:
-                            if subtype is not self:
-                                deps.add(subtype.get_name(schema))
-
-        return deps
 
     def is_scalar(self):
         return True

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3201,44 +3201,25 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             'DESCRIBE TYPE schema::ObjectType',
 
-            [
-                # the links order is non-deterministic
-                """
-                CREATE TYPE schema::ObjectType
-                EXTENDING schema::BaseObjectType {
-                    CREATE MULTI LINK links :=
-                        (.pointers[IS schema::Link]);
-                    CREATE MULTI LINK properties :=
-                        (.pointers[IS schema::Property]);
-                };
-                """,
-                """
-                CREATE TYPE schema::ObjectType
-                EXTENDING schema::BaseObjectType {
-                    CREATE MULTI LINK properties :=
-                        (.pointers[IS schema::Property]);
-                    CREATE MULTI LINK links :=
-                        (.pointers[IS schema::Link]);
-                };
-                """,
-            ],
+            # the links order is non-deterministic
+            """
+            CREATE TYPE schema::ObjectType
+            EXTENDING schema::BaseObjectType {
+                CREATE MULTI LINK links :=
+                    (.pointers[IS schema::Link]);
+                CREATE MULTI LINK properties :=
+                    (.pointers[IS schema::Property]);
+            };
+            """,
 
             'DESCRIBE TYPE schema::ObjectType AS SDL',
 
-            [
-                """
-                type schema::ObjectType extending schema::BaseObjectType {
-                    multi link links := (.pointers[IS schema::Link]);
-                    multi link properties := (.pointers[IS schema::Property]);
-                };
-                """,
-                """
-                type schema::ObjectType extending schema::BaseObjectType {
-                    multi link properties := (.pointers[IS schema::Property]);
-                    multi link links := (.pointers[IS schema::Link]);
-                };
-                """,
-            ],
+            """
+            type schema::ObjectType extending schema::BaseObjectType {
+                multi link links := (.pointers[IS schema::Link]);
+                multi link properties := (.pointers[IS schema::Property]);
+            };
+            """,
         )
 
     def test_describe_bad_01(self):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3240,3 +3240,17 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 """,
             ],
         )
+
+    def test_describe_bad_01(self):
+        with self.assertRaisesRegex(
+            errors.InvalidReferenceError,
+            "schema item 'std::Tuple' does not exist",
+        ):
+            self._assert_describe(
+                """
+                """,
+
+                'DESCRIBE OBJECT std::Tuple',
+
+                '',
+            )

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 32.22)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 36.85)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 36.82)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 6.86)


### PR DESCRIPTION
Make DESCRIBE deterministic

There are currently some remnants of the old clunky dependency sorting that
are a) no longer necessary, and b) make the order of commands in schema
deltas nondeterministic, which, in turn, makes
`DESCRIBE .. AS DDL` nondeterministic.  Fix this by removing the 
unnecessary bits.

Fix a case of invalid argument passed to schema.get()

An incorrect type annotation led to one spot, where `None` was being passed
for the list of schema class filters instead of a tuple.