### PR TITLE
Improve wording on message fragmentation

### DIFF
--- a/docs/internals/protocol/overview.rst
+++ b/docs/internals/protocol/overview.rst
@@ -75,7 +75,7 @@ The server and the client *MUST* not fragment messages. I.e the complete
 message must be sent before starting a new message. It's advised that whole
 message should be buffered before initiating a network call (but this
 requirement is neither observable nor enforceable at the other side). It's
-also common to buffer whole message on receiver before starting to process
+also common to buffer the whole message on receiver before starting to process
 it.
 
 Errors

--- a/docs/internals/protocol/overview.rst
+++ b/docs/internals/protocol/overview.rst
@@ -71,11 +71,12 @@ All messages in the EdgeDB wire protocol have the following format:
         int8  payload[payload_length - 4];
     };
 
-The server and the client *MUST* always send a complete message, i.e. the
-entire message must be buffered before initiating a network call.  Conversely,
-when receiving a message, the recipient *SHOULD* buffer the incoming message
-before processing it.
-
+The server and the client *MUST* not fragment messages. I.e the complete
+message must be sent before starting a new message. It's advised that whole
+message should be buffered before initiating a network call (but this
+requirement is neither observable nor enforceable at the other side). It's
+also common to buffer whole message on receiver before starting to process
+it.
 
 Errors
 ======


### PR DESCRIPTION
The requirement that messages should be buffered as a whole is neither
enforcable nor observable nor strictly necessary.