### PR TITLE
Assorted fixes to the DESCRIBE command

### DIFF
--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -720,10 +720,15 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         if self.limit_ref_classes:
             commands = [
                 c for c in commands
-                # Command names are ObjectRefs unless it's `SET expr`,
-                # but we want to keep `SET expr`.
-                if ((isinstance(c, qlast.SetSpecialField) and c.name == 'expr')
-                    or (c.name.itemclass in self.limit_ref_classes))
+                # If c.name is an ObjectRef we want to check if the
+                # property in in the white list;
+                # if it's not, then it's a regular SetField for things
+                # like 'default' or 'readonly'.
+                if (
+                    (isinstance(c.name, qlast.ObjectRef)
+                        and c.name.itemclass in self.limit_ref_classes)
+                    or not isinstance(c.name, qlast.ObjectRef)
+                )
             ]
 
         if len(commands) == 1 and allow_short:

--- a/edb/pgsql/datasources/schema/indexes.py
+++ b/edb/pgsql/datasources/schema/indexes.py
@@ -31,7 +31,10 @@ async def fetch(
     return await conn.fetch("""
         SELECT
                 i.id            AS id,
-                i.bases         AS bases,
+                edgedb._resolve_type_name(i.bases)
+                                AS bases,
+                edgedb._resolve_type_name(i.ancestors)
+                                AS ancestors,
                 i.name          AS name,
                 i.expr          AS expr,
                 i.origexpr      AS origexpr,

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -580,6 +580,8 @@ class IntrospectionMech:
             self.connection, modules=only_modules,
             exclude_modules=exclude_modules)
 
+        basemap = {}
+
         for index_data in indexes:
             subj = schema.get(index_data['subject_name'])
             subj_table_name = common.get_backend_name(
@@ -610,6 +612,12 @@ class IntrospectionMech:
                 expr=self.unpack_expr(index_data['expr'], schema))
 
             schema = subj.add_index(schema, index)
+
+            basemap[index] = (index_data['bases'], index_data['ancestors'])
+
+        for scls, (basenames, ancestors) in basemap.items():
+            schema = self._set_reflist(schema, scls, 'bases', basenames)
+            schema = self._set_reflist(schema, scls, 'ancestors', ancestors)
 
         if pg_indexes and not only_modules and not exclude_modules:
             details = f'Extraneous PostgreSQL indexes found: {pg_indexes!r}'

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -437,6 +437,7 @@ def _text_from_delta(
     context = sd.CommandContext(
         descriptive_mode=descriptive_mode,
         emit_oids=emit_oids,
+        declarative=sdlmode,
     )
     text = []
     for command in delta.get_subcommands():

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1455,7 +1455,22 @@ class AlterObjectProperty(Command):
             return
 
         if self.source == 'inheritance':
-            return
+            # We don't want to show inherited properties unless
+            # we are in "descriptive_mode" and ...
+
+            if not (
+                context.descriptive_mode and
+                self.property in {'default', 'readonly'}
+            ):
+                # If property isn't 'default' or 'readonly' --
+                # skip the AST for it.
+                return
+
+            parentop_sn = sn.shortname_from_fullname(parent_op.classname).name
+            if self.property == 'default' and parentop_sn == 'id':
+                # If it's 'default' for the 'id' property --
+                # skip the AST for it.
+                return
 
         if new_value_empty:
             return

--- a/edb/schema/derivable.py
+++ b/edb/schema/derivable.py
@@ -77,7 +77,7 @@ class DerivableObject(so.InheritingObjectBase, DerivableObjectBase):
     declared_overloaded = so.SchemaField(
         bool,
         default=False, compcoef=None,
-        introspectable=False, inheritable=False)
+        introspectable=False, inheritable=False, ephemeral=True)
 
     # Whether the object is a result of refdict inheritance
     # merge.

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -33,12 +33,6 @@ from . import utils
 
 class InheritingObjectCommand(sd.ObjectCommand):
 
-    def _apply_field_ast(self, schema, context, node, op):
-        if op.source == 'inheritance':
-            pass
-        else:
-            return super()._apply_field_ast(schema, context, node, op)
-
     def _create_begin(self, schema, context):
         schema = super()._create_begin(schema, context)
 
@@ -704,6 +698,9 @@ class RebaseInheritingObject(AlterInheritingObjectFragment):
 
 
 class InheritingObject(derivable.DerivableObject):
+
+    #: True if the object has an explicit definition and is not
+    #: purely inherited.
     is_local = so.SchemaField(
         bool,
         default=False,

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -196,6 +196,18 @@ class LinkCommand(lproperties.PropertySourceCommand,
                 context=srcctx,
             )
 
+    def _get_ast(self, schema, context):
+        node = super()._get_ast(schema, context)
+        # __type__ link is special, and while it exists on every object
+        # it doesn not have a defined default in the schema (and therefore
+        # it isn't marked as required.)  We intervene here to mark all
+        # __type__ links required when rendering for SDL/TEXT.
+        if (context.declarative and
+                node is not None and
+                node.name.name == '__type__'):
+            node.is_required = True
+        return node
+
 
 class CreateLink(LinkCommand, referencing.CreateReferencedInheritingObject):
     astnode = [qlast.CreateConcreteLink, qlast.CreateLink]

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -391,10 +391,17 @@ class SchemaField(Field[Type_T]):
 
 class RefDict(struct.Struct):
 
-    attr = struct.Field(str, frozen=True)
-    backref_attr = struct.Field(str, default='subject', frozen=True)
-    requires_explicit_inherit = struct.Field(bool, default=False, frozen=True)
-    ref_cls = struct.Field(type, frozen=True)
+    attr = struct.Field(
+        str, frozen=True)
+
+    backref_attr = struct.Field(
+        str, default='subject', frozen=True)
+
+    requires_explicit_overloaded = struct.Field(
+        bool, default=False, frozen=True)
+
+    ref_cls = struct.Field(
+        type, frozen=True)
 
 
 class ObjectMeta(type):

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -41,7 +41,7 @@ class SourceCommand(indexes.IndexSourceCommand):
 class Source(indexes.IndexableSubject):
     pointers_refs = so.RefDict(
         attr='pointers',
-        requires_explicit_inherit=True,
+        requires_explicit_overloaded=True,
         backref_attr='source',
         ref_cls=pointers.Pointer)
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 20191127
+EDGEDB_CATALOG_VERSION = 20191128_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -18,6 +18,7 @@
 
 
 from __future__ import annotations
+from typing import *  # NoQA
 
 import functools
 import os
@@ -137,7 +138,14 @@ class BaseDocTest(unittest.TestCase, metaclass=DocTestMeta):
     def run_test(self, *, source, spec, expected=None):
         raise NotImplementedError
 
-    def assert_equal(self, expected, result, *, re_filter=None):
+    def assert_equal(
+        self,
+        expected,
+        result,
+        *,
+        re_filter: Optional[str] = None,
+        message: Optional[str] = None
+    ) -> None:
         if re_filter is None:
             re_filter = self.re_filter
 
@@ -151,7 +159,8 @@ class BaseDocTest(unittest.TestCase, metaclass=DocTestMeta):
         self.assertEqual(
             expected_stripped,
             result_stripped,
-            f'\nexpected:\n{expected}\nreturned:\n{result}'
+            (f'{message if message else ""}' +
+                f'\nexpected:\n{expected}\nreturned:\n{result}')
         )
 
 

--- a/tests/schemas/issues.esdl
+++ b/tests/schemas/issues.esdl
@@ -35,6 +35,7 @@ abstract type Dictionary extending Named {
     overloaded required property name -> str {
         delegated constraint exclusive;
     }
+    index on (__subject__.name);
 }
 
 type User extending Dictionary {

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 36.82)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 36.93)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 7.09)


### PR DESCRIPTION
* DESCRIBE in SDL shows link/property cardinality,
  readonly flag, the default expression,  and the
  required flag;

* Fix a bug w.r.t. loading schema: indexes now have
  a correct information about their bases/ancestors;

* 'declared_overloaded' schema field is now ephemeral;

* 'requires_explicit_inherit' is renamed to
  'requires_explicit_overloaded'.