### PR TITLE
Make it easier to invoke the full compiler directly in scripts

### DIFF
--- a/edb/common/devmode.py
+++ b/edb/common/devmode.py
@@ -129,7 +129,7 @@ def read_dev_mode_cache(cache_key, path):
 
     if full_path.exists():
         with open(full_path, 'rb') as f:
-            src_hash = f.read(16)
+            src_hash = f.read(len(cache_key))
             if src_hash == cache_key:
                 try:
                     return pickle.load(f)

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -20,7 +20,8 @@
 from __future__ import annotations
 
 from .compiler import Compiler, BaseCompiler, CompilerDatabaseState
-from .compiler import compile_bootstrap_script, load_std_schema
+from .compiler import compile_edgeql_script, compile_bootstrap_script
+from .compiler import load_std_schema
 from .dbstate import QueryUnit
 from .enums import Capability, CompileStatementMode, ResultCardinality
 
@@ -29,6 +30,7 @@ __all__ = (
     'Compiler', 'BaseCompiler', 'CompilerDatabaseState',
     'QueryUnit',
     'Capability', 'CompileStatementMode', 'ResultCardinality',
+    'compile_edgeql_script',
     'compile_bootstrap_script',
-    'load_std_schema'
+    'load_std_schema',
 )

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -94,27 +94,54 @@ DEFAULT_MODULE_ALIASES_MAP = immutables.Map(
 pg_ql = lambda o: pg_common.quote_literal(str(o))
 
 
-def compile_bootstrap_script(std_schema: s_schema.Schema,
-                             schema: s_schema.Schema,
-                             eql: str, *,
-                             single_statement: bool = False,
-                             expected_cardinality_one: bool = False):
+def compile_bootstrap_script(
+    std_schema: s_schema.Schema,
+    schema: s_schema.Schema,
+    eql: str, *,
+    single_statement: bool = False,
+    expected_cardinality_one: bool = False,
+) -> Tuple[s_schema.Schema, str]:
+
+    return compile_edgeql_script(
+        std_schema=std_schema,
+        schema=schema,
+        eql=eql,
+        single_statement=single_statement,
+        expected_cardinality_one=expected_cardinality_one,
+        json_parameters=True,
+        bootstrap_mode=True,
+        output_format=pg_compiler.OutputFormat.JSON,
+    )
+
+
+def compile_edgeql_script(
+    std_schema: s_schema.Schema,
+    schema: s_schema.Schema,
+    eql: str, *,
+    single_statement: bool = False,
+    modaliases: Optional[Mapping[Optional[str], str]] = None,
+    expected_cardinality_one: bool = False,
+    json_parameters: bool = False,
+    bootstrap_mode: bool = False,
+    output_format: pg_compiler.OutputFormat = pg_compiler.OutputFormat.NATIVE,
+) -> Tuple[s_schema.Schema, str]:
 
     state = dbstate.CompilerConnectionState(
         0,
         schema,
-        EMPTY_MAP,
+        immutables.Map(modaliases) if modaliases else EMPTY_MAP,
         EMPTY_MAP,
         enums.Capability.ALL)
 
     ctx = CompileContext(
         state=state,
-        output_format=pg_compiler.OutputFormat.JSON,
+        output_format=output_format,
         expected_cardinality_one=expected_cardinality_one,
-        json_parameters=True,
+        json_parameters=json_parameters,
         stmt_mode=(
             enums.CompileStatementMode.SINGLE
-            if single_statement else enums.CompileStatementMode.ALL)
+            if single_statement else enums.CompileStatementMode.ALL
+        )
     )
 
     compiler = Compiler(None, None)

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -267,7 +267,7 @@ def lookup(spec: spec.Spec, name: str, *configs: Mapping,
            allow_unrecognized: bool = False):
     try:
         setting = spec[name]
-    except KeyError:
+    except (KeyError, TypeError):
         if allow_unrecognized:
             return None
         else:

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -300,9 +300,9 @@ class BaseSchemaTest(BaseDocTest):
         return current_schema
 
     @classmethod
-    def load_schema(cls, source):
+    def load_schema(cls, source: str, modname: str='test') -> s_schema.Schema:
         decls = [
-            ('test', qlparser.parse_sdl(source))
+            (modname, qlparser.parse_sdl(source))
         ]
 
         schema = _load_std_schema()

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -1,0 +1,48 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from edb.testbase import lang as tb
+from edb.server import compiler
+
+
+class TestServerCompiler(tb.BaseSchemaLoadTest):
+
+    SCHEMA = '''
+        type Foo {
+            property bar -> str;
+        }
+    '''
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._std_schema = tb._load_std_schema()
+
+    def test_server_compiler_compile_edgeql_script(self):
+
+        compiler.compile_edgeql_script(
+            self._std_schema,
+            self.schema,
+            modaliases={None: 'test'},
+            eql='''
+                SELECT Foo {
+                    bar
+                }
+            ''',
+        )

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -248,13 +248,13 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "schema", 36.93)
 
     def test_cqa_type_coverage_server(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server", 7.09)
+        self.assertFunctionCoverage(EDB_DIR / "server", 7.56)
 
     def test_cqa_type_coverage_server_cache(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "cache", 0)
 
     def test_cqa_type_coverage_server_compiler(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server" / "compiler", 12.77)
+        self.assertFunctionCoverage(EDB_DIR / "server" / "compiler", 14.74)
 
     def test_cqa_type_coverage_server_config(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "config", 18.75)
@@ -289,7 +289,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "server" / "procpool", 5.36)
 
     def test_cqa_type_coverage_testbase(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "testbase", 0)
+        self.assertFunctionCoverage(EDB_DIR / "testbase", 1.04)
 
     def test_cqa_type_coverage_tools(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "tools", 17.41)


### PR DESCRIPTION
Add `compiler.compile_edgeql_script()` as a slight modification of the
existing `compiler.compile_bootstrap_script()` to make it easier to
invoke the compiler directly.