### PR TITLE
Fix comparison of collections of distinct (but compatible) types

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -297,14 +297,22 @@ def compile_operator(
                     coll_opers, args=args, kwargs={}, ctx=ctx)
 
             else:
-                # Ultimately the operator will be the same, regardless of the
-                # specific operand types, as long as it passed validation, so
-                # we just use the first operand type for the purpose of
-                # finding the callable.
+                # The recursive operators are usually defined as
+                # being polymorphic on all parameters, and so this has
+                # a side-effect of forcing both operands to be of
+                # the same type (via casting) before the operator is
+                # applied.  This might seem suboptmial, since there might
+                # be a more specific operator for the types of the
+                # elements, but the current version of Postgres
+                # actually requires tuples and arrays to be of the
+                # same type in comparison, so this behavior is actually
+                # what we want.
                 matched = polyres.find_callable(
                     coll_opers,
-                    args=[(args[0][0], args[0][1]), (args[0][0], args[1][1])],
-                    kwargs={}, ctx=ctx)
+                    args=args,
+                    kwargs={},
+                    ctx=ctx,
+                )
 
                 # Now that we have an operator, we need to validate that it
                 # can be applied to the tuple or array elements.

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -1751,35 +1751,16 @@ class TestExpressions(tb.QueryTestCase):
             # this operation should always be valid and True
             await self.assert_query_result(query, {True})
 
-    # FIXME: once the arrays and tuples work fully with the following
-    # tests, we can integrate tests of the comparison operators for
-    # them into the _test_boolop. For now it's better to have
-    # non-exhaustive, but simple to view tests of some basic
-    # functionality.
-
-    # The naked scalars should produce the same result as these
-    # scalars wrapped in a tuple or an array. The purpose of the
-    # wrapping test is to make sure that tuples and arrays of
-    # compatible types (like numeric types) can resolve the
-    # comparison operator (e.g. [1] = [1.0]).
-    @test.xfail('''
-        Fails in Postgres:
-        operator does not exist: bigint[] = numeric[]
-    ''')
     async def test_edgeql_expr_valid_collection_01(self):
         await self.assert_query_result(
             r'''SELECT [1] = [<decimal>1];''',
             [True]
         )
 
-    @test.xfail('''
-        Fails in Postgres:
-        operator does not exist: double precision[] = numeric[]
-    ''')
     async def test_edgeql_expr_valid_collection_02(self):
         await self.assert_query_result(
             r'''
-                SELECT [1.0] = [<decimal>1];
+                SELECT [<int16>1] = [<decimal>1];
             ''',
             [True]
         )
@@ -1794,29 +1775,6 @@ class TestExpressions(tb.QueryTestCase):
 
     async def test_edgeql_expr_valid_collection_04(self):
         await self.assert_query_result(
-            r'''
-                SELECT (1.0,) = (<decimal>1,);
-            ''',
-            [True]
-        )
-
-    async def test_edgeql_expr_valid_collection_05(self):
-        await self.assert_query_result(
-            r'''
-                SELECT (1, <int32>2, <int16>3, <float32>4, 5.0) =
-                    (<decimal>1, <decimal>2, <decimal>3,
-                     <decimal>4, <decimal>5);
-            ''',
-            [True]
-        )
-
-    @test.xfail('''
-        Fails in Postgres:
-        cannot compare dissimilar column types bigint and numeric at
-        record column 1
-    ''')
-    async def test_edgeql_expr_valid_collection_06(self):
-        await self.assert_query_result(
             '''
                 SELECT
                     [([(1,          )],)] =
@@ -1825,46 +1783,31 @@ class TestExpressions(tb.QueryTestCase):
             [True]
         )
 
-    @test.xfail('''
-        Fails in Postgres:
-        cannot compare dissimilar column types smallint and numeric at
-        record column 1
-    ''')
-    async def test_edgeql_expr_valid_collection_07(self):
+    async def test_edgeql_expr_valid_collection_05(self):
         await self.assert_query_result(
             r'''
                 SELECT
                     (1, <int32>2, (
-                        (<int16>3, <float32>4), 5.0)) =
+                        (<int16>3, <int64>4), <decimal>5)) =
                     (<decimal>1, <decimal>2, (
                         (<decimal>3, <decimal>4), <decimal>5));
             ''',
             [True]
         )
 
-    @test.xfail('''
-        Fails in Postgres:
-        cannot compare dissimilar column types real[] and numeric[] at
-        record column 1
-    ''')
-    async def test_edgeql_expr_valid_collection_08(self):
+    async def test_edgeql_expr_valid_collection_06(self):
         await self.assert_query_result(
             r'''
                 SELECT
                     (1, <int32>2, (
-                        [<int16>3, <float32>4], 5.0)) =
+                        [<int16>3, <int32>4], <decimal>5)) =
                     (<decimal>1, <decimal>2, (
                         [<decimal>3, <decimal>4], <decimal>5));
             ''',
             [True]
         )
 
-    # and now the same tests for ?=
-    @test.xfail('''
-        Fails in Postgres:
-        operator does not exist: bigint[] = numeric[]
-    ''')
-    async def test_edgeql_expr_valid_collection_11(self):
+    async def test_edgeql_expr_valid_collection_07(self):
         await self.assert_query_result(
             r'''
                 SELECT [1] ?= [<decimal>1];
@@ -1872,19 +1815,7 @@ class TestExpressions(tb.QueryTestCase):
             [True]
         )
 
-    @test.xfail('''
-        Fails in Postgres:
-        operator does not exist: double precision[] = numeric[]
-    ''')
-    async def test_edgeql_expr_valid_collection_12(self):
-        await self.assert_query_result(
-            r'''
-                SELECT [1.0] ?= [<decimal>1];
-            ''',
-            [True]
-        )
-
-    async def test_edgeql_expr_valid_collection_13(self):
+    async def test_edgeql_expr_valid_collection_08(self):
         await self.assert_query_result(
             r'''
                 SELECT (1,) ?= (<decimal>1,);
@@ -1892,30 +1823,7 @@ class TestExpressions(tb.QueryTestCase):
             [True]
         )
 
-    async def test_edgeql_expr_valid_collection_14(self):
-        await self.assert_query_result(
-            r'''
-                SELECT (1.0,) ?= (<decimal>1,);
-            ''',
-            [True]
-        )
-
-    async def test_edgeql_expr_valid_collection_15(self):
-        await self.assert_query_result(
-            r'''
-                SELECT (1, <int32>2, <int16>3, <float32>4, 5.0) ?=
-                    (<decimal>1, <decimal>2, <decimal>3,
-                     <decimal>4, <decimal>5);
-            ''',
-            [True]
-        )
-
-    @test.xfail('''
-        Fails in Postgres:
-        cannot compare dissimilar column types bigint and numeric at
-        record column 1
-    ''')
-    async def test_edgeql_expr_valid_collection_16(self):
+    async def test_edgeql_expr_valid_collection_09(self):
         await self.assert_query_result(
             '''
                 SELECT
@@ -1925,45 +1833,31 @@ class TestExpressions(tb.QueryTestCase):
             [True]
         )
 
-    @test.xfail('''
-        Fails in Postgres:
-        cannot compare dissimilar column types smallint and numeric at
-        record column 1
-    ''')
-    async def test_edgeql_expr_valid_collection_17(self):
+    async def test_edgeql_expr_valid_collection_10(self):
         await self.assert_query_result(
             r'''
                 SELECT
                     (1, <int32>2, (
-                        (<int16>3, <float32>4), 5.0)) ?=
+                        (<int16>3, <int32>4), <decimal>5)) ?=
                     (<decimal>1, <decimal>2, (
                         (<decimal>3, <decimal>4), <decimal>5));
             ''',
             [True]
         )
 
-    @test.xfail('''
-        Fails in Postgres:
-        cannot compare dissimilar column types real[] and numeric[] at
-        record column 1
-    ''')
-    async def test_edgeql_expr_valid_collection_18(self):
+    async def test_edgeql_expr_valid_collection_11(self):
         await self.assert_query_result(
             r'''
                 SELECT
                     (1, <int32>2, (
-                        [<int16>3, <float32>4], 5.0)) ?=
+                        [<int16>3, <int32>4], <decimal>5)) ?=
                     (<decimal>1, <decimal>2, (
                         [<decimal>3, <decimal>4], <decimal>5));
             ''',
             [True]
         )
 
-    @test.xfail('''
-        Fails in Postgres:
-        operator does not exist: bigint[] = numeric[]
-    ''')
-    async def test_edgeql_expr_valid_collection_21(self):
+    async def test_edgeql_expr_valid_collection_12(self):
         await self.assert_query_result(
             r'''
                 SELECT [1] IN [<decimal>1];
@@ -1971,19 +1865,7 @@ class TestExpressions(tb.QueryTestCase):
             [True]
         )
 
-    @test.xfail('''
-        Fails in Postgres:
-        operator does not exist: double precision[] = numeric[]
-    ''')
-    async def test_edgeql_expr_valid_collection_22(self):
-        await self.assert_query_result(
-            r'''
-                SELECT [1.0] IN [<decimal>1];
-            ''',
-            [True]
-        )
-
-    async def test_edgeql_expr_valid_collection_23(self):
+    async def test_edgeql_expr_valid_collection_13(self):
         await self.assert_query_result(
             r'''
                 SELECT (1,) IN (<decimal>1,);
@@ -1991,30 +1873,7 @@ class TestExpressions(tb.QueryTestCase):
             [True]
         )
 
-    async def test_edgeql_expr_valid_collection_24(self):
-        await self.assert_query_result(
-            r'''
-                SELECT (1.0,) IN (<decimal>1,);
-            ''',
-            [True]
-        )
-
-    async def test_edgeql_expr_valid_collection_25(self):
-        await self.assert_query_result(
-            r'''
-                SELECT (1, <int32>2, <int16>3, <float32>4, 5.0) IN
-                    (<decimal>1, <decimal>2, <decimal>3,
-                     <decimal>4, <decimal>5);
-            ''',
-            [True]
-        )
-
-    @test.xfail('''
-        Fails in Postgres:
-        cannot compare dissimilar column types bigint and numeric at
-        record column 1
-    ''')
-    async def test_edgeql_expr_valid_collection_26(self):
+    async def test_edgeql_expr_valid_collection_14(self):
         await self.assert_query_result(
             '''
                 SELECT
@@ -2024,34 +1883,25 @@ class TestExpressions(tb.QueryTestCase):
             [True]
         )
 
-    @test.xfail('''
-        Fails in Postgres:
-        cannot compare dissimilar column types smallint and numeric at
-        record column 1
-    ''')
-    async def test_edgeql_expr_valid_collection_27(self):
+    @test.xfail('fails due to incorrect unnesting of tuples in rhs')
+    async def test_edgeql_expr_valid_collection_15(self):
         await self.assert_query_result(
             r'''
                 SELECT
-                    (1, <int32>2, (
-                        (<int16>3, <float32>4), 5.0)) IN
+                    (1, <int32>2, ( (<int16>3, <int32>4), <decimal>5)) IN
                     (<decimal>1, <decimal>2, (
                         (<decimal>3, <decimal>4), <decimal>5));
             ''',
             [True]
         )
 
-    @test.xfail('''
-        Fails in Postgres:
-        cannot compare dissimilar column types real[] and numeric[] at
-        record column 1
-    ''')
-    async def test_edgeql_expr_valid_collection_28(self):
+    @test.xfail('fails due to incorrect unnesting of tuples in rhs')
+    async def test_edgeql_expr_valid_collection_16(self):
         await self.assert_query_result(
             r'''
                 SELECT
                     (1, <int32>2, (
-                        [<int16>3, <float32>4], 5.0)) IN
+                        [<int16>3, <int32>4], <decimal>5)) IN
                     (<decimal>1, <decimal>2, (
                         [<decimal>3, <decimal>4], <decimal>5));
             ''',


### PR DESCRIPTION
The current recursive resolution of operators on collections incorrectly
assumes that a mere presence of a valid operator for the elements of the
collection is enough, and that would be OK, if operators on collections
were actually implemented in terms of the element-wise application of
the correct operator of the element types.  Unfortunately, current
Postgres does not support comparison of arrays or rows of distinct
types, even if a corresponding operator for the element types exists.
Fortunately, since the generic recursive collection operator is defined
as polymorphic on all parameters, the resulting call binding will force
a cast on the arguments to bring them to the same type.