### PR TITLE
std::anynumeric tightening

### DIFF
--- a/edb/lib/std/25-numoperators.edgeql
+++ b/edb/lib/std/25-numoperators.edgeql
@@ -41,11 +41,6 @@
 # decimal casts as both directions can lose precision. Discussion
 # about precision loss of float to numeric casts can be found here:
 # https://www.postgresql.org/message-id/5A937D7E.60305%40anastigmatix.net
-# The practical consequence is that whenever the cast is needed, such
-# as for comparison operators, it is preferable to cast decimal into
-# float and not vice-versa. So we can go with Postgres behavior in
-# regards to the comparison operators (but not arithmetic) with
-# decimal as one of the operands.
 
 # EQUALITY
 
@@ -246,7 +241,7 @@ std::`=` (l: std::decimal, r: std::decimal) -> std::bool {
 
 
 CREATE INFIX OPERATOR
-std::`=` (l: std::decimal, r: std::anyreal) -> std::bool {
+std::`=` (l: std::decimal, r: std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL OPERATOR r'=';
 };
@@ -267,21 +262,21 @@ std::`?=` (l: OPTIONAL std::decimal, r: OPTIONAL std::decimal) -> std::bool {
 
 
 CREATE INFIX OPERATOR
-std::`?=` (l: OPTIONAL std::decimal, r: OPTIONAL std::anyreal) -> std::bool {
+std::`?=` (l: OPTIONAL std::decimal, r: OPTIONAL std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
-std::`=` (l: std::anyreal, r: std::decimal) -> std::bool {
+std::`=` (l: std::anyint, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL OPERATOR r'=';
 };
 
 
 CREATE INFIX OPERATOR
-std::`?=` (l: OPTIONAL std::anyreal, r: OPTIONAL std::decimal) -> std::bool {
+std::`?=` (l: OPTIONAL std::anyint, r: OPTIONAL std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL EXPRESSION;
 };
@@ -486,7 +481,7 @@ std::`!=` (l: std::decimal, r: std::decimal) -> std::bool {
 
 
 CREATE INFIX OPERATOR
-std::`!=` (l: std::decimal, r: std::anyreal) -> std::bool {
+std::`!=` (l: std::decimal, r: std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL OPERATOR r'<>';
 };
@@ -507,21 +502,21 @@ std::`?!=` (l: OPTIONAL std::decimal, r: OPTIONAL std::decimal) -> std::bool {
 
 
 CREATE INFIX OPERATOR
-std::`?!=` (l: OPTIONAL std::decimal, r: OPTIONAL std::anyreal) -> std::bool {
+std::`?!=` (l: OPTIONAL std::decimal, r: OPTIONAL std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
-std::`!=` (l: std::anyreal, r: std::decimal) -> std::bool {
+std::`!=` (l: std::anyint, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL OPERATOR r'<>';
 };
 
 
 CREATE INFIX OPERATOR
-std::`?!=` (l: OPTIONAL std::anyreal, r: OPTIONAL std::decimal) -> std::bool {
+std::`?!=` (l: OPTIONAL std::anyint, r: OPTIONAL std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL EXPRESSION;
 };
@@ -664,14 +659,14 @@ std::`>` (l: std::decimal, r: std::decimal) -> std::bool {
 
 
 CREATE INFIX OPERATOR
-std::`>` (l: std::anyreal, r: std::decimal) -> std::bool {
+std::`>` (l: std::anyint, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL OPERATOR r'>';
 };
 
 
 CREATE INFIX OPERATOR
-std::`>` (l: std::decimal, r: std::anyreal) -> std::bool {
+std::`>` (l: std::decimal, r: std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL OPERATOR r'>';
 };
@@ -813,14 +808,14 @@ std::`>=` (l: std::decimal, r: std::decimal) -> std::bool {
 
 
 CREATE INFIX OPERATOR
-std::`>=` (l: std::anyreal, r: std::decimal) -> std::bool {
+std::`>=` (l: std::anyint, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL OPERATOR r'>=';
 };
 
 
 CREATE INFIX OPERATOR
-std::`>=` (l: std::decimal, r: std::anyreal) -> std::bool {
+std::`>=` (l: std::decimal, r: std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL OPERATOR r'>=';
 };
@@ -962,14 +957,14 @@ std::`<` (l: std::decimal, r: std::decimal) -> std::bool {
 
 
 CREATE INFIX OPERATOR
-std::`<` (l: std::anyreal, r: std::decimal) -> std::bool {
+std::`<` (l: std::anyint, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL OPERATOR r'<';
 };
 
 
 CREATE INFIX OPERATOR
-std::`<` (l: std::decimal, r: std::anyreal) -> std::bool {
+std::`<` (l: std::decimal, r: std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL OPERATOR r'<';
 };
@@ -1111,14 +1106,14 @@ std::`<=` (l: std::decimal, r: std::decimal) -> std::bool {
 
 
 CREATE INFIX OPERATOR
-std::`<=` (l: std::anyreal, r: std::decimal) -> std::bool {
+std::`<=` (l: std::anyint, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL OPERATOR r'<=';
 };
 
 
 CREATE INFIX OPERATOR
-std::`<=` (l: std::decimal, r: std::anyreal) -> std::bool {
+std::`<=` (l: std::decimal, r: std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL OPERATOR r'<=';
 };

--- a/edb/lib/std/25-numoperators.edgeql
+++ b/edb/lib/std/25-numoperators.edgeql
@@ -1781,8 +1781,24 @@ CREATE CAST FROM std::float32 TO std::bigint {
 
 
 CREATE CAST FROM std::float32 TO std::decimal {
-    SET volatility := 'IMMUTABLE';
-    USING SQL CAST;
+    SET volatility := 'STABLE';
+    USING SQL $$
+        SELECT
+            (CASE WHEN val != 'NaN'
+                       AND val != 'Infinity'
+                       AND val != '-Infinity'
+            THEN
+                val::numeric
+            ELSE
+                edgedb._raise_specific_exception(
+                    'invalid_text_representation',
+                    'invalid value for numeric: ' || quote_literal(val),
+                    '',
+                    NULL::numeric
+                )
+            END)
+        ;
+    $$;
 };
 
 
@@ -1811,8 +1827,24 @@ CREATE CAST FROM std::float64 TO std::bigint {
 
 
 CREATE CAST FROM std::float64 TO std::decimal {
-    SET volatility := 'IMMUTABLE';
-    USING SQL CAST;
+    SET volatility := 'STABLE';
+    USING SQL $$
+        SELECT
+            (CASE WHEN val != 'NaN'
+                       AND val != 'Infinity'
+                       AND val != '-Infinity'
+            THEN
+                val::numeric
+            ELSE
+                edgedb._raise_specific_exception(
+                    'invalid_text_representation',
+                    'invalid value for numeric: ' || quote_literal(val),
+                    '',
+                    NULL::numeric
+                )
+            END)
+        ;
+    $$;
 };
 
 
@@ -1849,14 +1881,14 @@ CREATE CAST FROM std::str TO std::float64 {
 
 
 CREATE CAST FROM std::str TO std::bigint {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'STABLE';
     USING SQL FUNCTION 'edgedb.str_to_bigint';
 };
 
 
 CREATE CAST FROM std::str TO std::decimal {
-    SET volatility := 'IMMUTABLE';
-    USING SQL CAST;
+    SET volatility := 'STABLE';
+    USING SQL FUNCTION 'edgedb.str_to_decimal';
 };
 
 

--- a/edb/lib/std/30-jsonfuncs.edgeql
+++ b/edb/lib/std/30-jsonfuncs.edgeql
@@ -344,7 +344,9 @@ CREATE CAST FROM std::json TO std::float64 {
 CREATE CAST FROM std::json TO std::decimal {
     SET volatility := 'STABLE';
     USING SQL $$
-    SELECT edgedb.jsonb_extract_scalar(val, 'number')::numeric;
+    SELECT edgedb.str_to_decimal(
+        edgedb.jsonb_extract_scalar(val, 'number')
+    );
     $$;
 };
 

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -626,7 +626,7 @@ std::to_decimal(s: std::str, fmt: OPTIONAL str={}) -> std::decimal
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
-            "s"::numeric
+            edgedb.str_to_decimal("s")
         WHEN "fmt" = '' THEN
             edgedb._raise_specific_exception(
                 'invalid_parameter_value',

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -241,6 +241,50 @@ class TestEdgeQLDT(tb.QueryTestCase):
         ):
             await self.con.execute(
                 r'''
-                    SELECT <bigint><decimal>'NaN'
+                    SELECT <bigint><float64>'NaN'
+                '''
+            )
+
+    async def test_edgeql_dt_decimal_01(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError,
+            "invalid value for std::decimal",
+        ):
+            await self.con.execute(
+                r'''
+                    SELECT <decimal><float64>'NaN'
+                '''
+            )
+
+    async def test_edgeql_dt_decimal_02(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError,
+            "invalid value for std::decimal",
+        ):
+            await self.con.execute(
+                r'''
+                    SELECT <decimal><float64>'Infinity'
+                '''
+            )
+
+    async def test_edgeql_dt_decimal_03(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError,
+            "invalid value for std::decimal",
+        ):
+            await self.con.execute(
+                r'''
+                    SELECT <decimal><float64>'-Infinity'
+                '''
+            )
+
+    async def test_edgeql_dt_decimal_04(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError,
+            "invalid value for std::decimal",
+        ):
+            await self.con.execute(
+                r'''
+                    SELECT <decimal>(<float64>'Infinity' / <float64>'Infinity')
                 '''
             )

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 42.62)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.17)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.22)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)


### PR DESCRIPTION
* Prohibit implicit comparisons between anynumeric and anyfloat

Comparing decimals and bigints with floats without an explicit cast is now
prohibited.  This is mostly for consistency with our general stance on the
decimal/float separation, but also because current operators don't work for
collection comparisons, which require a common implicit cast, and there is
none between floats and decimals.

* Prohibit NaN as a std::decimal value

NaN in PostgreSQL numeric is a weird thing.  First of all, none of the 
special IEEE 754 values are supported (i.e. there is no infinity).  Zero 
division always raises an exception, so `0/0` is not a thing either. 
Similarly, other "undefined" operations, such as `log(-1)` are also an 
error.

Given this apparent lack of usefulness, and a significant number of 
potential pitfalls (comparison weirdness, virality etc), it seems better to
just ban the use of NaNs in `std::decimal`.