### PR TITLE
edgeql: Update the SDL syntax.

### DIFF
--- a/docs/edgeql/ddl/migrations.rst
+++ b/docs/edgeql/ddl/migrations.rst
@@ -80,8 +80,10 @@ syntax:
 .. code-block:: edgeql
 
     CREATE MIGRATION init TO {
-        type User {
-            property username -> str
+        module default {
+            type User {
+                property username -> str
+            }
         }
     };
 
@@ -91,12 +93,12 @@ Create a new migration for the "payments" module using explicit DDL:
 
     START TRANSACTION;
 
-    CREATE MIGRATION payments::alter_tx {
-        ALTER TYPE Payment CREATE PROPERTY amount -> str;
-        ALTER TYPE CreditCard CREATE PROPERTY cvv -> str;
+    CREATE MIGRATION alter_tx {
+        ALTER TYPE payments::Payment CREATE PROPERTY amount -> str;
+        ALTER TYPE payments::CreditCard CREATE PROPERTY cvv -> str;
     };
 
-    COMMIT MIGRATION payments::alter_tx;
+    COMMIT MIGRATION alter_tx;
 
     COMMIT;
 

--- a/docs/edgeql/sdl/index.rst
+++ b/docs/edgeql/sdl/index.rst
@@ -29,16 +29,18 @@ specific schema state. For example:
     db> START TRANSACTION;
     START TRANSACTION
     db> CREATE MIGRATION movies TO {
-    ...     type Movie {
-    ...         required property title -> str;
-    ...         # the year of release
-    ...         property year -> int64;
-    ...         required link director -> Person;
-    ...         required multi link cast -> Person;
-    ...     }
-    ...     type Person {
-    ...         required property first_name -> str;
-    ...         required property last_name -> str;
+    ...     module default {
+    ...         type Movie {
+    ...             required property title -> str;
+    ...             # the year of release
+    ...             property year -> int64;
+    ...             required link director -> Person;
+    ...             required multi link cast -> Person;
+    ...         }
+    ...         type Person {
+    ...             required property first_name -> str;
+    ...             required property last_name -> str;
+    ...         }
     ...     }
     ... };
     CREATE MIGRATION

--- a/docs/tutorial/createdb.rst
+++ b/docs/tutorial/createdb.rst
@@ -60,16 +60,18 @@ Migrations have to be done inside a :ref:`transaction
     tutorial> START TRANSACTION;
     START TRANSACTION
     tutorial> CREATE MIGRATION movies TO {
-    .........     type Movie {
-    .........         required property title -> str;
-    .........         # the year of release
-    .........         property year -> int64;
-    .........         required link director -> Person;
-    .........         multi link cast -> Person;
-    .........     }
-    .........     type Person {
-    .........         required property first_name -> str;
-    .........         required property last_name -> str;
+    .........     module default {
+    .........         type Movie {
+    .........             required property title -> str;
+    .........             # the year of release
+    .........             property year -> int64;
+    .........             required link director -> Person;
+    .........             multi link cast -> Person;
+    .........         }
+    .........         type Person {
+    .........             required property first_name -> str;
+    .........             required property last_name -> str;
+    .........         }
     .........     }
     ......... };
     CREATE MIGRATION

--- a/docs/tutorial/queries.rst
+++ b/docs/tutorial/queries.rst
@@ -227,20 +227,22 @@ the ``first_name`` and ``last_name`` properties. This time we will use
     tutorial> START TRANSACTION;
     START TRANSACTION
     tutorial> CREATE MIGRATION movies TO {
-    .........     type Movie {
-    .........         required property title -> str;
-    .........         # the year of release
-    .........         property year -> int64;
-    .........         required link director -> Person;
-    .........         multi link cast -> Person;
-    .........     }
-    .........     type Person {
-    .........         property first_name -> str;
-    .........         required property last_name -> str;
-    .........         property name :=
-    .........             .first_name ++ ' ' ++ .last_name
-    .........             IF EXISTS .first_name
-    .........             ELSE .last_name;
+    .........     module default {
+    .........         type Movie {
+    .........             required property title -> str;
+    .........             # the year of release
+    .........             property year -> int64;
+    .........             required link director -> Person;
+    .........             multi link cast -> Person;
+    .........         }
+    .........         type Person {
+    .........             property first_name -> str;
+    .........             required property last_name -> str;
+    .........             property name :=
+    .........                 .first_name ++ ' ' ++ .last_name
+    .........                 IF EXISTS .first_name
+    .........                 ELSE .last_name;
+    .........         }
     .........     }
     ......... };
     CREATE MIGRATION

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -664,7 +664,6 @@ class Delta:
 
 class CreateMigration(CreateObject, Delta):
     parents: typing.List[ObjectRef]
-    language: str
     target: typing.Any
 
 
@@ -1017,8 +1016,15 @@ class SDL(Base):
     __abstract_node__ = True
 
 
-class Schema(SDL):
+class ModuleDeclaration(SDL):
+    # The 'name' is treated same as in CreateModule, for consistency,
+    # since this declaration also implies creating a module.
+    name: ObjectRef
     declarations: typing.List[DDL]
+
+
+class Schema(SDL):
+    declarations: typing.List[typing.Union[DDL, ModuleDeclaration]]
 
 
 #

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -964,18 +964,11 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 self.visit(node.parents)
 
             if node.target:
-                if node.language:
-                    self.write(' TO ', node.language, ' ')
-                    # generate source from the target node
-                    self.write(
-                        edgeql_quote.dollar_quote_literal(
-                            generate_source(node.target)))
-                else:
-                    self.write(' TO {')
-                    self._block_ws(1)
-                    self.visit(node.target)
-                    self.indentation -= 1
-                    self.write('}')
+                self.write(' TO {')
+                self._block_ws(1)
+                self.visit(node.target)
+                self.indentation -= 1
+                self.write('}')
 
         self._visit_CreateObject(node, 'MIGRATION', after_name=after_name)
 
@@ -1622,6 +1615,16 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         sdl_codegen.current_line = self.current_line
         sdl_codegen.visit_list(node.declarations, terminator=';')
         self.result.extend(sdl_codegen.result)
+
+    def visit_ModuleDeclaration(self, node: qlast.ModuleDeclaration) -> None:
+        self.write('module ')
+        # the name is always unqualified here
+        self.write(ident_to_str(node.name.name))
+        self.write('{')
+        self._block_ws(1)
+        self.visit_list(node.declarations, terminator=';')
+        self._block_ws(-1)
+        self.write('}')
 
     @classmethod
     def to_source(  # type: ignore

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import sys
 import types
+from typing import *  # noqa
 
 from edb.errors import EdgeQLSyntaxError
 
@@ -48,6 +49,20 @@ def _parse_language(node):
         raise EdgeQLSyntaxError(
             f'{node.val} is not a valid language',
             context=node.context) from None
+
+
+def _validate_declarations(
+    declarations: Sequence[Union[qlast.ModuleDeclaration, qlast.DDLCommand]]
+) -> None:
+    # Check that top-level declarations either use fully-qualified
+    # names or are module blocks.
+    for decl in declarations:
+        if (not isinstance(decl, qlast.ModuleDeclaration) and
+                decl.name.module is None):
+            raise EdgeQLSyntaxError(
+                "only fully-qualified name is allowed in "
+                "top-level declaration",
+                context=decl.name.context)
 
 
 class NewNontermHelper:

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -431,51 +431,21 @@ class OptDeltaTarget(Nonterm):
 #
 
 
-class SDLCommandBlock(Nonterm):
-    # this command block can be empty
-    def reduce_LBRACE_OptSemicolons_RBRACE(self, *kids):
-        self.val = qlast.Schema(declarations=[])
-
-    def reduce_statement_without_semicolons(self, *kids):
-        r"""%reduce LBRACE \
-                OptSemicolons SDLShortStatement \
-            RBRACE
-        """
-        self.val = qlast.Schema(declarations=[kids[2].val])
-
-    def reduce_statements_without_optional_trailing_semicolons(self, *kids):
-        r"""%reduce LBRACE \
-                OptSemicolons SDLStatements \
-                OptSemicolons SDLShortStatement \
-            RBRACE
-        """
-        self.val = qlast.Schema(declarations=kids[2].val + [kids[4].val])
-
-    def reduce_LBRACE_OptSemicolons_SDLStatements_RBRACE(self, *kids):
-        self.val = qlast.Schema(declarations=kids[2].val)
-
-    def reduce_statements_without_optional_trailing_semicolons2(self, *kids):
-        r"""%reduce LBRACE \
-                OptSemicolons SDLStatements \
-                Semicolons \
-            RBRACE
-        """
-        self.val = qlast.Schema(declarations=kids[2].val)
-
-
 class CreateMigrationStmt(Nonterm):
     def reduce_CreateMigration_SDL(self, *kids):
-        r"""%reduce CREATE MIGRATION NodeName \
+        r"""%reduce CREATE MIGRATION ShortNodeName \
                     OptDeltaParents TO SDLCommandBlock
         """
+        declarations = kids[5].val
+        commondl._validate_declarations(declarations)
         self.val = qlast.CreateMigration(
             name=kids[2].val,
             parents=kids[3].val,
-            target=kids[5].val,
+            target=qlast.Schema(declarations=declarations),
         )
 
     def reduce_CreateMigration_Commands(self, *kids):
-        r"""%reduce CREATE MIGRATION NodeName \
+        r"""%reduce CREATE MIGRATION ShortNodeName \
                     OptDeltaParents LBRACE InnerDDLStmtBlock OptSemicolons \
                     RBRACE
         """

--- a/edb/edgeql/parser/grammar/sdldocument.py
+++ b/edb/edgeql/parser/grammar/sdldocument.py
@@ -19,33 +19,43 @@
 
 from __future__ import annotations
 
-from edb.edgeql import ast as esast
+from edb.edgeql import ast as qlast
 
 from .expressions import Nonterm
 from .sdl import *  # NOQA
+
+from . import commondl
 
 
 class SDLDocument(Nonterm):
     "%start"
 
     def reduce_OptSemicolons_EOF(self, *kids):
-        self.val = esast.Schema(declarations=[])
+        self.val = qlast.Schema(declarations=[])
 
     def reduce_statement_without_semicolons(self, *kids):
         r"""%reduce \
             OptSemicolons SDLShortStatement EOF
         """
-        self.val = esast.Schema(declarations=[kids[1].val])
+        declarations = [kids[1].val]
+        commondl._validate_declarations(declarations)
+        self.val = qlast.Schema(declarations=declarations)
 
     def reduce_statements_without_optional_trailing_semicolons(self, *kids):
         r"""%reduce \
             OptSemicolons SDLStatements \
             OptSemicolons SDLShortStatement EOF
         """
-        self.val = esast.Schema(declarations=kids[1].val + [kids[3].val])
+        declarations = kids[1].val + [kids[3].val]
+        commondl._validate_declarations(declarations)
+        self.val = qlast.Schema(declarations=declarations)
 
     def reduce_OptSemicolons_SDLStatements_EOF(self, *kids):
-        self.val = esast.Schema(declarations=kids[1].val)
+        declarations = kids[1].val
+        commondl._validate_declarations(declarations)
+        self.val = qlast.Schema(declarations=declarations)
 
     def reduce_OptSemicolons_SDLStatements_Semicolons_EOF(self, *kids):
-        self.val = esast.Schema(declarations=kids[1].val)
+        declarations = kids[1].val
+        commondl._validate_declarations(declarations)
+        self.val = qlast.Schema(declarations=declarations)

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -29,7 +29,7 @@ from . import delta as sd
 from . import objects as so
 
 
-class Migration(so.Object, s_abc.Migration):
+class Migration(so.UnqualifiedObject, s_abc.Migration):
 
     parents = so.SchemaField(
         so.ObjectList,
@@ -49,7 +49,7 @@ class MigrationCommandContext(sd.ObjectCommandContext):
     pass
 
 
-class MigrationCommand(sd.ObjectCommand, schema_metaclass=Migration,
+class MigrationCommand(sd.UnqualifiedObjectCommand, schema_metaclass=Migration,
                        context_class=MigrationCommandContext):
     pass
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -394,8 +394,8 @@ class TestConstraintsSchemaMigration(tb.QueryTestCase):
 
         async with self.con.transaction():
             await self.con.execute(f'''
-                CREATE MIGRATION test::d1 TO {{ {new_schema} }};
-                COMMIT MIGRATION test::d1;
+                CREATE MIGRATION d1 TO {{ module test {{ {new_schema} }} }};
+                COMMIT MIGRATION d1;
             ''')
 
         async with self._run_and_rollback():
@@ -1026,11 +1026,13 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
     async def test_constraints_ddl_error_05(self):
         # Test that constraint expression returns a boolean.
         qry = """
-            CREATE MIGRATION test::ddl_error_05 TO {
-                type User {
-                    required property login -> str {
-                        constraint expression on (len(__subject__))
-                    }
+            CREATE MIGRATION ddl_error_05 TO {
+                module test {
+                    type User {
+                        required property login -> str {
+                            constraint expression on (len(__subject__))
+                        }
+                    };
                 };
             };
         """

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -254,7 +254,7 @@ class TestDocSnippets(unittest.TestCase):
                 if lang == 'edgeql':
                     ql_parser.parse_block(snippet)
                 elif lang == 'sdl':
-                    ql_parser.parse_sdl(snippet)
+                    ql_parser.parse_sdl(f'module default {{ {snippet} }}')
                 elif lang == 'edgeql-result':
                     # REPL results
                     pass

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -48,7 +48,9 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             mname = self.migration_name
             await self.con.execute(f"""
                 CREATE MIGRATION {mname} TO {{
-                    {migration}
+                    module test {{
+                        {migration}
+                    }}
                 }};
                 COMMIT MIGRATION {mname};
             """)

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -24,21 +24,23 @@ from edb.testbase import server as tb
 
 class TestEdgeQLDT(tb.QueryTestCase):
     SETUP = '''
-        CREATE MIGRATION default::m TO {
-            scalar type seq_t extending sequence;
-            scalar type seq2_t extending sequence;
-            scalar type enum_t extending enum<'foo', 'bar'>;
+        CREATE MIGRATION mig TO {
+            module default {
+                scalar type seq_t extending sequence;
+                scalar type seq2_t extending sequence;
+                scalar type enum_t extending enum<'foo', 'bar'>;
 
-            type Obj {
-                property seq_prop -> seq_t;
-            };
+                type Obj {
+                    property seq_prop -> seq_t;
+                };
 
-            type Obj2 {
-                property seq_prop -> seq2_t;
+                type Obj2 {
+                    property seq_prop -> seq2_t;
+                };
             };
         };
 
-        COMMIT MIGRATION default::m;
+        COMMIT MIGRATION mig;
     '''
 
     async def test_edgeql_dt_datetime_01(self):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2003,15 +2003,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute("""
-            CREATE MIGRATION test::mig1 TO {
-                abstract annotation attr2;
+            CREATE MIGRATION mig1 TO {
+                module test {
+                    abstract annotation attr2;
 
-                scalar type TestAttrType1 extending std::str {
-                    annotation attr2 := 'aaaa';
+                    scalar type TestAttrType1 extending std::str {
+                        annotation attr2 := 'aaaa';
+                    };
                 };
             };
 
-            COMMIT MIGRATION test::mig1;
+            COMMIT MIGRATION mig1;
         """)
 
         await self.assert_query_result(
@@ -2039,15 +2041,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         """)
 
         await self.con.execute("""
-            CREATE MIGRATION test::mig1 TO {
-                abstract annotation attr2;
+            CREATE MIGRATION mig1 TO {
+                module test {
+                    abstract annotation attr2;
 
-                type TestAttrType2 {
-                    annotation attr2 := 'aaaa';
+                    type TestAttrType2 {
+                        annotation attr2 := 'aaaa';
+                    };
                 };
             };
 
-            COMMIT MIGRATION test::mig1;
+            COMMIT MIGRATION mig1;
         """)
 
         await self.assert_query_result(
@@ -2296,11 +2300,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute(r'''
-            SET MODULE test;
             CREATE MIGRATION m TO {
-                type BaseAnno07 {
-                    property name -> str;
-                    index ON (.name);
+                module test {
+                    type BaseAnno07 {
+                        property name -> str;
+                        index ON (.name);
+                    }
                 }
             };
             COMMIT MIGRATION m;
@@ -2362,12 +2367,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute(r'''
-            SET MODULE test;
             CREATE MIGRATION m TO {
-                type BaseAnno08 {
-                    property name -> str;
-                    index ON (.name) {
-                        annotation title := 'name index';
+                module test {
+                    type BaseAnno08 {
+                        property name -> str;
+                        index ON (.name) {
+                            annotation title := 'name index';
+                        }
                     }
                 }
             };
@@ -2801,10 +2807,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         try:
             async with self.con.transaction():
                 await self.con.execute(r"""
-                    CREATE MIGRATION test::d1 TO {
-                        type Status extending test_other::UniquelyNamed;
+                    CREATE MIGRATION d1 TO {
+                        type test::Status extending test_other::UniquelyNamed;
                     };
-                    COMMIT MIGRATION test::d1;
+                    COMMIT MIGRATION d1;
                 """)
 
             await self.con.execute("""
@@ -3377,10 +3383,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute(r'''
-            SET MODULE test;
             CREATE MIGRATION m TO {
-                scalar type contest3_t extending int64 {
-                    constraint expression on (__subject__ > 0);
+                module test {
+                    scalar type contest3_t extending int64 {
+                        constraint expression on (__subject__ > 0);
+                    };
                 };
             };
             COMMIT MIGRATION m;
@@ -3443,12 +3450,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute(r'''
-            SET MODULE test;
             CREATE MIGRATION m TO {
-                scalar type contest4_t extending int64 {
-                    constraint expression on (__subject__ > 0) {
-                        annotation title := 'my constraint 5';
-                    }
+                module test {
+                    scalar type contest4_t extending int64 {
+                        constraint expression on (__subject__ > 0) {
+                            annotation title := 'my constraint 5';
+                        }
+                    };
                 };
             };
             COMMIT MIGRATION m;
@@ -3619,12 +3627,14 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_unicode_01(self):
         await self.con.execute(r"""
             # setup delta
-            CREATE MIGRATION test::u1 TO {
-                type Пример {
-                    required property номер -> int16;
+            CREATE MIGRATION u1 TO {
+                module test {
+                    type Пример {
+                        required property номер -> int16;
+                    };
                 };
             };
-            COMMIT MIGRATION test::u1;
+            COMMIT MIGRATION u1;
             SET MODULE test;
 
             INSERT Пример {

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -24,17 +24,19 @@ from edb.testbase import server as tb
 
 class TestDelete(tb.QueryTestCase):
     SETUP = """
-        CREATE MIGRATION test::d_delete01 TO {
-            type DeleteTest {
-                property name -> str;
-            };
+        CREATE MIGRATION d_delete01 TO {
+            module test {
+                type DeleteTest {
+                    property name -> str;
+                };
 
-            type DeleteTest2 {
-                property name -> str;
+                type DeleteTest2 {
+                    property name -> str;
+                };
             };
         };
 
-        COMMIT MIGRATION test::d_delete01;
+        COMMIT MIGRATION d_delete01;
     """
 
     async def test_edgeql_delete_bad_01(self):

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2737,49 +2737,53 @@ aa';
 
     def test_edgeql_syntax_ddl_delta_01(self):
         """
-        ALTER MIGRATION test::d_links01_0 {
+        ALTER MIGRATION d_links01_0 {
             RENAME TO test::pretty_name;
         };
 
 % OK %
 
-        ALTER MIGRATION test::d_links01_0
+        ALTER MIGRATION d_links01_0
             RENAME TO test::pretty_name;
         """
 
     def test_edgeql_syntax_ddl_delta_02(self):
         """
-        CREATE MIGRATION test::d_links01_0 TO {type Foo;};
-        ALTER MIGRATION test::d_links01_0
+        CREATE MIGRATION d_links01_0 TO {type test::Foo;};
+        ALTER MIGRATION d_links01_0
             RENAME TO test::pretty_name;
-        COMMIT MIGRATION test::d_links01_0;
-        DROP MIGRATION test::d_links01_0;
+        COMMIT MIGRATION d_links01_0;
+        DROP MIGRATION d_links01_0;
         """
 
     def test_edgeql_syntax_ddl_delta_03(self):
         """
-        CREATE MIGRATION test::d_links01_0 TO {type Foo;};
+        CREATE MIGRATION d_links01_0 TO {
+            module test {
+                type Foo;
+            };
+        };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected 'BadLang'", line=2, col=47)
+                  "Unexpected 'BadLang'", line=2, col=41)
     def test_edgeql_syntax_ddl_delta_04(self):
         """
-        CREATE MIGRATION test::d_links01_0 TO BadLang $$type Foo$$;
+        CREATE MIGRATION d_links01_0 TO BadLang $$type test::Foo$$;
         """
 
     def test_edgeql_syntax_ddl_delta_05(self):
         """
-        CREATE MIGRATION test::d_links01_0 TO {
-            type Foo {
+        CREATE MIGRATION d_links01_0 TO {
+            type test::Foo {
                 property bar -> str
             }
         };
 
 % OK %
 
-        CREATE MIGRATION test::d_links01_0 TO {
-            type Foo {
+        CREATE MIGRATION d_links01_0 TO {
+            type test::Foo {
                 property bar -> str;
             };
         };

--- a/tests/test_edgeql_tutorial.py
+++ b/tests/test_edgeql_tutorial.py
@@ -30,16 +30,18 @@ class TestEdgeQLTutorial(tb.QueryTestCase):
         await self.con.execute(r'''
             START TRANSACTION;
             CREATE MIGRATION movies TO {
-                type Movie {
-                    required property title -> str;
-                    # the year of release
-                    property year -> int64;
-                    required link director -> Person;
-                    multi link cast -> Person;
-                }
-                type Person {
-                    required property first_name -> str;
-                    required property last_name -> str;
+                module default {
+                    type Movie {
+                        required property title -> str;
+                        # the year of release
+                        property year -> int64;
+                        required link director -> Person;
+                        multi link cast -> Person;
+                    }
+                    type Person {
+                        required property first_name -> str;
+                        required property last_name -> str;
+                    }
                 }
             };
             COMMIT MIGRATION movies;
@@ -203,20 +205,22 @@ class TestEdgeQLTutorial(tb.QueryTestCase):
         await self.con.execute(r'''
             START TRANSACTION;
             CREATE MIGRATION movies TO {
-                type Movie {
-                    required property title -> str;
-                    # the year of release
-                    property year -> int64;
-                    required link director -> Person;
-                    multi link cast -> Person;
-                }
-                type Person {
-                    property first_name -> str;
-                    required property last_name -> str;
-                    property name :=
-                        .first_name ++ ' ' ++ .last_name
-                        IF EXISTS .first_name
-                        ELSE .last_name;
+                module default {
+                    type Movie {
+                        required property title -> str;
+                        # the year of release
+                        property year -> int64;
+                        required link director -> Person;
+                        multi link cast -> Person;
+                    }
+                    type Person {
+                        property first_name -> str;
+                        required property last_name -> str;
+                        property name :=
+                            .first_name ++ ' ' ++ .last_name
+                            IF EXISTS .first_name
+                            ELSE .last_name;
+                    }
                 }
             };
             COMMIT MIGRATION movies;

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -27,18 +27,20 @@ class TestIndexes(tb.DDLTestCase):
     async def test_index_01(self):
         await self.con.execute(r"""
             # setup delta
-            CREATE MIGRATION test::d1 TO {
-                type Person {
-                    property first_name -> str;
-                    property last_name -> str;
+            CREATE MIGRATION d1 TO {
+                module test {
+                    type Person {
+                        property first_name -> str;
+                        property last_name -> str;
 
-                    index on ((.first_name, .last_name));
+                        index on ((.first_name, .last_name));
+                    };
+
+                    type Person2 extending Person;
                 };
-
-                type Person2 extending Person;
             };
 
-            COMMIT MIGRATION test::d1;
+            COMMIT MIGRATION d1;
         """)
 
         await self.assert_query_result(

--- a/tests/test_link_target_delete.py
+++ b/tests/test_link_target_delete.py
@@ -887,8 +887,8 @@ class TestLinkTargetDeleteMigrations(stb.NonIsolatedDDLTestCase):
                 schema = f.read()
 
             await self.con.execute(f'''
-                CREATE MIGRATION test::d_m01 TO {{ {schema} }};
-                COMMIT MIGRATION test::d_m01;
+                CREATE MIGRATION d_m01 TO {{ module test {{ {schema} }} }};
+                COMMIT MIGRATION d_m01;
                 ''')
 
             await self.con.execute('''
@@ -917,8 +917,8 @@ class TestLinkTargetDeleteMigrations(stb.NonIsolatedDDLTestCase):
                 schema = f.read()
 
             await self.con.execute(f'''
-                CREATE MIGRATION test::d_m01 TO {{ {schema} }};
-                COMMIT MIGRATION test::d_m01;
+                CREATE MIGRATION d_m01 TO {{ module test {{ {schema} }} }};
+                COMMIT MIGRATION d_m01;
                 ''')
 
             await self.con.execute("""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -54,7 +54,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.SchemaDefinitionError,
                   "'name'.*must be declared using the `overloaded` keyword",
-                  position=214)
+                  position=228)
     def test_schema_overloaded_02(self):
         """
             type UniqueName {
@@ -72,7 +72,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.SchemaDefinitionError,
                   "'name'.*cannot be declared `overloaded`",
-                  position=47)
+                  position=61)
     def test_schema_overloaded_03(self):
         """
             type UniqueName {
@@ -82,7 +82,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.InvalidLinkTargetError,
                   'invalid link target, expected object type, got scalar type',
-                  position=55)
+                  position=69)
     def test_schema_bad_link_01(self):
         """
             type Object {
@@ -92,7 +92,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.InvalidLinkTargetError,
                   'invalid link target, expected object type, got scalar type',
-                  position=55)
+                  position=69)
     def test_schema_bad_link_02(self):
         """
             type Object {
@@ -102,7 +102,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.SchemaDefinitionError,
                   'link or property name length exceeds the maximum.*',
-                  position=43)
+                  position=57)
     def test_schema_bad_link_03(self):
         """
             type Object {
@@ -114,7 +114,7 @@ _123456789_123456789_123456789 -> Object
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "invalid property type: expected a scalar type, "
                   "or a scalar collection, got object type 'test::Object'",
-                  position=59)
+                  position=73)
     def test_schema_bad_prop_01(self):
         """
             type Object {
@@ -125,7 +125,7 @@ _123456789_123456789_123456789 -> Object
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "invalid property type: expected a scalar type, "
                   "or a scalar collection, got object type 'test::Object'",
-                  position=59)
+                  position=73)
     def test_schema_bad_prop_02(self):
         """
             type Object {
@@ -135,7 +135,7 @@ _123456789_123456789_123456789 -> Object
 
     @tb.must_fail(errors.SchemaDefinitionError,
                   'link or property name length exceeds the maximum.*',
-                  position=43)
+                  position=57)
     def test_schema_bad_prop_03(self):
         """
             type Object {
@@ -146,7 +146,7 @@ _123456789_123456789_123456789 -> str
 
     @tb.must_fail(errors.InvalidReferenceError,
                   "type 'int' does not exist",
-                  position=59,
+                  position=73,
                   hint='did you mean one of these: int16, int32, int64?')
     def test_schema_bad_type_01(self):
         """
@@ -158,7 +158,7 @@ _123456789_123456789_123456789 -> str
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "expected a scalar type, or a scalar collection, "
                   "got collection 'array<test::Foo>'",
-                  position=80)
+                  position=94)
     def test_schema_bad_type_02(self):
         """
             type Foo;
@@ -171,7 +171,7 @@ _123456789_123456789_123456789 -> str
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "expected a scalar type, or a scalar collection, "
                   "got collection 'tuple<test::Foo>'",
-                  position=80)
+                  position=94)
     def test_schema_bad_type_03(self):
         """
             type Foo;
@@ -184,7 +184,7 @@ _123456789_123456789_123456789 -> str
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "expected a scalar type, or a scalar collection, "
                   "got collection 'tuple<std::str, array<test::Foo>>'",
-                  position=80)
+                  position=94)
     def test_schema_bad_type_04(self):
         """
             type Foo;
@@ -613,13 +613,14 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
     def setUpClass(cls):
         super().setUpClass()
         cls.std_schema = tb._load_std_schema()
-        cls.schema = cls.run_ddl(cls.schema, 'CREATE MODULE default;')
 
     def _assert_migration_consistency(self, schema_text):
 
         migration_text = f'''
             CREATE MIGRATION m TO {{
-                {schema_text}
+                module default {{
+                    {schema_text}
+                }}
             }};
         '''
 
@@ -696,7 +697,9 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         for i, state in enumerate(migrations):
             mig_text = f'''
                 CREATE MIGRATION m{i} TO {{
-                    {state}
+                    module default {{
+                        {state}
+                    }}
                 }};
                 COMMIT MIGRATION m{i};
             '''

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -59,469 +59,607 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
 
     def test_eschema_syntax_tabs_01(self):
         """
-\tabstract type Foo {
+\tabstract type test::Foo {
 \t\trequired property foo -> str;
 \t};
 
-\tabstract type Bar {
+\tabstract type test::Bar {
 \t\trequired property bar -> str;
 \t};
         """
 
     def test_eschema_syntax_tabs_02(self):
         """
-\t  abstract type Foo {
+\t  abstract type test::Foo {
 \t      required property foo -> str;
 };
 
-\t  abstract type Bar {
+\t  abstract type test::Bar {
 \t      required property bar -> str;
 };
         """
     def test_eschema_syntax_semicolon_01(self):
         """
-        abstract type OwnedObject {
+        abstract type test::OwnedObject {
             required link owner -> User
         };
 
 % OK %
 
-        abstract type OwnedObject {
+        abstract type test::OwnedObject {
             required link owner -> User;
         };
         """
 
     def test_eschema_syntax_semicolon_02(self):
         """
-        abstract type OwnedObject {
-            required property tag -> str
-        };
+        module test {
+            abstract type OwnedObject {
+                required property tag -> str
+            }
+        }
 
 % OK %
 
-        abstract type OwnedObject {
-            required property tag -> str;
+        module test {
+            abstract type OwnedObject {
+                required property tag -> str;
+            };
         };
         """
 
     def test_eschema_syntax_semicolon_03(self):
         """
-        abstract type OwnedObject {
+        abstract type test::OwnedObject {
             required link owner -> User;
             required property tag -> str
         };
 
 % OK %
 
-        abstract type OwnedObject {
+        abstract type test::OwnedObject {
             required link owner -> User;
             required property tag -> str;
         };
         """
 
     def test_eschema_syntax_type_01(self):
-        """type User extending builtins::NamedObject;"""
+        """type test::User extending builtins::NamedObject;"""
 
     def test_eschema_syntax_type_02(self):
         """
-        abstract type OwnedObject {
+        abstract type test::OwnedObject {
             required link owner -> User;
         };
         """
 
     def test_eschema_syntax_type_03(self):
         """
-        abstract type Text {
-            required property body -> str {
-                constraint max_len_value (10000);
+        module test {
+            abstract type Text {
+                required property body -> str {
+                    constraint max_len_value (10000);
+                };
             };
         };
         """
 
     def test_eschema_syntax_type_04(self):
         """
-        type LogEntry extending OwnedObject, Text {
-            required property spent_time -> int64;
+        module test {
+            type LogEntry extending OwnedObject, Text {
+                required property spent_time -> int64;
+            };
         };
         """
 
     def test_eschema_syntax_type_05(self):
         """
-        type LogEntry extending OwnedObject, Text {
-           link start_date := (SELECT datetime::datetime_current());
+        module test {
+            type LogEntry extending OwnedObject, Text {
+               link start_date := (SELECT datetime::datetime_current());
+            };
         };
         """
 
     def test_eschema_syntax_type_06(self):
         """
-        type LogEntry extending OwnedObject, Text {
-            property start_date -> datetime {
-               default :=
-                    (SELECT datetime::datetime_current());
-               title := 'Start Date';
-           };
+        module test {
+            type LogEntry extending OwnedObject, Text {
+                property start_date -> datetime {
+                   default :=
+                        (SELECT datetime::datetime_current());
+                   title := 'Start Date';
+               };
+            };
         };
         """
 
     def test_eschema_syntax_type_07(self):
         """
-        type Issue extending `foo.bar`::NamedObject, OwnedObject, Text {
-            required link number -> issue_num_t {
-                readonly := true;
+        module test {
+            type Issue extending `foo.bar`::NamedObject, OwnedObject, Text {
+                required link number -> issue_num_t {
+                    readonly := true;
+                };
+
+                required link status -> Status;
+
+                link priority -> Priority;
+
+                multi link watchers extending orderable -> User {
+                    property foo extending bar -> str;
+                };
+
+                multi link time_spent_log -> LogEntry;
+
+                link start_date := (SELECT datetime::datetime_current());
+
+                multi link related_to -> Issue;
+
+                property time_estimate -> int64;
+
+                property start_date -> datetime {
+                   default :=
+                        (SELECT datetime::datetime_current());
+                   title := 'Start Date';
+                };
+
+                property due_date -> datetime;
             };
-
-            required link status -> Status;
-
-            link priority -> Priority;
-
-            multi link watchers extending orderable -> User {
-                property foo extending bar -> str;
-            };
-
-            multi link time_spent_log -> LogEntry;
-
-            link start_date := (SELECT datetime::datetime_current());
-
-            multi link related_to -> Issue;
-
-            property time_estimate -> int64;
-
-            property start_date -> datetime {
-               default :=
-                    (SELECT datetime::datetime_current());
-               title := 'Start Date';
-            };
-
-            property due_date -> datetime;
         };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected 'unit'", line=4, col=26)
+                  "Unexpected 'unit'", line=5, col=30)
     def test_eschema_syntax_type_08(self):
         """
-        type Foo {
-            property time_estimate -> int64 {
-                property unit {
-                    default := 'minute';
+        module test {
+            type Foo {
+                property time_estimate -> int64 {
+                    property unit {
+                        default := 'minute';
+                    };
                 };
             };
         };
-       """
+        """
 
     def test_eschema_syntax_type_09(self):
         """
-        type LogEntry extending OwnedObject, Text {
-            required link attachment -> Post | File | User;
+        module test {
+            type LogEntry extending OwnedObject, Text {
+                required link attachment -> Post | File | User;
+            };
         };
         """
 
     def test_eschema_syntax_type_10(self):
         """
-        type `Log-Entry` extending `OwnedObject`, `Text` {
-            required link attachment -> `Post` | `File` | `User`;
+        module test {
+            type `Log-Entry` extending `OwnedObject`, `Text` {
+                required link attachment -> `Post` | `File` | `User`;
+            };
         };
 
 % OK %
 
-        type `Log-Entry` extending OwnedObject, Text {
-            required link attachment -> Post | File | User;
+        module test {
+            type `Log-Entry` extending OwnedObject, Text {
+                required link attachment -> Post | File | User;
+            };
         };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError, "Unexpected 'Commit'",
-                  line=2, col=14)
+                  line=3, col=18)
     def test_eschema_syntax_type_11(self):
         """
-        type Commit {
-            required property name -> std::str;
+        module test {
+            type Commit {
+                required property name -> std::str;
+            };
         };
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=14)
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=3, col=18)
     def test_eschema_syntax_type_12(self):
         """
-        type __Foo__ {
-            required property name -> std::str;
+        module test {
+            type __Foo__ {
+                required property name -> std::str;
+            };
         };
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=14)
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=3, col=18)
     def test_eschema_syntax_type_13(self):
         """
-        type `__Foo__` {
-            required property name -> std::str;
+        module test {
+            type `__Foo__` {
+                required property name -> std::str;
+            };
         };
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=3, col=31)
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=4, col=35)
     def test_eschema_syntax_type_14(self):
         """
-        type __Foo {
-            required property __name__ -> std::str;
+        module test {
+            type __Foo {
+                required property __name__ -> std::str;
+            };
         };
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=3, col=31)
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=4, col=35)
     def test_eschema_syntax_type_15(self):
         """
-        type `__Foo` {
-            required property `__name__` -> std::str;
+        module test {
+            type `__Foo` {
+                required property `__name__` -> std::str;
+            };
         };
         """
 
     def test_eschema_syntax_type_16(self):
         """
-        type Пример {
-            required property номер -> int16;
+        module test {
+            type Пример {
+                required property номер -> int16;
+            };
         };
         """
 
     def test_eschema_syntax_type_17(self):
         """
-        type Foo {
-            link bar0 -> Bar {
-                on target delete restrict;
-            };
-            link bar1 -> Bar {
-                on target delete delete source;
-            };
-            link bar2 -> Bar {
-                on target delete allow;
-            };
-            link bar3 -> Bar {
-                on target delete deferred restrict;
+        module test {
+            type Foo {
+                link bar0 -> Bar {
+                    on target delete restrict;
+                };
+                link bar1 -> Bar {
+                    on target delete delete source;
+                };
+                link bar2 -> Bar {
+                    on target delete allow;
+                };
+                link bar3 -> Bar {
+                    on target delete deferred restrict;
+                };
             };
         };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
                   "more than one 'on target delete' specification",
-                  line=5, col=17)
+                  line=6, col=21)
     def test_eschema_syntax_type_18(self):
         """
-        type Foo {
-            link bar0 -> Bar {
-                on target delete restrict;
-                on target delete delete source;
+        module test {
+            type Foo {
+                link bar0 -> Bar {
+                    on target delete restrict;
+                    on target delete delete source;
+                };
             };
         };
         """
 
     def test_eschema_syntax_type_19(self):
         """
-        type Foo {
-            property foo -> str {
-                default := some_func(
-    1, 2, 3);
+        module test {
+            type Foo {
+                property foo -> str {
+                    default := some_func(
+        1, 2, 3);
+                };
             };
         };
         """
 
     def test_eschema_syntax_type_22(self):
         """
-        type Foo {
-            property foo -> str {
-                # if it's defined on the same line as :=
-                # the definition must be a one-liner
-                default := some_func(1, 2, 3);
-            };
-            property bar -> str {
-                # multi-line definition with correct indentation
-                default :=
-                    some_func('
-                    1, 2, 3');
-            };
-            property baz -> str {
-                # multi-line definition with correct indentation
-                default :=
-                    $$some_func(
-                    1, 2, 3)$$;
+        module test {
+            type Foo {
+                property foo -> str {
+                    # if it's defined on the same line as :=
+                    # the definition must be a one-liner
+                    default := some_func(1, 2, 3);
+                };
+                property bar -> str {
+                    # multi-line definition with correct indentation
+                    default :=
+                        some_func('
+                        1, 2, 3');
+                };
+                property baz -> str {
+                    # multi-line definition with correct indentation
+                    default :=
+                        $$some_func(
+                        1, 2, 3)$$;
+                };
             };
         };
         """
 
     def test_eschema_syntax_type_23(self):
         """
-        type Foo {
-            single link foo -> Foo;
-            multi link bar -> Bar;
-            required single link baz -> Baz;
-            required multi link spam -> Spam;
-            overloaded required single link ham -> Ham;
-            overloaded required multi link eggs -> Egg;
-            overloaded link knight;
-            overloaded link clinic {
-                property argument -> int64;
-            };
-            overloaded property castle;
-            overloaded property tower {
-                constraint exclusive;
+        module test {
+            type Foo {
+                single link foo -> Foo;
+                multi link bar -> Bar;
+                required single link baz -> Baz;
+                required multi link spam -> Spam;
+                overloaded required single link ham -> Ham;
+                overloaded required multi link eggs -> Egg;
+                overloaded link knight;
+                overloaded link clinic {
+                    property argument -> int64;
+                };
+                overloaded property castle;
+                overloaded property tower {
+                    constraint exclusive;
+                };
             };
         };
         """
 
     def test_eschema_syntax_type_24(self):
         """
-        type Foo {
-            single property foo -> str;
-            multi property bar -> str;
-            required single property baz -> str;
-            required multi property spam -> str;
-            overloaded required single property ham -> str;
-            overloaded required multi property eggs -> str;
+        module test {
+            type Foo {
+                single property foo -> str;
+                multi property bar -> str;
+                required single property baz -> str;
+                required multi property spam -> str;
+                overloaded required single property ham -> str;
+                overloaded required multi property eggs -> str;
+            };
         };
         """
 
     def test_eschema_syntax_type_25(self):
         """
-        type Foo {
-            single property foo -> str
-        }
+        module test {
+            type Foo {
+                single property foo -> str
+            }
 
-        type Bar {
-            multi property bar -> str
-        }
+            type Bar {
+                multi property bar -> str
+            }
 
-        type Baz {
-            required single property baz -> str
-        }
+            type Baz {
+                required single property baz -> str
+            }
 
-        type Spam {
-            required multi property spam -> str
-        }
+            type Spam {
+                required multi property spam -> str
+            }
 
-        type Ham {
-            overloaded required single property ham -> str
-        }
+            type Ham {
+                overloaded required single property ham -> str
+            }
 
-        type Eggs {
-            overloaded required multi property eggs -> str
+            type Eggs {
+                overloaded required multi property eggs -> str
+            }
         }
 
 % OK %
 
-        type Foo {
-            single property foo -> str;
-        };
+        module test {
+            type Foo {
+                single property foo -> str;
+            };
 
-        type Bar {
-            multi property bar -> str;
-        };
+            type Bar {
+                multi property bar -> str;
+            };
 
-        type Baz {
-            required single property baz -> str;
-        };
+            type Baz {
+                required single property baz -> str;
+            };
 
-        type Spam {
-            required multi property spam -> str;
-        };
+            type Spam {
+                required multi property spam -> str;
+            };
 
-        type Ham {
-            overloaded required single property ham -> str;
-        };
+            type Ham {
+                overloaded required single property ham -> str;
+            };
 
-        type Eggs {
-            overloaded required multi property eggs -> str;
+            type Eggs {
+                overloaded required multi property eggs -> str;
+            };
         };
         """
 
     def test_eschema_syntax_type_26(self):
         """
-        type Foo {
-            single property foo -> str {
-                constraint max_len_value (10000)
-            }
+        module test {
+            type Foo {
+                single property foo -> str {
+                    constraint max_len_value (10000)
+                }
 
-            multi property bar -> str {
-                constraint max_len_value (10000)
+                multi property bar -> str {
+                    constraint max_len_value (10000)
+                }
             }
         }
 
 % OK %
 
-        type Foo {
-            single property foo -> str {
-                constraint max_len_value (10000);
-            };
+        module test {
+            type Foo {
+                single property foo -> str {
+                    constraint max_len_value (10000);
+                };
 
-            multi property bar -> str {
-                constraint max_len_value (10000);
+                multi property bar -> str {
+                    constraint max_len_value (10000);
+                };
+            };
+        };
+        """
+
+    def test_eschema_syntax_type_27(self):
+        """
+        type foo::Bar {
+            property name -> str;
+        };
+        """
+
+    def test_eschema_syntax_type_28(self):
+        """
+        module foo {
+            type Bar {
+                property name -> str;
+            };
+        };
+        """
+
+    @tb.must_fail(
+        errors.EdgeQLSyntaxError,
+        "fully-qualified name is not allowed in a module declaration",
+        line=3, col=18)
+    def test_eschema_syntax_type_29(self):
+        """
+        module foo {
+            type foo::Bar {
+                property name -> str;
+            };
+        };
+        """
+
+    def test_eschema_syntax_type_30(self):
+        """
+        module foo {
+            type Bar {
+                property name -> str;
+            };
+        };
+
+        type foo::Bar2 {
+            property name -> str;
+        };
+
+        module foo {
+            type Bar3 {
+                property name -> str;
+            };
+        };
+        """
+
+    def test_eschema_syntax_type_31(self):
+        """
+        module foo {
+            type Bar {
+                property name -> str;
+            };
+        };
+
+        type bar::Bar {
+            property name -> str;
+        };
+
+        module baz {
+            type Bar {
+                property name -> str;
             };
         };
         """
 
     def test_eschema_syntax_link_target_type_01(self):
         """
-        type User {
-            required link todo -> array<str>;
+        module test {
+            type User {
+                required link todo -> array<str>;
+            };
         };
         """
 
     def test_eschema_syntax_link_target_type_03(self):
         """
-        type User {
-            required link todo -> tuple<str, int64, float64>;
+        module test {
+            type User {
+                required link todo -> tuple<str, int64, float64>;
+            };
         };
         """
 
     def test_eschema_syntax_link_target_type_04(self):
         """
-        type User {
-            required link todo ->
-                tuple<str, tuple<str, array<str>>, array<float64>>;
+        module test {
+            type User {
+                required link todo ->
+                    tuple<str, tuple<str, array<str>>, array<float64>>;
+            };
         };
         """
 
     def test_eschema_syntax_index_01(self):
         """
-        type LogEntry extending OwnedObject, Text {
-            required link owner -> User;
-            index on (SELECT datetime::datetime_current());
+        module test {
+            type LogEntry extending OwnedObject, Text {
+                required link owner -> User;
+                index on (SELECT datetime::datetime_current());
+            };
         };
         """
 
     def test_eschema_syntax_index_02(self):
         """
-        abstract link foobar {
-            property foo -> str {
-                title := 'Sample property';
+        module test {
+            abstract link foobar {
+                property foo -> str {
+                    title := 'Sample property';
+                };
+                index on (__subject__@foo);
             };
-            index on (__subject__@foo);
         };
         """
 
     # FIXME: obscure error message
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"Unexpected 'prop'", line=3, col=19)
+                  r"Unexpected 'prop'", line=4, col=23)
     def test_eschema_syntax_index_03(self):
         """
-        scalar type foobar {
-            index prop on (__source__);
+        module test {
+            scalar type foobar {
+                index prop on (__source__);
+            };
         };
         """
 
     def test_eschema_syntax_index_04(self):
         """
-        type User {
-            property name -> str;
-            index on (.name);
+        module test {
+            type User {
+                property name -> str;
+                index on (.name);
+            };
         };
         """
 
     def test_eschema_syntax_index_05(self):
         """
-        type User {
-            property name -> str;
+        module test {
+            type User {
+                property name -> str;
 
-            index on (.name) {
-                annotation title := 'User name index';
+                index on (.name) {
+                    annotation title := 'User name index';
+                };
             };
         };
         """
 
     def test_eschema_syntax_ws_01(self):
         """
+        module test {
 type LogEntry extending    OwnedObject,    Text {
 
     # irrelevant comment indent
@@ -543,15 +681,16 @@ type LogEntry extending    OwnedObject,    Text {
                        title := 'Start Date';
 
         };};
+        };
         """
 
     def test_eschema_syntax_ws_02(self):
         """
-        scalar type newScalarType extending str#:
+        scalar type test::newScalarType extending str#:
 
 % OK %
 
-        scalar type newScalarType extending str;
+        scalar type test::newScalarType extending str;
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -559,137 +698,161 @@ type LogEntry extending    OwnedObject,    Text {
                   line=4, col=9)
     def test_eschema_syntax_ws_03(self):
         """
-        scalar type newScalarType0 extending str#:
+        scalar type test::newScalarType0 extending str#:
 
-        scalar type newScalarType1 extending str#:
+        scalar type test::newScalarType1 extending str#:
         """
 
     def test_eschema_syntax_scalar_01(self):
         """
-        scalar type issue_num_t extending std::sequence;
+        module test {
+            scalar type issue_num_t extending std::sequence;
+        };
         """
 
     def test_eschema_syntax_scalar_02(self):
         """
-        scalar type issue_num_t extending int {
-            default := 42;
+        module test {
+            scalar type issue_num_t extending int {
+                default := 42;
+            };
         };
         """
 
     def test_eschema_syntax_scalar_03(self):
         r"""
-        scalar type basic extending int {
-            delegated constraint min_value(0);
-            constraint max_value(123456);
-            constraint must_be_even;
+        module test {
+            scalar type basic extending int {
+                delegated constraint min_value(0);
+                constraint max_value(123456);
+                constraint must_be_even;
 
-            title := 'Basic ScalarType';
-            default := 2;
+                title := 'Basic ScalarType';
+                default := 2;
+            };
         };
         """
 
     def test_eschema_syntax_scalar_04(self):
         """
-        scalar type basic extending int {
-            constraint min_value(0);
-            constraint max_value(123456);
-            delegated constraint expr on (__subject__ % 2 = 0);
+        module test {
+            scalar type basic extending int {
+                constraint min_value(0);
+                constraint max_value(123456);
+                delegated constraint expr on (__subject__ % 2 = 0);
 
-            title := 'Basic ScalarType';
-            default := 2;
+                title := 'Basic ScalarType';
+                default := 2;
+            };
         };
         """
 
     def test_eschema_syntax_scalar_05(self):
         """
-        scalar type basic extending int {
-            constraint expr {
-                prop :=
-                    (__subject__ % 2 = 0);
-            };
-            constraint min_value(0);
-            constraint max_value(123456);
+        module test {
+            scalar type basic extending int {
+                constraint expr {
+                    prop :=
+                        (__subject__ % 2 = 0);
+                };
+                constraint min_value(0);
+                constraint max_value(123456);
 
-            title := 'Basic ScalarType';
-            default := 2;
+                title := 'Basic ScalarType';
+                default := 2;
+            };
         };
         """
 
     def test_eschema_syntax_scalar_06(self):
         """
-        scalar type basic extending int {
-            constraint min_value(0);
-            constraint max_value(123456);
-            constraint expr {
-                abc := (__subject__ % 2 = 0);
+        module test {
+            scalar type basic extending int {
+                constraint min_value(0);
+                constraint max_value(123456);
+                constraint expr {
+                    abc := (__subject__ % 2 = 0);
+                };
+
+                title := 'Basic ScalarType';
+                default := 2;
             };
 
-            title := 'Basic ScalarType';
-            default := 2;
+            scalar type inherits_default extending basic;
+
+            abstract scalar type abstract_scalar extending int;
         };
-
-        scalar type inherits_default extending basic;
-
-        abstract scalar type abstract_scalar extending int;
         """
 
     def test_eschema_syntax_scalar_07(self):
         """
-        final scalar type none;
+        module test {
+            final scalar type none;
+        };
         """
 
     def test_eschema_syntax_scalar_08(self):
         """
-        scalar type basic extending int {
-            constraint special_constraint;
-            title := 'Basic ScalarType';
-            default := 2;
+        module test {
+            scalar type basic extending int {
+                constraint special_constraint;
+                title := 'Basic ScalarType';
+                default := 2;
+            };
         };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError, r"Unexpected ':='",
-                  line=3, col=43)
+                  line=4, col=47)
     def test_eschema_syntax_scalar_09(self):
         """
-        scalar type special extending int {
-            constraint special_constraint := [42, 100, 9001];
+        module test {
+            scalar type special extending int {
+                constraint special_constraint := [42, 100, 9001];
+            };
         };
         """
 
     def test_eschema_syntax_scalar_10(self):
         """
-        scalar type special extending int {
-            constraint special_constraint {
-                using (__subject__ % 2 = 0);
+        module test {
+            scalar type special extending int {
+                constraint special_constraint {
+                    using (__subject__ % 2 = 0);
+                };
+                title := 'Special ScalarType';
             };
-            title := 'Special ScalarType';
         };
         """
 
     def test_eschema_syntax_scalar_11(self):
         """
-        scalar type constraint_length extending str {
-             constraint max_len_value(16+1, len(([1])));
+        module test {
+            scalar type constraint_length extending str {
+                 constraint max_len_value(16+1, len(([1])));
+            };
         };
         """
 
     def test_eschema_syntax_scalar_12(self):
         """
-        scalar type constraint_length extending str {
-             constraint max_len_value((16+(4*2))/((4)-1), len(([1])));
+        module test {
+            scalar type constraint_length extending str {
+                 constraint max_len_value((16+(4*2))/((4)-1), len(([1])));
+            };
         };
         """
 
     def test_eschema_syntax_constraint_01(self):
         """
-        abstract constraint max_value(param:anytype) on (()) {
+        abstract constraint test::max_value(param:anytype) on (()) {
             using (__subject__ <= $param);
             errmessage := 'Maximum allowed value for {subject} is {$param}.';
         };
 
 % OK %
 
-        abstract constraint max_value(param:anytype) on (()) {
+        abstract constraint test::max_value(param:anytype) on (()) {
             using (__subject__ <= $param);
             errmessage := 'Maximum allowed value for {subject} is {$param}.';
         };
@@ -697,157 +860,191 @@ type LogEntry extending    OwnedObject,    Text {
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
                   r"Unexpected 'delegated'",
-                  line=2, col=9)
+                  line=3, col=13)
     def test_eschema_syntax_constraint_02(self):
         """
-        delegated constraint length {
-            subject := str::len(<str>__subject__);
+        module test {
+            delegated constraint length {
+                subject := str::len(<str>__subject__);
+            };
         };
         """
 
     def test_eschema_syntax_constraint_03(self):
         """
-        abstract constraint max_len_value(param:anytype)
-                extending max, length {
-            errmessage :=
-                '{subject} must be no longer than {$param} characters.';
+        module test {
+            abstract constraint max_len_value(param:anytype)
+                    extending max, length {
+                errmessage :=
+                    '{subject} must be no longer than {$param} characters.';
+            };
         };
         """
 
     def test_eschema_syntax_constraint_04(self):
         """
-        abstract constraint max_value(param:anytype) {
-            using (__subject__ <= $param);
-            errmessage := 'Maximum allowed value for {subject} is {$param}.';
-        };
+        module test {
+            abstract constraint max_value(param:anytype) {
+                using (__subject__ <= $param);
+                errmessage :=
+                    'Maximum allowed value for {subject} is {$param}.';
+            };
 
-        abstract constraint length {
-            subject := str::len(<str>__subject__);
-        };
+            abstract constraint length {
+                subject := str::len(<str>__subject__);
+            };
 
-        abstract constraint max_len_value(param:anytype)
-                extending max_value, length {
-            errmessage :=
-                '{subject} must be no longer than {$param} characters.';
+            abstract constraint max_len_value(param:anytype)
+                    extending max_value, length {
+                errmessage :=
+                    '{subject} must be no longer than {$param} characters.';
+            };
         };
         """
 
     def test_eschema_syntax_constraint_05(self):
         """
-        abstract constraint distance {
-            subject :=
-                <float64>__subject__;
-        };
+        module test {
+            abstract constraint distance {
+                subject :=
+                    <float64>__subject__;
+            };
 
-        abstract constraint maxldistance extending max, distance {
-            errmessage := '{subject} must be no longer than {$param} meters.';
+            abstract constraint maxldistance extending max, distance {
+                errmessage :=
+                    '{subject} must be no longer than {$param} meters.';
+            };
         };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
                   r"missing type declaration.*`param`",
-                  line=2, col=43)
+                  line=3, col=47)
     def test_eschema_syntax_constraint_06(self):
         """
-        abstract constraint max_len_value(param) extending max, length;
+        module test {
+            abstract constraint max_len_value(param) extending max, length;
+        };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
                   r"Unexpected 'constraint'",
-                  line=3, col=22)
+                  line=4, col=26)
     def test_eschema_syntax_constraint_07(self):
         """
-        scalar type special extending int {
-            abstract constraint length {
-                subject := str::len(<str>__subject__);
+        module test {
+            scalar type special extending int {
+                abstract constraint length {
+                    subject := str::len(<str>__subject__);
+                };
             };
         };
         """
 
     def test_eschema_syntax_constraint_08(self):
         """
-        abstract constraint foo(param:Foo) on (len(__subject__.bar))
-            extending max {
-                errmessage := 'bar must be no more than {$param}.';
+        module test {
+            abstract constraint foo(param:Foo) on (len(__subject__.bar))
+                extending max {
+                    errmessage := 'bar must be no more than {$param}.';
+            };
         };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError, r"Unexpected 'constraint'",
-                  line=2, col=9)
+                  line=3, col=13)
     def test_eschema_syntax_constraint_09(self):
         """
-        constraint foo;
+        module test {
+            constraint foo;
+        };
         """
 
     def test_eschema_syntax_constraint_10(self):
         """
-        scalar type foo extending str {
-            constraint maxldistance {
-                errmessage :=
-                    '{__subject__} must be no longer than {$param} meters.';
-            };
+        module test {
+            scalar type foo extending str {
+                constraint maxldistance {
+                    errmessage :=
+                      '{__subject__} must be no longer than {$param} meters.';
+                };
 
-            constraint max_len_value(4);
+                constraint max_len_value(4);
+            };
         };
         """
 
     def test_eschema_syntax_property_01(self):
         """
-abstract property foo {
+abstract property test::foo {
     title := 'Sample property';
 };
         """
 
     def test_eschema_syntax_property_02(self):
         """
-        abstract property bar extending foo;
+        module test {
+            abstract property bar extending foo;
+        };
         """
 
     def test_eschema_syntax_property_03(self):
         """
-        abstract property bar extending foo {
-            title := 'Another property';
+        module test {
+            abstract property bar extending foo {
+                title := 'Another property';
+            };
         };
         """
 
     def test_eschema_syntax_property_04(self):
         """
-        abstract property foo {
-            title := 'Sample property';
-        };
+        module test {
+            abstract property foo {
+                title := 'Sample property';
+            };
 
-        abstract property bar extending foo {
-            title := 'Another property';
+            abstract property bar extending foo {
+                title := 'Another property';
+            };
         };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError, r"Unexpected 'property'",
-                  line=2, col=9)
+                  line=3, col=13)
     def test_eschema_syntax_property_05(self):
         """
-        property foo;
+        module test {
+            property foo;
+        };
         """
 
     def test_eschema_syntax_link_01(self):
         """
-        abstract link coollink;
+        module test {
+            abstract link coollink;
+        };
         """
 
     def test_eschema_syntax_link_02(self):
         """
-        abstract link coollink extending boringlink;
+        module test {
+            abstract link coollink extending boringlink;
+        };
         """
 
     def test_eschema_syntax_link_03(self):
         """
-        abstract link coollink {
-            property foo -> int64;
+        module test {
+            abstract link coollink {
+                property foo -> int64;
+            };
         };
         """
 
     def test_eschema_syntax_link_04(self):
         """
-        abstract link coollink {
+        abstract link test::coollink {
             property foo -> int64;
             property bar -> int64;
 
@@ -858,102 +1055,120 @@ abstract property foo {
 
     def test_eschema_syntax_link_05(self):
         """
-        abstract property foo {
-            title := 'Sample property';
-        };
-
-        abstract property bar extending foo {
-            title := 'Another property';
-        };
-
-        abstract link coollink {
-            property foo -> int64 {
-                constraint min_value(0);
-                constraint max_value(123456);
-                constraint expr on (__subject__ % 2 = 0) {
-                    title := 'aaa';
-                };
-                default := 2;
+        module test {
+            abstract property foo {
+                title := 'Sample property';
             };
 
-            property bar -> int64;
+            abstract property bar extending foo {
+                title := 'Another property';
+            };
 
-            constraint expr on (self.foo = self.bar);
+            abstract link coollink {
+                property foo -> int64 {
+                    constraint min_value(0);
+                    constraint max_value(123456);
+                    constraint expr on (__subject__ % 2 = 0) {
+                        title := 'aaa';
+                    };
+                    default := 2;
+                };
+
+                property bar -> int64;
+
+                constraint expr on (self.foo = self.bar);
+            };
         };
         """
 
     # FIXME: should the link property be banned from being required?
     def test_eschema_syntax_link_06(self):
         """
-        abstract link coollink {
-            required property foo -> int64;
+        module test {
+            abstract link coollink {
+                required property foo -> int64;
+            };
         };
         """
 
     def test_eschema_syntax_link_07(self):
         """
-        abstract link time_estimate {
-           property unit -> str {
-               constraint my_constraint(0);
-           };
+        module test {
+            abstract link time_estimate {
+               property unit -> str {
+                   constraint my_constraint(0);
+               };
+            };
         };
         """
 
     def test_eschema_syntax_link_08(self):
         """
-        abstract link time_estimate {
-           property unit -> str {
-               constraint my_constraint(0, <str>(42^2));
-           };
+        module test {
+            abstract link time_estimate {
+               property unit -> str {
+                   constraint my_constraint(0, <str>(42^2));
+               };
+            };
         };
         """
 
     def test_eschema_syntax_link_09(self):
         """
-        abstract link time_estimate {
-           property unit -> str{
-               constraint my_constraint(')', `)`($$)$$));
-           };
+        module test {
+            abstract link time_estimate {
+               property unit -> str{
+                   constraint my_constraint(')', `)`($$)$$));
+               };
+            };
         };
         """
 
     def test_eschema_syntax_link_10(self):
         """
-        abstract link coollink;
+        module test {
+            abstract link coollink;
+        };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError, r"Unexpected 'link'",
-                  line=2, col=9)
+                  line=3, col=13)
     def test_eschema_syntax_link_11(self):
         """
-        link foo;
+        module test {
+            link foo;
+        };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError, r"Unexpected '::'",
-                  line=3, col=21)
+                  line=4, col=25)
     def test_eschema_syntax_link_12(self):
         """
-        type Foo {
-            link mod::name to std::str;
-        }
+        module test {
+            type Foo {
+                link mod::name to std::str;
+            }
+        };
         """
 
     def test_eschema_syntax_function_01(self):
         """
-        function len() -> std::int64
-            using sql function 'length';
+        module test {
+            function len() -> std::int64
+                using sql function 'length';
+        };
         """
 
     def test_eschema_syntax_function_02(self):
         r"""
-        function some_func(foo: std::int64 = 42) -> std::str
+        function test::some_func(foo: std::int64 = 42) -> std::str
             using sql $$
                 SELECT 'life';
             $$;
 
 % OK %
 
-        function some_func(foo: std::int64 = 42) -> std::str
+        function test::some_func(foo: std::int64 = 42) -> std::str
             using sql $$
                 SELECT 'life';
             $$;
@@ -961,274 +1176,330 @@ abstract property foo {
 
     def test_eschema_syntax_function_03(self):
         r"""
-        function some_func(foo: std::int64 = 42) -> std::str
-            using (
-                SELECT 'life'
-            );
+        module test {
+            function some_func(foo: std::int64 = 42) -> std::str
+                using (
+                    SELECT 'life'
+                );
+        };
         """
 
     def test_eschema_syntax_function_04(self):
         """
-        function myfunc(arg1: str, arg2: str = 'DEFAULT',
-                        variadic arg3: std::int64) -> set of int {
-            annotation description := 'myfunc sample';
-            using sql
-                $$SELECT blarg;$$;
+        module test {
+            function myfunc(arg1: str, arg2: str = 'DEFAULT',
+                            variadic arg3: std::int64) -> set of int {
+                annotation description := 'myfunc sample';
+                using sql
+                    $$SELECT blarg;$$;
+            };
         };
         """
 
     def test_eschema_syntax_function_05(self):
         """
-        function myfunc(arg1: str,
-                        arg2: str = 'DEFAULT',
-                        variadic arg3: std::int64,
-                        named only arg4: std::int64,
-                        named only arg5: std::int64) -> set of int
-            using (
-                SELECT blarg
-            );
+        module test {
+            function myfunc(arg1: str,
+                            arg2: str = 'DEFAULT',
+                            variadic arg3: std::int64,
+                            named only arg4: std::int64,
+                            named only arg5: std::int64) -> set of int
+                using (
+                    SELECT blarg
+                );
+        };
         """
 
     def test_eschema_syntax_function_06(self):
         """
-        function some_func(foo: std::int64 = 42) -> std::str {
-            initial_value := 'bad';
-            using (
-                SELECT 'life'
-            );
+        module test {
+            function some_func(foo: std::int64 = 42) -> std::str {
+                initial_value := 'bad';
+                using (
+                    SELECT 'life'
+                );
+            };
         };
         """
 
     def test_eschema_syntax_function_07(self):
         """
-        function some_func(foo: std::int64 = bar(42)) -> std::str
-            using sql function 'some_other_func';
+        module test {
+            function some_func(foo: std::int64 = bar(42)) -> std::str
+                using sql function 'some_other_func';
+        };
         """
 
     def test_eschema_syntax_function_08(self):
         """
-        function some_func(foo: str = ')') -> std::str
-            using sql function 'some_other_func';
+        module test {
+            function some_func(foo: str = ')') -> std::str
+                using sql function 'some_other_func';
+        };
         """
 
     def test_eschema_syntax_function_09(self):
         """
-        function some_func(foo: str = $$)$$) -> std::str
-            using sql function 'some_other_func';
+        module test {
+            function some_func(foo: str = $$)$$) -> std::str
+                using sql function 'some_other_func';
+        };
         """
 
     def test_eschema_syntax_function_10(self):
         """
-        function some_func(foo: str = $a1$)$a1$) -> std::str
-            using sql function 'some_other_func';
+        module test {
+            function some_func(foo: str = $a1$)$a1$) -> std::str
+                using sql function 'some_other_func';
+        };
         """
 
     def test_eschema_syntax_function_11(self):
         """
-        function some_func(`(`: str = ')') -> std::str
-            using sql function 'some_other_func';
+        module test {
+            function some_func(`(`: str = ')') -> std::str
+                using sql function 'some_other_func';
+        };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
                   r"function parameters do not need a \$",
-                  line=2, col=28)
+                  line=3, col=32)
     def test_eschema_syntax_function_12(self):
         """
-        function some_func($`(`: str = ) ) -> std::str {
-            using edgeql function 'some_other_func';
-        }
+        module test {
+            function some_func($`(`: str = ) ) -> std::str {
+                using edgeql function 'some_other_func';
+            }
+        };
         """
 
     def test_eschema_syntax_function_13(self):
         r"""
-        function some_func(`(`:
-                str = ')',
-                bar: int = bar()) -> std::str
-            using sql function 'some_other_func';
+        module test {
+            function some_func(`(`:
+                    str = ')',
+                    bar: int = bar()) -> std::str
+                using sql function 'some_other_func';
+        };
         """
 
     def test_eschema_syntax_function_15(self):
         """
-        function foo() -> tuple<
-                    str,
-                    array<tuple<int, str>>
-                >
-            using sql function 'some_other_func';
+        module test {
+            function foo() -> tuple<
+                        str,
+                        array<tuple<int, str>>
+                    >
+                using sql function 'some_other_func';
+        };
         """
 
     def test_eschema_syntax_function_16(self):
         """
-        function foo() -> tuple<
-                    str,
-                    array<tuple<int, `Foo:>`>>
-                >
-            using sql function 'some_other_func';
+        module test {
+            function foo() -> tuple<
+                        str,
+                        array<tuple<int, `Foo:>`>>
+                    >
+                using sql function 'some_other_func';
+        };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError, r"Unexpected '>'",
-                  line=5, col=17)
+                  line=6, col=21)
     def test_eschema_syntax_function_17(self):
         """
-        function foo() -> tuple<
-                    str,
-                    array<tuple<int, Foo>>>
-                > {
-            using sql function 'some_other_func';
+        module test {
+            function foo() -> tuple<
+                        str,
+                        array<tuple<int, Foo>>>
+                    > {
+                using sql function 'some_other_func';
+            };
         };
         """
 
     def test_eschema_syntax_function_18(self):
         """
-        function len1() -> std::int64
-            using sql function 'length1';
+        module test {
+            function len1() -> std::int64
+                using sql function 'length1';
 
-        function len2() -> std::int64
-            using sql function 'length2';
+            function len2() -> std::int64
+                using sql function 'length2';
 
-        function len3() -> std::int64
-            using sql function 'length3';
+            function len3() -> std::int64
+                using sql function 'length3';
 
-        function len4() -> std::int64
-            using sql function 'length4';
+            function len4() -> std::int64
+                using sql function 'length4';
+        }
 
 % OK %
 
-        function len1() ->  std::int64
-            using SQL function 'length1';
-        function len2() ->  std::int64
-            using SQL function 'length2';
-        function len3() ->  std::int64
-            using SQL function 'length3';
-        function len4() ->  std::int64
-            using SQL function 'length4';
+        module test {
+            function len1() ->  std::int64
+                using SQL function 'length1';
+            function len2() ->  std::int64
+                using SQL function 'length2';
+            function len3() ->  std::int64
+                using SQL function 'length3';
+            function len4() ->  std::int64
+                using SQL function 'length4';
+        };
         """
 
     def test_eschema_syntax_function_19(self):
         """
-        function len1() ->  std::int64 {
-            using SQL function 'length1'
+        module test {
+            function len1() ->  std::int64 {
+                using SQL function 'length1'
+            }
+            function len2() ->  std::int64 {
+                using SQL function 'length2'
+            }
+            function len3() ->  std::int64 {
+                using SQL function 'length3'
+            }
+            function len4() ->  std::int64 {
+                using SQL function 'length4'
+            }
         }
-        function len2() ->  std::int64 {
-            using SQL function 'length2'
-        }
-        function len3() ->  std::int64 {
-            using SQL function 'length3'
-        }
-        function len4() ->  std::int64 {
-            using SQL function 'length4'
-        }
-
 
 % OK %
 
-        function len1() ->  std::int64
-            using SQL function 'length1';
-        function len2() ->  std::int64
-            using SQL function 'length2';
-        function len3() ->  std::int64
-            using SQL function 'length3';
-        function len4() ->  std::int64
-            using SQL function 'length4';
+        module test {
+            function len1() ->  std::int64
+                using SQL function 'length1';
+            function len2() ->  std::int64
+                using SQL function 'length2';
+            function len3() ->  std::int64
+                using SQL function 'length3';
+            function len4() ->  std::int64
+                using SQL function 'length4';
+        };
         """
 
     def test_eschema_syntax_function_20(self):
         """
-        function len1() ->  std::int64 {
-            using SQL function 'length1'
-        }
-        function len2() ->  std::int64
-            using SQL function 'length2';
+        module test {
+            function len1() ->  std::int64 {
+                using SQL function 'length1'
+            }
+            function len2() ->  std::int64
+                using SQL function 'length2';
 
-        function len3() ->  std::int64 {
-            using SQL function 'length3'
+            function len3() ->  std::int64 {
+                using SQL function 'length3'
+            }
+            function len4() ->  std::int64
+                using SQL function 'length4';
         }
-        function len4() ->  std::int64
-            using SQL function 'length4';
-
 
 % OK %
 
-        function len1() ->  std::int64
-            using SQL function 'length1';
-        function len2() ->  std::int64
-            using SQL function 'length2';
-        function len3() ->  std::int64
-            using SQL function 'length3';
-        function len4() ->  std::int64
-            using SQL function 'length4';
+        module test {
+            function len1() ->  std::int64
+                using SQL function 'length1';
+            function len2() ->  std::int64
+                using SQL function 'length2';
+            function len3() ->  std::int64
+                using SQL function 'length3';
+            function len4() ->  std::int64
+                using SQL function 'length4';
+        };
         """
 
     def test_eschema_syntax_view_01(self):
         """
-        view FooBaz {
-            annotation description := 'Special Foo';
-            using (SELECT Foo FILTER Foo.bar = 'baz');
+        module test {
+            view FooBaz {
+                annotation description := 'Special Foo';
+                using (SELECT Foo FILTER Foo.bar = 'baz');
+            };
         };
         """
 
     def test_eschema_syntax_view_02(self):
         """
-        view FooBaz {
-            using (
+        module test {
+            view FooBaz {
+                using (
+                    SELECT Foo
+                    FILTER Foo.bar = 'baz'
+                );
+            };
+        }
+
+% OK %
+
+        module test {
+            view FooBaz := (
                 SELECT Foo
                 FILTER Foo.bar = 'baz'
             );
         };
-
-% OK %
-
-        view FooBaz := (
-            SELECT Foo
-            FILTER Foo.bar = 'baz'
-        );
         """
 
     def test_eschema_syntax_view_03(self):
         """
-        view FooBaz := (
-            SELECT Foo
-            FILTER Foo.bar = 'baz'
-        );
+        module test {
+            view FooBaz := (
+                SELECT Foo
+                FILTER Foo.bar = 'baz'
+            );
+        };
         """
 
     def test_eschema_syntax_annotation_01(self):
         """
-        abstract annotation foobar;
+        module test {
+            abstract annotation foobar;
+        };
         """
 
     def test_eschema_syntax_annotation_03(self):
         """
-        abstract annotation foobar extending baz;
+        module test {
+            abstract annotation foobar extending baz;
+        };
         """
 
     def test_eschema_syntax_annotation_04(self):
         """
-        abstract annotation foobar {
-            title := 'Some title';
+        module test {
+            abstract annotation foobar {
+                title := 'Some title';
+            };
         };
         """
 
     def test_eschema_syntax_annotation_06(self):
         """
-        abstract annotation foobar extending baz {
-            title := 'Some title';
+        module test {
+            abstract annotation foobar extending baz {
+                title := 'Some title';
+            };
         };
         """
 
     def test_eschema_syntax_annotation_08(self):
         """
-        abstract annotation foobar extending foo1, foo2;
+        module test {
+            abstract annotation foobar extending foo1, foo2;
+        };
         """
 
     def test_eschema_syntax_annotation_09(self):
         """
-        abstract annotation foobar extending foo1,
+        abstract annotation test::foobar extending foo1,
     foo2;
         """
 
     def test_eschema_syntax_annotation_10(self):
         """
-        abstract annotation foobar extending foo1,
+        abstract annotation test::foobar extending foo1,
     foo2 {
             title := 'Title';
         };
@@ -1236,29 +1507,37 @@ abstract property foo {
 
     def test_eschema_syntax_annotation_11(self):
         """
-        abstract annotation as extending foo;
+        module test {
+            abstract annotation as extending foo;
+        };
         """
 
     def test_eschema_syntax_annotation_12(self):
         """
-        abstract inheritable annotation foo;
+        module test {
+            abstract inheritable annotation foo;
+        };
         """
 
     def test_eschema_syntax_annotation_13(self):
         """
-        abstract inheritable annotation foo extending bar;
+        module test {
+            abstract inheritable annotation foo extending bar;
+        };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"Unexpected 'extending'", line=2, col=42)
+                  r"Unexpected 'extending'", line=3, col=46)
     def test_eschema_syntax_annotation_14(self):
         """
-        abstract annotation as extending extending foo;
+        module test {
+            abstract annotation as extending extending foo;
+        };
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError, r"Unexpected 'annotation'",
                   line=2, col=1)
     def test_eschema_syntax_annotation_15(self):
         """
-annotation foo;
+annotation test::foo;
         """

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1635,16 +1635,18 @@ class TestServerProto(tb.QueryTestCase):
     async def test_server_proto_tx_15(self):
         commands = [
             '''
-            CREATE MIGRATION test::ttt TO {
-                type User {
-                    required property login -> str {
-                        constraint exclusive;
+            CREATE MIGRATION ttt TO {
+                module default {
+                    type User {
+                        required property login -> str {
+                            constraint exclusive;
+                        };
                     };
                 };
             };
             ''',
-            '''GET MIGRATION test::ttt;''',
-            '''COMMIT MIGRATION test::ttt;''',
+            '''GET MIGRATION ttt;''',
+            '''COMMIT MIGRATION ttt;''',
         ]
 
         for command in commands:

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -21,7 +21,6 @@ import inspect
 import unittest
 
 from edb.edgeql import ast as qlast
-from edb.edgeql import declarative
 from edb.edgeql import tracer
 from edb.edgeql.compiler.inference import cardinality
 from edb.edgeql.compiler.inference import types
@@ -48,18 +47,6 @@ class TestTracer(unittest.TestCase):
 
                 if dispatcher.dispatch(astcls) is not_implemented:
                     self.fail(f'trace for {name} is not implemented')
-
-    def test_trace_dependencies_dispatch(self):
-        dispatcher = declarative.trace_dependencies
-        not_implemented = dispatcher.registry[object]
-
-        for name, astcls in inspect.getmembers(qlast, inspect.isclass):
-            if (issubclass(astcls, qlast.SDL)
-                    and not astcls.__abstract_node__):
-
-                if dispatcher.dispatch(astcls) is not_implemented:
-                    self.fail(
-                        f'trace_dependencies for {name} is not implemented')
 
     def test_get_status_dispatch(self):
         dispatcher = status.get_status

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,13 +206,13 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.14)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.21)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)
 
     def test_cqa_type_coverage_edgeql_parser(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql" / "parser", 0)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql" / "parser", 0.16)
 
     def test_cqa_type_coverage_edgeql_pygments(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "pygments", 0)


### PR DESCRIPTION
The `MIGRATION` DDL commands now must use an unqualified name for the
migration. The idea is that migrations are global objects and represent
the entire schema.

The SDL used in the `CREATE MIGRATION` command now must follow these
rules:
0) It ignores the default module from `SET MODULE` command. Anything
from the `std` module may be referenced without being fully-qualified.
1) The SDL describes the entire user-created schema.
2) A `module <name> { ... }` may wrap SDL declarations belonging to the
same module. Inside the module block top-level names MUST be unqualified
and are always assumend to belong to the module named by the block. All
other names (extending, targets, etc.) may be fully-qualified.
Unqualified names are interpreted as if the module named in the block
declaration is currently the default module.
3) Module blocks cannot be nested.
4) Any declaration appearing outside of a `module` block MUST use
fully-qualified names at top-level. The module portion of the
fully-qualified name will be used to determine which module the declared
entity belongs to.

Issue #907