### PR TITLE
edgeql: Allow trailing commas in WITH block.

### DIFF
--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -240,6 +240,12 @@ class WithBlock(Nonterm):
             aliases.append(w)
         self.val = WithBlockData(aliases=aliases)
 
+    def reduce_WITH_WithDeclList_COMMA(self, *kids):
+        aliases = []
+        for w in kids[1].val:
+            aliases.append(w)
+        self.val = WithBlockData(aliases=aliases)
+
 
 class AliasDecl(Nonterm):
     def reduce_MODULE_ModuleName(self, *kids):

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1958,6 +1958,32 @@ aa';
         WITH MODULE `~all.abstract.bar` SELECT Foo;
         """
 
+    def test_edgeql_syntax_with_09(self):
+        # trailing commas in WITH block
+        """
+        WITH MODULE foo, SELECT Bar;
+        WITH
+            MODULE foo,
+            x := {1, 2, 3},
+        SELECT Bar;
+        WITH
+            x := {1, 2, 3},
+            MODULE foo,
+        SELECT Bar;
+
+% OK %
+
+        WITH MODULE foo SELECT Bar;
+        WITH
+            MODULE foo,
+            x := {1, 2, 3}
+        SELECT Bar;
+        WITH
+            x := {1, 2, 3},
+            MODULE foo
+        SELECT Bar;
+        """
+
     def test_edgeql_syntax_detached_01(self):
         """
         WITH F := DETACHED Foo

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.21)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.17)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
We allow traling commas in many other contexts there's no reason to
disallow it in WITH block.

Fixes: #868