### PR TITLE
edgeql: Fix `.>` for tuples.

### DIFF
--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1033,6 +1033,23 @@ class Path(Nonterm):
             steps=self._float_to_path(kids[1], kids[0].context),
             partial=True)
 
+    @parsing.precedence(precedence.P_DOT)
+    def reduce_Expr_DOTFW_FCONST(self, *kids):
+        # this is a valid link-like syntax for accessing unnamed tuples
+        path = kids[0].val
+        if not isinstance(path, qlast.Path):
+            path = qlast.Path(steps=[path])
+
+        path.steps.extend(self._float_to_path(kids[2], kids[1].context))
+        self.val = path
+
+    @parsing.precedence(precedence.P_DOT)
+    def reduce_DOTFW_FCONST(self, *kids):
+        # this is a valid link-like syntax for accessing unnamed tuples
+        self.val = qlast.Path(
+            steps=self._float_to_path(kids[1], kids[0].context),
+            partial=True)
+
     def _float_to_path(self, token, context):
         from edb.schema import pointers as s_pointers
 
@@ -1074,6 +1091,15 @@ class PathStep(Nonterm):
         )
 
     def reduce_DOT_ICONST(self, *kids):
+        # this is a valid link-like syntax for accessing unnamed tuples
+        from edb.schema import pointers as s_pointers
+
+        self.val = qlast.Ptr(
+            ptr=qlast.ObjectRef(name=kids[1].val),
+            direction=s_pointers.PointerDirection.Outbound
+        )
+
+    def reduce_DOTFW_ICONST(self, *kids):
         # this is a valid link-like syntax for accessing unnamed tuples
         from edb.schema import pointers as s_pointers
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -3298,6 +3298,31 @@ class TestExpressions(tb.QueryTestCase):
             [[1, 2]],
         )
 
+    async def test_edgeql_expr_tuple_18(self):
+        await self.assert_query_result(
+            '''
+                WITH TUP := (1, (2, 3))
+                SELECT TUP.1.1;
+            ''',
+            [3],
+        )
+
+        await self.assert_query_result(
+            '''
+                WITH TUP := (1, (2, 3))
+                SELECT TUP.>1.1;
+            ''',
+            [3],
+        )
+
+        await self.assert_query_result(
+            '''
+                WITH TUP := (1, (2, 3))
+                SELECT TUP.>1.>1;
+            ''',
+            [3],
+        )
+
     async def test_edgeql_expr_tuple_indirection_01(self):
         await self.assert_query_result(
             r"""

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1763,6 +1763,19 @@ aa';
         SELECT TUP.0.1n.2;
         """
 
+    def test_edgeql_syntax_path_28(self):
+        """
+        SELECT TUP.1.1;
+        SELECT TUP.>1.1;
+        SELECT TUP.>1.>1;
+
+% OK %
+
+        SELECT TUP.1.1;
+        SELECT TUP.1.1;
+        SELECT TUP.1.1;
+        """
+
     def test_edgeql_syntax_type_interpretation_01(self):
         """
         SELECT Foo[IS Bar].spam;

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.17)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.06)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
The `.>` should be perfectly equivalent to `.` in tuples. In particular
when used with index dereferencing e.g. `SELECT tup.>0.>1`.