### PR TITLE
An assortment of DML fixes

### DIFF
--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -75,6 +75,9 @@ class CompilerContextLevel(compiler.ContextLevel):
     #: the top-level SQL statement
     toplevel_stmt: pgast.Query
 
+    #: Record of DML CTEs generated for the corresponding IR DML.
+    dml_stmts: Dict[irast.MutatingStmt, pgast.CommonTableExpr]
+
     #: SQL statement corresponding to the IR statement
     #: currently being compiled.
     stmt: pgast.SelectStmt
@@ -167,6 +170,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.stmt = NO_STMT
             self.rel = NO_STMT
             self.rel_hierarchy = {}
+            self.dml_stmts = {}
             self.parent_rel = None
             self.pending_query = None
 
@@ -193,6 +197,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.stmt = prevlevel.stmt
             self.rel = prevlevel.rel
             self.rel_hierarchy = prevlevel.rel_hierarchy
+            self.dml_stmts = prevlevel.dml_stmts
             self.parent_rel = prevlevel.parent_rel
             self.pending_query = prevlevel.pending_query
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -470,10 +470,6 @@ def process_update_body(
 
     external_updates = []
 
-    toplevel = ctx.toplevel_stmt
-    toplevel.ctes.append(range_cte)
-    toplevel.ctes.append(update_cte)
-
     with ctx.newscope() as subctx:
         # It is necessary to process the expressions in
         # the UpdateStmt shape body in the context of the
@@ -541,6 +537,10 @@ def process_update_body(
             view_path_id_map=update_stmt.view_path_id_map.copy(),
             ptr_join_map=update_stmt.ptr_join_map.copy(),
         )
+
+    toplevel = ctx.toplevel_stmt
+    toplevel.ctes.append(range_cte)
+    toplevel.ctes.append(update_cte)
 
     # Process necessary updates to the link tables.
     for expr, _props_only in external_updates:

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 
 from typing import *  # NoQA
 
+from edb import errors
+
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
 from edb.ir import utils as irutils
@@ -904,13 +906,16 @@ def range_for_ptrref(
 
     set_ops = []
 
-    if only_self:
+    if ptrref.union_components:
+        refs = ptrref.union_components
+        if only_self and len(refs) > 1:
+            raise errors.InternalServerError(
+                'unexpected union link'
+            )
+    elif only_self:
         refs = {ptrref}
     else:
-        if ptrref.union_components:
-            refs = ptrref.union_components
-        else:
-            refs = {ptrref} | ptrref.descendants
+        refs = {ptrref} | ptrref.descendants
 
     for src_ptrref in refs:
         assert isinstance(src_ptrref, irast.PointerRef), \

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -42,6 +42,7 @@ from edb.pgsql import types as pg_types
 from . import astutils
 from . import context
 from . import dispatch
+from . import dml
 from . import expr as exprcomp
 from . import output
 from . import pathctx
@@ -935,7 +936,17 @@ def process_set_as_subquery(
                     pathctx.get_path_identity_output(
                         subrel, path_id=ir_source.path_id, env=ctx.env)
 
-        dispatch.visit(ir_set.expr, ctx=newctx)
+        if (isinstance(ir_set.expr, irast.MutatingStmt)
+                and ir_set.expr in ctx.dml_stmts):
+            # The DML table-routing logic may result in the same
+            # DML subquery to be visited twice, such as in the case
+            # of a nested INSERT declaring link properties, so guard
+            # against generating a duplicate DML CTE.
+            with newctx.substmt() as subrelctx:
+                dml_cte = ctx.dml_stmts[ir_set.expr]
+                dml.wrap_dml_cte(ir_set.expr, dml_cte, ctx=subrelctx)
+        else:
+            dispatch.visit(ir_set.expr, ctx=newctx)
 
         if semi_join:
             src_ref = pathctx.maybe_get_path_identity_var(

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -4534,14 +4534,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [('test', 42, [1.2, 4.5])],
         )
 
-    @test.xfail('''
-        edgedb.errors.InternalServerError:
-        subquery must return only one column
-
-        The error occurs on UPDATE.
-
-        See `test_edgeql_update_collection_01` for a minimal test.
-    ''')
     async def test_edgeql_migration_collections_04(self):
         await self.con.execute("""
             SET MODULE test;

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -420,12 +420,6 @@ class TestInsert(tb.QueryTestCase):
             'subordinates': [{'name': 'nested sub 8.1'}]
         }])
 
-    @test.xfail('''
-        edgedb.errors.InternalServerError: could not find std::target
-        in insert computable
-
-        Probably related to `test_edgeql_insert_derived_02`.
-    ''')
     async def test_edgeql_insert_nested_09(self):
         # test a single link with a link property
         await self.con.execute(r'''

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -18,7 +18,6 @@
 
 
 import os.path
-import unittest
 import uuid
 
 import edgedb
@@ -1055,7 +1054,6 @@ class TestInsert(tb.QueryTestCase):
             {1, 2, 3}
         )
 
-    @unittest.expectedFailure
     async def test_edgeql_insert_as_expr_01(self):
         await self.con.execute(r'''
             # insert several objects, then annotate one of the inserted batch
@@ -1084,7 +1082,7 @@ class TestInsert(tb.QueryTestCase):
                         name,
                         l2,
                         l3,
-                        <subject: {
+                        subject := .<subject {
                             name,
                             note,
                         }
@@ -1098,19 +1096,19 @@ class TestInsert(tb.QueryTestCase):
                     'name': 'insert expr 1',
                     'l2': 2,
                     'l3': 'test',
-                    'subject': None,
+                    'subject': [],
                 },
                 {
                     'name': 'insert expr 1',
                     'l2': 3,
                     'l3': 'test',
-                    'subject': None,
+                    'subject': [],
                 },
                 {
                     'name': 'insert expr 1',
                     'l2': 5,
                     'l3': 'test',
-                    'subject': None,
+                    'subject': [],
                 },
                 {
                     'name': 'insert expr 1',
@@ -1124,14 +1122,13 @@ class TestInsert(tb.QueryTestCase):
             ]
         )
 
-    @unittest.expectedFailure
     async def test_edgeql_insert_polymorphic_01(self):
         await self.con.execute(r'''
             WITH MODULE test
             INSERT Directive {
-                args: {
+                args := (INSERT InputValue {
                     val := "something"
-                },
+                }),
             };
         ''')
 
@@ -1145,7 +1142,7 @@ class TestInsert(tb.QueryTestCase):
                 };
             ''',
             [{
-                'args': {'val': 'something'},
+                'args': [{'val': 'something'}],
             }]
         )
 
@@ -1171,7 +1168,7 @@ class TestInsert(tb.QueryTestCase):
                 };
             ''',
             [{
-                'args': {'val': 'something'},
+                'args': [{'val': 'something'}],
             }],
         )
 
@@ -1512,13 +1509,6 @@ class TestInsert(tb.QueryTestCase):
             ]
         )
 
-    @test.xfail('''
-        edgedb.errors.InternalServerError: relation
-        "edgedb_cf30b32c-dbf7-11e9-a772-0fb6315b40c8.cf535282-dbf7-11e9-9870-dda602d7da1c"
-        does not exist
-
-        Probably related to `test_edgeql_insert_nested_09`.
-    ''')
     async def test_edgeql_insert_derived_02(self):
         await self.con.execute(r"""
             WITH MODULE test

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1544,10 +1544,6 @@ class TestInsert(tb.QueryTestCase):
             ]
         )
 
-    @test.xfail('''
-        edgedb.errors.InternalServerError: cannot cast type record to
-        "338fc9bb-51be-555d-b2f7-abe53ff0567f_t"
-    ''')
     async def test_edgeql_insert_collection_01(self):
         await self.con.execute(r"""
             INSERT test::CollectionTest {

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -24,7 +24,6 @@ import uuid
 import edgedb
 
 from edb.testbase import server as tb
-from edb.tools import test
 
 
 class TestUpdate(tb.QueryTestCase):
@@ -1729,9 +1728,6 @@ class TestUpdate(tb.QueryTestCase):
             ]
         )
 
-    @test.xfail('''
-        edgedb.errors.InternalServerError: relation "m~2" does not exist
-    ''')
     async def test_edgeql_update_new_02(self):
         # test and UPDATE with a new object
         await self.assert_query_result(
@@ -1764,7 +1760,7 @@ class TestUpdate(tb.QueryTestCase):
                 {
                     'name': 'update-test1',
                     'status': {
-                        'name': 'new tag',
+                        'name': 'new status',
                     },
                 },
             ]

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -1770,10 +1770,6 @@ class TestUpdate(tb.QueryTestCase):
             ]
         )
 
-    @test.xfail('''
-        edgedb.errors.InternalServerError:
-        subquery must return only one column
-    ''')
     async def test_edgeql_update_collection_01(self):
         # test and UPDATE with a collection
         await self.con.execute(


### PR DESCRIPTION
* Fix nested DML statements in UPDATE

`UPDATE` is currently adding its CTEs too eagerly, so if any of the update
expressions contain DML statements the CTE order would be wrong.

* Fix handling of tuples in INSERT and UPDATE

Tuple values must be properly formed row expressions with an explicit cast
into an appropriate underlying composite type.

* Fix nested INSERT into a single link with properties

Using a nested INSERT to populate a `single` link with properties currently
crashes the compiler due to an old kludge that was trying to do an ad-hoc
tuple-serialization of a nested insert.  This hack is no longer necessary,
and removing it fixes the crash.  This fix unmasked another issue: the
sub-INSERT was visited twice due to how link properties and object
properties are routed in DML, so a basic memo and a guard are added to
prevent having duplicate DML CTEs.

* Fix inserts into purely-inherited links

When a pointer is not local (i.e inherited from a single parent), we do not
create a table for it.  Make sure `INSERT` handles this case correctly.