### PR TITLE
edgeql: Update the semantics of line continuation in strings.

### DIFF
--- a/docs/edgeql/lexical.rst
+++ b/docs/edgeql/lexical.rst
@@ -143,7 +143,8 @@ Here's a list of valid :token:`str_escapes`:
 +--------------------+---------------------------------------------+
 | Escape Sequence    | Meaning                                     |
 +====================+=============================================+
-| ``\[newline]``     | Backslash and newline ignored               |
+| ``\[newline]``     | Backslash and all whitespace up to next     |
+|                    | non-whitespace character is ignored         |
 +--------------------+---------------------------------------------+
 | ``\\``             | Backslash (\\)                              |
 +--------------------+---------------------------------------------+
@@ -182,8 +183,13 @@ Here's some examples of regular strings using escape sequences
     world'}
 
     db> SELECT 'hello \
-    ... world';
+    ...         world';
     {'hello world'}
+
+    db> SELECT 'https://edgedb.com/\
+    ...         docs/edgeql/lexical\
+    ...         #constants';
+    {'https://edgedb.com/docs/edgeql/lexical#constants'}
 
     db> SELECT 'hello \\ world';
     {'hello \ world'}

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -20,7 +20,6 @@
 from __future__ import annotations
 
 import collections
-import re
 import typing
 
 from edb.common import parsing, context
@@ -939,8 +938,8 @@ class EscapedStringConstant(Nonterm):
         quote = match.group('Q')
         val = match.group('body')
 
-        # handle line continuations
-        val = re.sub(r'\\\n', '', val)
+        # collapse the whitespace after a line continuation
+        val = lexutils.collapse_newline_whitespace(val)
 
         self.val = qlast.StringConstant(value=val, quote=quote)
 

--- a/edb/edgeql/parser/grammar/lexutils.py
+++ b/edb/edgeql/parser/grammar/lexutils.py
@@ -151,3 +151,10 @@ def unescape_string(st):
         return chr(int(m.group(g), 16))
 
     return STRING_ESCAPE_RE.sub(cb, st)
+
+
+STRING_LINE_CONT_RE = re.compile(r'\\\n\s*')
+
+
+def collapse_newline_whitespace(st):
+    return STRING_LINE_CONT_RE.sub(r'', st)

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -3039,16 +3039,17 @@ class TestExpressions(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
-            r'''SELECT 'aa\
-            bb \
-            aa';
-            ''',
-            ['aa            bb             aa'],
-        )
-
-        await self.assert_query_result(
             r'''SELECT r'\n';''',
             ['\\n'],
+        )
+
+    async def test_edgeql_expr_string_09(self):
+        await self.assert_query_result(
+            r'''SELECT 'bb\
+            aa \
+            bb';
+            ''',
+            ['bbaa bb'],
         )
 
         await self.assert_query_result(

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -353,10 +353,10 @@ aa';
     def test_edgeql_syntax_constants_31(self):
         r"""
         SELECT 'aa\
-        bb \
-        aa';
+                bb \
+                aa';
 % OK %
-        SELECT 'aa bb aa';
+        SELECT 'aabb aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -365,8 +365,8 @@ aa';
     def test_edgeql_syntax_constants_32(self):
         r"""
         SELECT 'aa\
-        bb \
-        aa\';
+                bb \
+                aa\';
 % OK %
         SELECT 'aabb aa';
         """

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.21)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.17)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
Regular strings in EdgeQL will now treat line continuation (`\`
terminating a line) as discarding not only the newline, but also all the
whitespace leading up to the next non-whitespace character. Thus the
following are equivalent:
```
SELECT 'hello world';
SELECT 'hello \
        world';
```

Issue #921.