### PR TITLE
Change how constraint error message is handled.

### DIFF
--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -54,28 +54,33 @@ class TestConstraintsSchema(tb.QueryTestCase):
     async def test_constraints_scalar_length(self):
         data = {
             # max-length is 10
-            (10 ** 10, 'must be no longer than 10 characters.'),
+            (10 ** 10,
+             'constraint_length must be no longer than 10 characters.'),
             (10 ** 10 - 1, 'good'),
-            (10 ** 7 - 1, 'must be no shorter than 8 characters'),
+            (10 ** 7 - 1,
+             'constraint_length must be no shorter than 8 characters'),
             (10 ** 7, 'good'),
         }
 
         await self._run_link_tests(data, 'test::Object', 'c_length')
 
         data = {
-            (10 ** 10, 'must be no longer than 10 characters.'),
+            (10 ** 10,
+             'constraint_length must be no longer than 10 characters.'),
             (10 ** 10 - 1, 'good'),
 
-            (10 ** 8 - 1, 'must be no shorter than 9 characters'),
+            (10 ** 8 - 1,
+             'constraint_length_2 must be no shorter than 9 characters'),
             (10 ** 8, 'good'),
         }
 
         await self._run_link_tests(data, 'test::Object', 'c_length_2')
 
         data = {
-            (10 ** 10, 'must be no longer than 10 characters.'),
+            (10 ** 10,
+             'constraint_length must be no longer than 10 characters.'),
             (10 ** 10 - 1, 'good'),
-            (10 ** 9 - 1, 'must be no shorter than 10 characters'),
+            (10 ** 9 - 1, 'c_length_3 must be no shorter than 10 characters'),
         }
 
         await self._run_link_tests(data, 'test::Object', 'c_length_3')

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -535,7 +535,7 @@ class TestIntrospection(tb.QueryTestCase):
                                 'return_type': {'name': 'std::bool'},
                                 'errmessage':
                                     '{__subject__} must be no longer than '
-                                    '10000 characters.'
+                                    '{max} characters.'
                             }
                         ]
                     },
@@ -598,7 +598,7 @@ class TestIntrospection(tb.QueryTestCase):
                         'return_typemod': 'SINGLETON',
                         'return_type': {'name': 'std::bool'},
                         'errmessage':
-                            "{__subject__} must be one of: ['ONE', 'MANY']."
+                            "{__subject__} must be one of: {vals}."
                     }
                 ]
             }]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2864,10 +2864,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                         annotation test::anno := 'annotated constraint';
                     };
                     single property p -> test::int_t {
-                        constraint std::max_value(10) {
-                            errmessage := 'Maximum allowed value
-                                           for {__subject__} is 10.';
-                        };
+                        constraint std::max_value(10);
                     };
                 };
                 required single property id -> std::uuid {
@@ -2906,10 +2903,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             """
             scalar type test::int_t extending std::int64 {
                 annotation test::anno := 'ext int';
-                constraint std::max_value(15) {
-                    errmessage := 'Maximum allowed value \
-                                   for {__subject__} is 15.';
-                };
+                constraint std::max_value(15);
             };
             """,
 


### PR DESCRIPTION
The `errormsg` is no longer implicitly amended every time a concrete
constraint is specified, but it is interpolated with the concrete
constraint arguments during error processing.

Fixes: #933.