### PR TITLE
Add an error hint for incorrect string line continuation.

### DIFF
--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -934,6 +934,11 @@ class EscapedStringConstant(Nonterm):
                 f"invalid string literal: invalid escape sequence "
                 f"'{match.group('err_esc')}'",
                 context=str_tok.context)
+        elif match.group('err_cont'):
+            raise EdgeQLSyntaxError(
+                f"invalid string literal: invalid line continuation",
+                hint="newline has to immediately follow '\\'",
+                context=str_tok.context)
 
         quote = match.group('Q')
         val = match.group('body')

--- a/edb/edgeql/parser/grammar/lexutils.py
+++ b/edb/edgeql/parser/grammar/lexutils.py
@@ -60,6 +60,13 @@ VALID_STRING_RE = re.compile(r'''
 
 ''' + _STRING_ESCAPE_RE + r''' |    # valid escape sequences above
 
+            (?P<err_cont>           # capture invalid line continuation
+                \\\s+\n             # \s+ won't match a \n here because
+                                    # there's already an explicit match for
+                                    # '\\\n' which will match the newline
+                                    # immediately after '\'
+            )
+            |
             (?P<err_esc>            # capture any invalid \escape sequence
                 \\x.{1,2} |
                 \\u.{1,4} |

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -3053,11 +3053,39 @@ class TestExpressions(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
+            r'''SELECT 'bb\
+            aa \
+
+
+            bb';
+            ''',
+            ['bbaa bb'],
+        )
+
+        await self.assert_query_result(
             r'''SELECT r'aa\
             bb \
             aa';''',
             ['aa\\\n            bb \\\n            aa'],
         )
+
+    async def test_edgeql_expr_string_10(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'invalid string literal: invalid line continuation',
+                _hint="newline has to immediately follow '\\'"):
+            await self.con.execute(
+                r"SELECT 'bb\   "
+                "\naa';"
+            )
+
+    async def test_edgeql_expr_string_11(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r"invalid string literal: invalid escape sequence '\\ '"):
+            await self.con.execute(
+                r"SELECT 'bb\   aa';"
+            )
 
     async def test_edgeql_expr_tuple_01(self):
         await self.assert_query_result(


### PR DESCRIPTION
Detect when a line continuation `\` in a regular string is followed by
space before a newline and provide a custom error message with a hint
for this situation.