### PR TITLE
Change the scoping logic for tuples and tuple dereference

### DIFF
--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -299,7 +299,29 @@ class ScopeTreeNode:
             new_child = ScopeTreeNode(path_id=prefix)
             parent.attach_child(new_child)
 
-            if not (is_lprop or prefix.is_linkprop_path()):
+            # If the path is a link property, or a tuple
+            # indirection, then its prefix is added at
+            # the *same* scope level, otherwise, the prefix
+            # is nested.
+            #
+            # For example, Foo.bar.baz, where Foo is an object type,
+            # forms this scope shape:
+            #   Foo.bar.baz
+            #    |-Foo.bar
+            #       |-Foo
+            #
+            # Whereas, <tuple>.bar.baz results in this:
+            #   <tuple>
+            #   <tuple>.bar
+            #   <tuple>.bar.baz
+            #
+            # This is because both link properties and tuples are
+            # *always* singletons, and so there is no semantic ambiguity
+            # as to the cardinality of the path prefix in different
+            # contexts.
+            if (not (is_lprop or prefix.is_linkprop_path())
+                    and (prefix.src_path() is None
+                         or not prefix.src_path().is_tuple_path())):
                 parent = new_child
 
             is_lprop = False

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1371,8 +1371,8 @@ def process_set_as_tuple_indirection(
             stmt.view_path_id_map[ir_set.path_id] = expr.path_id
             rvar = relctx.new_rel_rvar(ir_set, stmt, ctx=subctx)
 
-        source_rvar = pathctx.maybe_get_path_rvar(
-            stmt, tuple_set.path_id, aspect='source', env=subctx.env)
+        source_rvar = relctx.maybe_get_path_rvar(
+            stmt, tuple_set.path_id, aspect='source', ctx=subctx)
 
         if source_rvar is None:
             # Lack of visible tuple source means we are


### PR DESCRIPTION
Currently, expressions in the form `A.b.c` are handled in the same way
regardless of whether it is an object pointer dereference or a tuple
element dereference.  Since tuple elements are *always* singletons, the
common prefix ambiguity restriction we have for object paths is not very
useful, so remove it.  In practical terms this means that the following
expression is now valid:

    WITH
        MODULE test,
        letter := {'A', 'B'},
        tup := (
            letter,
            (
                SELECT User
                FILTER .name[0] = letter
            )
        )
    SELECT tup.1 {
        l := tup.0,
    };