### PR TITLE
Fix rendering of the reverse flamegraph

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -170,6 +170,14 @@ ignore_errors = False
 follow_imports = True
 ignore_errors = False
 
+[mypy-edb.tools.profiling.cli]
+follow_imports = True
+ignore_errors = False
+
+[mypy-edb.tools.profiling.profiler]
+follow_imports = True
+ignore_errors = False
+
 [mypy-edb.repl.*]
 follow_imports = True
 ignore_errors = False


### PR DESCRIPTION
Without this fix, the details line is not well aligned with the rest of the
reverse flamegraph.

Before:
<img width="689" alt="Screenshot 2019-12-06 at 00 53 55" src="https://user-images.githubusercontent.com/55281/70284940-1d413e80-17c6-11ea-96ca-37df28661e9c.png">

After:
<img width="738" alt="Screenshot 2019-12-06 at 00 56 28" src="https://user-images.githubusercontent.com/55281/70284951-2b8f5a80-17c6-11ea-9a02-72101b9998f3.png">
