### PR TITLE
Disable days and months units in std::duration

### DIFF
--- a/docs/datamodel/scalars/datetime.rst
+++ b/docs/datamodel/scalars/datetime.rst
@@ -198,9 +198,9 @@ EdgeDB stores and outputs timezone-aware values in UTC.
         db> select <cal::local_time>'22:00' + <duration>'1 hour';
         {<cal::local_time>'23:00:00'}
 
-    See functions :eql:func:`duration_get`, :eql:func:`to_duration`,
-    and :eql:func:`to_str` and date/time :eql:op:`operators <DTMINUS>`
-    for more ways of working with :eql:type:`duration`.
+    See functions :eql:func:`to_duration`, and :eql:func:`to_str` and
+    date/time :eql:op:`operators <DTMINUS>` for more ways of working with
+    :eql:type:`duration`.
 
 
 See Also

--- a/docs/edgeql/funcops/datetime.rst
+++ b/docs/edgeql/funcops/datetime.rst
@@ -564,25 +564,13 @@ Date and Time
         {<duration>'1:20:45'}
 
 
-.. eql:function:: std::duration_to_seconds(cur: duration) -> float64
+.. eql:function:: std::duration_to_seconds(cur: duration) -> decimal
 
     Return duration as total number of seconds in interval.
 
     .. code-block:: edgeql-repl
 
         db> SELECT duration_to_seconds(<duration>'1 hour');
-        {3600.0}
+        {3600.0d}
         db> SELECT duration_to_seconds(<duration>'10 second 100 millis');
-        {10.1}
-
-
-.. eql:function:: std::duration_to_micros(cur: duration) -> int64
-
-    Return duration as total number of microseconds.
-
-    .. code-block:: edgeql-repl
-
-        db> SELECT duration_to_micros(<duration>'1 hour');
-        {3600000000}
-        db> SELECT duration_to_micros(<duration>'10 second 100 millis');
-        {10100000}
+        {10.1d}

--- a/docs/edgeql/funcops/datetime.rst
+++ b/docs/edgeql/funcops/datetime.rst
@@ -562,3 +562,27 @@ Date and Time
         {<duration>'1:20:45'}
         db> SELECT to_duration(seconds := 4845);
         {<duration>'1:20:45'}
+
+
+.. eql:function:: std::duration_to_seconds(cur: duration) -> float64
+
+    Return duration as total number of seconds in interval.
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT duration_to_seconds(<duration>'1 hour');
+        {3600.0}
+        db> SELECT duration_to_seconds(<duration>'10 second 100 millis');
+        {10.1}
+
+
+.. eql:function:: std::duration_to_micros(cur: duration) -> int64
+
+    Return duration as total number of microseconds.
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT duration_to_micros(<duration>'1 hour');
+        {3600000000}
+        db> SELECT duration_to_micros(<duration>'10 second 100 millis');
+        {10100000}

--- a/docs/edgeql/funcops/datetime.rst
+++ b/docs/edgeql/funcops/datetime.rst
@@ -342,20 +342,22 @@ Date and Time
 
     Truncate the input duration to a particular precision.
 
-    The valid *unit* values are the same as for :eql:func:`datetime_trunc`.
+    The valid *unit* values are:
+    - ``'microseconds'``
+    - ``'milliseconds'``
+    - ``'seconds'``
+    - ``'minutes'``
+    - ``'hours'``
 
     .. code-block:: edgeql-repl
 
         db> SELECT duration_trunc(
-        ...     <duration>'3 days 15:01:22', 'day');
-        {'3 days'}
+        ...     <duration>'15:01:22', 'hours');
+        {'15:00:00'}
 
         db> SELECT duration_trunc(
-        ...     <duration>'15:01:22.306916', 'minute');
+        ...     <duration>'15:01:22.306916', 'minutes');
         {'15:01:00'}
-
-    The usual caveat that :eql:type:`duration` doesn't automatically
-    convert units applies to how truncation works.
 
 
 ----------

--- a/docs/edgeql/funcops/datetime.rst
+++ b/docs/edgeql/funcops/datetime.rst
@@ -47,9 +47,6 @@ Date and Time
     * - :eql:func:`date_get`
       - :eql:func-desc:`date_get`
 
-    * - :eql:func:`duration_get`
-      - :eql:func-desc:`duration_get`
-
     * - :eql:func:`datetime_trunc`
       - :eql:func-desc:`datetime_trunc`
 
@@ -299,82 +296,6 @@ Date and Time
 ----------
 
 
-.. eql:function:: std::duration_get(dt: duration, el: str) -> float64
-
-    Extract a specific element of input duration by name.
-
-    The :eql:type:`duration` scalar has the following elements
-    available for extraction:
-
-    - ``'century'`` - the number of centuries, rounded towards 0
-    - ``'day'`` - the number of days
-    - ``'decade'`` - the number of decades, rounded towards 0
-    - ``'epoch'`` - the total number of seconds in the duration
-    - ``'hour'`` - the hour (0-23)
-    - ``'microseconds'`` - the seconds including fractional value expressed
-      as microseconds
-    - ``'millennium'`` - the number of millennia, rounded towards 0
-    - ``'milliseconds'`` - the seconds including fractional value expressed
-      as milliseconds
-    - ``'minute'`` - the minutes (0-59)
-    - ``'month'`` - the number of months, modulo 12 (0-11)
-    - ``'quarter'`` - the quarter of the year (1-4), based on months
-    - ``'second'`` - the seconds, including fractional value from 0 up to and
-      not including 60
-    - ``'year'`` - the number of years
-
-    Due to inherent ambiguity of counting days, months, and years the
-    :eql:type:`duration` does not attempt to automatically convert
-    between them. So ``<duration>'24 hours'`` is not necessarily
-    the same as ``<duration>'1 day'``. So one must be careful
-    when adding or subtracting :eql:type:`duration` values.
-
-    .. code-block:: edgeql-repl
-
-        db> SELECT duration_get(<duration>'24 hours', 'day');
-        {0}
-
-        db> SELECT duration_get(<duration>'24 hours', 'hour');
-        {24}
-
-        db> SELECT duration_get(<duration>'1 day', 'day');
-        {1}
-
-        db> SELECT duration_get(<duration>'1 day', 'hour');
-        {0}
-
-        db> SELECT duration_get(
-        ...     <duration>'24 hours' - <duration>'1 day', 'hour');
-        {24}
-
-        db> SELECT duration_get(
-        ...     <duration>'24 hours' - <duration>'1 day', 'day');
-        {-1}
-
-    However, ``'epoch'`` calculations assume that 1 day = 24 hours, 1
-    month = 30 days and 1 year = 365.25 days or 12 months (depending
-    on what is being converted).
-
-    .. code-block:: edgeql-repl
-
-        db> SELECT duration_get(
-        ...     <duration>'24 hours' - <duration>'1d', 'epoch');
-        {0}
-
-        db> SELECT duration_get(<duration>'1 year', 'epoch');
-        {31557600}
-
-        db> SELECT duration_get(<duration>'365.25 days', 'epoch');
-        {31557600}
-
-        db> SELECT duration_get(
-        ...     <duration>'365 days 6 hours', 'epoch');
-        {31557600}
-
-
-----------
-
-
 .. eql:function:: std::datetime_trunc(dt: datetime, unit: str) -> datetime
 
     Truncate the input datetime to a particular precision.
@@ -619,13 +540,10 @@ Date and Time
 
 
 .. eql:function:: std::to_duration( \
-                    NAMED ONLY years: int64=0, \
-                    NAMED ONLY months: int64=0, \
-                    NAMED ONLY weeks: int64=0, \
-                    NAMED ONLY days: int64=0, \
                     NAMED ONLY hours: int64=0, \
                     NAMED ONLY minutes: int64=0, \
-                    NAMED ONLY seconds: float64=0 \
+                    NAMED ONLY seconds: float64=0, \
+                    NAMED ONLY microseconds: int64=0 \
                   ) -> duration
 
     :index: duration
@@ -634,7 +552,7 @@ Date and Time
 
     This function uses ``NAMED ONLY`` arguments  to create a
     :eql:type:`duration` value. The available duration fields are:
-    *years*, *months*, *weeks*, *days*, *hours*, *minutes*, *seconds*.
+    *hours*, *minutes*, *seconds*, *microseconds*.
 
     .. code-block:: edgeql-repl
 

--- a/edb/edgeql/pygments/meta.py
+++ b/edb/edgeql/pygments/meta.py
@@ -241,7 +241,6 @@ class EdgeQL:
         "datetime_of_statement",
         "datetime_of_transaction",
         "datetime_trunc",
-        "duration_get",
         "duration_trunc",
         "enumerate",
         "find",

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -459,13 +459,6 @@ std::`-` (l: cal::local_time, r: std::duration) -> cal::local_time {
 };
 
 
-CREATE INFIX OPERATOR
-std::`-` (l: cal::local_time, r: cal::local_time) -> std::duration {
-    SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR r'-';
-};
-
-
 ## Date/time casts
 ## ---------------
 

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -292,7 +292,9 @@ std::`-` (l: cal::local_datetime, r: std::duration) -> cal::local_datetime {
 CREATE INFIX OPERATOR
 std::`-` (l: cal::local_datetime, r: cal::local_datetime) -> std::duration {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR r'-';
+    USING SQL $$
+        SELECT EXTRACT(epoch FROM "l" - "r")::text::interval
+    $$
 };
 
 
@@ -388,7 +390,7 @@ CREATE INFIX OPERATOR
 std::`-` (l: cal::local_date, r: cal::local_date) -> std::duration {
     SET volatility := 'IMMUTABLE';
     USING SQL $$
-    SELECT make_interval(days => "l" - "r")
+        SELECT ("l" - "r") * INTERVAL '24 hours'
     $$;
 };
 

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -289,15 +289,6 @@ std::`-` (l: cal::local_datetime, r: std::duration) -> cal::local_datetime {
 };
 
 
-CREATE INFIX OPERATOR
-std::`-` (l: cal::local_datetime, r: cal::local_datetime) -> std::duration {
-    SET volatility := 'IMMUTABLE';
-    USING SQL $$
-        SELECT EXTRACT(epoch FROM "l" - "r")::text::interval
-    $$
-};
-
-
 ## Operators on cal::local_date
 ## ----------------------------
 

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -377,15 +377,6 @@ std::`-` (l: cal::local_date, r: std::duration) -> cal::local_date
 };
 
 
-CREATE INFIX OPERATOR
-std::`-` (l: cal::local_date, r: cal::local_date) -> std::duration {
-    SET volatility := 'IMMUTABLE';
-    USING SQL $$
-        SELECT ("l" - "r") * INTERVAL '24 hours'
-    $$;
-};
-
-
 ## Operators on cal::local_time
 ## ----------------------------
 

--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -76,6 +76,27 @@ std::duration_trunc(dt: std::duration, unit: std::str) -> std::duration
 };
 
 
+CREATE FUNCTION
+std::duration_to_seconds(dur: std::duration) -> std::float64
+{
+    SET volatility := 'IMMUTABLE';
+    USING SQL $$
+    SELECT EXTRACT(epoch FROM dur)
+    $$;
+};
+
+
+CREATE FUNCTION
+std::duration_to_micros(dur: std::duration) -> std::int64
+{
+    SET volatility := 'IMMUTABLE';
+    USING SQL $$
+    SELECT EXTRACT(epoch FROM date_trunc('minute', dur))::bigint*1000000 +
+           EXTRACT(microsecond FROM dur)::bigint
+    $$;
+};
+
+
 ## Date/time operators
 ## -------------------
 

--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -71,10 +71,9 @@ std::duration_trunc(dt: std::duration, unit: std::str) -> std::duration
 {
     SET volatility := 'IMMUTABLE';
     USING SQL $$
-    SELECT CASE WHEN "unit" in ('microseconds', 'milliseconds')
+    SELECT CASE WHEN "unit" in ('microseconds', 'milliseconds',
+                                'seconds', 'minutes', 'hours')
         THEN date_trunc("unit", "dt")
-        WHEN "unit" in ('seconds', 'minutes', 'hours')
-        THEN date_trunc(substring("unit" for length("unit")-1), "dt")
         ELSE
             edgedb._raise_specific_exception(
                 'invalid_datetime_format',

--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -77,22 +77,12 @@ std::duration_trunc(dt: std::duration, unit: std::str) -> std::duration
 
 
 CREATE FUNCTION
-std::duration_to_seconds(dur: std::duration) -> std::float64
+std::duration_to_seconds(dur: std::duration) -> std::decimal
 {
     SET volatility := 'IMMUTABLE';
     USING SQL $$
-    SELECT EXTRACT(epoch FROM dur)
-    $$;
-};
-
-
-CREATE FUNCTION
-std::duration_to_micros(dur: std::duration) -> std::int64
-{
-    SET volatility := 'IMMUTABLE';
-    USING SQL $$
-    SELECT EXTRACT(epoch FROM date_trunc('minute', dur))::bigint*1000000 +
-           EXTRACT(microsecond FROM dur)::bigint
+    SELECT EXTRACT(epoch FROM date_trunc('minute', dur))::bigint::decimal +
+           '0.000001'::decimal*EXTRACT(microsecond FROM dur)::decimal
     $$;
 };
 

--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -56,16 +56,6 @@ std::datetime_get(dt: std::datetime, el: std::str) -> std::float64
 
 
 CREATE FUNCTION
-std::duration_get(dt: std::duration, el: std::str) -> std::float64
-{
-    SET volatility := 'IMMUTABLE';
-    USING SQL $$
-    SELECT date_part("el", "dt")
-    $$;
-};
-
-
-CREATE FUNCTION
 std::datetime_trunc(dt: std::datetime, unit: std::str) -> std::datetime
 {
     # date_trunc of timestamptz is STABLE in PostgreSQL
@@ -174,7 +164,9 @@ std::`-` (l: std::datetime, r: std::duration) -> std::datetime {
 CREATE INFIX OPERATOR
 std::`-` (l: std::datetime, r: std::datetime) -> std::duration {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR r'-';
+    USING SQL $$
+        SELECT EXTRACT(epoch FROM "l" - "r")::text::interval
+    $$
 };
 
 
@@ -274,7 +266,7 @@ CREATE CAST FROM std::str TO std::datetime {
 
 CREATE CAST FROM std::str TO std::duration {
     SET volatility := 'STABLE';
-    USING SQL CAST;
+    USING SQL FUNCTION 'edgedb.duration_in';
 };
 
 

--- a/edb/lib/std/30-jsonfuncs.edgeql
+++ b/edb/lib/std/30-jsonfuncs.edgeql
@@ -253,7 +253,7 @@ CREATE CAST FROM std::json TO std::datetime {
 CREATE CAST FROM std::json TO std::duration {
     SET volatility := 'STABLE';
     USING SQL $$
-    SELECT edgedb.jsonb_extract_scalar(val, 'string')::interval;
+    SELECT edgedb.duration_in(edgedb.jsonb_extract_scalar(val, 'string'));
     $$;
 };
 

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -304,26 +304,23 @@ std::to_datetime(year: std::int64, month: std::int64, day: std::int64,
 
 CREATE FUNCTION
 std::to_duration(
-        NAMED ONLY years: std::int64=0,
-        NAMED ONLY months: std::int64=0,
-        NAMED ONLY weeks: std::int64=0,
-        NAMED ONLY days: std::int64=0,
         NAMED ONLY hours: std::int64=0,
         NAMED ONLY minutes: std::int64=0,
-        NAMED ONLY seconds: std::float64=0
+        NAMED ONLY seconds: std::float64=0,
+        NAMED ONLY microseconds: std::int64=0
     ) -> std::duration
 {
     SET volatility := 'IMMUTABLE';
     USING SQL $$
     SELECT make_interval(
-        "years"::int,
-        "months"::int,
-        "weeks"::int,
-        "days"::int,
+        0,
+        0,
+        0,
+        0,
         "hours"::int,
         "minutes"::int,
         "seconds"
-    )
+    ) + (microseconds::text || ' microseconds')::interval
     $$;
 };
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -1491,8 +1491,8 @@ class DurationInFunction(dbops.Function):
                     'invalid_datetime_format',
                     'invalid input syntax for type std::duration: '
                         || quote_literal(val),
-                    '{"hint":"You can''t use days or units ' ||
-                        'larger, like weeks, months or years for duration."}',
+                    '{"hint":"Units bigger than days cannot be used ' ||
+                    'for std::duration."}',
                     NULL::interval
                 )
             ELSE v.column1

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -1479,7 +1479,7 @@ class DatetimeInFunction(dbops.Function):
 
 
 class DurationInFunction(dbops.Function):
-    """Cast text into duration, ensuring there is no month units"""
+    """Cast text into duration, ensuring there is no days or months units"""
     text = r'''
         SELECT
             CASE WHEN
@@ -1489,7 +1489,7 @@ class DurationInFunction(dbops.Function):
             THEN
                 edgedb._raise_specific_exception(
                     'invalid_datetime_format',
-                    'invalid input syntax for type duration: '
+                    'invalid input syntax for type std::duration: '
                         || quote_literal(val),
                     '{"hint":"You can''t use days or units ' ||
                         'larger, like weeks, months or years for duration."}',

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 20191205_00_00
+EDGEDB_CATALOG_VERSION = 20191206_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/testbase/serutils.py
+++ b/edb/testbase/serutils.py
@@ -25,6 +25,7 @@ import functools
 import uuid
 
 import edgedb
+from edgedb.datatypes.datatypes import Duration
 
 
 @functools.singledispatch
@@ -84,8 +85,9 @@ def _set(o):
     return [serialize(el) for el in o]
 
 
-@serialize.register
-def _uuid(o: uuid.UUID):
+@serialize.register(uuid.UUID)
+@serialize.register(Duration)
+def _stringify(o):
     return str(o)
 
 

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -253,6 +253,7 @@ class TestEdgeQLDT(tb.QueryTestCase):
             ['8760:00:00'],
         )
 
+    @test.not_implemented('local_time diff is cal::relativedelta')
     async def test_edgeql_dt_local_time_01(self):
         await self.assert_query_result(
             r'''SELECT <cal::local_time>'10:01:01' + <duration>'24 hours';''',

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -46,30 +46,30 @@ class TestEdgeQLDT(tb.QueryTestCase):
     async def test_edgeql_dt_datetime_01(self):
         await self.assert_query_result(
             r'''SELECT <datetime>'2017-10-10T00:00:00+00' +
-                <duration>'1 day';''',
+                <duration>'24 hours';''',
             ['2017-10-11T00:00:00+00:00'],
         )
 
         await self.assert_query_result(
-            r'''SELECT <duration>'1 day' +
+            r'''SELECT <duration>'24 hours' +
                 <datetime>'2017-10-10 00:00:00+00';''',
             ['2017-10-11T00:00:00+00:00'],
         )
 
         await self.assert_query_result(
             r'''SELECT <datetime>'2017-10-10T00:00:00+00' -
-                <duration>'1 day';''',
+                <duration>'24 hours';''',
             ['2017-10-09T00:00:00+00:00'],
         )
 
         await self.assert_query_result(
-            r'''SELECT to_str(<duration>'1 day' + <duration>'1 day')''',
-            ['2 days'],
+            r'''SELECT to_str(<duration>'24 hours' + <duration>'24 hours')''',
+            ['48:00:00'],
         )
 
         await self.assert_query_result(
-            r'''SELECT to_str(<duration>'4 days' - <duration>'1 day')''',
-            ['3 days'],
+            r'''SELECT to_str(<duration>'4 hours' - <duration>'1 hour')''',
+            ['03:00:00'],
         )
 
         with self.assertRaisesRegex(
@@ -77,7 +77,7 @@ class TestEdgeQLDT(tb.QueryTestCase):
                 "operator '-' cannot be applied.*duration.*datetime"):
 
             await self.con.fetchall("""
-                SELECT <duration>'1 day' - <datetime>'2017-10-10T00:00:00+00';
+                SELECT <duration>'1 hour' - <datetime>'2017-10-10T00:00:00+00';
             """)
 
     async def test_edgeql_dt_datetime_02(self):
@@ -88,7 +88,7 @@ class TestEdgeQLDT(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''SELECT <str>(<datetime>'2017-10-10T00:00:00+00' -
-                             <duration>'1 day');
+                             <duration>'24 hours');
             ''',
             ['2017-10-09T00:00:00+00:00'],
         )
@@ -105,7 +105,7 @@ class TestEdgeQLDT(tb.QueryTestCase):
             r'''
                 SELECT (<tuple<str,datetime>>(
                     'foo', '2017-10-10T00:00:00+00')).1 +
-                   <duration>'1 month';
+                   <duration>'744 hours';
             ''',
             ['2017-11-10T00:00:00+00:00'],
         )
@@ -114,14 +114,14 @@ class TestEdgeQLDT(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 SELECT <cal::local_datetime>'2017-10-10T13:11' +
-                    <duration>'1 day';
+                    <duration>'24 hours';
             ''',
             ['2017-10-11T13:11:00'],
         )
 
         await self.assert_query_result(
             r'''
-                SELECT <duration>'1 day' +
+                SELECT <duration>'24 hours' +
                     <cal::local_datetime>'2017-10-10T13:11';
             ''',
             ['2017-10-11T13:11:00'],
@@ -130,31 +130,36 @@ class TestEdgeQLDT(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 SELECT <cal::local_datetime>'2017-10-10T13:11' -
-                    <duration>'1 day';
+                    <duration>'24 hours';
             ''',
             ['2017-10-09T13:11:00'],
         )
 
     async def test_edgeql_dt_local_date_01(self):
         await self.assert_query_result(
-            r'''SELECT <cal::local_date>'2017-10-10' + <duration>'1 day';''',
+            r'''SELECT
+                    <cal::local_date>'2017-10-10' + <duration>'24 hours';
+            ''',
             ['2017-10-11'],
         )
 
         await self.assert_query_result(
-            r'''SELECT <duration>'1 day' + <cal::local_date>'2017-10-10';''',
+            r'''SELECT
+                <duration>'24 hours' + <cal::local_date>'2017-10-10';
+            ''',
             ['2017-10-11'],
         )
 
         await self.assert_query_result(
-            r'''SELECT <cal::local_date>'2017-10-10' - <duration>'1 day';''',
+            r'''SELECT <cal::local_date>'2017-10-10' - <duration>'24 hours';
+            ''',
             ['2017-10-09'],
         )
 
     async def test_edgeql_dt_local_time_01(self):
         await self.assert_query_result(
-            r'''SELECT <cal::local_time>'10:01:01' + <duration>'1 hour';''',
-            ['11:01:01'],
+            r'''SELECT <cal::local_time>'10:01:01' + <duration>'24 hours';''',
+            ['10:01:01'],
         )
 
         await self.assert_query_result(

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -20,6 +20,7 @@
 import edgedb
 
 from edb.testbase import server as tb
+from edb.tools import test
 
 
 class TestEdgeQLDT(tb.QueryTestCase):
@@ -191,6 +192,7 @@ class TestEdgeQLDT(tb.QueryTestCase):
             ['2017-10-09T13:11:00'],
         )
 
+    @test.not_implemented('local time diff should return cal::relativedelta')
     async def test_edgeql_dt_local_datetime_02(self):
         await self.assert_query_result(
             r'''SELECT <cal::local_datetime>'2017-10-11T00:00:00' -

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -110,6 +110,62 @@ class TestEdgeQLDT(tb.QueryTestCase):
             ['2017-11-10T00:00:00+00:00'],
         )
 
+    async def test_edgeql_dt_datetime_04(self):
+        await self.assert_query_result(
+            r'''SELECT <datetime>'2017-10-11T00:00:00+00' -
+                <datetime>'2017-10-10T00:00:00+00';''',
+            ['24:00:00'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT <datetime>'2018-10-10T00:00:00+00' -
+                <datetime>'2017-10-10T00:00:00+00';''',
+            ['8760:00:00'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT <datetime>'2017-10-17T01:02:03.004005+00' -
+                <datetime>'2017-10-10T00:00:00+00';''',
+            ['169:02:03.004005'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT <datetime>'2017-10-10T01:02:03.004005-02' -
+                <datetime>'2017-10-10T00:00:00+00';''',
+            ['03:02:03.004005'],
+        )
+
+    async def test_edgeql_dt_duration_01_err(self):
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                "invalid input syntax for type std::duration: '7 days'"):
+            await self.con.execute("SELECT <duration>'7 days';")
+
+    async def test_edgeql_dt_duration_02_err(self):
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                "invalid input syntax for type std::duration: '13 months'"):
+            await self.con.execute("SELECT <duration>'13 months';")
+
+    async def test_edgeql_dt_duration_03_err(self):
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                "invalid input syntax for type std::duration: '17 years'"):
+            await self.con.execute("SELECT <duration>'17 years';")
+
+    async def test_edgeql_dt_duration_04_err(self):
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                "invalid input syntax for type std::duration: "
+                "'100 centuries'"):
+            await self.con.execute("SELECT <duration>'100 centuries';")
+
+    async def test_edgeql_dt_duration_05_err(self):
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                'invalid input syntax for type std::duration: "100 cats"'):
+            await self.con.execute("SELECT <duration>'100 cats';")
+
     async def test_edgeql_dt_local_datetime_01(self):
         await self.assert_query_result(
             r'''
@@ -135,6 +191,31 @@ class TestEdgeQLDT(tb.QueryTestCase):
             ['2017-10-09T13:11:00'],
         )
 
+    async def test_edgeql_dt_local_datetime_02(self):
+        await self.assert_query_result(
+            r'''SELECT <cal::local_datetime>'2017-10-11T00:00:00' -
+                <cal::local_datetime>'2017-10-10T00:00:00';''',
+            ['24:00:00'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT <cal::local_datetime>'2018-10-10T00:00:00' -
+                <cal::local_datetime>'2017-10-10T00:00:00';''',
+            ['8760:00:00'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT <cal::local_datetime>'2017-10-17T01:02:03.004005' -
+                <cal::local_datetime>'2017-10-10T00:00:00';''',
+            ['169:02:03.004005'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT <cal::local_datetime>'2017-10-10T01:02:03.004005' -
+                <cal::local_datetime>'2017-10-10T00:00:00';''',
+            ['01:02:03.004005'],
+        )
+
     async def test_edgeql_dt_local_date_01(self):
         await self.assert_query_result(
             r'''SELECT
@@ -156,6 +237,18 @@ class TestEdgeQLDT(tb.QueryTestCase):
             ['2017-10-09'],
         )
 
+        await self.assert_query_result(
+            r'''SELECT <cal::local_date>'2017-10-11' -
+                <cal::local_date>'2017-10-10';''',
+            ['24:00:00'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT <cal::local_date>'2018-10-10' -
+                <cal::local_date>'2017-10-10';''',
+            ['8760:00:00'],
+        )
+
     async def test_edgeql_dt_local_time_01(self):
         await self.assert_query_result(
             r'''SELECT <cal::local_time>'10:01:01' + <duration>'24 hours';''',
@@ -170,6 +263,12 @@ class TestEdgeQLDT(tb.QueryTestCase):
         await self.assert_query_result(
             r'''SELECT <cal::local_time>'10:01:01' - <duration>'1 hour';''',
             ['09:01:01'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT <cal::local_time>'01:02:03.004005' -
+                <cal::local_time>'00:00:00';''',
+            ['01:02:03.004005'],
         )
 
     async def test_edgeql_dt_sequence_01(self):

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -192,7 +192,7 @@ class TestEdgeQLDT(tb.QueryTestCase):
             ['2017-10-09T13:11:00'],
         )
 
-    @test.not_implemented('local time diff should return cal::relativedelta')
+    @test.not_implemented('local_datetime diff is cal::relativedelta')
     async def test_edgeql_dt_local_datetime_02(self):
         await self.assert_query_result(
             r'''SELECT <cal::local_datetime>'2017-10-11T00:00:00' -
@@ -239,6 +239,8 @@ class TestEdgeQLDT(tb.QueryTestCase):
             ['2017-10-09'],
         )
 
+    @test.not_implemented('local date diff should return cal::relativedelta')
+    async def test_edgeql_dt_local_date_02(self):
         await self.assert_query_result(
             r'''SELECT <cal::local_date>'2017-10-11' -
                 <cal::local_date>'2017-10-10';''',

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -1325,7 +1325,10 @@ class TestExpressions(tb.QueryTestCase):
                 if rdesc.signed:  # duration
                     restype = ldesc.typename
                 elif rdesc.typename == ldesc.typename:
-                    restype = 'duration'
+                    if rdesc.typename.startswith('cal::local_date'):
+                        restype = None
+                    else:
+                        restype = 'duration'
                 else:
                     restype = None
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -1325,7 +1325,8 @@ class TestExpressions(tb.QueryTestCase):
                 if rdesc.signed:  # duration
                     restype = ldesc.typename
                 elif rdesc.typename == ldesc.typename:
-                    if rdesc.typename.startswith('cal::local_date'):
+                    if rdesc.typename.startswith('cal::local_'):
+                        # TODO(tailhook) restype = 'cal::relativedelta'
                         restype = None
                     else:
                         restype = 'duration'

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -1232,19 +1232,10 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         )
 
     async def test_edgeql_functions_duration_trunc_01(self):
-        # basically this doesn't make sense
         await self.assert_query_result(
             r'''
             SELECT <str>duration_trunc(
-                <duration>'73 hours', 'day');
-            ''',
-            {'00:00:00'},
-        )
-
-        await self.assert_query_result(
-            r'''
-            SELECT <str>duration_trunc(
-                <duration>'15:01:22.306916', 'hour');
+                <duration>'15:01:22.306916', 'hours');
             ''',
             {'15:00:00'},
         )
@@ -1252,7 +1243,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             SELECT <str>duration_trunc(
-                <duration>'15:01:22.306916', 'minute');
+                <duration>'15:01:22.306916', 'minutes');
             ''',
             {'15:01:00'},
         )
@@ -1260,10 +1251,37 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             SELECT <str>duration_trunc(
-                <duration>'15:01:22.306916', 'second');
+                <duration>'15:01:22.306916', 'seconds');
             ''',
             {'15:01:22'},
         )
+
+        await self.assert_query_result(
+            r'''
+            SELECT <str>duration_trunc(
+                <duration>'15:01:22.306916', 'milliseconds');
+            ''',
+            {'15:01:22.306'},
+        )
+
+        # Currently no-op but may be useful if precision is improved
+        await self.assert_query_result(
+            r'''
+            SELECT <str>duration_trunc(
+                <duration>'15:01:22.306916', 'microseconds');
+            ''',
+            {'15:01:22.306916'},
+        )
+
+    async def test_edgeql_functions_duration_trunc_02(self):
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                'invalid input syntax for type std::duration_trunc'):
+            await self.con.execute(
+                r'''
+                SELECT <str>duration_trunc(
+                    <duration>'73 hours', 'day');
+                ''')
 
     async def test_edgeql_functions_to_datetime_01(self):
         await self.assert_query_result(

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -1174,39 +1174,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {22.306916},
         )
 
-    async def test_edgeql_functions_duration_get_01(self):
-        await self.assert_query_result(
-            r'''
-                SELECT duration_get(
-                    <duration>'15:01:22.306916', 'hour');
-            ''',
-            {15},
-        )
-
-        await self.assert_query_result(
-            r'''
-                SELECT duration_get(
-                    <duration>'15:01:22.306916', 'minute');
-            ''',
-            {1},
-        )
-
-        await self.assert_query_result(
-            r'''
-                SELECT duration_get(
-                    <duration>'15:01:22.306916', 'second');
-            ''',
-            {22.306916},
-        )
-
-        await self.assert_query_result(
-            r'''
-                SELECT duration_get(
-                    <duration>'3 days 15:01:22', 'day');
-            ''',
-            {3},
-        )
-
     async def test_edgeql_functions_datetime_trunc_01(self):
         await self.assert_query_result(
             r'''
@@ -1265,12 +1232,13 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         )
 
     async def test_edgeql_functions_duration_trunc_01(self):
+        # basically this doesn't make sense
         await self.assert_query_result(
             r'''
             SELECT <str>duration_trunc(
-                <duration>'3 days 15:01:22', 'day');
+                <duration>'73 hours', 'day');
             ''',
-            {'3 days'},
+            {'00:00:00'},
         )
 
         await self.assert_query_result(
@@ -1564,46 +1532,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
     async def test_edgeql_functions_to_duration_01(self):
         await self.assert_query_result(
-            r'''SELECT <str>to_duration(years:=20);''',
-            ['20 years'],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <str>to_duration(months:=20);''',
-            ['1 year 8 months'],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <str><duration>'1 year 8 months';''',
-            ['1 year 8 months'],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <str><duration>'13 months';''',
-            ['1 year 1 month'],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <str><duration>'13 months 1 day';''',
-            ['1 year 1 month 1 day'],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <str><duration>'14 months 1 day';''',
-            ['1 year 2 months 1 day'],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <str>to_duration(weeks:=20);''',
-            ['140 days'],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT <str>to_duration(days:=20);''',
-            ['20 days'],
-        )
-
-        await self.assert_query_result(
             r'''SELECT <str>to_duration(hours:=20);''',
             ['20:00:00'],
         )
@@ -1623,27 +1551,12 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             ['00:00:20.15'],
         )
 
+        await self.assert_query_result(
+            r'''SELECT <str>to_duration(microseconds:=100);''',
+            ['00:00:00.0001'],
+        )
+
     async def test_edgeql_functions_to_duration_02(self):
-        await self.assert_query_result(
-            r'''SELECT to_duration(years:=20) > to_duration(months:=20);''',
-            [True],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT to_duration(months:=20) > to_duration(weeks:=20);''',
-            [True],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT to_duration(weeks:=20) > to_duration(days:=20);''',
-            [True],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT to_duration(days:=20) > to_duration(hours:=20);''',
-            [True],
-        )
-
         await self.assert_query_result(
             r'''SELECT to_duration(hours:=20) > to_duration(minutes:=20);''',
             [True],
@@ -1798,7 +1711,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                                     '"fmt" argument must be'):
             async with self.con.transaction():
                 await self.con.fetchall(r'''
-                    WITH DT := to_duration(months:=20)
+                    WITH DT := to_duration(hours:=20)
                     SELECT to_str(DT, '');
                 ''')
 

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -1578,15 +1578,12 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [3723.000123],
         )
 
-    async def test_edgeql_functions_duration_to_micros(self):
+    async def test_edgeql_functions_duration_to_seconds_exact(self):
+        # at this value extract(epoch from duration) is imprecise
         await self.assert_query_result(
-            r'''SELECT duration_to_micros(<duration>'20 hours');''',
-            [72_000_000_000],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT duration_to_micros(<duration>'1:02:03.000123');''',
-            [3_723_000_123],
+            r'''SELECT duration_to_seconds(
+                <duration>'1801439850 seconds 123456 microseconds');''',
+            [1801439850.123456],
         )
 
     async def test_edgeql_functions_to_str_01(self):

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -1567,6 +1567,28 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [True],
         )
 
+    async def test_edgeql_functions_duration_to_seconds(self):
+        await self.assert_query_result(
+            r'''SELECT duration_to_seconds(<duration>'20 hours');''',
+            [72000.0],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT duration_to_seconds(<duration>'1:02:03.000123');''',
+            [3723.000123],
+        )
+
+    async def test_edgeql_functions_duration_to_micros(self):
+        await self.assert_query_result(
+            r'''SELECT duration_to_micros(<duration>'20 hours');''',
+            [72_000_000_000],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT duration_to_micros(<duration>'1:02:03.000123');''',
+            [3_723_000_123],
+        )
+
     async def test_edgeql_functions_to_str_01(self):
         # at the very least the cast <str> should be equivalent to
         # a call to to_str() without explicit format for simple scalars

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 42.62)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.22)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.28)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)


### PR DESCRIPTION
This also removes `duration_get` as it doesn't make sense with this
semantics (we'll return it back when `cal::relativedelta` is alive).

Other than that it looks simpler than I expected.

The controversial part is if we want to allow `<duration>'10 days'` (by normalizing it into seconds). Currently I have it disabled, but technically we can re-enable that in the future (for example `timedelta(days=10)` is perfectly valid and clear in python). 