### PR TITLE
WIP: Add initial rust module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "edb/server/pgproto"]
 	path = edb/server/pgproto
 	url = https://github.com/MagicStack/py-pgproto.git
+[submodule "edgedb-rust"]
+	path = edgedb-rust
+	url = https://github.com/edgedb/edgedb-rust

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,10 @@
 recursive-include edb *.edgeql *.esdl *.py *.txt
 recursive-include tests *.edgeql *.esdl *.py
 include LICENSE README.md logo.svg
+
+include edgedb-rust/Cargo.toml
+include edgedb-rust/Cargo.lock
+include edgedb-rust/edgeql-parser/Cargo.toml
+recursive-include edgedb-rust/edgeql-parser/src *
+include edgedb-rust/edgeql-python/Cargo.toml
+recursive-include edgedb-rust/edgeql-python/src *

--- a/docs/internals/dev.rst
+++ b/docs/internals/dev.rst
@@ -16,6 +16,7 @@ Linux or macOS.  Windows is not currently supported.
 
 * GNU make version 3.80 or newer;
 * C compiler (GCC or clang);
+* Rust compiler 1.39 or later;
 * autotools;
 * Python 3.8 dev package;
 * Bison 1.875 or later;

--- a/edb/edgeql/parser/grammar/lexer.py
+++ b/edb/edgeql/parser/grammar/lexer.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import re
 
 from edb.common import lexer
-from edb.edgeql import _edgeql_rust
+from edb.edgeql import _edgeql_rust  # noqa
 
 from .keywords import edgeql_keywords
 

--- a/edb/edgeql/parser/grammar/lexer.py
+++ b/edb/edgeql/parser/grammar/lexer.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import re
 
 from edb.common import lexer
+from edb.edgeql import _edgeql_rust
 
 from .keywords import edgeql_keywords
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.black]
 line-length = 79
 target-version = ['py37', 'py38']
+
+[build-system]
+requires = ["setuptools", "setuptools-rust"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
 [tool.black]
 line-length = 79
 target-version = ['py37', 'py38']
-
-[build-system]
-requires = ["setuptools", "setuptools-rust"]

--- a/setup.py
+++ b/setup.py
@@ -420,12 +420,27 @@ class build_ext(distutils_build_ext.build_ext):
         if self.distribution.rust_extensions:
             distutils.log.info("running build_rust")
             build_rust = self.get_finalized_command("build_rust")
+            # Workaround a bug in setuptools-rust: it uses
+            # shutil.copyfile(), which is not safe w.r.t mmap,
+            # so if the target module has been previously loaded
+            # bad things will happen.
+            build_ext = self.get_finalized_command("build_ext")
+            orig_inplace = build_ext.inplace
+            build_ext.inplace = True
+            for ext in self.distribution.rust_extensions:
+                target_path = build_ext.get_ext_fullpath(ext.name)
+                if os.path.exists(target_path):
+                    os.unlink(target_path)
+
             # Always build in-place because later stages of the build
-            # may depend on the modules having been built.
+            # may depend on the modules having been built
             build_rust.inplace = True
+            build_rust.debug = self.debug
             os.environ['CARGO_TARGET_DIR'] = (
                 str(pathlib.Path(self.build_temp) / 'rust'))
             build_rust.run()
+
+            build_ext.inplace = orig_inplace
 
         super().run()
 

--- a/setup.py
+++ b/setup.py
@@ -281,10 +281,12 @@ class gen_build_cache_key(setuptools.Command):
     user_options = []
 
     def run(self, *args, **kwargs):
-        import edb.edgeql.parser.grammar as _grammar
+        import edb as _edb
         from edb.common.devmode import hash_dirs
 
-        parser_hash = hash_dirs([(_grammar.__path__[0], '.py')])
+        parser_hash = hash_dirs([(
+            os.path.join(_edb.__path__[0], 'edgeql/parser/grammar'),
+            '.py')])
 
         proc = subprocess.run(
             ['git', 'submodule', 'status', 'postgres'],

--- a/setup.py
+++ b/setup.py
@@ -264,15 +264,15 @@ class build(distutils_build.build):
 class develop(setuptools_develop.develop):
 
     def run(self, *args, **kwargs):
-        _compile_parsers(pathlib.Path('build/lib'), inplace=True)
-        _compile_postgres(pathlib.Path('build').resolve())
-
         scripts = self.distribution.entry_points['console_scripts']
         patched_scripts = [s + '_dev' for s in scripts]
         patched_scripts.append('edb = edb.tools.edb:edbcommands')
         self.distribution.entry_points['console_scripts'] = patched_scripts
 
         super().run(*args, **kwargs)
+
+        _compile_parsers(pathlib.Path('build/lib'), inplace=True)
+        _compile_postgres(pathlib.Path('build').resolve())
 
 
 class gen_build_cache_key(setuptools.Command):

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ RUNTIME_DEPS = [
     'psutil~=5.6.1',
     'Pygments~=2.3.0',
     'setproctitle~=1.1.10',
+    'setuptools-rust==0.10.3',
     'setuptools_scm~=3.2.0',
     'typing_inspect~=0.5.0',
     'uvloop~=0.14.0',
@@ -70,7 +71,6 @@ DOCS_DEPS = [
 
 BUILD_DEPS = [
     CYTHON_DEPENDENCY,
-    'setuptools-rust==0.10.3',
 ]
 
 EXTRA_DEPS = {

--- a/setup.py
+++ b/setup.py
@@ -420,7 +420,9 @@ class build_ext(distutils_build_ext.build_ext):
         if self.distribution.rust_extensions:
             distutils.log.info("running build_rust")
             build_rust = self.get_finalized_command("build_rust")
-            build_rust.inplace = self.inplace
+            # Always build in-place because later stages of the build
+            # may depend on the modules having been built.
+            build_rust.inplace = True
             os.environ['CARGO_TARGET_DIR'] = (
                 str(pathlib.Path(self.build_temp) / 'rust'))
             build_rust.run()

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,10 @@ import textwrap
 
 from distutils import extension as distutils_extension
 from distutils.command import build as distutils_build
-from distutils.command import build_ext as distutils_build_ext
 
 import setuptools
+import setuptools_rust
+from setuptools_rust import build_ext as base_build_ext
 from setuptools.command import develop as setuptools_develop
 
 
@@ -325,9 +326,9 @@ class build_postgres(setuptools.Command):
             build_contrib=self.build_contrib)
 
 
-class build_ext(distutils_build_ext.build_ext):
+class build_ext(base_build_ext):
 
-    user_options = distutils_build_ext.build_ext.user_options + [
+    user_options = base_build_ext.user_options + [
         ('cython-annotate', None,
             'Produce a colorized HTML version of the Cython source.'),
         ('cython-directives=', None,
@@ -429,6 +430,12 @@ setuptools.setup(
             'edgedb-server = edb.server.main:main',
         ]
     },
+    rust_extensions=[
+        setuptools_rust.RustExtension(
+            "edb.edgeql._edgeql_rust",
+            path="edgedb-rust/edgeql-python/Cargo.toml",
+            binding=setuptools_rust.Binding.RustCPython),
+    ],
     ext_modules=[
         distutils_extension.Extension(
             "edb.server.pgproto.pgproto",

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ RUNTIME_DEPS = [
     'Pygments~=2.3.0',
     'setproctitle~=1.1.10',
     'setuptools_scm~=3.2.0',
+    'setuptools-rust==0.10.6',
     'typing_inspect~=0.5.0',
     'uvloop~=0.14.0',
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@
 
 
 import binascii
+import os
 import os.path
 import pathlib
 import platform
@@ -69,7 +70,7 @@ DOCS_DEPS = [
 
 BUILD_DEPS = [
     CYTHON_DEPENDENCY,
-    'setuptools-rust==0.10.6',
+    'setuptools-rust==0.10.3',
 ]
 
 EXTRA_DEPS = {
@@ -420,6 +421,8 @@ class build_ext(distutils_build_ext.build_ext):
             distutils.log.info("running build_rust")
             build_rust = self.get_finalized_command("build_rust")
             build_rust.inplace = self.inplace
+            os.environ['CARGO_TARGET_DIR'] = (
+                str(pathlib.Path(self.build_temp) / 'rust'))
             build_rust.run()
 
         super().run()


### PR DESCRIPTION
Here is the first attempt. Currently it just imports an empty module. Basically, it's to help up ensure that the module builds well on all our workstations, CI, and packages well.

Questions: how to put the module into `PYTHONPATH` of the build?
* In current commit, you need `PYTHONPATH=build/rustlib` to make it work
* It looks like cython modules are just put into sources. So should I just copy the module somewhere to `edb/edgeql/_rust_lexer.cpython-bla-bla.so` ?

Notes to myself:
* Update submodule url to public URL before merging in