### PR TITLE
Fix a bunch of issues with dependencies in SDL.

### DIFF
--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -810,7 +810,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             else:
                 self.write(ident_to_str(node.name.module), '::',
                            ident_to_str(node.name.name))
-        if node.create_if_not_exists:
+        if node.create_if_not_exists and not self.sdlmode:
             self.write(' IF NOT EXISTS')
         if after_name:
             after_name()
@@ -1002,6 +1002,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_CreateModule(self, node: qlast.CreateModule) -> None:
         self._visit_CreateObject(node, 'MODULE')
+        # Hack to handle the SDL version of this with an empty block.
+        if self.sdlmode and not node.commands:
+            self.write('{}')
 
     def visit_AlterModule(self, node: qlast.AlterModule) -> None:
         self._visit_AlterObject(node, 'MODULE')

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -501,7 +501,6 @@ class CreateConstraint(ConstraintCommand,
             props.pop('subject', None)
             fullname = self.classname
             shortname = sn.shortname_from_fullname(fullname)
-
             constr_base, attrs, inh = Constraint.get_concrete_constraint_attrs(
                 schema,
                 subject,

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -371,6 +371,7 @@ def apply_sdl(
             cmd = cmd_from_ddl(
                 ddl_stmt, schema=target_schema, modaliases={},
                 context=context, testmode=testmode)
+
             delta.add(cmd)
             target_schema, _ = delta.apply(target_schema, context)
             context.schema = target_schema

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.45)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.53)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
SDL was very sensitive to definition order to the point where simple
linear dependencies caused failures. Generally, "using" something
(function, annotation, constraint, etc.) before declaring it caused
errors when tring to create an SDL migration. Dependencies on other
modules were similarly broken.

Schema migration tests now attempt to dump the schema into SDL (using
the same code-path as used by `DESCRIBE`). Then the schema produced by
the generated SDL is compared to the original to check correctness of
generated SDL syntax and semantics.

The current version fixes many dependency issues, however, it also
highlighted a couple of deficiencies in other areas, which should be
fixed independently:
1) SDL for index does not support fields, so there's no equivalent to a
valid `SET origexpr := ...` in SDL.
2) There are some cases where `exclusive` constraints get resolved as
`default::std::exclusive` instead of `std::exclusive`. This seems to
happen after the step that deals with SDL conversion to DDL and
dependency resolution. The issue is intermittent given the same input
SDL.