### PR TITLE
Fix internal schema introspection ordering issues

### DIFF
--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1002,6 +1002,24 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
                 };
             """)
 
+    async def test_constraints_ddl_function(self):
+        await self.con.execute('''\
+            CREATE FUNCTION test::comp_func(s: str) -> str {
+                USING (
+                    SELECT str_lower(s)
+                );
+                SET volatility := 'IMMUTABLE';
+            };
+
+            CREATE TYPE test::CompPropFunction {
+                CREATE PROPERTY title -> str {
+                    CREATE CONSTRAINT exclusive ON
+                        (test::comp_func(__subject__));
+                };
+                CREATE PROPERTY comp_prop := test::comp_func(.title);
+            };
+        ''')
+
     async def test_constraints_ddl_error_02(self):
         # testing that subjectexpr cannot be overridden after it is
         # specified explicitly

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 100.00)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.28)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.20)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)


### PR DESCRIPTION
The current intromech is loading expression fields too eagerly, which
may result in "nonexistent object" errors.  Clean this up by loading
expressions consistently after all objects have been introspected.

This fixes an introspection error reported in #957.