### PR TITLE
edgeql: Update SDL syntax allowing setting fields on indexes.

### DIFF
--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -541,6 +541,7 @@ class AnnotationDeclarationShort(Nonterm):
 #
 sdl_commands_block(
     'CreateIndex',
+    SetField,
     SetAnnotation)
 
 


### PR DESCRIPTION
The `index` in SDL now allows to set `origexpr` field explicitly, just
as DDL.