### PR TITLE
Fix an issue with inherited constraint name.

### DIFF
--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -274,12 +274,19 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase):
                 ref_field_type = referrer_cls.get_field(refdict.attr).type
                 refname = ref_field_type.get_key_for(schema, self.scls)
 
+                # Mimicking the get_inherited_ref_layout behavior and
+                # reducing refname to shortname.
+                if sn.Name.is_qualified(refname):
+                    shortname = sn.shortname_from_fullname(sn.Name(refname))
+                else:
+                    shortname = refname
+
                 if context.enable_recursion:
                     for child in referrer.children(schema):
                         alter = alter_cmd(classname=child.get_name(schema))
                         with alter.new_context(schema, context, child):
                             schema, cmd = self._propagate_ref_creation(
-                                schema, context, refdict, refname, child)
+                                schema, context, refdict, shortname, child)
                             alter.add(cmd)
                         self.add(alter)
             else:


### PR DESCRIPTION
There are two ways of inheriting a constraint:
1) Two types are created, one extending the other, then the
constraint is added to the base type.
2) The base type is created with a constraint and then it's extended by
another type.

These two ways should end up with the same constraints on the extending
type, in particular the internal generated name of the concrete
constraint should be the same in both cases. Names that don't match can
cause problems in migrations or simply fail to be properly processed.