### PR TITLE
Don't even run `self.check_field_type()` in `AST.__init__` unless type checks are enabled

### DIFF
--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -192,12 +192,10 @@ class AST(object, metaclass=MetaAST):
                 f'cannot instantiate abstract AST node '
                 f'{self.__class__.__name__!r}')
 
-        self._init_fields(kwargs)
-
-    def _init_fields(self, values):
+        should_check_types = __debug__ and _check_type is _check_type_real
         for field_name, field in self.__class__._fields.items():
-            if field_name in values:
-                value = values[field_name]
+            if field_name in kwargs:
+                value = kwargs[field_name]
             elif field.default is not None:
                 if callable(field.default):
                     value = field.default()
@@ -206,7 +204,7 @@ class AST(object, metaclass=MetaAST):
             else:
                 value = None
 
-            if __debug__:
+            if should_check_types:
                 self.check_field_type(field, value)
 
             # Bypass overloaded setattr

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -197,10 +197,10 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "cli", 0)
 
     def test_cqa_type_coverage_common(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "common", 24.55)
+        self.assertFunctionCoverage(EDB_DIR / "common", 24.60)
 
     def test_cqa_type_coverage_common_ast(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "common" / "ast", 7.46)
+        self.assertFunctionCoverage(EDB_DIR / "common" / "ast", 7.58)
 
     def test_cqa_type_coverage_common_markup(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)


### PR DESCRIPTION
This method has been run >500,000 times in the `get_movie()` benchmark query
alone.  At this rate micro-optimizations like the one employed provide actual
time savings. In fact, it's kinda stupid but it's a 5% speedup.

Before:
```
compile_edgeql_script: Mean +- std dev: 2.62 ms +- 0.10 ms
compile_edgeql_script_webapp_configure_system: Mean +- std dev: 43.2 ms +- 3.5 ms
compile_edgeql_script_webapp_get_movie: Mean +- std dev: 250 ms +- 67 ms
compile_edgeql_script_webapp_get_person: Mean +- std dev: 295 ms +- 88 ms
compile_edgeql_script_webapp_get_user: Mean +- std dev: 125 ms +- 7 ms
compile_edgeql_script_webapp_insert_movie: Mean +- std dev: 161 ms +- 4 ms
compile_edgeql_script_webapp_insert_person: Mean +- std dev: 62.6 ms +- 1.4 ms
compile_edgeql_script_webapp_insert_review: Mean +- std dev: 93.8 ms +- 2.3 ms
```

After:
```
compile_edgeql_script: Mean +- std dev: 2.44 ms +- 0.07 ms
compile_edgeql_script_webapp_configure_system: Mean +- std dev: 40.1 ms +- 1.3 ms
compile_edgeql_script_webapp_get_movie: Mean +- std dev: 245 ms +- 67 ms
compile_edgeql_script_webapp_get_person: Mean +- std dev: 281 ms +- 88 ms
compile_edgeql_script_webapp_get_user: Mean +- std dev: 118 ms +- 5 ms
compile_edgeql_script_webapp_insert_movie: Mean +- std dev: 153 ms +- 4 ms
compile_edgeql_script_webapp_insert_person: Mean +- std dev: 58.6 ms +- 1.7 ms
compile_edgeql_script_webapp_insert_review: Mean +- std dev: 88.9 ms +- 2.3 ms
```