### PR TITLE
Cache ptrref_from_ptrcls

### DIFF
--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -156,6 +156,7 @@ def extend_path_id(
         schema=ctx.env.schema,
         ptrcls=ptrcls,
         direction=direction,
+        cache=ctx.env.ptr_ref_cache,
     )
     stmtctx.ensure_ptrref_cardinality(ptrcls, ptrref, ctx=ctx)
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -807,35 +807,13 @@ def computable_ptr_set(
             source_set, stype=source_set_stype,
             preserve_scope_ns=True, ctx=ctx)
         source_set.shape = []
-
         if source_set.rptr is not None:
-            schema = ctx.env.schema
-            source_rptrref = source_set.rptr.ptrref
-            source_rptrcls = irtyputils.ptrcls_from_ptrref(
-                source_rptrref, schema=schema)
-            bases = source_rptrcls.get_bases(schema)
-            if bases:
-                base = bases.first(schema)
-                if (not base.generic(schema)
-                        and ptrcls.is_link_property(schema)):
-                    source_rptrref = irtyputils.ptrref_from_ptrcls(
-                        source_ref=source_rptrref.dir_source,
-                        target_ref=source_rptrref.dir_target,
-                        direction=source_rptrref.direction,
-                        parent_ptr=source_rptrref.parent_ptr,
-                        ptrcls=base,
-                        schema=schema,
-                    )
-
-                    source_set.rptr = irast.Pointer(
-                        source=source_set.rptr.source,
-                        target=source_set,
-                        ptrref=source_rptrref,
-                        direction=source_set.rptr.direction,
-                    )
-
-                    stmtctx.ensure_ptrref_cardinality(
-                        base, source_set.rptr.ptrref, ctx=ctx)
+            source_set.rptr = irast.Pointer(
+                source=source_set.rptr.source,
+                target=source_set,
+                ptrref=source_set.rptr.ptrref.base_ptr,
+                direction=source_set.rptr.direction,
+            )
 
     qlctx: Optional[context.ContextLevel]
     inner_source_path_id: Optional[irast.PathId]

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -53,6 +53,7 @@ from . import inference
 from . import pathctx
 from . import schemactx
 from . import stmtctx
+from . import typegen
 
 if TYPE_CHECKING:
     from edb.schema import objects as s_obj
@@ -255,8 +256,7 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
             if ptr_expr.type == 'property':
                 # Link property reference; the source is the
                 # link immediately preceding this step in the path.
-                ptr = irtyputils.ptrcls_from_ptrref(
-                    path_tip.rptr.ptrref, schema=ctx.env.schema)
+                ptr = typegen.ptrcls_from_ptrref(path_tip.rptr.ptrref, ctx=ctx)
                 assert isinstance(ptr, s_links.Link)
                 source = ptr
             else:
@@ -275,8 +275,8 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
                         ignore_computable=True,
                         source_context=step.context, ctx=subctx)
 
-                    ptrcls = irtyputils.ptrcls_from_ptrref(
-                        path_tip.rptr.ptrref, schema=ctx.env.schema)
+                    ptrcls = typegen.ptrcls_from_ptrref(
+                        path_tip.rptr.ptrref, ctx=ctx)
                     if _is_computable_ptr(ptrcls, ctx=ctx):
                         computables.append(path_tip)
 
@@ -793,7 +793,7 @@ def computable_ptr_set(
         from_default_expr: bool=False,
         ctx: context.ContextLevel) -> irast.Set:
     """Return ir.Set for a pointer defined as a computable."""
-    ptrcls = irtyputils.ptrcls_from_ptrref(rptr.ptrref, schema=ctx.env.schema)
+    ptrcls = typegen.ptrcls_from_ptrref(rptr.ptrref, ctx=ctx)
     source_set = rptr.source
     source_scls = get_set_type(source_set, ctx=ctx)
     # process_view() may generate computable pointer expressions

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -733,7 +733,7 @@ def compile_query_subject(
         and expr_rptr.direction is s_pointers.PointerDirection.Outbound
         and (
             view_rptr.ptrcls_is_linkprop
-            == (expr_rptr.ptrref.parent_ptr is not None)
+            == (expr_rptr.ptrref.source_ptr is not None)
         )
     )
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -52,6 +52,7 @@ from . import setgen
 from . import viewgen
 from . import schemactx
 from . import stmtctx
+from . import typegen
 
 
 @dispatch.compile.register(qlast.SelectQuery)
@@ -743,8 +744,7 @@ def compile_query_subject(
         # the parent shape, ie. Spam { alias := Spam.bar }, so
         # `Spam.alias` should be a subclass of `Spam.bar` inheriting
         # its properties.
-        base_ptrcls = irtyputils.ptrcls_from_ptrref(
-            expr_rptr.ptrref, schema=ctx.env.schema)
+        base_ptrcls = typegen.ptrcls_from_ptrref(expr_rptr.ptrref, ctx=ctx)
         assert isinstance(base_ptrcls, s_pointers.Pointer)
         view_rptr.base_ptrcls = base_ptrcls
         view_rptr.ptrcls_is_alias = True

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -30,6 +30,7 @@ from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
 
 from edb.schema import abc as s_abc
+from edb.schema import pointers as s_pointers
 from edb.schema import types as s_types
 
 from edb.edgeql import ast as qlast
@@ -127,3 +128,15 @@ def _ql_typename_to_type(
             return coll.from_subtypes(ctx.env.schema, a_subtypes)
     else:
         return schemactx.get_schema_type(ql_t.maintype, ctx=ctx)
+
+
+def ptrcls_from_ptrref(
+    ptrref: irast.BasePointerRef, *,
+    ctx: context.ContextLevel,
+) -> s_pointers.PointerLike:
+
+    cached = ctx.env.ptr_ref_cache.get_ptrcls_for_ref(ptrref)
+    if cached is not None:
+        return cached
+
+    return irtyputils.ptrcls_from_ptrref(ptrref, schema=ctx.env.schema)

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -46,6 +46,7 @@ from . import pathctx
 from . import schemactx
 from . import setgen
 from . import stmtctx
+from . import typegen
 
 if TYPE_CHECKING:
     from edb.schema import lproperties as s_props
@@ -758,8 +759,7 @@ def _get_shape_configuration(
         rptr = ir_set.rptr
 
     if rptr is not None:
-        rptrcls = irtyputils.ptrcls_from_ptrref(
-            rptr.ptrref, schema=ctx.env.schema)
+        rptrcls = typegen.ptrcls_from_ptrref(rptr.ptrref, ctx=ctx)
     else:
         rptrcls = None
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -164,12 +164,11 @@ class BasePointerRef(ImmutableBase):
     name: sn.Name
     shortname: sn.Name
     std_parent_name: sn.Name
-    dir_source: TypeRef
-    dir_target: TypeRef
     out_source: TypeRef
     out_target: TypeRef
     direction: s_pointers.PointerDirection
-    parent_ptr: PointerRef
+    source_ptr: PointerRef
+    base_ptr: typing.Optional[BasePointerRef]
     material_ptr: BasePointerRef
     descendants: typing.Set[BasePointerRef]
     union_components: typing.Set[BasePointerRef]

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -163,6 +163,7 @@ class BasePointerRef(ImmutableBase):
 
     name: sn.Name
     shortname: sn.Name
+    path_id_name: typing.Optional[sn.Name]
     std_parent_name: sn.Name
     out_source: TypeRef
     out_target: TypeRef

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -278,16 +278,9 @@ class PathId:
                 raise ValueError(
                     'link property path extension on a non-link path')
 
-            ptr_ref = typeutils.ptrref_from_ptrcls(
-                source_ref=None, target_ref=target_ref,
-                parent_ptr=self.rptr(), ptrcls=ptrcls,
-                direction=direction, schema=schema,
-            )
-        else:
-            ptr_ref = typeutils.ptrref_from_ptrcls(
-                source_ref=self.target, target_ref=target_ref,
-                ptrcls=ptrcls, direction=direction, schema=schema,
-            )
+        ptr_ref = typeutils.ptrref_from_ptrcls(
+            ptrcls=ptrcls, direction=direction, schema=schema,
+        )
 
         result = self.__class__()
         result._path = self._path + ((ptr_ref, direction), target_ref)
@@ -425,7 +418,7 @@ class PathId:
             else:
                 ptr = ptrspec[0].shortname.name
             ptrdir = ptrspec[1]
-            is_lprop = ptrspec[0].parent_ptr is not None
+            is_lprop = ptrspec[0].source_ptr is not None
 
             if tgtspec.material_type is not None:
                 mat_tgt = tgtspec.material_type
@@ -471,7 +464,7 @@ class PathId:
 
             ptr_name = ptrspec[0].shortname
             ptrdir = ptrspec[1]
-            is_lprop = ptrspec[0].parent_ptr is not None
+            is_lprop = ptrspec[0].source_ptr is not None
 
             if is_lprop:
                 step = '@'

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -274,7 +274,8 @@ def ptrref_from_ptrcls(
     *,
     schema: s_schema.Schema,
     ptrcls: s_pointers.PointerLike,
-    direction: s_pointers.PointerDirection,
+    direction: s_pointers.PointerDirection = (
+        s_pointers.PointerDirection.Outbound),
     include_descendants: bool = True,
 ) -> irast.BasePointerRef:
     """Return an IR pointer descriptor for a given schema pointer.
@@ -440,6 +441,7 @@ def ptrref_from_ptrcls(
         out_target=out_target,
         name=ptrcls.get_name(schema),
         shortname=ptrcls.get_shortname(schema),
+        path_id_name=ptrcls.get_path_id_name(schema),
         std_parent_name=std_parent_name,
         direction=direction,
         source_ptr=source_ptr,

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -25,7 +25,10 @@ from typing import *  # NoQA
 from edb.edgeql import qltypes
 
 from edb.schema import abc as s_abc
+from edb.schema import links as s_links
+from edb.schema import lproperties as s_props
 from edb.schema import modules as s_mod
+from edb.schema import objtypes as s_objtypes
 from edb.schema import pointers as s_pointers
 from edb.schema import pseudo as s_pseudo
 from edb.schema import scalars as s_scalars
@@ -271,10 +274,7 @@ def ptrref_from_ptrcls(
     *,
     schema: s_schema.Schema,
     ptrcls: s_pointers.PointerLike,
-    source_ref: Optional[irast.TypeRef],
-    target_ref: irast.TypeRef,
     direction: s_pointers.PointerDirection,
-    parent_ptr: Optional[irast.BasePointerRef] = None,
     include_descendants: bool = True,
 ) -> irast.BasePointerRef:
     """Return an IR pointer descriptor for a given schema pointer.
@@ -288,18 +288,8 @@ def ptrref_from_ptrcls(
         ptrcls:
             A :class:`schema.pointers.Pointer` instance for which to
             return the PointerRef.
-        source_ref:
-            A :class:`ir.ast.TypeRef` instance describing the directional
-            source of the pointer.  If the pointer is a link property,
-            this will be ``None``.
-        target_ref:
-            A :class:`ir.ast.TypeRef` instance describing the directional
-            target of the pointer.
         direction:
             The direction of the pointer in the path expression.
-        parent_ptr:
-            If *ptrcls* is a link property, this should be a
-            ``PointerRef`` instance describing the link.
         include_descendants:
             Whether to include the corresponding pointer of the
             subtypes of the source type.
@@ -330,6 +320,30 @@ def ptrref_from_ptrcls(
 
     out_source: Optional[irast.TypeRef]
 
+    target = ptrcls.get_far_endpoint(schema, direction)
+    if isinstance(target, s_types.Type):
+        target_ref = type_to_typeref(schema, target)
+    else:
+        target_ref = target
+
+    source = ptrcls.get_near_endpoint(schema, direction)
+
+    source_ptr: Optional[irast.BasePointerRef]
+    if (isinstance(ptrcls, s_props.Property)
+            and isinstance(source, s_links.Link)):
+        source_ptr = ptrref_from_ptrcls(
+            ptrcls=source,
+            direction=direction,
+            schema=schema,
+        )
+        source_ref = None
+    else:
+        if isinstance(source, s_types.Type):
+            source_ref = type_to_typeref(schema, source)
+        else:
+            source_ref = source
+        source_ptr = None
+
     if direction is s_pointers.PointerDirection.Inbound:
         out_source = target_ref
         out_target = source_ref
@@ -350,11 +364,8 @@ def ptrref_from_ptrcls(
     material_ptr: Optional[irast.BasePointerRef]
     if material_ptrcls is not None and material_ptrcls is not ptrcls:
         material_ptr = ptrref_from_ptrcls(
-            source_ref=source_ref,
-            target_ref=target_ref,
             ptrcls=material_ptrcls,
             direction=direction,
-            parent_ptr=parent_ptr,
             schema=schema)
     else:
         material_ptr = None
@@ -366,11 +377,8 @@ def ptrref_from_ptrcls(
             material_comp = component.material_type(schema)
             union_components.add(
                 ptrref_from_ptrcls(
-                    source_ref=source_ref,
-                    target_ref=target_ref,
                     ptrcls=material_comp,
                     direction=direction,
-                    parent_ptr=parent_ptr,
                     schema=schema,
                 )
             )
@@ -380,11 +388,8 @@ def ptrref_from_ptrcls(
         for base in ptrcls.as_locally_defined(schema):
             union_components.add(
                 ptrref_from_ptrcls(
-                    source_ref=source_ref,
-                    target_ref=target_ref,
                     ptrcls=base,
                     direction=direction,
-                    parent_ptr=parent_ptr,
                     schema=schema,
                     include_descendants=False,
                 )
@@ -393,8 +398,7 @@ def ptrref_from_ptrcls(
     descendants: Set[irast.BasePointerRef] = set()
 
     if not union_components:
-        source = ptrcls.get_source(schema)
-        if isinstance(source, s_abc.ObjectType) and include_descendants:
+        if isinstance(source, s_objtypes.ObjectType) and include_descendants:
             ptrs = {material_ptrcls}
             ptrname = ptrcls.get_shortname(schema).name
             for descendant in source.descendants(schema):
@@ -406,11 +410,8 @@ def ptrref_from_ptrcls(
                         ptrs.add(desc_material_ptr)
                         descendants.add(
                             ptrref_from_ptrcls(
-                                source_ref=source_ref,
-                                target_ref=target_ref,
                                 ptrcls=desc_material_ptr,
                                 direction=direction,
-                                parent_ptr=parent_ptr,
                                 schema=schema,
                             )
                         )
@@ -422,16 +423,27 @@ def ptrref_from_ptrcls(
             std_parent_name = ancestor_name
             break
 
+    is_derived = ptrcls.get_is_derived(schema)
+    base_ptr: Optional[irast.BasePointerRef]
+    if is_derived:
+        base_ptrcls = ptrcls.get_bases(schema).first(schema)
+        base_ptr = ptrref_from_ptrcls(
+            ptrcls=base_ptrcls,
+            direction=direction,
+            schema=schema,
+        )
+    else:
+        base_ptr = None
+
     kwargs.update(dict(
-        dir_source=source_ref,
-        dir_target=target_ref,
         out_source=out_source,
         out_target=out_target,
         name=ptrcls.get_name(schema),
         shortname=ptrcls.get_shortname(schema),
         std_parent_name=std_parent_name,
         direction=direction,
-        parent_ptr=parent_ptr,
+        source_ptr=source_ptr,
+        base_ptr=base_ptr,
         material_ptr=material_ptr,
         is_derived=ptrcls.get_is_derived(schema),
         descendants=descendants,

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -363,7 +363,7 @@ def process_insert_body(
             if ptrref.material_ptr is not None:
                 ptrref = ptrref.material_ptr
 
-            if (ptrref.parent_ptr is not None and
+            if (ptrref.source_ptr is not None and
                     rptr.source.path_id != ir_stmt.subject.path_id):
                 continue
 
@@ -562,7 +562,7 @@ def is_props_only_update(shape_el: irast.Set, *,
     """
     return (
         bool(shape_el.shape) and
-        all(el.rptr.ptrref.parent_ptr is not None for el in shape_el.shape)
+        all(el.rptr.ptrref.source_ptr is not None for el in shape_el.shape)
     )
 
 
@@ -598,7 +598,7 @@ def process_link_update(
     rptr = ir_set.rptr
     ptrref = rptr.ptrref
     assert isinstance(ptrref, irast.PointerRef)
-    target_is_scalar = irtyputils.is_scalar(ptrref.dir_target)
+    target_is_scalar = irtyputils.is_scalar(ir_set.typeref)
     path_id = ir_set.path_id
 
     # The links in the dml class shape have been derived,

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -630,7 +630,7 @@ def _compile_set_in_singleton_mode(
             ptrref = node.rptr.ptrref
             source = node.rptr.source
 
-            if ptrref.parent_ptr is None and source.rptr is not None:
+            if ptrref.source_ptr is None and source.rptr is not None:
                 raise RuntimeError(
                     'unexpectedly long path in simple expr')
 

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -327,7 +327,7 @@ def tuple_var_as_json_object(
             rptr = element.path_id.rptr()
             assert rptr is not None
             name = rptr.shortname.name
-            if rptr.parent_ptr is not None:
+            if rptr.source_ptr is not None:
                 name = '@' + name
             keyvals.append(pgast.StringConstant(val=name))
             val = serialize_expr(

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -216,7 +216,7 @@ def get_path_var(
             # This is an scalar set derived from an expression.
             src_path_id = path_id
 
-    elif ptrref.parent_ptr is not None:
+    elif ptrref.source_ptr is not None:
         if ptr_info.table_type != 'link' and not is_inbound:
             # This is a link prop that is stored in source rel,
             # step back to link source rvar.

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -721,7 +721,7 @@ def process_set_as_path(
         ptrref, resolve_type=False, link_bias=False)
 
     # Path is a link property.
-    is_linkprop = ptrref.parent_ptr is not None
+    is_linkprop = ptrref.source_ptr is not None
     # Path is a reference to a relationship stored in the source table.
     is_inline_ref = ptr_info.table_type == 'ObjectType'
     is_primitive_ref = not irtyputils.is_object(ptrref.out_target)

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -388,11 +388,11 @@ def get_ptrref_storage_info(
             f'cannot determine backend storage parameters for the '
             f'{ptrref.name!r} pointer: the cardinality is not known')
 
-    is_lprop = ptrref.parent_ptr is not None
+    is_lprop = ptrref.source_ptr is not None
 
     if source is None:
         if is_lprop:
-            source = ptrref.parent_ptr
+            source = ptrref.source_ptr
         else:
             source = ptrref.out_source
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -495,6 +495,14 @@ class PseudoPointer(s_abc.Pointer):
     def get_target(self, schema) -> s_types.Type:
         raise NotImplementedError
 
+    def get_near_endpoint(self, schema, direction):
+        if direction is PointerDirection.Outbound:
+            return self.get_source(schema)
+        else:
+            raise AssertionError(
+                f'inbound direction is not valid for {type(self)}'
+            )
+
     def get_far_endpoint(self, schema, direction):
         if direction is PointerDirection.Outbound:
             return self.get_target(schema)

--- a/tests/test_edgeql_ir_pathid.py
+++ b/tests/test_edgeql_ir_pathid.py
@@ -21,6 +21,7 @@ import os.path
 
 from edb.testbase import lang as tb
 from edb.ir import pathid
+from edb.ir import typeutils as irtyputils
 from edb.schema import pointers as s_pointers
 
 
@@ -48,7 +49,11 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
         self.assertIsNone(pid_1.rptr_name())
         self.assertIsNone(pid_1.src_path())
 
-        pid_2 = pid_1.extend(ptrcls=deck_ptr, schema=self.schema)
+        deck_ptr_ref = irtyputils.ptrref_from_ptrcls(
+            schema=self.schema,
+            ptrcls=deck_ptr,
+        )
+        pid_2 = pid_1.extend(ptrref=deck_ptr_ref, schema=self.schema)
         self.assertEqual(
             str(pid_2),
             '(test::User).>deck[IS test::Card]')
@@ -70,7 +75,11 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
 
         self.assertEqual(ptr_pid.tgt_path(), pid_2)
 
-        prop_pid = ptr_pid.extend(ptrcls=count_prop, schema=self.schema)
+        count_prop_ref = irtyputils.ptrref_from_ptrcls(
+            schema=self.schema,
+            ptrcls=count_prop,
+        )
+        prop_pid = ptr_pid.extend(ptrref=count_prop_ref, schema=self.schema)
         self.assertEqual(
             str(prop_pid),
             '(test::User).>deck[IS test::Card]@count[IS std::int64]')
@@ -84,12 +93,20 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_pathid_startswith(self):
         User = self.schema.get('test::User')
         deck_ptr = User.getptr(self.schema, 'deck')
+        deck_ptr_ref = irtyputils.ptrref_from_ptrcls(
+            schema=self.schema,
+            ptrcls=deck_ptr,
+        )
         count_prop = deck_ptr.getptr(self.schema, 'count')
+        count_prop_ref = irtyputils.ptrref_from_ptrcls(
+            schema=self.schema,
+            ptrcls=count_prop,
+        )
 
         pid_1 = pathid.PathId.from_type(self.schema, User)
-        pid_2 = pid_1.extend(ptrcls=deck_ptr, schema=self.schema)
+        pid_2 = pid_1.extend(ptrref=deck_ptr_ref, schema=self.schema)
         ptr_pid = pid_2.ptr_path()
-        prop_pid = ptr_pid.extend(ptrcls=count_prop, schema=self.schema)
+        prop_pid = ptr_pid.extend(ptrref=count_prop_ref, schema=self.schema)
 
         self.assertTrue(pid_2.startswith(pid_1))
         self.assertFalse(pid_1.startswith(pid_2))
@@ -105,13 +122,21 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_pathid_namespace_01(self):
         User = self.schema.get('test::User')
         deck_ptr = User.getptr(self.schema, 'deck')
+        deck_ptr_ref = irtyputils.ptrref_from_ptrcls(
+            schema=self.schema,
+            ptrcls=deck_ptr,
+        )
         count_prop = deck_ptr.getptr(self.schema, 'count')
+        count_prop_ref = irtyputils.ptrref_from_ptrcls(
+            schema=self.schema,
+            ptrcls=count_prop,
+        )
 
         ns = frozenset(('foo',))
         pid_1 = pathid.PathId.from_type(self.schema, User, namespace=ns)
-        pid_2 = pid_1.extend(ptrcls=deck_ptr, schema=self.schema)
+        pid_2 = pid_1.extend(ptrref=deck_ptr_ref, schema=self.schema)
         ptr_pid = pid_2.ptr_path()
-        prop_pid = ptr_pid.extend(ptrcls=count_prop, schema=self.schema)
+        prop_pid = ptr_pid.extend(ptrref=count_prop_ref, schema=self.schema)
 
         self.assertEqual(pid_1.namespace, ns)
         self.assertEqual(pid_2.namespace, ns)
@@ -127,22 +152,35 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
         Card = self.schema.get('test::Card')
         User = self.schema.get('test::User')
         owners_ptr = Card.getptr(self.schema, 'owners')
+        owners_ptr_ref = irtyputils.ptrref_from_ptrcls(
+            schema=self.schema,
+            ptrcls=owners_ptr,
+        )
         deck_ptr = User.getptr(self.schema, 'deck')
+        deck_ptr_ref = irtyputils.ptrref_from_ptrcls(
+            schema=self.schema,
+            ptrcls=deck_ptr,
+        )
         count_prop = deck_ptr.getptr(self.schema, 'count')
+        count_prop_ref = irtyputils.ptrref_from_ptrcls(
+            schema=self.schema,
+            ptrcls=count_prop,
+        )
 
         ns_1 = frozenset(('foo',))
         ns_2 = frozenset(('bar',))
 
         pid_1 = pathid.PathId.from_type(self.schema, Card)
-        pid_2 = pid_1.extend(ptrcls=owners_ptr, ns=ns_1, schema=self.schema)
-        pid_2_no_ns = pid_1.extend(ptrcls=owners_ptr, schema=self.schema)
+        pid_2 = pid_1.extend(ptrref=owners_ptr_ref, ns=ns_1,
+                             schema=self.schema)
+        pid_2_no_ns = pid_1.extend(ptrref=owners_ptr_ref, schema=self.schema)
 
         self.assertNotEqual(pid_2, pid_2_no_ns)
         self.assertEqual(pid_2.src_path(), pid_1)
 
-        pid_3 = pid_2.extend(ptrcls=deck_ptr, ns=ns_2, schema=self.schema)
+        pid_3 = pid_2.extend(ptrref=deck_ptr_ref, ns=ns_2, schema=self.schema)
         ptr_pid = pid_3.ptr_path()
-        prop_pid = ptr_pid.extend(ptrcls=count_prop, schema=self.schema)
+        prop_pid = ptr_pid.extend(ptrref=count_prop_ref, schema=self.schema)
 
         self.assertEqual(prop_pid.src_path().namespace, ns_1 | ns_2)
         self.assertEqual(prop_pid.src_path().src_path().namespace, ns_1)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 38.68)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 38.64)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 7.56)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.22)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.43)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
The original intent of this PR was to make `ptrref_from_ptrcls()` easier to cache by reducing its signature.  Doing that, however, made the function slower (since it now must do more work).  Then, while working on fixing #969, I realized that we actually need the `ptrref` -> `ptrcls` cache, so I then implemented the `ptrcls -> ptrref` cache and its inverse.  This brought the `get_movie` benchmark to the status quo:

compile_edgeql_script_webapp_get_movie: Mean +- std dev: 213 ms +- 5 ms

Looking at the profile details for this benchmark, `ptrref_from_ptrcls()` now uses sligthly fewer cycles: -12%, but the overall effect of the cumulative change is negligible.