### PR TITLE
Make unions produced by reverse link navigation universal

### DIFF
--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -67,14 +67,21 @@ def get_tuple_indirection_path_id(
 
 
 def get_type_indirection_path_id(
-        path_id: irast.PathId, target_type: s_types.Type, *,
-        optional: bool, ancestral: bool, cardinality: qltypes.Cardinality,
-        ctx: context.ContextLevel) -> irast.PathId:
+    path_id: irast.PathId,
+    target_type: s_types.Type,
+    *,
+    optional: bool,
+    is_supertype: bool,
+    is_subtype: bool,
+    cardinality: qltypes.Cardinality,
+    ctx: context.ContextLevel,
+) -> irast.PathId:
     ptrcls = irast.TypeIndirectionLink(
         irtyputils.ir_typeref_to_type(ctx.env.schema, path_id.target),
         target_type,
         optional=optional,
-        ancestral=ancestral,
+        is_supertype=is_supertype,
+        is_subtype=is_subtype,
         cardinality=cardinality,
     )
 

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -26,7 +26,6 @@ from typing import *  # NoQA
 
 from edb import errors
 
-from edb.edgeql import qltypes
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
 
@@ -64,33 +63,6 @@ def get_tuple_indirection_path_id(
     )
 
     return tuple_path_id.extend(schema=ctx.env.schema, ptrref=ptrref)
-
-
-def get_type_indirection_path_id(
-    path_id: irast.PathId,
-    target_type: s_types.Type,
-    *,
-    optional: bool,
-    is_supertype: bool,
-    is_subtype: bool,
-    cardinality: qltypes.Cardinality,
-    ctx: context.ContextLevel,
-) -> irast.PathId:
-    ptrcls = irast.TypeIndirectionLink(
-        irtyputils.ir_typeref_to_type(ctx.env.schema, path_id.target),
-        target_type,
-        optional=optional,
-        is_supertype=is_supertype,
-        is_subtype=is_subtype,
-        cardinality=cardinality,
-    )
-
-    ptrref = irtyputils.ptrref_from_ptrcls(
-        schema=ctx.env.schema,
-        ptrcls=ptrcls,
-    )
-
-    return path_id.extend(schema=ctx.env.schema, ptrref=ptrref,)
 
 
 def get_expression_path_id(

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -642,10 +642,17 @@ def class_indirection_set(
     else:
         cardinality = qltypes.Cardinality.ONE
     stype = get_set_type(source_set, ctx=ctx)
-    ancestral = stype.issubclass(ctx.env.schema, target_scls)
+    is_supertype = stype.issubclass(ctx.env.schema, target_scls)
+    is_subtype = target_scls.issubclass(ctx.env.schema, stype)
     poly_set.path_id = pathctx.get_type_indirection_path_id(
-        source_set.path_id, target_scls, optional=optional,
-        ancestral=ancestral, cardinality=cardinality, ctx=ctx)
+        source_set.path_id,
+        target_scls,
+        optional=optional,
+        is_supertype=is_supertype,
+        is_subtype=is_subtype,
+        cardinality=cardinality,
+        ctx=ctx,
+    )
 
     ptr = irast.TypeIndirectionPointer(
         source=source_set,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -252,7 +252,8 @@ class TypeIndirectionLink(s_pointers.PseudoPointer):
         target: s_types.Type,
         *,
         optional: bool,
-        ancestral: bool,
+        is_supertype: bool,
+        is_subtype: bool,
         cardinality: qltypes.Cardinality,
     ) -> None:
         name = 'optindirection' if optional else 'indirection'
@@ -261,7 +262,8 @@ class TypeIndirectionLink(s_pointers.PseudoPointer):
         self._target = target
         self._cardinality = cardinality
         self._optional = optional
-        self._ancestral = ancestral
+        self._is_supertype = is_supertype
+        self._is_subtype = is_subtype
 
     def get_name(self, schema: s_schema.Schema) -> sn.Name:
         return self._name
@@ -275,8 +277,11 @@ class TypeIndirectionLink(s_pointers.PseudoPointer):
     def is_optional(self) -> bool:
         return self._optional
 
-    def is_ancestral(self) -> bool:
-        return self._ancestral
+    def is_supertype(self) -> bool:
+        return self._is_supertype
+
+    def is_subtype(self) -> bool:
+        return self._is_subtype
 
     def get_source(self, schema: s_schema.Schema) -> so.Object:
         return self._source
@@ -302,7 +307,8 @@ class TypeIndirectionLink(s_pointers.PseudoPointer):
 class TypeIndirectionPointerRef(BasePointerRef):
 
     optional: bool
-    ancestral: bool
+    is_supertype: bool
+    is_subtype: bool
 
 
 class Pointer(Base):

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -182,6 +182,13 @@ class BasePointerRef(ImmutableBase):
     # Outbound cardinality of the pointer.
     out_cardinality: qltypes.Cardinality
 
+    @property
+    def dir_target(self) -> TypeRef:
+        if self.direction is s_pointers.PointerDirection.Outbound:
+            return self.out_target
+        else:
+            return self.out_source
+
 
 class PointerRef(BasePointerRef):
 
@@ -254,6 +261,7 @@ class TypeIndirectionLink(s_pointers.PseudoPointer):
         optional: bool,
         is_supertype: bool,
         is_subtype: bool,
+        rptr_specialization: typing.Iterable[PointerRef] = (),
         cardinality: qltypes.Cardinality,
     ) -> None:
         name = 'optindirection' if optional else 'indirection'
@@ -264,6 +272,7 @@ class TypeIndirectionLink(s_pointers.PseudoPointer):
         self._optional = optional
         self._is_supertype = is_supertype
         self._is_subtype = is_subtype
+        self._rptr_specialization = frozenset(rptr_specialization)
 
     def get_name(self, schema: s_schema.Schema) -> sn.Name:
         return self._name
@@ -282,6 +291,9 @@ class TypeIndirectionLink(s_pointers.PseudoPointer):
 
     def is_subtype(self) -> bool:
         return self._is_subtype
+
+    def get_rptr_specialization(self) -> typing.FrozenSet[PointerRef]:
+        return self._rptr_specialization
 
     def get_source(self, schema: s_schema.Schema) -> so.Object:
         return self._source
@@ -309,6 +321,7 @@ class TypeIndirectionPointerRef(BasePointerRef):
     optional: bool
     is_supertype: bool
     is_subtype: bool
+    rptr_specialization: typing.FrozenSet[PointerRef]
 
 
 class Pointer(Base):
@@ -328,6 +341,7 @@ class Pointer(Base):
 class TypeIndirectionPointer(Pointer):
 
     optional: bool
+    ptrref: TypeIndirectionPointerRef
 
 
 class Expr(Base):

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -335,7 +335,10 @@ class ScopeTreeNode:
                     and not prefix.is_tuple_indirection_path()):
                 parent = new_child
 
-            is_lprop = False
+            # Skip through type indirections (i.e [IS Foo]) until
+            # we actually get to the link.
+            if not prefix.is_type_indirection_path():
+                is_lprop = False
 
         self.attach_subtree(subtree)
 

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -317,6 +317,7 @@ def ptrref_from_ptrcls(
         kwargs['optional'] = ptrcls.is_optional()
         kwargs['is_supertype'] = ptrcls.is_supertype()
         kwargs['is_subtype'] = ptrcls.is_subtype()
+        kwargs['rptr_specialization'] = ptrcls.get_rptr_specialization()
     elif isinstance(ptrcls, s_pointers.Pointer):
         ircls = irast.PointerRef
         kwargs['id'] = ptrcls.id

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -315,7 +315,8 @@ def ptrref_from_ptrcls(
     elif isinstance(ptrcls, irast.TypeIndirectionLink):
         ircls = irast.TypeIndirectionPointerRef
         kwargs['optional'] = ptrcls.is_optional()
-        kwargs['ancestral'] = ptrcls.is_ancestral()
+        kwargs['is_supertype'] = ptrcls.is_supertype()
+        kwargs['is_subtype'] = ptrcls.is_subtype()
     elif isinstance(ptrcls, s_pointers.Pointer):
         ircls = irast.PointerRef
         kwargs['id'] = ptrcls.id
@@ -510,7 +511,8 @@ def ptrcls_from_ptrref(
             source=schema.get_by_id(ptrref.out_source.id),
             target=schema.get_by_id(ptrref.out_target.id),
             optional=ptrref.optional,
-            ancestral=ptrref.ancestral,
+            is_supertype=ptrref.is_supertype,
+            is_subtype=ptrref.is_subtype,
             cardinality=ptrref.out_cardinality,
         )
     elif isinstance(ptrref, irast.PointerRef):

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -250,6 +250,23 @@ def is_type_indirection_reference(ir_expr: irast.Base) -> bool:
     return source_is_type_indirection
 
 
+def collapse_type_indirection(
+    ir_set: irast.Set,
+) -> Tuple[irast.Set, List[irast.TypeIndirectionPointer]]:
+
+    result: List[irast.TypeIndirectionPointer] = []
+
+    source = ir_set
+    while True:
+        rptr = source.rptr
+        if not isinstance(rptr, irast.TypeIndirectionPointer):
+            break
+        result.append(rptr)
+        source = rptr.source
+
+    return source, result
+
+
 def get_nearest_dml_stmt(ir_set: irast.Set) -> Optional[irast.MutatingStmt]:
     """For a given *ir_set* representing a Path, return the nearest path
        step that is a DML expression.

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import enum
 import typing
+import uuid
 
 from edb.common import ast
 from edb.common import typeutils
@@ -143,7 +144,12 @@ class EdgeQLPathInfo(Base):
 class BaseRangeVar(ImmutableBaseExpr):
     """Range variable, used in FROM clauses."""
 
+    __ast_meta__ = {'schema_object_id'}
+
     alias: Alias
+
+    #: The id of the schema object this rvar represents
+    schema_object_id: typing.Optional[uuid.UUID] = None
 
 
 class BaseRelation(EdgeQLPathInfo, BaseExpr):

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -646,6 +646,20 @@ def process_set_as_link_property_ref(
     with ctx.new() as newctx:
         link_path_id = ir_set.path_id.src_path()
         assert link_path_id is not None
+        orig_link_path_id = link_path_id
+
+        rptr_specialization: Set[irast.PointerRef] = set()
+
+        if link_path_id.is_type_indirection_path():
+            link_prefix, ind_ptrs = (
+                irutils.collapse_type_indirection(ir_source))
+            for ind_ptr in ind_ptrs:
+                rptr_specialization.update(ind_ptr.ptrref.rptr_specialization)
+
+            link_path_id = link_prefix.path_id.ptr_path()
+        else:
+            link_prefix = ir_source
+
         source_scope_stmt = relctx.get_scope_stmt(
             ir_source.path_id, ctx=newctx)
 
@@ -654,7 +668,36 @@ def process_set_as_link_property_ref(
 
         if link_rvar is None:
             link_rvar = relctx.new_pointer_rvar(
-                ir_source.rptr, src_rvar=src_rvar, link_bias=True, ctx=newctx)
+                link_prefix.rptr, src_rvar=src_rvar,
+                link_bias=True, ctx=newctx)
+
+        if rptr_specialization and astutils.is_set_op_query(link_rvar.query):
+            # This is a link property reference to a link union narrowed
+            # by a type indirection.  We already know which union components
+            # match the indirection expression, and can route the link
+            # property references to correct UNION subqueries.
+            ptr_ids = {spec.id for spec in rptr_specialization}
+
+            def cb(subquery: pgast.Query) -> None:
+                if isinstance(subquery, pgast.SelectStmt):
+                    rvar = subquery.from_clause[0]
+                    assert isinstance(rvar, pgast.PathRangeVar)
+                    if rvar.schema_object_id in ptr_ids:
+                        pathctx.put_path_source_rvar(
+                            subquery, orig_link_path_id, rvar, env=ctx.env
+                        )
+                        return
+                # Spare get_path_var() from attempting to rebalance
+                # the UNION by recording an explicit NULL as as the
+                # link property var.
+                pathctx.put_path_value_var(
+                    subquery, ir_set.path_id,
+                    pgast.NullConstant(),
+                    env=ctx.env,
+                )
+
+            assert isinstance(link_rvar.query, pgast.Query)
+            astutils.for_each_query_in_set(link_rvar.query, cb)
 
         rvars.append(SetRVar(
             link_rvar, link_path_id, aspects=['value', 'source']))
@@ -733,9 +776,16 @@ def process_set_as_path(
     is_inline_primitive_ref = is_inline_ref and is_primitive_ref
     is_id_ref_to_inline_source = False
 
+    if is_linkprop:
+        backtrack_src = ir_source
+        ctx.disable_semi_join.add(backtrack_src.path_id)
+        while backtrack_src.path_id.is_type_indirection_path():
+            backtrack_src = ir_source.rptr.source
+            ctx.disable_semi_join.add(backtrack_src.path_id)
+
     semi_join = (
         not source_is_visible and
-        ir_source.path_id not in ctx.disable_semi_join and
+        ir_set.path_id not in ctx.disable_semi_join and
         not (is_linkprop or is_primitive_ref)
     )
 
@@ -783,9 +833,6 @@ def process_set_as_path(
 
     elif not source_is_visible:
         with ctx.subrel() as srcctx:
-            if is_linkprop:
-                srcctx.disable_semi_join.add(ir_source.path_id)
-
             get_set_rvar(ir_source, ctx=srcctx)
 
             if is_inline_primitive_ref:

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -459,10 +459,13 @@ def _storable_in_source(ptrref: irast.PointerRef) -> bool:
 
 
 def _storable_in_pointer(ptrref: irast.PointerRef) -> bool:
-    return (
-        ptrref.out_cardinality is qltypes.Cardinality.MANY
-        or ptrref.has_properties
-    )
+    if ptrref.union_components:
+        return all(_storable_in_pointer(c) for c in ptrref.union_components)
+    else:
+        return (
+            ptrref.out_cardinality is qltypes.Cardinality.MANY
+            or ptrref.has_properties
+        )
 
 
 _TypeDescNode = collections.namedtuple(

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -88,7 +88,7 @@ class BaseObjectType(sources.Source,
             else:
                 return mtype.get_displayname(schema)
 
-    def getrptrs(self, schema, name):
+    def getrptrs(self, schema, name, *, sources=()):
         if sn.Name.is_qualified(name):
             raise ValueError(
                 'references to concrete pointers must not be qualified')
@@ -96,18 +96,24 @@ class BaseObjectType(sources.Source,
         ptrs = {
             l for l in schema.get_referrers(self, scls_type=links.Link,
                                             field_name='target')
-            if (l.get_shortname(schema).name == name
+            if (
+                l.get_shortname(schema).name == name
                 and not l.get_source(schema).is_view(schema)
-                and l.get_is_local(schema))
+                and l.get_is_local(schema)
+                and (not sources or l.get_source(schema) in sources)
+            )
         }
 
         for obj in self.get_ancestors(schema).objects(schema):
             ptrs.update(
                 l for l in schema.get_referrers(obj, scls_type=links.Link,
                                                 field_name='target')
-                if (l.get_shortname(schema).name == name
+                if (
+                    l.get_shortname(schema).name == name
                     and not l.get_source(schema).is_view(schema)
-                    and l.get_is_local(schema))
+                    and l.get_is_local(schema)
+                    and (not sources or l.get_source(schema) in sources)
+                )
             )
 
         return ptrs

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -969,12 +969,18 @@ def get_or_create_union_pointer(
     source,
     direction: PointerDirection,
     components: Iterable[Pointer], *,
-    modname: Optional[str]=None,
+    opaque: bool = False,
+    modname: Optional[str] = None,
 ) -> Tuple[s_schema.Schema, Pointer]:
+
+    components = list(components)
+
+    if len(components) == 1 and direction is PointerDirection.Outbound:
+        return components[0]
 
     targets = [p.get_far_endpoint(schema, direction) for p in components]
     schema, target = utils.get_union_type(
-        schema, targets, opaque=False, module=modname)
+        schema, targets, opaque=opaque, module=modname)
 
     cardinality = qltypes.Cardinality.ONE
     for component in components:
@@ -982,7 +988,6 @@ def get_or_create_union_pointer(
             cardinality = qltypes.Cardinality.MANY
             break
 
-    components = list(components)
     metacls = type(components[0])
     genptr = schema.get(metacls.get_default_base_name())
 

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -60,7 +60,7 @@ class Source(indexes.IndexableSubject):
                 'references to concrete pointers must not be qualified')
         return self.get_pointers(schema).get(schema, name, None)
 
-    def getrptrs(self, schema, name):
+    def getrptrs(self, schema, name, *, sources=()):
         return set()
 
     def add_pointer(self, schema, pointer, *, replace=False):

--- a/tests/schemas/issues.esdl
+++ b/tests/schemas/issues.esdl
@@ -48,7 +48,9 @@ type User extending Dictionary {
 
 abstract type Owned {
     # By default links are optional.
-    required link owner -> User;
+    required link owner -> User {
+        property note -> str;
+    }
 }
 
 type Status extending Dictionary;
@@ -70,6 +72,10 @@ type Comment extending Text, Owned {
 }
 
 type Issue extending Named, Owned, Text {
+    overloaded required link owner {
+        property since -> datetime;
+    }
+
     required property number -> issue_num_t {
         readonly := true;
         constraint exclusive;

--- a/tests/schemas/issues_setup.edgeql
+++ b/tests/schemas/issues_setup.edgeql
@@ -61,7 +61,14 @@ INSERT File {
 
 WITH MODULE test
 INSERT LogEntry {
-    owner := (SELECT User FILTER User.name = 'Elvis'),
+    owner := (
+        SELECT
+            User {
+                @note := 'reassigned'
+            }
+        FILTER
+            User.name = 'Elvis'
+    ),
     spent_time := 50000,
     body := 'Rewriting everything.'
 };
@@ -71,7 +78,11 @@ INSERT Issue {
     number := '1',
     name := 'Release EdgeDB',
     body := 'Initial public release of EdgeDB.',
-    owner := (SELECT User FILTER User.name = 'Elvis'),
+    owner := (SELECT User {
+                @since := <datetime>'2018-01-01T00:00+00',
+                @note := 'automatic assignment',
+              }
+              FILTER User.name = 'Elvis'),
     watchers := (SELECT User FILTER User.name = 'Yury'),
     status := (SELECT Status FILTER Status.name = 'Open'),
     time_spent_log := (SELECT LogEntry),

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -976,7 +976,7 @@ class TestEdgeQLGroup(tb.QueryTestCase):
                 # group by link property
                 WITH MODULE cards
                 GROUP Card
-                USING B := Card.<deck@count
+                USING B := Card.<deck[IS User]@count
                 BY B
                 INTO Card
                 UNION _ := (
@@ -1021,7 +1021,7 @@ class TestEdgeQLGroup(tb.QueryTestCase):
                     cards := array_agg(
                         DISTINCT Card.name ORDER BY Card.name),
                     element := El,
-                    count := sum(Card.<deck@count),
+                    count := sum(Card.<deck[IS User]@count),
                 ) ORDER BY _.count;
             """,
             [
@@ -1056,8 +1056,8 @@ class TestEdgeQLGroup(tb.QueryTestCase):
                 GROUP User
                 # get the nickname that this user from Alice (if any)
                 USING B := (
-                    SELECT User.<friends@nickname
-                    FILTER User.<friends.name = 'Alice'
+                    SELECT User.<friends[IS User]@nickname
+                    FILTER User.<friends[IS User].name = 'Alice'
                 )
                 BY B
                 INTO F

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1076,7 +1076,7 @@ class TestInsert(tb.QueryTestCase):
                         name,
                         l2,
                         l3,
-                        subject := .<subject {
+                        subject := .<subject[IS Note] {
                             name,
                             note,
                         }

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -520,10 +520,10 @@ class TestEdgeQLScope(tb.QueryTestCase):
                         name,
                         percent_cost := (
                             SELECT <int64>(100 * Card.cost /
-                                           Card.<deck.deck_cost)
+                                           Card.<deck[IS User].deck_cost)
                         ),
                     },
-                    Card.<deck { name }
+                    Card.<deck[IS User] { name }
                 )
                 ORDER BY x.1.name THEN x.0.name;
             ''',
@@ -964,7 +964,9 @@ class TestEdgeQLScope(tb.QueryTestCase):
                         WITH
                             F := (
                                 SELECT User
-                                FILTER User.<friends@nickname = 'Firefighter'
+                                FILTER
+                                    User.<friends[IS User]@nickname
+                                    = 'Firefighter'
                             )
                         SELECT
                             # cardinality should be inferable here:
@@ -1053,7 +1055,9 @@ class TestEdgeQLScope(tb.QueryTestCase):
                         WITH
                             F := (
                                 SELECT User
-                                FILTER User.<friends@nickname = 'Firefighter'
+                                FILTER
+                                    User.<friends[IS User]@nickname
+                                    = 'Firefighter'
                             )
                         SELECT
                             # cardinality should be inferable here:
@@ -1536,7 +1540,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                             FILTER .<friends = User
                         )
                         SELECT F0 {name}
-                        FILTER .<friends@nickname = 'Firefighter'
+                        FILTER .<friends[IS User]@nickname = 'Firefighter'
                     )
                 }
                 ORDER BY .name;

--- a/tests/test_edgeql_views.py
+++ b/tests/test_edgeql_views.py
@@ -363,7 +363,7 @@ class TestEdgeQLViews(tb.QueryTestCase):
                 SELECT Card {
                     name,
                     owned := (
-                        WITH O := Card.<deck
+                        WITH O := Card.<deck[IS User]
                         SELECT O {
                             name,
                             # simple computable

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 100.00)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.20)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.25)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 38.64)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 38.81)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 7.56)


### PR DESCRIPTION
Currently, a reverse link path expression (e.g `User.<owner`) produces a 
regular union type of all possible types that have an `owner` link to
`User`.  While this may seem fine at a glance, this behavior actually leads
to fragile queries due to the "action at a distance" effect. The meaning of
the expression might change unintentionally via the addition of new types
(not all of which are directly controlled by the user).

For this reason, make it so that reverse link navigation produces a 
univesral union, i.e the union of all possible types, which is
`std::Object`.  Then, to access further links or properties (other than the
ones defined on `std::Object`), an explicit type filter operator
(`[IS ..]`) must be used, so instead of `User.<owner.number` one must to 
write `User.<owner[IS Issue].number`.

While working on this I also realized that there is a subtle issue related
to how link properties are treated in the context of link unions.  First of
all, this commit actually makes paths like
`User.<owner[IS Issue]@note` work.  Notably, the implementation here
*does not* attempt to generate link unions based on inheritance resolution
of link source, so in `Foo.<link[IS Bar]` the link `Bar.link` must actually
exist.  Whether to change this so that a union of `link` links of all
subtypes of `Bar` is generated is left for further discussion and work.

Fixes: #969