### PR TITLE
Hoist iterator scopes when compiling computables in nested shapes

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -116,23 +116,44 @@ def compile_ForQuery(
         init_stmt(stmt, qlstmt, ctx=sctx, parent_ctx=ctx)
 
         with sctx.newscope(fenced=True) as scopectx:
+            iterator_ctx = None
+            if (ctx.expr_exposed and ctx.iterator_ctx is not None
+                    and ctx.iterator_ctx is not sctx):
+                iterator_ctx = ctx.iterator_ctx
+
+            if iterator_ctx is not None:
+                iterator_scope_parent = iterator_ctx.path_scope
+                path_id_ns = iterator_ctx.path_id_namespace
+            else:
+                iterator_scope_parent = sctx.path_scope
+                path_id_ns = sctx.path_id_namespace
+
             iterator = qlstmt.iterator
             if isinstance(iterator, qlast.Set) and len(iterator.elements) == 1:
                 iterator = iterator.elements[0]
 
             iterator_view = stmtctx.declare_view(
-                iterator, qlstmt.iterator_alias, ctx=scopectx)
+                iterator, qlstmt.iterator_alias,
+                path_id_namespace=path_id_ns, ctx=scopectx)
 
-            stmt.iterator_stmt = setgen.new_set_from_set(
-                iterator_view, ctx=scopectx)
+            iterator_stmt = setgen.new_set_from_set(
+                iterator_view, preserve_scope_ns=True, ctx=scopectx)
 
-            iterator_scope = scopectx.path_scope_map.get(iterator_view)
+            if iterator_ctx is not None and iterator_ctx.stmt is not None:
+                iterator_ctx.stmt.hoisted_iterators.append(iterator_stmt)
 
-        pathctx.register_set_in_scope(stmt.iterator_stmt, ctx=sctx)
-        node = sctx.path_scope.find_descendant(stmt.iterator_stmt.path_id)
-        assert node is not None
-        assert iterator_scope is not None
-        node.attach_subtree(iterator_scope)
+            stmt.iterator_stmt = iterator_stmt
+
+            iterator_scope, _ = scopectx.path_scope_map[iterator_view]
+
+        pathctx.register_set_in_scope(
+            iterator_stmt,
+            path_scope=iterator_scope_parent,
+            ctx=sctx,
+        )
+        node = iterator_scope_parent.find_descendant(iterator_stmt.path_id)
+        if node is not None:
+            node.attach_subtree(iterator_scope)
 
         stmt.result = compile_result_clause(
             qlstmt.result,
@@ -549,8 +570,11 @@ def init_stmt(
         ctx.path_id_namespace |= pending_full_ns
 
     metadata = ctx.stmt_metadata.get(qlstmt)
-    if metadata is not None and metadata.is_unnest_fence:
-        ctx.path_scope.unnest_fence = True
+    if metadata is not None:
+        if metadata.is_unnest_fence:
+            ctx.path_scope.unnest_fence = True
+        if metadata.iterator_target:
+            ctx.iterator_ctx = ctx
 
     irstmt.parent_stmt = parent_ctx.stmt
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -474,6 +474,9 @@ def _normalize_view_ptr_expr(
                 shape_expr_ctx.empty_result_type_hint = \
                     ptrcls.get_target(ctx.env.schema)
 
+            shape_expr_ctx.stmt_metadata[qlexpr] = context.StatementMetadata(
+                iterator_target=True,
+            )
             irexpr = dispatch.compile(qlexpr, ctx=shape_expr_ctx)
 
             irexpr.context = compexpr.context
@@ -897,7 +900,8 @@ def _compile_view_shapes_in_set(
         for path_tip, ptr in shape_ptrs:
             element = setgen.extend_path(
                 path_tip, ptr, is_mut_assign=is_mutation,
-                unnest_fence=True, same_computable_scope=True, ctx=ctx)
+                unnest_fence=True, same_computable_scope=True,
+                hoist_iterators=True, ctx=ctx)
 
             element_scope = pathctx.get_set_scope(element, ctx=ctx)
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -642,6 +642,7 @@ class Stmt(Expr):
     cardinality: qltypes.Cardinality
     parent_stmt: typing.Optional[Stmt]
     iterator_stmt: typing.Optional[Set]
+    hoisted_iterators: typing.List[Set]
 
 
 class FilteredStmt(Stmt):

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -280,3 +280,13 @@ def get_nearest_dml_stmt(ir_set: irast.Set) -> Optional[irast.MutatingStmt]:
             ir_set = ir_set.rptr.source
         else:
             ir_set = None
+
+
+def get_iterator_sets(stmt: irast.Stmt) -> Sequence[irast.Set]:
+    iterators = []
+    if stmt.iterator_stmt is not None:
+        iterators.append(stmt.iterator_stmt)
+    if stmt.hoisted_iterators:
+        iterators.extend(stmt.hoisted_iterators)
+
+    return iterators

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -608,16 +608,17 @@ def update_scope(
         assert p.path_id is not None
         ctx.path_scope[p.path_id] = stmt
 
-    iter_path_id = None
-    if (isinstance(ir_set.expr, irast.Stmt) and
-            ir_set.expr.iterator_stmt is not None):
-        iter_path_id = ir_set.expr.iterator_stmt.path_id
+    if isinstance(ir_set.expr, irast.Stmt):
+        iterators = irutils.get_iterator_sets(ir_set.expr)
+        iter_paths = {it.path_id for it in iterators}
+    else:
+        iter_paths = set()
 
     for child_path in scope_tree.get_all_paths():
         parent_scope = scope_tree.parent
         if ((parent_scope is None or
                 not parent_scope.is_visible(child_path)) and
-                child_path != iter_path_id):
+                child_path not in iter_paths):
             stmt.path_id_mask.add(child_path)
 
 

--- a/edb/pgsql/compiler/shapecomp.py
+++ b/edb/pgsql/compiler/shapecomp.py
@@ -45,8 +45,8 @@ def compile_shape(
     with ctx.newscope() as shapectx:
         shapectx.disable_semi_join.add(ir_set.path_id)
 
-        if (isinstance(ir_set.expr, irast.Stmt) and
-                ir_set.expr.iterator_stmt is not None):
+        if isinstance(ir_set.expr, irast.Stmt):
+            iterators = irutils.get_iterator_sets(ir_set.expr)
             # The source set for this shape is a FOR statement,
             # which is special in that besides set path_id it
             # should also expose the path_id of the FOR iterator
@@ -60,8 +60,9 @@ def compile_shape(
             #
             # the path scope when processing the shape of Bar.foo
             # should be {'Bar.foo', 'x'}.
-            iter_path_id = ir_set.expr.iterator_stmt.path_id
-            shapectx.path_scope[iter_path_id] = ctx.rel
+            if iterators:
+                for iterator in iterators:
+                    shapectx.path_scope[iterator.path_id] = ctx.rel
 
         for el in shape:
             rptr = el.rptr

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from typing import *  # NoQA
 
 from edb.ir import ast as irast
+from edb.ir import utils as irutils
 
 from edb.pgsql import ast as pgast
 
@@ -49,11 +50,11 @@ def compile_SelectStmt(
 
         query = ctx.stmt
 
-        iterator_set = stmt.iterator_stmt
-        if (iterator_set is not None and
-                not isinstance(stmt.result.expr, irast.MutatingStmt)):
-            # Process FOR clause.
-            clauses.compile_iterator_expr(query, iterator_set, ctx=ctx)
+        if not isinstance(stmt.result.expr, irast.MutatingStmt):
+            iterators = irutils.get_iterator_sets(stmt)
+            for iterator_set in iterators:
+                # Process FOR clause.
+                clauses.compile_iterator_expr(query, iterator_set, ctx=ctx)
 
         # Process the result expression;
         outvar = clauses.compile_output(stmt.result, ctx=ctx)


### PR DESCRIPTION
Nested shape annotations are usually specified syntactically nested in a
subquery, e.g:

    WITH MODULE test
    SELECT User {
        select_deck := (
            SELECT _ := (
                FOR letter IN {'I', 'B'}
                UNION (
                    SELECT User.deck {
                        name,
                        letter := letter
                    }
                    FILTER .name[0] = letter
                )
            )
            ORDER BY _.name
        )
    } FILTER .name = 'Alice';

In the example above, the objects selected in the `select_deck`
computable will have the `name` and the `letter` properties, the
latter is itself a computable.   The canonical IR form for
such nested shape structure is actually as follows:

    WITH MODULE test
    SELECT User {
        select_deck := (
            SELECT _ := (
                FOR letter IN {'I', 'B'}
                UNION (
                    SELECT User.deck
                    FILTER .name[0] = letter
                )
            )
            ORDER BY _.name
        ) {
            name,
            letter := <letter>
        }
    } FILTER .name = 'Alice';

Note that the nested shape has been pulled out.  However, the
computable `letter` references the iterator variable, and, if that
symbol isn't pulled out to the scope where the nested shape is now,
the cardinality of the `letter` computable would be wrong.

Fixes: #834