### PR TITLE
Place restrictions on the use of DML statements

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -435,6 +435,9 @@ class ContextLevel(compiler.ContextLevel):
     defining_view: bool
     """Whether a view is currently being defined (as opposed to be compiled)"""
 
+    in_conditional: Optional[parsing.ParserContext]
+    """Whether currently in a conditional branch."""
+
     def __init__(
         self,
         prevlevel: Optional[ContextLevel],
@@ -442,6 +445,7 @@ class ContextLevel(compiler.ContextLevel):
         *,
         env: Optional[Environment] = None,
     ) -> None:
+
         self.mode = mode
 
         if prevlevel is None:
@@ -488,6 +492,7 @@ class ContextLevel(compiler.ContextLevel):
             self.special_computables_in_mutation_shape = frozenset()
             self.empty_result_type_hint = None
             self.defining_view = False
+            self.in_conditional = None
 
         else:
             self.env = prevlevel.env
@@ -526,6 +531,7 @@ class ContextLevel(compiler.ContextLevel):
                 prevlevel.special_computables_in_mutation_shape
             self.empty_result_type_hint = prevlevel.empty_result_type_hint
             self.defining_view = prevlevel.defining_view
+            self.in_conditional = prevlevel.in_conditional
 
             if mode == ContextSwitchMode.SUBQUERY:
                 self.anchors = prevlevel.anchors.copy()

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -417,7 +417,7 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
             # along with the view scope.
             continue
 
-        fuse_scope_branch(ir_set, node, scope, ctx=ctx)
+        node.fuse_subtree(scope)
         if ir_set.path_scope_id is None:
             pathctx.assign_set_scope(ir_set, node, ctx=ctx)
 
@@ -453,28 +453,6 @@ def resolve_special_anchor(
         )
 
     return path_tip
-
-
-def fuse_scope_branch(
-        ir_set: irast.Set, parent: irast.ScopeTreeNode,
-        branch: irast.ScopeTreeNode, *,
-        ctx: context.ContextLevel) -> None:
-    if parent.path_id is None:
-        parent.attach_subtree(branch)
-    else:
-        if branch.path_id is None and len(branch.children) == 1:
-            target_branch = next(iter(branch.children))
-        else:
-            target_branch = branch
-
-        if parent.path_id == target_branch.path_id:
-            new_root = irast.new_scope_tree()
-            for child in tuple(target_branch.children):
-                new_root.attach_child(child)
-
-            parent.attach_subtree(new_root)
-        else:
-            parent.attach_subtree(branch)
 
 
 def ptr_step_set(

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -463,3 +463,31 @@ class TestDelete(tb.QueryTestCase):
                 'name': 'not delete union 2'
             }],
         )
+
+    async def test_edgeql_delete_in_conditional_bad_01(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                'DELETE statements cannot be used'):
+            await self.con.execute(r'''
+                WITH MODULE test
+                SELECT
+                    (SELECT DeleteTest2)
+                    ??
+                    (DELETE DeleteTest2);
+            ''')
+
+    async def test_edgeql_update_in_conditional_bad_02(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                'DELETE statements cannot be used'):
+            await self.con.execute(r'''
+                WITH MODULE test
+                SELECT
+                    (SELECT DeleteTest FILTER .name = 'foo')
+                    IF EXISTS DeleteTest
+                    ELSE (
+                        (SELECT DeleteTest)
+                        UNION
+                        (DELETE DeleteTest)
+                    );
+            ''')

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.58)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.53)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
The behavior of DML CTEs in Postgres dictates that they: a) must be a
top-level CTE; b) always execute to completion. These restrictions must
be respected by the semantics of EdgeQL DML. The top-level CTE
requirement can only be satisfied if the use of correlated vars inside a
DML statement is prohibited, i.e:

    SELECT (Foo, (INSERT Bar { foo := Foo }));

The execute-to-completion requirement can be satisfied by prohibiting
the use of DML inside a conditional construct, like `??` or `IF`.

Closes: #741