### PR TITLE
Add a cookbook section and a an article about links

### DIFF
--- a/docs/cookbook/aggregates.rst
+++ b/docs/cookbook/aggregates.rst
@@ -1,0 +1,4 @@
+.. _ref_cookbook_aggregates:
+
+Aggregates
+==========

--- a/docs/cookbook/index.rst
+++ b/docs/cookbook/index.rst
@@ -1,0 +1,12 @@
+========
+Cookbook
+========
+
+This sections shows common idioms, approaches and recipes for using EdgeDB.
+
+.. toctree::
+    :maxdepth: 1
+    :hidden:
+
+    aggregates
+    links

--- a/docs/cookbook/index.rst
+++ b/docs/cookbook/index.rst
@@ -2,7 +2,7 @@
 Cookbook
 ========
 
-This sections shows common idioms, approaches and recipes for using EdgeDB.
+These sections show common idioms, approaches, and recipes for using EdgeDB.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/cookbook/links.rst
+++ b/docs/cookbook/links.rst
@@ -4,7 +4,7 @@
 Links
 =====
 
-Link items define a specific relationship between two object types.
+Links define a specific relationship between two object types.
 Links have a direction, but can be traversed in both ways forward and
 :ref:`backward <ref_cookbook_links_bw>`.
 

--- a/docs/cookbook/links.rst
+++ b/docs/cookbook/links.rst
@@ -215,7 +215,7 @@ Now the next step is quite simple, just add a filter:
     ......... } FILTER .first_name = 'Ryan';
     {Object {
         first_name: 'Ryan',
-        collegues: {
+        colleagues: {
             Object { first_name: 'Ana' },
             Object { first_name: 'Harrison' },
         }

--- a/docs/cookbook/links.rst
+++ b/docs/cookbook/links.rst
@@ -12,7 +12,7 @@ Links have a direction, but can be traversed in both ways forward and
 Movie Example
 =============
 
-To define a relationship we use ``link`` keyword:
+To define a relationship we use the ``link`` keyword:
 
 .. code-block:: sdl
 

--- a/docs/cookbook/links.rst
+++ b/docs/cookbook/links.rst
@@ -161,7 +161,7 @@ Or more complex example:
         }
     }
 
-Now you may notice that the Ryan (Gosling) is mentioned as a colleague of
+Now you may notice that Ryan Gosling is mentioned as a colleague of
 himself. To fix it we need few more concepts.
 
 First note that the request above is an equivalent of:

--- a/docs/cookbook/links.rst
+++ b/docs/cookbook/links.rst
@@ -120,10 +120,11 @@ traversal ``.<`` operator:
         }
     }}
 
-You might also note that we've added ``[IS Movie]`` type filter. This is how
-backward link traversal works: EdgeDB fetches every object in the entire
-database having the field ``actors`` which is a ``Person``. So we narrow down
-the set of objects to ``Movie`` and select a title from it.
+You might also note that we've added ``[IS Movie]``, which we call
+:eql:op:`type intersection <ISINTERSECT>` operator. This is how backward link
+traversal works: EdgeDB fetches every object in the entire database having the
+field ``actors`` which is a ``Person``. So we narrow down the set of objects to
+``Movie`` and select a title from it.
 
 All other tools work on backward link:
 

--- a/docs/cookbook/links.rst
+++ b/docs/cookbook/links.rst
@@ -5,8 +5,8 @@ Links
 =====
 
 Link items define a specific relationship between two object types.
-Links have a direction, but can be traversed in both ways :ref:`forward and
-backward <ref_cookbook_links_fw_bw>`.
+Links have a direction, but can be traversed in both ways forward and
+:ref:`backward <ref_cookbook_links_bw>`.
 
 
 Movie Example

--- a/docs/cookbook/links.rst
+++ b/docs/cookbook/links.rst
@@ -1,0 +1,239 @@
+.. _ref_cookbook_links:
+
+=====
+Links
+=====
+
+Link items define a specific relationship between two object types.
+Links have a direction, but can be traversed in both ways :ref:`forward and
+backward <ref_cookbook_links_fw_bw>`.
+
+
+Movie Example
+=============
+
+To define a relationship we use ``link`` keyword:
+
+.. code-block:: edgeql
+
+    module default {
+        type Movie {
+            required property title -> str;
+            required link director -> Person;
+            multi link cast -> Person;
+        }
+        type Person {
+            required property first_name -> str;
+            required property last_name -> str;
+        }
+    }
+
+In terms of SQL database we defined two foreign keys on the table containing
+movies. But link is much more than that.
+
+
+Nested Sets
+-----------
+
+Links allow fetching relatioships using single query:
+
+.. code-block:: edgeql-repl
+
+    tutorial> select Movie {
+    .........    director: { first_name },
+    .........    cast: { first_name },
+    ......... };
+    {
+        Object {
+            director: Object { first_name: 'Denis' },
+            cast: {
+                Object { first_name: 'Harrison' },
+                Object { first_name: 'Ryan' },
+                Object { first_name: 'Ana' },
+            }
+        }
+    }
+
+Aggregates
+----------
+
+Similarly you can run some aggregates on the nested sets:
+
+.. code-block:: edgeql-repl
+
+    tutorial> SELECT Movie { title, cast_size:=count(.cast) };
+    {Object { title: 'Blade Runner 2049', cast_size: 3 }}
+
+You can find more information on aggregates in the
+:ref:`Cookbook <ref_cookbook_aggregates>` and the reference of
+:ref:`set functions <ref_eql_operators_set>` (or just search for "aggregate").
+
+
+.. _ref_cookbook_links_bw:
+
+Backward Links
+--------------
+
+In the movie example above, we have only shown a forward link traversal:
+
+.. code-block:: edgeql-repl
+
+    tutorial> SELECT Movie { title, cast: { first_name } };
+    {
+        Object {
+            title: 'Blade Runner 2049',
+            cast: {
+                Object { first_name: 'Harrison' },
+                Object { first_name: 'Ryan' },
+                Object { first_name: 'Ana' },
+            }
+        }
+    }
+
+Here is a another example of using forward link. This time we only return
+last names of the artists as plain string (not an object). In this case, we
+need to alias the field with ``:=``. This example uses **forward link** ``.>``
+operator to make the code clearer:
+
+.. code-block:: edgeql-repl
+
+    tutorial> SELECT Movie {
+    .........     title,
+    .........     starring := Movie.>cast.last_name,
+    ......... };
+    {Object {
+        title: 'Blade Runner 2049',
+        starring: {
+            'Ford',
+            'Gosling',
+            'de Armas',
+        }
+    }}
+
+To find all movies that a person is starred in we use a **backward link**
+``.<`` operator:
+
+.. code-block:: edgeql-repl
+
+    tutorial> SELECT Person {
+    .........     first_name,
+    .........     movies := Person.<cast[IS Movie].title,
+    ......... } FILTER .first_name = 'Ryan';
+    {Object {
+        first_name: 'Ryan',
+        movies: {
+            'Blade Runner 2049',
+        }
+    }}
+
+You might also note that we've added ``[IS Movie]`` cast. This is how backward
+links work: they fetch every object in the entire database having the field
+``cast`` which is a ``Person``. So we narrow down the set of objects to
+``Movie`` and select a title from it.
+
+All other tools work on backward link:
+
+.. code-block:: edgeql-repl
+
+    tutorial> SELECT Person {
+    .........     first_name,
+    .........     movies := Person.<cast[IS Movie] { title, year }
+    ......... } FILTER .first_name = 'Ryan';
+    {Object {
+        first_name: 'Ryan',
+        movies: {
+            Object { title: 'Blade Runner 2049', year: 2017 },
+        }
+    }}
+
+Or more complex example:
+
+.. code-block:: edgeql-repl
+
+    tutorial>     SELECT Person {
+    .........         first_name,
+    .........         colleagues := Person.<cast[IS Movie].cast {
+    .........             first_name
+    .........         }
+    .........     } FILTER .first_name = 'Ryan';
+    {
+        Object {
+            first_name: 'Ryan',
+            colleagues: {
+                Object { first_name: 'Ana' },
+                Object { first_name: 'Harrison' },
+                Object { first_name: 'Ryan' },
+            }
+        }
+    }
+
+Now you may notice that the Ryan (Gosling) is mentioned as a colleague of
+himself. To fix it we need few more concepts.
+
+First note that the request above is an equivalent of:
+
+.. code-block:: edgeql-repl
+
+    tutorial> SELECT Person {
+    .........     first_name,
+    .........     collegues := (
+    .........         SELECT Person.<cast[IS Movie].cast {
+    .........             first_name,
+    .........         }
+    .........     ),
+    ......... } FILTER .first_name = 'Ryan';
+
+Note: we wrapped a backward link access by ``SELECT`` subquery.
+
+Still we can't filter out by ``Person.id != Person.id`` because EdgeDB can't
+distinguish them. To make that work we should factor the inner query out:
+
+.. code-block:: edgeql-repl
+
+    tutorial> WITH
+    .........     Peer := (SELECT Person.<cast[IS Movie].cast)
+    ......... SELECT Person {
+    .........     first_name,
+    .........     collegues := Peer { first_name },
+    ......... } FILTER .first_name = 'Ryan';
+    {
+        Object {
+            first_name: 'Ryan',
+            collegues: {
+                Object { first_name: 'Ana' },
+                Object { first_name: 'Harrison' },
+                Object { first_name: 'Ryan' },
+            }
+        }
+    }
+
+Note what, while it looks pretty similar to textual replacement, what we've
+actually factored out is "view".  This is the reason of why we have a
+``{ first_name }`` in the actual ``colleague`` field not in the ``WITH``
+clause.
+
+Now the next step is quite simple, we wrap ``Peer`` selector by a
+``SELECT`` subquery and add a filter:
+
+.. code-block:: edgeql-repl
+
+    tutorial> WITH
+    .........     Peer := (SELECT Person.<cast[IS Movie].cast { first_name })
+    ......... SELECT Person {
+    .........     first_name,
+    .........     collegues := (SELECT Peer { first_name }
+                                FILTER Peer.id != Person.id)
+    ......... } FILTER .first_name = 'Ryan';
+    .........
+    {Object {
+        first_name: 'Ryan',
+        collegues: {
+            Object { first_name: 'Ana' },
+            Object { first_name: 'Harrison' },
+        }
+    }}
+
+.. _ref_cookbook_links_fw_bw:
+
+Forward vs Backward Links
+=========================

--- a/docs/cookbook/links.rst
+++ b/docs/cookbook/links.rst
@@ -163,42 +163,21 @@ Or more complex example:
     }
 
 Now you may notice that Ryan Gosling is mentioned as a colleague of
-himself. To fix it we need few more concepts.
-
-First note that the request above is an equivalent of:
+himself. To fix it we can add a filter:
 
 .. code-block:: edgeql-repl
 
     tutorial> SELECT Person {
     .........     first_name,
     .........     colleagues := (
-    .........         SELECT Person.<actors[IS Movie].actors {
-    .........             first_name,
-    .........         }
+    .........         SELECT Person.<actors[IS Movie].actors { first_name }
+    .........         FILTER Person.<actors[IS Movie].actors != Person
     .........     ),
     ......... } FILTER .first_name = 'Ryan';
 
-Note: we wrapped a backward link access by ``SELECT`` subquery.
+Note: we wrapped a backward link access by ``SELECT`` subquery to add a filter.
 
-Still we can't filter out by ``Person != Person`` because EdgeDB can't
-distinguish them. To make that work we should give the inner query an alias:
-
-.. code-block:: edgeql-repl
-
-    tutorial> SELECT Person {
-    .........     first_name,
-    .........     colleagues := (
-    .........         WITH Peer := Person.<actors[IS Movie].actors
-    .........         SELECT Peer {
-    .........             first_name,
-    .........         }
-    .........     ),
-    ......... } FILTER .first_name = 'Ryan';
-
-The ``WITH`` clause makes an alias to the :ref:`set <ref_eql_fundamentals_set>`
-of actors. And then we can work with that set as usual.
-
-Now the next step is quite simple, just add a filter:
+The last query can be rewritten in a nicer way using an alias:
 
 .. code-block:: edgeql-repl
 

--- a/docs/cookbook/links.rst
+++ b/docs/cookbook/links.rst
@@ -85,7 +85,7 @@ In the movie example above, we have only shown a forward link traversal:
         }
     }
 
-Here is a another example of using forward link. This time we only return
+Here is another example of using a forward link. This time we only return
 last names of the artists as plain string (not an object). In this case, we
 need to alias the field with ``:=``:
 

--- a/docs/cookbook/links.rst
+++ b/docs/cookbook/links.rst
@@ -28,14 +28,13 @@ To define a relationship we use ``link`` keyword:
         }
     }
 
-In terms of SQL database we defined two foreign keys on the table containing
-movies. But link is much more than that.
+
 
 
 Nested Sets
 -----------
 
-Links allow fetching relatioships using single query:
+Links allow fetching relationships with a single query:
 
 .. code-block:: edgeql-repl
 
@@ -126,10 +125,10 @@ To find all movies that a person is starred in we use a **backward link**
         }
     }}
 
-You might also note that we've added ``[IS Movie]`` actors. This is how backward
-links work: they fetch every object in the entire database having the field
-``actors`` which is a ``Person``. So we narrow down the set of objects to
-``Movie`` and select a title from it.
+You might also note that we've added ``[IS Movie]`` type filter. This is how
+backward link traversal works: EdgeDB fetches every object in the entire
+database having the field ``actors`` which is a ``Person``. So we narrow down
+the set of objects to ``Movie`` and select a title from it.
 
 All other tools work on backward link:
 
@@ -176,7 +175,7 @@ First note that the request above is an equivalent of:
 
     tutorial> SELECT Person {
     .........     first_name,
-    .........     collegues := (
+    .........     colleagues := (
     .........         SELECT Person.<actors[IS Movie].actors {
     .........             first_name,
     .........         }

--- a/docs/cookbook/links.rst
+++ b/docs/cookbook/links.rst
@@ -14,21 +14,17 @@ Movie Example
 
 To define a relationship we use ``link`` keyword:
 
-.. code-block:: edgeql
+.. code-block:: sdl
 
-    module default {
-        type Movie {
-            required property title -> str;
-            required link director -> Person;
-            multi link actors -> Person;
-        }
-        type Person {
-            required property first_name -> str;
-            required property last_name -> str;
-        }
+    type Movie {
+        required property title -> str;
+        required link director -> Person;
+        multi link actors -> Person;
     }
-
-
+    type Person {
+        required property first_name -> str;
+        required property last_name -> str;
+    }
 
 
 Nested Sets

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -41,12 +41,13 @@ Links also have a policy of handling link target *deletion*. There are
 This :ref:`section <ref_eql_ddl_links_syntax>` covers the syntax of
 how to set these policies in more detail.
 
-
 See Also
 --------
+
+:ref:`Cookbook <ref_cookbook_links>` section about links.
 
 Link
 :ref:`SDL <ref_eql_sdl_links>`,
 :ref:`DDL <ref_eql_ddl_links>`,
-and :ref:`introspection <ref_eql_introspection_object_types>`
+:ref:`introspection <ref_eql_introspection_object_types>`
 (as part of overall object introspection).

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -15,6 +15,16 @@ Glossary
       syntax used to define the structuring of schemas. Common DDL
       statements include ``CREATE``, ``DROP``, and ``ALTER``.
 
+   link
+      Link items define a specific relationship between two object types. Link
+      instances relate one object to one or more different objects.
+
+      Comparing to SQL link is a way to define relationship, foreign key,
+      and optional junction table.
+
+      More on links in :ref:`Data Model <ref_datamodel_links>` and
+      :ref:`Cookbook <ref_cookbook_links>`.
+
    set reference
       An identifier that represents a set of values. It can be the name of an
       object type or an *expression alias* (defined in a statement :ref:`WITH

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -19,9 +19,6 @@ Glossary
       Link items define a specific relationship between two object types. Link
       instances relate one object to one or more different objects.
 
-      Comparing to SQL link is a way to define relationship, foreign key,
-      and optional junction table.
-
       More on links in :ref:`Data Model <ref_datamodel_links>` and
       :ref:`Cookbook <ref_cookbook_links>`.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Welcome to the EdgeDB |version| documentation.
 
     intro
     tutorial/index
+    cookbook/index
     datamodel/__toc__
     edgeql/__toc__
     clients/__toc__


### PR DESCRIPTION
The idea of the cookbook is to have some tutorial-like explanations, but not in chronological order. I.e. guides and examples for specific topics.

Please, review carefully. I'm not sure I fully understand underlying concepts.

Also, take a closer look (and maybe add more text?) to the last query or two. Because I find the implicit join between Person's in high-level select and `Person` in the `Peer` view kinda subtle and non-obviuos.

[Rendered links cookbook](https://github.com/edgedb/edgedb/blob/cookbook_links/docs/cookbook/links.rst)