### PR TITLE
edgeql: Drop `.>` path operator.

### DIFF
--- a/docs/edgeql/expressions/paths.rst
+++ b/docs/edgeql/expressions/paths.rst
@@ -34,7 +34,7 @@ The individual path components are:
 :eql:synopsis:`<step-direction>`
     It can be one of the following:
 
-    - ``.`` or ``.>`` for an outgoing or "forward" link reference
+    - ``.`` for an outgoing or "forward" link reference
     - ``.<`` for an incoming or "backward" link reference
     - ``@`` for a link property reference
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1029,23 +1029,6 @@ class Path(Nonterm):
             steps=self._float_to_path(kids[1], kids[0].context),
             partial=True)
 
-    @parsing.precedence(precedence.P_DOT)
-    def reduce_Expr_DOTFW_FCONST(self, *kids):
-        # this is a valid link-like syntax for accessing unnamed tuples
-        path = kids[0].val
-        if not isinstance(path, qlast.Path):
-            path = qlast.Path(steps=[path])
-
-        path.steps.extend(self._float_to_path(kids[2], kids[1].context))
-        self.val = path
-
-    @parsing.precedence(precedence.P_DOT)
-    def reduce_DOTFW_FCONST(self, *kids):
-        # this is a valid link-like syntax for accessing unnamed tuples
-        self.val = qlast.Path(
-            steps=self._float_to_path(kids[1], kids[0].context),
-            partial=True)
-
     def _float_to_path(self, token, context):
         from edb.schema import pointers as s_pointers
 
@@ -1092,23 +1075,6 @@ class PathStep(Nonterm):
 
         self.val = qlast.Ptr(
             ptr=qlast.ObjectRef(name=kids[1].val),
-            direction=s_pointers.PointerDirection.Outbound
-        )
-
-    def reduce_DOTFW_ICONST(self, *kids):
-        # this is a valid link-like syntax for accessing unnamed tuples
-        from edb.schema import pointers as s_pointers
-
-        self.val = qlast.Ptr(
-            ptr=qlast.ObjectRef(name=kids[1].val),
-            direction=s_pointers.PointerDirection.Outbound
-        )
-
-    def reduce_DOTFW_PathStepName(self, *kids):
-        from edb.schema import pointers as s_pointers
-
-        self.val = qlast.Ptr(
-            ptr=kids[1].val,
             direction=s_pointers.PointerDirection.Outbound
         )
 

--- a/edb/edgeql/parser/grammar/lexer.py
+++ b/edb/edgeql/parser/grammar/lexer.py
@@ -109,10 +109,6 @@ class EdgeQLLexer(lexer.Lexer):
              next_state=STATE_KEEP,
              regexp=r'\.<'),
 
-        Rule(token='.>',
-             next_state=STATE_KEEP,
-             regexp=r'\.>'),
-
         Rule(token='//',
              next_state=STATE_KEEP,
              regexp=r'//'),

--- a/edb/edgeql/parser/grammar/precedence.py
+++ b/edb/edgeql/parser/grammar/precedence.py
@@ -143,7 +143,7 @@ class P_PAREN(Precedence, assoc='left', tokens=('LPAREN', 'RPAREN')):
     pass
 
 
-class P_DOT(Precedence, assoc='left', tokens=('DOT', 'DOTFW', 'DOTBW')):
+class P_DOT(Precedence, assoc='left', tokens=('DOT', 'DOTBW')):
     pass
 
 

--- a/edb/edgeql/parser/grammar/tokens.py
+++ b/edb/edgeql/parser/grammar/tokens.py
@@ -47,10 +47,6 @@ class T_DOT(Token, lextoken='.'):
     pass
 
 
-class T_DOTFW(Token, lextoken='.>'):
-    pass
-
-
 class T_DOTBW(Token, lextoken='.<'):
     pass
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -3325,22 +3325,6 @@ class TestExpressions(tb.QueryTestCase):
             [3],
         )
 
-        await self.assert_query_result(
-            '''
-                WITH TUP := (1, (2, 3))
-                SELECT TUP.>1.1;
-            ''',
-            [3],
-        )
-
-        await self.assert_query_result(
-            '''
-                WITH TUP := (1, (2, 3))
-                SELECT TUP.>1.>1;
-            ''',
-            [3],
-        )
-
     async def test_edgeql_expr_tuple_indirection_01(self):
         await self.assert_query_result(
             r"""

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1531,25 +1531,19 @@ aa';
     def test_edgeql_syntax_path_01(self):
         """
         SELECT Foo.bar;
-        SELECT Foo.>bar;
         SELECT Foo.<bar;
         SELECT Foo.bar@spam;
-        SELECT Foo.>bar@spam;
         SELECT Foo.<bar@spam;
         SELECT Foo.bar[IS Baz];
-        SELECT Foo.>bar[IS Baz];
         SELECT Foo.<bar[IS Baz];
         SELECT Foo.<var[IS Baz][IS Spam].bar[IS Foo];
 
 % OK %
 
         SELECT Foo.bar;
-        SELECT Foo.bar;
         SELECT Foo.<bar;
         SELECT Foo.bar@spam;
-        SELECT Foo.bar@spam;
         SELECT Foo.<bar@spam;
-        SELECT Foo.bar[IS Baz];
         SELECT Foo.bar[IS Baz];
         SELECT Foo.<bar[IS Baz];
         SELECT Foo.<var[IS Baz][IS Spam].bar[IS Foo];
@@ -1558,24 +1552,18 @@ aa';
     def test_edgeql_syntax_path_02(self):
         """
         SELECT Foo.event;
-        SELECT Foo.>event;
         SELECT Foo.<event;
         SELECT Foo.event@action;
-        SELECT Foo.>event@action;
         SELECT Foo.<event@action;
         SELECT Foo.event[IS Action];
-        SELECT Foo.>event[IS Action];
         SELECT Foo.<event[IS Action];
 
 % OK %
 
         SELECT Foo.event;
-        SELECT Foo.event;
         SELECT Foo.<event;
         SELECT Foo.event@action;
-        SELECT Foo.event@action;
         SELECT Foo.<event@action;
-        SELECT Foo.event[IS Action];
         SELECT Foo.event[IS Action];
         SELECT Foo.<event[IS Action];
         """
@@ -1766,14 +1754,6 @@ aa';
     def test_edgeql_syntax_path_28(self):
         """
         SELECT TUP.1.1;
-        SELECT TUP.>1.1;
-        SELECT TUP.>1.>1;
-
-% OK %
-
-        SELECT TUP.1.1;
-        SELECT TUP.1.1;
-        SELECT TUP.1.1;
         """
 
     def test_edgeql_syntax_path_29(self):
@@ -1793,19 +1773,6 @@ aa';
         # legal when `$0`, `$1`, `$a` and `$abc` are tuples
         """
         SELECT $1.1.1;
-        SELECT $1.>1.1;
-        SELECT $1.>1.>1;
-        SELECT $a.1.1;
-        SELECT $a.>1.1;
-        SELECT $a.>1.>1;
-
-% OK %
-
-        SELECT $1.1.1;
-        SELECT $1.1.1;
-        SELECT $1.1.1;
-        SELECT $a.1.1;
-        SELECT $a.1.1;
         SELECT $a.1.1;
         """
 

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.43)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.58)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
Drop the redundant `.>` path operator in favor of using only `.`.

Fixes #982.