### PR TITLE
Make order of schema::InheritingObject.bases and .ancestors introspectable

### DIFF
--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -61,6 +61,11 @@ CREATE ABSTRACT LINK schema::reference {
 };
 
 
+CREATE ABSTRACT LINK schema::ordered {
+    CREATE PROPERTY index -> std::int64;
+};
+
+
 CREATE TYPE schema::Module EXTENDING schema::Object;
 
 
@@ -106,8 +111,10 @@ CREATE ABSTRACT TYPE schema::AnnotationSubject EXTENDING schema::Object {
 
 
 CREATE ABSTRACT TYPE schema::InheritingObject EXTENDING schema::Object {
-    CREATE MULTI LINK bases -> schema::InheritingObject;
-    CREATE MULTI LINK ancestors -> schema::InheritingObject;
+    CREATE MULTI LINK bases EXTENDING schema::ordered
+        -> schema::InheritingObject;
+    CREATE MULTI LINK ancestors EXTENDING schema::ordered
+        -> schema::InheritingObject;
     CREATE PROPERTY inherited_fields -> array<std::str>;
 
     CREATE REQUIRED PROPERTY is_abstract -> std::bool {

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2566,10 +2566,22 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r"""
-                SELECT (SELECT schema::ObjectType
-                        FILTER .name = 'test::ExtC3').ancestors.name;
+                SELECT schema::ObjectType {
+                    ancestors: {
+                        name
+                    } ORDER BY @index
+                }
+                FILTER .name = 'test::ExtC3'
             """,
-            {'std::Object', 'test::ExtA3', 'test::ExtB3'}
+            [{
+                'ancestors': [{
+                    'name': 'test::ExtB3',
+                }, {
+                    'name': 'test::ExtA3',
+                }, {
+                    'name': 'std::Object',
+                }],
+            }]
         )
 
         await self.con.execute(r"""
@@ -2578,10 +2590,20 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r"""
-                SELECT (SELECT schema::ObjectType
-                        FILTER .name = 'test::ExtC3').ancestors.name;
+                SELECT schema::ObjectType {
+                    ancestors: {
+                        name
+                    } ORDER BY @index
+                }
+                FILTER .name = 'test::ExtC3'
             """,
-            {'std::Object', 'test::ExtB3'}
+            [{
+                'ancestors': [{
+                    'name': 'test::ExtB3',
+                }, {
+                    'name': 'std::Object',
+                }],
+            }]
         )
 
     async def test_edgeql_ddl_extending_04(self):

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -289,6 +289,42 @@ class TestIntrospection(tb.QueryTestCase):
             }]
         )
 
+    async def test_edgeql_introspection_bases_01(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE schema
+                SELECT ObjectType {
+                    bases: {
+                        name
+                    } ORDER BY @index,
+                    ancestors: {
+                        name
+                    } ORDER BY @index
+                }
+                FILTER
+                    .name = 'test::Issue';
+            """,
+            [{
+                'bases': [{
+                    'name': 'test::Named',
+                }, {
+                    'name': 'test::Owned',
+                }, {
+                    'name': 'test::Text',
+                }],
+
+                'ancestors': [{
+                    'name': 'test::Named',
+                }, {
+                    'name': 'test::Owned',
+                }, {
+                    'name': 'test::Text',
+                }, {
+                    'name': 'std::Object',
+                }],
+            }]
+        )
+
     async def test_edgeql_introspection_link_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
Currently, there is no way to introspect the original order of type
bases (specified in the `extending` clause) using the schema
introspection queries.  Ditto for the entire ancestry.  Fix this.

Fixes: #854.