### PR TITLE
Fix issues with rebasing and constraints.

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1013,7 +1013,6 @@ class AlterConstraint(
             return schema
 
         subject = constraint.get_subject(schema)
-        ctx = context.get(s_constr.ConstraintCommandContext)
 
         subcommands = list(self.get_subcommands())
         if (not subcommands or
@@ -1029,7 +1028,8 @@ class AlterConstraint(
 
             bconstr = schemac_to_backendc(subject, constraint, schema)
 
-            orig_schema = ctx.original_schema
+            delta_root_ctx = context.top()
+            orig_schema = delta_root_ctx.original_schema
             orig_bconstr = schemac_to_backendc(
                 constraint.get_subject(orig_schema),
                 constraint, orig_schema)
@@ -1064,6 +1064,12 @@ class DeleteConstraint(
 
         schema, _ = super().apply(schema, context)
         return schema, constraint
+
+
+class RebaseConstraint(
+        ConstraintCommand, RebaseObject,
+        adapts=s_constr.RebaseConstraint):
+    pass
 
 
 class ViewCapableObjectMetaCommand(ObjectMetaCommand):

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -197,6 +197,7 @@ class CreateIndex(IndexCommand, referencing.CreateReferencedInheritingObject):
 
     @classmethod
     def as_inherited_ref_ast(cls, schema, context, name, parent):
+        nref = cls.get_inherited_ref_name(schema, context, parent, name)
         astnode_cls = cls.referenced_astnode
         expr = parent.get_expr(schema)
         if expr is not None:
@@ -205,10 +206,7 @@ class CreateIndex(IndexCommand, referencing.CreateReferencedInheritingObject):
             expr_ql = None
 
         return astnode_cls(
-            name=qlast.ObjectRef(
-                name=name,
-                module=parent.get_shortname(schema).module,
-            ),
+            name=nref,
             expr=expr_ql,
         )
 

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -114,13 +114,8 @@ class InheritingObjectCommand(sd.ObjectCommand):
                 create_cmd = sd.ObjectCommandMeta.get_command_class_or_die(
                     sd.CreateObject, mcls)
 
-                if sn.Name.is_qualified(k):
-                    shortname = sn.shortname_from_fullname(sn.Name(k))
-                else:
-                    shortname = k
-
                 astnode = create_cmd.as_inherited_ref_ast(
-                    schema, context, shortname, v)
+                    schema, context, k, v)
 
                 fqname = create_cmd._classname_from_ast(
                     schema, astnode, context)
@@ -139,17 +134,12 @@ class InheritingObjectCommand(sd.ObjectCommand):
         dropped_refs = {}
         for k, v in local_refs.items(schema):
             if not v.get_is_local(schema):
-                if sn.Name.is_qualified(k):
-                    shortname = sn.shortname_from_fullname(sn.Name(k))
-                else:
-                    shortname = k
-
                 mcls = type(v)
                 create_cmd = sd.ObjectCommandMeta.get_command_class_or_die(
                     sd.CreateObject, mcls)
 
                 astnode = create_cmd.as_inherited_ref_ast(
-                    schema, context, shortname, v)
+                    schema, context, k, v)
 
                 fqname = create_cmd._classname_from_ast(
                     schema, astnode, context)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 38.81)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 38.84)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 7.56)


### PR DESCRIPTION
It is important that alternative DDL paths that lead to the same
conceptual state of the database should in fact produce identical
schemas. This includes all the names and bases for the affected
concepts. It is especially important for concrete constraints that were
created by different DDL paths as they have automatically-generated
names which are then used in determining the behavior of the next
migration or other schema alterations.