### PR TITLE
Cache type_to_typeref

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -596,7 +596,7 @@ def get_param_anchors_for_callable(
     if inlined_defaults:
         anchors['__defaults_mask__'] = irast.Parameter(
             name='__defaults_mask__',
-            typeref=irtyputils.type_to_typeref(
+            typeref=irtyputils.type_to_typeref(  # note: no cache
                 schema,
                 cast(s_scalars.ScalarType, schema.get('std::bytes')),
             ),

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -71,7 +71,9 @@ def compile_cast(
 
     elif irutils.is_untyped_empty_array_expr(ir_expr):
         # Ditto for empty arrays.
-        new_typeref = irtyputils.type_to_typeref(ctx.env.schema, new_stype)
+        new_typeref = irtyputils.type_to_typeref(
+            ctx.env.schema, new_stype, cache=ctx.env.type_ref_cache
+        )
         return setgen.ensure_set(
             irast.Array(elements=[], typeref=new_typeref), ctx=ctx)
 
@@ -161,8 +163,12 @@ def _cast_to_ir(
         new_stype: s_types.Type, *,
         ctx: context.ContextLevel) -> irast.Set:
 
-    orig_typeref = irtyputils.type_to_typeref(ctx.env.schema, orig_stype)
-    new_typeref = irtyputils.type_to_typeref(ctx.env.schema, new_stype)
+    orig_typeref = irtyputils.type_to_typeref(
+        ctx.env.schema, orig_stype, cache=ctx.env.type_ref_cache
+    )
+    new_typeref = irtyputils.type_to_typeref(
+        ctx.env.schema, new_stype, cache=ctx.env.type_ref_cache,
+    )
     cast_name = cast.get_name(ctx.env.schema)
     cast_ir = irast.TypeCast(
         expr=ir_set,
@@ -185,8 +191,12 @@ def _inheritance_cast_to_ir(
         new_stype: s_types.Type, *,
         ctx: context.ContextLevel) -> irast.Set:
 
-    orig_typeref = irtyputils.type_to_typeref(ctx.env.schema, orig_stype)
-    new_typeref = irtyputils.type_to_typeref(ctx.env.schema, new_stype)
+    orig_typeref = irtyputils.type_to_typeref(
+        ctx.env.schema, orig_stype, cache=ctx.env.type_ref_cache,
+    )
+    new_typeref = irtyputils.type_to_typeref(
+        ctx.env.schema, new_stype, cache=ctx.env.type_ref_cache,
+    )
     cast_ir = irast.TypeCast(
         expr=ir_set,
         from_type=orig_typeref,
@@ -485,8 +495,12 @@ def _cast_array_literal(
 
     assert isinstance(ir_set.expr, irast.Array)
 
-    orig_typeref = irtyputils.type_to_typeref(ctx.env.schema, orig_stype)
-    new_typeref = irtyputils.type_to_typeref(ctx.env.schema, new_stype)
+    orig_typeref = irtyputils.type_to_typeref(
+        ctx.env.schema, orig_stype, cache=ctx.env.type_ref_cache,
+    )
+    new_typeref = irtyputils.type_to_typeref(
+        ctx.env.schema, new_stype, cache=ctx.env.type_ref_cache,
+    )
 
     direct_cast = _find_cast(orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
 

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -29,7 +29,6 @@ from edb import errors
 from edb.common import parsing
 
 from edb.ir import ast as irast
-from edb.ir import typeutils as irtyputils
 from edb.ir import utils as irutils
 
 from edb.schema import casts as s_casts
@@ -71,9 +70,7 @@ def compile_cast(
 
     elif irutils.is_untyped_empty_array_expr(ir_expr):
         # Ditto for empty arrays.
-        new_typeref = irtyputils.type_to_typeref(
-            ctx.env.schema, new_stype, cache=ctx.env.type_ref_cache
-        )
+        new_typeref = typegen.type_to_typeref(new_stype, ctx.env)
         return setgen.ensure_set(
             irast.Array(elements=[], typeref=new_typeref), ctx=ctx)
 
@@ -163,12 +160,8 @@ def _cast_to_ir(
         new_stype: s_types.Type, *,
         ctx: context.ContextLevel) -> irast.Set:
 
-    orig_typeref = irtyputils.type_to_typeref(
-        ctx.env.schema, orig_stype, cache=ctx.env.type_ref_cache
-    )
-    new_typeref = irtyputils.type_to_typeref(
-        ctx.env.schema, new_stype, cache=ctx.env.type_ref_cache,
-    )
+    orig_typeref = typegen.type_to_typeref(orig_stype, env=ctx.env)
+    new_typeref = typegen.type_to_typeref(new_stype, env=ctx.env)
     cast_name = cast.get_name(ctx.env.schema)
     cast_ir = irast.TypeCast(
         expr=ir_set,
@@ -191,12 +184,8 @@ def _inheritance_cast_to_ir(
         new_stype: s_types.Type, *,
         ctx: context.ContextLevel) -> irast.Set:
 
-    orig_typeref = irtyputils.type_to_typeref(
-        ctx.env.schema, orig_stype, cache=ctx.env.type_ref_cache,
-    )
-    new_typeref = irtyputils.type_to_typeref(
-        ctx.env.schema, new_stype, cache=ctx.env.type_ref_cache,
-    )
+    orig_typeref = typegen.type_to_typeref(orig_stype, env=ctx.env)
+    new_typeref = typegen.type_to_typeref(new_stype, env=ctx.env)
     cast_ir = irast.TypeCast(
         expr=ir_set,
         from_type=orig_typeref,
@@ -495,13 +484,8 @@ def _cast_array_literal(
 
     assert isinstance(ir_set.expr, irast.Array)
 
-    orig_typeref = irtyputils.type_to_typeref(
-        ctx.env.schema, orig_stype, cache=ctx.env.type_ref_cache,
-    )
-    new_typeref = irtyputils.type_to_typeref(
-        ctx.env.schema, new_stype, cache=ctx.env.type_ref_cache,
-    )
-
+    orig_typeref = typegen.type_to_typeref(orig_stype, env=ctx.env)
+    new_typeref = typegen.type_to_typeref(new_stype, env=ctx.env)
     direct_cast = _find_cast(orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
 
     if direct_cast is None:

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -46,8 +46,6 @@ if TYPE_CHECKING:
     from edb.schema import objtypes as s_objtypes
     from edb.schema import sources as s_sources
 
-    TypeRefCacheKey = Tuple[uuid.UUID, Optional[s_name.Name]]
-
 
 class ContextSwitchMode(enum.Enum):
     NEW = enum.auto()
@@ -217,7 +215,7 @@ class Environment:
 
     # Caches for costly operations in edb.ir.typeutils
     ptr_ref_cache: PointerRefCache
-    type_ref_cache: Dict[TypeRefCacheKey, irast.TypeRef]
+    type_ref_cache: Dict[uuid.UUID, irast.TypeRef]
 
     def __init__(
         self,

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -46,6 +46,8 @@ if TYPE_CHECKING:
     from edb.schema import objtypes as s_objtypes
     from edb.schema import sources as s_sources
 
+    TypeRefCacheKey = Tuple[uuid.UUID, Optional[s_name.Name]]
+
 
 class ContextSwitchMode(enum.Enum):
     NEW = enum.auto()
@@ -213,7 +215,9 @@ class Environment:
     allow_generic_type_output: bool
     """Whether to allow the expression to be of a generic type."""
 
+    # Caches for costly operations in edb.ir.typeutils
     ptr_ref_cache: PointerRefCache
+    type_ref_cache: Dict[TypeRefCacheKey, irast.TypeRef]
 
     def __init__(
         self,
@@ -249,6 +253,7 @@ class Environment:
         self.func_params = func_params
         self.parent_object_type = parent_object_type
         self.ptr_ref_cache = PointerRefCache()
+        self.type_ref_cache = {}
 
     def get_track_schema_object(
         self,

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -219,6 +219,7 @@ def compile_BaseConstant(
     ct = irtyputils.type_to_typeref(
         ctx.env.schema,
         ctx.env.get_track_schema_type(std_type),
+        cache=ctx.env.type_ref_cache,
     )
     return setgen.ensure_set(node_cls(value=value, typeref=ct), ctx=ctx)
 
@@ -445,7 +446,10 @@ def compile_TypeCast(
                     context=expr.expr.context)
 
             json_typeref = irtyputils.type_to_typeref(
-                ctx.env.schema, ctx.env.get_track_schema_type('std::json'))
+                ctx.env.schema,
+                ctx.env.get_track_schema_type('std::json'),
+                cache=ctx.env.type_ref_cache,
+            )
 
             param = casts.compile_cast(
                 irast.Parameter(
@@ -461,7 +465,11 @@ def compile_TypeCast(
         else:
             param = setgen.ensure_set(
                 irast.Parameter(
-                    typeref=irtyputils.type_to_typeref(ctx.env.schema, pt),
+                    typeref=irtyputils.type_to_typeref(
+                        ctx.env.schema,
+                        pt,
+                        cache=ctx.env.type_ref_cache,
+                    ),
                     name=param_name,
                     context=expr.expr.context,
                 ),
@@ -499,6 +507,7 @@ def compile_Introspect(
                 s_objtypes.ObjectType,
                 ctx.env.schema.get('std::Object'),
             ),
+            cache=ctx.env.type_ref_cache,
         )
 
     if irtyputils.is_view(typeref):

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -216,10 +216,9 @@ def compile_BaseConstant(
     else:
         raise RuntimeError(f'unexpected constant type: {type(expr)}')
 
-    ct = irtyputils.type_to_typeref(
-        ctx.env.schema,
+    ct = typegen.type_to_typeref(
         ctx.env.get_track_schema_type(std_type),
-        cache=ctx.env.type_ref_cache,
+        env=ctx.env,
     )
     return setgen.ensure_set(node_cls(value=value, typeref=ct), ctx=ctx)
 
@@ -445,10 +444,9 @@ def compile_TypeCast(
                     'accept positional parameters',
                     context=expr.expr.context)
 
-            json_typeref = irtyputils.type_to_typeref(
-                ctx.env.schema,
+            json_typeref = typegen.type_to_typeref(
                 ctx.env.get_track_schema_type('std::json'),
-                cache=ctx.env.type_ref_cache,
+                env=ctx.env,
             )
 
             param = casts.compile_cast(
@@ -465,11 +463,7 @@ def compile_TypeCast(
         else:
             param = setgen.ensure_set(
                 irast.Parameter(
-                    typeref=irtyputils.type_to_typeref(
-                        ctx.env.schema,
-                        pt,
-                        cache=ctx.env.type_ref_cache,
-                    ),
+                    typeref=typegen.type_to_typeref(pt, env=ctx.env),
                     name=param_name,
                     context=expr.expr.context,
                 ),
@@ -501,13 +495,12 @@ def compile_Introspect(
     if typeref.material_type and not irtyputils.is_object(typeref):
         typeref = typeref.material_type
     if typeref.is_opaque_union:
-        typeref = irtyputils.type_to_typeref(
-            ctx.env.schema,
+        typeref = typegen.type_to_typeref(
             typing.cast(
                 s_objtypes.ObjectType,
                 ctx.env.schema.get('std::Object'),
             ),
-            cache=ctx.env.type_ref_cache,
+            env=ctx.env,
         )
 
     if irtyputils.is_view(typeref):

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -120,7 +120,9 @@ def compile_FunctionCall(
     if variadic_param is not None:
         variadic_param_type = irtyputils.type_to_typeref(
             env.schema,
-            variadic_param.get_type(env.schema))
+            variadic_param.get_type(env.schema),
+            cache=env.type_ref_cache,
+        )
 
     matched_func_ret_type = func.get_return_type(env.schema)
     is_polymorphic = (
@@ -189,7 +191,9 @@ def compile_FunctionCall(
         error_on_null_result=func.get_error_on_null_result(env.schema),
         params_typemods=params_typemods,
         context=expr.context,
-        typeref=irtyputils.type_to_typeref(env.schema, rtype),
+        typeref=irtyputils.type_to_typeref(
+            env.schema, rtype, cache=env.type_ref_cache
+        ),
         typemod=matched_call.func.get_return_typemod(env.schema),
         has_empty_variadic=matched_call.has_empty_variadic,
         variadic_param_type=variadic_param_type,
@@ -485,7 +489,9 @@ def compile_operator(
         operator_kind=oper.get_operator_kind(env.schema),
         params_typemods=params_typemods,
         context=qlexpr.context,
-        typeref=irtyputils.type_to_typeref(env.schema, rtype),
+        typeref=irtyputils.type_to_typeref(
+            env.schema, rtype, cache=env.type_ref_cache
+        ),
         typemod=oper.get_return_typemod(env.schema),
     )
 

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -26,7 +26,6 @@ from typing import *  # NoQA
 from edb import errors
 
 from edb.ir import ast as irast
-from edb.ir import typeutils as irtyputils
 from edb.ir import utils as irutils
 
 from edb.schema import constraints as s_constr
@@ -118,10 +117,9 @@ def compile_FunctionCall(
     variadic_param = matched_func_params.find_variadic(env.schema)
     variadic_param_type = None
     if variadic_param is not None:
-        variadic_param_type = irtyputils.type_to_typeref(
-            env.schema,
+        variadic_param_type = typegen.type_to_typeref(
             variadic_param.get_type(env.schema),
-            cache=env.type_ref_cache,
+            env=env,
         )
 
     matched_func_ret_type = func.get_return_type(env.schema)
@@ -191,8 +189,8 @@ def compile_FunctionCall(
         error_on_null_result=func.get_error_on_null_result(env.schema),
         params_typemods=params_typemods,
         context=expr.context,
-        typeref=irtyputils.type_to_typeref(
-            env.schema, rtype, cache=env.type_ref_cache
+        typeref=typegen.type_to_typeref(
+            rtype, env=env,
         ),
         typemod=matched_call.func.get_return_typemod(env.schema),
         has_empty_variadic=matched_call.has_empty_variadic,
@@ -489,9 +487,7 @@ def compile_operator(
         operator_kind=oper.get_operator_kind(env.schema),
         params_typemods=params_typemods,
         context=qlexpr.context,
-        typeref=irtyputils.type_to_typeref(
-            env.schema, rtype, cache=env.type_ref_cache
-        ),
+        typeref=typegen.type_to_typeref(rtype, env=env),
         typemod=oper.get_return_typemod(env.schema),
     )
 

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -47,7 +47,9 @@ def amend_empty_set_type(
     env.set_types[es] = t
     alias = es.path_id.target_name_hint.name
     typename = s_name.Name(module='__derived__', name=alias)
-    es.path_id = irast.PathId.from_type(env.schema, t, typename=typename)
+    es.path_id = irast.PathId.from_type(
+        env.schema, t, env=env, typename=typename
+    )
 
 
 def _infer_common_type(

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -41,8 +41,10 @@ def get_path_id(stype: s_types.Type, *,
                 typename: Optional[s_name.Name]=None,
                 ctx: context.ContextLevel) -> irast.PathId:
     return irast.PathId.from_type(
-        ctx.env.schema, stype,
+        ctx.env.schema,
+        stype,
         typename=typename,
+        env=ctx.env,
         namespace=ctx.path_id_namespace)
 
 
@@ -60,6 +62,7 @@ def get_tuple_indirection_path_id(
     ptrref = irtyputils.ptrref_from_ptrcls(
         schema=ctx.env.schema,
         ptrcls=ptrcls,
+        typeref_cache=ctx.env.type_ref_cache,
     )
 
     return tuple_path_id.extend(schema=ctx.env.schema, ptrref=ptrref)
@@ -136,6 +139,7 @@ def extend_path_id(
         ptrcls=ptrcls,
         direction=direction,
         cache=ctx.env.ptr_ref_cache,
+        typeref_cache=ctx.env.type_ref_cache,
     )
     stmtctx.ensure_ptrref_cardinality(ptrcls, ptrref, ctx=ctx)
 

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -62,8 +62,9 @@ def get_tuple_indirection_path_id(
     ptrref = irtyputils.ptrref_from_ptrcls(
         schema=ctx.env.schema,
         ptrcls=ptrcls,
-        cache=ctx.env.ptr_ref_cache,
-        typeref_cache=ctx.env.type_ref_cache,
+        # FIXME: caching disabled here since it breaks tests
+        # cache=ctx.env.ptr_ref_cache,
+        # typeref_cache=ctx.env.type_ref_cache,
     )
 
     return tuple_path_id.extend(schema=ctx.env.schema, ptrref=ptrref)

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -62,6 +62,7 @@ def get_tuple_indirection_path_id(
     ptrref = irtyputils.ptrref_from_ptrcls(
         schema=ctx.env.schema,
         ptrcls=ptrcls,
+        cache=ctx.env.ptr_ref_cache,
         typeref_cache=ctx.env.type_ref_cache,
     )
 

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -216,10 +216,11 @@ def try_bind_call_args(
             bargs: List[BoundArg] = []
             if has_inlined_defaults:
                 bytes_t = ctx.env.get_track_schema_type('std::bytes')
+                typeref = irtyputils.type_to_typeref(
+                    schema, bytes_t, cache=ctx.env.type_ref_cache
+                )
                 argval = setgen.ensure_set(
-                    irast.BytesConstant(
-                        value=b'\x00',
-                        typeref=irtyputils.type_to_typeref(schema, bytes_t)),
+                    irast.BytesConstant(value=b'\x00', typeref=typeref),
                     typehint=bytes_t,
                     ctx=ctx)
                 bargs = [BoundArg(None, bytes_t, argval, bytes_t, 0)]
@@ -438,10 +439,11 @@ def try_bind_call_args(
         # bit-mask as a first argument.
         bytes_t = ctx.env.get_track_schema_type('std::bytes')
         bm = defaults_mask.to_bytes(nparams // 8 + 1, 'little')
+        typeref = irtyputils.type_to_typeref(
+            ctx.env.schema, bytes_t, cache=ctx.env.type_ref_cache
+        )
         bm_set = setgen.ensure_set(
-            irast.BytesConstant(
-                value=bm,
-                typeref=irtyputils.type_to_typeref(ctx.env.schema, bytes_t)),
+            irast.BytesConstant(value=bm, typeref=typeref),
             typehint=bytes_t, ctx=ctx)
         bound_param_args.insert(0, BoundArg(None, bytes_t, bm_set, bytes_t, 0))
 

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -27,7 +27,6 @@ from typing import *  # NoQA
 from edb import errors
 
 from edb.ir import ast as irast
-from edb.ir import typeutils as irtyputils
 from edb.ir import utils as irutils
 
 from edb.schema import functions as s_func
@@ -38,6 +37,7 @@ from edb.edgeql import qltypes as ft
 from . import context
 from . import dispatch
 from . import setgen
+from . import typegen
 
 
 class BoundArg(NamedTuple):
@@ -216,9 +216,7 @@ def try_bind_call_args(
             bargs: List[BoundArg] = []
             if has_inlined_defaults:
                 bytes_t = ctx.env.get_track_schema_type('std::bytes')
-                typeref = irtyputils.type_to_typeref(
-                    schema, bytes_t, cache=ctx.env.type_ref_cache
-                )
+                typeref = typegen.type_to_typeref(bytes_t, env=ctx.env)
                 argval = setgen.ensure_set(
                     irast.BytesConstant(value=b'\x00', typeref=typeref),
                     typehint=bytes_t,
@@ -439,9 +437,7 @@ def try_bind_call_args(
         # bit-mask as a first argument.
         bytes_t = ctx.env.get_track_schema_type('std::bytes')
         bm = defaults_mask.to_bytes(nparams // 8 + 1, 'little')
-        typeref = irtyputils.type_to_typeref(
-            ctx.env.schema, bytes_t, cache=ctx.env.type_ref_cache
-        )
+        typeref = typegen.type_to_typeref(bytes_t, env=ctx.env)
         bm_set = setgen.ensure_set(
             irast.BytesConstant(value=bm, typeref=typeref),
             typehint=bytes_t, ctx=ctx)

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -69,9 +69,7 @@ def new_set(*, stype: s_types.Type, ctx: context.ContextLevel,
     Absolutely all ir.Set instances must be created using this
     constructor.
     """
-    typeref = irtyputils.type_to_typeref(
-        ctx.env.schema, stype, cache=ctx.env.type_ref_cache
-    )
+    typeref = typegen.type_to_typeref(stype, env=ctx.env)
     ir_set = irast.Set(typeref=typeref, **kwargs)
     ctx.env.set_types[ir_set] = stype
     return ir_set
@@ -86,9 +84,7 @@ def new_empty_set(*, stype: Optional[s_types.Type]=None, alias: str,
         if srcctx is not None:
             ctx.env.type_origins[stype] = srcctx
 
-    typeref = irtyputils.type_to_typeref(
-        ctx.env.schema, stype, cache=ctx.env.type_ref_cache
-    )
+    typeref = typegen.type_to_typeref(stype, env=ctx.env)
     path_id = pathctx.get_expression_path_id(stype, alias, ctx=ctx)
     ir_set = irast.EmptySet(path_id=path_id, typeref=typeref)
     ctx.env.set_types[ir_set] = stype
@@ -154,9 +150,7 @@ def new_tuple_set(
             path_id=elem_path_id,
         ))
 
-    typeref = irtyputils.type_to_typeref(
-        ctx.env.schema, stype, cache=ctx.env.type_ref_cache,
-    )
+    typeref = typegen.type_to_typeref(stype, env=ctx.env)
     final_tup = irast.Tuple(elements=final_elems, named=named, typeref=typeref)
     return ensure_set(final_tup, path_id=result_path_id,
                       type_override=stype, ctx=ctx)
@@ -176,9 +170,7 @@ def new_array_set(
         if srcctx is not None:
             ctx.env.type_origins[anytype] = srcctx
 
-    typeref = irtyputils.type_to_typeref(
-        ctx.env.schema, stype, cache=ctx.env.type_ref_cache
-    )
+    typeref = typegen.type_to_typeref(stype, env=ctx.env)
     arr = irast.Array(elements=elements, typeref=typeref)
     return ensure_set(arr, type_override=stype, ctx=ctx)
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -69,7 +69,9 @@ def new_set(*, stype: s_types.Type, ctx: context.ContextLevel,
     Absolutely all ir.Set instances must be created using this
     constructor.
     """
-    typeref = irtyputils.type_to_typeref(ctx.env.schema, stype)
+    typeref = irtyputils.type_to_typeref(
+        ctx.env.schema, stype, cache=ctx.env.type_ref_cache
+    )
     ir_set = irast.Set(typeref=typeref, **kwargs)
     ctx.env.set_types[ir_set] = stype
     return ir_set
@@ -84,7 +86,9 @@ def new_empty_set(*, stype: Optional[s_types.Type]=None, alias: str,
         if srcctx is not None:
             ctx.env.type_origins[stype] = srcctx
 
-    typeref = irtyputils.type_to_typeref(ctx.env.schema, stype)
+    typeref = irtyputils.type_to_typeref(
+        ctx.env.schema, stype, cache=ctx.env.type_ref_cache
+    )
     path_id = pathctx.get_expression_path_id(stype, alias, ctx=ctx)
     ir_set = irast.EmptySet(path_id=path_id, typeref=typeref)
     ctx.env.set_types[ir_set] = stype
@@ -150,7 +154,9 @@ def new_tuple_set(
             path_id=elem_path_id,
         ))
 
-    typeref = irtyputils.type_to_typeref(ctx.env.schema, stype)
+    typeref = irtyputils.type_to_typeref(
+        ctx.env.schema, stype, cache=ctx.env.type_ref_cache,
+    )
     final_tup = irast.Tuple(elements=final_elems, named=named, typeref=typeref)
     return ensure_set(final_tup, path_id=result_path_id,
                       type_override=stype, ctx=ctx)
@@ -170,7 +176,9 @@ def new_array_set(
         if srcctx is not None:
             ctx.env.type_origins[anytype] = srcctx
 
-    typeref = irtyputils.type_to_typeref(ctx.env.schema, stype)
+    typeref = irtyputils.type_to_typeref(
+        ctx.env.schema, stype, cache=ctx.env.type_ref_cache
+    )
     arr = irast.Array(elements=elements, typeref=typeref)
     return ensure_set(arr, type_override=stype, ctx=ctx)
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -703,6 +703,8 @@ def type_intersection_set(
     ptrref = irtyputils.ptrref_from_ptrcls(
         schema=ctx.env.schema,
         ptrcls=ptrcls,
+        cache=ctx.env.ptr_ref_cache,
+        typeref_cache=ctx.env.type_ref_cache,
     )
 
     poly_set.path_id = source_set.path_id.extend(

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -27,7 +27,6 @@ from typing import *  # NoQA
 from edb import errors
 
 from edb.ir import ast as irast
-from edb.ir import typeutils as irtyputils
 
 from edb.schema import ddl as s_ddl
 from edb.schema import functions as s_func
@@ -545,10 +544,9 @@ def compile_DescribeStmt(
                 emit_oids=emit_oids.val,
             )
 
-        ct = irtyputils.type_to_typeref(
-            ctx.env.schema,
+        ct = typegen.type_to_typeref(
             ctx.env.get_track_schema_type('std::str'),
-            cache=ctx.env.type_ref_cache,
+            env=ctx.env,
         )
 
         stmt.result = setgen.ensure_set(

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -548,6 +548,7 @@ def compile_DescribeStmt(
         ct = irtyputils.type_to_typeref(
             ctx.env.schema,
             ctx.env.get_track_schema_type('std::str'),
+            cache=ctx.env.type_ref_cache,
         )
 
         stmt.result = setgen.ensure_set(

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -196,3 +196,11 @@ def collapse_type_intersection_rptr(
             for ptrref in rptr_specialization]
 
     return ind_prefix, ptrs
+
+
+def type_to_typeref(
+    t: s_types.Type, env: context.Environment
+) -> irast.TypeRef:
+    schema = env.schema
+    cache = env.type_ref_cache
+    return irtyputils.type_to_typeref(schema, t, cache=cache)

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -58,7 +58,9 @@ def ql_typeexpr_to_ir_typeref(
         ctx: context.ContextLevel) -> irast.TypeRef:
 
     stype = ql_typeexpr_to_type(ql_t, ctx=ctx)
-    return irtyputils.type_to_typeref(ctx.env.schema, stype)
+    return irtyputils.type_to_typeref(
+        ctx.env.schema, stype, cache=ctx.env.type_ref_cache
+    )
 
 
 def ql_typeexpr_to_type(

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     import uuid
 
     from edb.schema import schema as s_schema
+    from edb.edgeql.compiler import context as ql_compiler_ctx
 
 
 class WeakNamespace(str):
@@ -131,6 +132,7 @@ class PathId:
         schema: s_schema.Schema,
         t: s_types.Type,
         *,
+        env: Optional[ql_compiler_ctx.Environment] = None,
         namespace: AbstractSet[AnyNamespace] = frozenset(),
         typename: Optional[s_name.Name] = None,
     ) -> PathId:
@@ -145,6 +147,8 @@ class PathId:
                 A schema instance where the type *t* is defined.
             t:
                 The type of the variable being defined.
+            env:
+                Optional EdgeQL compiler environment, used for caching.
             namespace:
                 Optional namespace in which the variable is defined.
             typename:
@@ -158,7 +162,10 @@ class PathId:
             raise ValueError(
                 f'invalid PathId: bad source: {t!r}')
 
-        typeref = typeutils.type_to_typeref(schema, t, typename=typename)
+        cache = env.type_ref_cache if env is not None else None
+        typeref = typeutils.type_to_typeref(
+            schema, t, cache=cache, typename=typename
+        )
         return cls.from_typeref(typeref, namespace=namespace,
                                 typename=typename)
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -569,7 +569,7 @@ class CreateFunction(FunctionCommand, CreateObject,
         sql_text, _ = compiler.compile_ir_to_sql(
             body_ir,
             ignore_shapes=True,
-            explicit_top_cast=irtyputils.type_to_typeref(
+            explicit_top_cast=irtyputils.type_to_typeref(  # note: no cache
                 schema, func.get_return_type(schema)),
             output_format=compiler.OutputFormat.NATIVE,
             use_named_params=True)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.94)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.99)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
Before:
```
compile_edgeql_script: Mean +- std dev: 2.60 ms +- 0.07 ms
compile_edgeql_script_webapp_configure_system: Mean +- std dev: 44.0 ms +- 3.6 ms
compile_edgeql_script_webapp_get_movie: Mean +- std dev: 289 ms +- 55 ms
compile_edgeql_script_webapp_get_person: Mean +- std dev: 316 ms +- 73 ms
compile_edgeql_script_webapp_get_user: Mean +- std dev: 150 ms +- 4 ms
compile_edgeql_script_webapp_insert_movie: Mean +- std dev: 155 ms +- 2 ms
compile_edgeql_script_webapp_insert_person: Mean +- std dev: 59.6 ms +- 2.2 ms
compile_edgeql_script_webapp_insert_review: Mean +- std dev: 91.4 ms +- 1.7 ms
```

After:
```
compile_edgeql_script: Mean +- std dev: 2.44 ms +- 0.06 ms (6.2% faster)
compile_edgeql_script_webapp_configure_system: Mean +- std dev: 35.0 ms +- 0.9 ms (21% faster)
compile_edgeql_script_webapp_get_movie: Mean +- std dev: 256 ms +- 63 ms (11.5% faster)
compile_edgeql_script_webapp_get_person: Mean +- std dev: 325 ms +- 83 ms (2.8% SLOWER)
compile_edgeql_script_webapp_get_user: Mean +- std dev: 142 ms +- 3 ms (5.4% faster)
compile_edgeql_script_webapp_insert_movie: Mean +- std dev: 140 ms +- 3 ms (9.7% faster)
compile_edgeql_script_webapp_insert_person: Mean +- std dev: 54.6 ms +- 1.5 ms (8.4% faster)
compile_edgeql_script_webapp_insert_review: Mean +- std dev: 84.6 ms +- 2.0 ms (8.5% faster)
```

For big queries the jitter is higher due to GC activity as the cache needs to be cleaned out.

Other observations:
- only caching in the Environment didn't allow me to cache all places (see two marked spots) and got me thinking that it would be better to have a per-Schema "persistent" in-memory cache for this that would survive between compilation rounds; of course benchmarks would have to clean it up but for Real World use that would make the caches' hit rate much higher;
- I looked into why `get_person()` is actually slower now but have no answers yet;
- for benchmarks we want to disable GC when the function is being measured, given that those functions are not long-lived this should help with the jitter a lot;
- benchmarking with Wi-Fi off works better for me in terms of minimizing jitter;
- there are two failing tests due to the cache now but I'm not entirely sure if those are bugs, please look at them (test_edgeql_ir_scope_tree_19; test_edgeql_ir_scope_tree_24).