### PR TITLE
Support annotations for functions in SDL.

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -541,7 +541,9 @@ def _register_item(
                 if cmd_name.module not in s_schema.STD_MODULES:
                     deps.add(cmd_name)
 
-            if isinstance(cmd, qlast.ObjectDDL):
+            if (isinstance(cmd, qlast.ObjectDDL)
+                    # HACK: functions don't have alters at the moment
+                    and not isinstance(decl, qlast.CreateFunction)):
                 subcmds.append(cmd)
             elif (isinstance(cmd, qlast.SetField)
                   and not isinstance(cmd.value, qlast.BaseConstant)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1384,6 +1384,18 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_get_migration_30(self):
+        # Test annotated function SDL.
+        schema = r'''
+        function idx(num: int64) -> bool {
+            using (SELECT (num % 2) = 0);
+            volatility := 'IMMUTABLE';
+            annotation title := 'func anno';
+        }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_get_migration_multi_module_01(self):
         schema = r'''
             # The two declared types declared are from different


### PR DESCRIPTION
There's no `ALTER` command for functions, so stop function annotations
from being factored out into a separate `ALTER` step.

Issue #1006.