### PR TITLE
Implement rudimentary support for type intersection

### DIFF
--- a/docs/edgeql/expressions/paths.rst
+++ b/docs/edgeql/expressions/paths.rst
@@ -76,7 +76,7 @@ And this represents all sources of the ``owner`` links that have a
 
 By default backward links don't infer any type information beyond the
 fact that it's an :eql:type:`Object`. To ensure that this path
-specifically reaches ``Issue`` a :eql:op:`type filter <ISFILTER>`
+specifically reaches ``Issue`` a :eql:op:`type intersection <ISINTERSECT>`
 operator must be used:
 
 .. code-block:: edgeql

--- a/docs/edgeql/funcops/set.rst
+++ b/docs/edgeql/funcops/set.rst
@@ -167,13 +167,13 @@ Set
 ----------
 
 
-.. eql:operator:: ISFILTER: anytype [IS type] -> anytype
+.. eql:operator:: ISINTERSECT: anytype [IS type] -> anytype
 
-    :index: is type filter
+    :index: is type intersection
 
     Filter the set based on type.
 
-    The type filter operator removes all elements from the input set
+    The type intersection operator removes all elements from the input set
     that aren't of the specified type. Additionally, since it
     guarantees the type of the result set all the links and properties
     associated with the specified type can now be used on the
@@ -209,13 +209,14 @@ Set
 
     By default backward links don't infer any type information beyond the
     fact that it's an :eql:type:`Object`. To ensure that this path
-    specifically reaches ``Issue`` the type filter operator must be used:
+    specifically reaches ``Issue`` the type intersection operator must
+    be used:
 
     .. code-block:: edgeql
 
         SELECT User.<owner[IS Issue];
 
-        # With the use of type filter it's possible to refer to
+        # With the use of type intersection it's possible to refer to
         # specific property of Issue now:
         SELECT User.<owner[IS Issue].title;
 

--- a/docs/edgeql/funcops/type.rst
+++ b/docs/edgeql/funcops/type.rst
@@ -157,7 +157,7 @@ Types
     It is illegal to cast one :eql:type:`Object` into another. The
     only way to construct a new :eql:type:`Object` is by using
     :ref:`INSERT <ref_eql_statements_insert>`. However, the
-    :eql:op:`type filter <ISFILTER>` can be used to achieve an
+    :eql:op:`type intersection <ISINTERSECT>` can be used to achieve an
     effect similar to casting for Objects.
 
     When a cast is applied to an expression of a known type, it represents a

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -384,7 +384,7 @@ class IsOp(Expr):
     right: TypeExpr
 
 
-class TypeIndirection(Base):
+class TypeIntersection(Base):
     type: TypeExpr
 
 
@@ -395,7 +395,7 @@ class Ptr(Base):
 
 
 class Path(Expr):
-    steps: typing.List[typing.Union[Expr, Ptr, TypeIndirection, ObjectRef]]
+    steps: typing.List[typing.Union[Expr, Ptr, TypeIntersection, ObjectRef]]
     quantifier: Expr
     partial: bool = False
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -438,7 +438,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         for i, e in enumerate(node.steps):
             if i > 0 or node.partial:
                 if (getattr(e, 'type', None) != 'property'
-                        and not isinstance(e, qlast.TypeIndirection)):
+                        and not isinstance(e, qlast.TypeIntersection)):
                     self.write('.')
 
             if i == 0:
@@ -451,7 +451,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                                         qlast.Set,
                                         qlast.Tuple,
                                         qlast.NamedTuple,
-                                        qlast.TypeIndirection,
+                                        qlast.TypeIntersection,
                                         qlast.Parameter)):
                     self.write('(')
                     self.visit(e)
@@ -485,7 +485,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
         self.visit(node.ptr)
 
-    def visit_TypeIndirection(self, node: qlast.TypeIndirection) -> None:
+    def visit_TypeIntersection(self, node: qlast.TypeIntersection) -> None:
         self.write('[IS ')
         self.visit(node.type)
         self.write(']')
@@ -511,15 +511,15 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self.visit(node.expr)
         else:
             self.visit(node.expr.steps[0])
-            if not isinstance(node.expr.steps[1], qlast.TypeIndirection):
+            if not isinstance(node.expr.steps[1], qlast.TypeIntersection):
                 self.write('.')
                 self.visit(node.expr.steps[1])
 
         if not node.compexpr and (node.elements
                                   or isinstance(node.expr.steps[-1],
-                                                qlast.TypeIndirection)):
+                                                qlast.TypeIntersection)):
             self.write(': ')
-            if isinstance(node.expr.steps[-1], qlast.TypeIndirection):
+            if isinstance(node.expr.steps[-1], qlast.TypeIntersection):
                 self.visit(node.expr.steps[-1].type)
             if node.elements:
                 self._visit_shape(node.elements)

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -354,7 +354,7 @@ def get_config_type_shape(
 
             if t is not stype:
                 elem_path.append(
-                    qlast.TypeIndirection(
+                    qlast.TypeIntersection(
                         type=qlast.TypeName(
                             maintype=qlast.ObjectRef(
                                 module=t_name.module,

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -164,15 +164,15 @@ def __infer_set(
     if rptr is not None:
 
         rptrref = rptr.ptrref
-        if isinstance(rptrref, irast.TypeIndirectionPointerRef):
-            ind_prefix, ind_ptrs = irutils.collapse_type_indirection(ir)
+        if isinstance(rptrref, irast.TypeIntersectionPointerRef):
+            ind_prefix, ind_ptrs = irutils.collapse_type_intersection(ir)
             new_scope = _get_set_scope(ir, scope_tree)
             if ind_prefix.rptr is None:
                 return infer_cardinality(ind_prefix, new_scope, env)
             else:
-                # Expression before type indirection is a path,
+                # Expression before type intersection is a path,
                 # i.e Foo.<bar[IS Type].  In this case we must
-                # take possible indirection specialization of the
+                # take possible intersection specialization of the
                 # link union into account.
                 # We're basically restating the body of this function
                 # in this block, but with extra conditions.
@@ -184,10 +184,10 @@ def __infer_set(
                         rptr_spec.update(ind_ptr.ptrref.rptr_specialization)
 
                     if not rptr_spec:
-                        # The type indirection does not narrow the
+                        # The type intersection does not narrow the
                         # pointer union (or there is no union), so
                         # use the rptr cardinality as if there was no
-                        # indirection.
+                        # intersection.
                         if rptrref.dir_cardinality is qltypes.Cardinality.ONE:
                             return infer_cardinality(
                                 rptr.source, new_scope, env)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -777,7 +777,7 @@ def compile_query_subject(
     expr_stype = setgen.get_set_type(expr, ctx=ctx)
     expr_rptr = expr.rptr
 
-    while isinstance(expr_rptr, irast.TypeIndirectionPointer):
+    while isinstance(expr_rptr, irast.TypeIntersectionPointer):
         expr_rptr = expr_rptr.source.rptr
 
     is_ptr_alias = (

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -240,8 +240,8 @@ def _normalize_view_ptr_expr(
     target_typexpr = None
     source: qlast.Base
 
-    if plen >= 2 and isinstance(steps[-1], qlast.TypeIndirection):
-        # Target type indirection: foo: Type
+    if plen >= 2 and isinstance(steps[-1], qlast.TypeIntersection):
+        # Target type intersection: foo: Type
         target_typexpr = steps[-1].type
         plen -= 1
         steps = steps[:-1]
@@ -259,8 +259,8 @@ def _normalize_view_ptr_expr(
             assert isinstance(view_rptr.ptrcls, s_links.Link)
             ptrsource = view_rptr.ptrcls
         source = qlast.Source()
-    elif plen == 2 and isinstance(steps[0], qlast.TypeIndirection):
-        # Source type indirection: [IS Type].foo
+    elif plen == 2 and isinstance(steps[0], qlast.TypeIntersection):
+        # Source type intersection: [IS Type].foo
         source = qlast.Path(steps=[
             qlast.Source(),
             steps[0],
@@ -324,7 +324,7 @@ def _normalize_view_ptr_expr(
                 qlexpr = qlast.Path(steps=[
                     source,
                     lexpr,
-                    qlast.TypeIndirection(type=target_typexpr),
+                    qlast.TypeIntersection(type=target_typexpr),
                 ])
 
             qlexpr = astutils.ensure_qlstmt(qlexpr)

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -341,7 +341,7 @@ class ShapeElement(Nonterm):
         # this indicates a polymorphic shape and TypeExpr must be
         # extracted from the path steps
         if shape and isinstance(shape[0], qlast.TypeExpr):
-            self.val.expr.steps.append(qlast.TypeIndirection(
+            self.val.expr.steps.append(qlast.TypeIntersection(
                 type=shape[0], context=shape[0].context))
             self.val.elements = shape[1:]
         else:
@@ -398,7 +398,7 @@ class ShapePath(Nonterm):
 
         self.val = qlast.Path(
             steps=[
-                qlast.TypeIndirection(
+                qlast.TypeIntersection(
                     type=kids[0].val,
                 ),
                 qlast.Ptr(
@@ -1096,7 +1096,7 @@ class PathStep(Nonterm):
         )
 
     def reduce_LBRACKET_IS_FullTypeExpr_RBRACKET(self, *kids):
-        self.val = qlast.TypeIndirection(
+        self.val = qlast.TypeIntersection(
             type=kids[2].val,
         )
 

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -351,8 +351,8 @@ def trace_Path(node: qlast.Path, *,
             else:
                 if step.direction == '<':
                     if plen > i + 1 and isinstance(node.steps[i + 1],
-                                                   qlast.TypeIndirection):
-                        # A reverse link traversal with a type filter,
+                                                   qlast.TypeIntersection):
+                        # A reverse link traversal with a type intersection,
                         # process it on the next step.
                         pass
                     else:
@@ -374,7 +374,7 @@ def trace_Path(node: qlast.Path, *,
 
                     tip = ptr.get_target(ctx.schema)
 
-        elif isinstance(step, qlast.TypeIndirection):
+        elif isinstance(step, qlast.TypeIntersection):
             tip = _resolve_type_expr(step.type, ctx=ctx)
             prev_step = node.steps[i - 1]
             if prev_step.direction == '<':
@@ -449,8 +449,8 @@ def _resolve_type_expr(
 
 
 @trace.register
-def trace_TypeIndirection(node: qlast.TypeIndirection, *,
-                          ctx: TracerContext) -> None:
+def trace_TypeIntersection(node: qlast.TypeIntersection, *,
+                           ctx: TracerContext) -> None:
     trace(node.type, ctx=ctx)
 
 

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -448,7 +448,7 @@ class GraphQLTranslator:
         steps = []
         if include_base:
             base = spath[0].type
-            steps.append(qlast.TypeIndirection(
+            steps.append(qlast.TypeIntersection(
                 type=qlast.TypeName(
                     maintype=base.edb_base_name_ast
                 )

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -124,6 +124,9 @@ class TypeRef(ImmutableBase):
     # If this is a union type, this would be a set of
     # union elements.
     children: typing.FrozenSet[TypeRef]
+    # If this is an intersection type, this would be a set of
+    # intersection elements.
+    intersection: typing.FrozenSet[TypeRef]
     # If this is a union type, this would be the nearest common
     # ancestor of the union members.
     common_parent: typing.Optional[TypeRef]
@@ -250,8 +253,8 @@ class TupleIndirectionPointerRef(BasePointerRef):
     pass
 
 
-class TypeIndirectionLink(s_pointers.PseudoPointer):
-    """A Link-alike that can be used in type indirection path ids."""
+class TypeIntersectionLink(s_pointers.PseudoPointer):
+    """A Link-alike that can be used in type intersection path ids."""
 
     def __init__(
         self,
@@ -259,7 +262,7 @@ class TypeIndirectionLink(s_pointers.PseudoPointer):
         target: s_types.Type,
         *,
         optional: bool,
-        is_supertype: bool,
+        is_empty: bool,
         is_subtype: bool,
         rptr_specialization: typing.Iterable[PointerRef] = (),
         cardinality: qltypes.Cardinality,
@@ -270,7 +273,7 @@ class TypeIndirectionLink(s_pointers.PseudoPointer):
         self._target = target
         self._cardinality = cardinality
         self._optional = optional
-        self._is_supertype = is_supertype
+        self._is_empty = is_empty
         self._is_subtype = is_subtype
         self._rptr_specialization = frozenset(rptr_specialization)
 
@@ -280,14 +283,14 @@ class TypeIndirectionLink(s_pointers.PseudoPointer):
     def get_cardinality(self, schema: s_schema.Schema) -> qltypes.Cardinality:
         return self._cardinality
 
-    def is_type_indirection(self) -> bool:
+    def is_type_intersection(self) -> bool:
         return True
 
     def is_optional(self) -> bool:
         return self._optional
 
-    def is_supertype(self) -> bool:
-        return self._is_supertype
+    def is_empty(self) -> bool:
+        return self._is_empty
 
     def is_subtype(self) -> bool:
         return self._is_subtype
@@ -316,10 +319,10 @@ class TypeIndirectionLink(s_pointers.PseudoPointer):
         return self._target.is_scalar()
 
 
-class TypeIndirectionPointerRef(BasePointerRef):
+class TypeIntersectionPointerRef(BasePointerRef):
 
     optional: bool
-    is_supertype: bool
+    is_empty: bool
     is_subtype: bool
     rptr_specialization: typing.FrozenSet[PointerRef]
 
@@ -338,10 +341,10 @@ class Pointer(Base):
         return self.direction == s_pointers.PointerDirection.Inbound
 
 
-class TypeIndirectionPointer(Pointer):
+class TypeIntersectionPointer(Pointer):
 
     optional: bool
-    ptrref: TypeIndirectionPointerRef
+    ptrref: TypeIntersectionPointerRef
 
 
 class Expr(Base):

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -242,7 +242,7 @@ class PathId:
             ptrref:
                 A ``ir.ast.BasePointerRef`` instance that corresponds
                 to the path step.  This may be a regular link or property
-                object, or a pseudo-pointer, like a tuple or type indirection
+                object, or a pseudo-pointer, like a tuple or type intersection
                 step.
             direction:
                 The direction of the *ptrcls* pointer.  This makes sense
@@ -674,8 +674,8 @@ class PathId:
            expression, i.e ``Foo.bar@prop``."""
         return self._is_linkprop
 
-    def is_type_indirection_path(self) -> bool:
-        """Return True if this PathId represents a type indirection
+    def is_type_intersection_path(self) -> bool:
+        """Return True if this PathId represents a type intersection
            expression, i.e ``Foo[IS Bar]``."""
         rptr_name = self.rptr_name()
         if rptr_name is None:

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -375,9 +375,9 @@ class ScopeTreeNode:
                     and not prefix.is_tuple_indirection_path()):
                 parent = new_child
 
-            # Skip through type indirections (i.e [IS Foo]) until
+            # Skip through type intersections (i.e [IS Foo]) until
             # we actually get to the link.
-            if not prefix.is_type_indirection_path():
+            if not prefix.is_type_intersection_path():
                 is_lprop = False
 
         self.attach_subtree(subtree)

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -229,8 +229,8 @@ def get_source_context_as_json(
     return details
 
 
-def is_type_indirection_reference(ir_expr: irast.Base) -> bool:
-    """Return True if the given *ir_expr* is a type indirection, i.e
+def is_type_intersection_reference(ir_expr: irast.Base) -> bool:
+    """Return True if the given *ir_expr* is a type intersection, i.e
        ``Foo[IS Type]``.
     """
     if not isinstance(ir_expr, irast.Set):
@@ -242,24 +242,24 @@ def is_type_indirection_reference(ir_expr: irast.Base) -> bool:
 
     ir_source = rptr.source
 
-    if ir_source.path_id.is_type_indirection_path():
-        source_is_type_indirection = True
+    if ir_source.path_id.is_type_intersection_path():
+        source_is_type_intersection = True
     else:
-        source_is_type_indirection = False
+        source_is_type_intersection = False
 
-    return source_is_type_indirection
+    return source_is_type_intersection
 
 
-def collapse_type_indirection(
+def collapse_type_intersection(
     ir_set: irast.Set,
-) -> Tuple[irast.Set, List[irast.TypeIndirectionPointer]]:
+) -> Tuple[irast.Set, List[irast.TypeIntersectionPointer]]:
 
-    result: List[irast.TypeIndirectionPointer] = []
+    result: List[irast.TypeIntersectionPointer] = []
 
     source = ir_set
     while True:
         rptr = source.rptr
-        if not isinstance(rptr, irast.TypeIndirectionPointer):
+        if not isinstance(rptr, irast.TypeIntersectionPointer):
             break
         result.append(rptr)
         source = rptr.source

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -234,8 +234,10 @@ CREATE TYPE schema::BaseObjectType
         schema::AnnotationSubject, schema::Type, schema::Source;
 
 
-ALTER TYPE schema::BaseObjectType
+ALTER TYPE schema::BaseObjectType {
     CREATE MULTI LINK union_of -> schema::BaseObjectType;
+    CREATE MULTI LINK intersection_of -> schema::BaseObjectType;
+};
 
 
 CREATE TYPE schema::ObjectType EXTENDING schema::BaseObjectType;

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -38,7 +38,7 @@ def tuple_element_for_shape_el(
     *,
     ctx: context.CompilerContextLevel
 ) -> pgast.TupleElementBase:
-    if shape_el.path_id.is_type_indirection_path():
+    if shape_el.path_id.is_type_intersection_path():
         rptr = shape_el.rptr.source.rptr
     else:
         rptr = shape_el.rptr

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -121,10 +121,10 @@ def get_path_var(
         return rel.path_namespace[path_id, aspect]
 
     ptrref = path_id.rptr()
-    is_type_indirection = path_id.is_type_indirection_path()
+    is_type_intersection = path_id.is_type_intersection_path()
 
     src_path_id: Optional[irast.PathId] = None
-    if ptrref is not None and not is_type_indirection:
+    if ptrref is not None and not is_type_intersection:
         ptr_info = pg_types.get_ptrref_storage_info(
             ptrref, resolve_type=False, link_bias=False)
         ptr_dir = path_id.rptr_dir()
@@ -146,8 +146,8 @@ def get_path_var(
                 # column.  This can only be done if Foo is visible
                 # in scope, and Foo.__type__ is not a computable.
                 pid = src_path_id
-                while pid.is_type_indirection_path():
-                    # Skip type indirection step(s).
+                while pid.is_type_intersection_path():
+                    # Skip type intersection step(s).
                     src_pid = pid.src_path()
                     if src_pid is not None:
                         src_rptr = src_pid.rptr()
@@ -224,7 +224,7 @@ def get_path_var(
             assert _prefix_pid is not None
             src_path_id = _prefix_pid.src_path()
 
-    elif (is_type_indirection or
+    elif (is_type_intersection or
             (ptr_info.table_type != 'ObjectType' and not is_inbound)):
         # Ref is in the mapping rvar.
         src_path_id = path_id.ptr_path()
@@ -658,7 +658,7 @@ def _get_rel_path_output(
                 f'invalid request for non-scalar path {path_id} {aspect}')
 
         if (path_id == rel.path_id or
-                (rel.path_id.is_type_indirection_path() and
+                (rel.path_id.is_type_intersection_path() and
                  path_id == rel.path_id.src_path())):
 
             return _get_rel_object_id_output(

--- a/edb/pgsql/datasources/schema/objtypes.py
+++ b/edb/pgsql/datasources/schema/objtypes.py
@@ -35,6 +35,8 @@ async def fetch(
                 edgedb._resolve_type_name(c.bases) AS bases,
                 edgedb._resolve_type_name(c.ancestors) AS ancestors,
                 edgedb._resolve_type_name(c.union_of) AS union_of,
+                edgedb._resolve_type_name(c.intersection_of)
+                    AS intersection_of,
                 c.is_abstract AS is_abstract,
                 c.is_final AS is_final,
                 c.expr_type AS expr_type,

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -899,12 +899,19 @@ class IntrospectionMech:
             else:
                 union_of = None
 
+            if row['intersection_of']:
+                intersection_of = [schema.get(t)
+                                   for t in row['intersection_of']]
+            else:
+                intersection_of = None
+
             schema, objtype = s_objtypes.ObjectType.create_in_schema(
                 schema,
                 id=objtype['id'],
                 name=name,
                 is_abstract=objtype['is_abstract'],
                 union_of=union_of,
+                intersection_of=intersection_of,
                 is_final=objtype['is_final'],
                 expr_type=objtype['expr_type'],
                 alias_is_persistent=objtype['alias_is_persistent'],

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 20191220_00_01
+EDGEDB_CATALOG_VERSION = 20191222_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4033,32 +4033,32 @@ class TestExpressions(tb.QueryTestCase):
                 SELECT DISTINCT Issue ORDER BY Issue.name;
             ''')
 
-    async def test_edgeql_expr_type_filter_01(self):
+    async def test_edgeql_expr_type_intersection_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'invalid type filter operand: std::int64 is not '
-                r'an object type',
+                f"cannot apply type intersection operator to scalar type "
+                f"'std::int64': it is not an object type",
                 _position=25):
 
             await self.con.execute('''\
                 SELECT 10[IS std::Object];
             ''')
 
-    async def test_edgeql_expr_type_filter_02(self):
+    async def test_edgeql_expr_type_intersection_02(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'invalid type filter operand: std::str is not an object type',
+                r'cannot create an intersection of std::Object, std::str',
                 _position=33):
 
             await self.con.execute('''\
                 SELECT Object[IS str];
             ''')
 
-    async def test_edgeql_expr_type_filter_03(self):
+    async def test_edgeql_expr_type_intersection_03(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'invalid type filter operand: '
-                r'std::uuid is not an object type',
+                f"cannot apply type intersection operator to scalar type "
+                f"'std::uuid': it is not an object type",
                 _position=32):
 
             await self.con.execute('''\

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1254,7 +1254,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         )
 
     async def test_edgeql_select_polymorphic_09(self):
-        # Test simultaneous type indirection on source and target
+        # Test simultaneous type intersection on source and target
         # of a shape element.
         await self.assert_query_result(
             r'''
@@ -1315,24 +1315,21 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ['std::Object']
         )
 
-        with self.assertRaisesRegex(
-            edgedb.InvalidReferenceError,
-            "property 'since' is not defined",
-        ):
-            await self.con.execute(
-                r'''
-                WITH MODULE test
-                SELECT
-                    User.<owner[IS Text]@since
-                ''',
-            )
-
     async def test_edgeql_select_reverse_link_02(self):
         await self.assert_query_result(
             r'''
             WITH MODULE test
             SELECT
                 User.<owner[IS Issue]@since
+            ''',
+            ['2018-01-01T00:00:00+00:00'],
+        )
+
+        await self.assert_query_result(
+            r'''
+            WITH MODULE test
+            SELECT
+                User.<owner[IS Text]@since
             ''',
             ['2018-01-01T00:00:00+00:00'],
         )
@@ -1993,13 +1990,15 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         )
 
     async def test_edgeql_select_setops_16(self):
-        with self.assertRaisesRegex(
-                edgedb.QueryError, r"has no link or property 'number'"):
-            await self.con.fetchall(r"""
-                # Named doesn't have a property number.
-                WITH MODULE test
-                SELECT Issue[IS Named].number;
-            """)
+        await self.assert_query_result(
+            r"""
+            # Named doesn't have a property number.
+            WITH MODULE test
+            SELECT Issue[IS Named].number;
+            """,
+            ['1', '2', '3', '4'],
+            sort=True,
+        )
 
     async def test_edgeql_select_setops_17(self):
         with self.assertRaisesRegex(

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -1188,7 +1188,7 @@ class TestUpdate(tb.QueryTestCase):
                 FILTER .name LIKE 'update-test-10-%'
                 SET {
                     # every test is .<related to 'update-test1'
-                    related := UpdateTest.related.<related
+                    related := UpdateTest.related.<related[IS UpdateTest]
                 };
             """,
             [{}],

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.53)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.89)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 38.87)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 39.30)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 9.76)


### PR DESCRIPTION
While working on tightening the restrictions around derivation of type
variants, I realized that our current formulation of the `[IS <type>]`
operator is mostly wrong, at least from the standpoint of the type
system.

Currently, the result type of `<expr>[IS Type]` is always `Type`, and,
this is only OK if `Type` is a subtype of `TYPEOF <expr>`.  In other
cases `[IS ...]` strips useful type information unnecessarily.

This stems from viewing `[IS ...]` as a "type filter", whereas in
reality it is a *type intersection* operator.  It returns an
intersection of its argument set with the set of all instances of
`Type`, so the result type is not just `Type`, it's an *intersection
type* `TYPEOF <expr> & Type`.  Intersection types are described in
detail in #219, but the most important detail is that an intersection
type contains a union of all properties and links of its constituent
types, so, if we had a schema like:

   type Named {
       property name -> str;
   }
   type Text {
       property text -> str;
   }

Then, `Named[IS Text]` would be a type that has *both* the `name` and
the `text` properties.  Similarly, if the argument is a union type, the
intersection operator may *narrow* the union, and in any case, the
intersection type is always a subclass of its consituent types -- a
property that is vital for polymorphic expressions in shapes.