### PR TITLE
graphql: Fix an error on null variable.

### DIFF
--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -1444,7 +1444,9 @@ class GraphQLTranslator:
 
 
 def value_node_from_pyvalue(val: Any):
-    if isinstance(val, str):
+    if val is None:
+        return None
+    elif isinstance(val, str):
         val = val.replace('\\', '\\\\')
         value = eql_quote.quote_literal(val)
         return gql_ast.StringValue(value=value[1:-1])

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -488,6 +488,40 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             }],
         })
 
+    def test_graphql_functional_query_17(self):
+        # Test unused & null variables
+        self.assert_graphql_query_result(
+            r"""
+                query Person {
+                    Person
+                    {
+                        name
+                    }
+                }
+            """,
+            {
+                'Person': [{
+                    'name': 'Bob',
+                }],
+            },
+            variables={'name': None},
+        )
+
+        self.assert_graphql_query_result(
+            r"""
+                query Person($name: String) {
+                    Person(filter: {name: {eq: $name}})
+                    {
+                        name
+                    }
+                }
+            """,
+            {
+                'Person': [],
+            },
+            variables={'name': None},
+        )
+
     def test_graphql_functional_alias_01(self):
         self.assert_graphql_query_result(
             r"""


### PR DESCRIPTION
GraphQL queries should be able to accept `null` value for a variable.

Fixes: #933