### PR TITLE
Don't compute lineage every time you check subclassing

### DIFF
--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -757,8 +757,10 @@ class InheritingObject(derivable.DerivableObject):
         return self.get_bases(schema).names(schema)
 
     def get_topmost_concrete_base(self, schema):
-        # Get the topmost non-abstract base.
-        for ancestor in reversed(so.compute_lineage(schema, self)):
+        """Get the topmost non-abstract base."""
+        lineage = [self]
+        lineage.extend(self.get_ancestors(schema).objects(schema))
+        for ancestor in reversed(lineage):
             if not ancestor.get_is_abstract(schema):
                 return ancestor
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -2022,7 +2022,10 @@ class InheritingObjectBase(Object):
     def _issubclass(
         self, schema: s_schema.Schema, parent: InheritingObjectBase
     ) -> bool:
-        lineage = compute_lineage(schema, self)
+        if parent == self:
+            return True
+
+        lineage = self.get_ancestors(schema).objects(schema)
         return parent in lineage
 
     def issubclass(

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -170,10 +170,10 @@ class BaseObjectType(sources.Source,
                 for t in my_intersection.objects(schema)
             )
 
-        lineage = so.compute_lineage(schema, self)
-
+        lineage = self.get_ancestors(schema).objects(schema)
         if parent in lineage:
             return True
+
         elif isinstance(parent, BaseObjectType):
             parent_union = parent.get_union_of(schema)
             if parent_union:


### PR DESCRIPTION
This one is pretty good at big queries and invisible at small queries.

Before:
```
compile_edgeql_script: Mean +- std dev: 2.64 ms +- 0.09 ms
compile_edgeql_script_webapp_configure_system: Mean +- std dev: 40.9 ms +- 0.9 ms
compile_edgeql_script_webapp_get_movie: Mean +- std dev: 280 ms +- 71 ms
compile_edgeql_script_webapp_get_person: Mean +- std dev: 346 ms +- 84 ms
compile_edgeql_script_webapp_get_user: Mean +- std dev: 153 ms +- 3 ms
compile_edgeql_script_webapp_insert_movie: Mean +- std dev: 166 ms +- 33 ms
compile_edgeql_script_webapp_insert_person: Mean +- std dev: 61.0 ms +- 1.4 ms
compile_edgeql_script_webapp_insert_review: Mean +- std dev: 93.0 ms +- 2.0 ms
```

After:
```
compile_edgeql_script: Mean +- std dev: 2.59 ms +- 0.09 ms (1.89% faster)
compile_edgeql_script_webapp_configure_system: Mean +- std dev: 39.7 ms +- 0.9 ms (2.93% faster)
compile_edgeql_script_webapp_get_movie: Mean +- std dev: 277 ms +- 69 ms (1.07% faster)
compile_edgeql_script_webapp_get_person: Mean +- std dev: 335 ms +- 85 ms (3.18% faster)
compile_edgeql_script_webapp_get_user: Mean +- std dev: 152 ms +- 5 ms (0.65% faster)
compile_edgeql_script_webapp_insert_movie: Mean +- std dev: 158 ms +- 5 ms (4.82% faster)
compile_edgeql_script_webapp_insert_person: Mean +- std dev: 60.3 ms +- 1.5 ms (1.15% faster)
compile_edgeql_script_webapp_insert_review: Mean +- std dev: 91.6 ms +- 1.8 ms (1.51% faster)
```

### Possible problem
I uploaded the pull request with the actual function disabled and replaced with one that fails an assert on two tests to demonstrate that the fast computation through `get_ancestors()` and `objects()` leaves an additional Link in those two cases compared to using `compute_lineage()`:
- test_constraints_exclusive_migration
- test_edgeql_coalesce_object_01

The question is: is this difference safe? The tests pass otherwise, if you replace this custom function with the actual one.

(That also fails type coverage because of the additional function but I didn't change that since this is a temporary function.)