### PR TITLE
Fix two ancestry propagation bugs found by @ambv in #1014

### DIFF
--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -202,9 +202,22 @@ def get_objtype_backend_name(id, module_id, *, catenate=True, aspect=None):
     return convert_name(name, suffix=suffix, catenate=catenate)
 
 
-def get_pointer_backend_name(id, module_id, *, catenate=False):
+def get_pointer_backend_name(id, module_id, *, catenate=False, aspect=None):
+    if aspect is None:
+        aspect = 'table'
+
+    if aspect not in ('table', 'index'):
+        raise ValueError(
+            f'unexpected aspect for pointer backend name: {aspect!r}')
+
     name = s_name.Name(module=str(module_id), name=str(id))
-    return convert_name(name, suffix='', catenate=catenate)
+
+    if aspect != 'table':
+        suffix = aspect
+    else:
+        suffix = ''
+
+    return convert_name(name, suffix=suffix, catenate=catenate)
 
 
 _operator_map = {
@@ -304,7 +317,8 @@ def get_backend_name(schema, obj, catenate=True, *, aspect=None):
     elif isinstance(obj, s_abc.Pointer):
         name = obj.get_name(schema)
         module = schema.get_global(s_mod.Module, name.module)
-        return get_pointer_backend_name(obj.id, module.id, catenate=catenate)
+        return get_pointer_backend_name(obj.id, module.id, catenate=catenate,
+                                        aspect=aspect)
 
     elif isinstance(obj, s_scalars.ScalarType):
         name = obj.get_name(schema)

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2513,8 +2513,9 @@ class CreateLink(LinkMetaCommand, adapts=s_links.CreateLink):
                 if default_value is not None:
                     self.alter_pointer_default(link, schema, context)
 
-                index_name = common.convert_name(
-                    link.get_name(schema), 'idx', catenate=True)
+                index_name = common.get_backend_name(
+                    schema, link, catenate=False, aspect='index'
+                )[1]
 
                 pg_index = dbops.Index(
                     name=index_name, table_name=table_name,

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1991,7 +1991,7 @@ class InheritingObjectBase(Object):
         default=ObjectList,
         coerce=True,
         inheritable=False,
-        hashable=False,
+        compcoef=0.999,
     )
 
     # Attributes that have been set locally as opposed to inherited.


### PR DESCRIPTION
The recomputation of ancestry on `issubclass()` calls is currently
masking two bugs in the correct propagation of the `ancestors` field:

  * `ReferencedObject.derive_ref()` results in `ancestors` not matching
    the actual ancestry if the object being derived already exists
    and the base does not match the actual base.

  * When comparing schemas, the `ancestors` field does not participate
    in the comparison function, which means that the result delta will
    omit objects that had only their ancestors changed.