### PR TITLE
Make type variants made by shapes consistent with schema inheriance rules

### DIFF
--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -1092,7 +1092,7 @@ class GQLBaseType(metaclass=GQLTypeMeta):
 
         elif self.get_field_type(name).is_json:
             eql = filterable = parse_fragment(
-                f'''SELECT to_str({codegen.generate_source(parent)}.
+                f'''SELECT <json>to_str({codegen.generate_source(parent)}.
                         {codegen.generate_source(qlast.ObjectRef(name=name))})
                 ''')
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -332,6 +332,15 @@ def new_root_rvar(
     if typeref is None:
         typeref = ir_set.typeref
 
+    if typeref.intersection:
+        wrapper = pgast.SelectStmt()
+        for component in typeref.intersection:
+            component_rvar = new_root_rvar(ir_set, typeref=component, ctx=ctx)
+            pathctx.put_rvar_path_bond(component_rvar, ir_set.path_id)
+            include_rvar(wrapper, component_rvar, ir_set.path_id, ctx=ctx)
+
+        return rvar_for_rel(wrapper, ctx=ctx)
+
     dml_source = irutils.get_nearest_dml_stmt(ir_set)
     set_rvar = range_for_typeref(
         typeref, ir_set.path_id, dml_source=dml_source, ctx=ctx)
@@ -369,17 +378,6 @@ def new_root_rvar(
                 )
 
     return set_rvar
-
-
-def new_poly_rvar(
-        ir_set: irast.Set, *,
-        ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
-
-    rvar = new_root_rvar(ir_set, ctx=ctx)
-    prefix_path_id = ir_set.path_id.src_path()
-    assert prefix_path_id is not None, 'expected a path'
-    pathctx.put_rvar_path_bond(rvar, prefix_path_id)
-    return rvar
 
 
 def new_pointer_rvar(

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -248,33 +248,29 @@ class Pointer(referencing.ReferencedInheritingObject,
 
         if (isinstance(t1, s_abc.ScalarType) !=
                 isinstance(t2, s_abc.ScalarType)):
-            # Targets are not of the same node type
-
-            pn = ptr.get_shortname(schema)
-            ccn1 = type(t1).__name__
-            ccn2 = type(t2).__name__
-
-            detail = (
-                f'[{source.get_name(schema)}].[{pn}] '
-                f'targets {ccn1} "{t1.get_name(schema)}"'
-                f'while it also targets {ccn2} "{t2.get_name(schema)}"'
-                'in other parent.'
-            )
-
+            # Mixing a property with a link.
+            vnp = ptr.get_verbosename(schema, with_parent=True)
+            vn = ptr.get_verbosename(schema)
+            t1_vn = t1.get_verbosename(schema)
+            t2_vn = t2.get_verbosename(schema)
             raise errors.SchemaError(
-                f'could not merge "{pn}" pointer: invalid ' +
-                'target type mix', details=detail)
+                f'cannot redefine {vnp} as {t2_vn}',
+                details=f'{vn} is defined as a link to {t1_vn} in a '
+                        f'parent type'
+            )
 
         elif isinstance(t1, s_abc.ScalarType):
             # Targets are both scalars
             if t1 != t2:
-                vn = ptr.get_verbosename(schema, with_parent=True)
+                vnp = ptr.get_verbosename(schema, with_parent=True)
+                vn = ptr.get_verbosename(schema)
+                t1_vn = t1.get_verbosename(schema)
+                t2_vn = t2.get_verbosename(schema)
                 raise errors.SchemaError(
-                    f'could not merge {vn!r}: targets conflict',
-                    details=f'{vn} targets scalar type '
-                            f'{t1.get_displayname(schema)!r} while it also '
-                            f'targets incompatible scalar type '
-                            f'{t2.get_displayname(schema)!r} in a supertype.')
+                    f'cannot redefine {vnp} as {t2_vn}',
+                    details=f'{vn} is defined as {t1_vn} in a parent type, '
+                            f'which is incompatible with {t2_vn} ',
+                )
 
             return schema, t1
 
@@ -302,14 +298,14 @@ class Pointer(referencing.ReferencedInheritingObject,
                 # The link is neither a subclass, nor a superclass
                 # of the previously seen targets, which creates an
                 # unresolvable target requirement conflict.
-                vn = ptr.get_verbosename(schema, with_parent=True)
+                vnp = ptr.get_verbosename(schema, with_parent=True)
+                vn = ptr.get_verbosename(schema)
+                t2_vn = t2.get_verbosename(schema)
                 raise errors.SchemaError(
-                    f'could not merge {vn} pointer: targets conflict',
+                    f'cannot redefine {vnp} as {t2_vn}',
                     details=(
-                        f'{vn} targets '
-                        f'object {t2.get_verbosename(schema)!r} which '
-                        f'is not related to any of targets found in '
-                        f'other sources being merged: '
+                        f'{vn} targets {t2_vn} that is not related '
+                        f'to a type found in this link in the parent type: '
                         f'{t1.get_displayname(schema)!r}.'))
 
             if len(new_targets) > 1:

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -3563,7 +3563,8 @@ class TestExpressions(tb.QueryTestCase):
                 edgedb.QueryError, r'cannot assign to __type__'):
             await self.con.fetchall(r"""
                 SELECT test::Text {
-                    __type__ := 42
+                    __type__ := (SELECT schema::ObjectType
+                                 FILTER .name = 'test::Named')
                 };
             """)
 

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -279,9 +279,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         """
         WITH MODULE test
         SELECT User {
-            friends := (User.friends.name
+            friends := (User.friends
                         IF EXISTS User.friends
-                        ELSE User.deck.name)
+                        ELSE User.deck.<deck[IS User])
         }
         ORDER BY User.name
 
@@ -289,23 +289,25 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(test::User).>name[IS std::str]"
-            },
-            "FENCE": {
+                "(test::User).>friends[IS test::User]",
                 "FENCE": {
-                    "(test::User).>deck[IS test::Card].>name[IS std::str]": {
-                        "(test::User).>deck[IS test::Card]"
+                    "(test::User).>deck[IS test::Card].\
+<deck[IS __derived__::@SID@].>indirection[IS test::User]": {
+                        "(test::User).>deck[IS test::Card].\
+<deck[IS __derived__::@SID@]": {
+                            "(test::User).>deck[IS test::Card]"
+                        }
                     }
                 },
                 "FENCE": {
                     "(test::User).>friends[IS test::User]"
                 },
                 "FENCE": {
-                    "(test::User).>friends[IS test::User]\
-.>name[IS std::str]": {
-                        "(test::User).>friends[IS test::User]"
-                    }
+                    "(test::User).>friends[IS test::User]"
                 }
+            },
+            "FENCE": {
+                "(test::User).>name[IS std::str]"
             }
         }
         """

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -966,16 +966,30 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
                 WITH MODULE test
                 SELECT User {
                     name,
-                    deck := (SELECT x := User.deck.name
-                             ORDER BY x ASC
-                             LIMIT 2)
+                    deck := (SELECT x := User.deck
+                             ORDER BY x.name ASC
+                             LIMIT 2) {
+                                 name
+                             }
                 } ORDER BY .name;
             ''',
             [
-                {"deck": ["Bog monster", "Dragon"], "name": "Alice"},
-                {"deck": ["Bog monster", "Dwarf"], "name": "Bob"},
-                {"deck": ["Bog monster", "Djinn"], "name": "Carol"},
-                {"deck": ["Bog monster", "Djinn"], "name": "Dave"}
+                {
+                    "name": "Alice",
+                    "deck": [{"name": "Bog monster"}, {"name": "Dragon"}],
+                },
+                {
+                    "name": "Bob",
+                    "deck": [{"name": "Bog monster"}, {"name": "Dwarf"}],
+                },
+                {
+                    "name": "Carol",
+                    "deck": [{"name": "Bog monster"}, {"name": "Djinn"}],
+                },
+                {
+                    "name": "Dave",
+                    "deck": [{"name": "Bog monster"}, {"name": "Djinn"}],
+                },
             ]
         )
 

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1347,7 +1347,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 ''',
             )
 
-    async def test_edgeql_select_alias_01(self):
+    async def test_edgeql_select_tvariant_01(self):
         await self.assert_query_result(
             r'''
             WITH MODULE test
@@ -1380,7 +1380,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
-    async def test_edgeql_select_alias_02(self):
+    async def test_edgeql_select_tvariant_02(self):
         await self.assert_query_result(
             r'''
             WITH MODULE test
@@ -1408,7 +1408,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
-    async def test_edgeql_select_alias_03(self):
+    async def test_edgeql_select_tvariant_03(self):
         await self.assert_query_result(
             r'''
             WITH MODULE test
@@ -1440,7 +1440,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
-    async def test_edgeql_select_alias_04(self):
+    async def test_edgeql_select_tvariant_04(self):
         await self.assert_query_result(
             r"""
             WITH
@@ -1461,7 +1461,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
-    async def test_edgeql_select_alias_05(self):
+    async def test_edgeql_select_tvariant_05(self):
         await self.assert_query_result(
             r"""
             WITH MODULE test
@@ -1493,7 +1493,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
-    async def test_edgeql_select_alias_06(self):
+    async def test_edgeql_select_tvariant_06(self):
         await self.assert_query_result(
             r"""
             WITH MODULE test
@@ -1515,7 +1515,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
-    async def test_edgeql_select_alias_07(self):
+    async def test_edgeql_select_tvariant_07(self):
         await self.assert_query_result(
             r"""
             # semantically identical to the previous test
@@ -1541,7 +1541,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
-    async def test_edgeql_select_alias_08(self):
+    async def test_edgeql_select_tvariant_08(self):
         await self.assert_query_result(
             r"""
             # semantically similar to previous test, but involving
@@ -1564,6 +1564,62 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 },
             ],
         )
+
+    async def test_edgeql_select_tvariant_bad_01(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "cannot redefine property 'name' of object type 'test::User' "
+            "as scalar type 'std::int64'",
+            _position=92,
+        ):
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT User {
+                    name := 1
+                }
+            """)
+
+    async def test_edgeql_select_tvariant_bad_02(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "cannot redefine property 'name' of object type 'test::User' "
+            "as object type 'test::Issue'",
+            _position=92,
+        ):
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT User {
+                    name := Issue
+                }
+            """)
+
+    async def test_edgeql_select_tvariant_bad_03(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "cannot redefine link 'related_to' of object type 'test::Issue' "
+            "as scalar type 'std::int64'",
+            _position=99,
+        ):
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT Issue {
+                    related_to := 1
+                }
+            """)
+
+    async def test_edgeql_select_tvariant_bad_04(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "cannot redefine link 'related_to' of object type 'test::Issue' "
+            "as object type 'test::Text'",
+            _position=99,
+        ):
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT Issue {
+                    related_to := Text
+                }
+            """)
 
     async def test_edgeql_select_instance_01(self):
         await self.assert_query_result(
@@ -3293,7 +3349,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             WITH MODULE test
             SELECT Issue {
                 number,
-                name := <int64>{}
+                name := <str>{}
             } ORDER BY .number;
             """,
             [
@@ -4827,7 +4883,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 SELECT Issue.number FILTER .number > '1';
             ''')
 
-    async def test_edgeql_virtual_target_01(self):
+    async def test_edgeql_union_target_01(self):
         await self.assert_query_result(
             r'''
             WITH MODULE test

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.89)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.94)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 100.00)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.22)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.17)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)


### PR DESCRIPTION
Currently, overriding any link or property in a type variant produced by
a shape with a type that is incompatible with that of the base type is
allowed.  This is inconsistent with the normal schema inheritance rules,
and could lead to surprising behavior if the client receives instances
of a type with property types that it doesn't expect.

The only scenario I can think of where the current behavior is useful, is
schema emulation for backwards compatibility, and that use case should
be covered by the future introduction of proper computed types.