### PR TITLE
Make the "readonly" pointer declaration actually work

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -652,6 +652,13 @@ def _normalize_view_ptr_expr(
             msg = f'cannot assign to {ptrcls_sn.name}'
         raise errors.QueryError(msg, context=shape_el.context)
 
+    if is_update and ptrcls.get_readonly(ctx.env.schema):
+        raise errors.QueryError(
+            f'cannot update {ptrcls.get_verbosename(ctx.env.schema)}: '
+            f'it is declared as read-only',
+            context=compexpr.context,
+        )
+
     return ptrcls
 
 

--- a/tests/schemas/updates.edgeql
+++ b/tests/schemas/updates.edgeql
@@ -40,7 +40,9 @@ INSERT test::Tag {
 WITH MODULE test
 INSERT UpdateTest {
     name := 'update-test1',
-    status := (SELECT Status FILTER Status.name = 'Open')
+    status := (SELECT Status FILTER Status.name = 'Open'),
+    readonly_tag := (SELECT Tag FILTER .name = 'wow'),
+    readonly_note := 'this is read-only',
 };
 
 WITH MODULE test

--- a/tests/schemas/updates.esdl
+++ b/tests/schemas/updates.esdl
@@ -43,12 +43,23 @@ type UpdateTest {
     multi link tags -> Tag;
     multi link weighted_tags -> Tag {
         property weight -> int64;
+        property readonly_note -> str {
+            readonly := true;
+        }
     }
 
     # for testing links to sets of the same type as originator
     multi link related -> UpdateTest;
     multi link annotated_tests -> UpdateTest {
         property note -> str;
+    }
+
+    link readonly_tag -> Tag {
+        readonly := true;
+    }
+
+    property readonly_note -> str {
+        readonly := true;
     }
 }
 

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -1879,3 +1879,53 @@ class TestUpdate(tb.QueryTestCase):
                     Status,
                 );
             ''')
+
+    async def test_edgeql_update_protect_readonly_01(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "cannot update link 'readonly_tag': "
+            "it is declared as read-only",
+            _position=180,
+        ):
+            await self.con.execute(r'''
+                WITH MODULE test
+                UPDATE UpdateTest
+                FILTER .name = 'update-test-readonly'
+                SET {
+                    readonly_tag := (SELECT Tag FILTER .name = 'not read-only')
+                };
+            ''')
+
+    async def test_edgeql_update_protect_readonly_02(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "cannot update property 'readonly_note': "
+            "it is declared as read-only",
+            _position=181,
+        ):
+            await self.con.execute(r'''
+                WITH MODULE test
+                UPDATE UpdateTest
+                FILTER .name = 'update-test-readonly'
+                SET {
+                    readonly_note := 'not read-only',
+                };
+            ''')
+
+    async def test_edgeql_update_protect_readonly_03(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "cannot update property 'readonly_note': "
+            "it is declared as read-only",
+            _position=223,
+        ):
+            await self.con.execute(r'''
+                WITH MODULE test
+                UPDATE UpdateTest
+                FILTER .name = 'update-test-readonly'
+                SET {
+                    weighted_tags: {
+                        @readonly_note := 'not read-only',
+                    },
+                };
+            ''')


### PR DESCRIPTION
The `readonly` declaration on links and properties is currently ignored.
This is trivially fixable, so do it.

Fixes: #1008