### PR TITLE
Fix queries with unions with overlapping subtypes

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -268,13 +268,16 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
                         ctx=ctx,
                     )
 
-                    prefix_type = get_set_type(ind_prefix, ctx=ctx)
+                    prefix_type = get_set_type(ind_prefix.rptr.source, ctx=ctx)
                     assert isinstance(prefix_type, s_sources.Source)
 
+                    prefix_ptr_name = (
+                        next(iter(ptrs)).get_shortname(ctx.env.schema).name)
+
                     ptr = schemactx.get_union_pointer(
-                        ptrname=ptr_name,
+                        ptrname=prefix_ptr_name,
                         source=prefix_type,
-                        direction=direction,
+                        direction=ind_prefix.rptr.direction,
                         components=ptrs,
                         ctx=ctx,
                     )
@@ -516,8 +519,8 @@ def resolve_ptr(
         return ptr
 
     if isinstance(near_endpoint, s_links.Link):
-        msg = (f'{near_endpoint.get_verbosename(ctx.env.schema)} '
-               f'has no property {pointer_name!r}')
+        vname = near_endpoint.get_verbosename(ctx.env.schema, with_parent=True)
+        msg = f'{vname} has no property {pointer_name!r}'
 
     elif direction == s_pointers.PointerDirection.Outbound:
         msg = (f'{near_endpoint.get_verbosename(ctx.env.schema)} '

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -177,8 +177,8 @@ class BasePointerRef(ImmutableBase):
     source_ptr: PointerRef
     base_ptr: typing.Optional[BasePointerRef]
     material_ptr: BasePointerRef
-    descendants: typing.Set[BasePointerRef]
     union_components: typing.Set[BasePointerRef]
+    union_is_concrete: bool
     has_properties: bool
     required: bool
     is_derived: bool

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -123,7 +123,10 @@ class TypeRef(ImmutableBase):
     base_type: typing.Optional[TypeRef]
     # If this is a union type, this would be a set of
     # union elements.
-    children: typing.FrozenSet[TypeRef]
+    union: typing.FrozenSet[TypeRef]
+    # Whether the union is specified by an exhaustive list of
+    # types, and type inheritance should not be considered.
+    union_is_concrete: bool = False
     # If this is an intersection type, this would be a set of
     # intersection elements.
     intersection: typing.FrozenSet[TypeRef]

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -138,10 +138,17 @@ def type_to_typeref(
     elif not isinstance(t, s_abc.Collection):
         union_of = t.get_union_of(schema)
         if union_of:
-            children = frozenset(
-                type_to_typeref(schema, c) for c in union_of.objects(schema))
+            non_overlapping, union_is_concrete = (
+                s_utils.get_non_overlapping_union(
+                    schema,
+                    union_of.objects(schema),
+                )
+            )
+            union = frozenset(
+                type_to_typeref(schema, c) for c in non_overlapping)
         else:
-            children = frozenset()
+            union_is_concrete = False
+            union = frozenset()
 
         intersection_of = t.get_intersection_of(schema)
         if intersection_of:
@@ -190,7 +197,8 @@ def type_to_typeref(
             name_hint=name,
             material_type=material_typeref,
             base_type=base_typeref,
-            children=children,
+            union=union,
+            union_is_concrete=union_is_concrete,
             intersection=intersection,
             common_parent=common_parent_ref,
             element_name=_name,

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -195,7 +195,7 @@ class RelRangeVar(PathRangeVar):
     """Relation range variable, used in FROM clauses."""
 
     relation: typing.Union[BaseRelation, CommonTableExpr]
-    inhopt: bool
+    include_inherited: bool = True
 
     @property
     def query(self) -> BaseRelation:

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -407,6 +407,9 @@ class SQLSourceGenerator(codegen.SourceGenerator):
     def visit_RelRangeVar(self, node):
         rel = node.relation
 
+        if not node.include_inherited:
+            self.write(' ONLY (')
+
         if isinstance(rel, (pgast.Relation, pgast.NullRelation)):
             self.visit(rel)
         elif isinstance(rel, pgast.CommonTableExpr):
@@ -414,6 +417,9 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         else:
             raise SQLSourceGeneratorError(
                 'unexpected relation in RelRangeVar: {!r}'.format(rel))
+
+        if not node.include_inherited:
+            self.write(')')
 
         if node.alias:
             self.write(' AS ')

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -436,11 +436,11 @@ def compile_TypeCheckOp(
         else:
             right: pgast.BaseExpr
 
-            if expr.right.children:
+            if expr.right.union:
                 right = pgast.ArrayExpr(
                     elements=[
                         dispatch.compile(c, ctx=newctx)
-                        for c in expr.right.children
+                        for c in expr.right.union
                     ]
                 )
             else:

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -683,6 +683,7 @@ def range_for_material_objtype(
         typeref: irast.TypeRef,
         path_id: irast.PathId, *,
         include_overlays: bool=True,
+        include_descendants: bool=True,
         dml_source: Optional[irast.MutatingStmt]=None,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
 
@@ -706,6 +707,7 @@ def range_for_material_objtype(
 
     rvar: pgast.PathRangeVar = pgast.RelRangeVar(
         relation=relation,
+        include_inherited=include_descendants,
         alias=pgast.Alias(
             aliasname=env.aliases.get(typeref.name_hint.name)
         )
@@ -772,6 +774,7 @@ def range_for_typeref(
         typeref: irast.TypeRef,
         path_id: irast.PathId, *,
         include_overlays: bool=True,
+        include_descendants: bool=True,
         dml_source: Optional[irast.MutatingStmt]=None,
         common_parent: bool=False,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
@@ -781,21 +784,23 @@ def range_for_typeref(
             typeref.common_parent,
             path_id,
             include_overlays=include_overlays,
+            include_descendants=include_descendants,
             dml_source=dml_source,
             ctx=ctx,
         )
 
-    elif typeref.children:
+    elif typeref.union:
         # Union object types are represented as a UNION of selects
         # from their children, which is, for most purposes, equivalent
         # to SELECTing from a parent table.
         set_ops = []
 
-        for child in typeref.children:
+        for child in typeref.union:
             c_rvar = range_for_typeref(
                 child,
                 path_id=path_id,
                 include_overlays=include_overlays,
+                include_descendants=not typeref.union_is_concrete,
                 dml_source=dml_source,
                 ctx=ctx,
             )
@@ -819,6 +824,7 @@ def range_for_typeref(
             typeref,
             path_id,
             include_overlays=include_overlays,
+            include_descendants=include_descendants,
             dml_source=dml_source,
             ctx=ctx,
         )

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -691,8 +691,15 @@ def process_set_as_link_property_ref(
                 # the UNION by recording an explicit NULL as as the
                 # link property var.
                 pathctx.put_path_value_var(
-                    subquery, ir_set.path_id,
-                    pgast.NullConstant(),
+                    subquery,
+                    ir_set.path_id,
+                    pgast.TypeCast(
+                        arg=pgast.NullConstant(),
+                        type_name=pgast.TypeName(
+                            name=pg_types.pg_type_from_ir_typeref(
+                                ir_set.typeref),
+                        ),
+                    ),
                     env=ctx.env,
                 )
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2207,19 +2207,16 @@ class PointerMetaCommand(MetaCommand, sd.ObjectCommand,
                         if ptr_stor_info.table_type == 'link':
                             return True
                 return False
-        elif src.get_is_local(schema):
-            if src.is_link_property(schema):
-                return not src.singular(schema)
-            else:
-                ptr_stor_info = types.get_pointer_storage_info(
-                    src, resolve_type=False, schema=schema, link_bias=True)
-
-                return (
-                    ptr_stor_info is not None
-                    and ptr_stor_info.table_type == 'link'
-                )
+        elif src.is_link_property(schema):
+            return not src.singular(schema)
         else:
-            return False
+            ptr_stor_info = types.get_pointer_storage_info(
+                src, resolve_type=False, schema=schema, link_bias=True)
+
+            return (
+                ptr_stor_info is not None
+                and ptr_stor_info.table_type == 'link'
+            )
 
     def create_table(self, ptr, schema, context, conditional=False):
         c = self._create_table(ptr, schema, context, conditional=conditional)

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1976,6 +1976,10 @@ class ObjectList(ObjectCollection, container=tuple):
             return default
 
 
+InheritingObjectBaseT = TypeVar('InheritingObjectBaseT',
+                                bound='InheritingObjectBase')
+
+
 class InheritingObjectBase(Object):
 
     bases = SchemaField(

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -290,37 +290,12 @@ def get_or_create_union_type(
         )
 
         if not opaque:
-            union_pointers = {}
-
-            for pn, ptr in components[0].get_pointers(schema).items(schema):
-                ptrs = [ptr]
-                for component in components[1:]:
-                    other_ptr = component.get_pointers(schema).get(
-                        schema, pn, None)
-                    if other_ptr is None:
-                        break
-                    ptrs.append(other_ptr)
-
-                if len(ptrs) == len(components):
-                    # The pointer is present in all components.
-                    if len(ptrs) == 1:
-                        ptr = ptrs[0]
-                    else:
-                        ptrs = set(ptrs)
-                        schema, ptr = pointers.get_or_create_union_pointer(
-                            schema,
-                            ptrname=pn,
-                            source=objtype,
-                            direction=pointers.PointerDirection.Outbound,
-                            components=ptrs,
-                        )
-
-                    union_pointers[pn] = ptr
-
-            if union_pointers:
-                for pn, ptr in union_pointers.items():
-                    if objtype.getptr(schema, pn) is None:
-                        schema = objtype.add_pointer(schema, ptr)
+            schema = sources.populate_pointer_set_for_source_union(
+                schema,
+                components,
+                objtype,
+                modname=module,
+            )
 
     return schema, objtype, created
 

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -67,3 +67,47 @@ class Source(indexes.IndexableSubject):
         schema = self.add_classref(
             schema, 'pointers', pointer, replace=replace)
         return schema
+
+
+def populate_pointer_set_for_source_union(
+    schema: s_schema.Schema,
+    components: Iterable[Source],
+    union: Source,
+    *,
+    modname: str = '__derived__',
+) -> s_schema.Schema:
+
+    union_pointers = {}
+
+    for pn, ptr in components[0].get_pointers(schema).items(schema):
+        ptrs = [ptr]
+        for component in components[1:]:
+            other_ptr = component.get_pointers(schema).get(
+                schema, pn, None)
+            if other_ptr is None:
+                break
+            ptrs.append(other_ptr)
+
+        if len(ptrs) == len(components):
+            # The pointer is present in all components.
+            if len(ptrs) == 1:
+                ptr = ptrs[0]
+            else:
+                ptrs = set(ptrs)
+                schema, ptr = pointers.get_or_create_union_pointer(
+                    schema,
+                    ptrname=pn,
+                    source=union,
+                    direction=pointers.PointerDirection.Outbound,
+                    components=ptrs,
+                    modname=modname,
+                )
+
+            union_pointers[pn] = ptr
+
+    if union_pointers:
+        for pn, ptr in union_pointers.items():
+            if union.getptr(schema, pn) is None:
+                schema = union.add_pointer(schema, ptr)
+
+    return schema

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -497,21 +497,21 @@ def get_union_type(
 
 def get_non_overlapping_union(
     schema: s_schema.Schema,
-    types: Iterable[s_types.Type],
-) -> Tuple[FrozenSet[s_types.Type], bool]:
+    objects: Iterable[so.InheritingObjectBaseT],
+) -> Tuple[FrozenSet[so.InheritingObjectBaseT], bool]:
 
-    all_types: Set[s_types.Type] = set(types)
+    all_objects: Set[so.InheritingObjectBaseT] = set(objects)
     non_unique_count = 0
-    for t in types:
-        descendants = t.descendants(schema)
+    for obj in objects:
+        descendants = obj.descendants(schema)
         non_unique_count += len(descendants) + 1
-        all_types.update(descendants)
+        all_objects.update(descendants)
 
-    if non_unique_count == len(all_types):
-        # The input type set is already non-overlapping
-        return frozenset(types), False
+    if non_unique_count == len(all_objects):
+        # The input object set is already non-overlapping
+        return frozenset(objects), False
     else:
-        return frozenset(all_types), True
+        return frozenset(all_objects), True
 
 
 def _union_error(schema, components):

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -495,6 +495,25 @@ def get_union_type(
     return schema, union
 
 
+def get_non_overlapping_union(
+    schema: s_schema.Schema,
+    types: Iterable[s_types.Type],
+) -> Tuple[FrozenSet[s_types.Type], bool]:
+
+    all_types: Set[s_types.Type] = set(types)
+    non_unique_count = 0
+    for t in types:
+        descendants = t.descendants(schema)
+        non_unique_count += len(descendants) + 1
+        all_types.update(descendants)
+
+    if non_unique_count == len(all_types):
+        # The input type set is already non-overlapping
+        return frozenset(types), False
+    else:
+        return frozenset(all_types), True
+
+
 def _union_error(schema, components):
     names = ', '.join(sorted(c.get_displayname(schema) for c in components))
     return errors.SchemaError(f'cannot create a union of {names}')

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 20191222_00_00
+EDGEDB_CATALOG_VERSION = 20191225_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/schemas/advtypes.esdl
+++ b/tests/schemas/advtypes.esdl
@@ -1,0 +1,48 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+abstract type R {
+    required property name -> str {
+        delegated constraint exclusive;
+    }
+}
+type S extending R {
+    required property s -> str;
+}
+type T extending R {
+    required property t -> str;
+}
+abstract type U {
+    required property u -> str;
+}
+type V extending U, S, T;
+type W {
+    required property name -> str {
+        constraint exclusive;
+    }
+    link w -> W;
+}
+
+type Z {
+    required property name -> str {
+        constraint exclusive;
+    };
+
+    # have 'name' in common
+    link stw0 -> S | T | W;
+}

--- a/tests/schemas/advtypes.esdl
+++ b/tests/schemas/advtypes.esdl
@@ -21,16 +21,25 @@ abstract type R {
         delegated constraint exclusive;
     }
 }
+
+type A extending R;
+
 type S extending R {
     required property s -> str;
+    multi link l_a -> A;
 }
+
 type T extending R {
     required property t -> str;
+    multi link l_a -> A;
 }
+
 abstract type U {
     required property u -> str;
 }
+
 type V extending U, S, T;
+
 type W {
     required property name -> str {
         constraint exclusive;

--- a/tests/test_edgeql_advtypes.py
+++ b/tests/test_edgeql_advtypes.py
@@ -49,3 +49,26 @@ class TestEdgeQLAdvancedTypes(tb.QueryTestCase):
                 'stw0': {'name': 'v0'}
             }]
         )
+
+    async def test_edgeql_advtypes_overlapping_link_union(self):
+        await self.con.execute("""
+            INSERT A { name := 'a1' };
+            INSERT V {
+                name:= 'v1',
+                s := 's1',
+                t := 't1',
+                u := 'u1',
+                l_a := (SELECT A FILTER .name = 'a1'),
+            };
+        """)
+
+        await self.assert_query_result(
+            r"""
+            SELECT (DISTINCT (SELECT S UNION T)) {
+                cla := count(.l_a)
+            }
+            """,
+            [{
+                'cla': 1,
+            }]
+        )

--- a/tests/test_edgeql_advtypes.py
+++ b/tests/test_edgeql_advtypes.py
@@ -1,0 +1,51 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os.path
+
+from edb.testbase import server as tb
+
+
+class TestEdgeQLAdvancedTypes(tb.QueryTestCase):
+    '''Test type expressions'''
+
+    SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
+                                  'advtypes.esdl')
+
+    async def test_edgeql_advtypes_overlapping_union(self):
+        await self.con.execute('''
+            INSERT V {name:= 'v0', s := 's0', t := 't0', u := 'u0'};
+
+            INSERT Z {
+                name := 'z0',
+                stw0 := (
+                    SELECT V FILTER .name = 'v0'
+                    LIMIT 1
+                ),
+            };
+        ''')
+
+        await self.assert_query_result(
+            r'''
+                SELECT Z {stw0: {name}} FILTER .name = 'z0';
+            ''',
+            [{
+                'stw0': {'name': 'v0'}
+            }]
+        )

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4141,3 +4141,27 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.con.execute("""
             DROP TYPE test::`U S``E R`;
         """)
+
+    async def test_edgeql_ddl_link_overload_01(self):
+        await self.con.execute("""
+            CREATE TYPE T;
+            CREATE TYPE A {
+                CREATE MULTI LINK t -> T;
+            };
+            CREATE TYPE B EXTENDING A;
+            INSERT T;
+            INSERT B {
+                t := T
+            };
+            ALTER TYPE B ALTER LINK t SET ANNOTATION title := 'overloaded';
+            UPDATE B SET { t := T };
+        """)
+
+        await self.assert_query_result(
+            r"""
+            SELECT A { ct := count(.t) };
+            """,
+            [{
+                'ct': 1,
+            }]
+        )

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1329,12 +1329,29 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r'''
             WITH MODULE test
             SELECT
-                User.<owner[IS Text]@since
+                User.<owner[IS Named]@since
             ''',
             ['2018-01-01T00:00:00+00:00'],
         )
 
     async def test_edgeql_select_reverse_link_03(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidReferenceError,
+            "no property 'since'",
+        ):
+            # Property "since" is only defined on the
+            # Issue.owner link, whereas the Text intersection
+            # resolves to a union of links Issue.owner, LogEntry.owner,
+            # and Comment.owner.
+            await self.con.execute(
+                r'''
+                WITH MODULE test
+                SELECT
+                    User.<owner[IS Text]@since
+                ''',
+            )
+
+    async def test_edgeql_select_reverse_link_04(self):
         with self.assertRaisesRegex(
             edgedb.InvalidReferenceError,
             "no link or property 'number'",

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 39.37)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 39.51)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 9.76)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 39.30)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 39.37)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 9.76)


### PR DESCRIPTION
* Fix queries with unions of types with overlapping subtypes

Consider the following schema:

    type A;
    type B;
    type C extending A, B;
    type D { link ab -> A | B };

Currently, a query computing `D.ab` would erroneously duplicate
`C` objects, because it exists in descendant hierarchies of
both `A` and `B`.

Prevent this by ensuring that type unions are specified in a way that
ensures the generated query produces a distinct set.

* Fix a number of issues in handling of link unions

Like in the previous commit, the main issue is incorrect handling of
unions of links that have overlapping descendants.  This is fixed by
applying the same technique as for type unions.

The second issue is caused by the fact that we currently don't allocate
tables for purely-inherited links.  This was originally done as an
optimization, but it is actually exceedingly hard to handle cases when a
purely-inherited link becomes local and obtains a table.  The data
becomes split between two tables, which are also linked by inheritance,
which means that it is possible for a query to produce duplicate
results.

Finally, we are forgetting to actually include an intersection
of link properties in the union link object.

Fixes: #1010.