### PR TITLE
Fixes mock scram auth with new edgedb-python

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -506,7 +506,7 @@ async def _compile_sys_queries(schema, cluster):
 
 async def _populate_misc_instance_data(cluster):
 
-    mock_auth_nonce = scram.B64(scram.generate_nonce())
+    mock_auth_nonce = scram.generate_nonce()
     ver = buildmeta.get_version()
     json_instance_data = {
         'version': {


### PR DESCRIPTION
The edgedb-python that requires this is:
https://github.com/edgedb/edgedb-python/pull/60