### PR TITLE
Initial support for using a remote Postgres cluster as a backend

### DIFF
--- a/docs/admin/setup.rst
+++ b/docs/admin/setup.rst
@@ -68,3 +68,46 @@ method with the ``trust`` method:
 .. code-block:: bash
 
     $ edgedb --admin -h </data/dir> configure insert auth --method=trust
+
+
+Using remote PostgreSQL cluster as a backend
+============================================
+
+By default, EdgeDB creates and manages a local PostgreSQL database instance,
+however it is also possible to use a remote PostgreSQL instance, as long as it
+is version 12 or later.  Superuser access to the cluster is *required*.
+
+To setup EdgeDB using a remote PostgreSQL instance, instead of ``-D``,
+specify the ``-P`` (or ``--postgres-dsn``) option when starting the EdgeDB
+server:
+
+.. code-block:: bash
+
+    $ edgedb-server \
+        -P postgres://user:password@host:port/database?opt=val
+
+The format of the connection string generally follows that of `libpq`_,
+including support for specifying the connection parameters via
+`environment variables <postgres envvars>`_ and reading passwords from
+`the password file <postgres passfile>`_.  Unlike libpq, EdgeDB will treat
+unrecognized options as `PostgreSQL settings <postgres settings>`_ to be used
+for the connection.  Multiple hosts in the connection string are unsupported.
+
+.. note::
+
+    PostgreSQL DBaaS providers normally do not allow direct superuser access
+    to the database instance, which might prevent EdgeDB from working
+    correctly.  At this time, only Amazon RDS for PostgreSQL is supported.
+
+
+.. _libpq:
+    https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+
+.. _postgres envvars:
+    https://www.postgresql.org/docs/current/libpq-envars.html
+
+.. _postgres passfile:
+    https://www.postgresql.org/docs/current/libpq-pgpass.html
+
+.. _postgres settings:
+    https://www.postgresql.org/docs/current/static/runtime-config.html

--- a/docs/edgeql/introspection/operators.rst
+++ b/docs/edgeql/introspection/operators.rst
@@ -29,7 +29,6 @@ Introspection of the ``schema::Operator``:
             links: {
                 Object { name: '__type__' },
                 Object { name: 'annotations' },
-                Object { name: 'commutator' },
                 Object { name: 'params' },
                 Object { name: 'return_type' }
             },

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -215,6 +215,8 @@ cal::date_get(dt: cal::local_date, el: std::str) -> std::float64
 CREATE INFIX OPERATOR
 std::`=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -230,6 +232,8 @@ std::`?=` (l: OPTIONAL cal::local_datetime,
 CREATE INFIX OPERATOR
 std::`!=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -245,6 +249,8 @@ std::`?!=` (l: OPTIONAL cal::local_datetime,
 CREATE INFIX OPERATOR
 std::`>` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -252,6 +258,8 @@ std::`>` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -259,6 +267,8 @@ std::`>=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -266,6 +276,8 @@ std::`<` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -273,6 +285,7 @@ std::`<=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
 CREATE INFIX OPERATOR
 std::`+` (l: cal::local_datetime, r: std::duration) -> cal::local_datetime {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
 
@@ -280,6 +293,7 @@ std::`+` (l: cal::local_datetime, r: std::duration) -> cal::local_datetime {
 CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: cal::local_datetime) -> cal::local_datetime {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
 
@@ -297,6 +311,8 @@ std::`-` (l: cal::local_datetime, r: std::duration) -> cal::local_datetime {
 CREATE INFIX OPERATOR
 std::`=` (l: cal::local_date, r: cal::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -312,6 +328,8 @@ std::`?=` (l: OPTIONAL cal::local_date,
 CREATE INFIX OPERATOR
 std::`!=` (l: cal::local_date, r: cal::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -327,6 +345,8 @@ std::`?!=` (l: OPTIONAL cal::local_date,
 CREATE INFIX OPERATOR
 std::`>` (l: cal::local_date, r: cal::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -334,6 +354,8 @@ std::`>` (l: cal::local_date, r: cal::local_date) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: cal::local_date, r: cal::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -341,6 +363,8 @@ std::`>=` (l: cal::local_date, r: cal::local_date) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: cal::local_date, r: cal::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -348,6 +372,8 @@ std::`<` (l: cal::local_date, r: cal::local_date) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: cal::local_date, r: cal::local_date) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -356,8 +382,9 @@ CREATE INFIX OPERATOR
 std::`+` (l: cal::local_date, r: std::duration) -> cal::local_date
 {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '+';
+    SET commutator := 'std::+';
     SET force_return_cast := true;
+    USING SQL OPERATOR '+';
 };
 
 
@@ -365,8 +392,9 @@ CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: cal::local_date) -> cal::local_date
 {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '+';
+    SET commutator := 'std::+';
     SET force_return_cast := true;
+    USING SQL OPERATOR '+';
 };
 
 
@@ -374,8 +402,8 @@ CREATE INFIX OPERATOR
 std::`-` (l: cal::local_date, r: std::duration) -> cal::local_date
 {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '-';
     SET force_return_cast := true;
+    USING SQL OPERATOR '-';
 };
 
 
@@ -385,6 +413,8 @@ std::`-` (l: cal::local_date, r: std::duration) -> cal::local_date
 CREATE INFIX OPERATOR
 std::`=` (l: cal::local_time, r: cal::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -400,6 +430,8 @@ std::`?=` (l: OPTIONAL cal::local_time,
 CREATE INFIX OPERATOR
 std::`!=` (l: cal::local_time, r: cal::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -415,6 +447,8 @@ std::`?!=` (l: OPTIONAL cal::local_time,
 CREATE INFIX OPERATOR
 std::`>` (l: cal::local_time, r: cal::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -422,6 +456,8 @@ std::`>` (l: cal::local_time, r: cal::local_time) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: cal::local_time, r: cal::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -429,6 +465,8 @@ std::`>=` (l: cal::local_time, r: cal::local_time) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: cal::local_time, r: cal::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -436,6 +474,8 @@ std::`<` (l: cal::local_time, r: cal::local_time) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: cal::local_time, r: cal::local_time) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -443,6 +483,7 @@ std::`<=` (l: cal::local_time, r: cal::local_time) -> std::bool {
 CREATE INFIX OPERATOR
 std::`+` (l: cal::local_time, r: std::duration) -> cal::local_time {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
 
@@ -450,6 +491,7 @@ std::`+` (l: cal::local_time, r: std::duration) -> cal::local_time {
 CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: cal::local_time) -> cal::local_time {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -286,7 +286,6 @@ CREATE TYPE schema::Operator
     EXTENDING schema::CallableObject, schema::VolatilitySubject
 {
     CREATE PROPERTY operator_kind -> schema::OperatorKind;
-    CREATE LINK commutator -> schema::Operator;
     CREATE PROPERTY is_abstract -> std::bool {
         SET default := false;
     };

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -346,8 +346,10 @@ std::find(haystack: array<anytype>, needle: anytype,
 CREATE INFIX OPERATOR
 std::`=` (l: anytuple, r: anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '=';
     SET recursive := true;
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
+    USING SQL OPERATOR '=';
 };
 
 
@@ -362,8 +364,10 @@ std::`?=` (l: OPTIONAL anytuple, r: OPTIONAL anytuple) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: anytuple, r: anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '<>';
     SET recursive := true;
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
+    USING SQL OPERATOR '<>';
 };
 
 
@@ -378,30 +382,38 @@ std::`?!=` (l: OPTIONAL anytuple, r: OPTIONAL anytuple) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: anytuple, r: anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '>=';
     SET recursive := true;
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
+    USING SQL OPERATOR '>=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: anytuple, r: anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '>';
     SET recursive := true;
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
+    USING SQL OPERATOR '>';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: anytuple, r: anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '<=';
     SET recursive := true;
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
+    USING SQL OPERATOR '<=';
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: anytuple, r: anytuple) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '<';
     SET recursive := true;
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
+    USING SQL OPERATOR '<';
 };

--- a/edb/lib/std/25-booloperators.edgeql
+++ b/edb/lib/std/25-booloperators.edgeql
@@ -61,6 +61,8 @@ std::`NOT` (v: std::bool) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::bool, r: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -75,6 +77,8 @@ std::`?=` (l: OPTIONAL std::bool, r: OPTIONAL std::bool) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::bool, r: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -89,6 +93,8 @@ std::`?!=` (l: OPTIONAL std::bool, r: OPTIONAL std::bool) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::bool, r: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR '>=';
 };
 
@@ -96,6 +102,8 @@ std::`>=` (l: std::bool, r: std::bool) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::bool, r: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR '>';
 };
 
@@ -103,6 +111,8 @@ std::`>` (l: std::bool, r: std::bool) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::bool, r: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR '<=';
 };
 
@@ -110,6 +120,8 @@ std::`<=` (l: std::bool, r: std::bool) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::bool, r: std::bool) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR '<';
 };
 

--- a/edb/lib/std/25-enumoperators.edgeql
+++ b/edb/lib/std/25-enumoperators.edgeql
@@ -24,6 +24,8 @@
 CREATE INFIX OPERATOR
 std::`=` (l: std::anyenum, r: std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -38,6 +40,8 @@ std::`?=` (l: OPTIONAL std::anyenum, r: OPTIONAL std::anyenum) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::anyenum, r: std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -52,6 +56,8 @@ std::`?!=` (l: OPTIONAL std::anyenum, r: OPTIONAL std::anyenum) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::anyenum, r: std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR '>=';
 };
 
@@ -59,6 +65,8 @@ std::`>=` (l: std::anyenum, r: std::anyenum) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::anyenum, r: std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR '>';
 };
 
@@ -66,6 +74,8 @@ std::`>` (l: std::anyenum, r: std::anyenum) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::anyenum, r: std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR '<=';
 };
 
@@ -73,6 +83,8 @@ std::`<=` (l: std::anyenum, r: std::anyenum) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::anyenum, r: std::anyenum) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR '<';
 };
 

--- a/edb/lib/std/25-numoperators.edgeql
+++ b/edb/lib/std/25-numoperators.edgeql
@@ -47,6 +47,8 @@
 CREATE INFIX OPERATOR
 std::`=` (l: std::int16, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -61,6 +63,8 @@ std::`?=` (l: OPTIONAL std::int16, r: OPTIONAL std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::int16, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -75,6 +79,8 @@ std::`?=` (l: OPTIONAL std::int16, r: OPTIONAL std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::int16, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -89,6 +95,8 @@ std::`?=` (l: OPTIONAL std::int16, r: OPTIONAL std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::int32, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -103,6 +111,8 @@ std::`?=` (l: OPTIONAL std::int32, r: OPTIONAL std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::int32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -117,6 +127,8 @@ std::`?=` (l: OPTIONAL std::int32, r: OPTIONAL std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::int32, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -131,6 +143,8 @@ std::`?=` (l: OPTIONAL std::int32, r: OPTIONAL std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::int64, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -145,6 +159,8 @@ std::`?=` (l: OPTIONAL std::int64, r: OPTIONAL std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::int64, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -159,6 +175,8 @@ std::`?=` (l: OPTIONAL std::int64, r: OPTIONAL std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::int64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -173,6 +191,8 @@ std::`?=` (l: OPTIONAL std::int64, r: OPTIONAL std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::float32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -187,6 +207,8 @@ std::`?=` (l: OPTIONAL std::float32, r: OPTIONAL std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::float32, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -201,6 +223,8 @@ std::`?=` (l: OPTIONAL std::float32, r: OPTIONAL std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::float64, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -215,6 +239,8 @@ std::`?=` (l: OPTIONAL std::float64, r: OPTIONAL std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::float64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -229,6 +255,8 @@ std::`?=` (l: OPTIONAL std::float64, r: OPTIONAL std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::bigint, r: std::bigint) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=(numeric,numeric)';
 };
 
@@ -236,6 +264,8 @@ std::`=` (l: std::bigint, r: std::bigint) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::decimal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -243,6 +273,8 @@ std::`=` (l: std::decimal, r: std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::decimal, r: std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -271,6 +303,8 @@ std::`?=` (l: OPTIONAL std::decimal, r: OPTIONAL std::anyint) -> std::bool {
 CREATE INFIX OPERATOR
 std::`=` (l: std::anyint, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -287,6 +321,8 @@ std::`?=` (l: OPTIONAL std::anyint, r: OPTIONAL std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int16, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -301,6 +337,8 @@ std::`?!=` (l: OPTIONAL std::int16, r: OPTIONAL std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int16, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -315,6 +353,8 @@ std::`?!=` (l: OPTIONAL std::int16, r: OPTIONAL std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int16, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -329,6 +369,8 @@ std::`?!=` (l: OPTIONAL std::int16, r: OPTIONAL std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int32, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -343,6 +385,8 @@ std::`?!=` (l: OPTIONAL std::int32, r: OPTIONAL std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -357,6 +401,8 @@ std::`?!=` (l: OPTIONAL std::int32, r: OPTIONAL std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int32, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -371,6 +417,8 @@ std::`?!=` (l: OPTIONAL std::int32, r: OPTIONAL std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int64, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -385,6 +433,8 @@ std::`?!=` (l: OPTIONAL std::int64, r: OPTIONAL std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int64, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -399,6 +449,8 @@ std::`?!=` (l: OPTIONAL std::int64, r: OPTIONAL std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -413,6 +465,8 @@ std::`?!=` (l: OPTIONAL std::int64, r: OPTIONAL std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::float32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -427,6 +481,8 @@ std::`?!=` (l: OPTIONAL std::float32, r: OPTIONAL std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::float32, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -441,6 +497,8 @@ std::`?!=` (l: OPTIONAL std::float32, r: OPTIONAL std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::float64, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -455,6 +513,8 @@ std::`?!=` (l: OPTIONAL std::float64, r: OPTIONAL std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::float64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -469,6 +529,8 @@ std::`?!=` (l: OPTIONAL std::float64, r: OPTIONAL std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::bigint, r: std::bigint) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>(numeric,numeric)';
 };
 
@@ -476,6 +538,8 @@ std::`!=` (l: std::bigint, r: std::bigint) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::decimal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -483,6 +547,8 @@ std::`!=` (l: std::decimal, r: std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::decimal, r: std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -511,6 +577,8 @@ std::`?!=` (l: OPTIONAL std::decimal, r: OPTIONAL std::anyint) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::anyint, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -528,6 +596,8 @@ std::`?!=` (l: OPTIONAL std::anyint, r: OPTIONAL std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::int16, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -535,6 +605,8 @@ std::`>` (l: std::int16, r: std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::int16, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -542,6 +614,8 @@ std::`>` (l: std::int16, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::int16, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -549,6 +623,8 @@ std::`>` (l: std::int16, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::int32, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -556,6 +632,8 @@ std::`>` (l: std::int32, r: std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::int32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -563,6 +641,8 @@ std::`>` (l: std::int32, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::int32, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -570,6 +650,8 @@ std::`>` (l: std::int32, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::int32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR '>(float8,float8)';
 };
 
@@ -577,6 +659,8 @@ std::`>` (l: std::int32, r: std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::int64, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -584,6 +668,8 @@ std::`>` (l: std::int64, r: std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::int64, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -591,6 +677,8 @@ std::`>` (l: std::int64, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::int64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -598,6 +686,8 @@ std::`>` (l: std::int64, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::int64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>(float8,float8)';
 };
 
@@ -605,6 +695,8 @@ std::`>` (l: std::int64, r: std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::float32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -612,6 +704,8 @@ std::`>` (l: std::float32, r: std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::float32, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -619,6 +713,8 @@ std::`>` (l: std::float32, r: std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::float32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR '>(float8,float8)';
 };
 
@@ -626,6 +722,8 @@ std::`>` (l: std::float32, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::float64, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -633,6 +731,8 @@ std::`>` (l: std::float64, r: std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::float64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -640,6 +740,8 @@ std::`>` (l: std::float64, r: std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::float64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>(float8,float8)';
 };
 
@@ -647,6 +749,8 @@ std::`>` (l: std::float64, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::bigint, r: std::bigint) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>(numeric,numeric)';
 };
 
@@ -654,6 +758,8 @@ std::`>` (l: std::bigint, r: std::bigint) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::decimal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -661,6 +767,8 @@ std::`>` (l: std::decimal, r: std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::anyint, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -668,6 +776,8 @@ std::`>` (l: std::anyint, r: std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::decimal, r: std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -677,6 +787,8 @@ std::`>` (l: std::decimal, r: std::anyint) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int16, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -684,6 +796,8 @@ std::`>=` (l: std::int16, r: std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int16, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -691,6 +805,8 @@ std::`>=` (l: std::int16, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int16, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -698,6 +814,8 @@ std::`>=` (l: std::int16, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int32, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -705,6 +823,8 @@ std::`>=` (l: std::int32, r: std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -712,6 +832,8 @@ std::`>=` (l: std::int32, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int32, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -719,6 +841,8 @@ std::`>=` (l: std::int32, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR '>=(float8,float8)';
 };
 
@@ -726,6 +850,8 @@ std::`>=` (l: std::int32, r: std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int64, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -733,6 +859,8 @@ std::`>=` (l: std::int64, r: std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int64, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -740,6 +868,8 @@ std::`>=` (l: std::int64, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -747,6 +877,8 @@ std::`>=` (l: std::int64, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=(float8,float8)';
 };
 
@@ -754,6 +886,8 @@ std::`>=` (l: std::int64, r: std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -761,6 +895,8 @@ std::`>=` (l: std::float32, r: std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float32, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -768,6 +904,8 @@ std::`>=` (l: std::float32, r: std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR '>=(float8,float8)';
 };
 
@@ -775,6 +913,8 @@ std::`>=` (l: std::float32, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float64, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -782,6 +922,8 @@ std::`>=` (l: std::float64, r: std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -789,6 +931,8 @@ std::`>=` (l: std::float64, r: std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=(float8,float8)';
 };
 
@@ -796,6 +940,8 @@ std::`>=` (l: std::float64, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::bigint, r: std::bigint) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=(numeric,numeric)';
 };
 
@@ -803,6 +949,8 @@ std::`>=` (l: std::bigint, r: std::bigint) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::decimal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -810,6 +958,8 @@ std::`>=` (l: std::decimal, r: std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::anyint, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -817,6 +967,8 @@ std::`>=` (l: std::anyint, r: std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::decimal, r: std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -826,6 +978,8 @@ std::`>=` (l: std::decimal, r: std::anyint) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::int16, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -833,6 +987,8 @@ std::`<` (l: std::int16, r: std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::int16, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -840,6 +996,8 @@ std::`<` (l: std::int16, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::int16, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -847,6 +1005,8 @@ std::`<` (l: std::int16, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::int32, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -854,6 +1014,8 @@ std::`<` (l: std::int32, r: std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::int32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -861,6 +1023,8 @@ std::`<` (l: std::int32, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::int32, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -868,6 +1032,8 @@ std::`<` (l: std::int32, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::int32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR '<(float8,float8)';
 };
 
@@ -875,6 +1041,8 @@ std::`<` (l: std::int32, r: std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::int64, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -882,6 +1050,8 @@ std::`<` (l: std::int64, r: std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::int64, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -889,6 +1059,8 @@ std::`<` (l: std::int64, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::int64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -896,6 +1068,8 @@ std::`<` (l: std::int64, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::int64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<(float8,float8)';
 };
 
@@ -903,6 +1077,8 @@ std::`<` (l: std::int64, r: std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::float32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -910,6 +1086,8 @@ std::`<` (l: std::float32, r: std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::float32, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -917,6 +1095,8 @@ std::`<` (l: std::float32, r: std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::float32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR '<(float8,float8)';
 };
 
@@ -924,6 +1104,8 @@ std::`<` (l: std::float32, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::float64, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -931,6 +1113,8 @@ std::`<` (l: std::float64, r: std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::float64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -938,6 +1122,8 @@ std::`<` (l: std::float64, r: std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::float64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<(float8,float8)';
 };
 
@@ -945,6 +1131,8 @@ std::`<` (l: std::float64, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::bigint, r: std::bigint) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<(numeric,numeric)';
 };
 
@@ -952,6 +1140,8 @@ std::`<` (l: std::bigint, r: std::bigint) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::decimal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -959,6 +1149,8 @@ std::`<` (l: std::decimal, r: std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::anyint, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -966,6 +1158,8 @@ std::`<` (l: std::anyint, r: std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::decimal, r: std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -975,6 +1169,8 @@ std::`<` (l: std::decimal, r: std::anyint) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int16, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -982,6 +1178,8 @@ std::`<=` (l: std::int16, r: std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int16, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -989,6 +1187,8 @@ std::`<=` (l: std::int16, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int16, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -996,6 +1196,8 @@ std::`<=` (l: std::int16, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int32, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -1003,6 +1205,8 @@ std::`<=` (l: std::int32, r: std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -1010,6 +1214,8 @@ std::`<=` (l: std::int32, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int32, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -1017,6 +1223,8 @@ std::`<=` (l: std::int32, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR '<=(float8,float8)';
 };
 
@@ -1024,6 +1232,8 @@ std::`<=` (l: std::int32, r: std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int64, r: std::int16) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -1031,6 +1241,8 @@ std::`<=` (l: std::int64, r: std::int16) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int64, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -1038,6 +1250,8 @@ std::`<=` (l: std::int64, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -1045,6 +1259,8 @@ std::`<=` (l: std::int64, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=(float8,float8)';
 };
 
@@ -1052,6 +1268,8 @@ std::`<=` (l: std::int64, r: std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float32, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -1059,6 +1277,8 @@ std::`<=` (l: std::float32, r: std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float32, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -1066,6 +1286,8 @@ std::`<=` (l: std::float32, r: std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float32, r: std::int32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR '<=(float8,float8)';
 };
 
@@ -1073,6 +1295,8 @@ std::`<=` (l: std::float32, r: std::int32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float64, r: std::float32) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -1080,6 +1304,8 @@ std::`<=` (l: std::float64, r: std::float32) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float64, r: std::float64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -1087,6 +1313,8 @@ std::`<=` (l: std::float64, r: std::float64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float64, r: std::int64) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=(float8,float8)';
 };
 
@@ -1094,6 +1322,8 @@ std::`<=` (l: std::float64, r: std::int64) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::bigint, r: std::bigint) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=(numeric,numeric)';
 };
 
@@ -1101,6 +1331,8 @@ std::`<=` (l: std::bigint, r: std::bigint) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::decimal, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -1108,6 +1340,8 @@ std::`<=` (l: std::decimal, r: std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::anyint, r: std::decimal) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -1115,6 +1349,8 @@ std::`<=` (l: std::anyint, r: std::decimal) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::decimal, r: std::anyint) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -1124,6 +1360,7 @@ std::`<=` (l: std::decimal, r: std::anyint) -> std::bool {
 CREATE INFIX OPERATOR
 std::`+` (l: std::int16, r: std::int16) -> std::int16 {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
 
@@ -1131,6 +1368,7 @@ std::`+` (l: std::int16, r: std::int16) -> std::int16 {
 CREATE INFIX OPERATOR
 std::`+` (l: std::int32, r: std::int32) -> std::int32 {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
 
@@ -1138,6 +1376,7 @@ std::`+` (l: std::int32, r: std::int32) -> std::int32 {
 CREATE INFIX OPERATOR
 std::`+` (l: std::int64, r: std::int64) -> std::int64 {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
 
@@ -1145,6 +1384,7 @@ std::`+` (l: std::int64, r: std::int64) -> std::int64 {
 CREATE INFIX OPERATOR
 std::`+` (l: std::float32, r: std::float32) -> std::float32 {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
 
@@ -1152,6 +1392,7 @@ std::`+` (l: std::float32, r: std::float32) -> std::float32 {
 CREATE INFIX OPERATOR
 std::`+` (l: std::float64, r: std::float64) -> std::float64 {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
 
@@ -1159,6 +1400,7 @@ std::`+` (l: std::float64, r: std::float64) -> std::float64 {
 CREATE INFIX OPERATOR
 std::`+` (l: std::bigint, r: std::bigint) -> std::bigint {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+(numeric,numeric)';
 };
 
@@ -1166,6 +1408,7 @@ std::`+` (l: std::bigint, r: std::bigint) -> std::bigint {
 CREATE INFIX OPERATOR
 std::`+` (l: std::decimal, r: std::decimal) -> std::decimal {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
 
@@ -1329,6 +1572,7 @@ std::`-` (l: std::decimal) -> std::decimal {
 CREATE INFIX OPERATOR
 std::`*` (l: std::int16, r: std::int16) -> std::int16 {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::*';
     USING SQL OPERATOR r'*';
 };
 
@@ -1336,6 +1580,7 @@ std::`*` (l: std::int16, r: std::int16) -> std::int16 {
 CREATE INFIX OPERATOR
 std::`*` (l: std::int32, r: std::int32) -> std::int32 {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::*';
     USING SQL OPERATOR r'*';
 };
 
@@ -1343,6 +1588,7 @@ std::`*` (l: std::int32, r: std::int32) -> std::int32 {
 CREATE INFIX OPERATOR
 std::`*` (l: std::int64, r: std::int64) -> std::int64 {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::*';
     USING SQL OPERATOR r'*';
 };
 
@@ -1350,6 +1596,7 @@ std::`*` (l: std::int64, r: std::int64) -> std::int64 {
 CREATE INFIX OPERATOR
 std::`*` (l: std::float32, r: std::float32) -> std::float32 {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::*';
     USING SQL OPERATOR r'*';
 };
 
@@ -1357,6 +1604,7 @@ std::`*` (l: std::float32, r: std::float32) -> std::float32 {
 CREATE INFIX OPERATOR
 std::`*` (l: std::float64, r: std::float64) -> std::float64 {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::*';
     USING SQL OPERATOR r'*';
 };
 
@@ -1364,6 +1612,7 @@ std::`*` (l: std::float64, r: std::float64) -> std::float64 {
 CREATE INFIX OPERATOR
 std::`*` (l: std::bigint, r: std::bigint) -> std::bigint {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::*';
     USING SQL OPERATOR r'*(numeric,numeric)';
 };
 
@@ -1371,6 +1620,7 @@ std::`*` (l: std::bigint, r: std::bigint) -> std::bigint {
 CREATE INFIX OPERATOR
 std::`*` (l: std::decimal, r: std::decimal) -> std::decimal {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::*';
     USING SQL OPERATOR r'*';
 };
 

--- a/edb/lib/std/30-arrayfuncs.edgeql
+++ b/edb/lib/std/30-arrayfuncs.edgeql
@@ -63,8 +63,10 @@ std::array_get(
 CREATE INFIX OPERATOR
 std::`=` (l: array<anytype>, r: array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '=';
     SET recursive := true;
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
+    USING SQL OPERATOR '=';
 };
 
 
@@ -80,8 +82,10 @@ std::`?=` (l: OPTIONAL array<anytype>,
 CREATE INFIX OPERATOR
 std::`!=` (l: array<anytype>, r: array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '<>';
     SET recursive := true;
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
+    USING SQL OPERATOR '<>';
 };
 
 
@@ -96,29 +100,37 @@ std::`?!=` (l: OPTIONAL array<anytype>,
 CREATE INFIX OPERATOR
 std::`>=` (l: array<anytype>, r: array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '>=';
     SET recursive := true;
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
+    USING SQL OPERATOR '>=';
 };
 
 CREATE INFIX OPERATOR
 std::`>` (l: array<anytype>, r: array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '>';
     SET recursive := true;
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
+    USING SQL OPERATOR '>';
 };
 
 CREATE INFIX OPERATOR
 std::`<=` (l: array<anytype>, r: array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '<=';
     SET recursive := true;
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
+    USING SQL OPERATOR '<=';
 };
 
 CREATE INFIX OPERATOR
 std::`<` (l: array<anytype>, r: array<anytype>) -> std::bool {
     SET volatility := 'IMMUTABLE';
-    USING SQL OPERATOR '<';
     SET recursive := true;
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
+    USING SQL OPERATOR '<';
 };
 
 # Concatenation

--- a/edb/lib/std/30-bytesfuncs.edgeql
+++ b/edb/lib/std/30-bytesfuncs.edgeql
@@ -37,6 +37,8 @@ std::bytes_get_bit(bytes: std::bytes, num: int64) -> std::int64
 CREATE INFIX OPERATOR
 std::`=` (l: std::bytes, r: std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -51,6 +53,8 @@ std::`?=` (l: OPTIONAL std::bytes, r: OPTIONAL std::bytes) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::bytes, r: std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -72,6 +76,8 @@ std::`++` (l: std::bytes, r: std::bytes) -> std::bytes {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::bytes, r: std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR '>=';
 };
 
@@ -79,6 +85,8 @@ std::`>=` (l: std::bytes, r: std::bytes) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::bytes, r: std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR '>';
 };
 
@@ -86,6 +94,8 @@ std::`>` (l: std::bytes, r: std::bytes) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::bytes, r: std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR '<=';
 };
 
@@ -93,5 +103,7 @@ std::`<=` (l: std::bytes, r: std::bytes) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::bytes, r: std::bytes) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR '<';
 };

--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -107,6 +107,8 @@ std::duration_to_seconds(dur: std::duration) -> std::decimal
 CREATE INFIX OPERATOR
 std::`=` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -121,6 +123,8 @@ std::`?=` (l: OPTIONAL std::datetime, r: OPTIONAL std::datetime) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -135,6 +139,8 @@ std::`?!=` (l: OPTIONAL std::datetime, r: OPTIONAL std::datetime) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -142,6 +148,8 @@ std::`>` (l: std::datetime, r: std::datetime) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -149,6 +157,8 @@ std::`>=` (l: std::datetime, r: std::datetime) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -156,6 +166,8 @@ std::`<` (l: std::datetime, r: std::datetime) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -164,6 +176,7 @@ CREATE INFIX OPERATOR
 std::`+` (l: std::datetime, r: std::duration) -> std::datetime {
     # operators on timestamptz are STABLE in PostgreSQL
     SET volatility := 'STABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
 
@@ -172,6 +185,7 @@ CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: std::datetime) -> std::datetime {
     # operators on timestamptz are STABLE in PostgreSQL
     SET volatility := 'STABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
 
@@ -198,6 +212,8 @@ std::`-` (l: std::datetime, r: std::datetime) -> std::duration {
 CREATE INFIX OPERATOR
 std::`=` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -212,6 +228,8 @@ std::`?=` (l: OPTIONAL std::duration, r: OPTIONAL std::duration) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -229,6 +247,8 @@ std::`?!=` (
 CREATE INFIX OPERATOR
 std::`>` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -236,6 +256,8 @@ std::`>` (l: std::duration, r: std::duration) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 
@@ -243,6 +265,8 @@ std::`>=` (l: std::duration, r: std::duration) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -250,6 +274,8 @@ std::`<` (l: std::duration, r: std::duration) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -257,6 +283,7 @@ std::`<=` (l: std::duration, r: std::duration) -> std::bool {
 CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: std::duration) -> std::duration {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
 

--- a/edb/lib/std/30-jsonfuncs.edgeql
+++ b/edb/lib/std/30-jsonfuncs.edgeql
@@ -70,6 +70,8 @@ std::json_get(
 CREATE INFIX OPERATOR
 std::`=` (l: std::json, r: std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -84,6 +86,8 @@ std::`?=` (l: OPTIONAL std::json, r: OPTIONAL std::json) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::json, r: std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -98,6 +102,8 @@ std::`?!=` (l: OPTIONAL std::json, r: OPTIONAL std::json) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::json, r: std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR '>=';
 };
 
@@ -105,6 +111,8 @@ std::`>=` (l: std::json, r: std::json) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::json, r: std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR '>';
 };
 
@@ -112,6 +120,8 @@ std::`>` (l: std::json, r: std::json) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::json, r: std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR '<=';
 };
 
@@ -119,6 +129,8 @@ std::`<=` (l: std::json, r: std::json) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::json, r: std::json) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR '<';
 };
 

--- a/edb/lib/std/30-strfuncs.edgeql
+++ b/edb/lib/std/30-strfuncs.edgeql
@@ -22,6 +22,8 @@
 CREATE INFIX OPERATOR
 std::`=` (l: std::str, r: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -36,6 +38,8 @@ std::`?=` (l: OPTIONAL std::str, r: OPTIONAL std::str) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::str, r: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -86,6 +90,8 @@ std::`NOT ILIKE` (string: std::str, pattern: std::str) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::str, r: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
 };
 
@@ -93,6 +99,8 @@ std::`<` (l: std::str, r: std::str) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::str, r: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
 };
 
@@ -100,6 +108,8 @@ std::`<=` (l: std::str, r: std::str) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::str, r: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
 };
 
@@ -107,6 +117,8 @@ std::`>` (l: std::str, r: std::str) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::str, r: std::str) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
 };
 

--- a/edb/lib/std/30-uuidfuncs.edgeql
+++ b/edb/lib/std/30-uuidfuncs.edgeql
@@ -32,6 +32,8 @@ std::uuid_generate_v1mc() -> std::uuid {
 CREATE INFIX OPERATOR
 std::`=` (l: std::uuid, r: std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::=';
+    SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
 };
 
@@ -46,6 +48,8 @@ std::`?=` (l: OPTIONAL std::uuid, r: OPTIONAL std::uuid) -> std::bool {
 CREATE INFIX OPERATOR
 std::`!=` (l: std::uuid, r: std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::!=';
+    SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
 };
 
@@ -60,6 +64,8 @@ std::`?!=` (l: OPTIONAL std::uuid, r: OPTIONAL std::uuid) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>=` (l: std::uuid, r: std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<=';
+    SET negator := 'std::<';
     USING SQL OPERATOR '>=';
 };
 
@@ -67,6 +73,8 @@ std::`>=` (l: std::uuid, r: std::uuid) -> std::bool {
 CREATE INFIX OPERATOR
 std::`>` (l: std::uuid, r: std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::<';
+    SET negator := 'std::<=';
     USING SQL OPERATOR '>';
 };
 
@@ -74,6 +82,8 @@ std::`>` (l: std::uuid, r: std::uuid) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<=` (l: std::uuid, r: std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>=';
+    SET negator := 'std::>';
     USING SQL OPERATOR '<=';
 };
 
@@ -81,6 +91,8 @@ std::`<=` (l: std::uuid, r: std::uuid) -> std::bool {
 CREATE INFIX OPERATOR
 std::`<` (l: std::uuid, r: std::uuid) -> std::bool {
     SET volatility := 'IMMUTABLE';
+    SET commutator := 'std::>';
+    SET negator := 'std::>=';
     USING SQL OPERATOR '<';
 };
 

--- a/edb/pgsql/datasources/schema/operators.py
+++ b/edb/pgsql/datasources/schema/operators.py
@@ -44,7 +44,8 @@ async def fetch(
                 o.operator_kind,
                 o.volatility,
                 o.return_type,
-                edgedb._resolve_type_name(o.commutator) AS commutator,
+                o.commutator,
+                o.negator,
                 edgedb._resolve_type_name(o.params) AS params
             FROM
                 edgedb.operator o

--- a/edb/pgsql/datasources/schema/roles.py
+++ b/edb/pgsql/datasources/schema/roles.py
@@ -31,10 +31,12 @@ async def fetch(
                 a.rolname AS name,
                 a.rolsuper AS is_superuser,
                 a.rolcanlogin AS allow_login,
-                (d.description)->>'ph' AS password,
+                (d.description)->>'password_hash' AS password,
                 (
                     SELECT
-                        array_agg(((md.description)->>'id')::uuid)
+                        array_agg(
+                            ((md.description)->>'id')::uuid
+                        ) FILTER (WHERE (md.description)->>'id' IS NOT NULL)
                     FROM
                         pg_auth_members m
                         INNER JOIN pg_roles ma ON m.roleid = ma.oid
@@ -54,5 +56,5 @@ async def fetch(
                             AS description
                 ) AS d
             WHERE
-                (d.description)->>'__edgedb__' = '1'
+                (d.description)->>'id' IS NOT NULL
     """)

--- a/edb/pgsql/datasources/schema/roles.py
+++ b/edb/pgsql/datasources/schema/roles.py
@@ -31,13 +31,13 @@ async def fetch(
                 a.rolname AS name,
                 a.rolsuper AS is_superuser,
                 a.rolcanlogin AS allow_login,
-                a.rolpassword AS password,
+                (d.description)->>'ph' AS password,
                 (
                     SELECT
                         array_agg(((md.description)->>'id')::uuid)
                     FROM
                         pg_auth_members m
-                        INNER JOIN pg_authid ma ON m.roleid = ma.oid
+                        INNER JOIN pg_roles ma ON m.roleid = ma.oid
                         CROSS JOIN LATERAL (
                             SELECT
                                 edgedb.shobj_metadata(ma.oid, 'pg_authid')
@@ -47,7 +47,7 @@ async def fetch(
                  )
                               AS bases
             FROM
-                pg_authid AS a
+                pg_roles AS a
                 CROSS JOIN LATERAL (
                     SELECT
                         edgedb.shobj_metadata(a.oid, 'pg_authid')

--- a/edb/pgsql/dbops/ddl.py
+++ b/edb/pgsql/dbops/ddl.py
@@ -133,10 +133,16 @@ class ReassignOwned(DDLOperation):
         self.old_role = old_role
         self.new_role = new_role
 
+    def qi(self, ident: str) -> str:
+        if ident.upper() in ('CURRENT_USER', 'SESSION_USER'):
+            return ident
+        else:
+            return qi(ident)
+
     def code(self, block: base.PLBlock) -> str:
         return (
-            f'REASSIGN OWNED BY {qi(self.old_role)} '
-            f'TO {qi(self.new_role)}'
+            f'REASSIGN OWNED BY {self.qi(self.old_role)} '
+            f'TO {self.qi(self.new_role)}'
         )
 
 

--- a/edb/pgsql/dbops/operators.py
+++ b/edb/pgsql/dbops/operators.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import textwrap
 
-from ..common import qname as qn
 from ..common import quote_ident as qi
 from ..common import quote_literal as ql
 from ..common import quote_type as qt

--- a/edb/pgsql/dbops/roles.py
+++ b/edb/pgsql/dbops/roles.py
@@ -55,7 +55,7 @@ class RoleExists(base.Condition):
             SELECT
                 rolname
             FROM
-                pg_catalog.pg_authid
+                pg_catalog.pg_roles
             WHERE
                 rolname = {ql(self.name)}
         ''')

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3660,13 +3660,14 @@ class CreateRole(ObjectMetaCommand, adapts=s_roles.CreateRole):
         schema, role = s_roles.CreateRole.apply(self, schema, context)
         schema, _ = ObjectMetaCommand.apply(self, schema, context)
 
+        passwd = role.get_password(schema)
         role = dbops.Role(
             name=role.get_name(schema),
             allow_login=role.get_allow_login(schema),
             is_superuser=role.get_is_superuser(schema),
-            password=role.get_password(schema),
-            metadata=dict(id=str(role.id), __edgedb__='1'),
+            password=passwd,
             membership=list(role.get_bases(schema).names(schema)),
+            metadata=dict(id=str(role.id), ph=passwd, __edgedb__='1'),
         )
         self.pgops.add(dbops.CreateRole(role))
         return schema, role
@@ -3676,11 +3677,13 @@ class AlterRole(ObjectMetaCommand, adapts=s_roles.AlterRole):
     def apply(self, schema, context):
         schema, role = s_roles.AlterRole.apply(self, schema, context)
         schema, _ = ObjectMetaCommand.apply(self, schema, context)
+        passwd = role.get_password(schema)
         dbrole = dbops.Role(
             name=role.get_name(schema),
             allow_login=role.get_allow_login(schema),
             is_superuser=role.get_is_superuser(schema),
-            password=role.get_password(schema),
+            password=passwd,
+            metadata=dict(id=str(role.id), ph=passwd, __edgedb__='1'),
         )
         self.pgops.add(dbops.AlterRole(dbrole))
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3667,7 +3667,10 @@ class CreateRole(ObjectMetaCommand, adapts=s_roles.CreateRole):
             is_superuser=role.get_is_superuser(schema),
             password=passwd,
             membership=list(role.get_bases(schema).names(schema)),
-            metadata=dict(id=str(role.id), ph=passwd, __edgedb__='1'),
+            metadata=dict(
+                id=str(role.id),
+                password_hash=passwd,
+            ),
         )
         self.pgops.add(dbops.CreateRole(role))
         return schema, role
@@ -3683,7 +3686,10 @@ class AlterRole(ObjectMetaCommand, adapts=s_roles.AlterRole):
             allow_login=role.get_allow_login(schema),
             is_superuser=role.get_is_superuser(schema),
             password=passwd,
-            metadata=dict(id=str(role.id), ph=passwd, __edgedb__='1'),
+            metadata=dict(
+                id=str(role.id),
+                password_hash=passwd,
+            ),
         )
         self.pgops.add(dbops.AlterRole(dbrole))
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -2399,7 +2399,7 @@ def _generate_role_views(schema):
             a.rolname                                   AS name,
             a.rolsuper                                  AS is_superuser,
             a.rolcanlogin                               AS allow_login,
-            (d.description)->>'ph'                      AS password
+            (d.description)->>'password_hash'           AS password
         FROM
             pg_catalog.pg_roles AS a
             CROSS JOIN LATERAL (
@@ -2408,7 +2408,7 @@ def _generate_role_views(schema):
                         AS description
             ) AS d
         WHERE
-            (d.description)->>'__edgedb__' = '1';
+            (d.description)->>'id' IS NOT NULL
     '''
 
     link_query = f'''

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -2399,9 +2399,9 @@ def _generate_role_views(schema):
             a.rolname                                   AS name,
             a.rolsuper                                  AS is_superuser,
             a.rolcanlogin                               AS allow_login,
-            a.rolpassword                               AS password
+            (d.description)->>'ph'                      AS password
         FROM
-            pg_authid AS a
+            pg_catalog.pg_roles AS a
             CROSS JOIN LATERAL (
                 SELECT
                     edgedb.shobj_metadata(a.oid, 'pg_authid')
@@ -2416,7 +2416,7 @@ def _generate_role_views(schema):
             ((d.description)->>'id')::uuid              AS source,
             ((md.description)->>'id')::uuid             AS target
         FROM
-            pg_authid AS a
+            pg_catalog.pg_roles AS a
             CROSS JOIN LATERAL (
                 SELECT
                     edgedb.shobj_metadata(a.oid, 'pg_authid')

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -235,11 +235,6 @@ class CreateOperator(s_func.CreateCallableObject, OperatorCommand):
     def _cmd_tree_from_ast(cls, schema, astnode, context):
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
 
-        modaliases = context.modaliases
-
-        params = cls._get_param_desc_from_ast(
-            schema, modaliases, astnode)
-
         cmd.add(sd.AlterObjectProperty(
             property='operator_kind',
             new_value=astnode.kind,

--- a/edb/server/baseport.py
+++ b/edb/server/baseport.py
@@ -29,14 +29,13 @@ from edb.server import procpool
 class Port:
 
     def __init__(self, *, server, loop,
-                 pg_addr, pg_data_dir,
+                 pg_addr,
                  runstate_dir, internal_runstate_dir,
                  dbindex):
 
         self._server = server
         self._loop = loop
         self._pg_addr = pg_addr
-        self._pg_data_dir = pg_data_dir
         self._dbindex = dbindex
         self._runstate_dir = runstate_dir
         self._internal_runstate_dir = internal_runstate_dir
@@ -77,8 +76,7 @@ class Port:
 
         self._compiler_manager = await procpool.create_manager(
             runstate_dir=self._internal_runstate_dir,
-            worker_args=(dict(host=self._pg_addr),
-                         self._pg_data_dir),
+            worker_args=(dict(host=self._pg_addr),),
             worker_cls=self.get_compiler_worker_cls(),
             name=self.get_compiler_worker_name(),
         )

--- a/edb/server/baseport.py
+++ b/edb/server/baseport.py
@@ -76,7 +76,7 @@ class Port:
 
         self._compiler_manager = await procpool.create_manager(
             runstate_dir=self._internal_runstate_dir,
-            worker_args=(dict(host=self._pg_addr),),
+            worker_args=(self._pg_addr,),
             worker_cls=self.get_compiler_worker_cls(),
             name=self.get_compiler_worker_name(),
         )

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -148,7 +148,7 @@ def compile_edgeql_script(
         )
     )
 
-    compiler = Compiler(None, None)
+    compiler = Compiler(None)
     compiler._std_schema = std_schema
     compiler._bootstrap_mode = True
 
@@ -184,7 +184,7 @@ class BaseCompiler:
     _dbname: Optional[str]
     _cached_db: Optional[CompilerDatabaseState]
 
-    def __init__(self, connect_args: dict, data_dir: str):
+    def __init__(self, connect_args: dict):
         self._connect_args = connect_args
         self._dbname = None
         self._cached_db = None
@@ -257,8 +257,8 @@ class BaseCompiler:
 
 class Compiler(BaseCompiler):
 
-    def __init__(self, connect_args: dict, data_dir: str):
-        super().__init__(connect_args, data_dir)
+    def __init__(self, connect_args: dict):
+        super().__init__(connect_args)
 
         self._current_db_state = None
         self._bootstrap_mode = False

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -205,7 +205,6 @@ class BaseCompiler:
 
     async def new_connection(self):
         con_args = self._connect_args.copy()
-        con_args['user'] = defines.EDGEDB_SUPERUSER
         con_args['database'] = self._dbname
         try:
             return await asyncpg.connect(**con_args)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -275,9 +275,6 @@ cdef class DatabaseIndex:
         self._dbs = {}
 
         self._server = server
-
-        datadir = self._server.get_datadir()
-
         self._sys_queries = None
         self._instance_data = None
         self._sys_config = None

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 20191225_00_00
+EDGEDB_CATALOG_VERSION = 20191228_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -256,10 +256,12 @@ cdef class EdgeConnection:
         buf.write_buffer(msg_buf)
 
         if self.port.in_dev_mode():
+            pgaddr = dict(self.get_backend().pgcon.get_pgaddr())
+            if pgaddr.get('password'):
+                pgaddr['password'] = '********'
             msg_buf = WriteBuffer.new_message(b'S')
             msg_buf.write_len_prefixed_bytes(b'pgaddr')
-            msg_buf.write_len_prefixed_utf8(
-                str(self.get_backend().pgcon.get_pgaddr()))
+            msg_buf.write_len_prefixed_utf8(str(pgaddr))
             msg_buf.end_message()
             buf.write_buffer(msg_buf)
 

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -1,0 +1,716 @@
+# Copyright (C) 2016-present MagicStack Inc. and the EdgeDB authors.
+# Copyright (C) 2016-present the asyncpg authors and contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""PostgreSQL cluster management."""
+
+from __future__ import annotations
+from typing import *  # NoQA
+
+import asyncio
+import logging
+import os
+import os.path
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+import asyncpg
+from asyncpg import serverversion
+
+from edb.server import buildmeta
+from edb.server import defines
+
+from . import pgconnparams
+
+
+logger = logging.getLogger(__name__)
+
+_system = platform.uname().system
+
+if _system == 'Windows':
+    def platform_exe(name):
+        if name.endswith('.exe'):
+            return name
+        return name + '.exe'
+else:
+    def platform_exe(name):
+        return name
+
+
+class ClusterError(Exception):
+    pass
+
+
+class BaseCluster:
+
+    def __init__(self):
+        self._connection_addr = None
+        self._connection_params = None
+        self._default_session_auth = None
+
+    async def connect(self, loop=None, **kwargs):
+        conn_info = self.get_connection_spec()
+        conn_info.update(kwargs)
+        conn = await asyncpg.connect(loop=loop, **conn_info)
+
+        if (not kwargs.get('user')
+                and self._default_session_auth
+                and conn_info.get('user') != self._default_session_auth):
+            # No explicit user given, and the default
+            # SESSION AUTHORIZATION is different from the user
+            # used to connect.
+            await conn.execute(
+                f'SET SESSION AUTHORIZATION {self._default_session_auth};'
+            )
+
+        return conn
+
+    def get_superuser_role(self) -> Optional[str]:
+        return None
+
+    def get_connection_addr(self):
+        status = self.get_status()
+        if status != 'running':
+            raise ClusterError('cluster is not running')
+
+        return self._get_connection_addr()
+
+    def set_default_session_authorization(self, rolename: str) -> None:
+        self._default_session_auth = rolename
+
+    def set_connection_params(self, params):
+        self._connection_params = params
+
+    def get_connection_params(self):
+        return self._connection_params
+
+    def get_connection_spec(self):
+        conn_dict = {}
+        addr = self.get_connection_addr()
+        conn_dict['host'] = addr[0]
+        conn_dict['port'] = addr[1]
+        params = self.get_connection_params()
+        for k in ('user', 'password', 'database', 'ssl', 'server_settings'):
+            v = getattr(params, k)
+            if v is not None:
+                conn_dict[k] = v
+
+        return conn_dict
+
+    def _get_connection_addr(self):
+        return self._connection_addr
+
+
+class Cluster(BaseCluster):
+    def __init__(self, data_dir, *, pg_config_path=None):
+        super().__init__()
+        self._data_dir = data_dir
+        self._pg_config_path = pg_config_path
+        self._pg_bin_dir = os.environ.get('PGINSTALLATION')
+        self._pg_ctl = None
+        self._daemon_pid = None
+        self._daemon_process = None
+
+    def get_pg_version(self):
+        return self._pg_version
+
+    def is_managed(self):
+        return True
+
+    def get_data_dir(self):
+        return self._data_dir
+
+    def get_status(self):
+        if self._pg_ctl is None:
+            self._init_env()
+
+        process = subprocess.run(
+            [self._pg_ctl, 'status', '-D', self._data_dir],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = process.stdout, process.stderr
+
+        if (process.returncode == 4 or not os.path.exists(self._data_dir) or
+                not os.listdir(self._data_dir)):
+            return 'not-initialized'
+        elif process.returncode == 3:
+            return 'stopped'
+        elif process.returncode == 0:
+            r = re.match(r'.*PID\s?:\s+(\d+).*', stdout.decode())
+            if not r:
+                raise ClusterError(
+                    'could not parse pg_ctl status output: {}'.format(
+                        stdout.decode()))
+            self._daemon_pid = int(r.group(1))
+            return self._test_connection(timeout=0)
+        else:
+            raise ClusterError(
+                'pg_ctl status exited with status {:d}: {}'.format(
+                    process.returncode, stderr))
+
+    def ensure_initialized(self, **settings):
+        cluster_status = self.get_status()
+
+        if cluster_status == 'not-initialized':
+            logger.info(
+                'Initializing database cluster in %s', self._data_dir)
+            initdb_output = self.init(
+                username='postgres', locale='C', encoding='UTF8')
+            for line in initdb_output.splitlines():
+                logger.debug('initdb: %s', line)
+            self.reset_hba()
+            self.add_hba_entry(
+                type='local',
+                database='all',
+                user='postgres',
+                auth_method='trust'
+            )
+            self.add_hba_entry(
+                type='local',
+                database='all',
+                user=defines.EDGEDB_SUPERUSER,
+                auth_method='trust'
+            )
+
+            return True
+        else:
+            return False
+
+    def init(self, **settings):
+        """Initialize cluster."""
+        if self.get_status() != 'not-initialized':
+            raise ClusterError(
+                'cluster in {!r} has already been initialized'.format(
+                    self._data_dir))
+
+        if settings:
+            settings_args = ['--{}={}'.format(k, v)
+                             for k, v in settings.items()]
+            extra_args = ['-o'] + [' '.join(settings_args)]
+        else:
+            extra_args = []
+
+        process = subprocess.run(
+            [self._pg_ctl, 'init', '-D', self._data_dir] + extra_args,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+        output = process.stdout
+
+        if process.returncode != 0:
+            raise ClusterError(
+                'pg_ctl init exited with status {:d}:\n{}'.format(
+                    process.returncode, output.decode()))
+
+        return output.decode()
+
+    def start(self, wait=60, *, server_settings=None, port, **opts):
+        """Start the cluster."""
+        status = self.get_status()
+        if status == 'running':
+            return
+        elif status == 'not-initialized':
+            raise ClusterError(
+                'cluster in {!r} has not been initialized'.format(
+                    self._data_dir))
+
+        extra_args = ['--{}={}'.format(k, v) for k, v in opts.items()]
+        extra_args.append('--port={}'.format(port))
+
+        start_settings = {
+            'listen_addresses': '',  # we use Unix sockets
+            'unix_socket_permissions': '0700',
+            'unix_socket_directories': str(self._data_dir),
+            # TODO: EdgeDB must manage/monitor all client connections and
+            # have its own "max_connections".  We'll set this setting even
+            # higher when we have that fully implemented.
+            'max_connections': '500',
+        }
+
+        if server_settings:
+            start_settings.update(server_settings)
+
+        ssl_key = start_settings.get('ssl_key_file')
+        if ssl_key:
+            # Make sure server certificate key file has correct permissions.
+            keyfile = os.path.join(self._data_dir, 'srvkey.pem')
+            shutil.copy(ssl_key, keyfile)
+            os.chmod(keyfile, 0o600)
+            start_settings['ssl_key_file'] = keyfile
+
+        for k, v in start_settings.items():
+            extra_args.extend(['-c', '{}={}'.format(k, v)])
+
+        if _system == 'Windows':
+            # On Windows we have to use pg_ctl as direct execution
+            # of postgres daemon under an Administrative account
+            # is not permitted and there is no easy way to drop
+            # privileges.
+            if os.getenv('ASYNCPG_DEBUG_SERVER'):
+                stdout = sys.stdout
+            else:
+                stdout = subprocess.DEVNULL
+
+            process = subprocess.run(
+                [self._pg_ctl, 'start', '-D', self._data_dir,
+                 '-o', ' '.join(extra_args)],
+                stdout=stdout, stderr=subprocess.STDOUT)
+
+            if process.returncode != 0:
+                if process.stderr:
+                    stderr = ':\n{}'.format(process.stderr.decode())
+                else:
+                    stderr = ''
+                raise ClusterError(
+                    'pg_ctl start exited with status {:d}{}'.format(
+                        process.returncode, stderr))
+        else:
+            if os.getenv('ASYNCPG_DEBUG_SERVER'):
+                stdout = sys.stdout
+            else:
+                stdout = subprocess.DEVNULL
+
+            self._daemon_process = \
+                subprocess.Popen(
+                    [self._postgres, '-D', self._data_dir, *extra_args],
+                    stdout=stdout, stderr=subprocess.STDOUT)
+
+            self._daemon_pid = self._daemon_process.pid
+
+        self._test_connection(timeout=wait)
+
+    def reload(self):
+        """Reload server configuration."""
+        status = self.get_status()
+        if status != 'running':
+            raise ClusterError('cannot reload: cluster is not running')
+
+        process = subprocess.run(
+            [self._pg_ctl, 'reload', '-D', self._data_dir],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        stderr = process.stderr
+
+        if process.returncode != 0:
+            raise ClusterError(
+                'pg_ctl stop exited with status {:d}: {}'.format(
+                    process.returncode, stderr.decode()))
+
+    def stop(self, wait=60):
+        process = subprocess.run(
+            [self._pg_ctl, 'stop', '-D', self._data_dir, '-t', str(wait),
+             '-m', 'fast'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        stderr = process.stderr
+
+        if process.returncode != 0:
+            raise ClusterError(
+                'pg_ctl stop exited with status {:d}: {}'.format(
+                    process.returncode, stderr.decode()))
+
+        if (self._daemon_process is not None and
+                self._daemon_process.returncode is None):
+            self._daemon_process.kill()
+
+    def destroy(self):
+        status = self.get_status()
+        if status == 'stopped' or status == 'not-initialized':
+            shutil.rmtree(self._data_dir)
+        else:
+            raise ClusterError('cannot destroy {} cluster'.format(status))
+
+    def reset_wal(self, *, oid=None, xid=None):
+        status = self.get_status()
+        if status == 'not-initialized':
+            raise ClusterError(
+                'cannot modify WAL status: cluster is not initialized')
+
+        if status == 'running':
+            raise ClusterError(
+                'cannot modify WAL status: cluster is running')
+
+        opts = []
+        if oid is not None:
+            opts.extend(['-o', str(oid)])
+        if xid is not None:
+            opts.extend(['-x', str(xid)])
+        if not opts:
+            return
+
+        opts.append(self._data_dir)
+
+        try:
+            reset_wal = self._find_pg_binary('pg_resetwal')
+        except ClusterError:
+            reset_wal = self._find_pg_binary('pg_resetxlog')
+
+        process = subprocess.run(
+            [reset_wal] + opts,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        stderr = process.stderr
+
+        if process.returncode != 0:
+            raise ClusterError(
+                'pg_resetwal exited with status {:d}: {}'.format(
+                    process.returncode, stderr.decode()))
+
+    def reset_hba(self):
+        """Remove all records from pg_hba.conf."""
+        status = self.get_status()
+        if status == 'not-initialized':
+            raise ClusterError(
+                'cannot modify HBA records: cluster is not initialized')
+
+        pg_hba = os.path.join(self._data_dir, 'pg_hba.conf')
+
+        try:
+            with open(pg_hba, 'w'):
+                pass
+        except IOError as e:
+            raise ClusterError(
+                'cannot modify HBA records: {}'.format(e)) from e
+
+    def add_hba_entry(self, *, type='host', database, user, address=None,
+                      auth_method, auth_options=None):
+        """Add a record to pg_hba.conf."""
+        status = self.get_status()
+        if status == 'not-initialized':
+            raise ClusterError(
+                'cannot modify HBA records: cluster is not initialized')
+
+        if type not in {'local', 'host', 'hostssl', 'hostnossl'}:
+            raise ValueError('invalid HBA record type: {!r}'.format(type))
+
+        pg_hba = os.path.join(self._data_dir, 'pg_hba.conf')
+
+        record = '{} {} {}'.format(type, database, user)
+
+        if type != 'local':
+            if address is None:
+                raise ValueError(
+                    '{!r} entry requires a valid address'.format(type))
+            else:
+                record += ' {}'.format(address)
+
+        record += ' {}'.format(auth_method)
+
+        if auth_options is not None:
+            record += ' ' + ' '.join(
+                '{}={}'.format(k, v) for k, v in auth_options)
+
+        try:
+            with open(pg_hba, 'a') as f:
+                print(record, file=f)
+        except IOError as e:
+            raise ClusterError(
+                'cannot modify HBA records: {}'.format(e)) from e
+
+    def trust_local_connections(self):
+        self.reset_hba()
+
+        if _system != 'Windows':
+            self.add_hba_entry(type='local', database='all',
+                               user='all', auth_method='trust')
+        self.add_hba_entry(type='host', address='127.0.0.1/32',
+                           database='all', user='all',
+                           auth_method='trust')
+        self.add_hba_entry(type='host', address='::1/128',
+                           database='all', user='all',
+                           auth_method='trust')
+        status = self.get_status()
+        if status == 'running':
+            self.reload()
+
+    def trust_local_replication_by(self, user):
+        if _system != 'Windows':
+            self.add_hba_entry(type='local', database='replication',
+                               user=user, auth_method='trust')
+        self.add_hba_entry(type='host', address='127.0.0.1/32',
+                           database='replication', user=user,
+                           auth_method='trust')
+        self.add_hba_entry(type='host', address='::1/128',
+                           database='replication', user=user,
+                           auth_method='trust')
+        status = self.get_status()
+        if status == 'running':
+            self.reload()
+
+    def _init_env(self):
+        if not self._pg_bin_dir:
+            pg_config = self._find_pg_config(self._pg_config_path)
+            pg_config_data = self._run_pg_config(pg_config)
+
+            self._pg_bin_dir = pg_config_data.get('bindir')
+            if not self._pg_bin_dir:
+                raise ClusterError(
+                    'pg_config output did not provide the BINDIR value')
+
+        self._pg_ctl = self._find_pg_binary('pg_ctl')
+        self._postgres = self._find_pg_binary('postgres')
+        self._pg_version = self._get_pg_version()
+
+    def _get_connection_addr(self):
+        if self._connection_addr is None:
+            self._connection_addr = self._connection_addr_from_pidfile()
+
+        return self._connection_addr
+
+    def _connection_addr_from_pidfile(self):
+        pidfile = os.path.join(self._data_dir, 'postmaster.pid')
+
+        try:
+            with open(pidfile, 'rt') as f:
+                piddata = f.read()
+        except FileNotFoundError:
+            return None
+
+        lines = piddata.splitlines()
+
+        if len(lines) < 6:
+            # A complete postgres pidfile is at least 6 lines
+            return None
+
+        pmpid = int(lines[0])
+        if self._daemon_pid and pmpid != self._daemon_pid:
+            # This might be an old pidfile left from previous postgres
+            # daemon run.
+            return None
+
+        portnum = lines[3]
+        sockdir = lines[4]
+        hostaddr = lines[5]
+
+        if sockdir:
+            if sockdir[0] != '/':
+                # Relative sockdir
+                sockdir = os.path.normpath(
+                    os.path.join(self._data_dir, sockdir))
+            host_str = sockdir
+        else:
+            host_str = hostaddr
+
+        if host_str == '*':
+            host_str = 'localhost'
+        elif host_str == '0.0.0.0':
+            host_str = '127.0.0.1'
+        elif host_str == '::':
+            host_str = '::1'
+
+        return (host_str, portnum)
+
+    def _test_connection(self, timeout=60):
+        self._connection_addr = None
+
+        loop = asyncio.new_event_loop()
+
+        try:
+            for _ in range(timeout):
+                if self._connection_addr is None:
+                    conn_addr = self._get_connection_addr()
+                    if conn_addr is None:
+                        time.sleep(1)
+                        continue
+
+                try:
+                    con = loop.run_until_complete(
+                        asyncpg.connect(database='postgres',
+                                        user='postgres',
+                                        timeout=5,
+                                        loop=loop,
+                                        host=self._connection_addr[0],
+                                        port=self._connection_addr[1]))
+                except (OSError, asyncio.TimeoutError,
+                        asyncpg.CannotConnectNowError,
+                        asyncpg.PostgresConnectionError):
+                    time.sleep(1)
+                    continue
+                except asyncpg.PostgresError:
+                    # Any other error other than ServerNotReadyError or
+                    # ConnectionError is interpreted to indicate the server is
+                    # up.
+                    break
+                else:
+                    loop.run_until_complete(con.close())
+                    break
+        finally:
+            loop.close()
+
+        return 'running'
+
+    def _run_pg_config(self, pg_config_path):
+        process = subprocess.run(
+            pg_config_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = process.stdout, process.stderr
+
+        if process.returncode != 0:
+            raise ClusterError('pg_config exited with status {:d}: {}'.format(
+                process.returncode, stderr))
+        else:
+            config = {}
+
+            for line in stdout.splitlines():
+                k, eq, v = line.decode('utf-8').partition('=')
+                if eq:
+                    config[k.strip().lower()] = v.strip()
+
+            return config
+
+    def _find_pg_config(self, pg_config_path):
+        if pg_config_path is None:
+            pg_install = os.environ.get('PGINSTALLATION')
+            if pg_install:
+                pg_config_path = platform_exe(
+                    os.path.join(pg_install, 'pg_config'))
+            else:
+                pathenv = os.environ.get('PATH').split(os.pathsep)
+                for path in pathenv:
+                    pg_config_path = platform_exe(
+                        os.path.join(path, 'pg_config'))
+                    if os.path.exists(pg_config_path):
+                        break
+                else:
+                    pg_config_path = None
+
+        if not pg_config_path:
+            raise ClusterError('could not find pg_config executable')
+
+        if not os.path.isfile(pg_config_path):
+            raise ClusterError('{!r} is not an executable'.format(
+                pg_config_path))
+
+        return pg_config_path
+
+    def _find_pg_binary(self, binary):
+        bpath = platform_exe(os.path.join(self._pg_bin_dir, binary))
+
+        if not os.path.isfile(bpath):
+            raise ClusterError(
+                'could not find {} executable: '.format(binary) +
+                '{!r} does not exist or is not a file'.format(bpath))
+
+        return bpath
+
+    def _get_pg_version(self):
+        process = subprocess.run(
+            [self._postgres, '--version'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = process.stdout, process.stderr
+
+        if process.returncode != 0:
+            raise ClusterError(
+                'postgres --version exited with status {:d}: {}'.format(
+                    process.returncode, stderr))
+
+        version_string = stdout.decode('utf-8').strip(' \n')
+        prefix = 'postgres (PostgreSQL) '
+        if not version_string.startswith(prefix):
+            raise ClusterError(
+                'could not determine server version from {!r}'.format(
+                    version_string))
+        version_string = version_string[len(prefix):]
+
+        return serverversion.split_server_version_string(version_string)
+
+
+class TempCluster(Cluster):
+    def __init__(self, *,
+                 data_dir_suffix=None, data_dir_prefix=None,
+                 data_dir_parent=None, pg_config_path=None):
+        self._data_dir = tempfile.mkdtemp(suffix=data_dir_suffix,
+                                          prefix=data_dir_prefix,
+                                          dir=data_dir_parent)
+        super().__init__(self._data_dir, pg_config_path=pg_config_path)
+
+
+class RemoteCluster(BaseCluster):
+    def __init__(self, addr, params):
+        super().__init__()
+        self._connection_addr = addr
+        self._connection_params = params
+
+    def ensure_initialized(self, **settings):
+        return False
+
+    def is_managed(self):
+        return False
+
+    def get_status(self):
+        return 'running'
+
+    def init(self, **settings):
+        pass
+
+    def start(self, wait=60, **settings):
+        pass
+
+    def stop(self, wait=60):
+        pass
+
+    def destroy(self):
+        pass
+
+    def reset_hba(self):
+        raise ClusterError('cannot modify HBA records of unmanaged cluster')
+
+    def add_hba_entry(self, *, type='host', database, user, address=None,
+                      auth_method, auth_options=None):
+        raise ClusterError('cannot modify HBA records of unmanaged cluster')
+
+
+class RDSCluster(RemoteCluster):
+
+    def get_superuser_role(self) -> Optional[str]:
+        return 'rds_superuser'
+
+
+def get_local_pg_cluster(data_dir: os.PathLike) -> Cluster:
+    pg_config = buildmeta.get_pg_config_path()
+    return Cluster(data_dir=data_dir, pg_config_path=str(pg_config))
+
+
+def get_remote_pg_cluster(dsn: str) -> RemoteCluster:
+    addrs, params = pgconnparams.parse_dsn(dsn)
+    if len(addrs) > 1:
+        raise ValueError('multiple hosts in Postgres DSN are not supported')
+    rcluster = RemoteCluster(addrs[0], params)
+
+    loop = asyncio.new_event_loop()
+
+    async def _is_rds():
+        conn = await rcluster.connect()
+
+        try:
+            rds_super = await conn.fetch(
+                "SELECT * FROM pg_roles WHERE rolname = 'rds_superuser'"
+            )
+        finally:
+            await conn.close()
+
+        return bool(rds_super)
+
+    try:
+        is_rds = loop.run_until_complete(_is_rds())
+    finally:
+        loop.close()
+
+    if is_rds:
+        return RDSCluster(addrs[0], params)
+    else:
+        return rcluster

--- a/edb/server/pgcon/pgcon.pxd
+++ b/edb/server/pgcon/pgcon.pxd
@@ -41,6 +41,20 @@ cdef enum PGTransactionStatus:
     PQTRANS_UNKNOWN = 4              # cannot determine status
 
 
+cdef enum PGAuthenticationState:
+    PGAUTH_SUCCESSFUL = 0
+    PGAUTH_REQUIRED_KERBEROS = 2
+    PGAUTH_REQUIRED_PASSWORD = 3
+    PGAUTH_REQUIRED_PASSWORDMD5 = 5
+    PGAUTH_REQUIRED_SCMCRED = 6
+    PGAUTH_REQUIRED_GSS = 7
+    PGAUTH_REQUIRED_GSS_CONTINUE = 8
+    PGAUTH_REQUIRED_SSPI = 9
+    PGAUTH_REQUIRED_SASL = 10
+    PGAUTH_SASL_CONTINUE = 11
+    PGAUTH_SASL_FINAL = 12
+
+
 @cython.final
 cdef class PGProto:
 
@@ -80,3 +94,4 @@ cdef class PGProto:
     cdef before_prepare(self, stmt_name, dbver, WriteBuffer outbuf)
 
     cdef make_clean_stmt_message(self, bytes stmt_name)
+    cdef make_auth_password_md5_message(self, bytes salt)

--- a/edb/server/pgconnparams.py
+++ b/edb/server/pgconnparams.py
@@ -1,0 +1,485 @@
+# Copyright (C) 2016-present MagicStack Inc. and the EdgeDB authors.
+# Copyright (C) 2016-present the asyncpg authors and contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+from typing import *  # NoQA
+
+import dataclasses
+import getpass
+import os
+import pathlib
+import platform
+import re
+import ssl as ssl_module
+import stat
+import urllib.parse
+import warnings
+
+
+@dataclasses.dataclass
+class ConnectionParameters:
+    user: Optional[str] = None
+    password: Optional[str] = None
+    database: Optional[str] = None
+    ssl: Optional[ssl_module.SSLContext] = None
+    ssl_is_advisory: Optional[bool] = None
+    server_settings: Dict[str, str] = dataclasses.field(default_factory=dict)
+
+
+_system = platform.uname().system
+
+
+if _system == 'Windows':
+    import ctypes.wintypes
+
+    CSIDL_APPDATA = 0x001a
+    PGPASSFILE = 'pgpass.conf'
+
+    def get_pg_home_directory() -> Optional[pathlib.Path]:
+        # We cannot simply use expanduser() as that returns the user's
+        # home directory, whereas Postgres stores its config in
+        # %AppData% on Windows.
+        buf = ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
+        r = ctypes.windll.shell32.SHGetFolderPathW(  # type: ignore
+            0, CSIDL_APPDATA, 0, 0, buf)
+        if r:
+            return None
+        else:
+            return pathlib.Path(buf.value) / 'postgresql'
+else:
+    PGPASSFILE = '.pgpass'
+
+    def get_pg_home_directory() -> Optional[pathlib.Path]:
+        return pathlib.Path.home()
+
+
+def _read_password_file(passfile: pathlib.Path) -> List[Tuple[str, ...]]:
+
+    passtab = []
+
+    try:
+        if not passfile.exists():
+            return []
+
+        if not passfile.is_file():
+            warnings.warn(
+                'password file {!r} is not a plain file'.format(passfile))
+
+            return []
+
+        if _system != 'Windows':
+            if passfile.stat().st_mode & (stat.S_IRWXG | stat.S_IRWXO):
+                warnings.warn(
+                    'password file {!r} has group or world access; '
+                    'permissions should be u=rw (0600) or less'.format(
+                        passfile))
+
+                return []
+
+        with passfile.open('rt') as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    # Skip empty lines and comments.
+                    continue
+                # Backslash escapes both itself and the colon,
+                # which is a record separator.
+                line = line.replace(R'\\', '\n')
+                passtab.append(tuple(
+                    p.replace('\n', R'\\')
+                    for p in re.split(r'(?<!\\):', line, maxsplit=4)
+                ))
+    except IOError:
+        pass
+
+    return passtab
+
+
+def _read_password_from_pgpass(
+    *,
+    passfile: Optional[pathlib.Path],
+    hosts: List[str],
+    ports: List[int],
+    database: str,
+    user: str,
+) -> Optional[str]:
+    """Parse the pgpass file and return the matching password.
+
+    :return:
+        Password string, if found, ``None`` otherwise.
+    """
+
+    if passfile is not None:
+        passtab = _read_password_file(passfile)
+        if not passtab:
+            return None
+
+    for host, port in zip(hosts, ports):
+        if host.startswith('/'):
+            # Unix sockets get normalized into 'localhost'
+            host = 'localhost'
+
+        for phost, pport, pdatabase, puser, ppassword in passtab:
+            if phost != '*' and phost != host:
+                continue
+            if pport != '*' and pport != str(port):
+                continue
+            if pdatabase != '*' and pdatabase != database:
+                continue
+            if puser != '*' and puser != user:
+                continue
+
+            # Found a match.
+            return ppassword
+
+    return None
+
+
+def _validate_port_spec(
+    hosts: Collection[str],
+    port: Union[int, List[int]],
+) -> List[int]:
+    if isinstance(port, list):
+        # If there is a list of ports, its length must
+        # match that of the host list.
+        if len(port) != len(hosts):
+            raise ValueError(
+                'could not match {} port numbers to {} hosts'.format(
+                    len(port), len(hosts)))
+    else:
+        port = [port for _ in range(len(hosts))]
+
+    return port
+
+
+def _parse_hostlist(
+    hostlist: str,
+    port: Union[int, List[int]],
+    *,
+    unquote: bool = False,
+) -> Tuple[List[str], List[int]]:
+    if ',' in hostlist:
+        # A comma-separated list of host addresses.
+        hostspecs = hostlist.split(',')
+    else:
+        hostspecs = [hostlist]
+
+    hosts = []
+    hostlist_ports = []
+    result_port: List[int] = []
+
+    if not port:
+        portspec = os.environ.get('PGPORT')
+        specified_port: Union[int, List[int]]
+        if portspec:
+            if ',' in portspec:
+                specified_port = [int(p) for p in portspec.split(',')]
+            else:
+                specified_port = int(portspec)
+        else:
+            specified_port = 5432
+
+        default_port = _validate_port_spec(hostspecs, specified_port)
+
+    else:
+        result_port = _validate_port_spec(hostspecs, port)
+
+    for i, hostspec in enumerate(hostspecs):
+        if not hostspec.startswith('/'):
+            addr, _, hostspec_port = hostspec.partition(':')
+        else:
+            addr = hostspec
+            hostspec_port = ''
+
+        if unquote:
+            addr = urllib.parse.unquote(addr)
+
+        hosts.append(addr)
+        if not port:
+            if hostspec_port:
+                if unquote:
+                    hostspec_port = urllib.parse.unquote(hostspec_port)
+                hostlist_ports.append(int(hostspec_port))
+            else:
+                hostlist_ports.append(default_port[i])
+
+    if not result_port:
+        result_port = hostlist_ports
+
+    return hosts, result_port
+
+
+def parse_dsn(
+    dsn: str,
+) -> Tuple[
+    Tuple[Union[str, Tuple[str, int]], ...],
+    ConnectionParameters,
+]:
+    # `auth_hosts` is the version of host information for the purposes
+    # of reading the pgpass file.
+    auth_hosts = None
+    host: List[str] = []
+    port: Union[int, List[int]] = []
+    user = None
+    password = None
+    passfile = None
+    database = None
+    sslmode = None
+    server_settings: Dict[str, str] = {}
+
+    parsed = urllib.parse.urlparse(dsn)
+
+    if parsed.scheme not in {'postgresql', 'postgres'}:
+        raise ValueError(
+            'invalid DSN: scheme is expected to be either '
+            '"postgresql" or "postgres", got {!r}'.format(parsed.scheme))
+
+    if parsed.netloc:
+        if '@' in parsed.netloc:
+            dsn_auth, _, dsn_hostspec = parsed.netloc.partition('@')
+        else:
+            dsn_hostspec = parsed.netloc
+            dsn_auth = ''
+    else:
+        dsn_auth = dsn_hostspec = ''
+
+    if dsn_auth:
+        dsn_user, _, dsn_password = dsn_auth.partition(':')
+    else:
+        dsn_user = dsn_password = ''
+
+    if dsn_hostspec:
+        host, port = _parse_hostlist(dsn_hostspec, [], unquote=True)
+
+    if parsed.path:
+        dsn_database = parsed.path
+        if dsn_database.startswith('/'):
+            dsn_database = dsn_database[1:]
+        database = urllib.parse.unquote(dsn_database)
+
+    if dsn_user:
+        user = urllib.parse.unquote(dsn_user)
+
+    if dsn_password:
+        password = urllib.parse.unquote(dsn_password)
+
+    if parsed.query:
+        query: Dict[str, str] = {}
+        pq = urllib.parse.parse_qs(parsed.query, strict_parsing=True)
+        for k, v in pq.items():
+            if isinstance(v, list):
+                query[k] = v[-1]
+            else:
+                query[k] = cast(str, v)
+
+        if 'port' in query:
+            val = query.pop('port')
+            if not port and val:
+                port = [int(p) for p in val.split(',')]
+
+        if 'host' in query:
+            val = query.pop('host')
+            if not host and val:
+                host, port = _parse_hostlist(val, port)
+
+        if 'dbname' in query:
+            val = query.pop('dbname')
+            if database is None:
+                database = val
+
+        if 'database' in query:
+            val = query.pop('database')
+            if database is None:
+                database = val
+
+        if 'user' in query:
+            val = query.pop('user')
+            if user is None:
+                user = val
+
+        if 'password' in query:
+            val = query.pop('password')
+            if password is None:
+                password = val
+
+        if 'passfile' in query:
+            passfile = query.pop('passfile')
+
+        if 'sslmode' in query:
+            sslmode = query.pop('sslmode')
+
+        if query:
+            server_settings = query
+
+    if not host:
+        hostspec = os.environ.get('PGHOST')
+        if hostspec:
+            host, port = _parse_hostlist(hostspec, port)
+
+    if not host:
+        auth_hosts = ['localhost']
+
+        if _system == 'Windows':
+            host = ['localhost']
+        else:
+            host = ['/run/postgresql', '/var/run/postgresql',
+                    '/tmp', '/private/tmp', 'localhost']
+
+    if auth_hosts is None:
+        auth_hosts = host
+
+    if not port:
+        portspec = os.environ.get('PGPORT')
+        if portspec:
+            if ',' in portspec:
+                port = [int(p) for p in portspec.split(',')]
+            else:
+                port = int(portspec)
+        else:
+            port = 5432
+
+    elif isinstance(port, (list, tuple)):
+        port = [int(p) for p in port]
+
+    else:
+        port = int(port)
+
+    port = _validate_port_spec(host, port)
+
+    if user is None:
+        user = os.getenv('PGUSER')
+        if not user:
+            user = getpass.getuser()
+
+    if password is None:
+        password = os.getenv('PGPASSWORD')
+
+    if database is None:
+        database = os.getenv('PGDATABASE')
+
+    if database is None:
+        database = user
+
+    if user is None:
+        raise ValueError(
+            'could not determine user name to connect with')
+
+    if database is None:
+        raise ValueError(
+            'could not determine database name to connect to')
+
+    if password is None:
+        if passfile is None:
+            passfile = os.getenv('PGPASSFILE')
+
+        if passfile is None:
+            homedir = get_pg_home_directory()
+            if not homedir:
+                passfile_path = None
+            else:
+                passfile_path = homedir / PGPASSFILE
+        else:
+            passfile_path = pathlib.Path(passfile)
+
+        if passfile_path is not None:
+            password = _read_password_from_pgpass(
+                hosts=auth_hosts, ports=port,
+                database=database, user=user,
+                passfile=passfile_path)
+
+    addrs: List[Union[str, Tuple[str, int]]] = []
+    for h, p in zip(host, port):
+        if h.startswith('/'):
+            # UNIX socket name
+            if '.s.PGSQL.' not in h:
+                h = os.path.join(h, '.s.PGSQL.{}'.format(p))
+            addrs.append(h)
+        else:
+            # TCP host/port
+            addrs.append((h, p))
+
+    if not addrs:
+        raise ValueError(
+            'could not determine the database address to connect to')
+
+    if sslmode is None:
+        sslmode = os.getenv('PGSSLMODE')
+
+    # ssl_is_advisory is only allowed to come from the sslmode parameter.
+    ssl_is_advisory = None
+    if sslmode:
+        SSLMODES = {
+            'disable': 0,
+            'allow': 1,
+            'prefer': 2,
+            'require': 3,
+            'verify-ca': 4,
+            'verify-full': 5,
+        }
+        try:
+            sslmode_key = SSLMODES[sslmode]
+        except KeyError:
+            modes = ', '.join(SSLMODES.keys())
+            raise ValueError(
+                '`sslmode` parameter must be one of: {}'.format(modes))
+
+        # sslmode 'allow' is currently handled as 'prefer' because we're
+        # missing the "retry with SSL" behavior for 'allow', but do have the
+        # "retry without SSL" behavior for 'prefer'.
+        # Not changing 'allow' to 'prefer' here would be effectively the same
+        # as changing 'allow' to 'disable'.
+        if sslmode_key == SSLMODES['allow']:
+            sslmode_key = SSLMODES['prefer']
+
+        # docs at https://www.postgresql.org/docs/10/static/libpq-connect.html
+        # Not implemented: sslcert & sslkey & sslrootcert & sslcrl params.
+        if sslmode_key <= SSLMODES['allow']:
+            ssl = None
+            ssl_is_advisory = sslmode_key >= SSLMODES['allow']
+        else:
+            ssl = ssl_module.create_default_context()
+            ssl.check_hostname = sslmode_key >= SSLMODES['verify-full']
+            ssl.verify_mode = ssl_module.CERT_REQUIRED
+            if sslmode_key <= SSLMODES['require']:
+                ssl.verify_mode = ssl_module.CERT_NONE
+            ssl_is_advisory = sslmode_key <= SSLMODES['prefer']
+
+    if ssl:
+        for addr in addrs:
+            if isinstance(addr, str):
+                # UNIX socket
+                raise ValueError(
+                    '`ssl` parameter can only be enabled for TCP addresses, '
+                    'got a UNIX socket path: {!r}'.format(addr))
+
+    if server_settings is not None and (
+            not isinstance(server_settings, dict) or
+            not all(isinstance(k, str) for k in server_settings) or
+            not all(isinstance(v, str) for v in server_settings.values())):
+        raise ValueError(
+            'server_settings is expected to be None or '
+            'a Dict[str, str]')
+
+    params = ConnectionParameters(
+        user=user,
+        password=password,
+        database=database,
+        ssl=ssl,
+        ssl_is_advisory=ssl_is_advisory,
+        server_settings=server_settings,
+    )
+
+    return tuple(addrs), params

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -20,8 +20,6 @@
 from __future__ import annotations
 
 import logging
-import os
-import urllib.parse
 
 from edb import errors
 
@@ -95,20 +93,10 @@ class Server:
             key=lambda a: a.priority))
 
     def _get_pgaddr(self):
-        pg_con_spec = self._cluster.get_connection_spec()
-        if 'host' not in pg_con_spec and 'dsn' in pg_con_spec:
-            parsed = urllib.parse.urlparse(pg_con_spec['dsn'])
-            query = urllib.parse.parse_qs(parsed.query, strict_parsing=True)
-            host = query.get("host")[-1]
-            port = query.get("port")[-1]
-        else:
-            host = pg_con_spec.get("host")
-            port = pg_con_spec.get("port")
-
-        return os.path.join(host, f'.s.PGSQL.{port}')
+        return self._cluster.get_connection_spec()
 
     async def new_pgcon(self, dbname):
-        return await pgcon.connect(self._pg_addr, dbname)
+        return await pgcon.connect(self._get_pgaddr(), dbname)
 
     async def new_compiler(self, dbname, dbver):
         compiler_worker = await self._compiler_manager.spawn_worker()

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -55,7 +55,6 @@ class Server:
 
         self._cluster = cluster
         self._pg_addr = self._get_pgaddr()
-        self._pg_data_dir = self._cluster.get_data_dir()
 
         # DB state will be initialized in init().
         self._dbindex = None
@@ -125,7 +124,6 @@ class Server:
             server=self,
             loop=self._loop,
             pg_addr=self._pg_addr,
-            pg_data_dir=self._pg_data_dir,
             runstate_dir=self._runstate_dir,
             internal_runstate_dir=self._internal_runstate_dir,
             dbindex=self._dbindex,
@@ -260,9 +258,6 @@ class Server:
     async def _after_system_config_reset(self, setting_name):
         # CONFIGURE SYSTEM RESET setting_name;
         pass
-
-    def get_datadir(self):
-        return self._pg_data_dir
 
     def add_port(self, portcls, **kwargs):
         if self._serving:

--- a/mypy.ini
+++ b/mypy.ini
@@ -187,6 +187,22 @@ ignore_errors = False
 follow_imports = True
 ignore_errors = False
 
+[mypy-edb.server.pgconnparams]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+
 [mypy-edb.tools.profiling]
 follow_imports = True
 ignore_errors = False

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1716,7 +1716,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.con.execute('''
             CREATE INFIX OPERATOR test::`+++`
                 (left: int64, right: int64) -> int64
+            {
+                SET commutator := 'test::+++';
                 USING SQL OPERATOR r'+';
+            };
         ''')
 
         await self.assert_query_result(

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 100.00)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.17)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.31)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)
@@ -239,16 +239,16 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "datasources", 48.39)
 
     def test_cqa_type_coverage_pgsql_dbops(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 34.48)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 34.88)
 
     def test_cqa_type_coverage_repl(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 39.51)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 39.60)
 
     def test_cqa_type_coverage_server(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server", 9.76)
+        self.assertFunctionCoverage(EDB_DIR / "server", 10.92)
 
     def test_cqa_type_coverage_server_cache(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "cache", 0)


### PR DESCRIPTION
This adds the new `--postgres-dsn` option to `edgedb-server`.  When 
specified instead of `-D`, EdgeDB will connect to the specified cluster 
address instead of using a local data directory.

Supporting this requires a bunch of changes around how roles and 
connections are treated.  Since most DBaaS restrict direct superuser 
access, and instead provide a regular role with specific privileges, the 
bootstrap process became somewhat more involved.