### PR TITLE
Disable garbage collection during compilation as it casues too much thrashing

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -22,6 +22,7 @@ from typing import *  # NoQA
 
 import collections
 import dataclasses
+import gc
 import hashlib
 import pickle
 import uuid
@@ -152,7 +153,12 @@ def compile_edgeql_script(
     compiler._std_schema = std_schema
     compiler._bootstrap_mode = True
 
+    # Note: there is a lot of GC activity due to contexts and other
+    # Schema-related reference cycles.  Postponing collection until after
+    # the compilation is complete speeds it up between 7% - 25%.
+    gc.disable()
     units = compiler._compile(ctx=ctx, eql=eql.encode())
+    gc.enable()
 
     sql_stmts = []
     for u in units:


### PR DESCRIPTION
This causes momentary memory usage spikes but in my tests they were never more than 200MB for even the biggest queries. After re-enabling collection, the memory is freed so this causes no long-term memory usage rise.

I found this while trying to add GC disabling to `edbperf` itself and decided it belongs in the compiler instead. It provides a rather hefty performance increase:
```
compile_edgeql_script_simple: Mean +- std dev: 2.24 ms += 0.07 ms (6.84% faster)
compile_edgeql_script_webapp_configure_system: Mean +- std dev: 49.8 ms += 22.4 ms (28.12% SLOWER)
compile_edgeql_script_webapp_get_movie: Mean +- std dev: 209 ms += 7 ms (25.28% faster)
compile_edgeql_script_webapp_get_person: Mean +- std dev: 242 ms += 7 ms (24.96% faster)
compile_edgeql_script_webapp_get_user: Mean +- std dev: 135 ms += 7 ms (5.73% faster)
compile_edgeql_script_webapp_insert_movie: Mean +- std dev: 135 ms += 6 ms (9.06% faster)
compile_edgeql_script_webapp_insert_person: Mean +- std dev: 55.1 ms += 13.5 ms (6.59% faster)
compile_edgeql_script_webapp_insert_review: Mean +- std dev: 79.9 ms += 14.1 ms (6.16% faster)
```

Additionally, it decreases benchmark instability for big queries. Before (compare with std devs above):
```
compile_edgeql_script_webapp_get_movie: Mean +- std dev: 279 ms += 85 ms
compile_edgeql_script_webapp_get_person: Mean +- std dev: 322 ms += 87 ms
```

It does increase standard deviation for trivial queries due to the collection being bigger than before (compare with std devs above):
```
compile_edgeql_script_webapp_configure_system: Mean +- std dev: 38.9 ms += 0.9 ms
compile_edgeql_script_webapp_get_user: Mean +- std dev: 143 ms += 3 ms
compile_edgeql_script_webapp_insert_movie: Mean +- std dev: 149 ms += 3 ms
compile_edgeql_script_webapp_insert_person: Mean +- std dev: 59.0 ms += 1.6 ms
compile_edgeql_script_webapp_insert_review: Mean +- std dev: 85.2 ms += 1.5 ms
```

It's worth noting though that with the exception of `CONFIGURE SYSTEM`, those small queries are still faster than before.