### PR TITLE
Introduce memory profiling

### DIFF
--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -292,7 +292,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "testbase", 1.04)
 
     def test_cqa_type_coverage_tools(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "tools", 19.52)
+        self.assertFunctionCoverage(EDB_DIR / "tools", 21.46)
 
     def test_cqa_type_coverage_tools_docs(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "tools" / "docs", 0)


### PR DESCRIPTION
Generates memory usage SVG graphs.

Example:
[<img width="1920" alt="Screenshot 2019-12-31 at 19 24 16" src="https://user-images.githubusercontent.com/55281/71630789-43130500-2c05-11ea-862b-d81a208012f0.png">](http://langa.pl/random/graphs/get_movie_memory-2019-12-31.svg)

Explanation:
- the top of the graph is aggregate memory pressure generated by calling a given function;
- if you hover over a block, you see how much memory as well as the actual line code;
- the actual memory allocations happen in the orangish leaf nodes on the bottom, so if you're looking to optimize, look for the widest bars **at the bottom** of the graph;
- the greenish blocks have more than one child;
- the gray blocks only have a single child and don't perform significant allocations so they are boring; I only left them here for traceback completion.

This has edbperf integration in a separate PR.