### PR TITLE
Suggest to open a bug report on InternalServerError

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,15 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+<!-- Please search existing issues to avoid creating duplicates. -->
+- EdgeDB Version:
+- OS Version:
+
+Steps to Reproduce:
+
+1.
+2.
+
+<!-- If the issue is about a query error, please also provide your schema -->
+Schema:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url:  https://spectrum.chat/edgedb?tab=posts
+    about: Please ask and answer questions here.
+z

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,9 @@
+---
+name: Feature request
+about: Suggest a feature for EdgeDB
+
+---
+
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+<!-- Describe the feature you'd like to see implemented in EdgeDB. -->


### PR DESCRIPTION
`InternalServerError` is always a bug, so put a hint to open an issue on
Github.

Fixes: #930.

Add Github issue templates

This adds issue templates for bugs and feature requests and a link to 
Spectrum for questions.