### PR TITLE
Command-line fixes

### DIFF
--- a/docs/admin/installation.rst
+++ b/docs/admin/installation.rst
@@ -131,4 +131,4 @@ to the server container:
 
     docker run --link=edgedb-server --rm -it \
         edgedb/edgedb:latest \
-        edgedb -u edgedb -h edgedb-server
+        edgedb -u edgedb -H edgedb-server

--- a/docs/admin/setup.rst
+++ b/docs/admin/setup.rst
@@ -49,7 +49,7 @@ a newly created instance:
 
 .. code-block:: bash
 
-    $ edgedb --admin -h </data/dir> alter role <username> --password
+    $ edgedb --admin -H <edgedb-host> alter-role <username> --password
 
 The ``--admin`` option instructs the ``edgedb`` command to connect to
 the server using a dedicated administrative socket that does not require
@@ -67,7 +67,7 @@ method with the ``trust`` method:
 
 .. code-block:: bash
 
-    $ edgedb --admin -h </data/dir> configure insert auth --method=trust
+    $ edgedb --admin -H <edgedb-host> configure insert auth --method=trust
 
 
 Using remote PostgreSQL cluster as a backend
@@ -84,7 +84,7 @@ server:
 .. code-block:: bash
 
     $ edgedb-server \
-        -P postgres://user:password@host:port/database?opt=val
+        --postgres-dsn 'postgres://user:password@host:port/database?opt=val'
 
 The format of the connection string generally follows that of `libpq`_,
 including support for specifying the connection parameters via

--- a/docs/admin/setup.rst
+++ b/docs/admin/setup.rst
@@ -78,8 +78,7 @@ however it is also possible to use a remote PostgreSQL instance, as long as it
 is version 12 or later.  Superuser access to the cluster is *required*.
 
 To setup EdgeDB using a remote PostgreSQL instance, instead of ``-D``,
-specify the ``-P`` (or ``--postgres-dsn``) option when starting the EdgeDB
-server:
+specify the ``--postgres-dsn`` option when starting the EdgeDB server:
 
 .. code-block:: bash
 

--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -23,17 +23,17 @@ queries and seeing results interactively.
 Options
 =======
 
-:cli:synopsis:`-?, --help`
+:cli:synopsis:`-h, --help`
     Show help about the command and exit.
 
-:cli:synopsis:`-h <hostname>, --host=<hostname>`
+:cli:synopsis:`-H <hostname>, --host=<hostname>`
     Specifies the host name of the machine on which the server is running.
     If :cli:synopsis:<hostname> begins with a slash (``/``), it is used
     as the directory where the command looks for the server Unix-domain
     socket.  Defaults to the value of the ``EDGEDB_HOST`` environment
     variable.
 
-:cli:synopsis:`-p <port>, --port=<port>`
+:cli:synopsis:`-P <port>, --port=<port>`
     Specifies the TCP port or the local Unix-domain socket file extension
     on which the server is listening for connections.  Defaults to the value
     of the ``EDGEDB_PORT`` environment variable or, if not set, to ``5656``.

--- a/docs/cli/edgedb_connopts.rst
+++ b/docs/cli/edgedb_connopts.rst
@@ -8,14 +8,14 @@ Various EdgeDB terminal tools such as :ref:`ref_cli_edgedb` repl,
 :ref:`ref_cli_edgedb_configure`, :ref:`ref_cli_edgedb_dump`,
 and :ref:`ref_cli_edgedb_restore` use the following connection options:
 
-:cli:synopsis:`-h <hostname>, --host=<hostname>`
+:cli:synopsis:`-H <hostname>, --host=<hostname>`
     Specifies the host name of the machine on which the server is running.
     If :cli:synopsis:<hostname> begins with a slash (``/``), it is used
     as the directory where the command looks for the server Unix-domain
     socket.  Defaults to the value of the ``EDGEDB_HOST`` environment
     variable.
 
-:cli:synopsis:`-p <port>, --port=<port>`
+:cli:synopsis:`-P <port>, --port=<port>`
     Specifies the TCP port or the local Unix-domain socket file extension
     on which the server is listening for connections.  Defaults to the value
     of the ``EDGEDB_PORT`` environment variable or, if not set, to ``5656``.

--- a/docs/tutorial/install.rst
+++ b/docs/tutorial/install.rst
@@ -31,7 +31,7 @@ database superuser:
 
 .. code-block:: bash
 
-    $ sudo -u edgedb edgedb --admin alter role edgedb --password
+    $ sudo -u edgedb edgedb --admin alter-role edgedb --password
 
 With that done we should be able to connect to the EdgeDB server instance
 using the newly set password:

--- a/edb/cli/__init__.py
+++ b/edb/cli/__init__.py
@@ -31,7 +31,7 @@ from . import utils
 
 @click.group(
     invoke_without_command=True,
-    context_settings=dict(help_option_names=['-?', '--help']))
+    context_settings=dict(help_option_names=['-h', '--help']))
 @utils.connect_command
 @click.pass_context
 def cli(ctx):

--- a/edb/cli/__init__.py
+++ b/edb/cli/__init__.py
@@ -33,6 +33,7 @@ from . import utils
     invoke_without_command=True,
     context_settings=dict(help_option_names=['-?', '--help']))
 @utils.connect_command
+@click.pass_context
 def cli(ctx):
     if ctx.invoked_subcommand is None:
         status = repl.main(ctx.obj['connargs'])

--- a/edb/cli/dump/__init__.py
+++ b/edb/cli/dump/__init__.py
@@ -31,6 +31,7 @@ from . import restore as restoremod
 
 @cli.command()
 @utils.connect_command
+@click.pass_context
 @click.argument('file', type=click.Path(exists=False, dir_okay=False,
                                         resolve_path=True))
 def dump(ctx, file: str) -> None:
@@ -61,6 +62,7 @@ def is_empty_db(conn: edgedb.BlockingIOConnection) -> bool:
 
 @cli.command()
 @utils.connect_command
+@click.pass_context
 @click.option('--allow-nonempty', is_flag=True)
 @click.argument('file', type=click.Path(exists=True, dir_okay=False,
                                         resolve_path=True))

--- a/edb/cli/dump/__init__.py
+++ b/edb/cli/dump/__init__.py
@@ -29,7 +29,7 @@ from . import dump as dumpmod
 from . import restore as restoremod
 
 
-@cli.command()
+@cli.command(help="Create a database backup")
 @utils.connect_command
 @click.pass_context
 @click.argument('file', type=click.Path(exists=False, dir_okay=False,
@@ -60,7 +60,7 @@ def is_empty_db(conn: edgedb.BlockingIOConnection) -> bool:
     return ret.mods == ['default'] and ret.cnt == 0
 
 
-@cli.command()
+@cli.command(help="Restore the database from a backup")
 @utils.connect_command
 @click.pass_context
 @click.option('--allow-nonempty', is_flag=True)

--- a/edb/cli/mng.py
+++ b/edb/cli/mng.py
@@ -33,7 +33,7 @@ from edb.edgeql.quote import quote_literal as ql, quote_ident as qi
 
 
 @cli.group()
-@utils.connect_command
+@click.pass_context
 def configure(ctx):
     utils.connect(ctx)
 
@@ -273,24 +273,6 @@ def _process_configure_scalar(ctx, parameter, values):
     return parameter, cfg_props[0].target, cfg_props[0].cardinality
 
 
-@cli.group()
-@utils.connect_command
-def create(ctx):
-    utils.connect(ctx)
-
-
-@cli.group()
-@utils.connect_command
-def alter(ctx):
-    utils.connect(ctx)
-
-
-@cli.group()
-@utils.connect_command
-def drop(ctx):
-    utils.connect(ctx)
-
-
 def options(options):
     def _decorator(func):
         for option in reversed(options):
@@ -351,11 +333,13 @@ def _process_role_options(ctx, password, password_from_stdin, allow_login):
     return alters
 
 
-@create.command(name='role')
+@cli.command(name='create-role')
 @click.argument('role-name', type=str)
 @options(_role_options)
 @click.pass_context
 def create_role(ctx, role_name, **kwargs):
+    utils.connect(ctx)
+
     attrs = ";\n".join(_process_role_options(ctx, **kwargs))
 
     qry = f'''
@@ -370,11 +354,12 @@ def create_role(ctx, role_name, **kwargs):
         raise click.ClickException(str(e)) from e
 
 
-@alter.command(name='role')
+@cli.command(name='alter-role')
 @click.argument('role-name', type=str)
 @options(_role_options)
 @click.pass_context
 def alter_role(ctx, role_name, **kwargs):
+    utils.connect(ctx)
 
     attrs = ";\n".join(_process_role_options(ctx, **kwargs))
 
@@ -390,10 +375,11 @@ def alter_role(ctx, role_name, **kwargs):
         raise click.ClickException(str(e)) from e
 
 
-@drop.command(name='role')
+@cli.command(name='drop-role')
 @click.argument('role-name', type=str)
 @click.pass_context
 def drop_role(ctx, role_name, **kwargs):
+    utils.connect(ctx)
     qry = f'''
         DROP ROLE {qi(role_name)};
     '''

--- a/edb/cli/mng.py
+++ b/edb/cli/mng.py
@@ -334,7 +334,7 @@ def _process_role_options(ctx, password, password_from_stdin, allow_login):
 
 
 @cli.command(name='create-role',
-    help='Create a new database user')
+             help='Create a new database user')
 @click.argument('role-name', type=str)
 @options(_role_options)
 @click.pass_context

--- a/edb/cli/mng.py
+++ b/edb/cli/mng.py
@@ -32,7 +32,7 @@ from edb.cli import utils
 from edb.edgeql.quote import quote_literal as ql, quote_ident as qi
 
 
-@cli.group()
+@cli.group(help='Modify database configuration')
 @click.pass_context
 def configure(ctx):
     utils.connect(ctx)
@@ -333,7 +333,8 @@ def _process_role_options(ctx, password, password_from_stdin, allow_login):
     return alters
 
 
-@cli.command(name='create-role')
+@cli.command(name='create-role',
+    help='Create a new database user')
 @click.argument('role-name', type=str)
 @options(_role_options)
 @click.pass_context
@@ -354,7 +355,7 @@ def create_role(ctx, role_name, **kwargs):
         raise click.ClickException(str(e)) from e
 
 
-@cli.command(name='alter-role')
+@cli.command(name='alter-role', help='Modify role')
 @click.argument('role-name', type=str)
 @options(_role_options)
 @click.pass_context
@@ -375,7 +376,7 @@ def alter_role(ctx, role_name, **kwargs):
         raise click.ClickException(str(e)) from e
 
 
-@cli.command(name='drop-role')
+@cli.command(name='drop-role', help="Remove role")
 @click.argument('role-name', type=str)
 @click.pass_context
 def drop_role(ctx, role_name, **kwargs):

--- a/edb/cli/utils.py
+++ b/edb/cli/utils.py
@@ -96,7 +96,7 @@ def connect_command(func):
 
     @functools.wraps(func)
     def wrapper(
-        *,
+        *args,
         host,
         port,
         user,
@@ -159,7 +159,7 @@ def connect_command(func):
         if admin:
             cargs.admin = True
 
-        return func(ctx, **kwargs)
+        return func(*args, **kwargs)
 
     for option in reversed(_connect_params):
         wrapper = option(wrapper)

--- a/edb/cli/utils.py
+++ b/edb/cli/utils.py
@@ -82,8 +82,8 @@ class ConnectionArgs:
 
 
 _connect_params = [
-    click.option('-h', '--host'),
-    click.option('-p', '--port', type=int),
+    click.option('-H', '--host'),
+    click.option('-P', '--port', type=int),
     click.option('-u', '--user'),
     click.option('-d', '--database'),
     click.option('--admin', is_flag=True),

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -327,7 +327,7 @@ _server_options = [
         '-D', '--data-dir', type=str, envvar='EDGEDB_DATADIR',
         help='database cluster directory'),
     click.option(
-        '-P', '--postgres-dsn', type=str,
+        '--postgres-dsn', type=str,
         help='DSN of a remote Postgres cluster, if using one'),
     click.option(
         '-l', '--log-level',
@@ -405,9 +405,9 @@ def server_main(*, insecure=False, **kwargs):
         else:
             abort('Please specify the instance data directory '
                   'using the -D argument or the address of a remote '
-                  'PostgreSQL cluster using the -P argument')
+                  'PostgreSQL cluster using the --postgres-dsn argument')
     elif kwargs['postgres_dsn']:
-        abort('The -D and -P options are mutually exclusive.')
+        abort('The -D and --postgres-dsn options are mutually exclusive.')
 
     kwargs['insecure'] = insecure
 

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -360,7 +360,7 @@ _server_options = [
         '-I', '--bind-address', type=str, default=None,
         help='IP address to listen on', envvar='EDGEDB_BIND_ADDRESS'),
     click.option(
-        '-p', '--port', type=int, default=None,
+        '-P', '--port', type=int, default=None,
         help='port to listen on'),
     click.option(
         '-b', '--background', is_flag=True, help='daemonize'),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,7 @@ class TestCLI(tb.ConnectedTestCase, tb.CLITestCaseMixin):
     SERIALIZED = True
 
     async def test_cli_role(self):
-        self.run_cli('create', 'role', 'foo', '--allow-login',
+        self.run_cli('create-role', 'foo', '--allow-login',
                      '--password-from-stdin',
                      input='foo-pass\n')
 
@@ -38,7 +38,7 @@ class TestCLI(tb.ConnectedTestCase, tb.CLITestCaseMixin):
         )
         await conn.close()
 
-        self.run_cli('alter', 'role', 'foo', '--no-allow-login')
+        self.run_cli('alter-role', 'foo', '--no-allow-login')
 
         # good password, but allow_login is False
         with self.assertRaisesRegex(
@@ -49,7 +49,7 @@ class TestCLI(tb.ConnectedTestCase, tb.CLITestCaseMixin):
                 password='foo-pass',
             )
 
-        self.run_cli('alter', 'role', 'foo', '--allow-login',
+        self.run_cli('alter-role', 'foo', '--allow-login',
                      '--password-from-stdin',
                      input='foo-new-pass\n')
 
@@ -59,7 +59,7 @@ class TestCLI(tb.ConnectedTestCase, tb.CLITestCaseMixin):
         )
         await conn.close()
 
-        self.run_cli('drop', 'role', 'foo')
+        self.run_cli('drop-role', 'foo')
 
         with self.assertRaisesRegex(
                 edgedb.AuthenticationError,
@@ -69,7 +69,7 @@ class TestCLI(tb.ConnectedTestCase, tb.CLITestCaseMixin):
                 password='foo-new-pass',
             )
 
-        result = self.run_cli('create', 'role', 'foo', '--allow-login',
+        result = self.run_cli('create-role', 'foo', '--allow-login',
                               '--password', input='foo-pass\n')
         self.assertIn('input is not a TTY', result.output)
 

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -194,7 +194,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertEqual(coverage.untyped_lines, 0)
 
     def test_cqa_type_coverage_cli(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "cli", 37.14)
+        self.assertFunctionCoverage(EDB_DIR / "cli", 40.62)
 
     def test_cqa_type_coverage_common(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "common", 27.36)


### PR DESCRIPTION
Fixes #1029, #1030

I've left `configure` as is, but if we want to make it a form similar to other (verb-noun) they should have been `insert-config`/`reset-config`/`set-config`, which I'm not sure are good. Anyway, current `configure` is good for discoverability.