### PR TITLE
Implement _gen_series() (internal only)

### DIFF
--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -82,3 +82,48 @@ ALTER TYPE cfg::Config {
         SET ANNOTATION cfg::internal := 'true';
     };
 };
+
+
+# std::_gen_series
+
+CREATE FUNCTION
+std::_gen_series(
+    `start`: std::int64,
+    stop: std::int64
+) -> SET OF std::int64
+{
+    SET volatility := 'IMMUTABLE';
+    USING SQL FUNCTION 'generate_series';
+};
+
+CREATE FUNCTION
+std::_gen_series(
+    `start`: std::int64,
+    stop: std::int64,
+    step: std::int64
+) -> SET OF std::int64
+{
+    SET volatility := 'IMMUTABLE';
+    USING SQL FUNCTION 'generate_series';
+};
+
+CREATE FUNCTION
+std::_gen_series(
+    `start`: std::bigint,
+    stop: std::bigint
+) -> SET OF std::bigint
+{
+    SET volatility := 'IMMUTABLE';
+    USING SQL FUNCTION 'generate_series';
+};
+
+CREATE FUNCTION
+std::_gen_series(
+    `start`: std::bigint,
+    stop: std::bigint,
+    step: std::bigint
+) -> SET OF std::bigint
+{
+    SET volatility := 'IMMUTABLE';
+    USING SQL FUNCTION 'generate_series';
+};

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -4272,3 +4272,32 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             await self.con.fetchall(r'''
                 SELECT math::var_pop(<int64>{});
             ''')
+
+    async def test_edgeql_functions__genseries_01(self):
+        await self.assert_query_result(
+            r'''
+            SELECT _gen_series(1, 10)
+            ''',
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        )
+
+        await self.assert_query_result(
+            r'''
+            SELECT _gen_series(1, 10, 2)
+            ''',
+            [1, 3, 5, 7, 9]
+        )
+
+        await self.assert_query_result(
+            r'''
+            SELECT _gen_series(1n, 10n)
+            ''',
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        )
+
+        await self.assert_query_result(
+            r'''
+            SELECT _gen_series(1n, 10n, 2n)
+            ''',
+            [1, 3, 5, 7, 9]
+        )


### PR DESCRIPTION
This is useful for testing and data generation.  Not public, because
there will be `range_unpack()` once range types are implemented.