### PR TITLE
Add an option to inject an implicit limit into read queries

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -179,6 +179,7 @@ def compile_ast_to_ir(
     result_view_name: Optional[s_name.SchemaName] = None,
     derived_target_module: Optional[str] = None,
     parent_object_type: Optional[s_obj.ObjectMeta] = None,
+    implicit_limit: int = 0,
     implicit_id_in_shapes: bool = False,
     implicit_tid_in_shapes: bool = False,
     schema_view_mode: bool = False,
@@ -238,6 +239,10 @@ def compile_ast_to_ir(
             context of which this expression is compiled.  Used in schema
             definitions.
 
+        implicit_limit:
+            If set to a non-zero integer value, this will be injected
+            as an implicit `LIMIT` clause into each read query.
+
         implicit_id_in_shapes:
             Whether to include object id property in shapes by default.
 
@@ -283,6 +288,7 @@ def compile_ast_to_ir(
         func_params=func_params,
         derived_target_module=derived_target_module,
         result_view_name=result_view_name,
+        implicit_limit=implicit_limit,
         implicit_id_in_shapes=implicit_id_in_shapes,
         implicit_tid_in_shapes=implicit_tid_in_shapes,
         schema_view_mode=schema_view_mode,

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -429,6 +429,12 @@ class ContextLevel(compiler.ContextLevel):
     implicit_tid_in_shapes: bool
     """Whether to include the type id property in object shapes implicitly."""
 
+    implicit_limit: int
+    """Implicit LIMIT clause in SELECT statments."""
+
+    inhibit_implicit_limit: bool
+    """Whether implicit limit injection should be inhibited."""
+
     special_computables_in_mutation_shape: FrozenSet[str]
     """A set of "special" compiutable pointers allowed in mutation shape."""
 
@@ -492,6 +498,8 @@ class ContextLevel(compiler.ContextLevel):
             self.toplevel_result_view_name = None
             self.implicit_id_in_shapes = False
             self.implicit_tid_in_shapes = False
+            self.implicit_limit = 0
+            self.inhibit_implicit_limit = False
             self.special_computables_in_mutation_shape = frozenset()
             self.empty_result_type_hint = None
             self.defining_view = False
@@ -530,6 +538,8 @@ class ContextLevel(compiler.ContextLevel):
             self.toplevel_stmt = prevlevel.toplevel_stmt
             self.implicit_id_in_shapes = prevlevel.implicit_id_in_shapes
             self.implicit_tid_in_shapes = prevlevel.implicit_tid_in_shapes
+            self.implicit_limit = prevlevel.implicit_limit
+            self.inhibit_implicit_limit = prevlevel.inhibit_implicit_limit
             self.special_computables_in_mutation_shape = \
                 prevlevel.special_computables_in_mutation_shape
             self.empty_result_type_hint = prevlevel.empty_result_type_hint

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -57,23 +57,6 @@ from . import typegen
 @dispatch.compile.register(qlast.SelectQuery)
 def compile_SelectQuery(
         expr: qlast.SelectQuery, *, ctx: context.ContextLevel) -> irast.Set:
-    if astutils.is_degenerate_select(expr) and ctx.toplevel_stmt is not None:
-        # Compile implicit "SELECT Path" as "Path"
-        with ctx.new() as sctx:
-            process_with_block(expr, ctx=sctx, parent_ctx=ctx)
-            sctx.aliased_views = ctx.aliased_views.new_child()
-            sctx.modaliases = ctx.modaliases.copy()
-            sctx.anchors = ctx.anchors.copy()
-            result = compile_result_clause(
-                expr.result,
-                view_scls=ctx.view_scls,
-                view_rptr=ctx.view_rptr,
-                view_name=ctx.toplevel_result_view_name,
-                ctx=sctx)
-            result = fini_stmt(result, expr, ctx=sctx, parent_ctx=ctx)
-
-        return result
-
     with ctx.subquery() as sctx:
         stmt = irast.SelectStmt()
         init_stmt(stmt, expr, ctx=sctx, parent_ctx=ctx)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -75,6 +75,7 @@ def init_context(
         schema_view_mode: bool=False,
         disable_constant_folding: bool=False,
         allow_generic_type_output: bool=False,
+        implicit_limit: int=0,
         implicit_id_in_shapes: bool=False,
         implicit_tid_in_shapes: bool=False,
         json_parameters: bool=False,
@@ -117,6 +118,7 @@ def init_context(
     ctx.toplevel_result_view_name = result_view_name
     ctx.implicit_id_in_shapes = implicit_id_in_shapes
     ctx.implicit_tid_in_shapes = implicit_tid_in_shapes
+    ctx.implicit_limit = implicit_limit
 
     return ctx
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -907,6 +907,9 @@ def process_set_as_path(
         # Link range.
         if is_inline_ref:
             aspects = ['value']
+            # If this is a link that is stored inline, make sure
+            # the source aspect is actually accessible (not just value).
+            src_rvar = relctx.ensure_source_rvar(ir_source, stmt, ctx=ctx)
         else:
             aspects = ['value', 'source']
 

--- a/edb/repl/context.py
+++ b/edb/repl/context.py
@@ -43,6 +43,7 @@ class ReplContext:
     query_mode: QueryMode = QueryMode.Normal
     typenames: Optional[Dict[uuid.UUID, str]] = None
     last_exception: Optional[Exception] = None
+    implicit_limit: int = 100
 
     def toggle_query_mode(self) -> None:
         self.query_mode = self.query_mode.cycle()

--- a/edb/repl/render.py
+++ b/edb/repl/render.py
@@ -56,7 +56,8 @@ def render_json(
 ) -> None:
     data = json.loads(data)
     buf = terminal.Buffer(max_width=max_width, styled=repl_ctx.use_colors)
-    _json.walk(data, repl_ctx, buf)
+    render_ctx = _json.RenderContext(path=())
+    _json.walk(data, repl_ctx, render_ctx, buf)
     print(buf.flush())
 
 

--- a/edb/repl/render_binary.py
+++ b/edb/repl/render_binary.py
@@ -197,14 +197,26 @@ def _set(
     else:
         begin, end = '{', '}'
 
+    last_idx = len(o) - 1
     with buf.foldable_lines():
         buf.write(begin, style.bracket)
         with buf.indent():
             for idx, el in enumerate(o):
                 walk(el, repl_ctx, buf)
-                if idx < (len(o) - 1):
+                if idx < last_idx:
                     buf.write(',')
                     buf.mark_line_break()
+                if (repl_ctx.implicit_limit
+                        and (idx + 1) == repl_ctx.implicit_limit):
+                    if idx == last_idx:
+                        buf.write(',')
+                        buf.mark_line_break()
+
+                    buf.write('...')
+                    if repl_ctx.implicit_limit > 10:
+                        buf.write(f'(further results hidden '
+                                  f'\\limit {repl_ctx.implicit_limit})')
+                    break
         buf.write(end, style.bracket)
 
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -89,6 +89,7 @@ class CompileContext:
     expected_cardinality_one: bool
     stmt_mode: enums.CompileStatementMode
     json_parameters: bool = False
+    implicit_limit: int = 0
 
 
 EMPTY_MAP = immutables.Map()
@@ -337,6 +338,7 @@ class Compiler(BaseCompiler):
             implicit_id_in_shapes=implicit_fields,
             disable_constant_folding=disable_constant_folding,
             json_parameters=ctx.json_parameters,
+            implicit_limit=ctx.implicit_limit,
             session_mode=session_mode)
 
         if ir.cardinality is qltypes.Cardinality.ONE:
@@ -1049,6 +1051,7 @@ class Compiler(BaseCompiler):
         session_config: Optional[immutables.Map],
         stmt_mode: Optional[enums.CompileStatementMode],
         capability: enums.Capability,
+        implicit_limit: int=0,
         json_parameters: bool=False,
         schema: Optional[s_schema.Schema] = None
     ) -> CompileContext:
@@ -1083,6 +1086,7 @@ class Compiler(BaseCompiler):
             state=state,
             output_format=of,
             expected_cardinality_one=expect_one,
+            implicit_limit=implicit_limit,
             stmt_mode=stmt_mode,
             json_parameters=json_parameters)
 
@@ -1090,6 +1094,7 @@ class Compiler(BaseCompiler):
 
     async def _ctx_from_con_state(self, *, txid: int, json_mode: bool,
                                   expect_one: bool,
+                                  implicit_limit: int,
                                   stmt_mode: enums.CompileStatementMode):
         state = self._load_state(txid)
 
@@ -1102,6 +1107,7 @@ class Compiler(BaseCompiler):
             state=state,
             output_format=of,
             expected_cardinality_one=expect_one,
+            implicit_limit=implicit_limit,
             stmt_mode=stmt_mode)
 
         return ctx
@@ -1162,6 +1168,7 @@ class Compiler(BaseCompiler):
             sess_config: Optional[immutables.Map],
             json_mode: bool,
             expect_one: bool,
+            implicit_limit: int,
             stmt_mode: enums.CompileStatementMode,
             capability: enums.Capability,
             json_parameters: bool=False) -> List[dbstate.QueryUnit]:
@@ -1170,6 +1177,7 @@ class Compiler(BaseCompiler):
             dbver=dbver,
             json_mode=json_mode,
             expect_one=expect_one,
+            implicit_limit=implicit_limit,
             modaliases=sess_modaliases,
             session_config=sess_config,
             stmt_mode=enums.CompileStatementMode(stmt_mode),
@@ -1184,6 +1192,7 @@ class Compiler(BaseCompiler):
             eql: bytes,
             json_mode: bool,
             expect_one: bool,
+            implicit_limit: int,
             stmt_mode: enums.CompileStatementMode
     ) -> List[dbstate.QueryUnit]:
 
@@ -1191,6 +1200,7 @@ class Compiler(BaseCompiler):
             txid=txid,
             json_mode=json_mode,
             expect_one=expect_one,
+            implicit_limit=implicit_limit,
             stmt_mode=enums.CompileStatementMode(stmt_mode))
 
         return self._compile(ctx=ctx, eql=eql)

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -73,9 +73,10 @@ cdef class DatabaseConnectionView:
     cdef in_tx_error(self)
 
     cdef cache_compiled_query(self, bytes eql, bint json_mode,
-                              bint expect_one, query_unit)
+                              bint expect_one, int implicit_limit,
+                              query_unit)
     cdef lookup_compiled_query(self, bytes eql, bint json_mode,
-                               bint expect_one)
+                               bint expect_one, int implicit_limit)
 
     cdef tx_error(self)
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -162,11 +162,12 @@ cdef class DatabaseConnectionView:
         return self._tx_error
 
     cdef cache_compiled_query(self, bytes eql, bint json_mode, bint expect_one,
-                             query_unit):
+                              int implicit_limit, query_unit):
 
         assert query_unit.cacheable
 
-        key = (eql, json_mode, expect_one, self._modaliases, self._config)
+        key = (eql, json_mode, expect_one, implicit_limit,
+               self._modaliases, self._config)
 
         if self._in_tx_with_ddl:
             self._eql_to_compiled[key] = query_unit
@@ -174,13 +175,14 @@ cdef class DatabaseConnectionView:
             self._db._cache_compiled_query(key, query_unit)
 
     cdef lookup_compiled_query(self, bytes eql, bint json_mode,
-                               bint expect_one):
+                               bint expect_one, int implicit_limit):
         if (self._tx_error or
                 not self._query_cache_enabled or
                 self._in_tx_with_ddl):
             return None
 
-        key = (eql, json_mode, expect_one, self._modaliases, self._config)
+        key = (eql, json_mode, expect_one, implicit_limit,
+               self._modaliases, self._config)
 
         if self._in_tx_with_ddl or self._in_tx_with_set:
             query_unit = self._eql_to_compiled.get(key)

--- a/edb/server/http_edgeql_port/protocol.pyx
+++ b/edb/server/http_edgeql_port/protocol.pyx
@@ -135,6 +135,7 @@ cdef class Protocol(http.HttpProtocol):
                 None,  # session config
                 True,  # json mode
                 False, # expected cardinality is MANY
+                0,     # no implicit limit
                 compiler.CompileStatementMode.SINGLE,
                 compiler.Capability.QUERY,
                 True,  # json parameters

--- a/edb/server/mng_port/cpythonx.pxd
+++ b/edb/server/mng_port/cpythonx.pxd
@@ -1,0 +1,10 @@
+# Copyright (C) 2016-present the asyncpg authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of asyncpg and is released under
+# the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
+
+
+cdef extern from "Python.h":
+    object PyLong_FromUnicodeObject(
+        object u, int base)

--- a/edb/server/mng_port/edgecon.pxd
+++ b/edb/server/mng_port/edgecon.pxd
@@ -102,7 +102,10 @@ cdef class EdgeConnection:
 
     cdef inline reject_headers(self)
     cdef dict parse_headers(self)
+    cdef write_headers(self, WriteBuffer buf, dict headers)
 
     cdef write_log(self, EdgeSeverity severity, uint32_t code, str message)
 
     cdef get_backend(self)
+
+    cdef uint64_t _parse_implicit_limit(self, bytes v) except <uint64_t>-1

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -733,16 +733,14 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::Card)",
             "(test::Card).>name[IS std::str]",
             "FENCE": {
-                "FENCE": {
-                    "(__derived__::__derived__|A@@w~1)\
+                "(__derived__::__derived__|A@@w~1)\
 .>owners[IS test::User]": {
-                        "(__derived__::__derived__|A@@w~1)",
-                        "FENCE": {
-                            "ns~2@@(__derived__::__derived__|A@@w~1)\
+                    "(__derived__::__derived__|A@@w~1)",
+                    "FENCE": {
+                        "ns~2@@(__derived__::__derived__|A@@w~1)\
 .<deck[IS __derived__::@SID@].>indirection[IS test::User]": {
-                                "ns~2@@(__derived__::__derived__|A@@w~1)\
+                            "ns~2@@(__derived__::__derived__|A@@w~1)\
 .<deck[IS __derived__::@SID@]"
-                            }
                         }
                     }
                 }

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2374,3 +2374,120 @@ class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):
             await self.con.execute('''
                 DROP SCALAR TYPE tid_prop_02;
             ''')
+
+    async def test_server_proto_fetch_limit_01(self):
+        try:
+            await self.con.execute('''
+                CREATE TYPE test::FL_A {
+                    CREATE PROPERTY n -> int64;
+                };
+                CREATE TYPE test::FL_B {
+                    CREATE PROPERTY n -> int64;
+                    CREATE MULTI LINK a -> test::FL_A;
+                };
+
+                WITH MODULE test
+                FOR i IN {1, 2, 3, 4, 5}
+                UNION (
+                    INSERT FL_A {
+                        n := i
+                    }
+                );
+
+                WITH MODULE test
+                FOR i IN {1, 2, 3, 4, 5}
+                UNION (
+                    INSERT FL_B {
+                        n := i,
+                        a := FL_A,
+                    }
+                );
+            ''')
+
+            result = await self.con._fetchall(
+                r"""
+                    WITH MODULE test
+                    SELECT FL_B {
+                        a ORDER BY .n,
+                        a_arr := array_agg(.a)
+                    } ORDER BY .n
+                """,
+                __limit__=2
+            )
+
+            self.assertEqual(len(result), 2)
+            self.assertEqual(len(result[0].a), 2)
+            self.assertEqual(len(result[0].a_arr), 2)
+
+            # Check that things are not cached improperly.
+            result = await self.con._fetchall(
+                r"""
+                    WITH MODULE test
+                    SELECT FL_B {
+                        a ORDER BY .n,
+                        a_arr := array_agg(.a)
+                    } ORDER BY .n
+                """,
+                __limit__=3
+            )
+
+            self.assertEqual(len(result), 3)
+            self.assertEqual(len(result[0].a), 3)
+            self.assertEqual(len(result[0].a_arr), 3)
+
+            # Check that explicit LIMIT is not overridden
+            result = await self.con._fetchall(
+                r"""
+                    WITH MODULE test
+                    SELECT FL_B {
+                        a ORDER BY .n LIMIT 3,
+                        a_arr := array_agg((SELECT .a LIMIT 3)),
+                        a_count := count(.a),
+                    }
+                    ORDER BY .n
+                    LIMIT 3
+                """,
+                __limit__=2
+            )
+
+            self.assertEqual(len(result), 3)
+            self.assertEqual(len(result[0].a), 3)
+            self.assertEqual(len(result[0].a_arr), 3)
+            self.assertEqual(result[0].a_count, 5)
+
+            # Check that implicit limit does not break inline aliases.
+            result = await self.con._fetchall(
+                r"""
+                    WITH a := {11, 12, 13}
+                    SELECT _ := {9, 1, 13}
+                    FILTER _ IN a;
+                """,
+                __limit__=1
+            )
+
+            self.assertEqual(result, edgedb.Set([13]))
+
+        finally:
+            await self.con.execute('''
+                DROP TYPE test::FL_B;
+                DROP TYPE test::FL_A;
+            ''')
+
+    async def test_server_proto_fetch_limit_02(self):
+        with self.assertRaises(edgedb.ProtocolError):
+            await self.con._fetchall(
+                'SELECT {1, 2, 3}',
+                __limit__=-2,
+            )
+
+    async def test_server_proto_fetch_limit_03(self):
+        await self.con._fetchall(
+            'SELECT {1, 2, 3}',
+            __limit__=1,
+        )
+
+        with self.assertRaises(edgedb.ProtocolError):
+            await self.con._fetchall(
+                'SELECT {1, 2, 3}',
+                __limit__=-2,
+            )

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.97)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.92)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
The client can now, via a special header to the Parse, request the server
to inject a constatnt limit into all read queries. This is useful for
contexts where the precise cardinality of output is less important, and
injecting limits ensures that large linked sets in shapes don't bring
everything down.

This requires edgedb/edgedb-python#67.

Fixes: #846.