### PR TITLE
edgeql: Forbid redefinition of read-only flag.

### DIFF
--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -113,7 +113,8 @@ The following subcommands are allowed in the ``CREATE LINK`` block:
 
 :eql:synopsis:`SET readonly := {true | false}`
     If ``true``, the link is considered *read-only*.  Modifications
-    of this link are prohibited once an object is created.
+    of this link are prohibited once an object is created.  All of the
+    derived links **must** preserve the original *read-only* value.
 
 :eql:synopsis:`SET ANNOTATION <annotation-name> := <value>;`
     Add an annotation :eql:synopsis:`<annotation-name>`

--- a/docs/edgeql/ddl/props.rst
+++ b/docs/edgeql/ddl/props.rst
@@ -109,7 +109,8 @@ The following subcommands are allowed in the ``CREATE PROPERTY`` block:
 
 :eql:synopsis:`SET readonly := {true | false}`
     If ``true``, the property is considered *read-only*.  Modifications
-    of this property are prohibited once an object is created.
+    of this property are prohibited once an object is created.  All of the
+    derived properties **must** preserve the original *read-only* value.
 
 :eql:synopsis:`SET ANNOTATION <annotation-name> := <value>`
     Set property :eql:synopsis:`<annotation-name>` to

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -815,7 +815,17 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         if after_name:
             after_name()
 
-        commands = node.commands
+        commands = [
+            comm for comm in node.commands
+            # Throw out "SET readonly := False" from the commands as
+            # that is implied.
+            if not (
+                isinstance(comm, qlast.SetField)
+                and comm.name == 'readonly'
+                and isinstance(comm.value, qlast.BooleanConstant)
+                and comm.value.value.lower() == 'false'
+            )
+        ]
         if commands and render_commands:
             self._ddl_visit_body(
                 commands,

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4168,3 +4168,328 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 'ct': 1,
             }]
         )
+
+    async def test_edgeql_ddl_readonly_01(self):
+        # Test that read-only flag must be consistent in the
+        # inheritance hierarchy.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                "cannot redefine the readonly flag of property 'foo' of "
+                "object type 'test::Derived': it is defined as True in "
+                "property 'foo' of object type 'test::Derived' and as "
+                "False in property 'foo' of object type 'test::Base'."):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE PROPERTY foo -> str;
+                };
+                CREATE TYPE Derived EXTENDING Base {
+                    ALTER PROPERTY foo {
+                        SET readonly := True;
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_readonly_02(self):
+        # Test that read-only flag must be consistent in the
+        # inheritance hierarchy.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                "cannot redefine the readonly flag of property 'foo' of "
+                "object type 'test::Derived': it is defined as False in "
+                "property 'foo' of object type 'test::Derived' and as "
+                "True in property 'foo' of object type 'test::Base'."):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE PROPERTY foo -> str {
+                        SET readonly := True;
+                    };
+                };
+                CREATE TYPE Derived EXTENDING Base {
+                    ALTER PROPERTY foo {
+                        SET readonly := False;
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_readonly_03(self):
+        # Test that read-only flag must be consistent in the
+        # inheritance hierarchy.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                "cannot redefine the readonly flag of property 'foo' of "
+                "object type 'test::Derived': it is defined as False in "
+                "property 'foo' of object type 'test::Base0' and as "
+                "True in property 'foo' of object type 'test::Base1'."):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base0 {
+                    CREATE PROPERTY foo -> str;
+                };
+                CREATE TYPE Base1 {
+                    CREATE PROPERTY foo -> str {
+                        SET readonly := True;
+                    };
+                };
+                CREATE TYPE Derived EXTENDING Base0, Base1;
+            ''')
+
+    async def test_edgeql_ddl_readonly_04(self):
+        # Test that read-only flag must be consistent in the
+        # inheritance hierarchy.
+        await self.con.execute('''
+            SET MODULE test;
+
+            CREATE TYPE Base0 {
+                CREATE PROPERTY foo -> str;
+            };
+            CREATE TYPE Base1 {
+                CREATE PROPERTY foo -> str;
+            };
+            CREATE TYPE Derived EXTENDING Base0, Base1;
+        ''')
+
+        # XXX: The error message is awkward as it refers to conflict
+        # of the Derived with Base1, whereas the more accurate error
+        # message would refer to Base0 and Base1.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                "cannot redefine the readonly flag of property 'foo' of "
+                "object type 'test::Derived': it is defined as False in "
+                "property 'foo' of object type 'test::Derived' and as "
+                "True in property 'foo' of object type 'test::Base1'."):
+            await self.con.execute('''
+                ALTER TYPE Base1 {
+                    ALTER PROPERTY foo {
+                        SET readonly := True;
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_readonly_05(self):
+        # Test that read-only flag must be consistent in the
+        # inheritance hierarchy.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                "cannot redefine the readonly flag of link 'foo' of "
+                "object type 'test::Derived': it is defined as True in "
+                "link 'foo' of object type 'test::Derived' and as "
+                "False in link 'foo' of object type 'test::Base'."):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE LINK foo -> Object;
+                };
+                CREATE TYPE Derived EXTENDING Base {
+                    ALTER LINK foo {
+                        SET readonly := True;
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_readonly_06(self):
+        # Test that read-only flag must be consistent in the
+        # inheritance hierarchy.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                "cannot redefine the readonly flag of link 'foo' of "
+                "object type 'test::Derived': it is defined as False in "
+                "link 'foo' of object type 'test::Derived' and as "
+                "True in link 'foo' of object type 'test::Base'."):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE LINK foo -> Object {
+                        SET readonly := True;
+                    };
+                };
+                CREATE TYPE Derived EXTENDING Base {
+                    ALTER LINK foo {
+                        SET readonly := False;
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_readonly_07(self):
+        # Test that read-only flag must be consistent in the
+        # inheritance hierarchy.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                "cannot redefine the readonly flag of link 'foo' of "
+                "object type 'test::Derived': it is defined as False in "
+                "link 'foo' of object type 'test::Base0' and as "
+                "True in link 'foo' of object type 'test::Base1'."):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base0 {
+                    CREATE LINK foo -> Object;
+                };
+                CREATE TYPE Base1 {
+                    CREATE LINK foo -> Object {
+                        SET readonly := True;
+                    };
+                };
+                CREATE TYPE Derived EXTENDING Base0, Base1;
+            ''')
+
+    async def test_edgeql_ddl_readonly_08(self):
+        # Test that read-only flag must be consistent in the
+        # inheritance hierarchy.
+        await self.con.execute('''
+            SET MODULE test;
+
+            CREATE TYPE Base0 {
+                CREATE LINK foo -> Object;
+            };
+            CREATE TYPE Base1 {
+                CREATE LINK foo -> Object;
+            };
+            CREATE TYPE Derived EXTENDING Base0, Base1;
+        ''')
+
+        # XXX: The error message is awkward as it refers to conflict
+        # of the Derived with Base1, whereas the more accurate error
+        # message would refer to Base0 and Base1.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                "cannot redefine the readonly flag of link 'foo' of "
+                "object type 'test::Derived': it is defined as False in "
+                "link 'foo' of object type 'test::Derived' and as "
+                "True in link 'foo' of object type 'test::Base1'."):
+            await self.con.execute('''
+                ALTER TYPE Base1 {
+                    ALTER LINK foo {
+                        SET readonly := True;
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_readonly_09(self):
+        # Test that read-only flag must be consistent in the
+        # inheritance hierarchy.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                "cannot redefine the readonly flag of property 'bar' of "
+                "link 'foo' of object type 'test::Derived': it is defined "
+                "as True in property 'bar' of link 'foo' of object type "
+                "'test::Derived' and as False in property 'bar' of link "
+                "'foo' of object type 'test::Base'."):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE LINK foo -> Object {
+                        CREATE PROPERTY bar -> str;
+                    };
+                };
+                CREATE TYPE Derived EXTENDING Base {
+                    ALTER LINK foo {
+                        ALTER PROPERTY bar {
+                            SET readonly := True;
+                        }
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_readonly_10(self):
+        # Test that read-only flag must be consistent in the
+        # inheritance hierarchy.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                "cannot redefine the readonly flag of property 'bar' of "
+                "link 'foo' of object type 'test::Derived': it is defined "
+                "as False in property 'bar' of link 'foo' of object type "
+                "'test::Derived' and as True in property 'bar' of link "
+                "'foo' of object type 'test::Base'."):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE LINK foo -> Object {
+                        CREATE PROPERTY bar -> str {
+                            SET readonly := True;
+                        };
+                    };
+                };
+                CREATE TYPE Derived EXTENDING Base {
+                    ALTER LINK foo {
+                        ALTER PROPERTY bar {
+                            SET readonly := False;
+                        }
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_readonly_11(self):
+        # Test that read-only flag must be consistent in the
+        # inheritance hierarchy.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                "cannot redefine the readonly flag of property 'bar' of "
+                "link 'foo' of object type 'test::Derived': it is defined "
+                "as False in property 'bar' of link 'foo' of object type "
+                "'test::Base0' and as True in property 'bar' of link "
+                "'foo' of object type 'test::Base1'."):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base0 {
+                    CREATE LINK foo -> Object {
+                        CREATE PROPERTY bar -> str;
+                    };
+                };
+                CREATE TYPE Base1 {
+                    CREATE LINK foo -> Object {
+                        CREATE PROPERTY bar -> str {
+                            SET readonly := True;
+                        };
+                    };
+                };
+                CREATE TYPE Derived EXTENDING Base0, Base1;
+            ''')
+
+    async def test_edgeql_ddl_readonly_12(self):
+        # Test that read-only flag must be consistent in the
+        # inheritance hierarchy.
+        await self.con.execute('''
+            SET MODULE test;
+
+            CREATE TYPE Base0 {
+                CREATE LINK foo -> Object {
+                    CREATE PROPERTY bar -> str;
+                };
+            };
+            CREATE TYPE Base1 {
+                CREATE LINK foo -> Object {
+                    CREATE PROPERTY bar -> str;
+                };
+            };
+            CREATE TYPE Derived EXTENDING Base0, Base1;
+        ''')
+
+        # XXX: The error message is awkward as it refers to conflict
+        # of the Derived with Base1, whereas the more accurate error
+        # message would refer to Base0 and Base1.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                "cannot redefine the readonly flag of property 'bar' of "
+                "link 'foo' of object type 'test::Derived': it is defined "
+                "as False in property 'bar' of link 'foo' of object type "
+                "'test::Derived' and as True in property 'bar' of link "
+                "'foo' of object type 'test::Base1'."):
+            await self.con.execute('''
+                ALTER TYPE Base1 {
+                    ALTER LINK foo {
+                        ALTER PROPERTY bar {
+                            SET readonly := True;
+                        };
+                    };
+                };
+            ''')

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -379,7 +379,9 @@ class TestIntrospection(tb.QueryTestCase):
                     "@is_local": False
                 }, {
                     "name": "name",
-                    "inherited_fields": {"required", "cardinality"},
+                    "inherited_fields": {
+                        "readonly", "required", "cardinality"
+                    },
                     "@is_local": False
                 }]
             }]

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 39.60)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 39.77)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 10.92)


### PR DESCRIPTION
The read-only flag presents possible problems of interpretation if it's
allowed to be redefined in inheritance hierarchy. Specifically, consider
the following:

    type A {
        property foo -> str {
            readonly := True
        }
    }

    type B {
        property foo -> str {
            readonly := False;  # not omitted for clarity
        }
    }

    type C extending A, B;

If this is legal, then regardless of how we interpret the correct way to
inherit `readonly` in `C`, we will have unintuitive behavior of objects of
type `C`. It's not obvious to the end-user whether the property `foo` of
C should be more like A or like B.

The solution is to forbid mixing `readonly` flags much like it's
forbidden to mix or redefine cardinality via inheritance.

Issue: #1047