### PR TITLE
Simplify limit clause for simple case

### DIFF
--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -152,6 +152,9 @@ def compile_limit_offset_clause(
     if ir_set is None:
         return None
 
+    if isinstance(ir_set.expr, irast.IntegerConstant):
+        return pgast.NumericConstant(val=ir_set.expr.value)
+
     with ctx.new() as ctx1:
         ctx1.expr_exposed = False
 


### PR DESCRIPTION
Originally limit clause is compiled as:
```
LIMIT
(SELECT/*<pg.SelectStmt at 0x7ff168032f70>*/
    (10)::int8 AS "expr~13_value~1"
    )
```
With this patch it's compiled as:
```
LIMIT 10
```