### PR TITLE
Filter irrelevant `readonly` values in DESCRIBE.

### DIFF
--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -815,17 +815,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         if after_name:
             after_name()
 
-        commands = [
-            comm for comm in node.commands
-            # Throw out "SET readonly := False" from the commands as
-            # that is implied.
-            if not (
-                isinstance(comm, qlast.SetField)
-                and comm.name == 'readonly'
-                and isinstance(comm.value, qlast.BooleanConstant)
-                and comm.value.value.lower() == 'false'
-            )
-        ]
+        commands = node.commands
         if commands and render_commands:
             self._ddl_visit_body(
                 commands,

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -823,7 +823,13 @@ class ObjectCommand(Command, metaclass=ObjectCommandMeta):
                     f'module {modname} is read-only',
                     context=self.source_context)
 
-    def get_object(self, schema, context, *, name=None):
+    def get_object(
+        self,
+        schema: s_schema.Schema,
+        context: CommandContext,
+        *,
+        name: Optional[str] = None,
+    ) -> so.Object:
         if name is None:
             name = self.classname
             rename = context.renames.get(name)

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -874,6 +874,21 @@ class PointerCommand(constraints.ConsistencySubjectCommand,
         else:
             return super().compile_expr_field(schema, context, field, value)
 
+    def _apply_field_ast(self, schema, context, node, op):
+        if context.descriptive_mode:
+            # When generating AST for DESCRIBE AS TEXT, we want to
+            # omit 'readonly' flag if it's inherited and it actually
+            # has the default value.
+            if op.property == 'readonly':
+                pointer_obj = self.get_object(schema, context)
+                field = type(pointer_obj).get_field('readonly')
+                dval = field.default
+
+                if op.source == 'inheritance' and op.new_value is dval:
+                    return
+
+        super()._apply_field_ast(schema, context, node, op)
+
 
 class SetPointerType(
         referencing.ReferencedInheritingObjectCommand,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4193,6 +4193,36 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             '''
         )
 
+    def test_describe_08(self):
+        self._assert_describe(
+            """
+            type Foo {
+                property bar -> str {
+                    readonly := False;
+                }
+            };
+            """,
+
+            'DESCRIBE TYPE Foo',
+
+            """
+            CREATE TYPE test::Foo {
+                CREATE SINGLE PROPERTY bar -> std::str {
+                    SET readonly := false;
+                };
+            };
+            """,
+            'DESCRIBE TYPE Foo AS SDL',
+
+            """
+            type test::Foo {
+                single property bar -> std::str {
+                    readonly := false;
+                };
+            };
+            """,
+        )
+
     def test_describe_alias_01(self):
         self._assert_describe(
             """

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 40.62)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 40.68)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 10.92)


### PR DESCRIPTION
Prevent `SET readonly := False` from being generated by `DESCRIBE ... AS
TEXT` if the value is, in fact, inherited. This reduces the noise as
most links and properties are not read-only by default.