### PR TITLE
Make sure `SET id :=` is not emitted for ALTER commands in DESCRIBE

### DIFF
--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -39,6 +39,9 @@ from . import referencing
 from . import sources
 from . import utils
 
+if TYPE_CHECKING:
+    from . import schema as s_schema
+
 
 LinkTargetDeleteAction = qlast.LinkTargetDeleteAction
 
@@ -196,8 +199,14 @@ class LinkCommand(lproperties.PropertySourceCommand,
                 context=srcctx,
             )
 
-    def _get_ast(self, schema, context):
-        node = super()._get_ast(schema, context)
+    def _get_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        *,
+        parent_node: Optional[qlast.DDL],
+    ) -> Optional[qlast.DDL]:
+        node = super()._get_ast(schema, context, parent_node=parent_node)
         # __type__ link is special, and while it exists on every object
         # it doesn not have a defined default in the schema (and therefore
         # it isn't marked as required.)  We intervene here to mark all

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -407,7 +407,9 @@ class CreateObjectType(ObjectTypeCommand, inheriting.CreateInheritingObject):
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
-    ) -> Optional[qlast.Base]:
+        *,
+        parent_node: Optional[qlast.DDL],
+    ) -> Optional[qlast.DDL]:
         if (self.get_attribute_value('expr_type')
                 and not self.get_attribute_value('expr')):
             # This is a nested view type, e.g
@@ -415,7 +417,7 @@ class CreateObjectType(ObjectTypeCommand, inheriting.CreateInheritingObject):
             # and should obviously not appear as a top level definition.
             return None
         else:
-            return super()._get_ast(schema, context)
+            return super()._get_ast(schema, context, parent_node=parent_node)
 
     def _get_ast_node(self, schema, context):
         if self.get_attribute_value('expr_type'):

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -712,12 +712,19 @@ class CreateReferencedObject(ReferencedObjectCommand, sd.CreateObject):
 
         return cmd
 
-    def _get_ast(self, schema, context):
+    def _get_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        *,
+        parent_node: Optional[qlast.DDL],
+    ) -> Optional[qlast.DDL]:
         refctx = type(self).get_referrer_context(context)
         if refctx is not None:
             if not self.get_attribute_value('is_local'):
                 if context.descriptive_mode:
-                    astnode = super()._get_ast(schema, context)
+                    astnode = super()._get_ast(
+                        schema, context, parent_node=parent_node)
 
                     bases = self.get_attribute_value('bases')
                     bases_names = [
@@ -740,7 +747,8 @@ class CreateReferencedObject(ReferencedObjectCommand, sd.CreateObject):
                     return None
 
             else:
-                astnode = super()._get_ast(schema, context)
+                astnode = super()._get_ast(
+                    schema, context, parent_node=parent_node)
 
                 if context.declarative:
                     scls = self.get_object(schema, context)
@@ -753,7 +761,7 @@ class CreateReferencedObject(ReferencedObjectCommand, sd.CreateObject):
 
                 return astnode
         else:
-            return super()._get_ast(schema, context)
+            return super()._get_ast(schema, context, parent_node=parent_node)
 
     def _get_ast_node(self, schema, context):
         scls = self.get_object(schema, context)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1809,8 +1809,12 @@ class CollectionTypeCommand(sd.UnqualifiedObjectCommand,
                             context_class=CollectionTypeCommandContext):
 
     def get_ast(
-        self, schema: s_schema.Schema, context: sd.CommandContext
-    ) -> None:
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        *,
+        parent_node: Optional[qlast.DDL] = None,
+    ) -> Optional[qlast.DDL]:
         # CollectionTypeCommand cannot have its own AST because it is a
         # side-effect of some other command.
         return None

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 39.77)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 40.62)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 10.92)


### PR DESCRIPTION
`DESCRIBE SCHEMA EMIT OIDS` currently erroneously includes `SET id :=`
commands for commands that are rendered as `ALTER`, so schemas described
like that would fail to process.