### PR TITLE
edgeql: Make it invalid to `DROP REQUIRED` if it wasn't defined.

### DIFF
--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -166,6 +166,8 @@ class LinkCommand(lproperties.PropertySourceCommand,
                   schema_metaclass=Link, context_class=LinkCommandContext,
                   referrer_context_class=LinkSourceCommandContext):
 
+    _command_subject = 'link'
+
     def _set_pointer_type(self, schema, astnode, context, target_ref):
         slt = SetLinkType(classname=self.classname, type=target_ref)
         slt.set_attribute_value(

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -156,6 +156,8 @@ class PropertyCommand(pointers.PointerCommand,
                       context_class=PropertyCommandContext,
                       referrer_context_class=PropertySourceContext):
 
+    _command_subject = 'property'
+
     def _set_pointer_type(self, schema, astnode, context, target_ref):
         spt = SetPropertyType(classname=self.classname, type=target_ref)
         spt.set_attribute_value(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4493,3 +4493,216 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     };
                 };
             ''')
+
+    async def test_edgeql_ddl_required_01(self):
+        # Test that required qualifier cannot be dropped if it was not
+        # actually set on the particular property.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError, "cannot drop required"):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE PROPERTY foo -> str;
+                };
+                ALTER TYPE Base {
+                    ALTER PROPERTY foo {
+                        DROP REQUIRED;
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_required_02(self):
+        # Test that required qualifier cannot be dropped if it was not
+        # actually set on the particular property.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError, "cannot drop required"):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE REQUIRED PROPERTY foo -> str;
+                };
+                CREATE TYPE Derived EXTENDING Base;
+                ALTER TYPE Derived {
+                    ALTER PROPERTY foo {
+                        DROP REQUIRED;
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_required_03(self):
+        # Test that required qualifier cannot be dropped if it was not
+        # actually set on the particular property.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError, "cannot drop required"):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE REQUIRED PROPERTY foo -> str;
+                };
+                CREATE TYPE Derived EXTENDING Base {
+                    ALTER PROPERTY foo {
+                        DROP REQUIRED;
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_required_04(self):
+        # Test that required qualifier cannot be dropped if it was not
+        # actually set on the particular link.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError, "cannot drop required"):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE LINK foo -> Object;
+                };
+                ALTER TYPE Base {
+                    ALTER LINK foo {
+                        DROP REQUIRED;
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_required_05(self):
+        # Test that required qualifier cannot be dropped if it was not
+        # actually set on the particular link.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError, "cannot drop required"):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE REQUIRED LINK foo -> Object;
+                };
+                CREATE TYPE Derived EXTENDING Base;
+                ALTER TYPE Derived {
+                    ALTER LINK foo {
+                        DROP REQUIRED;
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_required_06(self):
+        # Test that required qualifier cannot be dropped if it was not
+        # actually set on the particular link.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError, "cannot drop required"):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE REQUIRED LINK foo -> Object;
+                };
+                CREATE TYPE Derived EXTENDING Base {
+                    ALTER LINK foo {
+                        DROP REQUIRED;
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_required_07(self):
+        # Test that required qualifier cannot be dropped if it was not
+        # actually set on the particular link property.
+        with self.assertRaisesRegex(
+                edgedb.SchemaError, "cannot drop required"):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE LINK foo -> Object {
+                        CREATE PROPERTY bar -> str;
+                    };
+                };
+                CREATE TYPE Derived EXTENDING Base {
+                    ALTER LINK foo {
+                        ALTER PROPERTY bar {
+                            DROP REQUIRED;
+                        };
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_required_08(self):
+        # Test normal that required qualifier behavior.
+
+        await self.con.execute(r"""
+            SET MODULE test;
+
+            CREATE TYPE Base {
+                CREATE REQUIRED PROPERTY foo -> str;
+            };
+            CREATE TYPE Derived EXTENDING Base {
+                ALTER PROPERTY foo {
+                    # overloading the property to be required
+                    # regardless of the ancestors
+                    SET REQUIRED;
+                };
+            };
+        """)
+
+        with self.assertRaisesRegex(
+                edgedb.MissingRequiredError,
+                r'Base.foo'):
+
+            async with self.con.transaction():
+                await self.con.execute("""
+                    INSERT Base;
+                """)
+
+        with self.assertRaisesRegex(
+                edgedb.MissingRequiredError,
+                r'Derived.foo'):
+
+            async with self.con.transaction():
+                await self.con.execute("""
+                    INSERT Derived;
+                """)
+
+        await self.con.execute("""
+            ALTER TYPE Base {
+                ALTER PROPERTY foo {
+                    DROP REQUIRED;
+                };
+            };
+        """)
+
+        await self.con.execute("""
+            INSERT Base;
+        """)
+        await self.assert_query_result(
+            r'''
+                SELECT count(Base);
+            ''',
+            [1],
+        )
+
+        with self.assertRaisesRegex(
+                edgedb.MissingRequiredError,
+                r'Derived.foo'):
+
+            async with self.con.transaction():
+                await self.con.execute("""
+                    INSERT Derived;
+                """)
+
+        await self.con.execute("""
+            ALTER TYPE Derived {
+                ALTER PROPERTY foo {
+                    DROP REQUIRED;
+                };
+            };
+        """)
+
+        await self.con.execute("""
+            INSERT Derived;
+        """)
+        await self.assert_query_result(
+            r'''
+                SELECT count(Derived);
+            ''',
+            [1],
+        )


### PR DESCRIPTION
`DROP REQUIRED` doesn't make sense when the required qualifier is not
set or is inherited. It can also lead to unintuitive results if it's
allowed since `DROP REQUIRED` cannot actually override an inherited `SET
REQUIRED`.

The solution is to only allow `DROP REQUIRED` in the contexts of a link
or property on which it was explicitly set.