### PR TITLE
Change SET ANNOTATION to CREATE/ALTER ANNOTATION

### DIFF
--- a/docs/edgeql/ddl/aliases.rst
+++ b/docs/edgeql/ddl/aliases.rst
@@ -24,7 +24,7 @@ CREATE ALIAS
     [ WITH <with-item> [, ...] ]
     CREATE ALIAS <alias-name> "{"
         USING <alias-expr>;
-        [ SET ANNOTATION <attr-name> := <attr-value>; ... ]
+        [ CREATE ANNOTATION <attr-name> := <attr-value>; ... ]
     "}" ;
 
     # where <with-item> is:
@@ -56,9 +56,9 @@ Parameters
 :eql:synopsis:`<alias-expr>`
     The aliased expression.  Can be any valid EdgeQL expression.
 
-:eql:synopsis:`SET ANNOTATION <annotation-name> := <value>;`
+:eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>;`
     An optional list of annotation values for the alias.
-    See :eql:stmt:`SET ANNOTATION` for details.
+    See :eql:stmt:`CREATE ANNOTATION` for details.
 
 :eql:synopsis:`[ <module-alias> := ] MODULE <module-name>`
     An optional list of module alias declarations to be used in the

--- a/docs/edgeql/ddl/annotations.rst
+++ b/docs/edgeql/ddl/annotations.rst
@@ -20,7 +20,7 @@ CREATE ABSTRACT ANNOTATION
     [ WITH <with-item> [, ...] ]
     CREATE ABSTRACT [ INHERITABLE ] ANNOTATION <name>
     [ "{"
-        SET ANNOTATION <annotation-name> := <value> ;
+        CREATE ANNOTATION <annotation-name> := <value> ;
         [...]
       "}" ] ;
 
@@ -44,21 +44,21 @@ be turned on by declaring the annotation with the *INHERITABLE* qualifier.
 The following subcommands are allowed in the
 ``CREATE ABSTRACT ANNOTATION`` block:
 
-:eql:synopsis:`SET ANNOTATION <annotation-name> := <value>`
+:eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>`
     Annotations can also have annotations. Set the
     :eql:synopsis:`<annotation-name>` of the
     enclosing annotation to a specific :eql:synopsis:`<value>`.
-    See :eql:stmt:`SET ANNOTATION` for details.
+    See :eql:stmt:`CREATE ANNOTATION` for details.
 
 
 Example
 -------
 
-Set the annotation ``title`` of object type ``User`` to ``"User"``:
+Declare an annotation ``extrainfo``.
 
 .. code-block:: edgeql
 
-    ALTER TYPE User SET ANNOTATION title := "User";
+    CREATE ABSTRACT ANNOTATION extrainfo;
 
 
 DROP ABSTRACT ANNOTATION
@@ -90,8 +90,8 @@ Drop the annotation ``extrainfo``:
     DROP ABSTRACT ANNOTATION extrainfo;
 
 
-SET ANNOTATION
-==============
+CREATE ANNOTATION
+=================
 
 :eql-statement:
 
@@ -99,12 +99,12 @@ Define an annotation value for a given schema item.
 
 .. eql:synopsis::
 
-    SET ANNOTATION <annotation-name> := <value>
+    CREATE ANNOTATION <annotation-name> := <value>
 
 Description
 -----------
 
-``SET ANNOTATION`` defines an annotation for a schema item.
+``CREATE ANNOTATION`` defines an annotation for a schema item.
 
 :eql:synopsis:`<annotation-name>` refers to the name of a defined annotation,
 and :eql:synopsis:`<value>` must be a constant EdgeQL expression
@@ -123,9 +123,45 @@ Create an object type ``User`` and set its ``title`` annotation to
 .. code-block:: edgeql
 
     CREATE TYPE User {
-        SET ANNOTATION title := "User type";
+        CREATE ANNOTATION title := "User type";
     };
 
+
+ALTER ANNOTATION
+================
+
+:eql-statement:
+
+Alter an annotation value for a given schema item.
+
+.. eql:synopsis::
+
+    ALTER ANNOTATION <annotation-name> := <value>
+
+Description
+-----------
+
+``ALTER ANNOTATION`` alters an annotation value on a schema item.
+
+:eql:synopsis:`<annotation-name>` refers to the name of a defined annotation,
+and :eql:synopsis:`<value>` must be a constant EdgeQL expression
+evaluating into a string.
+
+This statement can only be used as a subcommand in another
+DDL statement.
+
+
+Example
+-------
+
+Alter an object type ``User`` and alter the value of its previously set
+``title`` annotation to ``"User type"``.
+
+.. code-block:: edgeql
+
+    ALTER TYPE User {
+        ALTER ANNOTATION title := "User type";
+    };
 
 
 DROP ANNOTATION

--- a/docs/edgeql/ddl/constraints.rst
+++ b/docs/edgeql/ddl/constraints.rst
@@ -32,7 +32,7 @@ CREATE ABSTRACT CONSTRAINT
 
       USING <constr-expression>
       SET errmessage := <error-message>
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
 
 
 Description
@@ -93,11 +93,11 @@ CONSTRAINT`` block:
     - ``__subject__`` -- the value of the ``title`` annotation of the scalar
       type, property or link on which the constraint is defined.
 
-:eql:synopsis:`SET ANNOTATION <annotation-name> := <value>;`
+:eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>;`
     Set constraint :eql:synopsis:`<annotation-name>` to
     :eql:synopsis:`<value>`.
 
-    See :eql:stmt:`SET ANNOTATION` for details.
+    See :eql:stmt:`CREATE ANNOTATION` for details.
 
 
 Example
@@ -109,7 +109,7 @@ is a string in upper case.
 .. code-block:: edgeql
 
     CREATE ABSTRACT CONSTRAINT uppercase {
-        SET ANNOTATION title := "Upper case constraint";
+        CREATE ANNOTATION title := "Upper case constraint";
         USING (str_upper(__subject__) = __subject__);
         SET errmessage := "{__subject__} is not in upper case";
     };
@@ -135,7 +135,8 @@ Alter the definition of an
       RENAME TO <newname>
       USING <constr-expression>
       SET errmessage := <error-message>
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
+      ALTER ANNOTATION <annotation-name> := <value>
       DROP ANNOTATION <annotation-name>
 
 
@@ -165,6 +166,10 @@ CONSTRAINT`` block:
 :eql:synopsis:`RENAME TO <newname>`
     Change the name of the constraint to *newname*.  All concrete
     constraints inheriting from this constraint are also renamed.
+
+:eql:synopsis:`ALTER ANNOTATION <annotation-name>;`
+    Alter constraint :eql:synopsis:`<annotation-name>`.
+    See :eql:stmt:`ALTER ANNOTATION <ALTER ANNOTATION>` for details.
 
 :eql:synopsis:`DROP ANNOTATION <annotation-name>;`
     Remove constraint :eql:synopsis:`<annotation-name>`.
@@ -254,7 +259,7 @@ Define a concrete constraint on the specified schema item.
     # where <subcommand> is one of
 
       SET errmessage := <error-message>
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
 
 
 Description
@@ -317,9 +322,9 @@ The following subcommands are allowed in the ``CERATE CONSTRAINT`` block:
     paragraph in :eql:stmt:`CREATE ABSTRACT CONSTRAINT` for the rules
     of error message template syntax.
 
-:eql:synopsis:`SET ANNOTATION <annotation-name> := <value>;`
+:eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>;`
     An optional list of annotations for the constraint.
-    See :eql:stmt:`SET ANNOTATION` for details.
+    See :eql:stmt:`CREATE ANNOTATION` for details.
 
 
 Example
@@ -359,7 +364,8 @@ Alter the definition of a concrete constraint on the specified schema item.
       DROP DELEGATED
       RENAME TO <newname>
       SET errmessage := <error-message>
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
+      ALTER ANNOTATION <annotation-name>
       DROP ANNOTATION <annotation-name>
 
 
@@ -394,6 +400,10 @@ The following subcommands are allowed in the ``ALTER CONSTRAINT`` block:
 
 :eql:synopsis:`RENAME TO <newname>`
     Change the name of the constraint to :eql:synopsis:`<newname>`.
+
+:eql:synopsis:`ALTER ANNOTATION <annotation-name>;`
+    Alter constraint :eql:synopsis:`<annotation-name>`.
+    See :eql:stmt:`ALTER ANNOTATION <ALTER ANNOTATION>` for details.
 
 :eql:synopsis:`DROP ANNOTATION <annotation-name>;`
     Remove an *annotation*. See :eql:stmt:`DROP ANNOTATION` for details.

--- a/docs/edgeql/ddl/functions.rst
+++ b/docs/edgeql/ddl/functions.rst
@@ -50,7 +50,7 @@ CREATE FUNCTION
     # where <subcommand> is one of
 
       SET session_only := {true | false} ;
-      SET ANNOTATION <annotation-name> := <value> ;
+      CREATE ANNOTATION <annotation-name> := <value> ;
       USING ( <expr> ) ;
       USING <language> <functionbody> ;
 
@@ -156,11 +156,11 @@ block:
     :eql:func:`sys::advisory_lock`, :eql:func:`sys::advisory_unlock`,
     :eql:func:`sys::advisory_unlock_all`.
 
-:eql:synopsis:`SET ANNOTATION <annotation-name> := <value>`
+:eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>`
     Set the function's :eql:synopsis:`<annotation-name>` to
     :eql:synopsis:`<value>`.
 
-    See :eql:stmt:`SET ANNOTATION` for details.
+    See :eql:stmt:`CREATE ANNOTATION` for details.
 
 :eql:synopsis:`USING <language> <functionbody>`
     See the meaning of *language* and *functionbody* above.
@@ -195,7 +195,7 @@ Define a function using the block syntax:
         USING (
             SELECT a + b
         );
-        SET ANNOTATION title := "My sum function.";
+        CREATE ANNOTATION title := "My sum function.";
     };
 
 

--- a/docs/edgeql/ddl/indexes.rst
+++ b/docs/edgeql/ddl/indexes.rst
@@ -24,7 +24,7 @@ type or link.
 
     # where <subcommand> is one of
 
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
 
 
 Description
@@ -43,11 +43,11 @@ Parameters
 
 The only subcommand that is allowed in the ``CREATE INDEX`` block:
 
-:eql:synopsis:`SET ANNOTATION <annotation-name> := <value>`
+:eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>`
     Set object type :eql:synopsis:`<annotation-name>` to
     :eql:synopsis:`<value>`.
 
-    See :eql:stmt:`SET ANNOTATION` for details.
+    See :eql:stmt:`CREATE ANNOTATION` for details.
 
 
 Example
@@ -81,7 +81,8 @@ Alter the definition of an :ref:`index <ref_eql_sdl_indexes>`.
 
     # where <subcommand> is one of
 
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
+      ALTER ANNOTATION <annotation-name> := <value>
       DROP ANNOTATION <annotation-name>
 
 
@@ -102,11 +103,14 @@ Parameters
 
 The following subcommands are allowed in the ``ALTER INDEX`` block:
 
-:eql:synopsis:`SET ANNOTATION <annotation-name> := <value>`
-    Set object type :eql:synopsis:`<annotation-name>` to
+:eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>`
+    Set index :eql:synopsis:`<annotation-name>` to
     :eql:synopsis:`<value>`.
+    See :eql:stmt:`CREATE ANNOTATION` for details.
 
-    See :eql:stmt:`SET ANNOTATION` for details.
+:eql:synopsis:`ALTER ANNOTATION <annotation-name>;`
+    Alter index :eql:synopsis:`<annotation-name>`.
+    See :eql:stmt:`ALTER ANNOTATION <ALTER ANNOTATION>` for details.
 
 :eql:synopsis:`DROP ANNOTATION <annotation-name>;`
     Remove constraint :eql:synopsis:`<annotation-name>`.
@@ -123,7 +127,7 @@ Add an annotation to the index on the ``name`` property of object type
 
     ALTER TYPE User {
         ALTER INDEX ON (.name) {
-            SET ANNOTATION title := "User name index";
+            CREATE ANNOTATION title := "User name index";
         };
     };
 

--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -46,7 +46,7 @@ CREATE LINK
 
       SET default := <expression>
       SET readonly := {true | false}
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
       CREATE PROPERTY <property-name> ...
       CREATE CONSTRAINT <constraint-name> ...
       ON TARGET DELETE <action>
@@ -116,11 +116,11 @@ The following subcommands are allowed in the ``CREATE LINK`` block:
     of this link are prohibited once an object is created.  All of the
     derived links **must** preserve the original *read-only* value.
 
-:eql:synopsis:`SET ANNOTATION <annotation-name> := <value>;`
+:eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>;`
     Add an annotation :eql:synopsis:`<annotation-name>`
     set to :eql:synopsis:`<value>` to the type.
 
-    See :eql:stmt:`SET ANNOTATION` for details.
+    See :eql:stmt:`CREATE ANNOTATION` for details.
 
 :eql:synopsis:`CREATE PROPERTY <property-name> ...`
     Define a concrete property item for this link.  See
@@ -213,7 +213,8 @@ Change the definition of a :ref:`link <ref_datamodel_links>`.
       SET SINGLE
       SET MULTI
       SET TYPE <typename> [, ...]
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
+      ALTER ANNOTATION <annotation-name> := <value>
       DROP ANNOTATION <annotation-name>
       CREATE PROPERTY <property-name> ...
       ALTER PROPERTY <property-name> ...
@@ -285,6 +286,10 @@ The following subcommands are allowed in the ``ALTER LINK`` block:
     Change the target type of the link to the specified type or
     a union of types.  Only valid for concrete links.
 
+:eql:synopsis:`ALTER ANNOTATION <annotation-name>;`
+    Alter link annotation :eql:synopsis:`<annotation-name>`.
+    See :eql:stmt:`ALTER ANNOTATION <ALTER ANNOTATION>` for details.
+
 :eql:synopsis:`DROP ANNOTATION <annotation-name>;`
     Remove link item's annotation :eql:synopsis:`<annotation-name>`.
     See :eql:stmt:`DROP ANNOTATION <DROP ANNOTATION>` for details.
@@ -322,7 +327,7 @@ Set the ``title`` annotation of link ``friends`` of object type ``User`` to
 .. code-block:: edgeql
 
     ALTER TYPE User {
-        ALTER LINK interests SET ANNOTATION title := "Interests";
+        ALTER LINK interests CREATE ANNOTATION title := "Interests";
     };
 
 Add a minimum-length constraint to link ``name`` of object type ``User``:

--- a/docs/edgeql/ddl/objects.rst
+++ b/docs/edgeql/ddl/objects.rst
@@ -25,7 +25,7 @@ CREATE TYPE
 
     # where <subcommand> is one of
 
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
       CREATE LINK <link-name> ...
       CREATE PROPERTY <property-name> ...
       CREATE INDEX ON <index-expr>
@@ -74,11 +74,11 @@ Parameters
 
 The following subcommands are allowed in the ``CREATE TYPE`` block:
 
-:eql:synopsis:`SET ANNOTATION <annotation-name> := <value>`
+:eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>`
     Set object type :eql:synopsis:`<annotation-name>` to
     :eql:synopsis:`<value>`.
 
-    See :eql:stmt:`SET ANNOTATION` for details.
+    See :eql:stmt:`CREATE ANNOTATION` for details.
 
 :eql:synopsis:`CREATE LINK <link-name> ...`
     Define a new link for this object type.  See
@@ -130,7 +130,8 @@ Change the definition of an
 
       RENAME TO <newname>
       EXTENDING <parent> [, ...]
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
+      ALTER ANNOTATION <annotation-name> := <value>
       DROP ANNOTATION <annotation-name>
       CREATE LINK <link-name> ...
       ALTER LINK <link-name> ...
@@ -186,6 +187,10 @@ The following subcommands are allowed in the ``ALTER TYPE`` block:
       existing *parent*,
     * ``AFTER <parent>`` -- insert parent(s) after an existing
       *parent*.
+
+:eql:synopsis:`ALTER ANNOTATION <annotation-name>;`
+    Alter object type annotation :eql:synopsis:`<annotation-name>`.
+    See :eql:stmt:`ALTER ANNOTATION <ALTER ANNOTATION>` for details.
 
 :eql:synopsis:`DROP ANNOTATION <annotation-name>`
     Remove object type :eql:synopsis:`<annotation-name>`.

--- a/docs/edgeql/ddl/props.rst
+++ b/docs/edgeql/ddl/props.rst
@@ -47,7 +47,7 @@ CREATE PROPERTY
 
       SET default := <expression>
       SET readonly := {true | false}
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
       CREATE CONSTRAINT <constraint-name> ...
 
 
@@ -112,11 +112,11 @@ The following subcommands are allowed in the ``CREATE PROPERTY`` block:
     of this property are prohibited once an object is created.  All of the
     derived properties **must** preserve the original *read-only* value.
 
-:eql:synopsis:`SET ANNOTATION <annotation-name> := <value>`
+:eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>`
     Set property :eql:synopsis:`<annotation-name>` to
     :eql:synopsis:`<value>`.
 
-    See :eql:stmt:`SET ANNOTATION` for details.
+    See :eql:stmt:`CREATE ANNOTATION` for details.
 
 :eql:synopsis:`CREATE CONSTRAINT`
     Define a concrete constraint on the property.
@@ -188,7 +188,8 @@ Change the definition of a :ref:`property <ref_datamodel_props>`.
       SET SINGLE
       SET MULTI
       SET TYPE <typename> [, ...]
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
+      ALTER ANNOTATION <annotation-name> := <value>
       DROP ANNOTATION <annotation-name>
       CREATE CONSTRAINT <constraint-name> ...
       ALTER CONSTRAINT <constraint-name> ...
@@ -267,6 +268,10 @@ The following subcommands are allowed in the ``ALTER LINK`` block:
     Change the target type of the property to the specified type or
     a union of types.  Only valid for concrete properties.
 
+:eql:synopsis:`ALTER ANNOTATION <annotation-name>;`
+    Alter property annotation :eql:synopsis:`<annotation-name>`.
+    See :eql:stmt:`ALTER ANNOTATION <ALTER ANNOTATION>` for details.
+
 :eql:synopsis:`DROP ANNOTATION <annotation-name>;`
     Remove property :eql:synopsis:`<annotation-name>`.
     See :eql:stmt:`DROP ANNOTATION <DROP ANNOTATION>` for details.
@@ -293,7 +298,7 @@ Set the ``title`` annotation of property ``address`` of object type
 
     ALTER TYPE User {
         ALTER PROPERTY address
-            SET ANNOTATION title := "Home address";
+            CREATE ANNOTATION title := "Home address";
     };
 
 Add a maximum-length constraint to property ``address`` of object type

--- a/docs/edgeql/ddl/scalars.rst
+++ b/docs/edgeql/ddl/scalars.rst
@@ -24,7 +24,7 @@ CREATE SCALAR TYPE
 
     # where <subcommand> is one of
 
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
       CREATE CONSTRAINT <constraint-name> ...
 
 
@@ -63,11 +63,11 @@ subtype with constraints.
 
 The following subcommands are allowed in the ``CREATE SCALAR TYPE`` block:
 
-:eql:synopsis:`SET ANNOTATION <annotation-name> := <value>;`
+:eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>;`
     Set scalar type's :eql:synopsis:`<annotation-name>` to
     :eql:synopsis:`<value>`.
 
-    See :eql:stmt:`SET ANNOTATION` for details.
+    See :eql:stmt:`CREATE ANNOTATION` for details.
 
 :eql:synopsis:`CREATE CONSTRAINT <constraint-name> ...`
     Define a new constraint for this scalar type.  See
@@ -113,7 +113,8 @@ Alter the definition of a :ref:`scalar type <ref_datamodel_scalar_types>`.
 
       RENAME TO <newname>
       EXTENDING ...
-      SET ANNOTATION <annotation-name> := <value>
+      CREATE ANNOTATION <annotation-name> := <value>
+      ALTER ANNOTATION <annotation-name> := <value>
       DROP ANNOTATION <annotation-name>
       CREATE CONSTRAINT <constraint-name> ...
       ALTER CONSTRAINT <constraint-name> ...
@@ -136,10 +137,13 @@ The following subcommands are allowed in the ``ALTER SCALAR TYPE`` block:
     Alter the supertype list.  It works the same way as in
     :eql:stmt:`ALTER TYPE`.
 
+:eql:synopsis:`ALTER ANNOTATION <annotation-name>;`
+    Alter scalar type :eql:synopsis:`<annotation-name>`.
+    See :eql:stmt:`ALTER ANNOTATION <ALTER ANNOTATION>` for details.
+
 :eql:synopsis:`DROP ANNOTATION <annotation-name>`
     Remove scalar type's :eql:synopsis:`<annotation-name>` to
     :eql:synopsis:`<value>`.
-
     See :eql:stmt:`DROP ANNOTATION <DROP ANNOTATION>` for details.
 
 :eql:synopsis:`ALTER CONSTRAINT <constraint-name> ...`

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -881,6 +881,10 @@ class CreateAnnotationValue(CreateObject):
     value: Expr
 
 
+class AlterAnnotationValue(AlterObject):
+    value: Expr
+
+
 class DropAnnotationValue(DropObject):
     pass
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1060,7 +1060,16 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         if self.sdlmode:
             self.write('annotation ')
         else:
-            self.write('SET ANNOTATION ')
+            self.write('CREATE ANNOTATION ')
+        self.visit(node.name)
+        self.write(' := ')
+        self.visit(node.value)
+
+    def visit_AlterAnnotationValue(
+        self,
+        node: qlast.AlterAnnotationValue
+    ) -> None:
+        self.write('ALTER ANNOTATION ')
         self.visit(node.name)
         self.write(' := ')
         self.visit(node.value)

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -301,11 +301,19 @@ class SetFieldStmt(Nonterm):
         )
 
 
-class SetAnnotationValueStmt(Nonterm):
-    def reduce_SETANNOTATION_NodeName_ASSIGN_Expr(self, *kids):
+class CreateAnnotationValueStmt(Nonterm):
+    def reduce_CREATE_ANNOTATION_NodeName_ASSIGN_Expr(self, *kids):
         self.val = qlast.CreateAnnotationValue(
-            name=kids[1].val,
-            value=kids[3].val,
+            name=kids[2].val,
+            value=kids[4].val,
+        )
+
+
+class AlterAnnotationValueStmt(Nonterm):
+    def reduce_ALTER_ANNOTATION_NodeName_ASSIGN_Expr(self, *kids):
+        self.val = qlast.AlterAnnotationValue(
+            name=kids[2].val,
+            value=kids[4].val,
         )
 
 
@@ -325,7 +333,9 @@ commands_block(
     'Create',
     UsingStmt,
     SetFieldStmt,
-    SetAnnotationValueStmt)
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
+)
 
 
 commands_block(
@@ -333,7 +343,8 @@ commands_block(
     UsingStmt,
     RenameStmt,
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
     opt=False)
 
@@ -680,7 +691,8 @@ commands_block(
     RenameStmt,
     SetFieldStmt,
     SetDelegatedStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
     AlterAbstract,
     opt=False
@@ -718,7 +730,8 @@ class DropConcreteConstraintStmt(Nonterm):
 commands_block(
     'CreateScalarType',
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     CreateConcreteConstraintStmt)
 
 
@@ -767,7 +780,8 @@ commands_block(
     'AlterScalarType',
     RenameStmt,
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
     AlterExtending,
     CreateConcreteConstraintStmt,
@@ -835,7 +849,8 @@ class DropAnnotationStmt(Nonterm):
 commands_block(
     'AlterIndex',
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
     opt=False)
 
@@ -908,7 +923,8 @@ commands_block(
     'AlterProperty',
     RenameStmt,
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
     opt=False
 )
@@ -945,7 +961,8 @@ commands_block(
     'CreateConcreteProperty',
     UsingStmt,
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     CreateConcreteConstraintStmt
 )
 
@@ -1049,7 +1066,8 @@ commands_block(
     UsingStmt,
     RenameStmt,
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
     SetPropertyTypeStmt,
     SetCardinalityStmt,
@@ -1095,7 +1113,8 @@ class DropConcretePropertyStmt(Nonterm):
 commands_block(
     'CreateLink',
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     CreateConcreteConstraintStmt,
     CreateConcretePropertyStmt,
     CreateIndexStmt,
@@ -1123,7 +1142,8 @@ commands_block(
     'AlterLink',
     RenameStmt,
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
     AlterSimpleExtending,
     CreateConcreteConstraintStmt,
@@ -1184,7 +1204,8 @@ commands_block(
     'CreateConcreteLink',
     UsingStmt,
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     CreateConcreteConstraintStmt,
     CreateConcretePropertyStmt,
     commondl.OnTargetDeleteStmt,
@@ -1255,7 +1276,8 @@ commands_block(
     UsingStmt,
     RenameStmt,
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
     SetCardinalityStmt,
     SetRequiredStmt,
@@ -1308,7 +1330,8 @@ class DropConcreteLinkStmt(Nonterm):
 commands_block(
     'CreateObjectType',
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     CreateConcretePropertyStmt,
     AlterConcretePropertyStmt,
     CreateConcreteLinkStmt,
@@ -1352,7 +1375,8 @@ commands_block(
     'AlterObjectType',
     RenameStmt,
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
     AlterSimpleExtending,
     CreateConcretePropertyStmt,
@@ -1413,7 +1437,8 @@ commands_block(
     'CreateAlias',
     UsingStmt,
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     opt=False
 )
 
@@ -1453,7 +1478,8 @@ commands_block(
     UsingStmt,
     RenameStmt,
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
     opt=False
 )
@@ -1536,7 +1562,8 @@ commands_block(
     'CreateFunction',
     commondl.FromFunction,
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     opt=False
 )
 
@@ -1640,7 +1667,8 @@ class OperatorCode(Nonterm):
 commands_block(
     'CreateOperator',
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     OperatorCode,
     opt=False
 )
@@ -1769,7 +1797,8 @@ class CreateOperatorStmt(Nonterm):
 commands_block(
     'AlterOperator',
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
     opt=False
 )
@@ -1868,7 +1897,8 @@ class CastCode(Nonterm):
 commands_block(
     'CreateCast',
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     CastCode,
     CastAllowedUse,
     opt=False
@@ -1992,7 +2022,8 @@ class CreateCastStmt(Nonterm):
 commands_block(
     'AlterCast',
     SetFieldStmt,
-    SetAnnotationValueStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
     opt=False
 )

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -56,30 +56,30 @@ ALTER TYPE cfg::Config {
     CREATE MULTI LINK sysobj -> cfg::SystemConfig;
 
     CREATE PROPERTY __internal_testvalue -> std::int64 {
-        SET ANNOTATION cfg::internal := 'true';
-        SET ANNOTATION cfg::system := 'true';
+        CREATE ANNOTATION cfg::internal := 'true';
+        CREATE ANNOTATION cfg::system := 'true';
         SET default := 0;
     };
 
     CREATE PROPERTY __internal_no_const_folding -> std::bool {
-        SET ANNOTATION cfg::internal := 'true';
+        CREATE ANNOTATION cfg::internal := 'true';
         SET default := false;
     };
 
     CREATE PROPERTY __internal_testmode -> std::bool {
-        SET ANNOTATION cfg::internal := 'true';
+        CREATE ANNOTATION cfg::internal := 'true';
         SET default := false;
     };
 
     CREATE PROPERTY __internal_restart -> std::bool {
-        SET ANNOTATION cfg::internal := 'true';
-        SET ANNOTATION cfg::system := 'true';
-        SET ANNOTATION cfg::requires_restart := 'true';
+        CREATE ANNOTATION cfg::internal := 'true';
+        CREATE ANNOTATION cfg::system := 'true';
+        CREATE ANNOTATION cfg::requires_restart := 'true';
         SET default := false;
     };
 
     CREATE MULTI PROPERTY multiprop -> std::str {
-        SET ANNOTATION cfg::internal := 'true';
+        CREATE ANNOTATION cfg::internal := 'true';
     };
 };
 

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -95,20 +95,20 @@ CREATE TYPE cfg::Auth {
 
 CREATE TYPE cfg::Config {
     CREATE REQUIRED PROPERTY listen_port -> std::int16 {
-        SET ANNOTATION cfg::system := 'true';
+        CREATE ANNOTATION cfg::system := 'true';
         SET default := 5656;
     };
 
     CREATE REQUIRED MULTI PROPERTY listen_addresses -> std::str {
-        SET ANNOTATION cfg::system := 'true';
+        CREATE ANNOTATION cfg::system := 'true';
     };
 
     CREATE MULTI LINK ports -> cfg::Port {
-        SET ANNOTATION cfg::system := 'true';
+        CREATE ANNOTATION cfg::system := 'true';
     };
 
     CREATE MULTI LINK auth -> cfg::Auth {
-        SET ANNOTATION cfg::system := 'true';
+        CREATE ANNOTATION cfg::system := 'true';
     };
 
     # Exposed backend settings follow.
@@ -116,29 +116,29 @@ CREATE TYPE cfg::Config {
     # the _read_sys_config function to select the value
     # from pg_settings in the config_backend CTE.
     CREATE PROPERTY shared_buffers -> std::str {
-        SET ANNOTATION cfg::system := 'true';
-        SET ANNOTATION cfg::backend_setting := '"shared_buffers"';
-        SET ANNOTATION cfg::requires_restart := 'true';
+        CREATE ANNOTATION cfg::system := 'true';
+        CREATE ANNOTATION cfg::backend_setting := '"shared_buffers"';
+        CREATE ANNOTATION cfg::requires_restart := 'true';
         SET default := '-1';
     };
 
     CREATE PROPERTY query_work_mem -> std::str {
-        SET ANNOTATION cfg::backend_setting := '"work_mem"';
+        CREATE ANNOTATION cfg::backend_setting := '"work_mem"';
         SET default := '-1';
     };
 
     CREATE PROPERTY effective_cache_size -> std::str {
-        SET ANNOTATION cfg::backend_setting := '"effective_cache_size"';
+        CREATE ANNOTATION cfg::backend_setting := '"effective_cache_size"';
         SET default := '-1';
     };
 
     CREATE PROPERTY effective_io_concurrency -> std::str {
-        SET ANNOTATION cfg::backend_setting := '"effective_io_concurrency"';
+        CREATE ANNOTATION cfg::backend_setting := '"effective_io_concurrency"';
         SET default := '50';
     };
 
     CREATE PROPERTY default_statistics_target -> std::str {
-        SET ANNOTATION cfg::backend_setting := '"default_statistics_target"';
+        CREATE ANNOTATION cfg::backend_setting := '"default_statistics_target"';
         SET default := '100';
     };
 };

--- a/edb/pgsql/datasources/schema/annos.py
+++ b/edb/pgsql/datasources/schema/annos.py
@@ -65,7 +65,8 @@ async def fetch_values(
                 a.value                     AS value,
                 a.inheritable               AS inheritable,
                 a.inherited_fields          AS inherited_fields,
-                a.is_local                  AS is_local
+                a.is_local                  AS is_local,
+                a.is_final                  AS is_final
             FROM
                 edgedb.AnnotationValue a
             WHERE

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -845,6 +845,7 @@ class IntrospectionMech:
                 value=value,
                 inheritable=r['inheritable'],
                 is_local=r['is_local'],
+                is_final=r['is_final'],
             )
 
             basemap[anno] = (r['bases'], r['ancestors'])

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -93,6 +93,7 @@ def linearize_delta(
 
     for _key, info in ordered:
         op = info['op']
+        # Elide empty ALTER statements from output.
         if (isinstance(op, sd.AlterObject)
                 and not len(op.get_subcommands())):
             continue

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3030,7 +3030,7 @@ aa';
                         baz := __source__.a + __source__.b
                     }.baz
                 ) {
-                    SET ANNOTATION title := 'special';
+                    CREATE ANNOTATION title := 'special';
                 };
             };
         };
@@ -3044,7 +3044,7 @@ aa';
                         baz := (__source__.a + __source__.b)
                     }).baz
                 ) {
-                    SET ANNOTATION title := 'special';
+                    CREATE ANNOTATION title := 'special';
                 };
             };
         };
@@ -3055,7 +3055,7 @@ aa';
         ALTER TYPE Foo {
             ALTER LINK bar {
                 ALTER CONSTRAINT my_constraint ON (foo) {
-                    SET ANNOTATION title := 'special';
+                    CREATE ANNOTATION title := 'special';
                 };
             };
             ALTER LINK baz {
@@ -3196,7 +3196,7 @@ aa';
     def test_edgeql_syntax_ddl_function_25(self):
         """
         CREATE FUNCTION foo() -> std::str {
-            SET ANNOTATION description := 'aaaa';
+            CREATE ANNOTATION description := 'aaaa';
             USING SQL $a$SELECT $$foo$$$a$;
         };
         """
@@ -3205,7 +3205,7 @@ aa';
         """
         CREATE FUNCTION foo() -> std::str {
             SET volatility := 'VOLATILE';
-            SET ANNOTATION description := 'aaaa';
+            CREATE ANNOTATION description := 'aaaa';
             USING SQL $a$SELECT $$foo$$$a$;
         };
         """
@@ -3215,7 +3215,7 @@ aa';
     def test_edgeql_syntax_ddl_function_27(self):
         """
         CREATE FUNCTION foo() -> std::str {
-            SET ANNOTATION description := 'aaaa';
+            CREATE ANNOTATION description := 'aaaa';
         };
         """
 
@@ -3225,7 +3225,7 @@ aa';
         """
         CREATE FUNCTION foo() -> std::str {
             USING SQL 'SELECT 1';
-            SET ANNOTATION description := 'aaaa';
+            CREATE ANNOTATION description := 'aaaa';
             USING SQL 'SELECT 2';
         };
         """
@@ -3682,11 +3682,11 @@ aa';
             DROP INDEX ON (.title);
 
             CREATE INDEX ON (.title) {
-                SET ANNOTATION system := 'Foo';
+                CREATE ANNOTATION system := 'Foo';
             };
 
             ALTER INDEX ON (.title) {
-                SET ANNOTATION system := 'Foo';
+                ALTER ANNOTATION system := 'Foo';
             };
 
             ALTER INDEX ON (.title) {
@@ -3699,7 +3699,7 @@ aa';
         """
         ALTER TYPE Foo {
             ALTER INDEX ON (.title) {
-                SET ANNOTATION system := 'Foo'
+                CREATE ANNOTATION system := 'Foo'
             };
 
             ALTER INDEX ON (.title) {
@@ -3711,7 +3711,7 @@ aa';
 
         ALTER TYPE Foo {
             ALTER INDEX ON (.title) {
-                SET ANNOTATION system := 'Foo';
+                CREATE ANNOTATION system := 'Foo';
             };
 
             ALTER INDEX ON (.title) {

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -288,7 +288,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
     async def test_edgeql_userddl_22(self):
         await self.con.execute('''
             CREATE ABSTRACT CONSTRAINT test::uppercase {
-                SET ANNOTATION title := "Upper case constraint";
+                CREATE ANNOTATION title := "Upper case constraint";
                 USING (str_upper(__subject__) = __subject__);
                 SET errmessage := "{__subject__} is not in upper case";
             };

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -461,9 +461,9 @@ _123456789_123456789_123456789 -> str
             CREATE ABSTRACT INHERITABLE ANNOTATION default::inh_anno;
             CREATE ABSTRACT ANNOTATION default::noinh_anno;
             ALTER TYPE default::Base
-                SET ANNOTATION default::noinh_anno := 'foo';
+                CREATE ANNOTATION default::noinh_anno := 'foo';
             ALTER TYPE default::Base
-                SET ANNOTATION default::inh_anno := 'bar';
+                CREATE ANNOTATION default::inh_anno := 'bar';
         ''')
 
         inh_anno = schema.get('default::inh_anno')
@@ -1280,7 +1280,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             SELECT
                 Foo
             );
-            SET ANNOTATION std::title := 'A Foo alias';
+            CREATE ANNOTATION std::title := 'A Foo alias';
         };
     ''')
     def test_get_migration_16(self):
@@ -4281,7 +4281,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                         calc := 1
                     }
                 );
-                SET ANNOTATION std::title := 'bar alias';
+                CREATE ANNOTATION std::title := 'bar alias';
             };
             """
         )
@@ -4351,7 +4351,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             CREATE TYPE test::Foo {
                 CREATE SINGLE PROPERTY annotated_compprop {
                     USING ('foo');
-                    SET ANNOTATION std::title := 'compprop';
+                    CREATE ANNOTATION std::title := 'compprop';
                 };
                 CREATE SINGLE LINK annotated_link {
                     USING (WITH
@@ -4361,7 +4361,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     LIMIT
                         1
                     );
-                    SET ANNOTATION std::title := 'complink';
+                    CREATE ANNOTATION std::title := 'complink';
                 };
                 CREATE SINGLE LINK complink := (WITH
                     MODULE test
@@ -4398,7 +4398,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             CREATE TYPE test::Foo {
                 CREATE SINGLE PROPERTY annotated_compprop {
                     USING ('foo');
-                    SET ANNOTATION std::title := 'compprop';
+                    CREATE ANNOTATION std::title := 'compprop';
                 };
                 CREATE SINGLE LINK annotated_link {
                     USING (WITH
@@ -4408,7 +4408,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     LIMIT
                         1
                     );
-                    SET ANNOTATION std::title := 'complink';
+                    CREATE ANNOTATION std::title := 'complink';
                 };
                 CREATE SINGLE LINK complink := (WITH
                     MODULE test
@@ -4491,7 +4491,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             CREATE TYPE test::B EXTENDING test::A {
                 SET id := <std::uuid>'@SID@';
                 ALTER PROPERTY foo {
-                    SET ANNOTATION std::title := 'test';
+                    CREATE ANNOTATION std::title := 'test';
                 };
             };
             """

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1844,7 +1844,7 @@ class TestServerProto(tb.QueryTestCase):
                     SET MODULE test;
 
                     CREATE ABSTRACT CONSTRAINT uppercase {
-                        SET ANNOTATION title := "Upper case constraint";
+                        CREATE ANNOTATION title := "Upper case constraint";
                         USING (str_upper(__subject__) = __subject__);
                         SET errmessage := "{__subject__} is not in upper case";
                     };

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.96)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.97)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
Currently, the same syntax is used both to create and to alter
annotation values on schema objects: `SET ANNOTATION foo := 'value'`.
The current handling of the alter path is hacky and unreliable.
Additionally, there's no valid reason for the syntax (aside from
history) to differ from the usual `CREATE/ALTER` verbs used for every
other object.