### PR TITLE
docs: Update the documentation for SDL.

### DIFF
--- a/docs/datamodel/modules.rst
+++ b/docs/datamodel/modules.rst
@@ -29,5 +29,6 @@ Every EdgeDB schema contains the following standard modules:
 See Also
 --------
 
+:ref:`SDL <ref_eql_sdl_modules>`,
 :eql:stmt:`CREATE MODULE`,
 :eql:stmt:`DROP MODULE`.

--- a/docs/edgeql/ddl/migrations.rst
+++ b/docs/edgeql/ddl/migrations.rst
@@ -22,26 +22,14 @@ Create a new migration.
         [ ... ]
     "}" ;
 
-    [ WITH [ <module-alias> := ] MODULE <module-name> ]
-    CREATE MIGRATION <name> "{"
-        <ddl-command> ;
-        [ ... ]
-    "}" ;
-
 
 Description
 -----------
 
-``CREATE MIGRATION`` defines a new schema migration for a specific module.
-If *name* is qualified with a module name, then the migration is created
-for that module, owtherwise it is created for the current module, as
-determined by the session or the ``WITH`` block.
-
-There are two forms of ``CREATE MIGRATION`` as shown in the synopsis above.
-The first form uses a specific description of the target schema state and
-generates the necessary DDL commands automatically based on the current and
-the target state.  The second form uses explicit DDL command specifications
-for the migration.
+``CREATE MIGRATION`` defines a migration of the schema to a new state.
+The target schema state is described using :ref:`SDL <ref_eql_sdl>`
+and the migration generates the necessary :ref:`DDL <ref_eql_ddl>`
+commands behind the scenes based on the current and the target state.
 
 **Important:** ``CREATE MIGRATION`` and the follow-up
 :eql:stmt:`COMMIT MIGRATION` must be executed in a transaction block.
@@ -65,11 +53,6 @@ Parameters
     Module contents defined using the declarative :ref:`EdgeDB schema
     definition language<ref_eql_sdl>`.
 
-:eql:synopsis:`<ddl-command>`
-    A list of arbitrary DDL commands.  :ref:`Database <ref_admin_databases>`,
-    :ref:`module <ref_eql_ddl_modules>`, and migration commands cannot be
-    used here.
-
 
 Examples
 --------
@@ -86,21 +69,6 @@ syntax:
             }
         }
     };
-
-Create a new migration for the "payments" module using explicit DDL:
-
-.. code-block:: edgeql
-
-    START TRANSACTION;
-
-    CREATE MIGRATION alter_tx {
-        ALTER TYPE payments::Payment CREATE PROPERTY amount -> str;
-        ALTER TYPE payments::CreditCard CREATE PROPERTY cvv -> str;
-    };
-
-    COMMIT MIGRATION alter_tx;
-
-    COMMIT;
 
 
 COMMIT MIGRATION
@@ -138,7 +106,7 @@ Commit the "alter_tx" migration:
 
 .. code-block:: edgeql
 
-    COMMIT MIGRATION payments::alter_tx;
+    COMMIT MIGRATION init;
 
 
 DROP MIGRATION

--- a/docs/edgeql/ddl/modules.rst
+++ b/docs/edgeql/ddl/modules.rst
@@ -19,6 +19,10 @@ Create a new module.
 
     CREATE MODULE <name> ;
 
+There's a :ref:`corresponding SDL declaration <ref_eql_sdl_modules>`
+for a module, although in SDL a module declaration is likely to also
+include that module's content.
+
 Description
 -----------
 

--- a/docs/edgeql/sdl/index.rst
+++ b/docs/edgeql/sdl/index.rst
@@ -13,13 +13,18 @@ language and the imperative low-level :ref:`DDL <ref_eql_ddl>`.
 
 SDL is a declarative language optimized for human readability and
 expressing the state of the EdgeDB schema without getting into the
-details of how to arrive at that state.  Each *.esdl* file represents
-a complete schema state for a particular
-:ref:`module <ref_datamodel_modules>`.
+details of how to arrive at that state.  Each *SDL* block represents
+the complete schema state for a given :ref:`database
+<ref_datamodel_databases>`.
 
 Syntactically, an SDL declaration mirrors the ``CREATE`` DDL for the
 corresponding entity, but with all of the ``CREATE`` and ``SET``
-keywords omitted.
+keywords omitted.  The typical SDL structure is to use :ref:`module
+blocks <ref_eql_sdl_modules>` with the rest of the declarations being
+nested in their respective modules.
+
+Since SDL is declarative in nature, the specific order of
+declarations of module blocks or individual items does not matter.
 
 SDL is used to specify a :ref:`migration <ref_eql_ddl_migrations>` to a to a
 specific schema state. For example:
@@ -29,6 +34,7 @@ specific schema state. For example:
     db> START TRANSACTION;
     START TRANSACTION
     db> CREATE MIGRATION movies TO {
+    ...     # "default" module block
     ...     module default {
     ...         type Movie {
     ...             required property title -> str;
@@ -49,11 +55,41 @@ specific schema state. For example:
     db> COMMIT;
     COMMIT TRANSACTION
 
+It is possible to also omit the module blocks, but then individual
+declarations must use :ref:`fully-qualified names
+<ref_eql_fundamentals_name_resolution>` so that they can be assigned
+to their respective modules. For example the following is equivalent
+to the previous migration:
+
+.. code-block:: edgeql-repl
+
+    db> START TRANSACTION;
+    START TRANSACTION
+    db> CREATE MIGRATION movies TO {
+    ...     # no module block
+    ...     type default::Movie {
+    ...         required property title -> str;
+    ...         # the year of release
+    ...         property year -> int64;
+    ...         required link director -> default::Person;
+    ...         required multi link actors -> default::Person;
+    ...     }
+    ...     type default::Person {
+    ...         required property first_name -> str;
+    ...         required property last_name -> str;
+    ...     }
+    ... };
+    CREATE MIGRATION
+    db> COMMIT MIGRATION movies;
+    COMMIT MIGRATION
+    db> COMMIT;
+    COMMIT TRANSACTION
 
 .. toctree::
     :maxdepth: 3
     :hidden:
 
+    modules
     objects
     scalars
     links

--- a/docs/edgeql/sdl/modules.rst
+++ b/docs/edgeql/sdl/modules.rst
@@ -1,0 +1,102 @@
+.. _ref_eql_sdl_modules:
+
+=======
+Modules
+=======
+
+This section describes the SDL commands pertaining to
+:ref:`modules <ref_datamodel_modules>`.
+
+
+Example
+-------
+
+Declare an empty module:
+
+.. code-block:: sdl
+
+    module my_module {}
+
+
+Declare a module with some content:
+
+.. code-block:: sdl
+
+    module my_module {
+        type User {
+            required property name -> str;
+        }
+    }
+
+Syntax
+------
+
+Define a module corresponding to the :ref:`more explicit DDL
+commands <ref_eql_ddl_modules>`.
+
+.. sdl:synopsis::
+
+    module <ModuleName> "{"
+      [ <schema-declarations> ]
+      ...
+    "}"
+
+
+Description
+-----------
+
+The module block declaration defines a new module much like
+:eql:stmt:`CREATE MODULE`.  Unlike its DDL counterpart the module
+block can have sub-declarations:
+
+:sdl:synopsis:`<schema-declarations>`
+    Define various schema items that belong to this module.
+
+Unlike :eql:stmt:`CREATE MODULE` command, a module block with the
+same name can appear multiple times in an SDL document.  In that case
+all blocks with the same name are merged into a single module under
+that name. For example:
+
+.. code-block:: sdl
+
+    module my_module {
+        abstract type Named {
+            required property name -> str;
+        }
+    }
+
+    module my_module {
+        type User extending Named;
+    }
+
+The above is equivalent to:
+
+.. code-block:: sdl
+
+    module my_module {
+        abstract type Named {
+            required property name -> str;
+        }
+
+        type User extending Named;
+    }
+
+Typically, in the documentation examples of SDL the *module block* is
+omitted and instead its contents are described without assuming which
+specific module they belong to.
+
+It's also possible to declare modules implicitly. In this style SDL
+declaration uses :ref:`fully-qualified
+name<ref_eql_fundamentals_name_resolution>` for the item that is being
+declared.  The *module* part of the *fully-qualified* name implies
+that a module by that name will be automatically created in the
+schema.  The following declaration is equivalent to the previous
+examples, but it declares module ``my_module`` implicitly:
+
+.. code-block:: sdl
+
+    abstract type my_module::Named {
+        required property name -> str;
+    }
+
+    type my_module::User extending my_module::Named;

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -254,7 +254,21 @@ class TestDocSnippets(unittest.TestCase):
                 if lang == 'edgeql':
                     ql_parser.parse_block(snippet)
                 elif lang == 'sdl':
-                    ql_parser.parse_sdl(f'module default {{ {snippet} }}')
+                    # the snippet itself may either containt a module
+                    # block or have a fully-qualified top-level name
+                    if re.match(
+                            r'''(?xm)
+                                (\bmodule\s+\w+\s*{) |
+                                (^.*
+                                    (type|annotation|link|property|constraint)
+                                    \s+(\w+::\w+)\s+
+                                    ({|extending)
+                                )
+                            ''',
+                            snippet):
+                        ql_parser.parse_sdl(snippet)
+                    else:
+                        ql_parser.parse_sdl(f'module default {{ {snippet} }}')
                 elif lang == 'edgeql-result':
                     # REPL results
                     pass


### PR DESCRIPTION
Update the SDL overview documentaiton to indicate that the SDL describes
the schema as a whole as opposed to a single module.

Add a section to describe SDL module blocks.

Make doc tests aware that SDL may or may not contain a module block and
thus require slightly different handling of the syntax test.

Fixes: #974.