### PR TITLE
Untangle the CREATE DDL path

### DIFF
--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -243,7 +243,7 @@ ALTER TYPE schema::BaseObjectType {
 CREATE TYPE schema::ObjectType EXTENDING schema::BaseObjectType;
 
 
-CREATE TYPE schema::DerivedObjectType EXTENDING schema::BaseObjectType;
+CREATE TYPE schema::CompoundObjectType EXTENDING schema::BaseObjectType;
 
 
 CREATE TYPE schema::Link EXTENDING schema::Pointer, schema::Source;

--- a/edb/pgsql/datasources/schema/objtypes.py
+++ b/edb/pgsql/datasources/schema/objtypes.py
@@ -52,30 +52,3 @@ async def fetch(
                 AND ($2::text[] IS NULL
                      OR split_part(c.name, '::', 1) != all($2::text[]))
     """, modules, exclude_modules)
-
-
-async def fetch_derived(
-        conn: asyncpg.connection.Connection,
-        *,
-        modules=None,
-        exclude_modules=None) -> List[asyncpg.Record]:
-    return await conn.fetch("""
-        SELECT
-                c.id AS id,
-                c.name AS name,
-                edgedb._resolve_type_name(c.bases) AS bases,
-                edgedb._resolve_type_name(c.ancestors) AS ancestors,
-                c.is_abstract AS is_abstract,
-                c.is_final AS is_final,
-                c.expr_type AS expr_type,
-                c.alias_is_persistent AS alias_is_persistent,
-                c.expr AS expr,
-                c.inherited_fields AS inherited_fields
-            FROM
-                edgedb.DerivedObjectType c
-            WHERE
-                ($1::text[] IS NULL
-                 OR split_part(c.name, '::', 1) = any($1::text[]))
-                AND ($2::text[] IS NULL
-                     OR split_part(c.name, '::', 1) != all($2::text[]))
-    """, modules, exclude_modules)

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3153,7 +3153,11 @@ async def generate_views(conn, schema):
                     views[view.name] = view
 
         coltext = textwrap.indent(
-            ',\n'.join(('{} AS {}'.format(*c) for c in cols)), ' ' * 16)
+            ',\n'.join(
+                '{} AS {}'.format(*c) for c in sorted(cols, key=lambda c: c[1])
+            ),
+            ' ' * 16,
+        )
 
         if issubclass(mcls, s_inheriting.InheritingObject):
             objtab = 'edgedb.InheritingObject'

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -263,7 +263,7 @@ def delta_schemas(
                 extra_filters=filters + schema_a_filters,
             )
 
-        objects.update(so.Object.delta_sets(
+        objects.add(so.Object.delta_sets(
             old, new, old_schema=schema_a, new_schema=schema_b))
 
     if linearize_delta:
@@ -271,7 +271,7 @@ def delta_schemas(
             objects, old_schema=schema_a, new_schema=schema_b)
 
     if include_derived_types:
-        result.update(objects)
+        result.add(objects)
     else:
         for cmd in objects.get_subcommands():
             if isinstance(cmd, objtypes.ObjectTypeCommand):

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -339,7 +339,8 @@ class ParameterCommand(referencing.StronglyReferencedObjectCommand,
     pass
 
 
-class CreateParameter(ParameterCommand, sd.CreateObject):
+class CreateParameter(ParameterCommand, sd.CreateObject,
+                      sd.CreateObjectFragment):
 
     @classmethod
     def _cmd_tree_from_ast(cls, schema: s_schema.Schema, astnode, context):
@@ -598,7 +599,7 @@ class CallableObject(s_anno.AnnotationSubject, CallableLike):
             else:
                 newcoll = []
 
-            delta.update(cls.delta_sets(
+            delta.add(cls.delta_sets(
                 oldcoll, newcoll, context,
                 old_schema=old_schema, new_schema=new_schema))
 
@@ -665,14 +666,7 @@ class CallableCommand(sd.ObjectCommand):
         params = self.get_attribute_value('params')
 
         if params is None:
-            try:
-                params = self._get_params(schema, context)
-            except errors.InvalidReferenceError:
-                # Make sure the parameter objects exist.
-                for op in self.get_subcommands(metaclass=Parameter):
-                    schema, _ = op.apply(schema, context=context)
-
-                params = self._get_params(schema, context)
+            params = self._get_params(schema, context)
 
         schema, props = super()._prepare_create_fields(schema, context)
         props['params'] = params

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -271,12 +271,14 @@ class CreateLink(LinkCommand, referencing.CreateReferencedInheritingObject):
             super()._apply_field_ast(schema, context, node, op)
 
     def inherit_classref_dict(self, schema, context, refdict):
+        cmd = super().inherit_classref_dict(schema, context, refdict)
+
         if refdict.attr != 'pointers':
-            return super().inherit_classref_dict(schema, context, refdict)
+            return cmd
 
         parent_ctx = context.get(LinkSourceCommandContext)
         if parent_ctx is None:
-            return super().inherit_classref_dict(schema, context, refdict)
+            return cmd
 
         source_name = parent_ctx.op.classname
 
@@ -336,8 +338,7 @@ class CreateLink(LinkCommand, referencing.CreateReferencedInheritingObject):
             ),
         ))
 
-        self.add(src_prop)
-        schema, _ = src_prop.apply(schema, context)
+        cmd.prepend(src_prop)
 
         base_prop_name = sn.Name('std::target')
         s_name = sn.get_specialized_name(
@@ -393,10 +394,9 @@ class CreateLink(LinkCommand, referencing.CreateReferencedInheritingObject):
             ),
         ))
 
-        self.add(tgt_prop)
-        schema, _ = tgt_prop.apply(schema, context)
+        cmd.prepend(tgt_prop)
 
-        return super().inherit_classref_dict(schema, context, refdict)
+        return cmd
 
 
 class RenameLink(LinkCommand, sd.RenameObject):

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1107,7 +1107,7 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
             else:
                 newcoll_idx = []
 
-            delta.update(cls.delta_sets(
+            delta.add(cls.delta_sets(
                 oldcoll_idx, newcoll_idx, context,
                 old_schema=old_schema, new_schema=new_schema))
 
@@ -1442,7 +1442,7 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
                                  old_schema=old_schema,
                                  new_schema=new_schema))
 
-        adds_mods.update(dels)
+        adds_mods.add(dels)
         return adds_mods
 
     def dump(self, schema: s_schema.Schema) -> str:
@@ -1477,7 +1477,13 @@ class GlobalObject(UnqualifiedObject):
     pass
 
 
-class ObjectRef(Object):
+class BaseObjectRef:
+    # Object ref marker
+    def _resolve_ref(self, schema: s_schema.Schema) -> Object:
+        raise NotImplementedError
+
+
+class ObjectRef(Object, BaseObjectRef):
     _name: str
     _origname: Optional[str]
     _schemaclass: Optional[ObjectMeta]

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -575,7 +575,7 @@ class PointerCommandOrFragment:
             srcctx = self.get_attribute_source_context('target')
 
             if isinstance(target_ref, s_types.TypeExprRef):
-                schema, target = s_types.ensure_schema_type_expr_type(
+                target = s_types.ensure_schema_type_expr_type(
                     schema, target_ref, parent_cmd=self,
                     src_context=srcctx, context=context,
                 )

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 20191228_00_00
+EDGEDB_CATALOG_VERSION = 20200109_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2551,7 +2551,6 @@ class TestExpressions(tb.QueryTestCase):
                 'schema::Array',
                 'schema::Delta',
                 'schema::DerivedLink',
-                'schema::DerivedObjectType',
                 'schema::Object',
                 'schema::ObjectType',
                 'schema::Operator',

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -777,9 +777,9 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             r'''
                 WITH
                     MODULE schema,
-                    C2 := ObjectType
+                    C2 := ScalarType
                 SELECT
-                    count(re_match_all('(\\w+)', ObjectType.name)) =
+                    count(re_match_all('(\\w+)', ScalarType.name)) =
                     2 * count(C2);
             ''',
             [True],

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -95,9 +95,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "(test::Card)",
-            "(test::Card).<deck[IS __derived__::@SID@]\
+            "(test::Card).<deck[IS __derived__::(@SID@)]\
 .>indirection[IS test::User]": {
-                "(test::Card).<deck[IS __derived__::@SID@]"
+                "(test::Card).<deck[IS __derived__::(@SID@)]"
             },
             "FENCE": {
                 "(test::Card).>owner[IS test::User]"
@@ -118,9 +118,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "(test::Card)",
-            "(test::Card).<deck[IS __derived__::@SID@]\
+            "(test::Card).<deck[IS __derived__::(@SID@)]\
 .>indirection[IS test::User]": {
-                "(test::Card).<deck[IS __derived__::@SID@]"
+                "(test::Card).<deck[IS __derived__::(@SID@)]"
             },
             "FENCE": {
                 "(test::Card).>owner[IS test::User]"
@@ -292,9 +292,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 "(test::User).>friends[IS test::User]",
                 "FENCE": {
                     "(test::User).>deck[IS test::Card].\
-<deck[IS __derived__::@SID@].>indirection[IS test::User]": {
+<deck[IS __derived__::(@SID@)].>indirection[IS test::User]": {
                         "(test::User).>deck[IS test::Card].\
-<deck[IS __derived__::@SID@]": {
+<deck[IS __derived__::(@SID@)]": {
                             "(test::User).>deck[IS test::Card]"
                         }
                     }
@@ -322,9 +322,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::Card).>owners[IS test::User]": {
                 "(test::Card)",
                 "FENCE": {
-                    "ns~1@@(test::Card).<deck[IS __derived__::@SID@]\
+                    "ns~1@@(test::Card).<deck[IS __derived__::(@SID@)]\
 .>indirection[IS test::User]": {
-                        "ns~1@@(test::Card).<deck[IS __derived__::@SID@]"
+                        "ns~1@@(test::Card).<deck[IS __derived__::(@SID@)]"
                     }
                 }
             }
@@ -509,9 +509,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "FENCE": {
                 "(test::Card).>owners[IS test::User]": {
                     "FENCE": {
-                        "ns~1@@(test::Card).<deck[IS __derived__::@SID@]\
+                        "ns~1@@(test::Card).<deck[IS __derived__::(@SID@)]\
 .>indirection[IS test::User]": {
-                            "ns~1@@(test::Card).<deck[IS __derived__::@SID@]"
+                            "ns~1@@(test::Card).<deck[IS __derived__::(@SID@)]"
                         }
                     }
                 }
@@ -738,9 +738,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                     "(__derived__::__derived__|A@@w~1)",
                     "FENCE": {
                         "ns~2@@(__derived__::__derived__|A@@w~1)\
-.<deck[IS __derived__::@SID@].>indirection[IS test::User]": {
+.<deck[IS __derived__::(@SID@)].>indirection[IS test::User]": {
                             "ns~2@@(__derived__::__derived__|A@@w~1)\
-.<deck[IS __derived__::@SID@]"
+.<deck[IS __derived__::(@SID@)]"
                         }
                     }
                 }

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -230,13 +230,13 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 100.00)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.31)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.34)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)
 
     def test_cqa_type_coverage_pgsql_datasources(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql" / "datasources", 48.39)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql" / "datasources", 50.00)
 
     def test_cqa_type_coverage_pgsql_dbops(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 34.88)
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 40.68)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 40.82)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 10.92)


### PR DESCRIPTION
Currently, the order of processing of `CreateObject` subtrees is rather
awkward.  The generic implementation simply iterates over referenced
object subcommands, and various schema classes tack on their own hacks
to implement inheritance propagation etc.  On top of that, handling of
anonymous derived objects, like unions and collection types is hacky and
buggy as well.  To fix this, make the generic `CreateObject.apply` truly
generic, which makes it behave like `AlterObject.apply` already does.
This necessiated the addition of a concept of "prerequisites" for a
command, i.e. subcommands that must run before the object itself is
created.