### PR TITLE
Add args to the server for automatic temp cluster bootstrap

### DIFF
--- a/edb/server/buildmeta.py
+++ b/edb/server/buildmeta.py
@@ -18,6 +18,7 @@
 
 
 from __future__ import annotations
+from typing import *  # NoQA
 
 import enum
 import os
@@ -30,12 +31,12 @@ from edb.common import devmode
 try:
     import pkg_resources
 except ImportError:
-    pkg_resources = None
+    pkg_resources = None  # type: ignore
 
 try:
     import setuptools_scm
 except ImportError:
-    setuptools_scm = None
+    setuptools_scm = None  # type: ignore
 
 
 class MetadataError(Exception):
@@ -44,7 +45,7 @@ class MetadataError(Exception):
 
 def get_build_metadata_value(prop: str) -> str:
     try:
-        from . import _buildmeta
+        from . import _buildmeta  # type: ignore
         return getattr(_buildmeta, prop)
     except (ImportError, AttributeError):
         raise MetadataError(
@@ -53,7 +54,8 @@ def get_build_metadata_value(prop: str) -> str:
 
 def get_pg_config_path() -> pathlib.Path:
     if devmode.is_in_dev_mode():
-        root = pathlib.Path(edb.server.__path__[0]).parent.parent
+        edb_path: os.PathLike = edb.server.__path__[0]  # type: ignore
+        root = pathlib.Path(edb_path).parent.parent
         pg_config = (root / 'build' / 'postgres' /
                      'install' / 'bin' / 'pg_config').resolve()
         if not pg_config.is_file():
@@ -79,7 +81,7 @@ def get_pg_config_path() -> pathlib.Path:
     return pg_config
 
 
-def get_runstate_path(data_dir: os.PathLike) -> os.PathLike:
+def get_runstate_path(data_dir: pathlib.Path) -> pathlib.Path:
     if devmode.is_in_dev_mode():
         return data_dir
     else:
@@ -164,7 +166,7 @@ def get_version() -> Version:
         pv = pkg_resources.parse_version(version)
         version = parse_version(pv)
     else:
-        vertuple = list(get_build_metadata_value('VERSION'))
+        vertuple: List[Any] = list(get_build_metadata_value('VERSION'))
         vertuple[2] = VersionStage(vertuple[2])
         version = Version(*vertuple)
 

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -185,8 +185,7 @@ class Cluster:
         self._test_connection()
 
     def stop(self, wait=60):
-        if (
-                self._daemon_process is not None and
+        if (self._daemon_process is not None and
                 self._daemon_process.returncode is None):
             self._daemon_process.terminate()
             self._daemon_process.wait(wait)

--- a/edb/server/daemon/daemon.py
+++ b/edb/server/daemon/daemon.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import atexit
 import io
+import os
 import signal
 
 from . import lib, pidfile as pidfile_module
@@ -31,13 +32,13 @@ from .exceptions import DaemonError
 
 class DaemonContext:
     def __init__(
-            self, *, pidfile: str, files_preserve: list=None,
-            working_directory: str='/', umask: int=0o022, uid: int=None, gid:
-            int=None, detach_process: bool=None, prevent_core: bool=True,
+            self, *, pidfile: os.PathLike, files_preserve: list=None,
+            working_directory: str='/', umask: int=0o022, uid: int=None,
+            gid: int=None, detach_process: bool=None, prevent_core: bool=True,
             stdin: io.FileIO=None, stdout: io.FileIO=None, stderr:
             io.FileIO=None, signal_map: dict=None):
 
-        self.pidfile = pidfile
+        self.pidfile = os.fspath(pidfile)
         self.files_preserve = files_preserve
         self.working_directory = working_directory
         self.umask = umask

--- a/edb/server/mng_port/edgecon.pxd
+++ b/edb/server/mng_port/edgecon.pxd
@@ -82,6 +82,9 @@ cdef class EdgeConnection:
         bint debug
         bint query_cache_enabled
 
+        object server
+        bint authed
+
     cdef parse_json_mode(self, bytes mode)
     cdef parse_cardinality(self, bytes card)
     cdef char render_cardinality(self, query_unit) except -1

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -327,6 +327,7 @@ class Cluster(BaseCluster):
         if (self._daemon_process is not None and
                 self._daemon_process.returncode is None):
             self._daemon_process.kill()
+            self._daemon_process.wait(wait)
 
     def destroy(self):
         status = self.get_status()

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -1,0 +1,113 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os.path
+import subprocess
+import sys
+
+import edgedb
+
+from edb.testbase import server as tb
+
+
+class TestServerOps(tb.TestCase):
+
+    async def test_server_ops_temp_dir(self):
+        # Test that "edgedb-server" works as expected with the
+        # following arguments:
+        #
+        # * "--port=auto"
+        # * "--temp-dir"
+        # * "--auto-shutdown"
+        # * "--echo-runtime-info"
+
+        async def read_runtime_info(stdout: asyncio.StreamReader):
+            while True:
+                line = await stdout.readline()
+                if line.startswith(b'EDGEDB_SERVER_DATA:'):
+                    break
+
+            dataline = line.decode().split('EDGEDB_SERVER_DATA:', 1)[1]
+            data = json.loads(dataline)
+            return data
+
+        cmd = [
+            sys.executable, '-m', 'edb.server.main',
+            '--port', 'auto',
+            '--temp-dir',
+            '--auto-shutdown',
+            '--echo-runtime-info'
+        ]
+
+        # Note: for debug comment "stderr=subprocess.PIPE".
+        proc: asyncio.Process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+
+        try:
+            data = await asyncio.wait_for(
+                read_runtime_info(proc.stdout),
+                timeout=100)
+
+            runstate_dir = data['runstate_dir']
+            port = data['port']
+
+            self.assertTrue(os.path.exists(runstate_dir))
+
+            con1 = await edgedb.async_connect(
+                host=runstate_dir, port=port, admin=True)
+            self.assertEqual(await con1.fetchone('SELECT 1'), 1)
+
+            con2 = await edgedb.async_connect(
+                host=runstate_dir, port=port, admin=True)
+            self.assertEqual(await con2.fetchone('SELECT 1'), 1)
+
+            await con1.aclose()
+
+            self.assertEqual(await con2.fetchone('SELECT 42'), 42)
+            await con2.aclose()
+
+            with self.assertRaises(ConnectionError):
+                # Since both con1 and con2 are now disconnected and
+                # the cluster was started with an "--auto-shutdown"
+                # option, we expect this connection to be rejected
+                # and the cluster to be shutdown soon.
+                await edgedb.async_connect(
+                    host=runstate_dir, port=port, admin=True)
+
+            i = 600 * 5  # Give it up to 5 minutes to cleanup.
+            while i > 0:
+                if not os.path.exists(runstate_dir):
+                    break
+                else:
+                    i -= 1
+                    await asyncio.sleep(0.1)
+            else:
+                self.fail('temp directory was not cleaned up')
+
+        finally:
+            if proc.returncode is None:
+                proc.terminate()
+                await proc.wait()

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -248,7 +248,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "schema", 40.68)
 
     def test_cqa_type_coverage_server(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server", 10.92)
+        self.assertFunctionCoverage(EDB_DIR / "server", 11.23)
 
     def test_cqa_type_coverage_server_cache(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "cache", 0)
@@ -277,7 +277,7 @@ class TypeCoverageTests(unittest.TestCase):
         )
 
     def test_cqa_type_coverage_server_mng_port(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server" / "mng_port", 0)
+        self.assertFunctionCoverage(EDB_DIR / "server" / "mng_port", 6.67)
 
     def test_cqa_type_coverage_server_pgcon(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "pgcon", 0)


### PR DESCRIPTION
This adds the following args to the edgedb server:

* --temp-dir - to pick a random temp dir for the db cluster
* --auto-shutdown - to shutdown automatically when last connection
  disconnects
* --echo-runtime-info - to echo JSON with runtime parameters
  (runstate dir & the port the server listens on)