### PR TITLE
Avoid leaking concrete link module prefix in introspection

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3106,7 +3106,9 @@ async def generate_views(conn, schema):
                             f'ELSE {shortname_expr} END)'
                         )
                     else:
-                        col_expr = shortname_expr
+                        col_expr = (
+                            f"replace({shortname_expr}, '__::', '')"
+                        )
 
                 elif pn == 'inherited_fields':
                     col_expr = f'''

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 20200109_00_00
+EDGEDB_CATALOG_VERSION = 20200109_00_01
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs


### PR DESCRIPTION
All concrete links have a placeholder for the module name, make sure it
does not show up in introspection queries.

Fixes: #995.