### PR TITLE
Fix how DESCRIBE handles ON TARGET DELETE.

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -50,13 +50,6 @@ NonesFirst = NonesOrder.First
 NonesLast = NonesOrder.Last
 
 
-class LinkTargetDeleteAction(s_enum.StrEnum):
-    RESTRICT = 'RESTRICT'
-    DELETE_SOURCE = 'DELETE SOURCE'
-    ALLOW = 'ALLOW'
-    DEFERRED_RESTRICT = 'DEFERRED RESTRICT'
-
-
 class Base(ast.AST):
     __abstract_node__ = True
     __ast_hidden__ = {'context'}
@@ -610,7 +603,7 @@ class AlterDropInherit(DDLCommand, BasesMixin):
 
 
 class OnTargetDelete(DDLCommand):
-    cascade: LinkTargetDeleteAction
+    cascade: qltypes.LinkTargetDeleteAction
 
 
 class BaseSetField(DDLCommand):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1391,7 +1391,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self.visit(node.type)
 
     def visit_OnTargetDelete(self, node: qlast.OnTargetDelete) -> None:
-        self.write('ON TARGET DELETE ', node.cascade)
+        self._write_keywords('ON TARGET DELETE ', node.cascade)
 
     def visit_CreateObjectType(self, node: qlast.CreateObjectType) -> None:
         keywords = []

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -402,16 +402,16 @@ class ProcessFunctionBlockMixin:
 class OnTargetDeleteStmt(Nonterm):
     def reduce_ON_TARGET_DELETE_RESTRICT(self, *kids):
         self.val = qlast.OnTargetDelete(
-            cascade=qlast.LinkTargetDeleteAction.RESTRICT)
+            cascade=qltypes.LinkTargetDeleteAction.RESTRICT)
 
     def reduce_ON_TARGET_DELETE_DELETE_SOURCE(self, *kids):
         self.val = qlast.OnTargetDelete(
-            cascade=qlast.LinkTargetDeleteAction.DELETE_SOURCE)
+            cascade=qltypes.LinkTargetDeleteAction.DELETE_SOURCE)
 
     def reduce_ON_TARGET_DELETE_ALLOW(self, *kids):
         self.val = qlast.OnTargetDelete(
-            cascade=qlast.LinkTargetDeleteAction.ALLOW)
+            cascade=qltypes.LinkTargetDeleteAction.ALLOW)
 
     def reduce_ON_TARGET_DELETE_DEFERRED_RESTRICT(self, *kids):
         self.val = qlast.OnTargetDelete(
-            cascade=qlast.LinkTargetDeleteAction.DEFERRED_RESTRICT)
+            cascade=qltypes.LinkTargetDeleteAction.DEFERRED_RESTRICT)

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -107,3 +107,10 @@ class SchemaObjectClass(s_enum.StrEnum):
     PROPERTY = 'PROPERTY'
     SCALAR_TYPE = 'SCALAR TYPE'
     TYPE = 'TYPE'
+
+
+class LinkTargetDeleteAction(s_enum.StrEnum):
+    RESTRICT = 'RESTRICT'
+    DELETE_SOURCE = 'DELETE SOURCE'
+    ALLOW = 'ALLOW'
+    DEFERRED_RESTRICT = 'DEFERRED RESTRICT'

--- a/edb/pgsql/datasources/schema/links.py
+++ b/edb/pgsql/datasources/schema/links.py
@@ -45,6 +45,7 @@ async def fetch(
                 l.is_derived,
                 l.readonly,
                 l.default,
+                l.on_target_delete,
                 l.inherited_fields
             FROM
                 edgedb.link l

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -682,6 +682,12 @@ class IntrospectionMech:
             else:
                 cardinality = None
 
+            if r['on_target_delete']:
+                on_target_delete = qltypes.LinkTargetDeleteAction(
+                    r['on_target_delete'])
+            else:
+                on_target_delete = None
+
             schema, link = s_links.Link.create_in_schema(
                 schema,
                 id=r['id'],
@@ -696,6 +702,7 @@ class IntrospectionMech:
                 is_abstract=r['is_abstract'],
                 is_final=r['is_final'],
                 is_local=r['is_local'],
+                on_target_delete=on_target_delete,
                 readonly=r['readonly'],
             )
 


### PR DESCRIPTION
The code generation for `DESCRIBE` now correctly reflects all
`ON TARGET DELETE` settings for links.

Fixes: #1076.