### PR TITLE
Generalize preservation of original text in expression schema fields

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1037,3 +1037,11 @@ def get_targets(target: TypeExpr):
         return get_targets(target.left) + get_targets(target.right)
     else:
         return [target]
+
+
+def get_ddl_field_value(ddlcmd: ObjectDDL, name: str) -> typing.Optional[Expr]:
+    for cmd in ddlcmd.commands:
+        if isinstance(cmd, (SetField, SetSpecialField)) and cmd.name == name:
+            return cmd.value
+
+    return None

--- a/edb/lib/std/50-constraints.edgeql
+++ b/edb/lib/std/50-constraints.edgeql
@@ -63,7 +63,6 @@ CREATE ABSTRACT CONSTRAINT
 std::len_value ON (len(<std::str>__subject__)) EXTENDING std::constraint
 {
     SET errmessage := 'invalid {__subject__}';
-    SET orig_subjectexpr := r'len(<std::str>__subject__)';
 };
 
 

--- a/edb/pgsql/datasources/schema/constraints.py
+++ b/edb/pgsql/datasources/schema/constraints.py
@@ -43,7 +43,6 @@ async def fetch(
                                         AS ancestors,
                 a.expr                  AS expr,
                 a.subjectexpr           AS subjectexpr,
-                a.orig_subjectexpr      AS orig_subjectexpr,
                 a.finalexpr             AS finalexpr,
                 a.errmessage            AS errmessage,
                 a.args                  AS args,

--- a/edb/pgsql/datasources/schema/indexes.py
+++ b/edb/pgsql/datasources/schema/indexes.py
@@ -37,7 +37,6 @@ async def fetch(
                                 AS ancestors,
                 i.name          AS name,
                 i.expr          AS expr,
-                i.origexpr      AS origexpr,
                 i.is_local      AS is_local,
                 i.is_final      AS is_final,
                 i.is_abstract   AS is_abstract,

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -468,7 +468,6 @@ class IntrospectionMech:
                 is_final=r['is_final'],
                 is_local=r['is_local'],
                 delegated=r['delegated'],
-                orig_subjectexpr=r['orig_subjectexpr'],
                 errmessage=r['errmessage'],
                 args=([self.unpack_expr(arg, schema) for arg in r['args']]
                       if r['args'] is not None else None),
@@ -629,7 +628,6 @@ class IntrospectionMech:
                 name=index_name,
                 subject=subj,
                 is_local=index_data['is_local'],
-                origexpr=index_data['origexpr'],
                 inherited_fields=self._unpack_inherited_fields(
                     index_data['inherited_fields']),
                 expr=self.unpack_expr(index_data['expr'], schema))

--- a/edb/schema/abc.py
+++ b/edb/schema/abc.py
@@ -111,3 +111,7 @@ class Property(Pointer):
 
 class Link(Pointer):
     pass
+
+
+class Expression:
+    pass

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -32,7 +32,7 @@ from . import abc as s_abc
 from . import objects as so
 
 
-class Expression(struct.MixedStruct, s_abc.ObjectContainer):
+class Expression(struct.MixedStruct, s_abc.ObjectContainer, s_abc.Expression):
     text = struct.Field(str, frozen=True)
     origtext = struct.Field(str, default=None, frozen=True)
     refs = struct.Field(so.ObjectSet, coerce=True, default=None, frozen=True)
@@ -77,8 +77,17 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer):
             return compcoef
 
     @classmethod
-    def from_ast(cls, qltree, schema, modaliases, *, as_fragment=False):
-        orig_text = qlcodegen.generate_source(qltree, pretty=False)
+    def from_ast(
+        cls,
+        qltree,
+        schema,
+        modaliases,
+        *,
+        as_fragment=False,
+        orig_text=None,
+    ) -> Expression:
+        if orig_text is None:
+            orig_text = qlcodegen.generate_source(qltree, pretty=False)
         if not as_fragment:
             qltree = imprint_expr_context(qltree, modaliases)
         norm_text = qlcodegen.generate_source(qltree, pretty=False)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1663,19 +1663,8 @@ def ensure_schema_type_expr_type(
 
 class TypeCommand(sd.ObjectCommand):
     @classmethod
-    def _maybe_get_alias_expr(
-        cls, astnode: qlast.ObjectDDL
-    ) -> Optional[qlast.Expr]:
-        for subcmd in astnode.commands:
-            if (isinstance(subcmd, qlast.SetSpecialField) and
-                    subcmd.name == 'expr'):
-                return subcmd.value
-
-        return None
-
-    @classmethod
     def _get_alias_expr(cls, astnode: qlast.CreateAlias) -> qlast.Expr:
-        expr = cls._maybe_get_alias_expr(astnode)
+        expr = qlast.get_ddl_field_value(astnode, 'expr')
         if expr is None:
             raise errors.InvalidAliasDefinitionError(
                 f'missing required view expression', context=astnode.context)
@@ -1713,7 +1702,7 @@ class TypeCommand(sd.ObjectCommand):
     ) -> sd.Command:
         from . import ordering as s_ordering
 
-        view_expr = cls._maybe_get_alias_expr(astnode)
+        view_expr = qlast.get_ddl_field_value(astnode, 'expr')
         if view_expr is None:
             return cmd
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -4477,7 +4477,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                     WITH MODULE test
                     SELECT .name
                 ) {
-                    origexpr := '.name';
+                    orig_expr := '.name';
                 }
             }
         """)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -457,7 +457,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 SELECT ScalarType {
                     name,
                     constraints: {
-                        name
+                        name,
+                        subjectexpr,
                     }
                 }
                 FILTER .name LIKE '%bar%' OR .name LIKE '%foo%'
@@ -466,7 +467,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             [
                 {'name': 'bar::bar_t', 'constraints': []},
                 {'name': 'foo::foo_t', 'constraints': [
-                    {'name': 'std::expression'}
+                    {
+                        'name': 'std::expression',
+                        'subjectexpr': '(__subject__ > 0)',
+                    },
                 ]},
             ]
         )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3844,6 +3844,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             CREATE MODULE test IF NOT EXISTS;
 
             CREATE ABSTRACT CONSTRAINT test::my_one_of(one_of: array<anytype>){
+                SET orig_expr := r'contains(one_of, __subject__)';
                 USING (WITH
                     MODULE test
                 SELECT
@@ -4029,7 +4030,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 SELECT
                     __subject__.image
                 ) {
-                    origexpr := r'__subject__.image';
+                    orig_expr := r'__subject__.image';
                 };
                 required single property image -> std::str;
             };
@@ -4045,7 +4046,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 SELECT
                     __subject__.image
                 ) {
-                    SET origexpr := r'__subject__.image';
+                    SET orig_expr := r'__subject__.image';
                 };
             };
             '''
@@ -4099,6 +4100,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             '''
             CREATE ABSTRACT CONSTRAINT test::my_one_of(one_of: array<anytype>)
             {
+                SET orig_expr := r'contains(one_of, __subject__)';
                 USING (WITH
                     MODULE test
                 SELECT

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.92)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.97)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 42.50)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 42.62)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 11.23)


### PR DESCRIPTION
Currently, the expression text used in the original object definition is
handled by a bunch of duplicating hardcoded logic in the corresponding
object implementation.  This generalizes the mechanism and also makes
the "orig_expr" fields ephemeral, since the place for the storate of the
original text is in the main Expression structure.  The "orig_" fields
now essentially serve as markers that the corresponding expression field
should preserve the original text.  With a bit of further development,
it might be possible to elide the definition of these shadow fields
altogether and enable this behavior on all expression fields.