### PR TITLE
Prevent propagation of non-pointer refs into type variants

### DIFF
--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -31,6 +31,7 @@ from . import constraints
 from . import delta as sd
 from . import inheriting
 from . import name as sn
+from . import objects as so
 from . import pointers
 from . import referencing
 from . import sources
@@ -123,6 +124,21 @@ class Property(pointers.Pointer, s_abc.Property,
         if source is None:
             raise ValueError(f'{self.get_verbosename(schema)} is abstract')
         return isinstance(source, pointers.Pointer)
+
+    def allow_ref_propagation(
+        self,
+        schema: s_schema.Schema,
+        constext: sd.CommandContext,
+        refdict: so.RefDict,
+    ) -> bool:
+        source = self.get_source(schema)
+        if isinstance(source, pointers.Pointer):
+            if source.generic(schema):
+                return True
+            else:
+                return not source.get_source(schema).is_view(schema)
+        else:
+            return not self.get_source(schema).is_view(schema)
 
     @classmethod
     def get_root_classes(cls):

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -2096,6 +2096,14 @@ class InheritingObjectBase(Object):
                 f'field {field_name!r}'
             )
 
+    def allow_ref_propagation(
+        self,
+        schema: s_schema.Schema,
+        constext: sd.CommandContext,
+        refdict: RefDict,
+    ) -> bool:
+        return True
+
 
 @markup.serializer.serializer.register(Object)
 @markup.serializer.serializer.register(ObjectCollection)

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -248,6 +248,14 @@ class BaseObjectType(sources.Source,
                 None, self, old_schema=schema, new_schema=schema,
             )
 
+    def allow_ref_propagation(
+        self,
+        schema: s_schema.Schema,
+        constext: sd.CommandContext,
+        refdict: so.RefDict,
+    ) -> bool:
+        return not self.is_view(schema) or refdict.attr == 'pointers'
+
 
 class ObjectType(BaseObjectType, qlkind=qltypes.SchemaObjectClass.TYPE):
     pass

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -456,6 +456,14 @@ class Pointer(referencing.ReferencedInheritingObject,
     def has_user_defined_properties(self, schema):
         return False
 
+    def allow_ref_propagation(
+        self,
+        schema: s_schema.Schema,
+        constext: sd.CommandContext,
+        refdict: so.RefDict,
+    ) -> bool:
+        return not self.get_source(schema).is_view(schema)
+
 
 class PseudoPointer(s_abc.Pointer):
     # An abstract base class for pointer-like objects, i.e.

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -360,6 +360,14 @@ class Type(so.InheritingObjectBase, derivable.DerivableObjectBase, s_abc.Type):
     ) -> typing.Optional[sd.CreateObject]:
         return None
 
+    def allow_ref_propagation(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        refdict: so.RefDict,
+    ) -> bool:
+        return not self.is_view(schema)
+
 
 TypeExprRefT = typing.TypeVar('TypeExprRefT', bound='TypeExprRef')
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -555,11 +555,6 @@ _123456789_123456789_123456789 -> str
             'there should be no constraints on alias links or properties',
         )
 
-    @test.xfail('''
-        This DDL sequence results in a constraint propagated to the alias.
-
-        Issue #1005.
-    ''')
     def test_schema_constraint_inheritance_04(self):
         schema = tb._load_std_schema()
 

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 42.62)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 42.92)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 11.23)


### PR DESCRIPTION
Since type variants are ephemeral, the only inherited ref
propagation that makes sense is pointers, everything else
should not propagate.

Fixes: #1005