### PR TITLE
Change the syntax of target type intersection in shapes

### DIFF
--- a/docs/edgeql/introspection/colltypes.rst
+++ b/docs/edgeql/introspection/colltypes.rst
@@ -121,7 +121,7 @@ the :eql:func:`sys::get_version` function:
 
     db> WITH MODULE schema
     ... SELECT `Function` {
-    ...     return_type: Tuple {
+    ...     return_type[IS Tuple]: {
     ...         element_types: {
     ...             name,
     ...             type: { name }

--- a/docs/edgeql/overview.rst
+++ b/docs/edgeql/overview.rst
@@ -312,7 +312,7 @@ mix of everything:
     # User + favorite Articles only
     SELECT User {
         name,
-        favorites: Article {
+        favorites[IS Article]: {
             name,
             url
         }

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -513,16 +513,13 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self.visit(node.expr.steps[0])
             if not isinstance(node.expr.steps[1], qlast.TypeIntersection):
                 self.write('.')
-                self.visit(node.expr.steps[1])
+            self.visit(node.expr.steps[1])
+            if len(node.expr.steps) == 3:
+                self.visit(node.expr.steps[2])
 
-        if not node.compexpr and (node.elements
-                                  or isinstance(node.expr.steps[-1],
-                                                qlast.TypeIntersection)):
+        if not node.compexpr and node.elements:
             self.write(': ')
-            if isinstance(node.expr.steps[-1], qlast.TypeIntersection):
-                self.visit(node.expr.steps[-1].type)
-            if node.elements:
-                self._visit_shape(node.elements)
+            self._visit_shape(node.elements)
 
         if node.where:
             self.write(' FILTER ')

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -234,7 +234,7 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
                                     FILTER .name = 'owners')
                 SELECT
                     DCardOwners {
-                        target: ObjectType {
+                        target[IS ObjectType]: {
                             name,
                             pointers: {
                                 name

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -383,7 +383,7 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_nested_07(self):
         with self.assertRaisesRegex(
                 edgedb.EdgeQLSyntaxError,
-                "unexpected ':'"):
+                "Unexpected 'Subordinate'"):
             await self.con.execute('''
                 WITH MODULE test
                 INSERT InsertTest {

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -264,7 +264,7 @@ class TestIntrospection(tb.QueryTestCase):
                 WITH MODULE schema
                 SELECT ObjectType {
                     properties: {
-                        target: Array {
+                        target[IS Array]: {
                             name,
                             element_type: {
                                 name
@@ -394,7 +394,7 @@ class TestIntrospection(tb.QueryTestCase):
                     name,
                     params: {
                         num,
-                        type: schema::Array {
+                        type[IS schema::Array]: {
                             name,
                             element_type: {
                                 name

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1261,7 +1261,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             WITH MODULE test
             SELECT Named {
                 name,
-                [IS Issue].references: File {
+                [IS Issue].references[IS File]: {
                     name
                 }
             }
@@ -4945,7 +4945,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             WITH MODULE test
             SELECT Issue {
                 number,
-                references: Named {
+                references[IS Named]: {
                     __type__: {
                         name
                     },

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1247,7 +1247,7 @@ aa';
     def test_edgeql_syntax_shape_30(self):
         """
         SELECT Named {
-            [IS Issue].references: File {
+            [IS Issue].references[IS File]: {
                 name
             }
         };
@@ -2340,17 +2340,6 @@ aa';
         INSERT Foo{
             bar := 42,
             baz := (SELECT Baz FILTER (Baz.spam = 'ham'))
-        };
-        """
-
-    def test_edgeql_syntax_insert_14(self):
-        """
-        INSERT Foo{
-            bar := 42,
-            baz: Baz{
-                spam := 'ham',
-                @weight := 2,
-            }
         };
         """
 

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -484,7 +484,7 @@ class TestServerConfig(tb.QueryTestCase, tb.CLITestCaseMixin):
             '''
             SELECT cfg::Config.sysobj {
                 name,
-                obj: cfg::Subclass1 {
+                obj[IS cfg::Subclass1]: {
                     name,
                     sub1,
                 },

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.97)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.83)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
Currently, the syntax to specify the target type intersection in a shape
element expression is this:

    SELECT User {
        favorites: Book {  # Book is a type expression
            title
        }
    }

Despite being visually similar to the top shape, `Book` is not at all an
expression, it's a type expression equivalent to the inside of an
`[IS ...]` operator.  The confusion is further exacerbated by the fact
that changing the link from a traversal to a computable changes the
meaning of `Book` to be an expression:

    SELECT User {
        favorites:= Book {  # Book is an expression
            title
        }
    }

To avoid this confusion, change the target type intersection syntax in
shape navigation to use the `[IS ...]` syntax:

    SELECT User {
        favorites[IS Book]: {
            title
        }
    }

This has two nice properties:

a) We use `[IS ...]` consistently to express type intersection in all
   scenarios;

b) The shape construct becomes an almost perfect _folding_ of path syntax.
   Compare:

    AbstractUser[IS User].favorites[IS Book].title

and

    AbstractUser {
        [IS User].favorites[IS Book]: {
            title
        }
    }

The change is purely syntactic, since this is already represented as a
type intersection at the AST level.