### PR TITLE
Fix regression in restarting the management port

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -141,6 +141,7 @@ class Server:
                 mng_port.ManagementPort,
                 nethost=nethost,
                 netport=netport,
+                auto_shutdown=self._auto_shutdown,
             )
         except Exception:
             await self._mgmt_port.start()


### PR DESCRIPTION
Without this change the request crashes with:
```
Error: __init__() missing 1 required positional argument: 'auto_shutdown'
```
This was introduced in 5161de72b.