### PR TITLE
Fixes for server command-line

### DIFF
--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -416,11 +416,11 @@ def bump_rlimit_nofile() -> None:
                 logger.warning('could not set RLIMIT_NOFILE')
 
 
-def get_runstate_dir() -> Optional[str]:
+def _get_runstate_dir_default() -> str:
     try:
         return buildmeta.get_build_metadata_value("RUNSTATE_DIR")
     except buildmeta.MetadataError:
-        return None
+        return '<data-dir>'
 
 
 _server_options = [
@@ -474,9 +474,9 @@ _server_options = [
         '--daemon-group', type=int),
     click.option(
         '--runstate-dir', type=PathPath(), default=None,
-        help='directory where UNIX sockets will be created '
-             '(data-dir or {!r} by default)'
-             .format(get_runstate_dir())),
+        help=f'directory where UNIX sockets and other temporary '
+             f'runtime files will be placed ({_get_runstate_dir_default()} '
+             f'by default)'),
     click.option(
         '--max-backend-connections', type=int, default=100),
     click.option(

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -416,7 +416,7 @@ def bump_rlimit_nofile() -> None:
                 logger.warning('could not set RLIMIT_NOFILE')
 
 
-def get_runstate_dir():
+def get_runstate_dir() -> Optional[str]:
     try:
         return buildmeta.get_build_metadata_value("RUNSTATE_DIR")
     except buildmeta.MetadataError:

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -416,6 +416,13 @@ def bump_rlimit_nofile() -> None:
                 logger.warning('could not set RLIMIT_NOFILE')
 
 
+def get_runstate_dir():
+    try:
+        return buildmeta.get_build_metadata_value("RUNSTATE_DIR")
+    except buildmeta.MetadataError:
+        return None
+
+
 _server_options = [
     click.option(
         '-D', '--data-dir', type=PathPath(), envvar='EDGEDB_DATADIR',
@@ -459,7 +466,7 @@ _server_options = [
     click.option(
         '-b', '--background', is_flag=True, help='daemonize'),
     click.option(
-        '--pidfile', type=PathPath(), default='/run/edgedb/',
+        '--pidfile-dir', type=PathPath(), default='/run/edgedb/',
         help='path to PID file directory'),
     click.option(
         '--daemon-user', type=int),
@@ -468,7 +475,8 @@ _server_options = [
     click.option(
         '--runstate-dir', type=PathPath(), default=None,
         help='directory where UNIX sockets will be created '
-             '("/run" on Linux by default)'),
+             '(data-dir or {!r} by default)'
+             .format(get_runstate_dir())),
     click.option(
         '--max-backend-connections', type=int, default=100),
     click.option(

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -390,7 +390,7 @@ class ServerConfig(typing.NamedTuple):
     bind_address: str
     port: int
     background: bool
-    pidfile: pathlib.Path
+    pidfile_dir: pathlib.Path
     daemon_user: str
     daemon_group: str
     runstate_dir: pathlib.Path
@@ -539,7 +539,7 @@ def server_main(*, insecure=False, **kwargs):
 
     if kwargs['background']:
         daemon_opts = {'detach_process': True}
-        pidfile = kwargs['pidfile'] / f".s.EDGEDB.{kwargs['port']}.lock"
+        pidfile = kwargs['pidfile_dir'] / f".s.EDGEDB.{kwargs['port']}.lock"
         daemon_opts['pidfile'] = pidfile
         if kwargs['daemon_user']:
             daemon_opts['uid'] = kwargs['daemon_user']

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -248,7 +248,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "schema", 42.98)
 
     def test_cqa_type_coverage_server(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server", 11.23)
+        self.assertFunctionCoverage(EDB_DIR / "server", 11.41)
 
     def test_cqa_type_coverage_server_cache(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "cache", 0)


### PR DESCRIPTION
* rename `--pidfile` -> `--pidfile-dir`
* more correct description of `--runstate-dir`