### PR TITLE
Enable build optimizations for nightlies on Linux

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -31,6 +31,7 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "${{ matrix.platform }}"
         PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        EXTRA_OPTIMIZATIONS: "true"
 
     - name: Test (${{ matrix.target }})
       uses: edgedb/edgedb-pkg/integration/linux/test/<< tgt.name >>@master

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,6 +51,7 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "${{ matrix.platform }}"
         PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        EXTRA_OPTIMIZATIONS: "true"
 
     - name: Test (${{ matrix.target }})
       uses: edgedb/edgedb-pkg/integration/linux/test/debian-stretch@master
@@ -69,6 +70,7 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "${{ matrix.platform }}"
         PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        EXTRA_OPTIMIZATIONS: "true"
 
     - name: Test (${{ matrix.target }})
       uses: edgedb/edgedb-pkg/integration/linux/test/debian-buster@master
@@ -87,6 +89,7 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "${{ matrix.platform }}"
         PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        EXTRA_OPTIMIZATIONS: "true"
 
     - name: Test (${{ matrix.target }})
       uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-xenial@master
@@ -105,6 +108,7 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "${{ matrix.platform }}"
         PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        EXTRA_OPTIMIZATIONS: "true"
 
     - name: Test (${{ matrix.target }})
       uses: edgedb/edgedb-pkg/integration/linux/test/ubuntu-bionic@master
@@ -123,6 +127,7 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "${{ matrix.platform }}"
         PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        EXTRA_OPTIMIZATIONS: "true"
 
     - name: Test (${{ matrix.target }})
       uses: edgedb/edgedb-pkg/integration/linux/test/centos-7@master
@@ -141,6 +146,7 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "${{ matrix.platform }}"
         PKG_PLATFORM_VERSION: "${{ matrix.platform_version }}"
+        EXTRA_OPTIMIZATIONS: "true"
 
     - name: Test (${{ matrix.target }})
       uses: edgedb/edgedb-pkg/integration/linux/test/centos-8@master


### PR DESCRIPTION
This enables LTO and PGO for Python and LTO for Postgres on
supported platforms.