### PR TITLE
Fix performance regression in identity type intersection

### DIFF
--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -368,6 +368,7 @@ def apply_intersection(
             int_type = get_intersection_type((left, right), ctx=ctx)
         elif len(narrowed_union) == 1:
             int_type = narrowed_union[0]
+            is_subtype = int_type.issubclass(ctx.env.schema, left)
         else:
             int_type = get_union_type(narrowed_union, ctx=ctx)
     else:


### PR DESCRIPTION
When doing reverse link traversal, it is common to have identity type
intersections (i.e. A ∩ B ≡ A), since many links would have a single
definition.  The recent generalization of type intersections in paths
forgot to account for that, which resulted in extraneous JOINs generated
on SQL level.