### PR TITLE
Keep coverage results when running edb test --cov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ docs/_build
 /.vscode
 /.pytest_cache
 /.mypy_cache
+/coverage_results
+

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,4 @@ docs/_build
 /.vscode
 /.pytest_cache
 /.mypy_cache
-/coverage_results
 

--- a/edb/tools/test/__init__.py
+++ b/edb/tools/test/__init__.py
@@ -26,6 +26,7 @@ import pathlib
 import sys
 import tempfile
 import unittest
+import shutil
 
 import click
 
@@ -154,9 +155,27 @@ def test(*, files, jobs, include, exclude, verbose, quiet, debug,
     sys.exit(result)
 
 
+def _prepare_coverage_result_folder(container_folder: Path) -> None:
+    # it is best to delete a folder with result, if it exists,
+    # for two reasons: coverage might raise an exception if the folder
+    # contains a subfolder with reports (e.g. htmlcov), and results might be 
+    # outdated
+    if container_folder.exists():
+        
+        if container_folder.is_dir():
+            shutil.rmtree(container_folder)
+        else:
+            click.secho(
+                f'Error: "{container_folder}" exists and is not a folder, '
+                 'remove this file to use --cov')
+            sys.exit(1)
+    
+    os.makedirs(container_folder)
+
+
 def get_coverage_results_folder_path() -> str:
-    container_folder = pathlib.Path().absolute() / 'coverage_results'
-    os.makedirs(container_folder, exist_ok=True)
+    container_folder = pathlib.Path() / 'coverage_results'
+    _prepare_coverage_result_folder(container_folder)
     return str(container_folder)
 
 

--- a/edb/tools/test/__init__.py
+++ b/edb/tools/test/__init__.py
@@ -24,7 +24,6 @@ import functools
 import os
 import pathlib
 import sys
-import tempfile
 import unittest
 import shutil
 
@@ -155,21 +154,22 @@ def test(*, files, jobs, include, exclude, verbose, quiet, debug,
     sys.exit(result)
 
 
-def _prepare_coverage_result_folder(container_folder: Path) -> None:
+def _prepare_coverage_result_folder(container_folder: pathlib.Path) -> None:
     # it is best to delete a folder with result, if it exists,
     # for two reasons: coverage might raise an exception if the folder
-    # contains a subfolder with reports (e.g. htmlcov), and results might be 
+    # contains a subfolder with reports (e.g. htmlcov), and results might be
     # outdated
     if container_folder.exists():
-        
+
         if container_folder.is_dir():
             shutil.rmtree(container_folder)
         else:
             click.secho(
                 f'Error: "{container_folder}" exists and is not a folder, '
-                 'remove this file to use --cov')
+                'remove this file to use --cov'
+            )
             sys.exit(1)
-    
+
     os.makedirs(container_folder)
 
 
@@ -195,7 +195,7 @@ def _coverage_wrapper(paths):
             break
     else:
         raise RuntimeError('cannot locate the .coveragerc file')
-    
+
     td = get_coverage_results_folder_path()
 
     cov_config = devmode.CoverageConfig(

--- a/edb/tools/test/__init__.py
+++ b/edb/tools/test/__init__.py
@@ -155,8 +155,8 @@ def test(*, files, jobs, include, exclude, verbose, quiet, debug,
 
 
 def _prepare_coverage_result_folder(container_folder: pathlib.Path) -> None:
-    # it is best to delete a folder with result, if it exists,
-    # for two reasons: coverage might raise an exception if the folder
+    # it is best to delete a folder with results, if it exists,
+    # for two reasons: coverage lib might raise an exception if the folder
     # contains a subfolder with reports (e.g. htmlcov), and results might be
     # outdated
     if container_folder.exists():


### PR DESCRIPTION
* ~~instead of using a temporary folder, puts `coverage` results inside a folder "coverage_results" (folder added to .gitignore)~~
* ~~at every new run with --cov option, this folder is deleted if it exists, then created under `cwd`~~
* before exiting the context of the temporary folder, copies the `.coverage` file containing results into `cwd`
* this allows to create reports with `coverage` cli, for example `coverage html`, then `firefox htmlcov/index.html`