### PR TITLE
Switch to C.utf8 locale by default

### DIFF
--- a/edb/pgsql/dbops/databases.py
+++ b/edb/pgsql/dbops/databases.py
@@ -18,6 +18,7 @@
 
 
 from __future__ import annotations
+from typing import *  # NoQA
 
 import textwrap
 
@@ -29,10 +30,25 @@ from . import ddl
 
 
 class Database(base.DBObject):
-    def __init__(self, name, owner=None):
+    def __init__(
+        self,
+        name: str,
+        *,
+        owner: Optional[str] = None,
+        is_template: bool = False,
+        encoding: Optional[str] = None,
+        lc_collate: Optional[str] = None,
+        lc_ctype: Optional[str] = None,
+        template: Optional[str] = 'edgedb0',
+    ) -> None:
         super().__init__()
         self.name = name
         self.owner = owner
+        self.is_template = is_template
+        self.encoding = encoding
+        self.lc_collate = lc_collate
+        self.lc_ctype = lc_ctype
+        self.template = template
 
     def get_type(self):
         return 'DATABASE'
@@ -83,10 +99,21 @@ class CreateDatabase(ddl.CreateObject):
 
     def code(self, block: base.PLBlock) -> str:
         extra = ''
+
         if self.object.owner:
-            extra += f' OWNER={qi(self.object.owner)}'
-        return (f'CREATE DATABASE {self.object.get_id()} '
-                f'WITH TEMPLATE=edgedb0 {extra}')
+            extra += f' OWNER={ql(self.object.owner)}'
+        if self.object.is_template:
+            extra += f' IS_TEMPLATE = TRUE'
+        if self.object.template:
+            extra += f' TEMPLATE={ql(self.object.template)}'
+        if self.object.encoding:
+            extra += f' ENCODING={ql(self.object.encoding)}'
+        if self.object.lc_collate:
+            extra += f' LC_COLLATE={ql(self.object.lc_collate)}'
+        if self.object.lc_ctype:
+            extra += f' LC_CTYPE={ql(self.object.lc_ctype)}'
+
+        return (f'CREATE DATABASE {self.object.get_id()} {extra}')
 
 
 class DropDatabase(ddl.SchemaObjectOperation):

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -3404,8 +3404,8 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
     async def test_edgeql_functions_str_case_01(self):
         await self.assert_query_result(
-            r'''SELECT str_lower({'HeLlO', 'WoRlD!'});''',
-            {'hello', 'world!'},
+            r'''SELECT str_lower({'HeLlO', 'WoRlD!', 'ПриВет', 'мИр'});''',
+            {'hello', 'world!', 'привет', 'мир'},
         )
 
         await self.assert_query_result(

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 100.00)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.34)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.43)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)
@@ -239,7 +239,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "datasources", 50.00)
 
     def test_cqa_type_coverage_pgsql_dbops(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 34.88)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 35.12)
 
     def test_cqa_type_coverage_repl(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
@@ -248,7 +248,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "schema", 46.10)
 
     def test_cqa_type_coverage_server(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server", 11.41)
+        self.assertFunctionCoverage(EDB_DIR / "server", 11.96)
 
     def test_cqa_type_coverage_server_cache(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "cache", 0)


### PR DESCRIPTION
We currently use the bare "C" locale, which makes character handling
outside of the ASCII range not work as expected.  Switch to "C.utf8"
(but keep bare "C" for collation).

Fixes: #1105.