### PR TITLE
Fix C.UTF-8 locale detection when system locale is set to "C"

### DIFF
--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -56,17 +56,14 @@ else:
 
 
 def _is_c_utf8_locale_present() -> bool:
-    lang, encoding = locale.getlocale()
     try:
         locale.setlocale(locale.LC_CTYPE, 'C.UTF-8')
     except Exception:
         return False
     else:
-        if encoding:
-            current_locale = f'{lang}.{encoding}'
-        else:
-            current_locale = lang
-        locale.setlocale(locale.LC_CTYPE, current_locale)
+        # We specifically don't use locale.getlocale(), because
+        # it can lie and return a non-existent locale due to PEP 538.
+        locale.setlocale(locale.LC_CTYPE, '')
         return True
 
 


### PR DESCRIPTION
Per PEP 538, Python's `locale.getlocale()` will return `'en_US.UTF-8'`
if the system's locale is set to `"C"`, and so a subsequent
`locale.setlocale()` call will fail.  So, instead of doing save/restore,
do it the `setlocale` way and revert to the global default by passing an
empty string.