### PR TITLE
Revert "Disable garbage collection during compilation as it casues too much thrashing (#1028)"

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -22,7 +22,6 @@ from typing import *  # NoQA
 
 import collections
 import dataclasses
-import gc
 import hashlib
 import pickle
 import uuid
@@ -155,12 +154,7 @@ def compile_edgeql_script(
     compiler._std_schema = std_schema
     compiler._bootstrap_mode = True
 
-    # Note: there is a lot of GC activity due to contexts and other
-    # Schema-related reference cycles.  Postponing collection until after
-    # the compilation is complete speeds it up between 7% - 25%.
-    gc.disable()
     units = compiler._compile(ctx=ctx, eql=eql.encode())
-    gc.enable()
 
     sql_stmts = []
     for u in units:


### PR DESCRIPTION
This reverts commit 87a11fa66580a79fd3c3fbf79d59bf7b89fb3bf2.

This turned out not to make a significant impact on Linux, and latency
distribution got worse, so let's revert this for now until we have a
clear confirmation that disabling GC makes sense.