### PR TITLE
Expose --insecure-bootstrap-defaults

### DIFF
--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -95,6 +95,9 @@ class BaseCluster:
 
         return conn
 
+    def is_managed(self) -> bool:
+        raise NotImplementedError
+
     def get_superuser_role(self) -> Optional[str]:
         return None
 
@@ -145,7 +148,7 @@ class Cluster(BaseCluster):
     def get_pg_version(self):
         return self._pg_version
 
-    def is_managed(self):
+    def is_managed(self) -> bool:
         return True
 
     def supports_c_utf8_locale(self) -> bool:
@@ -673,7 +676,7 @@ class RemoteCluster(BaseCluster):
     def ensure_initialized(self, **settings):
         return False
 
-    def is_managed(self):
+    def is_managed(self) -> bool:
         return False
 
     def get_status(self):

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -44,7 +44,7 @@ def server(**kwargs):
     os.environ['EDGEDB_DEBUG_SERVER'] = '1'
     debug.init_debug_flags()
 
-    srv_main.server_main(insecure=True, **kwargs)
+    srv_main.server_main(insecure_bootstrap_defaults=True, **kwargs)
 
 
 # Import at the end of the file so that "edb.tools.edb.edbcommands"

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -248,7 +248,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "schema", 46.10)
 
     def test_cqa_type_coverage_server(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server", 11.96)
+        self.assertFunctionCoverage(EDB_DIR / "server", 12.76)
 
     def test_cqa_type_coverage_server_cache(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "cache", 0)


### PR DESCRIPTION
This allows bootstrapping a database that lets anybody in from any address.

Also: for non-managed databases, don't attempt to set buffer, cache and memory
sizes.