### PR TITLE
Make sys::get_version() return the actual version of the running server

### DIFF
--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -129,8 +129,8 @@ sys::__version_internal() -> tuple<major: std::int64,
                                    stage_no: std::int64,
                                    local: array<std::str>>
 {
-    # This function reads external data.
-    SET volatility := 'VOLATILE';
+    # This function reads from a table.
+    SET volatility := 'STABLE';
     USING SQL $$
     SELECT
         (v ->> 'major')::int8,
@@ -140,7 +140,7 @@ sys::__version_internal() -> tuple<major: std::int64,
         (SELECT coalesce(array_agg(el), ARRAY[]::text[])
          FROM jsonb_array_elements_text(v -> 'local') AS el)
     FROM
-        (SELECT edgedb.__syscache_instancedata() -> 'version' AS v) AS q;
+        edgedb._sys_version() as v
     $$;
 };
 
@@ -152,8 +152,7 @@ sys::get_version() -> tuple<major: std::int64,
                             stage_no: std::int64,
                             local: array<std::str>>
 {
-    # This function reads external data.
-    SET volatility := 'VOLATILE';
+    SET volatility := 'STABLE';
     USING (
         SELECT <tuple<major: std::int64,
                     minor: std::int64,
@@ -167,18 +166,15 @@ sys::get_version() -> tuple<major: std::int64,
 CREATE FUNCTION
 sys::get_version_as_str() -> std::str
 {
-    # This function reads external data.
-    SET volatility := 'VOLATILE';
+    SET volatility := 'STABLE';
     USING (
         WITH v := sys::get_version()
         SELECT
             <str>v.major
             ++ '.' ++ <str>v.minor
-            ++ ('-' ++ <str>v.stage
-                ++ '.' ++ <str>v.stage_no
-                ++ ('+' ++ std::to_str(v.local, '.')
-                    IF len(v.local) > 0 ELSE '')
-            ) IF v.stage != <sys::version_stage>'final' ELSE ''
+            ++ (('-' ++ <str>v.stage ++ '.' ++ <str>v.stage_no)
+                IF v.stage != <sys::version_stage>'final' ELSE '')
+            ++ (('+' ++ std::to_str(v.local, '.')) IF len(v.local) > 0 ELSE '')
     );
 };
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -1925,6 +1925,29 @@ class SysConfigFunction(dbops.Function):
         )
 
 
+class SysVersionFunction(dbops.Function):
+
+    text = f'''
+        BEGIN
+        RETURN (
+            SELECT value::jsonb
+            FROM _edgecon_state
+            WHERE name = 'server_version' AND type = 'R'
+        );
+        END;
+    '''
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', '_sys_version'),
+            args=[],
+            returns=('jsonb',),
+            language='plpgsql',
+            volatility='stable',
+            text=self.text,
+        )
+
+
 class SysGetTransactionIsolation(dbops.Function):
     "Get transaction isolation value as text compatible with EdgeDB's enum."
     text = r'''
@@ -2173,6 +2196,7 @@ async def bootstrap(conn):
         dbops.CreateFunction(BytesIndexWithBoundsFunction()),
         dbops.CreateCompositeType(SysConfigValueType()),
         dbops.CreateFunction(SysConfigFunction()),
+        dbops.CreateFunction(SysVersionFunction()),
         dbops.CreateFunction(SysGetTransactionIsolation()),
     ])
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -561,15 +561,8 @@ async def _compile_sys_queries(schema, cluster):
 async def _populate_misc_instance_data(cluster):
 
     mock_auth_nonce = scram.generate_nonce()
-    ver = buildmeta.get_version()
     json_instance_data = {
-        'version': {
-            'major': ver.major,
-            'minor': ver.minor,
-            'stage': ver.stage.name.lower(),
-            'stage_no': ver.stage_no,
-            'local': tuple(ver.local) if ver.local else (),
-        },
+        'version': dict(buildmeta.get_version_dict()),
         'catver': edbdef.EDGEDB_CATALOG_VERSION,
         'mock_auth_nonce': mock_auth_nonce,
     }

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -543,9 +543,10 @@ cdef class EdgeConnection:
                     if not sname:
                         sname = None
                     aliases = aliases.set(sname, svalue)
-                else:
-                    assert stype == b'S' and not sname
+                elif stype == b'S':
+                    assert not sname
                     sp_id = int(svalue)
+                # Ignore everything else in the state table.
 
         if self.debug:
             self.debug_print('RECOVER SP/ALIAS/CONF', sp_id, aliases, conf)

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,8 @@ def _compile_parsers(build_lib, inplace=False):
             shutil.copy2(cache, ROOT_PATH / pickle_path)
 
 
-def _compile_build_meta(build_lib, version, pg_config, runstatedir):
+def _compile_build_meta(build_lib, version, pg_config, runstatedir,
+                        version_suffix):
     import pkg_resources
     from edb.server import buildmeta
 
@@ -120,6 +121,8 @@ def _compile_build_meta(build_lib, version, pg_config, runstatedir):
 
     vertuple = list(parsed_version._asdict().values())
     vertuple[2] = int(vertuple[2])
+    if version_suffix:
+        vertuple[4] = tuple(version_suffix.split('.'))
     vertuple = tuple(vertuple)
 
     content = textwrap.dedent('''\
@@ -230,12 +233,14 @@ class build(distutils_build.build):
     user_options = distutils_build.build.user_options + [
         ('pg-config=', None, 'path to pg_config to use with this build'),
         ('runstatedir=', None, 'directory to use for the runtime state'),
+        ('version-suffix=', None, 'dot-separated local version suffix'),
     ]
 
     def initialize_options(self):
         super().initialize_options()
         self.pg_config = None
         self.runstatedir = None
+        self.version_suffix = None
 
     def finalize_options(self):
         super().finalize_options()
@@ -250,6 +255,7 @@ class build(distutils_build.build):
                 self.distribution.metadata.version,
                 self.pg_config,
                 self.runstatedir,
+                self.version_suffix,
             )
 
 

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 100.00)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.43)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.48)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)
@@ -248,7 +248,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "schema", 46.67)
 
     def test_cqa_type_coverage_server(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server", 13.37)
+        self.assertFunctionCoverage(EDB_DIR / "server", 13.73)
 
     def test_cqa_type_coverage_server_cache(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "cache", 0)


### PR DESCRIPTION
Currentlly, `sys::get_version()` returns the version of of a server that
was used to *bootstrap* an instance, since version metadata is written
into the instancedata storage.  This is obviously wrong, since one might
run a different, but compatible, version of EdgeDB on the same data
instance.  Fix this by switching `sys::get_version()` to use the session
state table instead.