### PR TITLE
edgeql: Change the grammar for `VERBOSE`.

### DIFF
--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3771,6 +3771,9 @@ aa';
         DESCRIBE TYPE foo::Bar AS TEXT VERBOSE;
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Unexpected 'VERBOSE'",
+                  line=2, col=39)
     def test_edgeql_syntax_describe_04(self):
         """
         DESCRIBE TYPE foo::Bar AS DDL VERBOSE;

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.79)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.94)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
`VERBOSE` is only valid in `AS TEXT VERBOSE` construct.

Fixes #1140.