### PR TITLE
Make expression aliases properly introspectable

### DIFF
--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -47,6 +47,11 @@ CREATE ABSTRACT TYPE schema::Object {
 CREATE ABSTRACT TYPE schema::Type EXTENDING schema::Object;
 CREATE TYPE schema::PseudoType EXTENDING schema::Type;
 
+ALTER TYPE schema::Type {
+    CREATE PROPERTY expr -> std::str;
+    CREATE PROPERTY is_from_alias := EXISTS(.expr);
+};
+
 
 ALTER TYPE std::Object {
     CREATE LINK __type__ -> schema::Type {

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -20,6 +20,7 @@
 """Database structure and objects supporting EdgeDB metadata."""
 
 from __future__ import annotations
+from typing import *  # NoQA
 
 import collections
 import re
@@ -2526,6 +2527,24 @@ def _generate_type_element_view(schema, type_fields):
             types AS q
         WHERE
             q.position IS NOT NULL
+
+        UNION ALL
+
+        SELECT
+            st.id           AS id,
+            (SELECT id FROM edgedb.Object
+                 WHERE name = 'schema::TypeElement')
+                            AS __type__,
+            st.maintype     AS type,
+            st.name         AS name,
+            st.position     AS num
+        FROM
+            edgedb.TupleExprAlias AS q,
+            LATERAL UNNEST ((q.element_types).types) AS st(
+                id, maintype, name, position
+            )
+        WHERE
+            st.position IS NOT NULL
     '''
 
     return dbops.View(name=tabname(schema, TypeElement), query=view_query)
@@ -2551,11 +2570,29 @@ def _generate_types_views(schema, type_fields):
                             AS __type__,
             {_lookup_type('q.subtypes[1]')}
                             AS element_type,
-            q.dimensions    AS dimensions
+            q.dimensions    AS dimensions,
+            NULL            AS expr
         FROM
             types AS q
         WHERE
             q.collection = 'array'
+
+        UNION ALL
+
+        SELECT
+            id              AS id,
+            name            AS name,
+            (SELECT id FROM edgedb.Object
+                 WHERE name = 'schema::Array')
+                            AS __type__,
+            (q.element_type).types[0].maintype
+                            AS element_type,
+            dimensions      AS dimensions,
+            (q.expr).origtext
+                            AS expr
+        FROM
+            edgedb.ArrayExprAlias AS q
+
     '''
 
     views.append(dbops.View(name=tabname(schema, Array), query=view_query))
@@ -2568,11 +2605,25 @@ def _generate_types_views(schema, type_fields):
             q.collection    AS name,
             (SELECT id FROM edgedb.Object
                  WHERE name = 'schema::Tuple')
-                            AS __type__
+                            AS __type__,
+            NULL            AS expr
         FROM
             types AS q
         WHERE
             q.collection = 'tuple'
+
+        UNION ALL
+
+        SELECT
+            id              AS id,
+            name            AS name,
+            (SELECT id FROM edgedb.Object
+                 WHERE name = 'schema::Tuple')
+                            AS __type__,
+            (q.expr).origtext
+                            AS expr
+        FROM
+            edgedb.TupleExprAlias q
     '''
 
     views.append(dbops.View(name=tabname(schema, Tuple), query=view_query))
@@ -2585,9 +2636,23 @@ def _generate_types_views(schema, type_fields):
             st.id           AS target
         FROM
             types AS q,
-            LATERAL UNNEST (q.subtypes) WITH ORDINALITY AS st(id)
+            LATERAL UNNEST (q.subtypes) AS st(id)
         WHERE
             q.collection = 'tuple'
+
+        UNION ALL
+
+        SELECT
+            q.id            AS source,
+            st.id           AS target
+        FROM
+            edgedb.TupleExprAlias AS q,
+            LATERAL UNNEST ((q.element_types).types) AS st(
+                id, maintype, name, position
+            )
+        WHERE
+            st.position IS NOT NULL
+
     '''
 
     link_views.append(
@@ -3227,6 +3292,7 @@ async def generate_views(conn, schema):
     types_view.query += '\nUNION ALL\n' + '\nUNION ALL\n'.join(f'''
         (
             SELECT
+                "expr",
                 "id",
                 "name",
                 "__type__"

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1781,6 +1781,7 @@ class TypeCommand(sd.ObjectCommand):
             ct = vt.as_create_delta(
                 new_schema, view_name=classname,
                 attrs={
+                    'id': uuidgen.uuid1mc(),
                     'expr': expr,
                     'alias_is_persistent': True,
                     'expr_type': ExprType.Select,

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -968,3 +968,46 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
                 ['Air'],
             ]
         )
+
+    async def test_edgeql_aliases_introspection(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE schema
+                SELECT Type {
+                    name
+                }
+                FILTER .is_from_alias AND .name LIKE 'test::Air%'
+                ORDER BY .name
+            """,
+            [{
+                'name': 'test::AirCard',
+            }]
+        )
+
+        await self.con.execute('''
+            CREATE ALIAS test::tuple_alias := ('foo', 10);
+        ''')
+
+        await self.assert_query_result(
+            r"""
+                WITH MODULE schema
+                SELECT Tuple {
+                    name,
+                    element_types: {
+                        name := .type.name
+                    } ORDER BY .num
+                }
+                FILTER
+                    .is_from_alias
+                    AND .name = 'test::tuple_alias'
+                ORDER BY .name
+            """,
+            [{
+                'name': 'test::tuple_alias',
+                'element_types': [{
+                    'name': 'std::str',
+                }, {
+                    'name': 'std::int64',
+                }]
+            }]
+        )


### PR DESCRIPTION
`schema::Type` now has an `expr` property that is non-empty if the
`Type` is a type variant, i.e. produced by an alias declaration.  The
new `is_from_alias` boolean computable is also added to simplify checks.

The REPL is taught to filter out type variants produced by aliases from
`\lt` and friends, and a new `\la` command is added to list aliases
specifically.