### PR TITLE
Implement the "edb wipe" command

### DIFF
--- a/edb/pgsql/datasources/schema/databases.py
+++ b/edb/pgsql/datasources/schema/databases.py
@@ -19,16 +19,23 @@
 
 from __future__ import annotations
 
-from . import annos  # NOQA
-from . import casts  # NOQA
-from . import constraints  # NOQA
-from . import databases  # NOQA
-from . import functions  # NOQA
-from . import indexes  # NOQA
-from . import links  # NOQA
-from . import modules  # NOQA
-from . import objtypes  # NOQA
-from . import operators  # NOQA
-from . import roles  # NOQA
-from . import scalars  # NOQA
-from . import types  # NOQA
+import asyncpg
+from typing import *  # NoQA
+
+
+async def fetch(
+        conn: asyncpg.connection.Connection) -> List[asyncpg.Record]:
+    return await conn.fetch("""
+        SELECT
+            ((d.description)->>'id')::uuid              AS id,
+            datname                                     AS name
+        FROM
+            pg_database dat
+            CROSS JOIN LATERAL (
+                SELECT
+                    edgedb.shobj_metadata(dat.oid, 'pg_database')
+                        AS description
+            ) AS d
+        WHERE
+            (d.description)->>'id' IS NOT NULL
+    """)

--- a/edb/pgsql/dbops/databases.py
+++ b/edb/pgsql/dbops/databases.py
@@ -40,6 +40,7 @@ class Database(base.DBObject):
         lc_collate: Optional[str] = None,
         lc_ctype: Optional[str] = None,
         template: Optional[str] = 'edgedb0',
+        metadata: Optional[Mapping[str, Any]] = None,
     ) -> None:
         super().__init__()
         self.name = name
@@ -49,6 +50,7 @@ class Database(base.DBObject):
         self.lc_collate = lc_collate
         self.lc_ctype = lc_ctype
         self.template = template
+        self.metadata = metadata
 
     def get_type(self):
         return 'DATABASE'
@@ -89,7 +91,7 @@ class DatabaseExists(base.Condition):
         ''')
 
 
-class CreateDatabase(ddl.CreateObject):
+class CreateDatabase(ddl.CreateObject, ddl.NonTransactionalDDLOperation):
     def __init__(
             self, db, *, conditions=None, neg_conditions=None, priority=0):
         super().__init__(
@@ -116,7 +118,8 @@ class CreateDatabase(ddl.CreateObject):
         return (f'CREATE DATABASE {self.object.get_id()} {extra}')
 
 
-class DropDatabase(ddl.SchemaObjectOperation):
+class DropDatabase(ddl.SchemaObjectOperation,
+                   ddl.NonTransactionalDDLOperation):
 
     def code(self, block: base.PLBlock) -> str:
         return f'DROP DATABASE {qi(self.name)}'

--- a/edb/pgsql/dbops/ddl.py
+++ b/edb/pgsql/dbops/ddl.py
@@ -18,6 +18,7 @@
 
 
 from __future__ import annotations
+from typing import *  # NoQA
 
 import json
 import textwrap
@@ -95,6 +96,17 @@ class DDLOperation(base.Command):
                 trigger.generate_after(block, self)
 
 
+class NonTransactionalDDLOperation(DDLOperation):
+    def generate_self_block(
+        self,
+        block: base.PLBlock,
+    ) -> Optional[base.PLBlock]:
+        block.add_command(self.code(block))
+        block.set_non_transactional()
+        self_block = block.add_block()
+        return self_block
+
+
 class SchemaObjectOperation(DDLOperation):
     def __init__(
             self, name, *, conditions=None, neg_conditions=None, priority=0):
@@ -156,11 +168,11 @@ class GetMetadata(base.Command):
         is_shared = self.object.is_shared()
         if isinstance(oid, base.Query):
             qry = oid.text
-            objoid = block.declare_var('oid')
             classoid = block.declare_var('oid')
+            objoid = block.declare_var('oid')
             objsubid = block.declare_var('oid')
             block.add_command(
-                qry + f' INTO {objoid}, {classoid}, {objsubid}')
+                qry + f' INTO {classoid}, {objoid}, {objsubid}')
         else:
             objoid, classoid, objsubid = oid
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3647,14 +3647,23 @@ class DeleteModule(ModuleMetaCommand, adapts=s_mod.DeleteModule):
 
 class CreateDatabase(ObjectMetaCommand, adapts=s_db.CreateDatabase):
     def apply(self, schema, context):
-        schema, _ = s_db.CreateDatabase.apply(self, schema, context)
-        self.pgops.add(dbops.CreateDatabase(dbops.Database(self.classname)))
+        schema, db = s_db.CreateDatabase.apply(self, schema, context)
+        self.pgops.add(
+            dbops.CreateDatabase(
+                dbops.Database(
+                    self.classname,
+                    metadata=dict(
+                        id=str(db.id),
+                    ),
+                )
+            )
+        )
         return schema, None
 
 
 class DropDatabase(ObjectMetaCommand, adapts=s_db.DropDatabase):
     def apply(self, schema, context):
-        schema, _ = s_db.CreateDatabase.apply(self, schema, context)
+        schema, _ = s_db.DropDatabase.apply(self, schema, context)
         self.pgops.add(dbops.DropDatabase(self.classname))
         return schema, None
 

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -33,6 +33,7 @@ from edb import schema as so
 from edb.schema import abc as s_abc
 from edb.schema import annos as s_anno
 from edb.schema import casts as s_casts
+from edb.schema import database as s_db
 from edb.schema import scalars as s_scalars
 from edb.schema import objtypes as s_objtypes
 from edb.schema import constraints as s_constr
@@ -70,6 +71,8 @@ class IntrospectionMech:
             schema = so.Schema()
 
         schema = await self.read_roles(
+            schema)
+        schema = await self.read_databases(
             schema)
         schema = await self.read_modules(
             schema, only_modules=modules, exclude_modules=exclude_modules)
@@ -147,6 +150,18 @@ class IntrospectionMech:
                     schema,
                     'bases',
                     [schema.get_by_id(b) for b in bases])
+
+        return schema
+
+    async def read_databases(self, schema):
+        dbs = await datasources.schema.databases.fetch(self.connection)
+
+        for row in dbs:
+            schema, _ = s_db.Database.create_in_schema(
+                schema,
+                id=row['id'],
+                name=row['name'],
+            )
 
         return schema
 

--- a/edb/repl/__init__.py
+++ b/edb/repl/__init__.py
@@ -857,7 +857,7 @@ class Cli:
         cmd = [
             str(psql),
             '-h', pgaddr['host'],
-            '-p', pgaddr['port'],
+            '-p', str(pgaddr['port']),
             '-d', self.connection.dbname,
             '-U', pgaddr['user']
         ]

--- a/edb/schema/database.py
+++ b/edb/schema/database.py
@@ -33,7 +33,7 @@ class Database(so.GlobalObject, s_anno.AnnotationSubject, s_abc.Database,
     pass
 
 
-class DatabaseCommandContext(sd.CommandContextToken):
+class DatabaseCommandContext(sd.ObjectCommandContext):
     pass
 
 
@@ -42,13 +42,13 @@ class DatabaseCommand(sd.GlobalObjectCommand, schema_metaclass=Database,
     pass
 
 
-class CreateDatabase(DatabaseCommand):
+class CreateDatabase(DatabaseCommand, sd.CreateObject):
     astnode = qlast.CreateDatabase
 
 
-class AlterDatabase(DatabaseCommand):
+class AlterDatabase(DatabaseCommand, sd.AlterObject):
     astnode = qlast.AlterDatabase
 
 
-class DropDatabase(DatabaseCommand):
+class DropDatabase(DatabaseCommand, sd.DeleteObject):
     astnode = qlast.DropDatabase

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -854,6 +854,7 @@ class ObjectCommand(Command, metaclass=ObjectCommandMeta):
 
     def _validate_legal_command(self, schema, context):
         from . import functions as s_functions
+        from . import modules as s_mod
 
         if (not context.stdmode and not context.testmode and
                 not isinstance(self, s_functions.ParameterCommand)):
@@ -861,11 +862,13 @@ class ObjectCommand(Command, metaclass=ObjectCommandMeta):
             if isinstance(self.classname, sn.Name):
                 shortname = sn.shortname_from_fullname(self.classname)
                 modname = self.classname.module
-            else:
+            elif issubclass(self.get_schema_metaclass(), s_mod.Module):
                 # modules have classname as simple strings
                 shortname = modname = self.classname
+            else:
+                modname = None
 
-            if modname in s_schema.STD_MODULES:
+            if modname is not None and modname in s_schema.STD_MODULES:
                 raise errors.SchemaDefinitionError(
                     f'cannot {self._delta_action} `{shortname}`: '
                     f'module {modname} is read-only',

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -70,11 +70,16 @@ class Query(BaseQuery):
     # Set only when a query is compiled with "json_parameters=True"
     in_type_args: Optional[Tuple[str, ...]] = None
 
+    is_transactional: bool = True
+    single_unit: bool = False
+
 
 @dataclasses.dataclass(frozen=True)
 class SimpleQuery(BaseQuery):
 
     sql: Tuple[bytes, ...]
+    is_transactional: bool = True
+    single_unit: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -84,22 +89,27 @@ class SessionStateQuery(BaseQuery):
     is_backend_setting: bool = False
     requires_restart: bool = False
     config_op: Optional[config.Operation] = None
+    is_transactional: bool = True
+    single_unit: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
 class DDLQuery(BaseQuery):
 
     new_types: FrozenSet[str] = frozenset()
+    is_transactional: bool = True
+    single_unit: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
 class TxControlQuery(BaseQuery):
 
     action: TxAction
-    single_unit: bool
     cacheable: bool
 
     modaliases: Optional[immutables.Map]
+    is_transactional: bool = True
+    single_unit: bool = False
 
 
 #############################
@@ -121,6 +131,10 @@ class QueryUnit:
     # Set only for units that contain queries that can be cached
     # as prepared statements in Postgres.
     sql_hash: bytes = b''
+
+    # True if all statments in *sql* can be executed inside a transaction.
+    # If False, they will be executed separately.
+    is_transactional: bool = True
 
     # True if this unit contains DDL commands.
     has_ddl: bool = False

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -659,8 +659,14 @@ cdef class EdgeConnection:
                 if query_unit.system_config:
                     await self._execute_system_config(query_unit)
                 else:
-                    await self.get_backend().pgcon.simple_query(
-                        b';'.join(query_unit.sql), ignore_data=True)
+                    if query_unit.is_transactional:
+                        await self.get_backend().pgcon.simple_query(
+                            b';'.join(query_unit.sql), ignore_data=True)
+                    else:
+                        for sql in query_unit.sql:
+                            await self.get_backend().pgcon.simple_query(
+                                sql, ignore_data=True)
+
                     if query_unit.config_ops:
                         await self.dbview.apply_config_ops(
                             self.get_backend().pgcon,

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -707,6 +707,9 @@ class RDSCluster(RemoteCluster):
     def get_superuser_role(self) -> Optional[str]:
         return 'rds_superuser'
 
+    def supports_c_utf8_locale(self) -> bool:
+        return False
+
 
 def get_local_pg_cluster(data_dir: os.PathLike) -> Cluster:
     pg_config = buildmeta.get_pg_config_path()

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -55,4 +55,5 @@ from . import gen_types  # noqa
 from . import gen_meta_grammars  # noqa
 from . import inittestdb  # noqa
 from . import test  # noqa
+from . import wipe  # noqa
 from .profiling import cli  # noqa

--- a/edb/tools/wipe.py
+++ b/edb/tools/wipe.py
@@ -1,0 +1,200 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+from typing import *  # NoQA
+
+import asyncio
+import json
+import pathlib
+import sys
+
+import asyncpg
+import click
+
+from edb.common import topological
+from edb.tools.edb import edbcommands
+
+from edb.server import cluster as edbcluster
+from edb.server import compiler
+from edb.server import defines as edbdef
+from edb.server import pgcluster
+from edb.server import pgconnparams
+
+from edb.pgsql.common import quote_ident as qi
+
+
+class AbsPath(click.Path):
+    name = 'path'
+
+    def convert(self, value, param, ctx):
+        return pathlib.Path(super().convert(value, param, ctx)).absolute()
+
+
+@edbcommands.command('wipe')
+@click.option(
+    '--postgres-dsn',
+    type=str,
+    help='DSN of the remote Postgres instance to wipe EdgeDB from')
+@click.option(
+    '-D',
+    '--data-dir',
+    type=AbsPath(),
+    help='database cluster directory')
+@click.option(
+    '-y',
+    'yes',
+    is_flag=True,
+    help='assume Yes response to all questions')
+@click.option(
+    '--dry-run',
+    is_flag=True,
+    help='give a summary of wipe operations without performing them')
+def wipe(*, postgres_dsn, data_dir, yes, dry_run):
+    if postgres_dsn:
+        cluster = pgcluster.get_remote_pg_cluster(postgres_dsn)
+    elif data_dir:
+        cluster = pgcluster.get_local_pg_cluster(data_dir)
+        cluster.set_connection_params(
+            pgconnparams.ConnectionParameters(
+                user='postgres',
+                database='template1',
+            ),
+        )
+    else:
+        raise click.UsageError(
+            'either --postgres-dsn or --data-dir is required'
+        )
+
+    if not yes and not click.confirm(
+            'This will DELETE all EdgeDB data from the target '
+            'PostgreSQL instance.  ARE YOU SURE?'):
+        click.echo('OK. Not proceeding.')
+
+    status = cluster.get_status()
+    cluster_started_by_us = False
+    if status != 'running':
+        if isinstance(cluster, pgcluster.RemoteCluster):
+            click.secho(f'Remote cluster is not running', fg='red')
+            sys.exit(1)
+        else:
+            cluster.start(port=edbcluster.find_available_port())
+            cluster_started_by_us = True
+
+    try:
+        asyncio.run(do_wipe(cluster, dry_run))
+    finally:
+        if cluster_started_by_us:
+            cluster.stop()
+
+
+async def do_wipe(
+    cluster: pgcluster.RemoteCluster,
+    dry_run: bool,
+) -> None:
+
+    try:
+        pgconn = await cluster.connect(database=edbdef.EDGEDB_SUPERUSER_DB)
+    except asyncpg.InvalidCatalogNameError:
+        click.secho(
+            f'Instance does not have the {edbdef.EDGEDB_SUPERUSER_DB!r} '
+            f'database. Is it already clean?'
+        )
+        return
+
+    try:
+        databases, roles = await _get_dbs_and_roles(pgconn)
+    finally:
+        await pgconn.close()
+
+    stmts = [
+        f'SET ROLE {edbdef.EDGEDB_SUPERUSER}',
+    ]
+
+    pgconn = await cluster.connect()
+
+    try:
+        for db in databases:
+            owner = await pgconn.fetchval("""
+                SELECT
+                    rolname
+                FROM
+                    pg_database d
+                    INNER JOIN pg_roles r
+                        ON (d.datdba = r.oid)
+                WHERE
+                    d.datname = $1
+            """, db)
+
+            stmts.append(f'SET ROLE {qi(owner)}')
+
+            if db == edbdef.EDGEDB_TEMPLATE_DB:
+                stmts.append(f'ALTER DATABASE {qi(db)} IS_TEMPLATE = false')
+
+            stmts.append(f'DROP DATABASE {qi(db)}')
+
+        stmts.append('RESET ROLE;')
+
+        for role in roles:
+            stmts.append(f'DROP ROLE {qi(role)}')
+
+        for stmt in stmts:
+            click.echo(stmt)
+            if not dry_run:
+                await pgconn.execute(stmt)
+    finally:
+        await pgconn.close()
+
+
+async def _get_dbs_and_roles(pgconn) -> Tuple[List[str], List[str]]:
+    std_schema = await compiler.load_std_schema(pgconn)
+
+    schema, get_databases_sql = compiler.compile_bootstrap_script(
+        std_schema,
+        std_schema,
+        'SELECT sys::Database.name',
+        expected_cardinality_one=False,
+        single_statement=True,
+    )
+
+    databases = list(sorted(
+        json.loads(await pgconn.fetchval(get_databases_sql)),
+        key=lambda dname: dname == edbdef.EDGEDB_TEMPLATE_DB,
+    ))
+
+    schema, get_roles_sql = compiler.compile_bootstrap_script(
+        std_schema,
+        std_schema,
+        '''SELECT sys::Role {
+            name,
+            parents := .member_of.name,
+        }''',
+        expected_cardinality_one=False,
+        single_statement=True,
+    )
+
+    roles = json.loads(await pgconn.fetchval(get_roles_sql))
+    sorted_roles = list(topological.sort({
+        r['name']: {
+            'item': r['name'],
+            'deps': r['parents'],
+        } for r in roles
+    }))
+
+    return databases, sorted_roles

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -230,16 +230,16 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 100.00)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.48)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 41.70)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)
 
     def test_cqa_type_coverage_pgsql_datasources(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql" / "datasources", 50.00)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql" / "datasources", 51.61)
 
     def test_cqa_type_coverage_pgsql_dbops(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 35.12)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql" / "dbops", 35.75)
 
     def test_cqa_type_coverage_repl(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -248,7 +248,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "schema", 46.67)
 
     def test_cqa_type_coverage_server(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server", 13.73)
+        self.assertFunctionCoverage(EDB_DIR / "server", 13.91)
 
     def test_cqa_type_coverage_server_cache(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "cache", 0)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -292,7 +292,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "testbase", 1.04)
 
     def test_cqa_type_coverage_tools(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "tools", 21.36)
+        self.assertFunctionCoverage(EDB_DIR / "tools", 21.43)
 
     def test_cqa_type_coverage_tools_docs(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "tools" / "docs", 0)


### PR DESCRIPTION
This development tool allows removing all traces of EdgeDB from the 
specified PostgreSQL cluster.  Useful for cases when debugging bootstrap 
and setting up new clusters is expensive.

There are a couple of prerequisite commits that are tagging along this
PR as well.