### PR TITLE
graphql: Create custom scalars.

### DIFF
--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -84,6 +84,7 @@ type ScalarTest {
     property p_float32 -> float32;
     property p_float64 -> float64;
     property p_decimal -> decimal;
+    property p_decimal_str := <str>.p_decimal;
     property p_json -> json;
     property p_bytes -> bytes;
 

--- a/tests/test_http_graphql_mutation.py
+++ b/tests/test_http_graphql_mutation.py
@@ -174,7 +174,7 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
         """
 
         self.assert_graphql_query_result(r"""
-            mutation insert_ScalarTest($num: Int!) {
+            mutation insert_ScalarTest($num: Int64!) {
                 insert_ScalarTest(
                     data: [{
                         p_str: "New ScalarTest02",
@@ -351,6 +351,67 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
                     filter: {p_str: {eq: "New \"ScalarTest05\"\\"}}
                 ) {
                     p_str
+                }
+            }
+        """, {
+            "delete_ScalarTest": [data]
+        })
+
+        # validate that the deletion worked
+        self.assert_graphql_query_result(validation_query, {
+            "ScalarTest": []
+        })
+
+    def test_graphql_mutation_insert_scalars_06(self):
+        # This tests float vs. decimal literals.
+        data = {
+            'p_str': 'New ScalarTest06',
+            'p_decimal':
+                123456789123456789123456789.123456789123456789123456789,
+            'p_decimal_str':
+                '123456789123456789123456789.123456789123456789123456789',
+        }
+
+        validation_query = r"""
+            query {
+                ScalarTest(filter: {p_str: {eq: "New ScalarTest06"}}) {
+                    p_str
+                    p_decimal
+                    p_decimal_str
+                }
+            }
+        """
+
+        self.assert_graphql_query_result(r"""
+            mutation insert_ScalarTest {
+                insert_ScalarTest(
+                    data: [{
+                        p_str: "New ScalarTest06",
+                        p_decimal:
+                    123456789123456789123456789.123456789123456789123456789,
+                    }]
+                ) {
+                    p_str
+                    p_decimal
+                    p_decimal_str
+                }
+            }
+        """, {
+            "insert_ScalarTest": [data]
+        })
+
+        self.assert_graphql_query_result(validation_query, {
+            "ScalarTest": [data]
+        })
+
+        self.assert_graphql_query_result(r"""
+            mutation delete_ScalarTest {
+                delete_ScalarTest(
+                    filter: {p_str: {eq: "New ScalarTest06"}}
+                ) {
+                    p_str
+                    p_decimal
+                    p_decimal_str
                 }
             }
         """, {
@@ -1176,11 +1237,11 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
                 $p_duration: String,
                 $p_int16: Int,
                 $p_int32: Int,
-                $p_int64: Int,
-                $p_bigint: Int,
+                $p_int64: Int64,
+                $p_bigint: Bigint,
                 $p_float32: Float,
                 $p_float64: Float,
-                $p_decimal: Float,
+                $p_decimal: Decimal,
             ) {
                 update_ScalarTest(
                     data: {
@@ -1279,7 +1340,7 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
         self.assert_graphql_query_result(r"""
             mutation update_ScalarTest(
                 $p_str: String,
-                $p_posint: Int,
+                $p_posint: Int64,
             ) {
                 update_ScalarTest(
                     data: {

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -393,7 +393,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         # Regression test: variables names were shadowing query names.
         self.assert_graphql_query_result(
             r"""
-                query users($name: String, $age: Int) {
+                query users($name: String, $age: Int64) {
                     User(filter: {or: [{name: {eq: $name}},
                                        {age: {gt: $age}}]},
                          order: {name: {dir: ASC}})
@@ -2226,7 +2226,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_02(self):
         self.assert_graphql_query_result(
             r"""
-                query($name: String, $age: Int) {
+                query($name: String, $age: Int64) {
                     User(filter: {or: [{name: {eq: $name}},
                                        {age: {gt: $age}}]},
                          order: {name: {dir: ASC}})
@@ -2332,7 +2332,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
 
     def test_graphql_functional_variables_08(self):
         self.assert_graphql_query_result(r"""
-            query($val: Int = 20) {
+            query($val: Int64 = 20) {
                 User(filter: {age: {eq: $val}}) {
                     name,
                 }
@@ -2672,7 +2672,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             for _ in range(2):
                 self.assert_graphql_query_result(
                     r"""
-                        query($val: Boolean!, $min_age: Int!) {
+                        query($val: Boolean!, $min_age: Int64!) {
                             User(filter: {age: {gt: $min_age}}) {
                                 name @include(if: $val),
                                 age
@@ -2685,7 +2685,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
 
             self.assert_graphql_query_result(
                 r"""
-                    query($val: Boolean!, $min_age: Int!) {
+                    query($val: Boolean!, $min_age: Int64!) {
                         User(filter: {age: {gt: $min_age}}) {
                             name @include(if: $val),
                             age

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -727,7 +727,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                                         "kind": "NON_NULL",
                                         "ofType": {
                                             "__typename": "__Type",
-                                            "name": "Int",
+                                            "name": "Int64",
                                             "kind": "SCALAR",
                                             "ofType": None
                                         }
@@ -933,7 +933,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                                     "kind": "NON_NULL",
                                     "ofType": {
                                         "__typename": "__Type",
-                                        "name": "Int",
+                                        "name": "Int64",
                                         "kind": "SCALAR"
                                     }
                                 },
@@ -1553,7 +1553,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                                     "kind": "NON_NULL",
                                     "ofType": {
                                         "__typename": "__Type",
-                                        "name": "Int",
+                                        "name": "Int64",
                                         "kind": "SCALAR"
                                     }
                                 },
@@ -2001,7 +2001,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     {
                         "name": "age",
                         "type": {
-                            "name": "FilterInt",
+                            "name": "FilterInt64",
                             "kind": "INPUT_OBJECT",
                             "ofType": None
                         }


### PR DESCRIPTION
Add `Int64`, `Bigint`, and `Decimal` custom scalars to map those scalars
from EdgeDB that don't map onto `Int` (32-bit) and `Float` (64-bit).

Fixes: #1138.