### PR TITLE
tests: Adjust some test to check `decimal` exact value.

### DIFF
--- a/docs/clients/90_edgeql/protocol.rst
+++ b/docs/clients/90_edgeql/protocol.rst
@@ -56,3 +56,16 @@ actually occurred. The ``error`` will further contain the ``message``
 field with the error message string, the ``type`` field with the name
 of the type of error and the ``code`` field with an integer
 :ref:`error code <ref_protocol_error_codes>`.
+
+.. note::
+
+    Caution is advised when reading ``decimal`` or ``bigint`` values
+    using HTTP protocol because the results are provides in JSON
+    format. The JSON specification does not have a limit on
+    significant digits, so a ``decimal`` or a ``bigint`` number can be
+    losslessly represented in JSON. However, JSON decoders in many
+    languages will read all such numbers as some kind of of 32- or
+    64-bit number type, which may result in errors or precision loss.
+    If such loss is unacceptable, then consider casting the value into
+    ``str`` and decoding it on the client side into a more appropriate
+    type.

--- a/docs/clients/99_graphql/protocol.rst
+++ b/docs/clients/99_graphql/protocol.rst
@@ -55,3 +55,17 @@ response is JSON of the following form::
 
 Note that the ``errors`` field will only be present if some errors
 actually occurred.
+
+.. note::
+
+    Caution is advised when reading ``decimal`` or ``bigint`` values
+    (mapped onto ``Decimal`` and ``Bigint`` GraphQL custom scalar
+    types) using HTTP protocol because the results are provides in
+    JSON format. The JSON specification does not have a limit on
+    significant digits, so a ``decimal`` or a ``bigint`` number can be
+    losslessly represented in JSON. However, JSON decoders in many
+    languages will read all such numbers as some kind of of 32- or
+    64-bit number type, which may result in errors or precision loss.
+    If such loss is unacceptable, then consider creating a computable
+    property which casts the value into ``str`` and decoding it on the
+    client side into a more appropriate type.

--- a/docs/datamodel/scalars/numeric.rst
+++ b/docs/datamodel/scalars/numeric.rst
@@ -114,6 +114,18 @@ from :eql:type:`str` and :eql:type:`json`.
         db> SELECT 1e+100n IS decimal;
         {true}
 
+    .. note::
+
+        Caution is advised when casting ``bigint`` values into
+        ``json``. The JSON specification does not have a limit on
+        significant digits, so a ``bigint`` number can be losslessly
+        represented in JSON. However, JSON decoders in many languages
+        will read all such numbers as some kind of 32- or 64-bit
+        number type, which may result in errors or precision loss. If
+        such loss is unacceptable, then consider casting the value
+        into ``str`` and decoding it on the client side into a more
+        appropriate type.
+
 
 ----------
 
@@ -154,6 +166,17 @@ from :eql:type:`str` and :eql:type:`json`.
 
         db> SELECT 42n IS bigint;
         {true}
+
+    .. note::
+
+        Caution is advised when casting ``decimal`` values into
+        ``json``. The JSON specification does not have a limit on
+        significant digits, so a ``decimal`` number can be losslessly
+        represented in JSON. However, JSON decoders in many languages
+        will read all such numbers as some kind of floating point
+        values, which may result in precision loss. If such loss is
+        unacceptable, then consider casting the value into ``str`` and
+        decoding it on the client side into a more appropriate type.
 
 
 ----------

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -23,6 +23,7 @@ import asyncio
 import atexit
 import collections
 import contextlib
+import decimal
 import functools
 import inspect
 import json
@@ -489,7 +490,7 @@ class ConnectedTestCaseMixin:
                     self.fail(
                         f'{message}: {data!r} != {shape!r} '
                         f'{_format_path(path)}')
-            elif isinstance(shape, (str, int, timedelta)):
+            elif isinstance(shape, (str, int, timedelta, decimal.Decimal)):
                 if data != shape:
                     self.fail(
                         f'{message}: {data!r} != {shape!r} '

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -17,6 +17,7 @@
 #
 
 
+import decimal
 import json
 import os.path
 
@@ -2378,17 +2379,20 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''SELECT to_decimal('123.457', '999.999');''',
-            {123.457},
+            exp_result_json={123.457},
+            exp_result_binary={decimal.Decimal('123.457')},
         )
 
         await self.assert_query_result(
             r'''SELECT to_decimal(' 123.456789000', '999.999999999');''',
-            {123.456789},
+            exp_result_json={123.456789},
+            exp_result_binary={decimal.Decimal('123.456789')},
         )
 
         await self.assert_query_result(
             r'''SELECT to_decimal('123.456789', 'FM999.999999999');''',
-            {123.456789},
+            exp_result_json={123.456789},
+            exp_result_binary={decimal.Decimal('123.456789')},
         )
 
         with self.assertRaisesRegex(edgedb.InvalidValueError,
@@ -2403,7 +2407,10 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                 '123456789123456789123456789.123456789123456789123456789',
                 'FM999999999999999999999999999.999999999999999999999999999');
             ''',
-            {123456789123456789123456789.123456789123456789123456789},
+            exp_result_json={
+                123456789123456789123456789.123456789123456789123456789},
+            exp_result_binary={decimal.Decimal(
+                '123456789123456789123456789.123456789123456789123456789')},
         )
 
     async def test_edgeql_functions_len_01(self):


### PR DESCRIPTION
A few tests that return `decimal` values now explicitly check the "json"
and "binary" results. The "binary" protocol is supposed to preserve type
information and actually produce a `decimal.Decimal` in Python. However,
fetching data as "json" can only produce a `float`.

Update the docs for the datatypes `bigint` and `decimal` with a note
about potential problems with JSON conversion.

Fixes: #1151.