### PR TITLE
Split re-running into a separate workflow

### DIFF
--- a/.github/workflows/issuenumber.yml
+++ b/.github/workflows/issuenumber.yml
@@ -1,0 +1,26 @@
+name: Issue Number
+
+on:
+  push:
+    branches:
+      - master
+      - ci
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+    branches:
+      - '*'
+
+jobs:
+  issuenumber-job:
+    runs-on: ubuntu-latest
+    name: Check Relevant Commits
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 10
+        submodules: false
+    - uses: ambv/gha-issuenumber@master
+      id: issuenumber
+    - name: Check output
+      run: "echo \"Last issue number is ${{ steps.issuenumber.outputs.issuenumber }}\""

--- a/.github/workflows/issuenumber.yml
+++ b/.github/workflows/issuenumber.yml
@@ -6,14 +6,13 @@ on:
       - master
       - ci
   pull_request:
-    types: [opened, synchronize, labeled, unlabeled]
     branches:
       - '*'
 
 jobs:
   issuenumber-job:
     runs-on: ubuntu-latest
-    name: Check Relevant Commits
+    name: Check Commit Messages
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,0 +1,18 @@
+name: Re-Run
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+    branches:
+      - '*'
+
+jobs:
+  issuenumber-job:
+    runs-on: ubuntu-latest
+    name: Issue Number
+
+    steps:
+    - uses: ambv/gha-issuenumber/trigger@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        check_to_rerun: "Check Commit Messages"


### PR DESCRIPTION
This avoids duplication of checks on the pull request.