### PR TITLE
Add Github Action to check for issue numbers in commit messages

### DIFF
--- a/.github/workflows/issuenumber.yml
+++ b/.github/workflows/issuenumber.yml
@@ -1,0 +1,25 @@
+name: Issue Number
+
+on:
+  push:
+    branches:
+      - master
+      - ci
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  issuenumber-job:
+    runs-on: ubuntu-latest
+    name: Check Commit Messages
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 9
+        submodules: false
+    - uses: ambv/gha-issuenumber/check@master
+      id: issuenumber
+    - name: Check output
+      run: "echo \"Last issue number is ${{ steps.issuenumber.outputs.issuenumber }}\""

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,0 +1,18 @@
+name: Re-Run
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+    branches:
+      - '*'
+
+jobs:
+  issuenumber-job:
+    runs-on: ubuntu-latest
+    name: Issue Number
+
+    steps:
+    - uses: ambv/gha-issuenumber/trigger@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        check_to_rerun: "Check Commit Messages"


### PR DESCRIPTION
This works on pushes as well as pull requests. You can use a "skip issue" label to make the check green.

## Caveat 1
Github Actions have a bug: [labeled and unlabeled events on pull requests create duplicate checks on pull requests](https://github.community/t5/GitHub-Actions/duplicate-checks-on-pull-request-event/td-p/33157) instead of replacing the previous check of the same type. This means we'd have an old failed check and a new passing check in the status, making merging impossible for the pull request. As per @elprans' advice, I attempted a workaround:
* don't handle labeled/unlabeled in the main action;
* create a separate action to re-run the previously failed check via API and subscribe *this one* to labeled/unlabeled.

This second action will also have duplicate entries on the pull request if there are many label/unlabel actions applied but since this action is implemented so that it always passes, this does not block the pull request.

## Caveat 2
[The Checks API](https://developer.github.com/v3/checks/suites/#rerequest-check-suite) required to re-request a run of the check is beta (since May 2018) and for some reason it doesn't work. We send the right request, the API server receives it and is happy with it (HTTP 201). The Check run gets stuck:
1. On the "Actions" view in the repository you can see that the check is supposed to re-run but it never does.
2. On the check suite view ("Details" from the pull request) you can see the failed check in the old state, not re-run. However, the status circle of the suite now shows the check pending and the check doesn't have the "Re-run check" button anymore. Instead, there's a "Cancel check suite" button that does nothing.

## Note
Updating the pull request's source code fixes the problems with duplication and stuck checks. Under the hood, Github Actions tie check suites with a commit SHA1 so a new commit creates an entirely new suite.

## Conclusion
I am rather unhappy with this state of things. We can do the following:
1. merge this as is and find some friends at Github/Microsoft to help us diagnose and fix either caveat 1 or caveat 2, both of which are bugs in my opinion;
2. merge this with automatic re-running disabled, then you'd have to either push a change to the pull request to re-run the check or re-run it yourself manually by going to it and clicking its "Re-run checks";
3. do not merge this, set up a $3.5/month instance on Amazon Lightsail with GidgetHub and do it like CPython does it which we know works pretty well.

The problem with Solution 1 is that it's probably long-term. The Checks API's been around since May 2018. Solution 2 will just be cumbersome. Solution 3 I can only tackle in February.

There's also a potential Solution 4 which would be to poke at the YAML files to figure out a magic combination that makes the Re-run workflow work. @elprans has seen it work in the release pipeline, it's unclear what's different between the two. However, I think this is taking too long and I don't want to sink more time into such a trivial thing.