### PR TITLE
Refactor `BaseConstant.from_python`.

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 # Do not import "from typing *"; this module contains
 # AST classes that name-clash with classes from the typing module.
 
-import decimal
 import typing
 
 from edb.common import enum as s_enum
@@ -263,20 +262,7 @@ class BaseConstant(Expr):
 
     @classmethod
     def from_python(cls, val: typing.Any) -> BaseConstant:
-        if isinstance(val, str):
-            return StringConstant.from_python(val)
-        elif isinstance(val, bool):
-            return BooleanConstant(value='true' if val else 'false')
-        elif isinstance(val, int):
-            return IntegerConstant(value=str(val))
-        elif isinstance(val, decimal.Decimal):
-            return DecimalConstant(value=f'{val}n')
-        elif isinstance(val, float):
-            return FloatConstant(value=str(val))
-        elif isinstance(val, bytes):
-            return BytesConstant.from_python(value=val)
-        else:
-            raise ValueError(f'unexpected constant type: {type(val)!r}')
+        raise NotImplementedError
 
 
 class StringConstant(BaseConstant):

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -37,6 +37,7 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import codegen as ql_codegen
 from edb.edgeql import qltypes
 from edb.edgeql import quote as eql_quote
+from edb.schema import utils as s_utils
 
 from . import types as gt
 from . import errors as g_errors
@@ -47,10 +48,6 @@ ARG_TYPES = {
     'Int': gql_ast.IntValue,
     'String': gql_ast.StringValue,
 }
-
-
-MAX_INT64 = 2 ** 63 - 1
-MIN_INT64 = -2 ** 63
 
 
 class GraphQLTranslatorContext:
@@ -1413,7 +1410,7 @@ class GraphQLTranslator:
     def visit_IntValue(self, node):
         # produces an int64 or bigint
         val = int(node.value)
-        if MIN_INT64 <= val <= MAX_INT64:
+        if s_utils.MIN_INT64 <= val <= s_utils.MAX_INT64:
             return qlast.IntegerConstant(value=str(val))
         else:
             return qlast.BigintConstant(value=f'{val}n')

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -139,7 +139,9 @@ def evaluate_OperatorCall(
         args.append(arg_val)
 
     value = eval_func(*args)
-    qlconst = qlast.BaseConstant.from_python(value)
+    # Since we only perform string concatenations here, the constant
+    # in question is always a StringConstant.
+    qlconst = qlast.StringConstant.from_python(value)
 
     result = ql_compiler.compile_constant_tree_to_ir(
         qlconst, styperef=opcall.typeref, schema=schema)

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -275,7 +275,7 @@ class CreateAnnotationValue(AnnotationValueCommand,
                          node: qlast.CreateAnnotationValue,
                          op: sd.AlterObjectProperty) -> None:
         if op.property == 'value':
-            node.value = qlast.BaseConstant.from_python(op.new_value)
+            node.value = qlast.StringConstant.from_python(op.new_value)
         else:
             super()._apply_field_ast(schema, context, node, op)
 
@@ -323,7 +323,7 @@ class AlterAnnotationValue(AnnotationValueCommand,
         op: sd.AlterObjectProperty
     ) -> None:
         if op.property == 'value':
-            node.value = qlast.BaseConstant.from_python(op.new_value)
+            node.value = qlast.StringConstant.from_python(op.new_value)
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1662,11 +1662,11 @@ class AlterObjectProperty(Command):
             )
         elif utils.is_nontrivial_container(value):
             value = qlast.Tuple(elements=[
-                qlast.BaseConstant.from_python(el) for el in value
+                utils.const_ast_from_python(el) for el in value
             ])
         elif isinstance(value, uuid.UUID):
             value = qlast.TypeCast(
-                expr=qlast.BaseConstant.from_python(str(value)),
+                expr=qlast.StringConstant.from_python(str(value)),
                 type=qlast.TypeName(
                     maintype=qlast.ObjectRef(
                         name='uuid',
@@ -1675,7 +1675,7 @@ class AlterObjectProperty(Command):
                 )
             )
         else:
-            value = qlast.BaseConstant.from_python(value)
+            value = utils.const_ast_from_python(value)
 
         return astcls(name=self.property, value=value)
 

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -233,7 +233,7 @@ class CreateScalarType(ScalarTypeCommand, inheriting.CreateInheritingObject):
                         maintype=qlast.ObjectRef(name='enum'),
                         subtypes=[
                             qlast.TypeExprLiteral(
-                                val=qlast.BaseConstant.from_python(v)
+                                val=qlast.StringConstant.from_python(v)
                             )
                             for v in enum_values
                         ]

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 50.26)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 50.31)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 13.91)


### PR DESCRIPTION
Move the `from_python` dispatch into a utils function. Replace the usage
of the dispatch with calling `from_python` on specific classes where
possible.

Fixes: #1145.