### PR TITLE
Fix itermittent failures of test_dump01_restore_compatibility

### DIFF
--- a/tests/test_dump01.py
+++ b/tests/test_dump01.py
@@ -67,13 +67,14 @@ class TestDump01(tb.QueryTestCase, tb.CLITestCaseMixin):
             if not entry.is_file():
                 continue
 
-            dumpfn = os.path.join(dumpsdir, entry.name)
-            await self.con.execute(f'CREATE DATABASE `{dumpfn}`')
+            dbname = entry.name
+            dumpfn = os.path.join(dumpsdir, dbname)
+            await self.con.execute(f'CREATE DATABASE `{dbname}`')
             try:
-                self.run_cli('restore', '-d', dumpfn, dumpfn)
-                con2 = await self.connect(database=dumpfn)
+                self.run_cli('restore', '-d', dbname, dumpfn)
+                con2 = await self.connect(database=dbname)
             except Exception:
-                await self.con.execute(f'DROP DATABASE `{dumpfn}`')
+                await self.con.execute(f'DROP DATABASE `{dbname}`')
                 raise
 
             oldcon = self.con
@@ -83,7 +84,7 @@ class TestDump01(tb.QueryTestCase, tb.CLITestCaseMixin):
             finally:
                 self.__class__.con = oldcon
                 await con2.aclose()
-                await self.con.execute(f'DROP DATABASE `{dumpfn}`')
+                await self.con.execute(f'DROP DATABASE `{dbname}`')
 
     async def ensure_schema_data_integrity(self):
         tx = self.con.transaction()


### PR DESCRIPTION
The path to the dump file is longer than the PostgreSQL's limit of 63
characters, and since the test uses the full path name for the database
name, it fails, because Postgres silently truncates long names (it
issues a NOTICE response, but not an error).

Issue: #1158