### PR TITLE
Fix erroneous scope construction for paths with computable links

### DIFF
--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -82,12 +82,16 @@ def get_expression_path_id(
 def register_set_in_scope(
         ir_set: irast.Set, *,
         path_scope: irast.ScopeTreeNode=None,
-        ctx: context.ContextLevel) -> None:
+        fence_points: FrozenSet[irast.PathId]=frozenset(),
+        ctx: context.ContextLevel) -> List[irast.ScopeTreeNode]:
     if path_scope is None:
         path_scope = ctx.path_scope
 
     try:
-        path_scope.attach_path(ir_set.path_id)
+        return path_scope.attach_path(
+            ir_set.path_id,
+            fence_points=fence_points,
+        )
     except irast.InvalidScopeConfiguration as e:
         raise errors.QueryError(
             e.args[0], context=ir_set.context) from e

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -21,7 +21,6 @@ import json
 import os.path
 
 from edb.testbase import server as tb
-from edb.tools import test
 
 
 class TestEdgeQLExprAliases(tb.QueryTestCase):
@@ -891,13 +890,6 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             ]
         )
 
-    @test.xfail('''
-        edgedb.errors.InternalServerError: missing FROM-clause entry
-        for table "SpecialCard~8"
-
-        See `test_edgeql_aliases_collection_04` or
-        `test_edgeql_aliases_collection_05` for minimal setup.
-    ''')
     async def test_edgeql_aliases_collection_02(self):
         await self.assert_query_result(
             r"""
@@ -909,13 +901,6 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             ]
         )
 
-    @test.xfail('''
-        edgedb.errors.InternalServerError: missing FROM-clause entry
-        for table "SpecialCard~8"
-
-        See `test_edgeql_aliases_collection_04` or
-        `test_edgeql_aliases_collection_05` for minimal setup.
-    ''')
     async def test_edgeql_aliases_collection_03(self):
         await self.assert_query_result(
             r"""
@@ -931,10 +916,6 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             ]
         )
 
-    @test.xfail('''
-        edgedb.errors.InternalServerError: missing FROM-clause entry
-        for table "SpecialCard~4"
-    ''')
     async def test_edgeql_aliases_collection_04(self):
         await self.assert_query_result(
             r"""
@@ -950,10 +931,6 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             ]
         )
 
-    @test.xfail('''
-        edgedb.errors.InternalServerError: missing FROM-clause entry
-        for table "SpecialCard~4"
-    ''')
     async def test_edgeql_aliases_collection_05(self):
         await self.assert_query_result(
             r"""

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -320,11 +320,15 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "(test::Card).>owners[IS test::User]": {
-                "(test::Card)",
+                "BRANCH": {
+                    "(test::Card)"
+                },
                 "FENCE": {
                     "ns~1@@(test::Card).<deck[IS __derived__::(@SID@)]\
 .>indirection[IS test::User]": {
-                        "ns~1@@(test::Card).<deck[IS __derived__::(@SID@)]"
+                        "ns~1@@(test::Card).<deck[IS __derived__::(@SID@)]": {
+                            "(test::Card)"
+                        }
                     }
                 }
             }
@@ -379,21 +383,28 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(__derived__::__derived__|U@@w~1).>cards[IS test::Card]\
 .>foo[IS std::float64]": {
-                "(__derived__::__derived__|U@@w~1)\
+                "BRANCH": {
+                    "(__derived__::__derived__|U@@w~1)\
 .>cards[IS test::Card]": {
-                    "(__derived__::__derived__|U@@w~1)": {
+                        "BRANCH": {
+                            "(__derived__::__derived__|U@@w~1)"
+                        },
                         "FENCE": {
-                            "(test::User)",
+                            "(test::Card)",
                             "FENCE": {
-                                "(test::User).>name[IS std::str]"
+                                "(__derived__::__derived__|U@@w~1)\
+.>deck[IS test::Card]": {
+                                    "(__derived__::__derived__|U@@w~1)": {
+                                        "FENCE": {
+                                            "(test::User)",
+                                            "FENCE": {
+                                                "(test::User)\
+.>name[IS std::str]"
+                                            }
+                                        }
+                                    }
+                                }
                             }
-                        }
-                    },
-                    "FENCE": {
-                        "(test::Card)",
-                        "FENCE": {
-                            "(__derived__::__derived__|U@@w~1)\
-.>deck[IS test::Card]"
                         }
                     }
                 }
@@ -733,14 +744,17 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::Card)",
             "(test::Card).>name[IS std::str]",
             "FENCE": {
-                "(__derived__::__derived__|A@@w~1)\
-.>owners[IS test::User]": {
-                    "(__derived__::__derived__|A@@w~1)",
+                "(__derived__::__derived__|A@@w~1).>owners[IS test::User]": {
+                    "BRANCH": {
+                        "(__derived__::__derived__|A@@w~1)"
+                    },
                     "FENCE": {
                         "ns~2@@(__derived__::__derived__|A@@w~1)\
 .<deck[IS __derived__::(@SID@)].>indirection[IS test::User]": {
                             "ns~2@@(__derived__::__derived__|A@@w~1)\
-.<deck[IS __derived__::(@SID@)]"
+.<deck[IS __derived__::(@SID@)]": {
+                                "(__derived__::__derived__|A@@w~1)"
+                            }
                         }
                     }
                 }

--- a/tests/test_edgeql_tree.py
+++ b/tests/test_edgeql_tree.py
@@ -336,11 +336,6 @@ class TestTree(tb.QueryTestCase):
             ['0'],
         )
 
-    @test.xfail('''
-        The query produces: ['0', '0']
-
-        See issue #1098.
-    ''')
     async def test_edgeql_tree_select_04(self):
         await self.assert_query_result(
             r"""
@@ -369,14 +364,6 @@ class TestTree(tb.QueryTestCase):
             {'000', '010'},
         )
 
-    @test.xfail('''
-        This test fails with the following error:
-
-        InternalServerError: missing FROM-clause entry for table
-        "Tree_children~5"
-
-        See issue #1098.
-    ''')
     async def test_edgeql_tree_select_07(self):
         await self.assert_query_result(
             r"""
@@ -395,14 +382,6 @@ class TestTree(tb.QueryTestCase):
             {'000', '010'},
         )
 
-    @test.xfail('''
-        This test fails with the following error:
-
-        InternalServerError: missing FROM-clause entry for table
-        "default|Tree@@view~1_children~4"
-
-        See issue #1098.
-    ''')
     async def test_edgeql_tree_select_09(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
When handling paths like `Tree.parent`, where `parent` is defined by an
expression, make sure that the scope tree is constructed such that
the `Tree` symbol is not visible from the computable expression (unless
it has been pulled into an outer scope).  In other words, make sure that
the `Tree.parent` expression is not treated as if it was part of
`(Tree, Tree.parent)` tuple.

Specifically, this means that instead of the following incorrect scope:

    (test::Tree).>parent[IS test::Tree]: {
        (test::Tree)
        "FENCE": {
            <expr-scope-for-"parent">
        }
    }

this is generated instead:

    (test::Tree).>parent[IS test::Tree]: {
        "BRANCH: {
            (test::Tree)
	},
        "FENCE": {
            <expr-scope-for-"parent">
        }
    }

Fixes: #1098