### PR TITLE
work in progress on annotating referencing.py

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -487,6 +487,7 @@ class CommandContext:
         self.renamed_objs = set()
         self.altered_targets = set()
         self.schema_object_ids = schema_object_ids
+        self.op: Optional[Command] = None
 
     @property
     def modaliases(self) -> Mapping[Optional[str], str]:
@@ -768,7 +769,9 @@ class ObjectCommand(Command, metaclass=ObjectCommandMeta):
         if subnode is not None:
             node.commands.append(subnode)
 
-    def _get_ast_node(self, schema, context):
+    def _get_ast_node(self,
+                      schema: s_schema.Schema,
+                      context: CommandContext) -> qlast.ObjectDDL:
         return self.__class__.astnode
 
     def _get_ast(
@@ -1136,7 +1139,7 @@ class AlterObjectFragment(ObjectCommand):
 class RenameObject(AlterObjectFragment):
     _delta_action = 'rename'
 
-    astnode = qlast.Rename
+    astnode: Union[qlast.DDLCommand, Iterable[qlast.DDLCommand]] = qlast.Rename
 
     new_name = struct.Field(sn.Name)
 

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -20,30 +20,35 @@
 from __future__ import annotations
 
 import hashlib
+from abc import abstractmethod
 from typing import *  # NoQA
 
+from edb import errors
 from edb.edgeql import ast as qlast
 
-from edb import errors
-
 from . import delta as sd
-from . import derivable
-from . import inheriting
+from . import derivable, inheriting
+from . import name as sn
 from . import objects as so
 from . import schema as s_schema
-from . import name as sn
 from . import utils
-
 
 ReferencedT = TypeVar('ReferencedT', bound='ReferencedObject')
 
 
+if TYPE_CHECKING:
+    from edb.schema import annos as s_annos
+    from edb.schema import inheriting as s_inheriting
+    from edb.schema import types as s_types
+
+
 class ReferencedObject(so.Object, derivable.DerivableObjectBase):
 
-    def get_referrer(self, schema):
+    def get_referrer(self,
+                     schema: s_schema.Schema) -> s_annos.AnnotationSubject:
         return self.get_subject(schema)
 
-    def delete(self, schema):
+    def delete(self, schema: s_schema.Schema) -> s_schema.Schema:
         cmdcls = sd.ObjectCommandMeta.get_command_class_or_die(
             sd.DeleteObject, type(self))
 
@@ -66,20 +71,21 @@ class ReferencedObject(so.Object, derivable.DerivableObjectBase):
 
     def derive_ref(
         self: ReferencedT,
-        schema,
-        referrer,
-        *qualifiers,
-        mark_derived=False,
-        attrs=None, dctx=None,
-        derived_name_base=None,
-        inheritance_merge=True,
-        preserve_path_id=None,
-        refdict_whitelist=None,
-        name=None,
-        **kwargs,
+        schema: s_schema.Schema,
+        referrer: so.InheritingObjectBase,
+        *qualifiers: str,
+        mark_derived: bool = False,
+        attrs: Optional[Dict[str, object]] = None,
+        dctx: Optional[sd.CommandContext] = None,
+        derived_name_base: Optional[str] = None,
+        inheritance_merge: bool = True,
+        preserve_path_id: Optional[bool] = None,
+        refdict_whitelist: Any = None,
+        name: Optional[str] = None,
+        **kwargs: Any,
     ) -> Tuple[s_schema.Schema, ReferencedT]:
         if name is None:
-            derived_name = self.get_derived_name(
+            derived_name: str = self.get_derived_name(
                 schema, referrer, *qualifiers,
                 mark_derived=mark_derived,
                 derived_name_base=derived_name_base)
@@ -124,6 +130,7 @@ class ReferencedObject(so.Object, derivable.DerivableObjectBase):
             old_bases = existing.get_bases(schema)
 
             if new_bases != old_bases:
+                assert isinstance(new_bases, so.ObjectList)
                 removed_bases, added_bases = inheriting.delta_bases(
                     [b.get_name(schema) for b in old_bases.objects(schema)],
                     [b.get_name(schema) for b in new_bases.objects(schema)],
@@ -166,13 +173,18 @@ class ReferencedObject(so.Object, derivable.DerivableObjectBase):
 
         derived = schema.get(derived_name)
 
-        return schema, derived
+        # type ignore because we cannot assert isinstance
+        # of ReferencedT or ReferencedObject, and mypy
+        # doesn't believe it is
+        return schema, derived  # type: ignore
 
 
 class ReferencedInheritingObject(inheriting.InheritingObject,
                                  ReferencedObject):
 
-    def get_implicit_bases(self, schema):
+    def get_implicit_bases(self,
+                           schema: s_schema.Schema
+                           ) -> List[s_inheriting.InheritingObject]:
         return [
             b for b in self.get_bases(schema).objects(schema)
             if not b.generic(schema)
@@ -182,11 +194,17 @@ class ReferencedInheritingObject(inheriting.InheritingObject,
 class ReferencedObjectCommandMeta(sd.ObjectCommandMeta):
     _transparent_adapter_subclass = True
 
-    def __new__(mcls, name, bases, clsdct, *,
-                referrer_context_class=None, **kwargs):
-        cls = super().__new__(mcls, name, bases, clsdct, **kwargs)
+    def __new__(mcls,
+                name: str,
+                bases: Tuple[type, ...],
+                clsdict: Dict[str, Any],
+                *,
+                referrer_context_class: Type[sd.CommandContext] = None,
+                **kwargs: Any) -> ReferencedObjectCommandMeta:
+        cls = super().__new__(mcls, name, bases, clsdict, **kwargs)
         if referrer_context_class is not None:
             cls._referrer_context_class = referrer_context_class
+        assert isinstance(cls, ReferencedObjectCommandMeta)
         return cls
 
 
@@ -203,7 +221,9 @@ class ReferencedObjectCommandBase(sd.ObjectCommand,
         return cls._referrer_context_class
 
     @classmethod
-    def get_referrer_context(cls, context) -> Optional[sd.CommandContext]:
+    def get_referrer_context(cls,
+                             context: sd.CommandContext
+                             ) -> Optional[sd.CommandContext]:
         """Get the context of the command for the referring object, if any.
 
         E.g. for a `create/alter/etc concrete link` command this would
@@ -219,11 +239,17 @@ class StronglyReferencedObjectCommand(ReferencedObjectCommandBase):
 class ReferencedObjectCommand(ReferencedObjectCommandBase):
 
     @classmethod
-    def _classname_from_ast(cls, schema, astnode, context):
+    def _classname_from_ast(cls,
+                            schema: s_schema.Schema,
+                            astnode: qlast.ObjectDDL,
+                            context: sd.CommandContext
+                            ) -> sn.Name:
         name = super()._classname_from_ast(schema, astnode, context)
 
         parent_ctx = cls.get_referrer_context(context)
         if parent_ctx is not None:
+            assert parent_ctx.op is not None
+            # TODO: what is the correct type here?
             referrer_name = parent_ctx.op.classname
 
             try:
@@ -240,13 +266,14 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase):
             pnn = sn.get_specialized_name(base_name, referrer_name, *quals)
             name = sn.Name(name=pnn, module=referrer_name.module)
 
+        assert isinstance(name, sn.Name)
         return name
 
     @classmethod
     def _classname_from_name(
         cls,
         name: sn.SchemaName,
-        referrer_name: str,
+        referrer_name: sn.SchemaName,
     ) -> sn.Name:
         base_name = sn.shortname_from_fullname(name)
         quals = cls._classname_quals_from_name(name)
@@ -254,33 +281,50 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase):
         return sn.Name(name=pnn, module=referrer_name.module)
 
     @classmethod
-    def _classname_quals_from_ast(cls, schema, astnode, base_name,
-                                  referrer_name, context):
+    def _classname_quals_from_ast(cls,
+                                  schema: s_schema.Schema,
+                                  astnode: qlast.ObjectDDL,
+                                  base_name: sn.SchemaName,
+                                  referrer_name: str,
+                                  context: sd.CommandContext
+                                  ) -> Tuple[str, ...]:
         return ()
 
     @classmethod
-    def _classname_quals_from_name(cls, name: sn.SchemaName) -> Tuple[str]:
+    def _classname_quals_from_name(cls,
+                                   name: sn.SchemaName
+                                   ) -> Tuple[str, ...]:
         return ()
 
     @classmethod
-    def _name_qual_from_exprs(cls, schema, exprs):
+    def _name_qual_from_exprs(cls,
+                              schema: s_schema.Schema,
+                              exprs: Iterable[str]) -> str:
         m = hashlib.sha1()
         for expr in exprs:
             m.update(expr.encode())
         return m.hexdigest()
 
-    def _get_ast_node(self, schema, context):
+    def _get_ast_node(self,
+                      schema: s_schema.Schema,
+                      context: sd.CommandContext
+                      ) -> qlast.ObjectDDL:
         subject_ctx = self.get_referrer_context(context)
         ref_astnode = getattr(self, 'referenced_astnode', None)
         if subject_ctx is not None and ref_astnode is not None:
+            assert isinstance(ref_astnode, qlast.ObjectDDL)
             return ref_astnode
         else:
+            # TODO: astnode must be defined as class attribute
             if isinstance(self.astnode, (list, tuple)):
-                return self.astnode[1]
+                return self.astnode[1]  # type: ignore
             else:
-                return self.astnode
+                return self.astnode  # type: ignore
 
-    def _create_innards(self, schema, context):
+    def _create_innards(self,
+                        schema: s_schema.Schema,
+                        context: sd.CommandContext
+                        ) ->  s_schema.Schema:
         referrer_ctx = self.get_referrer_context(context)
         if referrer_ctx is None:
             return super()._create_innards(schema, context)
@@ -302,8 +346,13 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase):
 
         return super()._create_innards(schema, context)
 
-    def _get_implicit_ref_bases(self, schema, context,
-                                referrer, refdict, fq_name):
+    def _get_implicit_ref_bases(self,
+                                schema: s_schema.Schema,
+                                context: sd.CommandContext,
+                                referrer: Optional[so.InheritingObjectBase],
+                                refdict: so.RefDict,
+                                fq_name: sn.SchemaName,
+                                ) -> List[s_inheriting.InheritingObject]:
         if not isinstance(referrer, inheriting.InheritingObject):
             return []
 
@@ -323,7 +372,12 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase):
 
         return implicit_bases
 
-    def _get_ref_rebase(self, schema, context, refcls, implicit_bases):
+    def _get_ref_rebase(self,
+                        schema: s_schema.Schema,
+                        context: sd.CommandContext,
+                        refcls: Any,
+                        implicit_bases: List[s_inheriting.InheritingObject]
+                        ) -> sd.Command:
         mcls = type(self.scls)
         ref_rebase_cmd = sd.ObjectCommandMeta.get_command_class_or_die(
             inheriting.RebaseInheritingObject, mcls)
@@ -347,11 +401,14 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase):
             added_bases=added_bases,
             removed_bases=removed_bases,
         )
-
+        assert isinstance(rebase_cmd, sd.Command)
         return rebase_cmd
 
-    def _propagate_ref_creation(self, schema, context, referrer):
-
+    def _propagate_ref_creation(self,
+                                schema: s_schema.Schema,
+                                context: sd.CommandContext,
+                                referrer: so.InheritingObjectBase
+                                ) -> s_schema.Schema:
         get_cmd = sd.ObjectCommandMeta.get_command_class_or_die
 
         mcls = type(self.scls)
@@ -404,8 +461,13 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase):
 
         return schema
 
-    def _implicit_ref_rebase(self, schema, context, child, existing,
-                             refdict, fq_name):
+    def _implicit_ref_rebase(self,
+                             schema: s_schema.Schema,
+                             context: sd.CommandContext,
+                             child: Any,
+                             existing: Any,
+                             refdict: so.RefDict,
+                             fq_name: sn.SchemaName) -> sd.Command:
         get_cmd = sd.ObjectCommandMeta.get_command_class_or_die
         mcls = type(self.scls)
 
@@ -418,9 +480,13 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase):
         cmd = ref_alter_cmd(classname=existing.get_name(schema))
         cmd.add(rebase_cmd)
 
+        assert isinstance(cmd, sd.Command)
         return cmd
 
-    def _delete_innards(self, schema, context, scls):
+    def _delete_innards(self,
+                        schema: s_schema.Schema,
+                        context: sd.CommandContext,
+                        scls: ReferencedInheritingObject) -> s_schema.Schema:
         schema = super()._delete_innards(schema, context, scls)
 
         referrer_ctx = self.get_referrer_context(context)
@@ -488,8 +554,14 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase):
 
         return schema
 
-    def _propagate_ref_deletion(self, schema, context,
-                                refdict, parent_fq_refname, child):
+    def _propagate_ref_deletion(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        refdict: so.RefDict,
+        parent_fq_refname: sn.SchemaName,
+        child: so.InheritingObjectBase
+    ) -> Tuple[s_schema.Schema, sd.Command]:
         get_cmd = sd.ObjectCommandMeta.get_command_class_or_die
         mcls = type(self.scls)
 
@@ -520,7 +592,14 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase):
 
         return schema, cmd
 
-    def _build_alter_cmd_stack(self, schema, context, scls, *, referrer=None):
+    def _build_alter_cmd_stack(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        scls: Any,
+        *,
+        referrer: Optional[so.InheritingObjectBase] = None
+    ) -> Tuple[sd.DeltaRoot, sd.Command]:
 
         delta = sd.DeltaRoot()
 
@@ -553,9 +632,12 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase):
 
 
 class ReferencedInheritingObjectCommand(
-        ReferencedObjectCommand, inheriting.InheritingObjectCommand):
+        ReferencedObjectCommand,
+        inheriting.InheritingObjectCommand):
 
-    def _create_begin(self, schema, context):
+    def _create_begin(self,
+                      schema: s_schema.Schema,
+                      context: sd.CommandContext) -> s_schema.Schema:
         referrer_ctx = self.get_referrer_context(context)
         implicit_bases = None
 
@@ -591,7 +673,11 @@ class ReferencedInheritingObjectCommand(
 
         return schema
 
-    def _alter_begin(self, schema, context, scls):
+    def _alter_begin(self,
+                     schema: s_schema.Schema,
+                     context: sd.CommandContext,
+                     scls: so.InheritingObjectBase) -> s_schema.Schema:
+        assert isinstance(scls, ReferencedInheritingObject)
         was_local = scls.get_is_local(schema)
         schema = super()._alter_begin(schema, context, scls)
         now_local = scls.get_is_local(schema)
@@ -599,13 +685,18 @@ class ReferencedInheritingObjectCommand(
             self._validate(schema, context)
         return schema
 
-    def _validate(self, schema, context):
+    def _validate(self,
+                  schema: s_schema.Schema,
+                  context: sd.CommandContext) -> None:
         implicit_bases = [
             b for b in self.scls.get_bases(schema).objects(schema)
             if not b.generic(schema)
         ]
 
         referrer_ctx = self.get_referrer_context(context)
+        assert referrer_ctx is not None  # TODO: right ???
+        # assert isinstance(referrer_ctx.op, so.InheritingObjectBase)
+
         objcls = self.get_schema_metaclass()
         referrer_class = referrer_ctx.op.get_schema_metaclass()
         refdict = referrer_class.get_refdict_for_class(objcls)
@@ -636,7 +727,12 @@ class ReferencedInheritingObjectCommand(
                     context=self.source_context,
                 )
 
-    def _propagate_ref_op(self, schema, context, scls, cb):
+    def _propagate_ref_op(self,
+                          schema: s_schema.Schema,
+                          context: sd.CommandContext,
+                          scls: ReferencedInheritingObject,
+                          cb: Callable[[sd.Command, str], None]
+                          ) -> s_schema.Schema:
 
         rec = context.current().enable_recursion
         context.current().enable_recursion = False
@@ -655,6 +751,7 @@ class ReferencedInheritingObjectCommand(
             sd.AlterObject, mcls)
 
         for descendant in scls.ordered_descendants(schema):
+            assert isinstance(descendant, ReferencedObject)
             d_name = descendant.get_name(schema)
             d_referrer = descendant.get_referrer(schema)
             d_alter_cmd = alter_cmdcls(classname=d_name)
@@ -675,15 +772,29 @@ class ReferencedInheritingObjectCommand(
         return schema
 
 
-class CreateReferencedObject(ReferencedObjectCommand, sd.CreateObject):
+class CreateReferencedObject(ReferencedObjectCommand,
+                             sd.CreateObject,
+                             Generic[qlast.ObjectDDL_T]):
+
+    referenced_astnode: Type[qlast.ObjectDDL]
+
     @classmethod
-    def _cmd_tree_from_ast(cls, schema, astnode, context):
+    def _cmd_tree_from_ast(cls,
+                           schema: s_schema.Schema,
+                           astnode: qlast.ObjectDDL_T,
+                           context: sd.CommandContext
+                           ) -> Any:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
 
         if isinstance(astnode, cls.referenced_astnode):
             objcls = cls.get_schema_metaclass()
 
             referrer_ctx = cls.get_referrer_context(context)
+            assert referrer_ctx is not None
+            # TODO: the following doesn't work; what is the type of
+            # referrer_ctx.op?
+            # assert isinstance(referrer_ctx.op, so.InheritingObjectBase)
+
             referrer_class = referrer_ctx.op.get_schema_metaclass()
             referrer_name = referrer_ctx.op.classname
             refdict = referrer_class.get_refdict_for_class(objcls)
@@ -732,6 +843,8 @@ class CreateReferencedObject(ReferencedObjectCommand, sd.CreateObject):
                         quals = sn.quals_from_fullname(bname)
                         inherited_from.append(quals[0])
 
+                    assert astnode is not None
+
                     astnode.system_comment = (
                         f'inherited from {", ".join(inherited_from)}'
                     )
@@ -745,37 +858,55 @@ class CreateReferencedObject(ReferencedObjectCommand, sd.CreateObject):
 
                 if context.declarative:
                     scls = self.get_object(schema, context)
+                    assert isinstance(scls, ReferencedInheritingObject)
                     implicit_bases = scls.get_implicit_bases(schema)
                     objcls = self.get_schema_metaclass()
+                    assert isinstance(refctx.op, ReferencedObjectCommand)
+
                     referrer_class = refctx.op.get_schema_metaclass()
                     refdict = referrer_class.get_refdict_for_class(objcls)
                     if refdict.requires_explicit_overloaded and implicit_bases:
+                        assert astnode is not None
                         astnode.declared_overloaded = True
 
                 return astnode
         else:
             return super()._get_ast(schema, context, parent_node=parent_node)
 
-    def _get_ast_node(self, schema, context):
+    def _get_ast_node(self,
+                      schema: s_schema.Schema,
+                      context: sd.CommandContext) -> qlast.ObjectDDL:
         scls = self.get_object(schema, context)
+        assert isinstance(scls, ReferencedInheritingObject)
+
         implicit_bases = scls.get_implicit_bases(schema)
         if implicit_bases and not context.declarative:
             mcls = self.get_schema_metaclass()
             Alter = sd.ObjectCommandMeta.get_command_class_or_die(
                 sd.AlterObject, mcls)
             alter = Alter(classname=self.classname)
+            assert isinstance(alter, sd.ObjectCommand)
+
             return alter._get_ast_node(schema, context)
         else:
             return super()._get_ast_node(schema, context)
 
     @classmethod
-    def as_inherited_ref_cmd(cls, schema, context, astnode, parents):
+    def as_inherited_ref_cmd(cls,
+                             schema: s_schema.Schema,
+                             context: sd.CommandContext,
+                             astnode: qlast.ObjectDDL,
+                             parents: Any) -> sd.Command:
         cmd = cls(classname=cls._classname_from_ast(schema, astnode, context))
         cmd.set_attribute_value('name', cmd.classname)
         return cmd
 
     @classmethod
-    def as_inherited_ref_ast(cls, schema, context, name, parent):
+    def as_inherited_ref_ast(cls,
+                             schema: s_schema.Schema,
+                             context: sd.CommandContext,
+                             name: str,
+                             parent: s_types.Type) -> qlast.ObjectDDL:
         nref = cls.get_inherited_ref_name(schema, context, parent, name)
         astnode_cls = cls.referenced_astnode
         astnode = astnode_cls(name=nref)
@@ -783,10 +914,15 @@ class CreateReferencedObject(ReferencedObjectCommand, sd.CreateObject):
         return astnode
 
     @classmethod
-    def get_inherited_ref_name(cls, schema, context, parent, name):
+    def get_inherited_ref_name(cls,
+                               schema: s_schema.Schema,
+                               context: sd.CommandContext,
+                               parent: s_types.Type,
+                               name: str
+                               ) -> qlast.ObjectRef:
         # reduce name to shortname
         if sn.Name.is_qualified(name):
-            shortname = sn.shortname_from_fullname(sn.Name(name))
+            shortname: str = sn.shortname_from_fullname(sn.Name(name))
         else:
             shortname = name
 
@@ -798,23 +934,30 @@ class CreateReferencedObject(ReferencedObjectCommand, sd.CreateObject):
         return nref
 
 
-class CreateReferencedInheritingObject(CreateReferencedObject,
-                                       inheriting.CreateInheritingObject):
+class CreateReferencedInheritingObject(
+    CreateReferencedObject[qlast.ObjectDDL],
+    inheriting.CreateInheritingObject[qlast.ObjectDDL]
+):
     pass
 
 
 class AlterReferencedInheritingObject(
         ReferencedInheritingObjectCommand,
-        inheriting.AlterInheritingObject):
+        inheriting.AlterInheritingObject[qlast.ObjectDDL]):
 
     @classmethod
-    def _cmd_tree_from_ast(cls, schema, astnode, context):
+    def _cmd_tree_from_ast(cls,
+                           schema: s_schema.Schema,
+                           astnode: qlast.ObjectDDL,
+                           context: sd.CommandContext
+                           ) -> AlterReferencedInheritingObject:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
 
         refctx = cls.get_referrer_context(context)
         if refctx is not None:
             cmd.set_attribute_value('is_local', True)
 
+        assert isinstance(cmd, AlterReferencedInheritingObject)
         return cmd
 
 
@@ -822,7 +965,11 @@ class RenameReferencedInheritingObject(
         ReferencedInheritingObjectCommand,
         sd.RenameObject):
 
-    def _rename_begin(self, schema, context, scls):
+    def _rename_begin(self,
+                      schema: s_schema.Schema,
+                      context: sd.CommandContext,
+                      scls: ReferencedInheritingObject
+                      ) -> s_schema.Schema:
         orig_schema = schema
         schema = super()._rename_begin(schema, context, scls)
 
@@ -859,11 +1006,16 @@ class RenameReferencedInheritingObject(
 
         return schema
 
-    def _propagate_ref_rename(self, schema, context, scls):
+    def _propagate_ref_rename(self,
+                              schema: s_schema.Schema,
+                              context: sd.CommandContext,
+                              scls: ReferencedInheritingObject
+                              ) -> s_schema.Schema:
         rename_cmdcls = sd.ObjectCommandMeta.get_command_class_or_die(
             sd.RenameObject, type(scls))
 
-        def _ref_rename(alter_cmd, refname):
+        def _ref_rename(alter_cmd: sd.Command,
+                        refname: str) -> None:
             astnode = rename_cmdcls.astnode(
                 new_name=qlast.ObjectRef(
                     name=refname,

--- a/mypy.ini
+++ b/mypy.ini
@@ -364,3 +364,19 @@ no_implicit_optional = True
 warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
+
+[mypy-edb.schema.referencing]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True


### PR DESCRIPTION
@elprans, sorry, I am stuck annotating `referencing` module. I am down to 25 problems from original 77, but there are a few parts that I don't understand.

1. What is the best way to address `"_create_innards" / "_delete_innards" undefined in superclass`, for example in `ReferencedObjectCommand`? I read how the class is used, and I understand it works by multi-inheritance, so for example in the case of "CreateConstraint" class, the super()._create_innards goes to the implementation in `CreateInheritingObject`. I don't know what is the best way to let mypy understand it, and make something that respects the original purpose of the code.
2. I have trouble understanding the `op` property that a `CommandContext` can have sometimes (set in `delta.Command._cmd_tree_from_ast` method). Is it an `Optional[Command]`?
3. The same for the `scls` property that a referrer context can have.

I would find it easier to understand these elements if there were more comments and possibly docstrings to describe some details (for example `op`, `scls`).