### PR TITLE
Add "cqa" prefix to the docs snippet test.

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -294,7 +294,7 @@ class TestDocSnippets(unittest.TestCase):
                 f'{block.filename}, around line {block.lineno}') from ex
 
     @unittest.skipIf(docutils is None, 'docutils is missing')
-    def test_doc_snippets(self):
+    def test_cqa_doc_snippets(self):
         edgepath = edgepath = find_edgedb_root()
         docspath = os.path.join(edgepath, 'docs')
 


### PR DESCRIPTION
In order to keep docs from being trivially broken, the docs snippets
test should be part of the "code quality assurance" tests (and hopefully
tested as part of a pre-push hook or integrated into workflow in some
other way).

I'm including all the engineering team here mainly to remind everyone that `edb test -k cqa` is a useful routine test to run before pushing your work and that code in the docs is still subject to the code quality assurance.