### PR TITLE
Fix self-referencing aliases.

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -441,7 +441,7 @@ class ContextLevel(compiler.ContextLevel):
     empty_result_type_hint: Optional[s_types.Type]
     """Type to use if the statement result expression is an empty set ctor."""
 
-    defining_view: bool
+    defining_view: Optional[s_types.Type]
     """Whether a view is currently being defined (as opposed to be compiled)"""
 
     in_conditional: Optional[parsing.ParserContext]
@@ -502,7 +502,7 @@ class ContextLevel(compiler.ContextLevel):
             self.inhibit_implicit_limit = False
             self.special_computables_in_mutation_shape = frozenset()
             self.empty_result_type_hint = None
-            self.defining_view = False
+            self.defining_view = None
             self.in_conditional = None
 
         else:

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -464,7 +464,7 @@ def _normalize_view_ptr_expr(
                 is_update=is_update,
             )
 
-            shape_expr_ctx.defining_view = True
+            shape_expr_ctx.defining_view = view_scls
             shape_expr_ctx.path_scope.unnest_fence = True
             shape_expr_ctx.partial_path_prefix = setgen.class_set(
                 view_scls.get_bases(ctx.env.schema).first(ctx.env.schema),

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3481,6 +3481,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ['rename alias 01']
         )
 
+    async def test_edgeql_ddl_illegal_alias_01(self):
+        # Issue #1187
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                "illegal self-reference in definition of 'IllegalAlias01'"):
+
+            await self.con.execute(r"""
+                WITH MODULE test
+                CREATE ALIAS IllegalAlias01 := Object {a := IllegalAlias01};
+            """)
+
     async def test_edgeql_ddl_inheritance_alter_01(self):
         await self.con.execute(r"""
             CREATE TYPE test::InhTest01 {

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.94)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 41.99)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
Self-referencing alises are illegal. They should be detected and an
error message provided at the time of creation.

Fixes: #1187