### PR TITLE
Add a GraphQL section to the cheat sheet.

### DIFF
--- a/docs/cheatsheet/__toc__.rst
+++ b/docs/cheatsheet/__toc__.rst
@@ -18,3 +18,4 @@ Cheat Sheet
     annotations
     migrations
     syntax
+    graphql

--- a/docs/cheatsheet/admin.rst
+++ b/docs/cheatsheet/admin.rst
@@ -72,6 +72,8 @@ Configure a port for accessing ``my_new_project`` database using EdgeQL:
     ... };
     CONFIGURE SYSTEM
 
+.. _ref_cheatsheet_admin_graphql:
+
 Configure a port for accessing ``my_new_project`` database using GraphQL:
 
 .. code-block:: edgeql-repl

--- a/docs/cheatsheet/aliases.rst
+++ b/docs/cheatsheet/aliases.rst
@@ -38,25 +38,4 @@ useful for GraphQL access:
     <ref_graphql_index>`.
 
 The aliases defined above allow you to query ``MovieAlias`` with
-:ref:`GraphQL <ref_graphql_index>` like this:
-
-.. code-block:: graphql
-
-    {
-        MovieAlias {
-            title
-            directors {
-                full_name
-            }
-            actors {
-                full_name
-            }
-            reviews {
-                body
-                rating
-                author {
-                    name
-                }
-            }
-        }
-    }
+:ref:`GraphQL <ref_cheatsheet_graphql>`.

--- a/docs/cheatsheet/graphql.rst
+++ b/docs/cheatsheet/graphql.rst
@@ -1,0 +1,173 @@
+.. _ref_cheatsheet_graphql:
+
+GraphQL
+=======
+
+.. note::
+
+    The types used in these queries are defined :ref:`here
+    <ref_cheatsheet_types>`.
+
+For configuring :ref:`GraphQL <ref_graphql_index>` access, :ref:`see
+here <ref_cheatsheet_admin_graphql>`.
+
+Select all users in the system:
+
+.. code-block:: graphql
+
+    {
+        User {
+            id
+            name
+            image
+        }
+    }
+
+Select a movie by title and release year with associated actors
+ordered by last name:
+
+.. code-block:: graphql
+
+    {
+        Movie(
+            filter: {
+                title: {eq: "Dune"},
+                year: {eq: 2020}
+            }
+        ) {
+            id
+            title
+            year
+            description
+
+            directors {
+                id
+                full_name
+            }
+
+            actors(order: {last_name: {dir: ASC}}) {
+                id
+                full_name
+            }
+        }
+    }
+
+Select movies with Keanu Reeves:
+
+.. code-block:: graphql
+
+    {
+        Movie(
+            filter: {
+                actors: {full_name: {eq: "Keanu Reeves"}}
+            }
+        ) {
+            id
+            title
+            year
+            description
+        }
+    }
+
+
+Select a movie by title and year with top 3 most recent reviews (this
+uses the :ref:`MovieAlias <ref_cheatsheet_aliases>` in order to access
+reviews):
+
+.. code-block:: graphql
+
+    {
+        MovieAlias(
+            filter: {
+                title: {eq: "Dune"},
+                year: {eq: 2020}
+            }
+        ) {
+            id
+            title
+            year
+            description
+            reviews(
+                order: {creation_time: {dir: DESC}},
+                first: 3
+            ) {
+                id
+                body
+                rating
+                creation_time
+                author {
+                    id
+                    name
+                }
+            }
+        }
+    }
+
+Use a GraphQL :ref:`mutation <ref_graphql_mutations>` to add a user:
+
+.. code-block:: graphql
+
+    mutation add_user {
+        insert_User(
+            data: {name: "Atreides", image: "atreides.jpg"}
+        ) {
+            id
+        }
+    }
+
+Use a GraphQL :ref:`mutation <ref_graphql_mutations>` to add a review
+by an existing user:
+
+.. code-block:: graphql
+
+    mutation add_review {
+        insert_Review(
+            data: {
+                # Since the movie already exists,
+                # we select it using the same filter
+                # mechanism as for queries.
+                movie: {
+                    filter: {title: {eq: "Dune"}, year: {eq: 2020}},
+                    first: 1
+                },
+                body: "Yay!",
+                rating: 5,
+                # Similarly to the movie we select
+                # the existing user.
+                author: {
+                    filter: {name: {eq: "Atreides"}},
+                    first: 1
+                }
+            }
+        ) {
+            id
+            body
+        }
+    }
+
+Use a GraphQL :ref:`mutation <ref_graphql_mutations>` to add an
+actress to a movie:
+
+.. code-block:: graphql
+
+    mutation add_actor {
+        update_Movie(
+            # Specify which movie needs to be updated.
+            filter: {title: {eq: "Dune"}, year: {eq: 2020}},
+            # Specify the movie data to be updated.
+            data: {
+                actors: {
+                    add: [{
+                        filter: {
+                            full_name: {eq: "Charlotte Rampling"}
+                        }
+                    }]
+                }
+            }
+        ) {
+            id
+            actors {
+                id
+            }
+        }
+    }

--- a/docs/cheatsheet/select.rst
+++ b/docs/cheatsheet/select.rst
@@ -45,7 +45,7 @@ Select movies with Keanu Reeves:
         year,
         description,
     }
-    FILTER .cast.full_name = 'Keanu Reeves'
+    FILTER .actors.full_name = 'Keanu Reeves'
 
 Select all actors that share the last name with other actors and
 include the same-last-name actor list as well:


### PR DESCRIPTION
The GraphQL cheat sheet features queries with filters and ordering as
well as several examples of mutations.

Issue #1163.

I actually ran all the GraphQL queries in our GraphiQL interface to the database created using the code from the migration cheat sheet. Of course, I populated some data that's used in the examples.