### PR TITLE
Use postgres/notify to invalidate query cache on DDL

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -76,7 +76,7 @@ from . import status
 @dataclasses.dataclass(frozen=True)
 class CompilerDatabaseState:
 
-    dbver: int
+    dbver: bytes
     schema: s_schema.Schema
 
 
@@ -225,7 +225,7 @@ class BaseCompiler:
 
         return schema
 
-    async def _get_database(self, dbver: int) -> CompilerDatabaseState:
+    async def _get_database(self, dbver: bytes) -> CompilerDatabaseState:
         if self._cached_db is not None and self._cached_db.dbver == dbver:
             return self._cached_db
 
@@ -250,7 +250,11 @@ class BaseCompiler:
 
     # API
 
-    async def connect(self, dbname: str, dbver: int) -> CompilerDatabaseState:
+    async def connect(
+        self,
+        dbname: str,
+        dbver: bytes
+    ) -> CompilerDatabaseState:
         self._dbname = dbname
         self._cached_db = None
         await self._get_database(dbver)
@@ -1061,7 +1065,7 @@ class Compiler(BaseCompiler):
         return units
 
     async def _ctx_new_con_state(
-        self, *, dbver: int, json_mode: bool, expect_one: bool,
+        self, *, dbver: bytes, json_mode: bool, expect_one: bool,
         modaliases,
         session_config: Optional[immutables.Map],
         stmt_mode: Optional[enums.CompileStatementMode],
@@ -1148,7 +1152,7 @@ class Compiler(BaseCompiler):
 
     # API
 
-    async def try_compile_rollback(self, dbver: int, eql: bytes):
+    async def try_compile_rollback(self, dbver: bytes, eql: bytes):
         statements = edgeql.parse_block(eql.decode())
 
         stmt = statements[0]
@@ -1180,7 +1184,7 @@ class Compiler(BaseCompiler):
 
     async def compile_eql(
             self,
-            dbver: int,
+            dbver: bytes,
             eql: bytes,
             sess_modaliases: Optional[immutables.Map],
             sess_config: Optional[immutables.Map],
@@ -1437,7 +1441,7 @@ class Compiler(BaseCompiler):
 
         schema = await self._introspect_schema_in_snapshot(tx_snapshot_id)
         ctx = await self._ctx_new_con_state(
-            dbver=-1,
+            dbver=b'',
             json_mode=False,
             expect_one=False,
             modaliases=DEFAULT_MODULE_ALIASES_MAP,

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -118,7 +118,7 @@ class TxControlQuery(BaseQuery):
 @dataclasses.dataclass
 class QueryUnit:
 
-    dbver: int
+    dbver: bytes
 
     sql: Tuple[bytes, ...]
 
@@ -353,7 +353,7 @@ class CompilerConnectionState:
 
     __slots__ = ('_savepoints_log', '_dbver', '_current_tx', '_capability')
 
-    def __init__(self, dbver: int,
+    def __init__(self, dbver: bytes,
                  schema: s_schema.Schema,
                  modaliases: immutables.Map,
                  config: immutables.Map,

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -24,7 +24,6 @@ cdef class DatabaseIndex:
         object _server
 
         object _sys_config
-        object _sys_config_ver
         object _sys_queries
         object _instance_data
 
@@ -37,7 +36,7 @@ cdef class Database:
         object _eql_to_compiled
         DatabaseIndex _index
 
-    cdef _signal_ddl(self)
+    cdef _signal_ddl(self, new_dbver)
     cdef _invalidate_caches(self)
     cdef _cache_compiled_query(self, key, query_unit)
     cdef _new_view(self, user, query_cache)
@@ -64,6 +63,8 @@ cdef class DatabaseConnectionView:
 
     cdef _invalidate_local_cache(self)
     cdef _reset_tx_state(self)
+
+    cdef on_remote_ddl(self, bytes new_dbver)
 
     cdef rollback_tx_to_savepoint(self, spid, modaliases, config)
     cdef recover_aliases_and_config(self, modaliases, config)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -20,13 +20,12 @@
 import json
 import os.path
 import pickle
-import time
 import typing
 
 import immutables
 
 from edb import errors
-from edb.common import lru
+from edb.common import lru, uuidgen
 from edb.server import defines, config
 from edb.server.compiler import dbstate
 from edb.pgsql import dbops
@@ -42,15 +41,18 @@ cdef class Database:
 
     def __init__(self, DatabaseIndex index, str name):
         self._name = name
-        self._dbver = time.monotonic_ns()
+        self._dbver = uuidgen.uuid1mc().bytes
 
         self._index = index
 
         self._eql_to_compiled = lru.LRUMapping(
             maxsize=defines._MAX_QUERIES_CACHE)
 
-    cdef _signal_ddl(self):
-        self._dbver = time.monotonic_ns()  # Advance the version
+    cdef _signal_ddl(self, new_dbver):
+        if new_dbver is None:
+            self._dbver = uuidgen.uuid1mc().bytes
+        else:
+            self._dbver = new_dbver
         self._invalidate_caches()
 
     cdef _invalidate_caches(self):
@@ -60,7 +62,7 @@ cdef class Database:
         assert compiled.cacheable
 
         existing = self._eql_to_compiled.get(key)
-        if existing is not None and existing.dbver > compiled.dbver:
+        if existing is not None and existing.dbver == compiled.dbver:
             # We already have a cached query for a more recent DB version.
             return
 
@@ -104,6 +106,11 @@ cdef class DatabaseConnectionView:
         self._in_tx_with_set = False
         self._tx_error = False
         self._invalidate_local_cache()
+
+    cdef on_remote_ddl(self, bytes new_dbver):
+        """Called when a DDL operation was applied at another server."""
+        if new_dbver != self._db._dbver:
+            self._db._signal_ddl(new_dbver)
 
     cdef rollback_tx_to_savepoint(self, spid, modaliases, config):
         self._tx_error = False
@@ -219,13 +226,16 @@ cdef class DatabaseConnectionView:
         self.tx_error()
 
     cdef on_success(self, query_unit):
+        signal_ddl = False
+
         if query_unit.tx_savepoint_rollback:
             # Need to invalidate the cache in case there were
             # SET ALIAS or CONFIGURE or DDL commands.
             self._invalidate_local_cache()
 
         if not self._in_tx and query_unit.has_ddl:
-            self._db._signal_ddl()
+            self._db._signal_ddl(None)
+            signal_ddl = True
 
         if query_unit.modaliases is not None:
             self._modaliases = query_unit.modaliases
@@ -238,7 +248,8 @@ cdef class DatabaseConnectionView:
                     '"commit" outside of a transaction')
             self._config = self._in_tx_config
             if self._in_tx_with_ddl:
-                self._db._signal_ddl()
+                self._db._signal_ddl(None)
+                signal_ddl = True
             self._reset_tx_state()
 
         elif query_unit.tx_rollback:
@@ -247,6 +258,8 @@ cdef class DatabaseConnectionView:
             # TODO: That said, we should send a *warning* when a ROLLBACK
             # is executed outside of a tx.
             self._reset_tx_state()
+
+        return signal_ddl
 
     async def apply_config_ops(self, conn, ops):
         for op in ops:
@@ -280,7 +293,6 @@ cdef class DatabaseIndex:
         self._sys_queries = None
         self._instance_data = None
         self._sys_config = None
-        self._sys_config_ver = time.monotonic_ns()
 
     async def get_sys_query(self, conn, key: str) -> bytes:
         if self._sys_queries is None:
@@ -365,8 +377,6 @@ cdef class DatabaseIndex:
         else:
             raise errors.UnsupportedFeatureError(
                 f'unsupported config operation: {op.opcode}')
-
-        self._sys_config_ver = time.monotonic_ns()
 
         if op.opcode is config.OpCode.CONFIG_ADD:
             await self._server._after_system_config_add(

--- a/edb/server/mng_port/edgecon.pxd
+++ b/edb/server/mng_port/edgecon.pxd
@@ -88,6 +88,8 @@ cdef class EdgeConnection:
         tuple protocol_version
         tuple max_protocol
 
+        object __weakref__
+
     cdef parse_json_mode(self, bytes mode)
     cdef parse_cardinality(self, bytes card)
     cdef char render_cardinality(self, query_unit) except -1

--- a/edb/server/pgcon/pgcon.pxd
+++ b/edb/server/pgcon/pgcon.pxd
@@ -82,6 +82,12 @@ cdef class PGProto:
         bint debug
 
         object pgaddr
+        object edgecon_ref
+
+        bint idle
+
+    cdef before_command(self)
+    cdef after_command(self)
 
     cdef write(self, buf)
 
@@ -90,6 +96,7 @@ cdef class PGProto:
 
     cdef parse_notification(self)
     cdef fallthrough(self)
+    cdef fallthrough_idle(self)
 
     cdef before_prepare(self, stmt_name, dbver, WriteBuffer outbuf)
 

--- a/edb/server/pgconnparams.py
+++ b/edb/server/pgconnparams.py
@@ -225,7 +225,7 @@ def _parse_hostlist(
 def parse_dsn(
     dsn: str,
 ) -> Tuple[
-    Tuple[Union[str, Tuple[str, int]], ...],
+    Tuple[Tuple[str, int], ...],
     ConnectionParameters,
 ]:
     # `auth_hosts` is the version of host information for the purposes
@@ -400,16 +400,9 @@ def parse_dsn(
                 database=database, user=user,
                 passfile=passfile_path)
 
-    addrs: List[Union[str, Tuple[str, int]]] = []
+    addrs: List[Tuple[str, int]] = []
     for h, p in zip(host, port):
-        if h.startswith('/'):
-            # UNIX socket name
-            if '.s.PGSQL.' not in h:
-                h = os.path.join(h, '.s.PGSQL.{}'.format(p))
-            addrs.append(h)
-        else:
-            # TCP host/port
-            addrs.append((h, p))
+        addrs.append((h, p))
 
     if not addrs:
         raise ValueError(

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -19,10 +19,14 @@
 import asyncio
 import json
 import uuid
+import subprocess
+import sys
+import tempfile
 
 import edgedb
 
 from edb.common import taskgroup as tg
+from edb.server import main as server_main
 from edb.testbase import server as tb
 from edb.tools import test
 
@@ -1886,6 +1890,138 @@ class TestServerProto(tb.QueryTestCase):
             ''')
             self.assertEqual(
                 result, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+
+class TestServerProtoMigration(tb.QueryTestCase):
+
+    ISOLATED_METHODS = False
+
+    async def test_server_proto_mig_01(self):
+        # Replicating the "test_edgeql_tutorial" test that might
+        # disappear at some point. That test was the only one that
+        # uncovered a regression in how server schema state is
+        # handled, so we need to keep some form of it.
+
+        typename = f'test_{uuid.uuid4().hex}'
+
+        await self.con.execute(f'''
+            START TRANSACTION;
+            CREATE MIGRATION def TO {{
+                module default {{
+                    type {typename} {{
+                        required property foo -> str;
+                    }}
+                }}
+            }};
+            COMMIT MIGRATION def;
+            COMMIT;
+
+            INSERT {typename} {{
+                foo := '123'
+            }};
+        ''')
+
+        await self.assert_query_result(
+            f'SELECT {typename}.foo',
+            ['123']
+        )
+
+
+class TestServerProtoDdlPropagation(tb.QueryTestCase):
+
+    ISOLATED_METHODS = False
+
+    async def test_server_proto_ddlprop_01(self):
+        conargs = self.get_connect_args()
+
+        settings = self.con.get_settings()
+        pgaddr = settings.get('pgaddr')
+        if pgaddr is None:
+            raise RuntimeError('test requires devmode')
+        pgaddr = json.loads(pgaddr)
+        pgdsn = (
+            f'postgres:///?user={pgaddr["user"]}&port={pgaddr["port"]}'
+            f'&host={pgaddr["host"]}'
+        )
+
+        await self.con.execute('''
+            CREATE TYPE Test {
+                CREATE PROPERTY foo -> int16;
+            };
+
+            INSERT Test { foo := 123 };
+        ''')
+
+        self.assertEqual(
+            await self.con.fetchone('SELECT Test.foo LIMIT 1'),
+            123
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            other_port = server_main.PortType.find_available_port()
+            cmd = [
+                sys.executable, '-m', 'edb.server.main',
+                '--postgres-dsn', pgdsn,
+                '--runstate-dir', tmp,
+                '--port', str(other_port),
+            ]
+
+            # Note: for debug comment "stderr=subprocess.PIPE".
+            proc: asyncio.Process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+            )
+
+            try:
+                attempt = 0
+                while True:
+                    attempt += 1
+                    try:
+                        con2 = await edgedb.async_connect(
+                            host=tmp,
+                            port=other_port,
+                            user=conargs.get('user'),
+                            password=conargs.get('password'),
+                            database=self.get_database_name(),
+                            admin=True,
+                        )
+                    except (ConnectionError, edgedb.ClientConnectionError):
+                        if attempt >= 100:
+                            raise
+                        await asyncio.sleep(0.1)
+                        continue
+                    else:
+                        break
+
+                self.assertEqual(
+                    await con2.fetchone('SELECT Test.foo LIMIT 1'),
+                    123
+                )
+
+                await self.con.execute('''
+                    CREATE TYPE Test2 {
+                        CREATE PROPERTY foo -> str;
+                    };
+
+                    INSERT Test2 { foo := 'text' };
+                ''')
+
+                self.assertEqual(
+                    await self.con.fetchone('SELECT Test2.foo LIMIT 1'),
+                    'text'
+                )
+
+                self.assertEqual(
+                    await con2.fetchone('SELECT Test2.foo LIMIT 1'),
+                    'text'
+                )
+
+                await con2.aclose()
+            finally:
+                if proc.returncode is None:
+                    proc.terminate()
+                    await proc.wait()
 
 
 class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):


### PR DESCRIPTION
This makes it possible to use different EdgeDB servers connected
to the same Postgres cluster.  With this change, when a DDL command
is committed, a `NOTIFY` command is issued which all EdgeDB
connections listen to.