### PR TITLE
Fix a minor REPL bug with commented out lines.

### DIFF
--- a/edb/repl/utils.py
+++ b/edb/repl/utils.py
@@ -59,6 +59,10 @@ def split_edgeql(
     buffer = []
     brace_level = 0
     for tok in lex.lex():
+        if tok.type == 'COMMENT':
+            # skip the comments completely
+            continue
+
         buffer.append(tok.text)
 
         if tok.type == '{':

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -119,7 +119,7 @@ class TestReplUtils(unittest.TestCase):
 
         self.assertEqual(
             utils.split_edgeql('SELECT 1 #;', script_mode=False),
-            ([], 'SELECT 1 #;'))
+            ([], 'SELECT 1 '))
 
     def test_repl_split_edgeql_05(self):
         # test invalid tokens


### PR DESCRIPTION
REPL should clean out the comments when breaking down the query text.
Otherwise it's possible to make REPL submit an empty query (type up a
comment and hit Alt+Enter) and cause a ProtocolError by not having an
actual query.