### PR TITLE
tests: Add another problematic test for alises.

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -103,7 +103,7 @@ def _process_view(
 
     if (view_name is None and ctx.env.schema_view_mode
             and view_rptr is not None):
-        # Make sure persistent schema exprssion aliases have properly formed
+        # Make sure persistent schema expression aliases have properly formed
         # names as opposed to the usual mangled form of the ephemeral
         # aliases.  This is needed for introspection readability, as well
         # as helps in maintaining proper type names for schema


### PR DESCRIPTION
When aliases with deeply nested shapes are created, implicit aliases
get created for every nested shape. Need to make sure that they also get
dropped when the parent explicit alias is dropped.

Issue #1184.