### PR TITLE
Fix several issues in handling of type intersections

### DIFF
--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -358,7 +358,8 @@ def apply_intersection(
     Returns:
         A :class:`~TypeIntersectionResult` named tuple containing the
         result intersection type, whether the type system considers
-        the intersection empty and whether *left* is a subtype of *right*.
+        the intersection empty and whether *left* is related to *right*
+        (i.e either is a subtype of another).
     """
 
     if left.issubclass(ctx.env.schema, right):
@@ -376,11 +377,12 @@ def apply_intersection(
         for component_type in union.objects(ctx.env.schema):
             if component_type.issubclass(ctx.env.schema, right):
                 narrowed_union.append(component_type)
+            elif right.issubclass(ctx.env.schema, component_type):
+                narrowed_union.append(right)
 
         if len(narrowed_union) == 0:
-            # No intersection.
-            empty_intersection = True
             int_type = get_intersection_type((left, right), ctx=ctx)
+            is_subtype = int_type.issubclass(ctx.env.schema, left)
         elif len(narrowed_union) == 1:
             int_type = narrowed_union[0]
             is_subtype = int_type.issubclass(ctx.env.schema, left)

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -186,6 +186,9 @@ class CommonTableExpr(Base):
 
 class PathRangeVar(BaseRangeVar):
 
+    #: The IR TypeRef this rvar represents (if any).
+    typeref: typing.Optional[irast.TypeRef]
+
     @property
     def query(self) -> BaseRelation:
         raise NotImplementedError
@@ -203,6 +206,11 @@ class RelRangeVar(PathRangeVar):
             return self.relation.query
         else:
             return self.relation
+
+
+class IntersectionRangeVar(PathRangeVar):
+
+    component_rvars: typing.List[PathRangeVar]
 
 
 class TypeName(ImmutableBase):

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -157,12 +157,13 @@ def wrap_dml_cte(
     dml_cte: pgast.CommonTableExpr,
     *,
     ctx: context.CompilerContextLevel,
-) -> pgast.RelRangeVar:
+) -> pgast.PathRangeVar:
 
     wrapper = ctx.rel
-    dml_rvar = pgast.RelRangeVar(
-        relation=dml_cte,
-        alias=pgast.Alias(aliasname=ctx.env.aliases.get('d'))
+    dml_rvar = relctx.rvar_for_rel(
+        dml_cte,
+        typeref=ir_stmt.subject.typeref,
+        ctx=ctx,
     )
     relctx.include_rvar(wrapper, dml_rvar, ir_stmt.subject.path_id, ctx=ctx)
     pathctx.put_path_bond(wrapper, ir_stmt.subject.path_id)

--- a/tests/schemas/advtypes.esdl
+++ b/tests/schemas/advtypes.esdl
@@ -47,13 +47,15 @@ type W {
     link w -> W;
 }
 
+type X extending W, U;
+
 type Z {
     required property name -> str {
         constraint exclusive;
     };
 
     # have 'name' in common
-    link stw0 -> S | T | W;
+    multi link stw0 -> S | T | W;
 }
 
 # 3 abstract base types and their concrete permutations

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 100.00)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 46.53)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 46.58)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)


### PR DESCRIPTION
The current handling of type intersections fails to account for the case
where a union is being narrowed by a *subtype* of one of the union types
(as opposed to a *supertype*, which is handled correctly).

Another issue is that the column routing code currently fails to account
for intersection relvars and just picks the first relation out of a set
of intersection type relations.  Fortunately, the "inherited" pointers
in compound types retain the information about the original defining
type, so it's relatively easy to pick the correct relvar by comparing
its typevar to the typevar of the pointer source.