### PR TITLE
Fix error creating role without any options

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,7 +64,8 @@ class TestCLI(tb.ConnectedTestCase, tb.CLITestCaseMixin):
             'create-superuser-role',
             'create-role-empty-options'
         )
-        assert result.exit_code == 0
+
+        self.assertEqual(result.exit_code, 0)
 
     async def test_cli_repl_script(self):
         result = self.run_cli(input='SELECT 1 + 1')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,7 +60,10 @@ class TestCLI(tb.ConnectedTestCase, tb.CLITestCaseMixin):
                               '--password', input='foo-pass\n')
         self.assertIn('input is not a TTY', result.output)
 
-        result = self.run_cli('create-superuser-role', 'create-role-empty-options')
+        result = self.run_cli(
+            'create-superuser-role',
+            'create-role-empty-options'
+        )
         assert result.exit_code == 0
 
     async def test_cli_repl_script(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,6 +60,9 @@ class TestCLI(tb.ConnectedTestCase, tb.CLITestCaseMixin):
                               '--password', input='foo-pass\n')
         self.assertIn('input is not a TTY', result.output)
 
+        result = self.run_cli('create-superuser-role', 'create-role-empty-options')
+        assert result.exit_code == 0
+
     async def test_cli_repl_script(self):
         result = self.run_cli(input='SELECT 1 + 1')
         self.assertEqual(list(result.output.split('\n'))[0], '{2}')


### PR DESCRIPTION
Added `allow_empty` argument to `_process_role_options`
Added test

Fixes #1119 