### PR TITLE
Make the flake8 typing plugin understand typing.* imports

### DIFF
--- a/edb/cli/dump/__init__.py
+++ b/edb/cli/dump/__init__.py
@@ -17,7 +17,7 @@
 #
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import click
 import edgedb

--- a/edb/cli/dump/dump.py
+++ b/edb/cli/dump/dump.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import functools
 import hashlib

--- a/edb/cli/dump/restore.py
+++ b/edb/cli/dump/restore.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import hashlib
 import io

--- a/edb/cli/utils.py
+++ b/edb/cli/utils.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import dataclasses
 import functools

--- a/edb/common/adapter.py
+++ b/edb/common/adapter.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 
 T = TypeVar("T")

--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -24,7 +24,7 @@ import collections.abc
 import functools
 import re
 import sys
-from typing import *  # NoQA
+from typing import *
 
 import typing_inspect
 

--- a/edb/common/ast/codegen.py
+++ b/edb/common/ast/codegen.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import itertools
 

--- a/edb/common/checked.py
+++ b/edb/common/checked.py
@@ -17,7 +17,7 @@
 #
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import collections.abc
 import functools

--- a/edb/common/compiler.py
+++ b/edb/common/compiler.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 import collections
 import re

--- a/edb/common/devmode.py
+++ b/edb/common/devmode.py
@@ -27,7 +27,7 @@ import os
 import pathlib
 import pickle
 import tempfile
-from typing import *  # NoQA
+from typing import *
 
 
 logger = logging.getLogger('edb.devmode.cache')

--- a/edb/common/ordered.py
+++ b/edb/common/ordered.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import collections
 import collections.abc

--- a/edb/common/struct.py
+++ b/edb/common/struct.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 from typing_extensions import Final
 
 import collections

--- a/edb/common/uuidgen.py
+++ b/edb/common/uuidgen.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import hashlib
 import os

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import itertools
 import re

--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -126,7 +126,7 @@ dispatch.py
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -21,7 +21,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from edb.edgeql import ast as qlast
 

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb.edgeql import ast as qlast
 from edb.ir import ast as irast

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -21,7 +21,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import json
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -20,7 +20,7 @@
 """EdgeQL to IR compiler context."""
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 from typing_extensions import Protocol  # type: ignore
 
 import collections

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -21,7 +21,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import functools
 

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import functools
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 import contextlib
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 import functools
 

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -23,7 +23,7 @@
 from __future__ import annotations
 
 import functools
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import copy
 import functools
 import re
-from typing import *  # NoQA
+from typing import *
 from collections import defaultdict
 
 from edb import errors

--- a/edb/edgeql/parser/grammar/keywords.py
+++ b/edb/edgeql/parser/grammar/keywords.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import re
-from typing import *  # NoQA
+from typing import *
 
 
 keyword_types = range(1, 4)

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import copy
 import itertools
-from typing import *  # NoQA
+from typing import *
 
 from edb.common import ast
 from edb.schema import schema as s_schema

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb.common import context as pctx
 from edb.common import exceptions as ex

--- a/edb/graphql/errors.py
+++ b/edb/graphql/errors.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -23,7 +23,7 @@ import contextlib
 import decimal
 import json
 import re
-from typing import *  # NoQA
+from typing import *
 
 import graphql
 from graphql.language import ast as gql_ast

--- a/edb/ir/astexpr.py
+++ b/edb/ir/astexpr.py
@@ -21,7 +21,7 @@
 # mypy does not understand.
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from edb.common.ast import match as astmatch
 

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from . import typeutils
 

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -20,7 +20,7 @@
 """Query scope tree implementation."""
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import textwrap
 import weakref

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -21,7 +21,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import dataclasses
 import decimal

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -20,7 +20,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb.edgeql import qltypes
 

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -20,7 +20,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import json
 

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/pgsql/compiler/aliases.py
+++ b/edb/pgsql/compiler/aliases.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from edb.common import compiler
 from edb.pgsql import common

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb.pgsql import ast as pgast
 from edb.pgsql import types as pg_types

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb.edgeql import qltypes
 from edb.ir import ast as irast

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -20,7 +20,7 @@
 """IR compiler context."""
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import collections
 import enum

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -33,7 +33,7 @@
 from __future__ import annotations
 
 import collections
-from typing import *  # NoQA
+from typing import *
 
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -23,7 +23,7 @@
 from __future__ import annotations
 
 import functools
-from typing import *  # NoQA
+from typing import *
 
 from edb.common import enum as s_enum
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -23,7 +23,7 @@
 from __future__ import annotations
 
 import contextlib
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/pgsql/compiler/shapecomp.py
+++ b/edb/pgsql/compiler/shapecomp.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb.edgeql import qltypes
 

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb.ir import ast as irast
 from edb.ir import utils as irutils

--- a/edb/pgsql/datasources/deltalog.py
+++ b/edb/pgsql/datasources/deltalog.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/introspection/constraints.py
+++ b/edb/pgsql/datasources/introspection/constraints.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/introspection/domains.py
+++ b/edb/pgsql/datasources/introspection/domains.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/introspection/schemas.py
+++ b/edb/pgsql/datasources/introspection/schemas.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/introspection/sequences.py
+++ b/edb/pgsql/datasources/introspection/sequences.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/introspection/tables.py
+++ b/edb/pgsql/datasources/introspection/tables.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch_tables(

--- a/edb/pgsql/datasources/introspection/types.py
+++ b/edb/pgsql/datasources/introspection/types.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/schema/annos.py
+++ b/edb/pgsql/datasources/schema/annos.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/schema/casts.py
+++ b/edb/pgsql/datasources/schema/casts.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/schema/constraints.py
+++ b/edb/pgsql/datasources/schema/constraints.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/schema/databases.py
+++ b/edb/pgsql/datasources/schema/databases.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/schema/functions.py
+++ b/edb/pgsql/datasources/schema/functions.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/schema/indexes.py
+++ b/edb/pgsql/datasources/schema/indexes.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/schema/links.py
+++ b/edb/pgsql/datasources/schema/links.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/schema/modules.py
+++ b/edb/pgsql/datasources/schema/modules.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/schema/objtypes.py
+++ b/edb/pgsql/datasources/schema/objtypes.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/schema/operators.py
+++ b/edb/pgsql/datasources/schema/operators.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/schema/roles.py
+++ b/edb/pgsql/datasources/schema/roles.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/schema/scalars.py
+++ b/edb/pgsql/datasources/schema/scalars.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch(

--- a/edb/pgsql/datasources/schema/types.py
+++ b/edb/pgsql/datasources/schema/types.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import asyncpg
-from typing import *  # NoQA
+from typing import *
 
 
 async def fetch_tuple_views(

--- a/edb/pgsql/dbops/base.py
+++ b/edb/pgsql/dbops/base.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import collections
 import numbers
 import textwrap
-from typing import *  # NoQA
+from typing import *
 
 from edb.common import markup
 from edb.common import struct

--- a/edb/pgsql/dbops/databases.py
+++ b/edb/pgsql/dbops/databases.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import textwrap
 

--- a/edb/pgsql/dbops/ddl.py
+++ b/edb/pgsql/dbops/ddl.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import json
 import textwrap

--- a/edb/pgsql/dbops/indexes.py
+++ b/edb/pgsql/dbops/indexes.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import json
 import textwrap
-from typing import *  # NoQA
+from typing import *
 
 from edb.common import ordered
 from edb.server import defines

--- a/edb/pgsql/dbops/roles.py
+++ b/edb/pgsql/dbops/roles.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import textwrap
 

--- a/edb/pgsql/dbops/triggers.py
+++ b/edb/pgsql/dbops/triggers.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import json
 import textwrap
-from typing import *  # NoQA
+from typing import *
 
 from ..common import qname as qn
 from ..common import quote_ident as qi

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -23,7 +23,7 @@ import collections.abc
 import itertools
 import json
 import textwrap
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -20,7 +20,7 @@
 """Database structure and objects supporting EdgeDB metadata."""
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import collections
 import re

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import collections
 import functools
-from typing import *  # NoQA
+from typing import *
 
 from edb.common import uuidgen
 from edb.edgeql import qltypes

--- a/edb/repl/__init__.py
+++ b/edb/repl/__init__.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import json
 import functools

--- a/edb/repl/cmd.py
+++ b/edb/repl/cmd.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import collections
 import typing_extensions

--- a/edb/repl/context.py
+++ b/edb/repl/context.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import dataclasses
 import enum
-from typing import *  # NoQA
+from typing import *
 import uuid
 
 

--- a/edb/repl/render.py
+++ b/edb/repl/render.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import json
 
@@ -29,7 +29,6 @@ from edb.errors import base as base_errors
 from edb.common.markup.renderers import terminal
 from edb.common.markup.renderers import styles
 
-from typing import *  # NoQA
 from . import context
 from . import render_binary as _binary
 from . import render_json as _json

--- a/edb/repl/render_binary.py
+++ b/edb/repl/render_binary.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import datetime
 import decimal

--- a/edb/repl/render_json.py
+++ b/edb/repl/render_json.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import dataclasses
 import functools

--- a/edb/repl/table.py
+++ b/edb/repl/table.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 from typing_extensions import Literal
 
 import math

--- a/edb/repl/utils.py
+++ b/edb/repl/utils.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import functools
 import re
-from typing import *  # NoQA
+from typing import *
 
 from edb.edgeql import quote as eql_quote
 from edb.edgeql.parser.grammar import lexer

--- a/edb/schema/_types.py
+++ b/edb/schema/_types.py
@@ -3,7 +3,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 
 import uuid

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import functools
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import collections
 import collections.abc

--- a/edb/schema/derivable.py
+++ b/edb/schema/derivable.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from . import abc as s_abc
 from . import name as sn

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -27,7 +27,7 @@ from edb.common import struct
 from edb.edgeql import ast as qlast_
 from edb.edgeql import codegen as qlcodegen
 from edb.edgeql import parser as qlparser
-from typing import *  # NoQA
+from typing import *
 
 from . import abc as s_abc
 from . import objects as so

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import abc
 import types
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from edb import edgeql
 from edb import errors

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from edb.common import struct
 from edb.edgeql import ast as qlast

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -21,7 +21,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from edb.edgeql import ast as qlast
 

--- a/edb/schema/name.py
+++ b/edb/schema/name.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import functools
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 from typing_extensions import Final
 
 import collections

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 import collections
 

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 from edb.common import checked

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import collections
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import hashlib
-from typing import *  # NoQA
+from typing import *
 
 from edb.edgeql import ast as qlast
 

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 import functools
 import itertools

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from . import indexes
 from . import name as sn

--- a/edb/schema/std.py
+++ b/edb/schema/std.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import pathlib
-from typing import *  # NoQA
+from typing import *
 
 from edb import lib as stdlib
 from edb import errors

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import collections
 import decimal
 import itertools
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import json
 import logging

--- a/edb/server/buildmeta.py
+++ b/edb/server/buildmeta.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import enum
 import json

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import collections
 import dataclasses

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import dataclasses
 import enum
 import time
-from typing import *  # NoQA
+from typing import *
 
 import immutables
 

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import enum
 import json
 import re
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 from edb.common import uuidgen

--- a/edb/server/config/__init__.py
+++ b/edb/server/config/__init__.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from .ops import OpLevel, OpCode, Operation, lookup
 from .ops import spec_to_json, to_json, from_json

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
-from typing import *  # NoQA
+from typing import *
 
 import immutables
 

--- a/edb/server/config/spec.py
+++ b/edb/server/config/spec.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import collections.abc
 import dataclasses
 import json
-from typing import *  # NoQA
+from typing import *
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import codegen as qlcodegen

--- a/edb/server/http_graphql_port/compiler.py
+++ b/edb/server/http_graphql_port/compiler.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import *  # NoQA
+from typing import *
 
 from edb import errors
 from edb import graphql

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import asyncio
 import contextlib

--- a/edb/server/mng_port/port.py
+++ b/edb/server/mng_port/port.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import asyncio
 import logging

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -17,7 +17,7 @@
 """PostgreSQL cluster management."""
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import asyncio
 import locale

--- a/edb/server/pgconnparams.py
+++ b/edb/server/pgconnparams.py
@@ -15,7 +15,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import dataclasses
 import getpass

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import json
 import logging

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import functools
 import os

--- a/edb/tools/mypy/plugin.py
+++ b/edb/tools/mypy/plugin.py
@@ -20,7 +20,7 @@
 
 from __future__ import annotations
 
-from typing import *  # NoQA
+from typing import *
 
 from mypy import exprtotype
 import mypy.plugin as mypy_plugin

--- a/edb/tools/profiling/__init__.py
+++ b/edb/tools/profiling/__init__.py
@@ -21,7 +21,7 @@ See README.md in this package for more details.
 """
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 from . import profiler
 

--- a/edb/tools/profiling/cli.py
+++ b/edb/tools/profiling/cli.py
@@ -22,7 +22,7 @@ See README.md in this package for more details.
 """
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import pathlib
 

--- a/edb/tools/profiling/profiler.py
+++ b/edb/tools/profiling/profiler.py
@@ -22,7 +22,7 @@ See README.md in this package for more details.
 """
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import ast
 import atexit

--- a/edb/tools/rewrite_typing.py
+++ b/edb/tools/rewrite_typing.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 import sys
-from typing import *  # NoQA
+from typing import *
 
 from black import lib2to3_parse, Visitor, Leaf, Node, LN, syms
 from blib2to3.pgen2 import token

--- a/edb/tools/test/mproc_fixes.py
+++ b/edb/tools/test/mproc_fixes.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import logging
 import multiprocessing.pool

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import collections.abc
 import enum

--- a/edb/tools/wipe.py
+++ b/edb/tools/wipe.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import *  # NoQA
+from typing import *
 
 import asyncio
 import json

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -292,7 +292,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "testbase", 1.04)
 
     def test_cqa_type_coverage_tools(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "tools", 21.59)
+        self.assertFunctionCoverage(EDB_DIR / "tools", 21.49)
 
     def test_cqa_type_coverage_tools_docs(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "tools" / "docs", 0)


### PR DESCRIPTION
With this change, we no longer have to `# NoQA` typing imports.