### PR TITLE
Fix dependency tracking.

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1552,6 +1552,28 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_get_migration_32(self):
+        # Test migration of index dependent on two links.
+        # Issue #1181
+        schema = r'''
+        type Author {
+            required property name -> str;
+        }
+
+        type Comment {
+            required property body -> str;
+        }
+
+        type CommentRating {
+            required link author -> Author;
+            required link comment -> Comment;
+
+            index on ((__subject__.author, __subject__.comment));
+        }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_get_migration_multi_module_01(self):
         schema = r'''
             # The two declared types declared are from different


### PR DESCRIPTION
The original DDL breaking up and merging algorithm made some incorrect
assumptions about how dependencies of sub-commands of a single top-level
command could be merged. Because of that some dependencies were
disregarded.

The updated algorithm makes no special assumptions about dependencies
regardless of whether they are across different top-level commands or
based on sibling sub-commands. A sub-command can be merged if and only
if all of its dependencies have been merged into preceding commands or
the current top-level command.

In particular this also fixes an issue with tracking dependencies of
indexes.

Fixes #1181.