### PR TITLE
Correctly process "object_in_use" error.

### DIFF
--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -60,6 +60,8 @@ class PGErrorCode(enum.Enum):
 
     InvalidCatalogNameError = '3D000'
 
+    ObjectInUse = '55006'
+
 
 class SchemaRequired:
     '''A sentinel used to signal that a particular error requires a schema.'''
@@ -312,6 +314,9 @@ def static_interpret_backend_error(fields):
 
     elif err_details.code == PGErrorCode.InvalidCatalogNameError:
         return errors.AuthenticationError(err_details.message)
+
+    elif err_details.code == PGErrorCode.ObjectInUse:
+        return errors.ExecutionError(err_details.message)
 
     return errors.InternalServerError(err_details.message)
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -17,6 +17,8 @@
 #
 
 
+import edgedb
+
 from edb.testbase import server as tb
 
 
@@ -26,6 +28,17 @@ class TestDatabase(tb.ConnectedTestCase):
 
         try:
             conn = await self.connect(database='mytestdb')
+
+            with self.assertRaisesRegex(edgedb.ExecutionError,
+                                        r'cannot drop the currently open '
+                                        r'database'):
+                await conn.execute('DROP DATABASE mytestdb;')
+
+            with self.assertRaisesRegex(edgedb.ExecutionError,
+                                        r'database "mytestdb" is being '
+                                        r'accessed by other users'):
+                await self.con.execute('DROP DATABASE mytestdb;')
+
             await conn.aclose()
         finally:
             await self.con.execute('DROP DATABASE mytestdb;')


### PR DESCRIPTION
Dropping a database while connected to it should generate
ExecutionError.