### PR TITLE
Add `get_current_database` function to `sys` module.

### DIFF
--- a/docs/edgeql/funcops/sys.rst
+++ b/docs/edgeql/funcops/sys.rst
@@ -29,6 +29,9 @@ System
     * - :eql:func:`sys::get_version_as_str`
       - :eql:func-desc:`sys::get_version_as_str`
 
+    * - :eql:func:`sys::get_current_database`
+      - :eql:func-desc:`sys::get_current_database`
+
 
 -----------
 
@@ -135,6 +138,9 @@ System
         {'1.0-alpha.1'}
 
 
+----------
+
+
 .. eql:function:: sys::get_transaction_isolation() -> \
                         sys::TransactionIsolation
 
@@ -147,6 +153,19 @@ System
 
         db> SELECT sys::get_transaction_isolation();
         {<enum>'REPEATABLE READ'}
+
+
+----------
+
+
+.. eql:function:: sys::get_current_database() -> str
+
+    Return the name of the current database as a string.
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT sys::get_current_database();
+        {'my_database'}
 
 
 -----------

--- a/edb/edgeql/pygments/meta.py
+++ b/edb/edgeql/pygments/meta.py
@@ -247,6 +247,7 @@ class EdgeQL:
         "enumerate",
         "find",
         "floor",
+        "get_current_database",
         "get_transaction_isolation",
         "get_version",
         "get_version_as_str",

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -187,3 +187,12 @@ sys::get_transaction_isolation() -> sys::TransactionIsolation
     SET force_return_cast := true;
     USING SQL FUNCTION 'edgedb._get_transaction_isolation';
 };
+
+
+CREATE FUNCTION
+sys::get_current_database() -> str
+{
+    # The results won't change within a single statement.
+    SET volatility := 'STABLE';
+    USING SQL FUNCTION 'current_database';
+};

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -23,7 +23,7 @@ from edb.testbase import server as tb
 
 
 class TestDatabase(tb.ConnectedTestCase):
-    async def test_database_create01(self):
+    async def test_database_create_01(self):
         await self.con.execute('CREATE DATABASE mytestdb;')
 
         try:
@@ -42,3 +42,16 @@ class TestDatabase(tb.ConnectedTestCase):
             await conn.aclose()
         finally:
             await self.con.execute('DROP DATABASE mytestdb;')
+
+    async def test_database_current_database_01(self):
+        await self.con.execute('CREATE DATABASE currentdb;')
+
+        try:
+            conn = await self.connect(database='currentdb')
+
+            dbname = await conn.fetchall('SELECT sys::get_current_database();')
+            self.assertEqual(dbname, ['currentdb'])
+
+            await conn.aclose()
+        finally:
+            await self.con.execute('DROP DATABASE currentdb;')


### PR DESCRIPTION
Reflect Postgres' `current_database()` into
`sys::get_current_database()`.

Issue #1213.