### PR TITLE
Allow tuple arrays in schema definitions

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -661,24 +661,13 @@ def finalize_args(
             assert isinstance(paramtype, s_types.Array)
             paramtype = list(paramtype.get_subtypes(ctx.env.schema))[0]
 
-        val_material_type = barg.valtype.material_type(ctx.env.schema)
-        param_material_type = paramtype.material_type(ctx.env.schema)
-
         # Check if we need to cast the argument value before passing
         # it to the callable.
-        compatible = val_material_type.issubclass(
-            ctx.env.schema, param_material_type
+        compatible = schemactx.is_type_compatible(
+            paramtype,
+            barg.valtype,
+            ctx=ctx,
         )
-        if compatible:
-            if (
-                isinstance(param_material_type, s_types.Tuple)
-                and isinstance(val_material_type, s_types.Tuple)
-            ):
-                # For tuples, we also check that the element names match.
-                compatible = (
-                    param_material_type.get_element_names(ctx.env.schema) ==
-                    val_material_type.get_element_names(ctx.env.schema)
-                )
 
         if not compatible:
             # The callable form was chosen via an implicit cast,

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -454,3 +454,28 @@ def get_union_pointer(
     ctx.env.created_schema_objects.add(ptr)
 
     return ptr
+
+
+def is_type_compatible(
+    type_a: s_types.Type,
+    type_b: s_types.Type,
+    *,
+    ctx: context.ContextLevel,
+) -> bool:
+
+    material_type_a = type_a.material_type(ctx.env.schema)
+    material_type_b = type_b.material_type(ctx.env.schema)
+
+    compatible = material_type_b.issubclass(ctx.env.schema, material_type_a)
+    if compatible:
+        if (
+            isinstance(material_type_a, s_types.Tuple)
+            and isinstance(material_type_b, s_types.Tuple)
+        ):
+            # For tuples, we also check that the element names match.
+            compatible = (
+                material_type_a.get_element_names(ctx.env.schema) ==
+                material_type_b.get_element_names(ctx.env.schema)
+            )
+
+    return compatible

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -220,6 +220,10 @@ def fini_expression(
         schema=ctx.env.schema,
         schema_refs=frozenset(
             ctx.env.schema_refs - ctx.env.created_schema_objects),
+        new_coll_types=frozenset(
+            t for t in ctx.env.created_schema_objects
+            if isinstance(t, s_types.Collection) and t != expr_type
+        ),
     )
     return result
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -401,6 +401,7 @@ class Statement(Command):
     view_shapes_metadata: typing.Dict[so.Object, ViewShapeMetadata]
     schema: s_schema.Schema
     schema_refs: typing.FrozenSet[so.Object]
+    new_coll_types: typing.FrozenSet[s_types.Collection]
     scope_tree: ScopeTreeNode
     source_map: typing.Dict[s_pointers.Pointer,
                             typing.Tuple[qlast.Expr,

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -274,12 +274,15 @@ class TupleVarBase(OutputVar):
     elements: typing.Sequence[TupleElementBase]
     named: bool
     nullable: bool
+    typeref: typing.Optional[irast.TypeRef]
 
     def __init__(self, elements: typing.List[TupleElementBase], *,
-                 named: bool=False, nullable: bool=False):
+                 named: bool=False, nullable: bool=False,
+                 typeref: typing.Optional[irast.TypeRef]=None):
         self.elements = elements
         self.named = named
         self.nullable = nullable
+        self.typeref = typeref
 
     def __repr__(self):
         return f'<{self.__class__.__name__} [{self.elements!r}]'
@@ -290,10 +293,12 @@ class TupleVar(TupleVarBase):
     elements: typing.Sequence[TupleElement]
 
     def __init__(self, elements: typing.List[TupleElement], *,
-                 named: bool=False, nullable: bool=False):
+                 named: bool=False, nullable: bool=False,
+                 typeref: typing.Optional[irast.TypeRef]=None):
         self.elements = elements
         self.named = named
         self.nullable = nullable
+        self.typeref = typeref
 
 
 class BaseParamRef(ImmutableBaseExpr):

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -56,7 +56,8 @@ def compile_ir_to_sql_tree(
             expected_cardinality_one=expected_cardinality_one,
             use_named_params=use_named_params,
             ignore_object_shapes=ignore_shapes,
-            explicit_top_cast=explicit_top_cast)
+            explicit_top_cast=explicit_top_cast,
+            singleton_mode=singleton_mode)
 
         if isinstance(ir_expr, irast.Statement):
             scope_tree = ir_expr.scope_tree

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -319,7 +319,11 @@ def get_rvar_var(
                 pgast.TupleElement(
                     path_id=el.path_id, name=el.name, val=val))
 
-        fieldref = pgast.TupleVar(elements, named=var.named)
+        fieldref = pgast.TupleVar(
+            elements,
+            named=var.named,
+            typeref=var.typeref,
+        )
 
     elif isinstance(var, pgast.ColumnRef):
         fieldref = get_column(rvar, var)
@@ -356,7 +360,11 @@ def strip_output_var(
                 pgast.TupleElement(
                     path_id=el.path_id, name=el_name, val=val))
 
-        result = pgast.TupleVar(elements, named=var.named)
+        result = pgast.TupleVar(
+            elements,
+            named=var.named,
+            typeref=var.typeref,
+        )
 
     elif isinstance(var, pgast.ColumnRef):
         result = pgast.ColumnRef(

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -272,6 +272,7 @@ class Environment:
     expected_cardinality_one: bool
     ignore_object_shapes: bool
     explicit_top_cast: Optional[irast.TypeRef]
+    singleton_mode: bool
 
     def __init__(
         self,
@@ -280,6 +281,7 @@ class Environment:
         use_named_params: bool,
         expected_cardinality_one: bool,
         ignore_object_shapes: bool,
+        singleton_mode: bool,
         explicit_top_cast: Optional[irast.TypeRef],
     ) -> None:
         self.aliases = aliases.AliasGenerator()
@@ -288,4 +290,5 @@ class Environment:
         self.ptrref_source_visibility = {}
         self.expected_cardinality_one = expected_cardinality_one
         self.ignore_object_shapes = ignore_object_shapes
+        self.singleton_mode = singleton_mode
         self.explicit_top_cast = explicit_top_cast

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -485,7 +485,7 @@ def compile_Tuple(
         val = dispatch.compile(e.val, ctx=ctx)
         elements.append(pgast.TupleElement(path_id=e.path_id, val=val))
 
-    result = pgast.TupleVar(elements=elements)
+    result = pgast.TupleVar(elements=elements, typeref=ttype)
 
     return output.output_as_value(result, env=ctx.env)
 

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -851,7 +851,11 @@ def _get_path_output(
             elements.append(pgast.TupleElementBase(
                 path_id=el_path_id, name=element))
 
-        result = pgast.TupleVarBase(elements=elements, named=ref.named)
+        result = pgast.TupleVarBase(
+            elements=elements,
+            named=ref.named,
+            typeref=ref.typeref,
+        )
 
     else:
         if astutils.is_set_op_query(rel):

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -556,8 +556,14 @@ def finalize_optional_rel(
                     tvarels.append(pgast.TupleElementBase(
                         path_id=element.path_id))
                 pathctx.put_path_value_var(
-                    optrel.emptyrel, path_id,
-                    pgast.TupleVarBase(elements=tvarels), env=subctx.env)
+                    optrel.emptyrel,
+                    path_id,
+                    pgast.TupleVarBase(
+                        elements=tvarels,
+                        typeref=tvar.typeref,
+                    ),
+                    env=subctx.env,
+                )
                 pathctx.put_path_source_rvar(
                     optrel.emptyrel, path_id, null_rvar, env=subctx.env)
 
@@ -1444,7 +1450,11 @@ def process_set_as_tuple(
                 pathctx.put_path_var(stmt, path_id, var,
                                      aspect='serialized', env=subctx.env)
 
-        set_expr = pgast.TupleVarBase(elements=elements, named=expr.named)
+        set_expr = pgast.TupleVarBase(
+            elements=elements,
+            named=expr.named,
+            typeref=ir_set.typeref,
+        )
 
     relctx.ensure_bond_for_expr(ir_set, stmt, ctx=ctx)
     pathctx.put_path_value_var(stmt, ir_set.path_id, set_expr, env=ctx.env)
@@ -1745,7 +1755,8 @@ def _process_set_func_with_ordinality(
                 )
                 for i, n in enumerate(colnames[:-1])
             ],
-            named=inner_named_tuple
+            named=inner_named_tuple,
+            typeref=inner_rtype,
         )
     else:
         inner_expr = astutils.get_column(
@@ -1852,7 +1863,8 @@ def _process_set_func(
                 )
                 for i, n in enumerate(colnames)
             ],
-            named=named_tuple
+            named=named_tuple,
+            typeref=rtype,
         )
 
         for element in set_expr.elements:

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -205,7 +205,7 @@ def pg_type_from_ir_typeref(
         return ('record',)
 
     elif irtyputils.is_tuple(ir_typeref):
-        if persistent_tuples:
+        if persistent_tuples or ir_typeref.in_schema:
             return common.get_tuple_backend_name(ir_typeref.id, catenate=False)
         else:
             return ('record',)

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -225,14 +225,6 @@ class PropertyCommand(pointers.PointerCommand,
                 context=srcctx,
             )
 
-        if target_type.is_collection():
-            srcctx = self.get_attribute_source_context('target')
-            s_types.ensure_schema_collection(
-                schema, target_type, self,
-                src_context=srcctx,
-                context=context,
-            )
-
 
 class CreateProperty(PropertyCommand,
                      referencing.CreateReferencedInheritingObject):

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import *
 
 import collections
+import uuid
 
 from edb.common import topological
 
@@ -30,6 +31,7 @@ from . import inheriting
 from . import name as sn
 from . import objects as so
 from . import referencing
+from . import types as s_types
 
 if TYPE_CHECKING:
     from . import schema as s_schema
@@ -359,7 +361,12 @@ def get_object(
 ) -> so.Object:
     metaclass = op.get_schema_metaclass()
 
-    if issubclass(metaclass, so.UnqualifiedObject):
+    if issubclass(metaclass, s_types.SchemaCollection):
+        if sn.Name.is_qualified(name):
+            return schema.get(name)
+        else:
+            return schema.get_by_id(uuid.UUID(name))
+    elif issubclass(metaclass, so.UnqualifiedObject):
         return schema.get_global(metaclass, name)
     else:
         return schema.get(name)

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -629,6 +629,17 @@ class PointerCommandOrFragment:
                         )
 
                 target = utils.reduce_to_typeref(schema, target_t)
+
+            elif isinstance(target_ref, s_types.Collection):
+                srcctx = self.get_attribute_source_context('target')
+                target = utils.resolve_typeref(target_ref, schema)
+                s_types.ensure_schema_collection(
+                    schema,
+                    target,
+                    parent_cmd=self,
+                    src_context=srcctx,
+                    context=context,
+                )
             else:
                 target = target_ref
 

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -196,14 +196,19 @@ class ReferencedObjectCommandBase(sd.ObjectCommand,
     _referrer_context_class = None
 
     @classmethod
-    def get_referrer_context_class(cls) -> Type[sd.CommandContext]:
+    def get_referrer_context_class(
+        cls,
+    ) -> Type[sd.CommandContextToken[sd.Command]]:
         if cls._referrer_context_class is None:
             raise TypeError(
                 f'referrer_context_class is not defined for {cls}')
         return cls._referrer_context_class
 
     @classmethod
-    def get_referrer_context(cls, context) -> Optional[sd.CommandContext]:
+    def get_referrer_context(
+        cls,
+        context,
+    ) -> Optional[sd.CommandContextToken[sd.Command]]:
         """Get the context of the command for the referring object, if any.
 
         E.g. for a `create/alter/etc concrete link` command this would

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -1171,17 +1171,21 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             ]
         )
 
-        with self.assertRaisesRegex(
-                edgedb.UnsupportedFeatureError,
-                'arrays of tuples are not supported'):
-            await self.con.execute('''
-                CREATE FUNCTION test::call33_2(
-                    a: array<tuple<int64, int64>>
-                ) -> int64
-                    USING EdgeQL $$
-                        SELECT a[0].0
-                    $$;
-            ''')
+        await self.con.execute('''
+            CREATE FUNCTION test::call33_2(
+                a: array<tuple<int64, int64>>
+            ) -> int64
+                USING EdgeQL $$
+                    SELECT a[0].0
+                $$;
+        ''')
+
+        await self.assert_query_result(
+            r'''SELECT test::call33_2([(1, 2), (3, 4)]);''',
+            [
+                1,
+            ]
+        )
 
     async def test_edgeql_calls_34(self):
         # Tuple return
@@ -1209,17 +1213,21 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             ]
         )
 
-        with self.assertRaisesRegex(
-                edgedb.UnsupportedFeatureError,
-                'arrays of tuples are not supported'):
-            await self.con.execute('''
-                CREATE FUNCTION test::call34_2(
-                    a: int64
-                ) -> array<tuple<int64>>
-                    USING EdgeQL $$
-                        SELECT [(a,)]
-                    $$;
-            ''')
+        await self.con.execute('''
+            CREATE FUNCTION test::call34_2(
+                a: int64
+            ) -> array<tuple<int64>>
+                USING EdgeQL $$
+                    SELECT [(a,)]
+                $$;
+        ''')
+
+        await self.assert_query_result(
+            r'''SELECT test::call34_2(1);''',
+            [
+                [[1]]
+            ]
+        )
 
     async def test_edgeql_calls_35(self):
         # define a function with positional arguments with defaults

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4260,6 +4260,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             };
         """)
 
+        await self.con.execute(r"""
+            ALTER TYPE test::TupProp02 {
+                CREATE PROPERTY p5 -> array<tuple<int64>>;
+            };
+        """)
+
         await self.con.execute('DECLARE SAVEPOINT t0;')
 
         with self.assertRaisesRegex(
@@ -4268,22 +4274,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             await self.con.execute(r"""
                 ALTER TYPE test::TupProp02 {
-                    CREATE PROPERTY p5 -> tuple<test::TupProp02>;
+                    CREATE PROPERTY p6 -> tuple<test::TupProp02>;
                 };
             """)
 
         # Recover.
         await self.con.execute('ROLLBACK TO SAVEPOINT t0;')
-
-        with self.assertRaisesRegex(
-                edgedb.UnsupportedFeatureError,
-                'arrays of tuples are not supported'):
-
-            await self.con.execute(r"""
-                ALTER TYPE test::TupProp02 {
-                    CREATE PROPERTY p5 -> array<tuple<int64>>;
-                };
-            """)
 
     async def test_edgeql_ddl_enum_01(self):
         await self.con.execute('''

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 42.41)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 42.46)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 66.23)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 66.26)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 13.88)


### PR DESCRIPTION
Currently, `array<tuple<...>>` is not allowed in schema definitions
(although expressions of such types are allowed in queries).
Originally, this restriction was placed because Postgres has
non-trivial limitations with respect to composite type casts.
Specifically, it is impossible to cast `record[]` to any composite type
array, and it is also impossible to cast a composite type into another
composite type even if they are compatible element-wise.

Fortunately, the casting infrastructure in the compiler is now advanced
enough to side-step the aforementioned issues and remove the tuple array
restriction.