### PR TITLE
Update Graphql section in tutorial - concurrency 1

### DIFF
--- a/docs/tutorial/graphql.rst
+++ b/docs/tutorial/graphql.rst
@@ -14,7 +14,7 @@ configuration:
     .........     address := "127.0.0.1",
     .........     port := 8888,
     .........     user := "http",
-    .........     concurrency := 4,
+    .........     concurrency := 1,
     ......... };
     CONFIGURE SYSTEM
 


### PR DESCRIPTION
This will make the tutorial work on machines with less than `1GB` of RAM. Addresses #1221