### PR TITLE
docs: Fix GraphQL filtering example in the Variables subsection

### DIFF
--- a/docs/clients/99_graphql/graphql.rst
+++ b/docs/clients/99_graphql/graphql.rst
@@ -363,10 +363,16 @@ mapped to variables in EdgeQL.
     | .. code-block:: graphql         | .. code-block:: edgeql          |
     |                                 |                                 |
     |     query ($title: String!) {   |     SELECT                      |
-    |         Book(title: $title) {   |         Book {                  |
-    |             title               |             title,              |
-    |             synopsis            |             synopsis,           |
-    |         }                       |         }                       |
-    |     }                           |     FILTER                      |
-    |                                 |         Book.title = $title;    |
+    |         Book(                   |        Book {                   |
+    |           filter: {             |            title,               |
+    |             title: {            |            synopsis,            |
+    |               eq: $title        |        }                        |
+    |             }                   |     FILTER                      |
+    |           }                     |         .title = $title;        |
+    |         ) {                     |                                 |
+    |             title               |                                 |
+    |             synopsis            |                                 |
+    |         }                       |                                 |
+    |     }                           |                                 |
+    |                                 |                                 |
     +---------------------------------+---------------------------------+


### PR DESCRIPTION
The filtering syntax is actually different now.