### PR TITLE
Generalize ParametricType and use it for ObjectCollections

### DIFF
--- a/edb/common/parametric.py
+++ b/edb/common/parametric.py
@@ -1,0 +1,159 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2011-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+from typing import *
+
+import functools
+import types
+
+
+__all__ = [
+    "ParametricType",
+    "SingleParameter",
+    "KeyValueParameter",
+]
+
+
+class ParametricType:
+    types: ClassVar[Optional[Tuple[type, ...]]] = None
+    _forward_refs: ClassVar[Dict[str, Tuple[int, str]]] = {}
+
+    def __init__(self) -> None:
+        if self._forward_refs:
+            raise TypeError(
+                f"{type(self)!r} unresolved type parameters"
+            )
+        if self.types is None:
+            raise TypeError(
+                f"{type(self)!r} must be parametrized to instantiate"
+            )
+
+        super().__init__()
+
+    @classmethod
+    @functools.lru_cache()
+    def __class_getitem__(
+        cls, params: Union[Union[type, str], Tuple[Union[type, str], ...]]
+    ) -> Type[ParametricType]:
+        """Return a dynamic subclass parametrized with `params`.
+
+        We cannot use `_GenericAlias` provided by `Generic[T]` because the
+        default `__class_getitem__` on `_GenericAlias` is not a real type and
+        so it doesn't retain information on generics on the class.  Even on
+        the object, it adds the relevant `__orig_class__` link too late, after
+        `__init__()` is called.  That means we wouldn't be able to type-check
+        in the initializer using built-in `Generic[T]`.
+        """
+        if cls.types is not None:
+            raise TypeError(f"{cls!r} is already parametrized")
+
+        if not isinstance(params, tuple):
+            params = (params,)
+        params_str = ", ".join(_type_repr(a) for a in params)
+        name = f"{cls.__name__}[{params_str}]"
+        bases = (cls,)
+        type_dict = {"types": params, "__module__": cls.__module__}
+        forward_refs: Dict[str, Tuple[int, str]] = {}
+        tuple_to_attr: Dict[int, str] = {}
+        if issubclass(cls, SingleParameter):
+            if len(params) != 1:
+                raise TypeError(f"{cls!r} expects one type parameter")
+            type_dict["type"] = params[0]
+            tuple_to_attr[0] = "type"
+        elif issubclass(cls, KeyValueParameter):
+            if len(params) != 2:
+                raise TypeError(f"{cls!r} expects two type parameters")
+            type_dict["keytype"] = params[0]
+            tuple_to_attr[0] = "keytype"
+            type_dict["valuetype"] = params[1]
+            tuple_to_attr[1] = "valuetype"
+        if not all(isinstance(param, type) for param in params):
+            if all(type(param) == TypeVar for param in params):
+                # All parameters are type variables: return the regular generic
+                # alias to allow proper subclassing.
+                generic = super(ParametricType, cls)
+                return generic.__class_getitem__(params)  # type: ignore
+            else:
+                forward_refs = {
+                    param: (i, tuple_to_attr[i])
+                    for i, param in enumerate(params)
+                    if isinstance(param, str)
+                }
+
+                if not forward_refs:
+                    raise TypeError(
+                        f"{cls!r} expects types as type parameters")
+
+        result = type(name, bases, type_dict)
+        assert issubclass(result, ParametricType)
+        result._forward_refs = forward_refs
+        return result
+
+    @classmethod
+    def is_fully_resolved(cls) -> bool:
+        return not cls._forward_refs
+
+    @classmethod
+    def resolve_types(cls, globalns: Dict[str, Any]) -> None:
+        if cls.types is None:
+            raise TypeError(
+                f"{cls!r} is not parametrized"
+            )
+
+        if not cls._forward_refs:
+            return
+
+        types = list(cls.types)
+
+        for ut, (idx, attr) in cls._forward_refs.items():
+            t = eval(ut, globalns, {})
+            if isinstance(t, type):
+                types[idx] = t
+                setattr(cls, attr, t)
+            else:
+                raise TypeError(
+                    f"{cls!r} expects types as type parameters, got {t!r:.100}"
+                )
+
+        cls.types = tuple(types)
+        cls._forward_refs = {}
+
+    def __reduce__(self) -> Tuple[Any, ...]:
+        raise NotImplementedError(
+            'must implement explicit __reduce__ for ParametricType subclass'
+        )
+
+
+class SingleParameter:
+    type: ClassVar[type]
+
+
+class KeyValueParameter:
+    keytype: ClassVar[type]
+    valuetype: ClassVar[type]
+
+
+def _type_repr(obj: Any) -> str:
+    if isinstance(obj, type):
+        if obj.__module__ == "builtins":
+            return obj.__qualname__
+        return f"{obj.__module__}.{obj.__qualname__}"
+    if isinstance(obj, types.FunctionType):
+        return obj.__name__
+    return repr(obj)

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -586,7 +586,7 @@ class IntrospectionMech:
         if refs is None:
             refs = []
 
-        refs = s_obj.ObjectSet.create(
+        refs = s_obj.ObjectSet[s_obj.Object].create(
             schema, [schema.get_by_id(ref) for ref in refs])
 
         return s_expr.Expression(text=text, origtext=origtext, refs=refs)

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -93,7 +93,7 @@ class AnnotationSubject(so.Object):
         ref_cls=AnnotationValue)
 
     annotations = so.SchemaField(
-        so.ObjectIndexByShortname,
+        so.ObjectIndexByShortname[AnnotationValue],
         inheritable=False, ephemeral=True, coerce=True, compcoef=0.909,
         default=so.DEFAULT_CONSTRUCTOR)
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -292,7 +292,7 @@ class ConsistencySubject(so.InheritingObject):
         ref_cls=Constraint)
 
     constraints = so.SchemaField(
-        so.ObjectIndexByFullname,
+        so.ObjectIndexByFullname[Constraint],
         inheritable=False, ephemeral=True, coerce=True, compcoef=0.887,
         default=so.DEFAULT_CONSTRUCTOR)
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -438,7 +438,7 @@ class ParameterLikeList(abc.ABC):
         raise NotImplementedError
 
 
-class FuncParameterList(so.ObjectList, ParameterLikeList, type=Parameter):
+class FuncParameterList(so.ObjectList[Parameter], ParameterLikeList):
 
     def get_by_name(self, schema: s_schema.Schema, name) -> Parameter:
         for param in self.objects(schema):

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -65,7 +65,7 @@ class IndexableSubject(so.InheritingObject):
         ref_cls=Index)
 
     indexes = so.SchemaField(
-        so.ObjectIndexByUnqualifiedName,
+        so.ObjectIndexByUnqualifiedName[Index],
         inheritable=False, ephemeral=True, coerce=True, compcoef=0.909,
         default=so.DEFAULT_CONSTRUCTOR)
 

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -46,7 +46,7 @@ class Source(indexes.IndexableSubject):
         ref_cls=pointers.Pointer)
 
     pointers = so.SchemaField(
-        so.ObjectIndexByUnqualifiedName,
+        so.ObjectIndexByUnqualifiedName[pointers.Pointer],
         inheritable=False, ephemeral=True, coerce=True, compcoef=0.857,
         default=so.DEFAULT_CONSTRUCTOR)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -127,6 +127,22 @@ warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
 
+[mypy-edb.common.parametric]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+
 [mypy-edb.common.struct]
 follow_imports = True
 ignore_errors = False

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -197,7 +197,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "cli", 36.67)
 
     def test_cqa_type_coverage_common(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "common", 34.29)
+        self.assertFunctionCoverage(EDB_DIR / "common", 34.79)
 
     def test_cqa_type_coverage_common_ast(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "common" / "ast", 7.58)
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 69.27)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 69.43)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 13.88)


### PR DESCRIPTION
`ObjectCollection` subclasses are fairly similar to the checked
collections found in `common.checked`, and the reflection infrastructure
could benefit from a more specific collection type specification in
fields.

This also adds limited support for forward references in type arguments.