### PR TITLE
graphql: Reflect "description" annotations into GraphQL descriptions.

### DIFF
--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -261,6 +261,14 @@ class GQLCoreSchema:
         else:
             return name
 
+    def _get_description(self, edb_type):
+        description_anno = edb_type.get_annotations(self.edb_schema).get(
+            self.edb_schema, 'std::description', None)
+        if description_anno is not None:
+            return description_anno.get_value(self.edb_schema)
+
+        return None
+
     def _convert_edb_type(self, edb_target):
         target = None
 
@@ -727,14 +735,16 @@ class GQLCoreSchema:
             values=OrderedDict(
                 ASC=GraphQLEnumValue(),
                 DESC=GraphQLEnumValue()
-            )
+            ),
+            description='Enum value used to specify ordering direction.',
         )
         self._gql_enums['nullsOrderingEnum'] = GraphQLEnumType(
             'nullsOrderingEnum',
             values=OrderedDict(
                 SMALLEST=GraphQLEnumValue(),
                 BIGGEST=GraphQLEnumValue(),
-            )
+            ),
+            description='Enum value used to specify how nulls are ordered.',
         )
 
         scalar_types = list(
@@ -750,7 +760,8 @@ class GQLCoreSchema:
                     values=OrderedDict(
                         (key, GraphQLEnumValue()) for key in
                         st.get_enum_values(self.edb_schema)
-                    )
+                    ),
+                    description=self._get_description(st),
                 )
 
                 self._gql_enums[gql_name] = enum_type
@@ -862,6 +873,7 @@ class GQLCoreSchema:
                 name=gql_name,
                 fields=partial(self.get_fields, t_name),
                 resolve_type=lambda obj, info: obj,
+                description=self._get_description(t),
             )
             self._gql_interfaces[t_name] = gqltype
 
@@ -913,6 +925,7 @@ class GQLCoreSchema:
                 name=gql_name + 'Type',
                 fields=partial(self.get_fields, t_name),
                 interfaces=interfaces,
+                description=self._get_description(t),
             )
             self._gql_objtypes[t_name] = gqltype
 

--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -18,6 +18,8 @@
 
 
 abstract type NamedObject {
+    annotation description := 'An object with a name';
+
     required property name -> str;
 }
 

--- a/tests/schemas/graphql_other.esdl
+++ b/tests/schemas/graphql_other.esdl
@@ -17,10 +17,14 @@
 #
 
 
-scalar type color_enum_t extending enum<'RED', 'GREEN', 'BLUE'>;
+scalar type ColorEnum extending enum<'RED', 'GREEN', 'BLUE'> {
+    annotation description := 'RGB color enum';
+}
 
 type Foo {
+    annotation description := 'Test type "Foo"';
+
     property `select` -> str;
     property after -> str;
-    required property color -> color_enum_t;
+    required property color -> ColorEnum;
 }

--- a/tests/schemas/graphql_schema.esdl
+++ b/tests/schemas/graphql_schema.esdl
@@ -18,6 +18,8 @@
 
 
 abstract type NamedObject {
+    annotation description := 'An object with a name';
+
     required property name -> str;
 }
 

--- a/tests/schemas/graphql_schema_other.esdl
+++ b/tests/schemas/graphql_schema_other.esdl
@@ -17,10 +17,14 @@
 #
 
 
-scalar type color_enum_t extending enum<'RED', 'GREEN', 'BLUE'>;
+scalar type ColorEnum extending enum<'RED', 'GREEN', 'BLUE'> {
+    annotation description := 'RGB color enum';
+}
 
 type Foo {
+    annotation description := 'Test type "Foo"';
+
     property `select` -> str;
     property after -> str;
-    property color -> color_enum_t;
+    required property color -> ColorEnum;
 }

--- a/tests/schemas/graphql_setup.edgeql
+++ b/tests/schemas/graphql_setup.edgeql
@@ -75,20 +75,20 @@ INSERT Person {
 WITH MODULE other
 INSERT Foo {
     `select` := 'a',
-    color := <color_enum_t>'RED',
+    color := 'RED',
 };
 
 WITH MODULE other
 INSERT Foo {
     `select` := 'b',
     after := 'w',
-    color := <color_enum_t>'GREEN',
+    color := 'GREEN',
 };
 
 WITH MODULE other
 INSERT Foo {
     after := 'q',
-    color := <color_enum_t>'BLUE',
+    color := 'BLUE',
 };
 
 INSERT ScalarTest {

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -861,7 +861,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                 "__typename": "__Type",
                 "kind": "INTERFACE",
                 "name": "NamedObject",
-                "description": None,
+                "description": "An object with a name",
                 "fields": [
                     {
                         "__typename": "__Field",
@@ -2391,10 +2391,11 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
     def test_graphql_schema_type_14(self):
         self.assert_graphql_query_result(r"""
             query {
-                __type(name:"other__color_enum_t") {
+                __type(name:"other__ColorEnum") {
                     __typename
                     name
                     kind
+                    description
                     enumValues {
                         name
                     }
@@ -2404,8 +2405,9 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
 
             "__type": {
                 "kind": "ENUM",
-                "name": "other__color_enum_t",
+                "name": "other__ColorEnum",
                 "__typename": "__Type",
+                "description": "RGB color enum",
                 "enumValues": [
                     {
                         "name": "RED"
@@ -2417,5 +2419,62 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                         "name": "BLUE"
                     },
                 ]
+            }
+        })
+
+    def test_graphql_schema_type_15(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                __type(name: "NamedObject") {
+                    __typename
+                    name
+                    kind
+                    description
+                }
+            }
+        """, {
+            "__type": {
+                "kind": "INTERFACE",
+                "name": "NamedObject",
+                "__typename": "__Type",
+                "description": 'An object with a name',
+            }
+        })
+
+    def test_graphql_schema_type_16(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                __type(name: "other__Foo") {
+                    __typename
+                    name
+                    kind
+                    description
+                }
+            }
+        """, {
+            "__type": {
+                "kind": "INTERFACE",
+                "name": "other__Foo",
+                "__typename": "__Type",
+                "description": 'Test type "Foo"',
+            }
+        })
+
+    def test_graphql_schema_type_17(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                __type(name: "other__FooType") {
+                    __typename
+                    name
+                    kind
+                    description
+                }
+            }
+        """, {
+            "__type": {
+                "kind": "OBJECT",
+                "name": "other__FooType",
+                "__typename": "__Type",
+                "description": 'Test type "Foo"',
             }
         })


### PR DESCRIPTION
When generating GraphQL types it is useful to reflect "description"
annotation if one is present.

Fixes: #1228