### PR TITLE
graphql: Fix deeply nested insert issue.

### DIFF
--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -114,3 +114,11 @@ type Rab {
 type Rab2 extending Rab {
     overloaded link blah -> Bar2;
 }
+
+type Genre extending NamedObject {
+    multi link games -> Game;
+}
+
+type Game extending NamedObject {
+    multi link players -> User
+}


### PR DESCRIPTION
The deeply nested inserts didn't correctly translate subquery filter
paths into relative paths. At this point the subqueries (used for
providing insert values for links) are correctly generated when deeply
nested.

Fixes: #1243