### PR TITLE
Bump mypy to 0.761

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ EXTRA_DEPS = {
         'black~=19.3b0',
         'flake8~=3.7.9',
         'flake8-bugbear~=19.8.0',
-        'mypy==0.750',
+        'mypy==0.761',
         'coverage~=4.5.2',
         'requests-xml~=0.2.3',
         'lxml',


### PR DESCRIPTION
With mypy==0.750 I get this on my machine:

```
Traceback (most recent call last):
  File "/Users/yury/dev/edge/edgedb/tests/test_sourcecode.py", line 111, in test_cqa_mypy
    raise AssertionError(
AssertionError: mypy validation failed:
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 192, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/yury/dev/venvs/edgedb/lib/python3.8/site-packages/mypy/__main__.py", line 12, in <module>
    main(None, sys.stdout, sys.stderr)
  File "mypy/main.py", line 89, in main
  File "mypy/build.py", line 166, in build
  File "mypy/build.py", line 235, in _build
  File "mypy/build.py", line 2620, in dispatch
  File "mypy/build.py", line 2922, in process_graph
  File "mypy/build.py", line 3000, in process_fresh_modules
  File "mypy/build.py", line 1930, in fix_cross_refs
  File "mypy/fixup.py", line 25, in fixup_module
  File "mypy/fixup.py", line 89, in visit_symbol_table
  File "mypy/fixup.py", line 60, in visit_type_info
  File "mypy/fixup.py", line 262, in lookup_qualified_typeinfo
  File "mypy/fixup.py", line 290, in lookup_qualified
  File "mypy/fixup.py", line 299, in lookup_qualified_stnode
  File "mypy/lookup.py", line 47, in lookup_fully_qualified
AssertionError: Cannot find component 'ParametricType' for 'edb.common.checked.ParametricType'
```

Upgrading to 0.761 fixes it.