### PR TITLE
graphql: Change the auto-generated type name template.

### DIFF
--- a/docs/clients/99_graphql/index.rst
+++ b/docs/clients/99_graphql/index.rst
@@ -48,6 +48,12 @@ Known Limitations
 - EdgeDB :eql:type:`tuples <std::tuple>` are not supported in GraphQL
   reflection currently.
 
+- Every non-abstract EdgeDB object type is simultaneously an interface
+  and an object in terms of GraphQL type system, which means that for
+  every one object type name two names are needed in reflected
+  GraphQL. This potentially results in name clashes if the convention
+  of using camel-case names for user types is not followed in EdgeDB.
+
 
 .. __: http://graphql.org/docs/queries/
 

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -866,7 +866,7 @@ class GQLCoreSchema:
             self.edb_schema.get_objects(included_modules=self.modules,
                                         type=s_objtypes.ObjectType))
 
-        # concrete types are also reflected as Type (with a 'Type' postfix)
+        # concrete types are also reflected as Type (with a '_Type' postfix)
         obj_types += [t for t in interface_types
                       if not t.get_is_abstract(self.edb_schema)]
 
@@ -927,7 +927,7 @@ class GQLCoreSchema:
 
             gql_name = self.get_gql_name(t_name)
             gqltype = GraphQLObjectType(
-                name=gql_name + 'Type',
+                name=gql_name + '_Type',
                 fields=partial(self.get_fields, t_name),
                 interfaces=interfaces,
                 description=self._get_description(t),
@@ -1107,9 +1107,9 @@ class GQLBaseType(metaclass=GQLTypeMeta):
         name = self.name
         module, shortname = name.split('::', 1)
         if module in {'default', 'std'}:
-            return f'{shortname}Type'
+            return f'{shortname}_Type'
         else:
-            return f'{module}__{shortname}Type'
+            return f'{module}__{shortname}_Type'
 
     @property
     def schema(self):

--- a/edb/lib/stdgraphql.edgeql
+++ b/edb/lib/stdgraphql.edgeql
@@ -42,6 +42,6 @@ CREATE FUNCTION stdgraphql::short_name(name: str) -> str {
             name[5:] IF name LIKE 'std::%' ELSE
             name[9:] IF name LIKE 'default::%' ELSE
             re_replace(r'(.+?)::(.+$)', r'\1__\2', name)
-        ) ++ 'Type'
+        ) ++ '_Type'
     );
 };

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -564,24 +564,24 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             {
                 "SettingAlias": [
                     {
-                        "__typename": "SettingAliasType",
+                        "__typename": "SettingAlias_Type",
                         "name": "perks",
                         "value": "full",
                     },
                     {
-                        "__typename": "SettingAliasType",
+                        "__typename": "SettingAlias_Type",
                         "name": "template",
                         "value": "blue",
                     },
                 ],
                 "Setting": [
                     {
-                        "__typename": "SettingType",
+                        "__typename": "Setting_Type",
                         "name": "perks",
                         "value": "full",
                     },
                     {
-                        "__typename": "SettingType",
+                        "__typename": "Setting_Type",
                         "name": "template",
                         "value": "blue",
                     },
@@ -608,20 +608,20 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             {
                 "SettingAlias": [
                     {
-                        "__typename": "SettingAliasType",
+                        "__typename": "SettingAlias_Type",
                         "name": "perks",
                         "value": "full",
                         "of_group": {
-                            "__typename": "UserGroupType",
+                            "__typename": "UserGroup_Type",
                             "name": "upgraded",
                         }
                     },
                     {
-                        "__typename": "SettingAliasType",
+                        "__typename": "SettingAlias_Type",
                         "name": "template",
                         "value": "blue",
                         "of_group": {
-                            "__typename": "UserGroupType",
+                            "__typename": "UserGroup_Type",
                             "name": "upgraded",
                         }
                     },
@@ -649,23 +649,23 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             {
                 "SettingAliasAugmented": [
                     {
-                        "__typename": "SettingAliasAugmentedType",
+                        "__typename": "SettingAliasAugmented_Type",
                         "name": "perks",
                         "value": "full",
                         "of_group": {
                             "__typename":
-                                "__SettingAliasAugmented__of_groupType",
+                                "__SettingAliasAugmented__of_group_Type",
                             "name": "upgraded",
                             "name_upper": "UPGRADED",
                         }
                     },
                     {
-                        "__typename": "SettingAliasAugmentedType",
+                        "__typename": "SettingAliasAugmented_Type",
                         "name": "template",
                         "value": "blue",
                         "of_group": {
                             "__typename":
-                                "__SettingAliasAugmented__of_groupType",
+                                "__SettingAliasAugmented__of_group_Type",
                             "name": "upgraded",
                             "name_upper": "UPGRADED",
                         }
@@ -693,12 +693,12 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             {
                 "ProfileAlias": [
                     {
-                        "__typename": "ProfileAliasType",
+                        "__typename": "ProfileAlias_Type",
                         "name": "Alice profile",
                         "value": "special",
                         "owner": [
                             {
-                                "__typename": "UserType",
+                                "__typename": "User_Type",
                                 "id": uuid.UUID,
                             }
                         ]
@@ -1854,27 +1854,27 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         """, {
             'User': [{
                 'name': 'Alice',
-                '__typename': 'UserType',
+                '__typename': 'User_Type',
                 'groups': []
             }, {
                 'name': 'Bob',
-                '__typename': 'PersonType',
+                '__typename': 'Person_Type',
                 'groups': []
             }, {
                 'name': 'Jane',
-                '__typename': 'UserType',
+                '__typename': 'User_Type',
                 'groups': [{
                     'id': uuid.UUID,
                     'name': 'upgraded',
-                    '__typename': 'UserGroupType',
+                    '__typename': 'UserGroup_Type',
                 }]
             }, {
                 'name': 'John',
-                '__typename': 'UserType',
+                '__typename': 'User_Type',
                 'groups': [{
                     'id': uuid.UUID,
                     'name': 'basic',
-                    '__typename': 'UserGroupType',
+                    '__typename': 'UserGroup_Type',
                 }]
             }],
         }, sort=lambda x: x['name'])
@@ -1906,10 +1906,10 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         """, {
             "foo": "Query",
             "User": [
-                {"bar": "UserType", "name": "Alice"},
-                {"bar": "PersonType", "name": "Bob"},
-                {"bar": "UserType", "name": "Jane"},
-                {"bar": "UserType", "name": "John"},
+                {"bar": "User_Type", "name": "Alice"},
+                {"bar": "Person_Type", "name": "Bob"},
+                {"bar": "User_Type", "name": "Jane"},
+                {"bar": "User_Type", "name": "John"},
             ]
         })
 
@@ -2833,10 +2833,10 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             }
         """, {
             'Bar': [{
-                '__typename': 'BarType',
+                '__typename': 'Bar_Type',
                 'q': 'bar',
             }, {
-                '__typename': 'Bar2Type',
+                '__typename': 'Bar2_Type',
                 'q': 'bar2',
             }],
         }, sort=lambda x: x['q'])
@@ -2857,15 +2857,15 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             }
         """, {
             'Rab': [{
-                '__typename': 'RabType',
+                '__typename': 'Rab_Type',
                 'blah': {
-                    '__typename': 'BarType',
+                    '__typename': 'Bar_Type',
                     'q': 'bar',
                 }
             }, {
-                '__typename': 'Rab2Type',
+                '__typename': 'Rab2_Type',
                 'blah': {
-                    '__typename': 'Bar2Type',
+                    '__typename': 'Bar2_Type',
                     'q': 'bar2',
                 }
             }],
@@ -2895,7 +2895,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         """, {
             'Rab2': [{
                 'blah': {
-                    '__typename': 'Bar2Type',
+                    '__typename': 'Bar2_Type',
                     'q': 'bar2',
                     'w': 'special'
                 }

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -253,7 +253,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
             ('INPUT_OBJECT', 'other__FilterFoo'),
             ('INPUT_OBJECT', 'other__OrderFoo'),
             ('INTERFACE', 'other__Foo'),
-            ('OBJECT', 'other__FooType'),
+            ('OBJECT', 'other__Foo_Type'),
             ('SCALAR', 'ID'),
             ('ENUM', 'directionEnum'),
             ('OBJECT', '__Schema'),
@@ -280,7 +280,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
             ('INPUT_OBJECT', 'other__FilterFoo'),
             ('INPUT_OBJECT', 'other__OrderFoo'),
             ('INTERFACE', 'other__Foo'),
-            ('OBJECT', 'other__FooType'),
+            ('OBJECT', 'other__Foo_Type'),
             ('SCALAR', 'ID'),
             ('ENUM', 'directionEnum'),
             ('OBJECT', '__Schema'),
@@ -309,7 +309,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
     def test_graphql_schema_type_02(self):
         self.assert_graphql_query_result(r"""
             query {
-                __type(name: "UserType") {
+                __type(name: "User_Type") {
                     __typename
                     kind
                     name
@@ -335,7 +335,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
             "__type": {
                 "__typename": "__Type",
                 "kind": "OBJECT",
-                "name": "UserType",
+                "name": "User_Type",
                 "description": None,
                 "interfaces": [
                     {"name": "NamedObject"},
@@ -384,8 +384,8 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                 "description": None,
                 "interfaces": None,
                 "possibleTypes": [
-                    {"name": "PersonType"},
-                    {"name": "UserType"}
+                    {"name": "Person_Type"},
+                    {"name": "User_Type"}
                 ],
                 "enumValues": None,
                 "inputFields": None,
@@ -519,7 +519,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
             }
 
             query {
-                __type(name: "UserGroupType") {
+                __type(name: "UserGroup_Type") {
                     ..._t
                     fields {
                         __typename
@@ -551,7 +551,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
         """, {
             "__type": {
                 "__typename": "__Type",
-                "name": "UserGroupType",
+                "name": "UserGroup_Type",
                 "kind": "OBJECT",
                 "fields": [
                     {
@@ -622,7 +622,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
     def test_graphql_schema_type_06(self):
         self.assert_graphql_query_result(r"""
             query {
-                __type(name: "ProfileType") {
+                __type(name: "Profile_Type") {
                     __typename
                     name
                     kind
@@ -666,7 +666,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
         """, {
             "__type": {
                 "__typename": "__Type",
-                "name": "ProfileType",
+                "name": "Profile_Type",
                 "kind": "OBJECT",
                 "fields": [
                     {
@@ -903,7 +903,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     {
                         "__typename": "__Type",
                         "kind": "OBJECT",
-                        "name": "PersonType",
+                        "name": "Person_Type",
                         "description": None,
                         "fields": [
                             {
@@ -1052,7 +1052,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     {
                         "__typename": "__Type",
                         "kind": "OBJECT",
-                        "name": "ProfileType",
+                        "name": "Profile_Type",
                         "description": None,
                         "fields": [
                             {
@@ -1166,7 +1166,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     {
                         "__typename": "__Type",
                         "kind": "OBJECT",
-                        "name": "SettingAliasAugmentedType",
+                        "name": "SettingAliasAugmented_Type",
                         "description": None,
                         "fields": [
                             {
@@ -1265,7 +1265,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     {
                         "__typename": "__Type",
                         "kind": "OBJECT",
-                        "name": "SettingAliasType",
+                        "name": "SettingAlias_Type",
                         "description": None,
                         "fields": [
                             {
@@ -1363,7 +1363,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     {
                         "__typename": "__Type",
                         "kind": "OBJECT",
-                        "name": "SettingType",
+                        "name": "Setting_Type",
                         "description": None,
                         "fields": [
                             {
@@ -1443,7 +1443,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     {
                         "__typename": "__Type",
                         "kind": "OBJECT",
-                        "name": "UserGroupType",
+                        "name": "UserGroup_Type",
                         "description": None,
                         "fields": [
                             {
@@ -1523,7 +1523,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     {
                         "__typename": "__Type",
                         "kind": "OBJECT",
-                        "name": "UserType",
+                        "name": "User_Type",
                         "description": None,
                         "fields": [
                             {
@@ -1667,7 +1667,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     {
                         "__typename": "__Type",
                         "kind": "OBJECT",
-                        "name": "__SettingAliasAugmented__of_groupType",
+                        "name": "__SettingAliasAugmented__of_group_Type",
                         "description": None,
                         "fields": [
                             {
@@ -1778,7 +1778,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
     def test_graphql_schema_type_08(self):
         self.assert_graphql_query_result(r"""
         query {
-            __type(name: "UserGroupType") {
+            __type(name: "UserGroup_Type") {
                 __typename
                 name
                 kind
@@ -1820,7 +1820,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
         """, {
             "__type": {
                 "__typename": "__Type",
-                "name": "UserGroupType",
+                "name": "UserGroup_Type",
                 "kind": "OBJECT",
                 "fields": [
                     {
@@ -2379,7 +2379,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
             ('INPUT_OBJECT', 'other__FilterFoo'),
             ('INPUT_OBJECT', 'other__OrderFoo'),
             ('INTERFACE', 'other__Foo'),
-            ('OBJECT', 'other__FooType'),
+            ('OBJECT', 'other__Foo_Type'),
             ('SCALAR', 'ID'),
             ('ENUM', 'directionEnum'),
             ('OBJECT', '__Schema'),
@@ -2463,7 +2463,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
     def test_graphql_schema_type_17(self):
         self.assert_graphql_query_result(r"""
             query {
-                __type(name: "other__FooType") {
+                __type(name: "other__Foo_Type") {
                     __typename
                     name
                     kind
@@ -2473,7 +2473,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
         """, {
             "__type": {
                 "kind": "OBJECT",
-                "name": "other__FooType",
+                "name": "other__Foo_Type",
                 "__typename": "__Type",
                 "description": 'Test type "Foo"',
             }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3795,7 +3795,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                         name[5:] IF name LIKE 'std::%' ELSE
                         name[9:] IF name LIKE 'default::%' ELSE
                         re_replace(r'(.+?)::(.+$)', r'\1__\2', name)
-                    ) ++ 'Type'
+                    ) ++ '_Type'
                 )
             ;};
             """,


### PR DESCRIPTION
When object types are reflected into GraphQL, we create an interface
with the original type name and an underlying type implementing that
interface with a name that has "\_Type" appended to it. The idea is that
since the convention in EdgeDB is to have camel-case type names adding
an "\_" will result in fewer cases of type name clashes.

Fixes: #1175.