### PR TITLE
Binary Protocol. Optimistic Execute inconsitent attribute type io_format

### DIFF
--- a/docs/internals/protocol/messages.rst
+++ b/docs/internals/protocol/messages.rst
@@ -510,7 +510,7 @@ Format:
         Headers             headers;
 
         // Data I/O format.
-        byte<IOFormat>      io_format;
+        int8<IOFormat>      io_format;
 
         // Expected result cardinality
         byte<Cardinality>   expected_cardinality;

--- a/docs/internals/protocol/overview.rst
+++ b/docs/internals/protocol/overview.rst
@@ -34,6 +34,9 @@ The following data types are used in the descriptions:
       - 64-bit integer, most significant byte first
     * - ``byte``
       - 8-bit unsigned integer
+    * - ``byte<T>``
+      - 8-bit unsigned integer enumeration, where *T* denotes the name of
+        the enumeration
     * - ``string``
       - a UTF-8 encoded text string prefixed with its byte length as ``int32``
     * - ``bytes``


### PR DESCRIPTION
Fixes on documentation  #1265
- Added byte<T> definition at overview
- Changed byte<T> to int8<T> for io_format at Optimistic Execute structure

I added a simple fix on the documentation for a given data type.

As I mentioned [here](https://spectrum.chat/edgedb/general/binary-protocol-optimistic-execute-inconsitent-attribute-type-io-format~16dbf1a8-8ec2-49b0-ab41-1850adbce190) is it make any sense to use `byte<T>` when referencing an enumeration by default? As every enumeration hold positive values.
The change for this will be moving each of the `int8<T>` into `byte<T>`, I'm not sure of the impact it's just convention. 