### PR TITLE
Corrects the annotation for anchors, improves constraints.py

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -169,11 +169,11 @@ def compile_ast_to_ir(
     modaliases: Optional[Mapping[Optional[str], str]] = None,
     anchors: Optional[
         Mapping[
-            Union[str, qlast.SpecialAnchorT],
-            Union[irast.Base, s_obj.Object],
+            irast.AnchorsKeyType,
+            irast.AnchorsValueType
         ]
     ] = None,
-    path_prefix_anchor: Optional[qlast.SpecialAnchorT] = None,
+    path_prefix_anchor: Optional[irast.AnchorsKeyType] = None,
     singletons: Sequence[s_types.Type] = (),
     func_params: Optional[s_func.ParameterLikeList] = None,
     result_view_name: Optional[s_name.SchemaName] = None,
@@ -340,9 +340,9 @@ def compile_ast_fragment_to_ir(
     *,
     modaliases: Optional[Mapping[Optional[str], str]] = None,
     anchors: Optional[
-        Mapping[Union[str, qlast.SpecialAnchorT], s_obj.Object]
+        Mapping[irast.AnchorsKeyType, irast.AnchorsValueType]
     ] = None,
-    path_prefix_anchor: Optional[qlast.SpecialAnchorT] = None,
+    path_prefix_anchor: Optional[irast.AnchorsKeyType] = None,
 ) -> irast.Statement:
     """Compile given EdgeQL AST fragment into EdgeDB IR.
 
@@ -504,8 +504,7 @@ def compile_func_to_ir(
 
     ir = compile_ast_to_ir(
         tree, schema,
-        anchors=param_anchors,  # type: ignore
-                                # (typing#273)
+        anchors=param_anchors,
         func_params=func.get_params(schema),
         # the body of a session_only function can contain calls to
         # other session_only functions

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -62,12 +62,8 @@ def init_context(
         func_params: Optional[s_func.ParameterLikeList]=None,
         parent_object_type: Optional[s_obj.ObjectMeta]=None,
         modaliases: Optional[Mapping[Optional[str], str]]=None,
-        anchors: Optional[
-            Mapping[
-                Union[str, qlast.SpecialAnchorT],
-                Union[s_obj.Object, irast.Base],
-            ],
-        ]=None,
+        anchors: Optional[Mapping[irast.AnchorsKeyType,
+                                  irast.AnchorsValueType]]=None,
         singletons: Optional[Iterable[s_types.Type]]=None,
         security_context: Optional[str]=None,
         derived_target_module: Optional[str]=None,
@@ -351,10 +347,7 @@ def compile_anchor(
 
 
 def populate_anchors(
-    anchors: Mapping[
-        Union[str, qlast.SpecialAnchorT],
-        Union[s_obj.Object, irast.Base],
-    ],
+    anchors: Mapping[irast.AnchorsKeyType, irast.AnchorsValueType],
     *,
     ctx: context.ContextLevel,
 ) -> None:

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -720,3 +720,7 @@ class ConfigReset(ConfigCommand):
 class ConfigInsert(ConfigCommand, Expr):
 
     expr: Set
+
+
+AnchorsKeyType = typing.TypeVar("AnchorsKeyType", str, qlast.SpecialAnchorT)
+AnchorsValueType = typing.TypeVar("AnchorsValueType", so.Object, Base)

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -491,13 +491,11 @@ class ConstraintCommand(
                 assert isinstance(referrer_ctx.op, sd.ObjectCommand)
                 anchors['__subject__'] = referrer_ctx.op.scls
 
-            # TODO: it is true, the Parameter does not inherit Object,
-            # how to resolve the type: ignore below?
             return s_expr.Expression.compiled(
                 value,
                 schema=schema,
                 modaliases=context.modaliases,
-                anchors=anchors,  # type: ignore
+                anchors=anchors,
                 func_params=params,
                 allow_generic_type_output=True,
                 parent_object_type=self.get_schema_metaclass(),
@@ -863,9 +861,9 @@ class AlterConstraint(ConstraintCommand,
 
         if isinstance(astnode, (qlast.CreateConcreteConstraint,
                                 qlast.AlterConcreteConstraint)):
-            # TODO: how to make the following in a more "type-compliant" way?
-            # ConsistencySubjectCommandContext is an empty mixin used to
-            # group some classes of ObjectCommand
+            # type ignore below, because mypy doesn't trust the
+            # ConsistencySubjectCommandContext to be a CommandContextToken_T
+            # even when it is sd.ObjectCommandContext[ConsistencySubject]
             subject_ctx = context \
                 .get(ConsistencySubjectCommandContext)  # type: ignore
             assert isinstance(subject_ctx, sd.ObjectCommandContext)

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -134,7 +134,7 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer, s_abc.Expression):
         modaliases: Optional[Mapping[Optional[str], str]] = None,
         parent_object_type: Optional[so.ObjectMeta] = None,
         anchors: Optional[
-            Mapping[Union[str, qlast_.SpecialAnchorT], so.Object]
+            Mapping[irast_.AnchorsKeyType, irast_.AnchorsValueType]
         ] = None,
         path_prefix_anchor: Optional[qlast_.SpecialAnchorT] = None,
         allow_generic_type_output: bool = False,

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -136,7 +136,7 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer, s_abc.Expression):
         anchors: Optional[
             Mapping[irast_.AnchorsKeyType, irast_.AnchorsValueType]
         ] = None,
-        path_prefix_anchor: Optional[qlast_.SpecialAnchorT] = None,
+        path_prefix_anchor: Optional[irast_.AnchorsKeyType] = None,
         allow_generic_type_output: bool = False,
         func_params: Optional[s_func.ParameterLikeList] = None,
         singletons: Sequence[s_types.Type] = (),


### PR DESCRIPTION
I finally understood that `Union` defines an _intersection_ of types, not a _sum_ of possible types. I was misled by its name and its closeness with concrete types, all along. It somehow looks like an interface in Java or C#, with the difference that it is an implicit interface under the _type POV_, while being explicit under the _possible concrete types POV_.

Then it became clear that the way we were thinking of the [`anchors`](https://github.com/edgedb/edgedb/pull/1261#discussion_r386141078) was wrong.

This is **not** the proper way:
```python
    anchors: Optional[
        Mapping[Union[str, qlast.SpecialAnchorT],
                Union[s_obj.Object, irast.Base]]
    ] = None,
```

This is the proper way:
```python
AnchorsKeyType = typing.TypeVar("AnchorsKeyType", str, qlast.SpecialAnchorT)
AnchorsValueType = typing.TypeVar("AnchorsValueType", so.Object, Base)

    anchors: Optional[
        Mapping[AnchorsKeyType, AnchorsValueType]
    ] = None,
```
