### PR TITLE
Reorganize schema class hierarchy with respect to schema object names

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -353,7 +353,7 @@ class ContextLevel(compiler.ContextLevel):
     ]
     """A mapping of computable pointers to QL source AST and context."""
 
-    view_nodes: Dict[s_name.SchemaName, s_types.Type]
+    view_nodes: Dict[str, s_types.Type]
     """A dictionary of newly derived Node classes representing views."""
 
     view_sets: Dict[s_types.Type, irast.Set]

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -463,6 +463,8 @@ def compile_operator(
         elif right_type.issubclass(env.schema, left_type):
             rtype = left_type
         else:
+            assert isinstance(left_type, s_types.InheritingType)
+            assert isinstance(right_type, s_types.InheritingType)
             rtype = schemactx.get_union_type([left_type, right_type], ctx=ctx)
 
     from_op = oper.get_from_operator(env.schema)

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -412,10 +412,7 @@ def _analyse_filter_clause(
         exclusive_constr: s_constr.Constraint = schema.get('std::exclusive')
 
         for ptr, _ in filtered_ptrs:
-            ptr = cast(
-                s_pointers.Pointer,
-                ptr.get_nearest_non_derived_parent(env.schema),
-            )
+            ptr = ptr.get_nearest_non_derived_parent(env.schema)
             is_unique = (
                 ptr.is_id_pointer(schema) or
                 any(c.issubclass(schema, exclusive_constr)

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -153,6 +153,7 @@ def derive_view(
         ctx: context.ContextLevel) -> s_types.Type:
 
     if derived_name is None:
+        assert isinstance(stype, s_obj.DerivableObject)
         derived_name = derive_view_name(
             stype=stype, derived_name_quals=derived_name_quals,
             derived_name_base=derived_name_base, ctx=ctx)
@@ -309,8 +310,13 @@ def get_union_type(
 
     if created:
         ctx.env.created_schema_objects.add(union)
-    elif (union not in ctx.env.created_schema_objects
-            and union.get_name(ctx.env.schema).module != '__derived__'):
+    elif (
+        union not in ctx.env.created_schema_objects
+        and (
+            not isinstance(union, s_obj.QualifiedObject)
+            or union.get_name(ctx.env.schema).module != '__derived__'
+        )
+    ):
         ctx.env.schema_refs.add(union)
 
     return union
@@ -327,8 +333,13 @@ def get_intersection_type(
 
     if created:
         ctx.env.created_schema_objects.add(intersection)
-    elif (intersection not in ctx.env.created_schema_objects
-            and intersection.get_name(ctx.env.schema).module != '__derived__'):
+    elif (
+        intersection not in ctx.env.created_schema_objects
+        and (
+            not isinstance(intersection, s_obj.QualifiedObject)
+            or intersection.get_name(ctx.env.schema).module != '__derived__'
+        )
+    ):
         ctx.env.schema_refs.add(intersection)
 
     return intersection

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -466,7 +466,7 @@ def compile_DescribeStmt(
                     f'cannot describe full schema as {ql.language}')
         else:
             modules = []
-            items = []
+            items: List[str] = []
             referenced_classes: List[s_obj.ObjectMeta] = []
 
             objref = ql.object

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -385,7 +385,8 @@ def declare_view(
 
         if cached_view_set is not None:
             subctx.view_scls = setgen.get_set_type(cached_view_set, ctx=ctx)
-            view_name = subctx.view_scls.get_name(ctx.env.schema)
+            view_name = s_name.SchemaName(
+                subctx.view_scls.get_name(ctx.env.schema))
         else:
             if isinstance(alias, s_name.SchemaName):
                 basename = alias

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -154,6 +154,7 @@ def type_to_typeref(
             name_hint=typename or t.get_name(schema),
         )
     elif not isinstance(t, s_abc.Collection):
+        assert isinstance(t, s_types.InheritingType)
         union_of = t.get_union_of(schema)
         if union_of:
             non_overlapping, union_is_concrete = (

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -144,8 +144,13 @@ def get_cast_fullname(
         name=sn.get_specialized_name(shortname, *quals))
 
 
-class Cast(s_anno.AnnotationSubject, s_func.VolatilitySubject, s_abc.Cast,
-           qlkind=qltypes.SchemaObjectClass.CAST):
+class Cast(
+    so.QualifiedObject,
+    s_anno.AnnotationSubject,
+    s_func.VolatilitySubject,
+    s_abc.Cast,
+    qlkind=qltypes.SchemaObjectClass.CAST,
+):
 
     from_type = so.SchemaField(
         s_types.Type, compcoef=0.5)
@@ -180,7 +185,7 @@ class CastCommandContext(sd.ObjectCommandContext,
     pass
 
 
-class CastCommand(sd.ObjectCommand,
+class CastCommand(sd.QualifiedObjectCommand,
                   schema_metaclass=Cast,
                   context_class=CastCommandContext):
 

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -161,7 +161,7 @@ def delta_schemas(
 
             def _filter(schema: s_schema.Schema, obj: so.Object) -> bool:
                 return (
-                    (not isinstance(obj, so.UnqualifiedObject)
+                    (isinstance(obj, so.QualifiedObject)
                         and (obj.get_name(schema).module
                              in s_schema.STD_MODULES))
                     or (isinstance(obj, modules.Module)
@@ -227,7 +227,7 @@ def delta_schemas(
     for sclass in get_global_dep_order():
         filters: List[Callable[[s_schema.Schema, so.Object], bool]] = []
 
-        if issubclass(sclass, so.UnqualifiedObject):
+        if not issubclass(sclass, so.QualifiedObject):
             # UnqualifiedObjects (like anonymous tuples and arrays)
             # should not use an included_modules filter.
             incl_modules = None

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -34,7 +34,11 @@ class AliasCommandContext(sd.ObjectCommandContext,
     pass
 
 
-class AliasCommand(s_types.TypeCommand, context_class=AliasCommandContext):
+class AliasCommand(
+    sd.QualifiedObjectCommand[s_types.Type],
+    s_types.TypeCommand,
+    context_class=AliasCommandContext,
+):
 
     _scalar_cmd_map = {
         qlast.CreateAlias: s_scalars.CreateScalarType,

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -542,7 +542,11 @@ class CallableLike:
         raise NotImplementedError
 
 
-class CallableObject(s_anno.AnnotationSubject, CallableLike):
+class CallableObject(
+    so.QualifiedObject,
+    s_anno.AnnotationSubject,
+    CallableLike,
+):
 
     params = so.SchemaField(
         FuncParameterList,
@@ -561,13 +565,13 @@ class CallableObject(s_anno.AnnotationSubject, CallableLike):
     @classmethod
     def delta(
         cls,
-        old,
-        new,
+        old: Optional[so.Object],
+        new: Optional[so.Object],
         *,
-        context=None,
-        old_schema: s_schema.Schema,
+        context: Optional[so.ComparisonContext] = None,
+        old_schema: Optional[s_schema.Schema],
         new_schema: s_schema.Schema,
-    ):
+    ) -> sd.ObjectCommand[so.Object]:
         context = context or so.ComparisonContext()
 
         def param_is_inherited(schema: s_schema.Schema, func, param):
@@ -654,7 +658,7 @@ class CallableObject(s_anno.AnnotationSubject, CallableLike):
         return not isinstance(reference, Parameter)
 
 
-class CallableCommand(sd.ObjectCommand):
+class CallableCommand(sd.QualifiedObjectCommand):
 
     def _get_params(self, schema: s_schema.Schema, context):
         params = []

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -86,10 +86,12 @@ class IndexCommandContext(sd.ObjectCommandContext,
     pass
 
 
-class IndexCommand(referencing.ReferencedInheritingObjectCommand,
-                   schema_metaclass=Index,
-                   context_class=IndexCommandContext,
-                   referrer_context_class=IndexSourceCommandContext):
+class IndexCommand(
+    referencing.ReferencedInheritingObjectCommand,
+    schema_metaclass=Index,
+    context_class=IndexCommandContext,
+    referrer_context_class=IndexSourceCommandContext,
+):
 
     @classmethod
     def _classname_from_ast(cls, schema, astnode, context):

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from . import schema as s_schema
 
 
-class Migration(so.UnqualifiedObject, s_abc.Migration):
+class Migration(so.Object, s_abc.Migration):
 
     parents = so.SchemaField(
         so.ObjectList,
@@ -53,7 +53,7 @@ class MigrationCommandContext(sd.ObjectCommandContext):
     pass
 
 
-class MigrationCommand(sd.UnqualifiedObjectCommand, schema_metaclass=Migration,
+class MigrationCommand(sd.ObjectCommand, schema_metaclass=Migration,
                        context_class=MigrationCommandContext):
     pass
 

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -27,7 +27,7 @@ from . import delta as sd
 from . import objects as so
 
 
-class Module(so.UnqualifiedObject, s_anno.AnnotationSubject,
+class Module(s_anno.AnnotationSubject,
              qlkind=qltypes.SchemaObjectClass.MODULE):
 
     builtin = so.SchemaField(
@@ -38,7 +38,7 @@ class ModuleCommandContext(sd.ObjectCommandContext):
     pass
 
 
-class ModuleCommand(sd.UnqualifiedObjectCommand, schema_metaclass=Module,
+class ModuleCommand(sd.ObjectCommand, schema_metaclass=Module,
                     context_class=ModuleCommandContext):
     pass
 

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -45,8 +45,8 @@ if TYPE_CHECKING:
 
 
 class ObjectType(
-    sources.Source,
     s_types.InheritingType,
+    sources.Source,
     constraints.ConsistencySubject,
     s_anno.AnnotationSubject,
     s_abc.ObjectType,
@@ -368,9 +368,9 @@ class ObjectTypeCommandContext(sd.ObjectCommandContext,
     pass
 
 
-class ObjectTypeCommand(constraints.ConsistencySubjectCommand,
+class ObjectTypeCommand(s_types.InheritingTypeCommand,
+                        constraints.ConsistencySubjectCommand,
                         sources.SourceCommand, links.LinkSourceCommand,
-                        s_types.TypeCommand,
                         schema_metaclass=ObjectType,
                         context_class=ObjectTypeCommandContext):
     pass

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -663,10 +663,12 @@ class PointerCommandOrFragment:
         return target, base
 
 
-class PointerCommand(constraints.ConsistencySubjectCommand,
-                     s_anno.AnnotationSubjectCommand,
-                     referencing.ReferencedInheritingObjectCommand,
-                     PointerCommandOrFragment):
+class PointerCommand(
+    referencing.ReferencedInheritingObjectCommand,
+    constraints.ConsistencySubjectCommand,
+    s_anno.AnnotationSubjectCommand,
+    PointerCommandOrFragment,
+):
 
     def _create_begin(self, schema, context):
         if not context.canonical:

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -184,11 +184,13 @@ class ScalarTypeCommandContext(sd.ObjectCommandContext[ScalarType],
     pass
 
 
-class ScalarTypeCommand(constraints.ConsistencySubjectCommand,
-                        s_anno.AnnotationSubjectCommand,
-                        s_types.TypeCommand,
-                        schema_metaclass=ScalarType,
-                        context_class=ScalarTypeCommandContext):
+class ScalarTypeCommand(
+    s_types.InheritingTypeCommand,
+    constraints.ConsistencySubjectCommand,
+    s_anno.AnnotationSubjectCommand,
+    schema_metaclass=ScalarType,
+    context_class=ScalarTypeCommandContext,
+):
     @classmethod
     def _cmd_tree_from_ast(
         cls,
@@ -198,7 +200,7 @@ class ScalarTypeCommand(constraints.ConsistencySubjectCommand,
     ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
 
-        assert isinstance(cmd, sd.ObjectCommand)
+        assert isinstance(cmd, sd.QualifiedObjectCommand)
         assert isinstance(astnode, qlast.ObjectDDL)
         return cls._handle_view_op(schema, cmd, astnode, context)
 

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -147,7 +147,7 @@ class Schema(s_abc.Schema):
         shortname_to_id = self._shortname_to_id
         globalname_to_id = self._globalname_to_id
         stype = type(scls)
-        is_global = issubclass(stype, so.UnqualifiedObject)
+        is_global = not issubclass(stype, so.QualifiedObject)
 
         has_sn_cache = issubclass(stype, (s_func.Function, s_oper.Operator))
 
@@ -459,7 +459,7 @@ class Schema(s_abc.Schema):
             refs_to=self._update_refs_to(scls, None, data),
         )
 
-        if (not isinstance(scls, so.UnqualifiedObject)
+        if (isinstance(scls, so.QualifiedObject)
                 and not self.has_module(name.module)):
             raise errors.UnknownModuleError(
                 f'module {name.module!r} is not in this schema')
@@ -907,14 +907,14 @@ class SchemaIterator(Generic[so.Object_T]):
             modules = frozenset(included_modules)
             filters.append(
                 lambda schema, obj:
-                    not isinstance(obj, so.UnqualifiedObject) and
+                    isinstance(obj, so.QualifiedObject) and
                     obj.get_name(schema).module in modules)
 
         if excluded_modules:
             excmod = frozenset(excluded_modules)
             filters.append(
                 lambda schema, obj: (
-                    isinstance(obj, so.UnqualifiedObject)
+                    not isinstance(obj, so.QualifiedObject)
                     or obj.get_name(schema).module not in excmod
                 )
             )

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -38,7 +38,7 @@ class SourceCommand(indexes.IndexSourceCommand):
     pass
 
 
-class Source(indexes.IndexableSubject):
+class Source(so.QualifiedObject, indexes.IndexableSubject):
     pointers_refs = so.RefDict(
         attr='pointers',
         requires_explicit_overloaded=True,

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -561,7 +561,7 @@ def ensure_union_type(
 
 def get_union_type(
     schema: s_schema.Schema,
-    types: Iterable[s_types.Type],
+    types: Iterable[s_types.InheritinType],
     *,
     opaque: bool = False,
     module: Optional[str] = None,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1278,10 +1278,10 @@ class Compiler(BaseCompiler):
         all_objects = schema.get_objects(excluded_modules=s_schema.STD_MODULES)
         ids = []
         for obj in all_objects:
-            if isinstance(obj, s_obj.UnqualifiedObject):
-                ql_class = str(type(obj).get_ql_class_or_die())
-            else:
+            if isinstance(obj, s_obj.QualifiedObject):
                 ql_class = ''
+            else:
+                ql_class = str(type(obj).get_ql_class_or_die())
 
             ids.append((
                 str(obj.get_name(schema)),

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1063,7 +1063,7 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "constraint expression expected to return a bool value, "
-                "got 'int64'"):
+                "got scalar type 'std::int64'"):
             async with self.con.transaction():
                 await self.con.execute(qry)
 
@@ -1078,7 +1078,7 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "constraint expression expected to return a bool value, "
-                "got 'int64'"):
+                "got scalar type 'std::int64'"):
             await self.con.execute(qry)
 
         qry = """
@@ -1096,7 +1096,7 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "constraint expression expected to return a bool value, "
-                "got 'str'"):
+                "got scalar type 'std::str'"):
             await self.con.execute(qry)
 
     async def test_constraints_ddl_error_06(self):

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 73.71)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 73.84)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)
@@ -292,13 +292,13 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "testbase", 1.04)
 
     def test_cqa_type_coverage_tools(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "tools", 21.49)
+        self.assertFunctionCoverage(EDB_DIR / "tools", 21.83)
 
     def test_cqa_type_coverage_tools_docs(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "tools" / "docs", 0)
 
     def test_cqa_type_coverage_tools_mypy(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "tools" / "mypy", 35.71)
+        self.assertFunctionCoverage(EDB_DIR / "tools" / "mypy", 40.00)
 
     def test_cqa_type_coverage_tools_test(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "tools" / "test", 4.17)


### PR DESCRIPTION
Currently, the base `Object` class assumes that the object name is
fully-qualified, and then there are a bunch of exceptions down the
inheritance hierarchy that override this assumption.  This inversion
arrangement is unsound, so reorganize the hierarchy such that the
name in `schema.Object` is considered unqualified, and explicit
inheritance from `schema.QualifiedObject` is needed to enable
module-qualified behavior for object names.