### PR TITLE
Add annotations for schema roles, operators, casts, and modules

### DIFF
--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -703,7 +703,7 @@ class CallableCommand(sd.QualifiedObjectCommand):
         schema: s_schema.Schema,
         context,
         cmd
-    ) -> List[ParameterDesc]:
+    ) -> Tuple[s_schema.Schema, List[ParameterDesc]]:
         params = []
         for subcmd in cmd.get_subcommands(type=CreateParameter):
             schema, param = ParameterDesc.from_create_delta(
@@ -716,7 +716,12 @@ class CallableCommand(sd.QualifiedObjectCommand):
 class CreateCallableObject(CallableCommand, sd.CreateObject):
 
     @classmethod
-    def _cmd_tree_from_ast(cls, schema: s_schema.Schema, astnode, context):
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
 
         params = cls._get_param_desc_from_ast(

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -34,22 +34,22 @@ class Module(s_anno.AnnotationSubject,
         bool, default=False, compcoef=0.4, introspectable=True)
 
 
-class ModuleCommandContext(sd.ObjectCommandContext):
+class ModuleCommandContext(sd.ObjectCommandContext[Module]):
     pass
 
 
-class ModuleCommand(sd.ObjectCommand, schema_metaclass=Module,
+class ModuleCommand(sd.ObjectCommand[Module], schema_metaclass=Module,
                     context_class=ModuleCommandContext):
     pass
 
 
-class CreateModule(ModuleCommand, sd.CreateObject):
+class CreateModule(ModuleCommand, sd.CreateObject[Module]):
     astnode = qlast.CreateModule
 
 
-class AlterModule(ModuleCommand, sd.AlterObject):
+class AlterModule(ModuleCommand, sd.AlterObject[Module]):
     astnode = qlast.AlterModule
 
 
-class DeleteModule(ModuleCommand, sd.DeleteObject):
+class DeleteModule(ModuleCommand, sd.DeleteObject[Module]):
     astnode = qlast.DropModule

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -23,7 +23,6 @@ from typing import *
 
 from edb import errors
 from edb.common import checked
-
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes as ft
 
@@ -32,6 +31,9 @@ from . import delta as sd
 from . import functions as s_func
 from . import name as sn
 from . import objects as so
+
+if TYPE_CHECKING:
+    from edb.schema import schema as s_schema
 
 
 class Operator(s_func.CallableObject, s_func.VolatilitySubject,
@@ -75,7 +77,7 @@ class Operator(s_func.CallableObject, s_func.VolatilitySubject,
     recursive = so.SchemaField(
         bool, default=False, compcoef=0.4, introspectable=False)
 
-    def get_display_signature(self, schema):
+    def get_display_signature(self, schema: s_schema.Schema) -> str:
         params = [
             p.get_type(schema).get_displayname(schema)
             for p in self.get_params(schema).objects(schema)
@@ -93,7 +95,12 @@ class Operator(s_func.CallableObject, s_func.VolatilitySubject,
         else:
             raise ValueError('unexpected operator kind')
 
-    def get_verbosename(self, schema, *, with_parent: bool=False) -> str:
+    def get_verbosename(
+        self,
+        schema: s_schema.Schema,
+        *,
+        with_parent: bool=False
+    ) -> str:
         return f'operator "{self.get_display_signature(schema)}"'
 
 
@@ -106,7 +113,12 @@ class OperatorCommand(s_func.CallableCommand,
                       context_class=OperatorCommandContext):
 
     @classmethod
-    def _cmd_tree_from_ast(cls, schema, astnode, context):
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.Command:
         if not context.stdmode and not context.testmode:
             raise errors.UnsupportedFeatureError(
                 'user-defined operators are not supported',
@@ -116,22 +128,29 @@ class OperatorCommand(s_func.CallableCommand,
         return super()._cmd_tree_from_ast(schema, astnode, context)
 
     @classmethod
-    def _classname_from_ast(cls, schema, astnode: qlast.OperatorCommand,
-                            context) -> sn.Name:
+    def _classname_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.NamedDDL,
+        context: sd.CommandContext,
+    ) -> sn.Name:
+        assert isinstance(astnode, qlast.CreateOperator)
         name = super()._classname_from_ast(schema, astnode, context)
 
         params = cls._get_param_desc_from_ast(
             schema, context.modaliases, astnode)
-
-        return cls.get_schema_metaclass().get_fqname(
+        return cls.get_schema_metaclass().get_fqname(  # type: ignore
             schema, name, params, astnode.kind)
 
 
 class CreateOperator(s_func.CreateCallableObject, OperatorCommand):
     astnode = qlast.CreateOperator
 
-    def _create_begin(self, schema, context):
-
+    def _create_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
         fullname = self.classname
         shortname = sn.shortname_from_fullname(fullname)
         schema, cp = self._get_param_desc_from_delta(schema, context, self)
@@ -232,7 +251,13 @@ class CreateOperator(s_func.CreateCallableObject, OperatorCommand):
         return schema
 
     @classmethod
-    def _cmd_tree_from_ast(cls, schema, astnode, context):
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.Command:
+        assert isinstance(astnode, qlast.CreateOperator)
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
 
         cmd.set_attribute_value(
@@ -273,7 +298,7 @@ class RenameOperator(sd.RenameObject, OperatorCommand):
     pass
 
 
-class AlterOperator(sd.AlterObject, OperatorCommand):
+class AlterOperator(sd.AlterObject[Operator], OperatorCommand):
     astnode = qlast.AlterOperator
 
 

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -134,7 +134,7 @@ class OperatorCommand(s_func.CallableCommand,
         astnode: qlast.NamedDDL,
         context: sd.CommandContext,
     ) -> sn.Name:
-        assert isinstance(astnode, qlast.CreateOperator)
+        assert isinstance(astnode, qlast.OperatorCommand)
         name = super()._classname_from_ast(schema, astnode, context)
 
         params = cls._get_param_desc_from_ast(

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from edb.schema import schema as s_schema
 
 
-class Role(so.GlobalObject, so.InheritingObject,  # type: ignore
+class Role(so.GlobalObject, so.InheritingObject,
            s_anno.AnnotationSubject, qlkind=qltypes.SchemaObjectClass.ROLE):
 
     is_superuser = so.SchemaField(

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from edb.schema import schema as s_schema
 
 
-class Role(so.GlobalObject, so.InheritingObject,
+class Role(so.GlobalObject, so.InheritingObject,  # type: ignore
            s_anno.AnnotationSubject, qlkind=qltypes.SchemaObjectClass.ROLE):
 
     is_superuser = so.SchemaField(

--- a/mypy.ini
+++ b/mypy.ini
@@ -476,3 +476,19 @@ no_implicit_optional = True
 warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
+
+[mypy-edb.schema.roles]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -477,7 +477,23 @@ warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
 
-[mypy-edb.schema.roles]
+# [mypy-edb.schema.roles]
+# follow_imports = True
+# ignore_errors = False
+# # Equivalent of --strict on the command line:
+# disallow_subclassing_any = True
+# disallow_any_generics = True
+# # disallow_untyped_calls = True
+# disallow_untyped_defs = True
+# disallow_incomplete_defs = True
+# check_untyped_defs = True
+# disallow_untyped_decorators = True
+# no_implicit_optional = True
+# warn_unused_ignores = True
+# warn_return_any = True
+# no_implicit_reexport = True
+
+[mypy-edb.schema.operators]
 follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
@@ -493,7 +509,7 @@ warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
 
-[mypy-edb.schema.operators]
+[mypy-edb.schema.casts]
 follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:

--- a/mypy.ini
+++ b/mypy.ini
@@ -524,3 +524,19 @@ no_implicit_optional = True
 warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
+
+[mypy-edb.schema.modules]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -492,3 +492,19 @@ no_implicit_optional = True
 warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
+
+[mypy-edb.schema.operators]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -477,21 +477,21 @@ warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
 
-# [mypy-edb.schema.roles]
-# follow_imports = True
-# ignore_errors = False
-# # Equivalent of --strict on the command line:
-# disallow_subclassing_any = True
-# disallow_any_generics = True
-# # disallow_untyped_calls = True
-# disallow_untyped_defs = True
-# disallow_incomplete_defs = True
-# check_untyped_defs = True
-# disallow_untyped_decorators = True
-# no_implicit_optional = True
-# warn_unused_ignores = True
-# warn_return_any = True
-# no_implicit_reexport = True
+[mypy-edb.schema.roles]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
 
 [mypy-edb.schema.operators]
 follow_imports = True

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 74.92)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 75.05)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 76.16)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 76.28)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 73.97)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 74.22)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 75.05)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 76.16)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 74.22)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 74.92)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)


### PR DESCRIPTION
~~@elprans, since `roles.Role` is the only class presenting problems with the mypy plugin; maybe we can exclude it temporarily and proceed with this PR? I have another branch with annotations for `links` module, and I would like to create a second PR once this one is done.~~

This PR will be merged after https://github.com/edgedb/edgedb/pull/1285 - since that PR resolves the issue appearing in roles.Role.