### PR TITLE
Fix computable pointer cardinality check in certain queries

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1012,7 +1012,12 @@ def computable_ptr_set(
             source_ctx=pending_cardinality.source_ctx,
             ctx=ctx)
 
-    stmtctx.enforce_pointer_cardinality(ptrcls, comp_ir_set_copy, ctx=ctx)
+    stmtctx.enforce_pointer_cardinality(
+        ptrcls,
+        comp_ir_set_copy,
+        singletons={source_path_id},
+        ctx=ctx,
+    )
 
     comp_ir_set = new_set_from_set(
         comp_ir_set, path_id=result_path_id, rptr=rptr, ctx=ctx)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -620,13 +620,20 @@ def ensure_ptrref_cardinality(
 
 
 def enforce_singleton_now(
-        irexpr: irast.Set, *,
-        ctx: context.ContextLevel) -> None:
+    irexpr: irast.Set,
+    *,
+    singletons: Collection[irast.PathId] = (),
+    ctx: context.ContextLevel,
+) -> None:
     scope = pathctx.get_set_scope(ir_set=irexpr, ctx=ctx)
     if scope is None:
         scope = ctx.path_scope
     cardinality = inference.infer_cardinality(
-        irexpr, scope_tree=scope, env=ctx.env)
+        irexpr,
+        scope_tree=scope,
+        singletons=singletons,
+        env=ctx.env,
+    )
 
     if cardinality != qltypes.Cardinality.ONE:
         raise errors.QueryError(
@@ -654,14 +661,16 @@ def enforce_singleton(
 
 def enforce_pointer_cardinality(
     ptrcls: s_pointers.Pointer,
-    irexpr: irast.Set, *,
+    irexpr: irast.Set,
+    *,
+    singletons: Collection[irast.PathId] = (),
     ctx: context.ContextLevel,
 ) -> None:
 
     if not ctx.defining_view:
         def _enforce_singleton(ctx: context.ContextLevel) -> None:
             if ptrcls.singular(ctx.env.schema):
-                enforce_singleton_now(irexpr, ctx=ctx)
+                enforce_singleton_now(irexpr, singletons=singletons, ctx=ctx)
 
         at_stmt_fini(_enforce_singleton, ctx=ctx)
 

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1305,6 +1305,22 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [True]
         )
 
+    async def test_edgeql_select_polymorphic_11(self):
+        await self.assert_query_result(
+            r'''
+            WITH
+                MODULE test,
+                Texts := Text {
+                    [IS LogEntry].spent_time
+                }
+            SELECT
+                _ := Texts.spent_time
+            ORDER BY
+                _
+            ''',
+            [50000]
+        )
+
     async def test_edgeql_select_reverse_link_01(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
When checking the cardinality of an expression that defines a computable
link or property, make sure that the source part of the path preceding
the computable is always treated as a singleton.

Fixes: #1201