### PR TITLE
Fix incorrect implicit limit injection in subqueries in computables

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -446,7 +446,9 @@ def _normalize_view_ptr_expr(
         qlexpr = astutils.ensure_qlstmt(compexpr)
 
         if ((ctx.expr_exposed or ctx.stmt is ctx.toplevel_stmt)
-                and ctx.implicit_limit):
+                and ctx.implicit_limit
+                and isinstance(qlexpr, qlast.OffsetLimitMixin)
+                and not qlexpr.limit):
             qlexpr.limit = qlast.IntegerConstant(value=str(ctx.implicit_limit))
 
         with ctx.newscope(fenced=True) as shape_expr_ctx:

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2583,6 +2583,7 @@ class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):
                         a ORDER BY .n LIMIT 3,
                         a_arr := array_agg((SELECT .a LIMIT 3)),
                         a_count := count(.a),
+                        a_comp := (SELECT .a LIMIT 3),
                     }
                     ORDER BY .n
                     LIMIT 3
@@ -2593,6 +2594,7 @@ class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):
             self.assertEqual(len(result), 3)
             self.assertEqual(len(result[0].a), 3)
             self.assertEqual(len(result[0].a_arr), 3)
+            self.assertEqual(len(result[0].a_comp), 3)
             self.assertEqual(result[0].a_count, 5)
 
             # Check that implicit limit does not break inline aliases.


### PR DESCRIPTION
In `SELECT Foo { bar := (SELECT Spam LIMIT 1) }` the explicit `LIMIT 1`
would be incorrectly replaced with the implicit limit due to a missing
check.

Fixes: #1271