### PR TITLE
Tighten checks for cardinality redefinition in computables

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -239,6 +239,7 @@ def _normalize_view_ptr_expr(
     qlexpr = None
     target_typexpr = None
     source: qlast.Base
+    base_ptrcls_is_alias = False
 
     if plen >= 2 and isinstance(steps[-1], qlast.TypeIntersection):
         # Target type intersection: foo: Type
@@ -505,6 +506,7 @@ def _normalize_view_ptr_expr(
 
             if base_ptrcls is None:
                 base_ptrcls = shape_expr_ctx.view_rptr.base_ptrcls
+                base_ptrcls_is_alias = shape_expr_ctx.view_rptr.ptrcls_is_alias
 
         ptr_cardinality = None
         ptr_target = inference.infer_type(irexpr, ctx.env)
@@ -681,11 +683,34 @@ def _normalize_view_ptr_expr(
             if qlexpr is None and ptrcls is not base_ptrcls:
                 ctx.pointer_derivation_map[base_ptrcls].append(ptrcls)
 
+            base_cardinality = None
+            if base_ptrcls is not None and not base_ptrcls_is_alias:
+                base_cardinality = base_ptrcls.get_cardinality(ctx.env.schema)
+
+            if base_cardinality is None:
+                specified_cardinality = shape_el.cardinality
+            else:
+                specified_cardinality = base_cardinality
+                if (shape_el.cardinality is not None
+                        and base_ptrcls is not None
+                        and shape_el.cardinality != base_cardinality):
+                    base_src = base_ptrcls.get_source(ctx.env.schema)
+                    assert base_src is not None
+                    base_src_name = base_src.get_verbosename(ctx.env.schema)
+                    raise errors.SchemaError(
+                        f'cannot redefine the cardinality of '
+                        f'{ptrcls.get_verbosename(ctx.env.schema)}: '
+                        f'it is defined as {base_cardinality.as_ptr_qual()!r} '
+                        f'in the base {base_src_name}',
+                        context=compexpr.context,
+                    )
+
             stmtctx.pend_pointer_cardinality_inference(
                 ptrcls=ptrcls,
-                specified_card=shape_el.cardinality,
+                specified_card=specified_cardinality,
                 source_ctx=shape_el.context,
-                ctx=ctx)
+                ctx=ctx,
+            )
 
             ctx.env.schema = ptrcls.set_field_value(
                 ctx.env.schema, 'cardinality', None)

--- a/tests/test_edgeql_coalesce.py
+++ b/tests/test_edgeql_coalesce.py
@@ -287,18 +287,18 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             r'''
                 WITH MODULE test
                 SELECT Issue {
-                    time_estimate := Issue.time_estimate ?? {-1, -2}
+                    comp_time_estimate := Issue.time_estimate ?? {-1, -2}
                 };
             ''',
             [
-                {'time_estimate': [-1, -2]},
-                {'time_estimate': [-1, -2]},
-                {'time_estimate': [-1, -2]},
-                {'time_estimate': [60]},
-                {'time_estimate': [90]},
-                {'time_estimate': [90]},
+                {'comp_time_estimate': [-1, -2]},
+                {'comp_time_estimate': [-1, -2]},
+                {'comp_time_estimate': [-1, -2]},
+                {'comp_time_estimate': [60]},
+                {'comp_time_estimate': [90]},
+                {'comp_time_estimate': [90]},
             ],
-            sort=lambda x: x['time_estimate']
+            sort=lambda x: x['comp_time_estimate']
         )
 
     async def test_edgeql_coalesce_set_02(self):

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1638,6 +1638,48 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 }
             """)
 
+    async def test_edgeql_select_tvariant_bad_05(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "possibly more than one element returned by an expression for a "
+            "computable link 'owner' declared as 'single'",
+            _position=85,
+        ):
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT Issue {
+                    owner := User
+                }
+            """)
+
+    async def test_edgeql_select_tvariant_bad_06(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "cannot redefine the cardinality of link 'owner': it is defined "
+            "as 'single' in the base object type 'test::Issue'",
+            _position=100,
+        ):
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT Issue {
+                    multi owner := User
+                }
+            """)
+
+    async def test_edgeql_select_tvariant_bad_07(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "cannot redefine the cardinality of link 'related_to': it is "
+            "defined as 'multi' in the base object type 'test::Issue'",
+            _position=106,
+        ):
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT Issue {
+                    single related_to := (SELECT Issue LIMIT 1)
+                }
+            """)
+
     async def test_edgeql_select_instance_01(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
Redefining the cardinality of a link or property with a computable
expression is an error.