### PR TITLE
Upgrade to mypy-0.770

### DIFF
--- a/edb/common/parametric.py
+++ b/edb/common/parametric.py
@@ -68,7 +68,10 @@ class ParametricType:
         params_str = ", ".join(_type_repr(a) for a in params)
         name = f"{cls.__name__}[{params_str}]"
         bases = (cls,)
-        type_dict = {"types": params, "__module__": cls.__module__}
+        type_dict: Dict[str, Any] = {
+            "types": params,
+            "__module__": cls.__module__,
+        }
         forward_refs: Dict[str, Tuple[int, str]] = {}
         tuple_to_attr: Dict[int, str] = {}
         if issubclass(cls, SingleParameter):

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -130,9 +130,8 @@ class Expr(Base):
 class SubExpr(Base):
     """A subexpression (used for anchors)."""
 
-    expr: typing.Union[Expr, object]
-    anchors: typing.Dict[typing.Union[str, ast.MetaAST],
-                         typing.Union[Expr, object]]
+    expr: Expr
+    anchors: typing.Dict[str, typing.Any]
 
 
 class Clause(Base):
@@ -215,19 +214,21 @@ class AnyTuple(PseudoObjectRef):
     pass
 
 
-class SpecialAnchor(Expr):
+class Anchor(Expr):
+    __abstract_node__ = True
+    name: str
+
+
+class SpecialAnchor(Anchor):
     __abstract_node__ = True
 
 
-SpecialAnchorT = typing.Type[SpecialAnchor]
-
-
 class Source(SpecialAnchor):  # __source__
-    pass
+    name: str = '__source__'
 
 
 class Subject(SpecialAnchor):  # __subject__
-    pass
+    name: str = '__subject__'
 
 
 class DetachedExpr(Expr):  # DETACHED Expr

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -461,8 +461,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             if i == 0:
                 if isinstance(e, qlast.ObjectRef):
                     self.visit(e)
-                elif isinstance(e, (qlast.Source,
-                                    qlast.Subject)):
+                elif isinstance(e, qlast.Anchor):
                     self.visit(e)
                 elif not isinstance(e, (qlast.Ptr,
                                         qlast.Set,
@@ -684,11 +683,14 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self.write('::')
         self.write(ident_to_str(node.name))
 
-    def visit_Source(self, node: qlast.Source) -> None:
-        self.write('__source__')
+    def visit_Anchor(self, node: qlast.Anchor) -> None:
+        self.write(node.name)
 
     def visit_Subject(self, node: qlast.Subject) -> None:
-        self.write('__subject__')
+        self.write(node.name)
+
+    def visit_Source(self, node: qlast.Source) -> None:
+        self.write(node.name)
 
     def visit_TypeExprLiteral(self, node: qlast.TypeExprLiteral) -> None:
         self.visit(node.val)

--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -167,13 +167,8 @@ def compile_ast_to_ir(
     schema: s_schema.Schema,
     *,
     modaliases: Optional[Mapping[Optional[str], str]] = None,
-    anchors: Optional[
-        Mapping[
-            irast.AnchorsKeyType,
-            irast.AnchorsValueType
-        ]
-    ] = None,
-    path_prefix_anchor: Optional[irast.AnchorsKeyType] = None,
+    anchors: Optional[Mapping[str, Any]] = None,
+    path_prefix_anchor: Optional[str] = None,
     singletons: Sequence[s_types.Type] = (),
     func_params: Optional[s_func.ParameterLikeList] = None,
     result_view_name: Optional[s_name.SchemaName] = None,
@@ -339,10 +334,8 @@ def compile_ast_fragment_to_ir(
     schema: s_schema.Schema,
     *,
     modaliases: Optional[Mapping[Optional[str], str]] = None,
-    anchors: Optional[
-        Mapping[irast.AnchorsKeyType, irast.AnchorsValueType]
-    ] = None,
-    path_prefix_anchor: Optional[irast.AnchorsKeyType] = None,
+    anchors: Optional[Mapping[str, Any]] = None,
+    path_prefix_anchor: Optional[str] = None,
 ) -> irast.Statement:
     """Compile given EdgeQL AST fragment into EdgeDB IR.
 

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -432,7 +432,7 @@ def __infer_index(
 
         result = json_t
 
-    elif isinstance(node_type, s_abc.Array):
+    elif isinstance(node_type, s_types.Array):
 
         if not index_type.implicitly_castable_to(int_t, env.schema):
             raise errors.QueryError(

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -178,7 +178,7 @@ def derive_view(
         ctx.env.schema, derived = stype.derive_subtype(
             ctx.env.schema, name=derived_name)
 
-    elif isinstance(stype, s_obj.InheritingObject):
+    elif isinstance(stype, s_obj.DerivableInheritingObject):
         ctx.env.schema, derived = stype.derive_subtype(
             ctx.env.schema,
             name=derived_name,

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -32,7 +32,6 @@ from edb.common import parsing
 
 from edb.ir import ast as irast
 
-from edb.schema import abc as s_abc
 from edb.schema import functions as s_func
 from edb.schema import modules as s_mod
 from edb.schema import name as s_name
@@ -62,8 +61,7 @@ def init_context(
         func_params: Optional[s_func.ParameterLikeList]=None,
         parent_object_type: Optional[s_obj.ObjectMeta]=None,
         modaliases: Optional[Mapping[Optional[str], str]]=None,
-        anchors: Optional[Mapping[irast.AnchorsKeyType,
-                                  irast.AnchorsValueType]]=None,
+        anchors: Optional[Mapping[str, Any]]=None,
         singletons: Optional[Iterable[s_types.Type]]=None,
         security_context: Optional[str]=None,
         derived_target_module: Optional[str]=None,
@@ -253,7 +251,7 @@ def _elide_derived_ancestors(
 
 
 def compile_anchor(
-    name: Union[str, qlast.SpecialAnchorT],
+    name: str,
     anchor: Union[qlast.Expr, irast.Base, s_obj.Object],
     *,
     ctx: context.ContextLevel,
@@ -261,7 +259,7 @@ def compile_anchor(
 
     show_as_anchor = True
 
-    if isinstance(anchor, s_abc.Type):
+    if isinstance(anchor, s_types.Type):
         step = setgen.class_set(anchor, ctx=ctx)
 
     elif (isinstance(anchor, s_pointers.Pointer) and
@@ -347,7 +345,7 @@ def compile_anchor(
 
 
 def populate_anchors(
-    anchors: Mapping[irast.AnchorsKeyType, irast.AnchorsValueType],
+    anchors: Mapping[str, Any],
     *,
     ctx: context.ContextLevel,
 ) -> None:

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -943,7 +943,7 @@ def _get_shape_configuration(
         )
         with ctx.newscope(fenced=True) as scopectx:
             scopectx.anchors = scopectx.anchors.copy()
-            scopectx.anchors[qlast.Source] = ir_set
+            scopectx.anchors[qlast.Source().name] = ir_set
             ptr = _normalize_view_ptr_expr(
                 ql, stype, path_id=ir_set.path_id, ctx=scopectx)
             view_shape = ctx.env.view_shapes[stype]

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -94,7 +94,7 @@ def index_parameters(
 
 class AnchorInliner(ast.NodeTransformer):
 
-    def __init__(self, anchors: Mapping[Any, qlast.Base]) -> None:
+    def __init__(self, anchors: Mapping[str, qlast.Base]) -> None:
         super().__init__()
         self.anchors = anchors
 
@@ -104,8 +104,8 @@ class AnchorInliner(ast.NodeTransformer):
 
         step0 = node.steps[0]
 
-        if isinstance(step0, (qlast.Subject, qlast.Source)):
-            node.steps[0] = self.anchors[step0.__class__]
+        if isinstance(step0, qlast.Anchor):
+            node.steps[0] = self.anchors[step0.name]
         elif isinstance(step0, qlast.ObjectRef) and step0.name in self.anchors:
             node.steps[0] = self.anchors[step0.name]
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -379,8 +379,8 @@ class Set(Base):
     typeref: TypeRef
     expr: Expr
     rptr: Pointer
-    anchor: typing.Union[str, ast.MetaAST]
-    show_as_anchor: typing.Union[str, ast.MetaAST]
+    anchor: typing.Optional[str]
+    show_as_anchor: typing.Optional[str]
     shape: typing.List[Set]
 
     def __repr__(self) -> str:
@@ -720,7 +720,3 @@ class ConfigReset(ConfigCommand):
 class ConfigInsert(ConfigCommand, Expr):
 
     expr: Set
-
-
-AnchorsKeyType = typing.TypeVar("AnchorsKeyType", str, qlast.SpecialAnchorT)
-AnchorsValueType = typing.TypeVar("AnchorsValueType", so.Object, Base)

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -24,7 +24,6 @@ from typing import *
 
 from edb.edgeql import qltypes
 
-from edb.schema import abc as s_abc
 from edb.schema import links as s_links
 from edb.schema import lproperties as s_props
 from edb.schema import modules as s_mod
@@ -153,7 +152,7 @@ def type_to_typeref(
             id=t.id,
             name_hint=typename or t.get_name(schema),
         )
-    elif not isinstance(t, s_abc.Collection):
+    elif not isinstance(t, s_types.Collection):
         assert isinstance(t, s_types.InheritingType)
         union_of = t.get_union_of(schema)
         if union_of:
@@ -236,7 +235,7 @@ def type_to_typeref(
             is_view=t.is_view(schema),
             is_opaque_union=t.get_is_opaque_union(schema),
         )
-    elif isinstance(t, s_abc.Tuple) and t.named:
+    elif isinstance(t, s_types.Tuple) and t.named:
         result = irast.TypeRef(
             id=t.id,
             name_hint=typename or t.get_name(schema),

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1775,7 +1775,7 @@ class CreateIndex(IndexCommand, CreateObject, adapts=s_indexes.CreateIndex):
         subject = schema.get(subject_name, default=None)
         if not isinstance(subject, s_pointers.Pointer):
             singletons = [subject]
-            path_prefix_anchor = ql_ast.Subject
+            path_prefix_anchor = ql_ast.Subject().name
         else:
             singletons = []
             path_prefix_anchor = None
@@ -1788,7 +1788,7 @@ class CreateIndex(IndexCommand, CreateObject, adapts=s_indexes.CreateIndex):
                 schema=schema,
                 modaliases=context.modaliases,
                 parent_object_type=self.get_schema_metaclass(),
-                anchors={ql_ast.Subject: subject},
+                anchors={ql_ast.Subject().name: subject},
                 path_prefix_anchor=path_prefix_anchor,
                 singletons=singletons,
             )

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -212,7 +212,7 @@ class ConstraintMech:
         ir = ql_compiler.compile_ast_to_ir(
             constraint.get_finalexpr(schema).qlast,
             schema,
-            anchors={qlast.Subject: subject},
+            anchors={qlast.Subject().name: subject},
         )
 
         terminal_refs = ir_utils.get_longest_paths(ir.expr.expr.result)

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -25,7 +25,6 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
 from . import delta as sd
-from . import inheriting
 from . import name as sn
 from . import referencing
 from . import objects as so
@@ -185,7 +184,7 @@ class AnnotationValueCommandContext(sd.ObjectCommandContext[AnnotationValue]):
 
 
 class AnnotationValueCommand(
-    referencing.ReferencedInheritingObjectCommand,
+    referencing.ReferencedInheritingObjectCommand[AnnotationValue],
     schema_metaclass=AnnotationValue,
     context_class=AnnotationValueCommandContext,
     referrer_context_class=AnnotationSubjectCommandContext,
@@ -204,8 +203,10 @@ class AnnotationValueCommand(
         return parent.del_annotation(schema, annotation_name)
 
 
-class CreateAnnotationValue(AnnotationValueCommand,
-                            referencing.CreateReferencedInheritingObject):
+class CreateAnnotationValue(
+    AnnotationValueCommand,
+    referencing.CreateReferencedInheritingObject[AnnotationValue],
+):
     astnode = qlast.CreateAnnotationValue
     referenced_astnode = qlast.CreateAnnotationValue
 
@@ -261,8 +262,10 @@ class CreateAnnotationValue(AnnotationValueCommand,
             super()._apply_field_ast(schema, context, node, op)
 
 
-class AlterAnnotationValue(AnnotationValueCommand,
-                           referencing.AlterReferencedInheritingObject):
+class AlterAnnotationValue(
+    AnnotationValueCommand,
+    referencing.AlterReferencedInheritingObject[AnnotationValue],
+):
 
     astnode = qlast.AlterAnnotationValue
     referenced_astnode = qlast.AlterAnnotationValue
@@ -312,7 +315,9 @@ class AlterAnnotationValue(AnnotationValueCommand,
             super()._apply_field_ast(schema, context, node, op)
 
 
-class DeleteAnnotationValue(AnnotationValueCommand,
-                            inheriting.DeleteInheritingObject):
+class DeleteAnnotationValue(
+    AnnotationValueCommand,
+    referencing.DeleteReferencedInheritingObject[AnnotationValue],
+):
 
     astnode = qlast.DropAnnotationValue

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -133,10 +133,8 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer, s_abc.Expression):
         as_fragment: bool = False,
         modaliases: Optional[Mapping[Optional[str], str]] = None,
         parent_object_type: Optional[so.ObjectMeta] = None,
-        anchors: Optional[
-            Mapping[irast_.AnchorsKeyType, irast_.AnchorsValueType]
-        ] = None,
-        path_prefix_anchor: Optional[irast_.AnchorsKeyType] = None,
+        anchors: Optional[Mapping[str, Any]] = None,
+        path_prefix_anchor: Optional[str] = None,
         allow_generic_type_output: bool = False,
         func_params: Optional[s_func.ParameterLikeList] = None,
         singletons: Sequence[s_types.Type] = (),

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -65,10 +65,14 @@ class AliasCommand(
     @classmethod
     def command_for_ast_node(cls, astnode, schema, context):
         modaliases = cls._modaliases_from_ast(schema, astnode, context)
+        ctx = AliasCommandContext(
+            schema,
+            op=sd._dummy_object,
+            scls=sd._dummy_object,
+            modaliases=modaliases,
+        )
 
-        with context(AliasCommandContext(
-                schema, op=None, modaliases=modaliases)):
-
+        with context(ctx):
             classname = cls._classname_from_ast(schema, astnode, context)
 
             if isinstance(astnode, qlast.CreateAlias):

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -148,7 +148,10 @@ class IndexCommand(
             ) from None
 
 
-class CreateIndex(IndexCommand, referencing.CreateReferencedInheritingObject):
+class CreateIndex(
+    IndexCommand,
+    referencing.CreateReferencedInheritingObject[Index],
+):
     astnode = qlast.CreateIndex
     referenced_astnode = qlast.CreateIndex
 
@@ -197,7 +200,7 @@ class CreateIndex(IndexCommand, referencing.CreateReferencedInheritingObject):
             subject = schema.get(subject_name, default=None)
             if not isinstance(subject, s_abc.Pointer):
                 singletons = [subject]
-                path_prefix_anchor = qlast.Subject
+                path_prefix_anchor = qlast.Subject().name
             else:
                 singletons = []
                 path_prefix_anchor = None
@@ -207,7 +210,7 @@ class CreateIndex(IndexCommand, referencing.CreateReferencedInheritingObject):
                 schema=schema,
                 modaliases=context.modaliases,
                 parent_object_type=self.get_schema_metaclass(),
-                anchors={qlast.Subject: subject},
+                anchors={qlast.Subject().name: subject},
                 path_prefix_anchor=path_prefix_anchor,
                 singletons=singletons,
             )
@@ -215,15 +218,24 @@ class CreateIndex(IndexCommand, referencing.CreateReferencedInheritingObject):
             return super().compile_expr_field(schema, context, field, value)
 
 
-class RenameIndex(IndexCommand, referencing.RenameReferencedInheritingObject):
+class RenameIndex(
+    IndexCommand,
+    referencing.RenameReferencedInheritingObject[Index],
+):
     pass
 
 
-class AlterIndex(IndexCommand, referencing.AlterReferencedInheritingObject):
+class AlterIndex(
+    IndexCommand,
+    referencing.AlterReferencedInheritingObject[Index],
+):
     astnode = qlast.AlterIndex
 
 
-class DeleteIndex(IndexCommand, inheriting.DeleteInheritingObject):
+class DeleteIndex(
+    IndexCommand,
+    referencing.DeleteReferencedInheritingObject[Index],
+):
     astnode = qlast.DropIndex
 
     @classmethod

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -128,7 +128,11 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObject]):
     ) -> Dict[
         sn.Name,
         Tuple[
-            Type[s_referencing.CreateReferencedObject],
+            Type[
+                s_referencing.CreateReferencedObject[
+                    s_referencing.ReferencedObject
+                ]
+            ],
             qlast.ObjectDDL,
             List[so.InheritingObject],
         ],
@@ -140,7 +144,11 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObject]):
         refs: Dict[
             sn.Name,
             Tuple[
-                Type[s_referencing.CreateReferencedObject],
+                Type[
+                    s_referencing.CreateReferencedObject[
+                        s_referencing.ReferencedObject
+                    ]
+                ],
                 qlast.ObjectDDL,
                 List[so.InheritingObject],
             ],
@@ -181,7 +189,11 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObject]):
         present_refs: Dict[
             sn.Name,
             Tuple[
-                Type[s_referencing.CreateReferencedObject],
+                Type[
+                    s_referencing.CreateReferencedObject[
+                        s_referencing.ReferencedObject
+                    ]
+                ],
                 qlast.ObjectDDL,
                 List[so.InheritingObject],
             ],

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -218,7 +218,10 @@ class LinkCommand(lproperties.PropertySourceCommand,
         return node
 
 
-class CreateLink(LinkCommand, referencing.CreateReferencedInheritingObject):
+class CreateLink(
+    LinkCommand,
+    referencing.CreateReferencedInheritingObject[Link],
+):
     astnode = [qlast.CreateConcreteLink, qlast.CreateLink]
     referenced_astnode = qlast.CreateConcreteLink
 
@@ -381,7 +384,10 @@ class SetTargetDeletePolicy(sd.Command):
         return cmd
 
 
-class AlterLink(LinkCommand, referencing.AlterReferencedInheritingObject):
+class AlterLink(
+    LinkCommand,
+    referencing.AlterReferencedInheritingObject[Link],
+):
     astnode = [qlast.AlterLink, qlast.AlterConcreteLink]
     referenced_astnode = qlast.AlterConcreteLink
 
@@ -394,7 +400,10 @@ class AlterLink(LinkCommand, referencing.AlterReferencedInheritingObject):
         return cmd
 
 
-class DeleteLink(LinkCommand, inheriting.DeleteInheritingObject):
+class DeleteLink(
+    LinkCommand,
+    referencing.DeleteReferencedInheritingObject[Link],
+):
     astnode = [qlast.DropLink, qlast.DropConcreteLink]
     referenced_astnode = qlast.DropConcreteLink
 

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -226,8 +226,10 @@ class PropertyCommand(pointers.PointerCommand,
             )
 
 
-class CreateProperty(PropertyCommand,
-                     referencing.CreateReferencedInheritingObject):
+class CreateProperty(
+    PropertyCommand,
+    referencing.CreateReferencedInheritingObject[Property],
+):
     astnode = [qlast.CreateConcreteProperty,
                qlast.CreateProperty]
 
@@ -281,8 +283,10 @@ class CreateProperty(PropertyCommand,
             super()._apply_field_ast(schema, context, node, op)
 
 
-class RenameProperty(PropertyCommand,
-                     referencing.RenameReferencedInheritingObject):
+class RenameProperty(
+    PropertyCommand,
+    referencing.RenameReferencedInheritingObject[Property],
+):
     pass
 
 
@@ -297,8 +301,10 @@ class SetPropertyType(pointers.SetPointerType,
     astnode = qlast.SetPropertyType
 
 
-class AlterProperty(PropertyCommand,
-                    referencing.AlterReferencedInheritingObject):
+class AlterProperty(
+    PropertyCommand,
+    referencing.AlterReferencedInheritingObject[Property],
+):
     astnode = [qlast.AlterConcreteProperty,
                qlast.AlterProperty]
 
@@ -326,7 +332,10 @@ class AlterProperty(PropertyCommand,
             super()._apply_field_ast(schema, context, node, op)
 
 
-class DeleteProperty(PropertyCommand, inheriting.DeleteInheritingObject):
+class DeleteProperty(
+    PropertyCommand,
+    referencing.DeleteReferencedInheritingObject[Property],
+):
     astnode = [qlast.DropConcreteProperty,
                qlast.DropProperty]
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1612,6 +1612,7 @@ class ObjectCollection(
 ):
     type: ClassVar[Type[Object]] = Object
     _container: ClassVar[Type[CollectionFactory]]
+    _ids: Collection[Union[uuid.UUID, ObjectRef]]
 
     def __init_subclass__(
         cls,
@@ -1623,7 +1624,7 @@ class ObjectCollection(
 
     def __init__(
         self,
-        ids: Union[Collection[uuid.UUID], Collection[ObjectRef]],
+        ids: Collection[Union[uuid.UUID, ObjectRef]],
         *,
         _private_init: bool,
     ) -> None:
@@ -1692,10 +1693,10 @@ class ObjectCollection(
         schema: s_schema.Schema,
         data: Iterable[Object_T],
     ) -> ObjectCollection_T:
-        ids = []
+        ids: List[Union[uuid.UUID, ObjectRef]] = []
 
         if isinstance(data, ObjectCollection):
-            ids = data._ids
+            ids.extend(data._ids)
         elif data:
             for v in data:
                 ids.append(cls._validate_value(schema, v))

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -631,8 +631,8 @@ class PointerCommandOrFragment:
             s_expr.Expression.from_ast(expr, schema, context.modaliases),
             schema=schema,
             modaliases=context.modaliases,
-            anchors={qlast.Source: source},
-            path_prefix_anchor=qlast.Source,
+            anchors={qlast.Source().name: source},
+            path_prefix_anchor=qlast.Source().name,
             singletons=[source],
         )
 
@@ -848,10 +848,10 @@ class PointerCommand(
                     s_sources.SourceCommandContext, self)
                 source_name = parent_ctx.op.classname
                 source = schema.get(source_name, default=None)
-                anchors[qlast.Source] = source
+                anchors[qlast.Source().name] = source
                 if not isinstance(source, Pointer):
                     singletons = [source]
-                    path_prefix_anchor = qlast.Source
+                    path_prefix_anchor = qlast.Source().name
 
             return type(value).compiled(
                 value,

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -70,6 +70,9 @@ class ScalarType(
     def is_polymorphic(self, schema: s_schema.Schema) -> bool:
         return self.get_is_abstract(schema)
 
+    def can_accept_constraints(self, schema: s_schema.Schema) -> bool:
+        return not self.is_enum(schema)
+
     def _resolve_polymorphic(
         self,
         schema: s_schema.Schema,
@@ -169,6 +172,16 @@ class ScalarType(
             return schema.get('std::anyenum')
         else:
             return super().get_base_for_cast(schema)
+
+    def get_verbosename(
+        self, schema: s_schema.Schema, *, with_parent: bool = False
+    ) -> str:
+        if self.is_enum(schema):
+            clsname = 'enumerated type'
+        else:
+            clsname = self.get_schema_class_displayname()
+        dname = self.get_displayname(schema)
+        return f"{clsname} '{dname}'"
 
 
 class AnonymousEnumTypeRef(so.ObjectRef):

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -491,6 +491,8 @@ class ExistingIntersectionTypeRef(  # type: ignore
 
 class Collection(Type, s_abc.Collection):
 
+    schema_name: typing.ClassVar[str]
+
     def is_polymorphic(self, schema: s_schema.Schema) -> bool:
         return any(st.is_polymorphic(schema)
                    for st in self.get_subtypes(schema))

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 def ast_objref_to_objref(
         node: qlast.ObjectRef, *,
         metaclass: Optional[so.ObjectMeta] = None,
-        modaliases: Dict[Optional[str], str],
+        modaliases: Mapping[Optional[str], str],
         schema: s_schema.Schema) -> so.Object:
 
     if metaclass is not None and issubclass(metaclass, so.GlobalObject):

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ EXTRA_DEPS = {
         'black~=19.3b0',
         'flake8~=3.7.9',
         'flake8-bugbear~=19.8.0',
-        'mypy==0.761',
+        'mypy==0.770',
         'coverage~=4.5.2',
         'requests-xml~=0.2.3',
         'lxml',

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4459,7 +4459,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.UnsupportedFeatureError,
-                'constraints cannot be defined on an enumerated type'):
+                'constraints cannot be defined on enumerated type.*'):
             await self.con.execute('''
                 CREATE SCALAR TYPE test::my_enum_3
                     EXTENDING enum<'foo', 'bar', 'baz'> {

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 42.36)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 42.41)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 73.84)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 73.97)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)


### PR DESCRIPTION
The improved type checking has necessiated some cleanups and code
movement.  Notably, I've simplified the type of the "anchors" dictionary
(symtable) as passed to the EdgeQL compiler.  There is also a fix to the
mypy plugin to make inference of schema field getters more robust.