### PR TITLE
Cardinality

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -467,7 +467,7 @@ class ShapeElement(OffsetLimitMixin, OrderByMixin, FilterMixin, Expr):
     expr: Path
     elements: typing.List[ShapeElement]
     compexpr: Expr
-    cardinality: qltypes.Cardinality
+    cardinality: qltypes.SchemaCardinality
     required: bool = False
 
 
@@ -743,7 +743,7 @@ class CreateConcretePointer(CreateObject, BasesMixin):
     is_required: bool = False
     declared_overloaded: bool = False
     target: typing.Optional[typing.Union[Expr, TypeExpr]]
-    cardinality: qltypes.Cardinality
+    cardinality: qltypes.SchemaCardinality
 
 
 class CreateConcreteProperty(CreateConcretePointer):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -514,10 +514,8 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         if node.required:
             quals.append('required')
 
-        if node.cardinality is qltypes.Cardinality.MANY:
-            quals.append('multi')
-        elif node.cardinality is qltypes.Cardinality.ONE:
-            quals.append('single')
+        if node.cardinality:
+            quals.append(node.cardinality.as_ptr_qual())
 
         if quals:
             self.write(*quals, delimiter=' ')
@@ -929,10 +927,8 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         elif fname == 'required':
             keywords.append('REQUIRED')
         elif fname == 'cardinality':
-            if node.value is qltypes.Cardinality.ONE:
-                keywords.append('SINGLE')
-            else:
-                keywords.append('MULTI')
+            if node.value:
+                keywords.append(node.value.as_ptr_qual().upper())
         else:
             raise EdgeQLSourceGeneratorError(
                 'unknown special field: {!r}'.format(fname))
@@ -1216,10 +1212,8 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             keywords.append('OVERLOADED')
         if node.is_required:
             keywords.append('REQUIRED')
-        if node.cardinality is qltypes.Cardinality.ONE:
-            keywords.append('SINGLE')
-        elif node.cardinality is qltypes.Cardinality.MANY:
-            keywords.append('MULTI')
+        if node.cardinality:
+            keywords.append(node.cardinality.as_ptr_qual().upper())
         keywords.append('PROPERTY')
 
         pure_computable = (
@@ -1326,10 +1320,8 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             keywords.append('OVERLOADED')
         if node.is_required:
             keywords.append('REQUIRED')
-        if node.cardinality is qltypes.Cardinality.ONE:
-            keywords.append('SINGLE')
-        elif node.cardinality is qltypes.Cardinality.MANY:
-            keywords.append('MULTI')
+        if node.cardinality:
+            keywords.append(node.cardinality.as_ptr_qual().upper())
         keywords.append('LINK')
 
         def after_name() -> None:

--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -520,7 +520,7 @@ def compile_func_to_ir(
 
     return_typemod = func.get_return_typemod(schema)
     if (return_typemod is not qltypes.TypeModifier.SET_OF
-            and ir.cardinality is qltypes.Cardinality.MANY):
+            and ir.cardinality.is_multi()):
         raise errors.InvalidFunctionDefinitionError(
             f'return cardinality mismatch in function declared to return '
             f'a singleton',

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 class SettingInfo(NamedTuple):
     param_name: str
     param_type: s_types.Type
-    cardinality: qltypes.Cardinality
+    cardinality: qltypes.SchemaCardinality
     requires_restart: bool
     backend_setting: str
 

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -689,7 +689,8 @@ def finalize_args(
                 arg, paramtype, srcctx=None, ctx=ctx)
 
         if param_mod is not ft.TypeModifier.SET_OF:
-            call_arg = irast.CallArg(expr=arg, cardinality=ft.Cardinality.ONE)
+            call_arg = irast.CallArg(expr=arg,
+                                     cardinality=ft.Cardinality.ONE)
         else:
             call_arg = irast.CallArg(expr=arg, cardinality=None)
             stmtctx.get_expr_cardinality_later(

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -447,7 +447,7 @@ def derive_dummy_ptr(
             derived_obj,
             derived_obj,
             attrs={
-                'cardinality': qltypes.Cardinality.MANY,
+                'cardinality': qltypes.SchemaCardinality.MANY,
             },
             name=derived_name,
             mark_derived=True)

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -735,7 +735,7 @@ def type_intersection_set(
         # The type intersection cannot increase the cardinality
         # of the input set, so semantically, the cardinality
         # of the type intersection "link" is, at most, ONE.
-        cardinality=qltypes.Cardinality.ONE,
+        cardinality=qltypes.SchemaCardinality.ONE,
     )
 
     ptrref = irtyputils.ptrref_from_ptrcls(

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -31,6 +31,7 @@ from edb import errors
 from edb.common import parsing
 
 from edb.ir import ast as irast
+from edb.ir import typeutils
 
 from edb.schema import functions as s_func
 from edb.schema import modules as s_mod
@@ -45,6 +46,7 @@ from edb.schema import types as s_types
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 from edb.edgeql import parser as qlparser
+from edb.edgeql.compiler.inference import cardinality as inf_card
 
 from . import astutils
 from . import context
@@ -146,7 +148,7 @@ def fini_expression(
         cardinality = inference.infer_cardinality(
             ir, scope_tree=ctx.path_scope, env=ctx.env)
     else:
-        cardinality = qltypes.Cardinality.ONE
+        cardinality = qltypes.Cardinality.AT_MOST_ONE
 
     if ctx.env.schema_view_mode:
         for view in ctx.view_nodes.values():
@@ -473,26 +475,43 @@ def _infer_pointer_cardinality(
         source_ctx: Optional[parsing.ParserContext] = None,
         ctx: context.ContextLevel) -> None:
 
+    # Infer cardinality and convert it back to schema values of "ONE/MANY".
     inferred_card = infer_expr_cardinality(irexpr=irexpr, ctx=ctx)
-    if specified_card is None or inferred_card is specified_card:
+
+    if specified_card is None:
         ptr_card = inferred_card
     else:
-        if specified_card is qltypes.Cardinality.MANY:
-            # Explicit many foo := <expr>, just take it.
+        if inf_card.is_subset_cardinality(inferred_card, specified_card):
+            # The inferred cardinality is within the boundaries of
+            # specified cardinality.
             ptr_card = specified_card
         else:
-            # Specified cardinality is ONE, but we inferred MANY, this
-            # is an error.
-            raise errors.QueryError(
-                f'possibly more than one element returned by an '
-                f'expression for a computable '
-                f'{ptrcls.get_verbosename(ctx.env.schema)} '
-                f"declared as 'single'",
-                context=source_ctx
-            )
+            sp_req, sp_card = specified_card.to_schema_value()
+            ic_req, ic_card = inferred_card.to_schema_value()
+            # Specified cardinality is stricter than inferred (e.g.
+            # ONE vs MANY), this is an error.
+            if sp_req and not ic_req:
+                raise errors.QueryError(
+                    f'possibly an empty set returned by an '
+                    f'expression for a computable '
+                    f'{ptrcls.get_verbosename(ctx.env.schema)} '
+                    f"declared as 'required'",
+                    context=source_ctx
+                )
+            else:
+                raise errors.QueryError(
+                    f'possibly more than one element returned by an '
+                    f'expression for a computable '
+                    f'{ptrcls.get_verbosename(ctx.env.schema)} '
+                    f"declared as 'single'",
+                    context=source_ctx
+                )
 
+    required, card = ptr_card.to_schema_value()
     ctx.env.schema = ptrcls.set_field_value(
-        ctx.env.schema, 'cardinality', ptr_card)
+        ctx.env.schema, 'cardinality', card)
+    ctx.env.schema = ptrcls.set_field_value(
+        ctx.env.schema, 'required', required)
     _update_cardinality_in_derived(ptrcls, ctx=ctx)
     _update_cardinality_callbacks(ptrcls, ctx=ctx)
 
@@ -524,7 +543,8 @@ def _update_cardinality_callbacks(
 def pend_pointer_cardinality_inference(
         *,
         ptrcls: s_pointers.Pointer,
-        specified_card: Optional[qltypes.Cardinality] = None,
+        specified_required: bool = False,
+        specified_card: Optional[qltypes.SchemaCardinality] = None,
         source_ctx: Optional[parsing.ParserContext] = None,
         ctx: context.ContextLevel) -> None:
 
@@ -534,8 +554,15 @@ def pend_pointer_cardinality_inference(
     else:
         callbacks = []
 
+    # Convert the SchemaCardinality into Cardinality used for inference.
+    if specified_card is None:
+        sc = None
+    else:
+        sc = qltypes.Cardinality.from_schema_value(
+            specified_required, specified_card)
+
     ctx.pending_cardinality[ptrcls] = context.PendingCardinality(
-        specified_cardinality=specified_card,
+        specified_cardinality=sc,
         source_ctx=source_ctx,
         callbacks=callbacks,
     )
@@ -605,13 +632,13 @@ def ensure_ptrref_cardinality(
             *,
             ctx: context.ContextLevel,
         ) -> None:
-            if ptrcls.singular(ctx.env.schema, ptrref.direction):
-                ptrref.dir_cardinality = qltypes.Cardinality.ONE
-            else:
-                ptrref.dir_cardinality = qltypes.Cardinality.MANY
-            out_cardinality = ptrcls.get_cardinality(ctx.env.schema)
-            assert out_cardinality is not None
-            ptrref.out_cardinality = out_cardinality
+
+            out_card, dir_card = typeutils.cardinality_from_ptrcls(
+                ctx.env.schema, ptrcls, direction=ptrref.direction)
+            assert dir_card is not None
+            assert out_card is not None
+            ptrref.dir_cardinality = dir_card
+            ptrref.out_cardinality = out_card
 
         once_pointer_cardinality_is_inferred(
             ptrcls, _update_ref_cardinality, ctx=ctx)
@@ -633,7 +660,7 @@ def enforce_singleton_now(
         env=ctx.env,
     )
 
-    if cardinality != qltypes.Cardinality.ONE:
+    if cardinality.is_multi():
         raise errors.QueryError(
             'possibly more than one element returned by an expression '
             'where only singletons are allowed',

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -364,6 +364,7 @@ def _normalize_view_ptr_expr(
             ctx.pointer_derivation_map[base_ptrcls].append(ptrcls)
             stmtctx.pend_pointer_cardinality_inference(
                 ptrcls=ptrcls,
+                specified_required=shape_el.required,
                 specified_card=shape_el.cardinality,
                 source_ctx=shape_el.context,
                 ctx=ctx)
@@ -690,13 +691,18 @@ def _normalize_view_ptr_expr(
                 ctx.pointer_derivation_map[base_ptrcls].append(ptrcls)
 
             base_cardinality = None
+            base_required = False
             if base_ptrcls is not None and not base_ptrcls_is_alias:
                 base_cardinality = base_ptrcls.get_cardinality(ctx.env.schema)
+                base_required = base_ptrcls.get_required(ctx.env.schema)
 
             if base_cardinality is None:
                 specified_cardinality = shape_el.cardinality
+                specified_required = shape_el.required
             else:
                 specified_cardinality = base_cardinality
+                specified_required = base_required
+
                 if (shape_el.cardinality is not None
                         and base_ptrcls is not None
                         and shape_el.cardinality != base_cardinality):
@@ -710,9 +716,12 @@ def _normalize_view_ptr_expr(
                         f'in the base {base_src_name}',
                         context=compexpr.context,
                     )
+                # The required flag may be inherited from the base
+                specified_required = shape_el.required or base_required
 
             stmtctx.pend_pointer_cardinality_inference(
                 ptrcls=ptrcls,
+                specified_required=specified_required,
                 specified_card=specified_cardinality,
                 source_ctx=shape_el.context,
                 ctx=ctx,
@@ -924,36 +933,40 @@ def _get_shape_configuration(
     if implicit_tid:
         assert isinstance(stype, s_objtypes.ObjectType)
 
-        ql = qlast.ShapeElement(
-            expr=qlast.Path(
-                steps=[qlast.Ptr(
-                    ptr=qlast.ObjectRef(name='__tid__'),
-                    direction=s_pointers.PointerDirection.Outbound,
-                )],
-            ),
-            compexpr=qlast.Path(
-                steps=[
-                    qlast.Source(),
-                    qlast.Ptr(
-                        ptr=qlast.ObjectRef(name='__type__'),
+        try:
+            ptr = setgen.resolve_ptr(stype, '__tid__', ctx=ctx)
+        except errors.InvalidReferenceError:
+            ql = qlast.ShapeElement(
+                expr=qlast.Path(
+                    steps=[qlast.Ptr(
+                        ptr=qlast.ObjectRef(name='__tid__'),
                         direction=s_pointers.PointerDirection.Outbound,
-                    ),
-                    qlast.Ptr(
-                        ptr=qlast.ObjectRef(name='id'),
-                        direction=s_pointers.PointerDirection.Outbound,
-                    )
-                ]
+                    )],
+                ),
+                compexpr=qlast.Path(
+                    steps=[
+                        qlast.Source(),
+                        qlast.Ptr(
+                            ptr=qlast.ObjectRef(name='__type__'),
+                            direction=s_pointers.PointerDirection.Outbound,
+                        ),
+                        qlast.Ptr(
+                            ptr=qlast.ObjectRef(name='id'),
+                            direction=s_pointers.PointerDirection.Outbound,
+                        )
+                    ]
+                )
             )
-        )
-        with ctx.newscope(fenced=True) as scopectx:
-            scopectx.anchors = scopectx.anchors.copy()
-            scopectx.anchors[qlast.Source().name] = ir_set
-            ptr = _normalize_view_ptr_expr(
-                ql, stype, path_id=ir_set.path_id, ctx=scopectx)
-            view_shape = ctx.env.view_shapes[stype]
-            if ptr not in view_shape:
-                view_shape.insert(0, ptr)
-                shape_ptrs.insert(0, (ir_set, ptr))
+            with ctx.newscope(fenced=True) as scopectx:
+                scopectx.anchors = scopectx.anchors.copy()
+                scopectx.anchors[qlast.Source().name] = ir_set
+                ptr = _normalize_view_ptr_expr(
+                    ql, stype, path_id=ir_set.path_id, ctx=scopectx)
+
+        view_shape = ctx.env.view_shapes[stype]
+        if ptr not in view_shape:
+            view_shape.insert(0, ptr)
+            shape_ptrs.insert(0, (ir_set, ptr))
 
     return shape_ptrs
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1046,13 +1046,13 @@ class SetCardinalityStmt(Nonterm):
     def reduce_SET_SINGLE(self, *kids):
         self.val = qlast.SetSpecialField(
             name='cardinality',
-            value=qltypes.Cardinality.ONE,
+            value=qltypes.SchemaCardinality.ONE,
         )
 
     def reduce_SET_MULTI(self, *kids):
         self.val = qlast.SetSpecialField(
             name='cardinality',
-            value=qltypes.Cardinality.MANY,
+            value=qltypes.SchemaCardinality.MANY,
         )
 
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -433,7 +433,7 @@ class ShapePointer(Nonterm):
 
 class PtrQualsSpec(typing.NamedTuple):
     required: typing.Optional[bool] = None
-    cardinality: typing.Optional[qltypes.Cardinality] = None
+    cardinality: typing.Optional[qltypes.SchemaCardinality] = None
 
 
 class PtrQuals(Nonterm):
@@ -441,18 +441,18 @@ class PtrQuals(Nonterm):
         self.val = PtrQualsSpec(required=True)
 
     def reduce_SINGLE(self, *kids):
-        self.val = PtrQualsSpec(cardinality=qltypes.Cardinality.ONE)
+        self.val = PtrQualsSpec(cardinality=qltypes.SchemaCardinality.ONE)
 
     def reduce_MULTI(self, *kids):
-        self.val = PtrQualsSpec(cardinality=qltypes.Cardinality.MANY)
+        self.val = PtrQualsSpec(cardinality=qltypes.SchemaCardinality.MANY)
 
     def reduce_REQUIRED_SINGLE(self, *kids):
         self.val = PtrQualsSpec(
-            required=True, cardinality=qltypes.Cardinality.ONE)
+            required=True, cardinality=qltypes.SchemaCardinality.ONE)
 
     def reduce_REQUIRED_MULTI(self, *kids):
         self.val = PtrQualsSpec(
-            required=True, cardinality=qltypes.Cardinality.MANY)
+            required=True, cardinality=qltypes.SchemaCardinality.MANY)
 
 
 class OptPtrQuals(Nonterm):
@@ -478,24 +478,24 @@ class ComputableShapePointer(Nonterm):
     def reduce_MULTI_SimpleShapePointer_ASSIGN_Expr(self, *kids):
         self.val = kids[1].val
         self.val.compexpr = kids[3].val
-        self.val.cardinality = qltypes.Cardinality.MANY
+        self.val.cardinality = qltypes.SchemaCardinality.MANY
 
     def reduce_SINGLE_SimpleShapePointer_ASSIGN_Expr(self, *kids):
         self.val = kids[1].val
         self.val.compexpr = kids[3].val
-        self.val.cardinality = qltypes.Cardinality.ONE
+        self.val.cardinality = qltypes.SchemaCardinality.ONE
 
     def reduce_REQUIRED_MULTI_SimpleShapePointer_ASSIGN_Expr(self, *kids):
         self.val = kids[2].val
         self.val.compexpr = kids[4].val
         self.val.required = True
-        self.val.cardinality = qltypes.Cardinality.MANY
+        self.val.cardinality = qltypes.SchemaCardinality.MANY
 
     def reduce_REQUIRED_SINGLE_SimpleShapePointer_ASSIGN_Expr(self, *kids):
         self.val = kids[2].val
         self.val.compexpr = kids[4].val
         self.val.required = True
-        self.val.cardinality = qltypes.Cardinality.ONE
+        self.val.cardinality = qltypes.SchemaCardinality.ONE
 
     def reduce_SimpleShapePointer_ASSIGN_Expr(self, *kids):
         self.val = kids[0].val

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -47,6 +47,10 @@ class Constraint(NamedObject):
     pass
 
 
+class ConcreteConstraint(NamedObject):
+    pass
+
+
 class Annotation(NamedObject):
     pass
 

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -575,7 +575,7 @@ class GraphQLTranslator:
                 # preserve the original cardinality of the computable,
                 # which is basically one of the top-level query
                 # fields, all of which are returning lists
-                cardinality=qltypes.Cardinality.MANY,
+                cardinality=qltypes.SchemaCardinality.MANY,
             )
 
         # INSERT mutations have different arguments from queries

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -1239,7 +1239,7 @@ class GQLBaseType(metaclass=GQLTypeMeta):
 
         ptr = self.edb_base.getptr(self.edb_schema, name)
         if not ptr.singular(self.edb_schema):
-            return qltypes.Cardinality.MANY
+            return qltypes.SchemaCardinality.MANY
 
         return None
 

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -308,7 +308,7 @@ def object_type_to_python_type(
         else:
             pytype = scalar_type_to_python_type(ptype, schema)
 
-        is_multi = p.get_cardinality(schema) is qltypes.Cardinality.MANY
+        is_multi = p.get_cardinality(schema) is qltypes.SchemaCardinality.MANY
         if is_multi:
             pytype = FrozenSet[pytype]  # type: ignore
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -264,7 +264,7 @@ ALTER TYPE schema::Pointer {
 
 
 ALTER TYPE schema::Link {
-    CREATE LINK properties := .pointers;
+    CREATE MULTI LINK properties := .pointers;
     CREATE PROPERTY on_target_delete -> schema::TargetDeleteAction;
 };
 

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -96,14 +96,14 @@ def compile_output(
 
 def compile_filter_clause(
         ir_set: irast.Set,
-        cardinality: qltypes.Cardinality, *,
+        cardinality: qltypes.SchemaCardinality, *,
         ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
     where_clause: pgast.BaseExpr
 
     with ctx.new() as ctx1:
         ctx1.expr_exposed = False
 
-        if cardinality is qltypes.Cardinality.ONE:
+        if cardinality is qltypes.SchemaCardinality.ONE:
             where_clause = dispatch.compile(ir_set, ctx=ctx)
         else:
             # In WHERE we compile ir.Set as a boolean disjunction:

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -44,7 +44,7 @@ def compile_ConfigSet(
         assert isinstance(val, pgast.SelectStmt), "expected ast.SelectStmt"
         pathctx.get_path_serialized_output(
             val, op.expr.path_id, env=ctx.env)
-        if op.cardinality is qltypes.Cardinality.MANY:
+        if op.cardinality is qltypes.SchemaCardinality.MANY:
             val = output.aggregate_json_output(val, op.expr, env=ctx.env)
 
     result_row = pgast.RowExpr(

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -290,8 +290,8 @@ def compile_OperatorCall(
         ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
 
     if (expr.func_shortname == 'std::IF'
-            and expr.args[0].cardinality is ql_ft.Cardinality.ONE
-            and expr.args[2].cardinality is ql_ft.Cardinality.ONE):
+            and expr.args[0].cardinality.is_single()
+            and expr.args[2].cardinality.is_single()):
         if_expr, condition, else_expr = (a.expr for a in expr.args)
         return pgast.CaseExpr(
             args=[

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1230,8 +1230,7 @@ def process_set_as_ifelse(
             stmt, path_id=condition.path_id,
             aspect='value', ctx=newctx)
 
-    if (if_expr_card is qltypes.Cardinality.ONE
-            and else_expr_card is qltypes.Cardinality.ONE
+    if (if_expr_card.is_single() and else_expr_card.is_single()
             and irtyputils.is_scalar(expr.typeref)):
         # For a simple case of singleton scalars on both ends of IF,
         # use a CASE WHEN construct, since it's normally faster than
@@ -1300,7 +1299,7 @@ def process_set_as_coalesce(
         left_ir, right_ir = (a.expr for a in expr.args)
         left_card, right_card = (a.cardinality for a in expr.args)
 
-        if right_card == qltypes.Cardinality.ONE:
+        if right_card.is_single():
             # Singleton RHS, simply use scalar COALESCE.
             left = dispatch.compile(left_ir, ctx=newctx)
 

--- a/edb/pgsql/compiler/shapecomp.py
+++ b/edb/pgsql/compiler/shapecomp.py
@@ -23,8 +23,6 @@ from __future__ import annotations
 
 from typing import *
 
-from edb.edgeql import qltypes
-
 from edb.ir import ast as irast
 from edb.ir import utils as irutils
 
@@ -67,7 +65,7 @@ def compile_shape(
         for el in shape:
             rptr = el.rptr
             ptrref = rptr.ptrref
-            is_singleton = ptrref.dir_cardinality is qltypes.Cardinality.ONE
+            is_singleton = ptrref.dir_cardinality.is_single()
             value: pgast.BaseExpr
 
             if (irutils.is_subquery_set(el) or

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2265,7 +2265,10 @@ class PointerMetaCommand(MetaCommand, sd.ObjectCommand,
             dbops.Column(
                 name=ptr_stor_info.column_name,
                 type=col_type,
-                required=pointer.get_required(schema),
+                required=(
+                    pointer.get_required(schema)
+                    and not pointer.is_pure_computable(schema)
+                ),
                 default=default,
                 comment=pointer.get_shortname(schema))
         ]
@@ -3039,7 +3042,8 @@ class CreateProperty(PropertyMetaCommand, adapts=s_props.CreateProperty):
                     cond = dbops.ColumnExists(
                         table_name=alter_table.name, column_name=col.name)
 
-                    if prop.get_required(schema):
+                    if (prop.get_required(schema)
+                            and not prop.is_pure_computable(schema)):
                         # For some reason, Postgres allows dropping NOT NULL
                         # constraints from inherited columns, but we really
                         # should only always increase constraints down the

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -694,7 +694,7 @@ class IntrospectionMech:
             required = r['required']
 
             if r['cardinality']:
-                cardinality = qltypes.Cardinality(r['cardinality'])
+                cardinality = qltypes.SchemaCardinality(r['cardinality'])
             else:
                 cardinality = None
 
@@ -773,7 +773,7 @@ class IntrospectionMech:
             schema, target = self.unpack_typeref(r['target'], schema)
 
             if r['cardinality']:
-                cardinality = qltypes.Cardinality(r['cardinality'])
+                cardinality = qltypes.SchemaCardinality(r['cardinality'])
             else:
                 cardinality = None
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -2741,7 +2741,7 @@ def _build_key_expr(key_components):
 def _build_data_source(schema, rptr, source_idx, *, alias=None):
 
     rptr_name = rptr.get_shortname(schema).name
-    rptr_multi = rptr.get_cardinality(schema) is qltypes.Cardinality.MANY
+    rptr_multi = rptr.get_cardinality(schema) is qltypes.SchemaCardinality.MANY
 
     if alias is None:
         alias = f'q{source_idx + 1}'
@@ -2789,7 +2789,7 @@ def _generate_config_type_view(schema, stype, *, path, rptr, _memo=None):
                 FROM edgedb._read_sys_config() cfg) AS q0''')
         else:
             rptr_multi = (
-                rptr.get_cardinality(schema) is qltypes.Cardinality.MANY)
+                rptr.get_cardinality(schema) is qltypes.SchemaCardinality.MANY)
 
             rptr_name = rptr.get_shortname(schema).name
 
@@ -2814,7 +2814,8 @@ def _generate_config_type_view(schema, stype, *, path, rptr, _memo=None):
         key_start = 0
 
         for i, (l, exc_props) in enumerate(path):
-            l_multi = l.get_cardinality(schema) is qltypes.Cardinality.MANY
+            l_multi = (l.get_cardinality(schema) is
+                       qltypes.SchemaCardinality.MANY)
             l_name = l.get_shortname(schema).name
 
             if i == 0:
@@ -2872,7 +2873,7 @@ def _generate_config_type_view(schema, stype, *, path, rptr, _memo=None):
 
         pp_type = pp.get_target(schema)
         pp_multi = (
-            pp.get_cardinality(schema) is qltypes.Cardinality.MANY
+            pp.get_cardinality(schema) is qltypes.SchemaCardinality.MANY
         )
 
         if pp_type.is_object_type():

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -24,7 +24,6 @@ import functools
 from typing import *
 
 from edb.common import uuidgen
-from edb.edgeql import qltypes
 
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
@@ -459,7 +458,7 @@ def get_ptrref_storage_info(
 
 
 def _storable_in_source(ptrref: irast.PointerRef) -> bool:
-    return ptrref.out_cardinality is qltypes.Cardinality.ONE
+    return ptrref.out_cardinality.is_single()
 
 
 def _storable_in_pointer(ptrref: irast.PointerRef) -> bool:
@@ -467,7 +466,7 @@ def _storable_in_pointer(ptrref: irast.PointerRef) -> bool:
         return all(_storable_in_pointer(c) for c in ptrref.union_components)
     else:
         return (
-            ptrref.out_cardinality is qltypes.Cardinality.MANY
+            ptrref.out_cardinality.is_multi()
             or ptrref.has_properties
         )
 

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -373,7 +373,8 @@ class CreateLink(
         src_prop.set_attribute_value('readonly', True)
         src_prop.set_attribute_value('is_final', True)
         src_prop.set_attribute_value('is_local', True)
-        src_prop.set_attribute_value('cardinality', qltypes.Cardinality.ONE)
+        src_prop.set_attribute_value('cardinality',
+                                     qltypes.SchemaCardinality.ONE)
 
         cmd.prepend(src_prop)
 
@@ -405,7 +406,8 @@ class CreateLink(
         tgt_prop.set_attribute_value('readonly', True)
         tgt_prop.set_attribute_value('is_final', True)
         tgt_prop.set_attribute_value('is_local', True)
-        tgt_prop.set_attribute_value('cardinality', qltypes.Cardinality.ONE)
+        tgt_prop.set_attribute_value('cardinality',
+                                     qltypes.SchemaCardinality.ONE)
 
         cmd.prepend(tgt_prop)
 

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -197,7 +197,7 @@ class PropertyCommand(pointers.PointerCommand,
                     context=self.source_context,
                 )
             if (self.get_attribute_value('cardinality')
-                    is qltypes.Cardinality.MANY):
+                    is qltypes.SchemaCardinality.MANY):
                 raise errors.InvalidPropertyDefinitionError(
                     "multi properties aren't supported for links",
                     context=self.source_context,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -353,7 +353,7 @@ class Compiler(BaseCompiler):
             implicit_limit=ctx.implicit_limit,
             session_mode=session_mode)
 
-        if ir.cardinality is qltypes.Cardinality.ONE:
+        if ir.cardinality.is_single():
             result_cardinality = enums.ResultCardinality.ONE
         else:
             result_cardinality = enums.ResultCardinality.MANY

--- a/edb/server/config/spec.py
+++ b/edb/server/config/spec.py
@@ -139,7 +139,7 @@ def load_spec_from_schema(schema):
             for a, v in p.get_annotations(schema).items(schema)
         }
 
-        set_of = p.get_cardinality(schema) is qltypes.Cardinality.MANY
+        set_of = p.get_cardinality(schema) is qltypes.SchemaCardinality.MANY
 
         deflt = p.get_default(schema)
         if deflt is not None:

--- a/edb/server/http_graphql_port/compiler.py
+++ b/edb/server/http_graphql_port/compiler.py
@@ -27,7 +27,6 @@ from edb import graphql
 
 from edb.common import debug
 from edb.edgeql import compiler as ql_compiler
-from edb.edgeql import qltypes
 from edb.pgsql import compiler as pg_compiler
 from edb.server import compiler
 
@@ -87,7 +86,7 @@ class Compiler(compiler.BaseCompiler):
             schema=db.schema,
             json_parameters=True)
 
-        if ir.cardinality is not qltypes.Cardinality.ONE:
+        if ir.cardinality.is_multi():
             raise errors.ResultCardinalityMismatchError(
                 f'compiled GrqphQL query has cardinality {ir.cardinality}, '
                 f'expected ONE')

--- a/setup.py
+++ b/setup.py
@@ -289,6 +289,7 @@ class develop(setuptools_develop.develop):
         subprocess.run(
             [
                 'cargo', 'install',
+                '--verbose', '--verbose',
                 '--git', EDGEDBCLI_REPO,
                 '--bin', 'edgedb',
                 '--root', rust_root,

--- a/tests/schemas/cards_ir_inference.esdl
+++ b/tests/schemas/cards_ir_inference.esdl
@@ -1,0 +1,102 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+abstract type Named {
+    required property name -> str {
+        delegated constraint exclusive;
+    }
+}
+
+type User extending Named {
+    multi link deck -> Card {
+        property count -> int64;
+    }
+
+    property deck_cost := sum(.deck.cost);
+
+    multi link friends -> User {
+        property nickname -> str;
+        # how the friend responded to requests for a favor
+        #property favor -> array<bool>
+    }
+
+    multi link awards -> Award {
+        constraint exclusive;
+    }
+
+    link avatar -> Card {
+        property text -> str;
+    }
+}
+
+type Card extending Named {
+    required property element -> str;
+    required property cost -> int64;
+    link owners := __source__.<deck[IS User];
+    # computable property
+    property elemental_cost := <str>.cost ++ ' ' ++ .element;
+}
+
+type SpecialCard extending Card;
+
+type Award extending Named {
+    link rec := .<awards[IS User]
+}
+
+
+alias AwardAlias := Award {
+    recipient := .<awards[IS User]
+};
+
+
+alias WaterOrEarthCard := (
+    SELECT Card {
+        owned_by_alice := EXISTS (SELECT Card.<deck[IS User].name = 'Alice')
+    }
+    FILTER .element = 'Water' OR .element = 'Earth'
+);
+
+
+alias EarthOrFireCard {
+    using (SELECT Card FILTER .element = 'Fire' OR .element = 'Earth')
+};
+
+
+alias SpecialCardAlias := SpecialCard {
+    el_cost := (.element, .cost)
+};
+
+
+type Eert {
+    required property val -> str {
+        constraint exclusive;
+    }
+
+    link parent := .<children[IS Eert];
+    multi link children -> Eert {
+        constraint exclusive;
+    }
+}
+
+
+type Report extending Named {
+    required link user -> User {
+        property note -> str;
+    }
+}

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -20,6 +20,7 @@
 import os.path
 import textwrap
 
+from edb import errors
 from edb.testbase import lang as tb
 
 from edb.edgeql import compiler
@@ -31,15 +32,43 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
     """Unit tests for cardinality inference."""
 
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
-                          'cards.esdl')
+                          'cards_ir_inference.esdl')
 
     def run_test(self, *, source, spec, expected):
         qltree = qlparser.parse(source)
         ir = compiler.compile_ast_to_ir(qltree, self.schema)
-        expected_cardinality = qltypes.Cardinality(
-            textwrap.dedent(expected).strip(' \n'))
-        self.assertEqual(ir.cardinality, expected_cardinality,
-                         'unexpected cardinality:\n' + source)
+
+        # The expected cardinality is either given for the whole query
+        # (by default) or for a specific element of the top-level
+        # shape. In case of the specific element the name of the shape
+        # element must be given followed by ":" and then the
+        # cardinality.
+        exp = textwrap.dedent(expected).strip(' \n').split(':')
+
+        if len(exp) == 1:
+            field = None
+            expected_cardinality = qltypes.Cardinality(exp[0])
+        elif len(exp) == 2:
+            field = exp[0].strip()
+            expected_cardinality = qltypes.Cardinality(exp[1].strip())
+        else:
+            raise ValueError(
+                f'unrecognized expected specification: {expected!r}')
+
+        if field is not None:
+            shape = ir.expr.expr.result.shape
+            for el in shape:
+                if el.path_id.rptr_name().endswith(field):
+                    card = el.rptr.ptrref.out_cardinality
+                    self.assertEqual(card, expected_cardinality,
+                                     'unexpected cardinality:\n' + source)
+                    break
+            else:
+                raise AssertionError(f'shape field not found: {field!r}')
+
+        else:
+            self.assertEqual(ir.cardinality, expected_cardinality,
+                             'unexpected cardinality:\n' + source)
 
     def test_edgeql_ir_card_inference_00(self):
         """
@@ -54,7 +83,7 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         WITH MODULE test
         SELECT Card FILTER Card.name = 'Djinn'
 % OK %
-        ONE
+        AT_MOST_ONE
         """
 
     def test_edgeql_ir_card_inference_02(self):
@@ -62,7 +91,7 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         WITH MODULE test
         SELECT Card FILTER 'Djinn' = Card.name
 % OK %
-        ONE
+        AT_MOST_ONE
         """
 
     def test_edgeql_ir_card_inference_03(self):
@@ -70,7 +99,7 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         WITH MODULE test
         SELECT Card FILTER 'foo' = 'foo' AND 'Djinn' = Card.name
 % OK %
-        ONE
+        AT_MOST_ONE
         """
 
     def test_edgeql_ir_card_inference_04(self):
@@ -86,7 +115,7 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         WITH MODULE test
         SELECT Card FILTER Card.id = <uuid>'...'
 % OK %
-        ONE
+        AT_MOST_ONE
         """
 
     def test_edgeql_ir_card_inference_06(self):
@@ -94,7 +123,7 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         WITH MODULE test, C2 := Card
         SELECT Card FILTER Card = (SELECT C2 FILTER C2.name = 'Djinn')
 % OK %
-        ONE
+        AT_MOST_ONE
         """
 
     def test_edgeql_ir_card_inference_07(self):
@@ -102,7 +131,7 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         WITH MODULE test, C2 := DETACHED Card
         SELECT Card FILTER Card = (SELECT C2 FILTER C2.name = 'Djinn')
 % OK %
-        ONE
+        AT_MOST_ONE
         """
 
     def test_edgeql_ir_card_inference_08(self):
@@ -110,7 +139,7 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         WITH MODULE test
         SELECT Card LIMIT 1
 % OK %
-        ONE
+        AT_MOST_ONE
         """
 
     def test_edgeql_ir_card_inference_09(self):
@@ -119,4 +148,316 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         SELECT Card FILTER Card.<deck[IS User].name = 'Bob'
 % OK %
         MANY
+        """
+
+    def test_edgeql_ir_card_inference_10(self):
+        """
+        SELECT 1
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_11(self):
+        """
+        SELECT {1, 2, 3}
+% OK %
+        AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_12(self):
+        """
+        WITH MODULE test
+        SELECT {1, 2, 3, Card.cost}
+% OK %
+        AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_13(self):
+        """
+        SELECT array_agg({1, 2, 3})
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_14(self):
+        """
+        WITH MODULE test
+        SELECT array_agg(Card.cost)
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_15(self):
+        """
+        WITH MODULE test
+        SELECT to_str(Card.cost)
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_card_inference_16(self):
+        """
+        WITH MODULE test
+        SELECT to_str((SELECT Card.cost LIMIT 1))
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_17(self):
+        """
+        WITH MODULE test
+        SELECT to_str({1, (SELECT Card.cost LIMIT 1)})
+% OK %
+        AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_18(self):
+        """
+        SELECT to_str(1)
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_19(self):
+        """
+        SELECT 1 + 2
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_20(self):
+        """
+        SELECT 1 + (2 UNION 3)
+% OK %
+        AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_21(self):
+        """
+        WITH MODULE test
+        SELECT 1 + Card.cost
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_card_inference_22(self):
+        """
+        WITH MODULE test
+        SELECT (SELECT Card LIMIT 1).cost ?? 99
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_23(self):
+        """
+        WITH MODULE test
+        SELECT (SELECT Card LIMIT 1).element ?? (SELECT User LIMIT 1).name
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_24(self):
+        """
+        WITH MODULE test
+        SELECT (SELECT Card LIMIT 1).element ?= 'fire'
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_25(self):
+        """
+        WITH MODULE test
+        SELECT Named {
+            name
+        }
+% OK %
+        name: ONE
+        """
+
+    def test_edgeql_ir_card_inference_26(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            foo := .name
+        }
+% OK %
+        foo: ONE
+        """
+
+    def test_edgeql_ir_card_inference_27(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            foo := 'prefix_' ++ .name
+        }
+% OK %
+        foo: ONE
+        """
+
+    def test_edgeql_ir_card_inference_28(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            deck_cost
+        }
+% OK %
+        deck_cost: ONE
+        """
+
+    def test_edgeql_ir_card_inference_29(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            dc := sum(.deck.cost)
+        }
+% OK %
+        dc: ONE
+        """
+
+    def test_edgeql_ir_card_inference_30(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            deck
+        }
+% OK %
+        deck: MANY
+        """
+
+    def test_edgeql_ir_card_inference_31(self):
+        """
+        WITH MODULE test
+        SELECT Card {
+            owners
+        }
+% OK %
+        owners: MANY
+        """
+
+    def test_edgeql_ir_card_inference_32(self):
+        """
+        WITH
+            MODULE test,
+            A := (SELECT Award LIMIT 1)
+        # the "awards" are exclusive
+        SELECT A.<awards[IS User]
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_33(self):
+        """
+        WITH MODULE test
+        SELECT Award {
+            # the "awards" are exclusive
+            recipient := .<awards[IS User]
+        }
+% OK %
+        recipient: AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_34(self):
+        """
+        WITH MODULE test
+        SELECT Award {
+            rec
+        }
+% OK %
+        rec: AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_35(self):
+        """
+        WITH MODULE test
+        SELECT AwardAlias {
+            recipient
+        }
+% OK %
+        recipient: AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_36(self):
+        """
+        WITH MODULE test
+        SELECT Eert {
+            parent
+        }
+% OK %
+        parent: AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_37(self):
+        """
+        WITH MODULE test
+        SELECT Report {
+            user_name := .user.name
+        }
+% OK %
+        user_name: ONE
+        """
+
+    def test_edgeql_ir_card_inference_38(self):
+        """
+        WITH MODULE test
+        SELECT Report {
+            name := .user.name
+        }
+% OK %
+        name: ONE
+        """
+
+    @tb.must_fail(errors.QueryError,
+                  "possibly an empty set", line=4, col=13)
+    def test_edgeql_ir_card_inference_39(self):
+        """
+        WITH MODULE test
+        SELECT Report {
+            name := <str>{}
+        }
+        """
+
+    @tb.must_fail(errors.QueryError,
+                  "possibly more than one element", line=4, col=13)
+    def test_edgeql_ir_card_inference_40(self):
+        """
+        WITH MODULE test
+        SELECT Report {
+            single foo := User.name
+        }
+        """
+
+    def test_edgeql_ir_card_inference_41(self):
+        """
+        WITH MODULE test
+        SELECT User.deck@count
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_card_inference_42(self):
+        """
+        WITH MODULE test
+        SELECT Report.user@note
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_card_inference_43(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            foo := .deck@count
+        }
+% OK %
+        foo: MANY
+        """
+
+    def test_edgeql_ir_card_inference_44(self):
+        """
+        WITH MODULE test
+        SELECT Report {
+            foo := .user@note
+        }
+% OK %
+        foo: AT_MOST_ONE
         """

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1658,13 +1658,13 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             "possibly more than one element returned by an expression for a "
-            "computable link 'owner' declared as 'single'",
+            "computable link 'priority' declared as 'single'",
             _position=85,
         ):
             await self.con.execute("""
                 WITH MODULE test
                 SELECT Issue {
-                    owner := User
+                    priority := Priority
                 }
             """)
 
@@ -1693,6 +1693,20 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 WITH MODULE test
                 SELECT Issue {
                     single related_to := (SELECT Issue LIMIT 1)
+                }
+            """)
+
+    async def test_edgeql_select_tvariant_bad_08(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "possibly an empty set returned by an expression for a "
+            "computable link 'owner' declared as 'required'",
+            _position=85,
+        ):
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT Issue {
+                    owner := User
                 }
             """)
 
@@ -3419,19 +3433,18 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_empty_04(self):
         await self.assert_query_result(
             r"""
-            # Perfectly legal way to mask 'name' with empty set of
-            # some arbitrary type.
+            # Perfectly legal way to mask 'time_estimate' with empty set.
             WITH MODULE test
             SELECT Issue {
                 number,
-                name := <str>{}
+                time_estimate := <int64>{}
             } ORDER BY .number;
             """,
             [
-                {'number': '1', 'name': None},
-                {'number': '2', 'name': None},
-                {'number': '3', 'name': None},
-                {'number': '4', 'name': None},
+                {'number': '1', 'time_estimate': None},
+                {'number': '2', 'time_estimate': None},
+                {'number': '3', 'time_estimate': None},
+                {'number': '4', 'time_estimate': None},
             ],
         )
 
@@ -3444,7 +3457,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 SELECT Issue {
                     number,
                     # the empty set is of an unspecified type
-                    name := {}
+                    time_estimate := {}
                 } ORDER BY .number;
                 """)
 

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -1710,8 +1710,13 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                                 "description": None,
                                 "type": {
                                     "__typename": "__Type",
-                                    "name": "String",
-                                    "kind": "SCALAR"
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "String",
+                                        "kind": "SCALAR"
+                                    }
                                 },
                                 "isDeprecated": False,
                                 "deprecationReason": None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -206,7 +206,7 @@ _123456789_123456789_123456789 -> str
         obj = schema.get('test::Object')
         self.assertEqual(
             obj.getptr(schema, 'foo_plus_bar').get_cardinality(schema),
-            qltypes.Cardinality.ONE)
+            qltypes.SchemaCardinality.ONE)
 
     def test_schema_computable_cardinality_inference_02(self):
         schema = self.load_schema("""
@@ -220,7 +220,7 @@ _123456789_123456789_123456789 -> str
         obj = schema.get('test::Object')
         self.assertEqual(
             obj.getptr(schema, 'foo_plus_bar').get_cardinality(schema),
-            qltypes.Cardinality.MANY)
+            qltypes.SchemaCardinality.MANY)
 
     def test_schema_refs_01(self):
         schema = self.load_schema("""
@@ -4411,7 +4411,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 LIMIT
                     1
                 );
-                CREATE SINGLE PROPERTY compprop := ('foo');
+                CREATE REQUIRED SINGLE PROPERTY compprop := ('foo');
             };
             """
         )
@@ -4458,7 +4458,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 LIMIT
                     1
                 );
-                CREATE SINGLE PROPERTY compprop := ('foo');
+                CREATE REQUIRED SINGLE PROPERTY compprop := ('foo');
             };
             """
         )

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 42.63)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 43.53)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 87.44)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 89.78)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.43)


### PR DESCRIPTION
We can squash the two commits into one. I just wanted to keep purely renaming one separate to make it easier to see what's going on.

Regarding naming: 
- The `SchemaCardinality` is what gets written to or read from the schema. So the field name should match the schema field "cardinality".
- Ideally the inferred cardinality with upper and lower bounds should have a different field/attribute name to reduce confusion. I'm open to suggestions for alternatives to "full_cardinality".

Regarding `CardinalityBound`: the bounds are used in conversion from schema "requirement + cardinality" format to a single enum and a some calculations. This makes it hard to refactor the class into `cardinality.py` cleanly, since then the conversion is invoked in a few places outside it.