### PR TITLE
Upgrade to graphql-core 3.0.3

### DIFF
--- a/edb/graphql/_patch_core.py
+++ b/edb/graphql/_patch_core.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 def patch_graphql_core():
     import graphql
-    import graphql.utils.type_comparators as type_comparators
+    import graphql.utilities.type_comparators as type_comparators
 
     old_is_type_sub_type_of = type_comparators.is_type_sub_type_of
 

--- a/edb/graphql/codegen.py
+++ b/edb/graphql/codegen.py
@@ -50,13 +50,13 @@ class GraphQLSourceGenerator(codegen.SourceGenerator):
             self.write(' on ')
             self.visit(node.type_condition)
 
-    def visit_Name(self, node):
+    def visit_NameNode(self, node):
         self.write(node.value)
 
-    def visit_Document(self, node):
+    def visit_DocumentNode(self, node):
         self._visit_list(node.definitions)
 
-    def visit_OperationDefinition(self, node):
+    def visit_OperationDefinitionNode(self, node):
         if node.operation:
             self.write(node.operation)
             if node.name:
@@ -70,14 +70,14 @@ class GraphQLSourceGenerator(codegen.SourceGenerator):
 
         self.visit(node.selection_set)
 
-    def visit_FragmentDefinition(self, node):
+    def visit_FragmentDefinitionNode(self, node):
         self.write('fragment ')
         self.visit(node.name)
         self._visit_type_condition(node)
         self._visit_directives(node)
         self.visit(node.selection_set)
 
-    def visit_SelectionSet(self, node):
+    def visit_SelectionSetNode(self, node):
         self.write('{')
         self.new_lines = 1
         self.indentation += 1
@@ -86,7 +86,7 @@ class GraphQLSourceGenerator(codegen.SourceGenerator):
         self.write('}')
         self.new_lines = 2
 
-    def visit_Field(self, node):
+    def visit_FieldNode(self, node):
         if node.alias:
             self.visit(node.alias)
             self.write(': ')
@@ -98,28 +98,28 @@ class GraphQLSourceGenerator(codegen.SourceGenerator):
         else:
             self.new_lines = 1
 
-    def visit_FragmentSpread(self, node):
+    def visit_FragmentSpreadNode(self, node):
         self.write('...')
         self.visit(node.name)
         self._visit_directives(node)
         self.new_lines = 1
 
-    def visit_InlineFragment(self, node):
+    def visit_InlineFragmentNode(self, node):
         self.write('...')
         self._visit_type_condition(node)
         self._visit_directives(node)
         self.visit(node.selection_set)
 
-    def visit_Argument(self, node):
+    def visit_ArgumentNode(self, node):
         self.visit(node.name)
         self.write(': ')
         self.visit(node.value)
 
-    def visit_ObjectField(self, node):
+    def visit_ObjectFieldNode(self, node):
         self.visit_Argument(node)
         self.new_lines = 1
 
-    def visit_VariableDefinition(self, node):
+    def visit_VariableDefinitionNode(self, node):
         self.visit(node.variable)
         self.write(': ')
         self.visit(node.type)
@@ -127,7 +127,7 @@ class GraphQLSourceGenerator(codegen.SourceGenerator):
             self.write(' = ')
             self.visit(node.default_value)
 
-    def visit_Directive(self, node):
+    def visit_DirectiveNode(self, node):
         self.write('@')
         self.visit(node.name)
         self._visit_arguments(node)

--- a/edb/graphql/codegen.py
+++ b/edb/graphql/codegen.py
@@ -132,28 +132,28 @@ class GraphQLSourceGenerator(codegen.SourceGenerator):
         self.visit(node.name)
         self._visit_arguments(node)
 
-    def visit_StringValue(self, node):
+    def visit_StringValueNode(self, node):
         # the GQL string works same as JSON string
         self.write(json.dumps(node.value))
 
-    def visit_IntValue(self, node):
+    def visit_IntValueNode(self, node):
         self.write(node.value)
 
-    def visit_FloatValue(self, node):
+    def visit_FloatValueNode(self, node):
         self.write(node.value)
 
-    def visit_BooleanValue(self, node):
+    def visit_BooleanValueNode(self, node):
         if node.value:
             self.write('true')
         else:
             self.write('false')
 
-    def visit_ListValue(self, node):
+    def visit_ListValueNode(self, node):
         self.write('[')
         self._visit_list(node.values, separator=', ')
         self.write(']')
 
-    def visit_ObjectValue(self, node):
+    def visit_ObjectValueNode(self, node):
         if node.fields:
             self.write('{')
             self.new_lines = 1
@@ -164,25 +164,25 @@ class GraphQLSourceGenerator(codegen.SourceGenerator):
         else:
             self.write('{}')
 
-    def visit_EnumValue(self, node):
+    def visit_EnumValueNode(self, node):
         self.write(node.value)
 
-    def visit_NullValue(self, node):
+    def visit_NullValueNode(self, node):
         self.write('null')
 
-    def visit_Variable(self, node):
+    def visit_VariableNode(self, node):
         self.write('$')
         self.visit(node.name)
 
-    def visit_NamedType(self, node):
+    def visit_NamedTypeNode(self, node):
         self.visit(node.name)
 
-    def visit_ListType(self, node):
+    def visit_ListTypeNode(self, node):
         self.write('[')
         self.visit(node.type)
         self.write(']')
 
-    def visit_NonNullType(self, node):
+    def visit_NonNullTypeNode(self, node):
         self.visit(node.type)
         self.write('!')
 

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -242,7 +242,10 @@ class GQLCoreSchema:
     def get_gql_name(self, name):
         module, shortname = name.split('::', 1)
         if module in {'default', 'std'}:
-            return shortname.lstrip('_')  # TODO(tailhook) not sure
+            if shortname.startswith('__'):
+                return '_edb' + shortname
+            else:
+                return shortname
         else:
             assert module != '', f'get_gl_name {name=}'
             return f'{module}__{shortname}'

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -27,7 +27,7 @@ from graphql import (
     GraphQLInterfaceType,
     GraphQLInputObjectType,
     GraphQLField,
-    GraphQLInputObjectField,
+    GraphQLInputField as GraphQLInputObjectField,
     GraphQLArgument,
     GraphQLList,
     GraphQLNonNull,
@@ -78,7 +78,7 @@ def coerce_bigint(value):
 
 
 def parse_int_literal(ast):
-    if isinstance(ast, gql_ast.IntValue):
+    if isinstance(ast, gql_ast.IntValueNode):
         return int(ast.value)
     return None
 
@@ -105,7 +105,7 @@ GraphQLBigint = GraphQLScalarType(
 
 
 def parse_decimal_literal(ast):
-    if isinstance(ast, (gql_ast.FloatValue, gql_ast.IntValue)):
+    if isinstance(ast, (gql_ast.FloatValueNode, gql_ast.IntValueNode)):
         return float(ast.value)
     return None
 
@@ -242,13 +242,15 @@ class GQLCoreSchema:
     def get_gql_name(self, name):
         module, shortname = name.split('::', 1)
         if module in {'default', 'std'}:
-            return shortname
+            return shortname.lstrip('_')  # TODO(tailhook) not sure
         else:
+            assert module != '', f'get_gl_name {name=}'
             return f'{module}__{shortname}'
 
     def get_input_name(self, inputtype, name):
         if '__' in name:
             module, shortname = name.split('__', 1)
+            assert module != '', f'get_input_name {name=}'
             return f'{module}__{inputtype}{shortname}'
         else:
             return f'{inputtype}{name}'
@@ -1109,6 +1111,7 @@ class GQLBaseType(metaclass=GQLTypeMeta):
         if module in {'default', 'std'}:
             return f'{shortname}_Type'
         else:
+            assert module != '', 'gql_typename ' + module
             return f'{module}__{shortname}_Type'
 
     @property

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -203,7 +203,8 @@ class GraphQLTestCase(BaseHttpTest, server.QueryTestCase):
             ex_type = getattr(edgedb, typename)
         except AttributeError:
             raise AssertionError(
-                f'server returned an invalid exception typename: {typename!r}')
+                f'server returned an invalid exception typename: {typename!r}'
+                f'\n  Message: {msg}')
 
         ex = ex_type(msg)
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ RUNTIME_DEPS = [
     'typing_inspect~=0.5.0',
     'uvloop~=0.14.0',
 
-    'graphql-core~=2.2.1',
+    'graphql-core~=3.0.3',
     'promise~=2.2.0',
 
     'edgedb>=0.8.0a1',

--- a/tests/test_http_graphql_mutation.py
+++ b/tests/test_http_graphql_mutation.py
@@ -1222,7 +1222,7 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
     def test_graphql_mutation_insert_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Cannot query field "insert_SettingAlias"'):
+                r"Cannot query field 'insert_SettingAlias'"):
             self.graphql_query(r"""
                 mutation insert_SettingAlias {
                     insert_SettingAlias(
@@ -1239,9 +1239,9 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
 
     def test_graphql_mutation_insert_bad_02(self):
         with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r'Argument "data" has invalid value(.|\n)*'
-                r'In field "favorites": .*In field "data": Unknown field'):
+            edgedb.QueryError,
+            r"Field 'data' is not defined by type NestedInsertNamedObject"
+        ):
             self.graphql_query(r"""
                 mutation insert_User {
                     insert_User(
@@ -2375,7 +2375,7 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
     def test_graphql_mutation_update_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Cannot query field "update_SettingAlias"'):
+                r"Cannot query field 'update_SettingAlias'"):
             self.graphql_query(r"""
                 mutation update_SettingAlias {
                     update_SettingAlias(

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -239,7 +239,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_query_05(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Cannot query field "Bogus" on type "Query"',
+                r"Cannot query field 'Bogus' on type 'Query'",
                 _line=3, _col=21):
             self.graphql_query(r"""
                 query {
@@ -256,7 +256,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_query_06(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Cannot query field "bogus" on type "User"',
+                r"Cannot query field 'bogus' on type 'User'",
                 _line=5, _col=25):
             self.graphql_query(r"""
                 query {
@@ -274,7 +274,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_query_07(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Cannot query field "age" on type "NamedObject"',
+                r"Cannot query field 'age' on type 'NamedObject'",
                 _line=5, _col=25):
             self.graphql_query(r"""
                 query {
@@ -423,7 +423,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         # Test special case errors.
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r"Cannot query field \"gibberish\" on type \"Query\"\. "
+                r"Cannot query field 'gibberish' on type 'Query'\. "
                 r"There's no corresponding type or alias \"gibberish\" "
                 r"exposed in EdgeDB\. Please check the configuration settings "
                 r"for this port to make sure that you're connecting to the "
@@ -439,7 +439,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         # Test special case errors.
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r"Cannot query field \"more__gibberish\" on type \"Query\"\. "
+                r"Cannot query field 'more__gibberish' on type 'Query'\. "
                 r"There's no corresponding type or alias \"more::gibberish\" "
                 r"exposed in EdgeDB\. Please check the configuration settings "
                 r"for this port to make sure that you're connecting to the "
@@ -455,8 +455,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         # Test special case errors.
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r"Cannot query field \"Uxer\" on type \"Query\"\. "
-                r"Did you mean \"User\"\?",
+                r"Cannot query field 'Uxer' on type 'Query'\. "
+                r"Did you mean 'User'\?",
                 _line=3, _col=21):
             self.graphql_query(r"""
                 query {
@@ -1138,8 +1138,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_arguments_18(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type "String", found 42',
-                _line=3, _col=34):
+                r'Expected type String, found 42',
+                _line=3, _col=46):
             self.graphql_query(r"""
                 query {
                     User(filter: {name: {eq: 42}}) {
@@ -1151,8 +1151,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_arguments_19(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type "String", found 20\.5',
-                _line=3, _col=34):
+                r'Expected type String, found 20\.5',
+                _line=3, _col=46):
             self.graphql_query(r"""
                 query {
                     User(filter: {name: {eq: 20.5}}) {
@@ -1164,8 +1164,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_arguments_20(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type "Float", found "3\.5"',
-                _line=3, _col=34):
+                r'Expected type Float, found "3\.5"',
+                _line=3, _col=47):
             self.graphql_query(r"""
                 query {
                     User(filter: {score: {eq: "3.5"}}) {
@@ -1177,8 +1177,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_arguments_21(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type "Boolean", found 0',
-                _line=3, _col=34):
+                r'Expected type Boolean, found 0\.',
+                _line=3, _col=48):
             self.graphql_query(r"""
                 query {
                     User(filter: {active: {eq: 0}}) {
@@ -1462,8 +1462,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_fragment_type_04(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'userFrag cannot be spread.*?'
-                r'UserGroup can never be of type User',
+                r"Fragment 'userFrag' cannot be spread here "
+                r"as objects of type 'UserGroup' can never be of type 'User'.",
                 _line=9, _col=25):
             self.graphql_query(r"""
                 fragment userFrag on User {
@@ -1481,8 +1481,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_fragment_type_05(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'userFrag cannot be spread.*?'
-                r'UserGroup can never be of type User',
+                r"Fragment 'userFrag' cannot be spread here "
+                r"as objects of type 'UserGroup' can never be of type 'User'.",
                 _line=8, _col=21):
             self.graphql_query(r"""
                 fragment userFrag on User {
@@ -1560,7 +1560,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_fragment_type_08(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                'Cannot query field "age" on type "NamedObject"',
+                "Cannot query field 'age' on type 'NamedObject'",
                 _line=5, _col=21):
             self.graphql_query(r"""
                 fragment frag on NamedObject {
@@ -1579,7 +1579,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_fragment_type_09(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                'Cannot query field "age" on type "NamedObject"',
+                "Cannot query field 'age' on type 'NamedObject'",
                 _line=7, _col=29):
             self.graphql_query(r"""
                 query {
@@ -1827,7 +1827,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_directives_07(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                'invalid value "true"',
+                'Expected type Boolean!, found "true".',
                 _line=4, _col=43):
             self.graphql_query(r"""
                 query {
@@ -1971,7 +1971,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_scalars_03(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Cannot query field "p_bytes" on type "ScalarTest"',
+                r"Cannot query field 'p_bytes' on type 'ScalarTest'",
                 _line=4, _col=25):
             self.graphql_query(r"""
                 query {
@@ -1984,7 +1984,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_scalars_04(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Cannot query field "p_array_json" on type "ScalarTest"',
+                r"Cannot query field 'p_array_json' on type 'ScalarTest'",
                 _line=4, _col=25):
             self.graphql_query(r"""
                 query {
@@ -1997,7 +1997,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_scalars_05(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Cannot query field "p_array_bytes" on type "ScalarTest"',
+                r"Cannot query field 'p_array_bytes' on type 'ScalarTest'",
                 _line=4, _col=25):
             self.graphql_query(r"""
                 query {
@@ -2139,7 +2139,6 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             ]
         })
 
-    @test.xfail('graphql parser has an issue here')
     def test_graphql_functional_duplicates_06(self):
         self.assert_graphql_query_result(r"""
             query {
@@ -2258,6 +2257,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             }
         )
 
+    @test.xfail('seems graphql-core 3.x disabled Int to Float casting')
     def test_graphql_functional_variables_03(self):
         self.assert_graphql_query_result(r"""
             query($val: Int = 3) {
@@ -2289,19 +2289,21 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         })
 
     def test_graphql_functional_variables_05(self):
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r'val. of type "Boolean!" is required and '
-                r'will not use the default value',
-                _line=2, _col=40):
-            self.graphql_query(r"""
-                query($val: Boolean! = true) {
-                    User {
-                        name @include(if: $val),
-                        id
-                    }
+        self.assert_graphql_query_result(r"""
+            query($val: Boolean! = true) {
+                User(order: {name: {dir: ASC}}) {
+                    name @include(if: $val),
+                    id
                 }
-            """)
+            }
+        """, {
+            "User": [
+                {"name": "Alice"},
+                {"name": "Bob"},
+                {"name": "Jane"},
+                {"name": "John"},
+            ]
+        })
 
     def test_graphql_functional_variables_06(self):
         with self.assertRaisesRegex(
@@ -2352,6 +2354,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             "User": []
         })
 
+    @test.xfail('seems graphql-core 3.x disabled Int to Float casting')
     def test_graphql_functional_variables_10(self):
         self.assert_graphql_query_result(r"""
             query($val: Int = 3) {
@@ -2377,8 +2380,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_12(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "Boolean" '
-                r'has invalid default value: 1',
+                r'Expected type Boolean, found 1\.',
                 _line=2, _col=39):
             self.graphql_query(r"""
                 query($val: Boolean = 1) {
@@ -2392,8 +2394,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_13(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "Boolean" '
-                r'has invalid default value: "1"',
+                r'Expected type Boolean, found "1"\.',
                 _line=2, _col=39):
             self.graphql_query(r"""
                 query($val: Boolean = "1") {
@@ -2407,8 +2408,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_14(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "Boolean" '
-                r'has invalid default value: 1\.3',
+                r'Expected type Boolean, found 1\.3\.',
                 _line=2, _col=39):
             self.graphql_query(r"""
                 query($val: Boolean = 1.3) {
@@ -2422,8 +2422,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_15(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "String" '
-                r'has invalid default value: 1',
+                r'Expected type String, found 1\.',
                 _line=2, _col=38):
             self.graphql_query(r"""
                 query($val: String = 1) {
@@ -2436,8 +2435,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_16(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "String" '
-                r'has invalid default value: 1\.1',
+                r'Expected type String, found 1\.1\.',
                 _line=2, _col=38):
             self.graphql_query(r"""
                 query($val: String = 1.1) {
@@ -2450,8 +2448,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_17(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "String" '
-                r'has invalid default value: true',
+                r'Expected type String, found true\.',
                 _line=2, _col=38):
             self.graphql_query(r"""
                 query($val: String = true) {
@@ -2464,8 +2461,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_18(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "Int" '
-                r'has invalid default value: 1\.1',
+                r'Expected type Int, found 1\.1\.',
                 _line=2, _col=35):
             self.graphql_query(r"""
                 query($val: Int = 1.1) {
@@ -2478,8 +2474,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_19(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "Int" '
-                r'has invalid default value: "1"',
+                r'Expected type Int, found "1".',
                 _line=2, _col=35):
             self.graphql_query(r"""
                 query($val: Int = "1") {
@@ -2492,8 +2487,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_20(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "Int" '
-                r'has invalid default value: true',
+                r'Expected type Int, found true.',
                 _line=2, _col=35):
             self.graphql_query(r"""
                 query($val: Int = true) {
@@ -2506,8 +2500,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_21(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "Float" '
-                r'has invalid default value: "1"',
+                r'Expected type Float, found "1".',
                 _line=2, _col=37):
             self.graphql_query(r"""
                 query($val: Float = "1") {
@@ -2520,8 +2513,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_22(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "Float" '
-                r'has invalid default value: true',
+                r'Expected type Float, found true.',
                 _line=2, _col=37):
             self.graphql_query(r"""
                 query($val: Float = true) {
@@ -2545,8 +2537,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_25(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "ID" '
-                r'has invalid default value: 1\.1',
+                r'Expected type ID, found 1\.1\.',
                 _line=2, _col=34):
             self.graphql_query(r"""
                 query($val: ID = 1.1) {
@@ -2559,8 +2550,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_26(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "ID" '
-                r'has invalid default value: true',
+                r'Expected type ID, found true\.',
                 _line=2, _col=34):
             self.graphql_query(r"""
                 query($val: ID = true) {
@@ -2573,8 +2563,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_27(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "\[String\]" '
-                r'used in position expecting type "String"'):
+                r"Variable '\$val' of type '\[String\]' used in position "
+                r"expecting type 'String'\."):
             self.graphql_query(r"""
                 query($val: [String] = "Foo") {
                     User(filter: {name: {eq: $val}}) {
@@ -2586,8 +2576,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_28(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "\[String\]" '
-                r'used in position expecting type "String"'):
+                r"Variable '\$val' of type '\[String\]' used in position "
+                r"expecting type 'String'\."):
             self.graphql_query(r"""
                 query($val: [String]) {
                     User(filter: {name: {eq: $val}}) {
@@ -2599,8 +2589,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_29(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "\[String\]!" '
-                r'used in position expecting type "String"'):
+                r"Variable '\$val' of type '\[String\]!' used in position "
+                r"expecting type 'String'."):
             self.graphql_query(r"""
                 query($val: [String]!) {
                     User(filter: {name: {eq: $val}}) {
@@ -2624,9 +2614,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_31(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "\[String\]" '
-                r'has invalid default value: \["Foo", 123\]',
-                _line=2, _col=40):
+                r"Expected type String, found 123\.",
+                _line=2, _col=48):
             self.graphql_query(r"""
                 query($val: [String] = ["Foo", 123]) {
                     User(filter: {name: {eq: $val}}) {
@@ -2638,8 +2627,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_32(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'val. of type "\[String\]" '
-                r'used in position expecting type "String"'):
+                r"Variable '\$val' of type '\[String\]' used in position "
+                r"expecting type 'String'\."):
             self.graphql_query(r"""
                 query($val: [String]) {
                     User(filter: {name: {eq: $val}}) {
@@ -2768,8 +2757,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_38(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Variable "limit" of type "String!" used in '
-                r'position expecting type "Int"'):
+                r"Variable '\$limit' of type 'String!' used in position "
+                r"expecting type 'Int'."):
             self.graphql_query(
                 r"""
                     query($limit: String!) {
@@ -2808,8 +2797,8 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_enum_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type "String", found admin',
-                _line=4, _col=39):
+                r'Expected type String, found admin\.',
+                _line=4, _col=51):
             self.graphql_query(r"""
                 query {
                     # enum supplied instead of a string

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -78,10 +78,10 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
 
                                     "Explains why this element was "
                                     "deprecated, usually also including "
-                                    "a suggestion for how toaccess "
-                                    "supported similar data. Formatted "
-                                    "in [Markdown](https://daringfireba"
-                                    "ll.net/projects/markdown/).",
+                                    "a suggestion for how to access "
+                                    "supported similar data. Formatted using "
+                                    "the Markdown syntax, as specified by "
+                                    "[CommonMark](https://commonmark.org/).",
 
                                 "type": {
                                     "kind": "SCALAR",
@@ -225,7 +225,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
     def test_graphql_schema_base_05(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Unknown argument "name" on field "__schema" of type "Query"',
+                r"Unknown argument 'name' on field '__schema' of type 'Query'",
                 _line=3, _col=30):
             self.graphql_query(r"""
                 query {
@@ -1210,7 +1210,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                                 "type": {
                                     "__typename": "__Type",
                                     "name":
-                                        "__SettingAliasAugmented__of_group",
+                                        "SettingAliasAugmented__of_group",
                                     "kind": "INTERFACE",
                                     "ofType": None
                                 },
@@ -1254,6 +1254,103 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                             {
                                 "__typename": "__Type",
                                 "name": "SettingAliasAugmented",
+                                "kind": "INTERFACE"
+                            },
+                        ],
+                        "possibleTypes": None,
+                        "enumValues": None,
+                        "inputFields": None,
+                        "ofType": None
+                    },
+                    {
+                        "__typename": "__Type",
+                        "kind": "OBJECT",
+                        "name": "SettingAliasAugmented__of_group_Type",
+                        "description": None,
+                        "fields": [
+                            {
+                                "__typename": "__Field",
+                                "name": "id",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "ID",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "name",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "String",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "name_upper",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": "String",
+                                    "kind": "SCALAR"
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "settings",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "LIST",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": None,
+                                        "kind": "NON_NULL"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            }
+                        ],
+                        "interfaces": [
+                            {
+                                "__typename": "__Type",
+                                "name": "NamedObject",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "Object",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "SettingAliasAugmented__of_group",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "UserGroup",
                                 "kind": "INTERFACE"
                             },
                         ],
@@ -1656,103 +1753,6 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                             {
                                 "__typename": "__Type",
                                 "name": "User",
-                                "kind": "INTERFACE"
-                            },
-                        ],
-                        "possibleTypes": None,
-                        "enumValues": None,
-                        "inputFields": None,
-                        "ofType": None
-                    },
-                    {
-                        "__typename": "__Type",
-                        "kind": "OBJECT",
-                        "name": "__SettingAliasAugmented__of_group_Type",
-                        "description": None,
-                        "fields": [
-                            {
-                                "__typename": "__Field",
-                                "name": "id",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "NON_NULL",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": "ID",
-                                        "kind": "SCALAR"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "name",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "NON_NULL",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": "String",
-                                        "kind": "SCALAR"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "name_upper",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": "String",
-                                    "kind": "SCALAR"
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "settings",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "LIST",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": None,
-                                        "kind": "NON_NULL"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            }
-                        ],
-                        "interfaces": [
-                            {
-                                "__typename": "__Type",
-                                "name": "NamedObject",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "Object",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "UserGroup",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "__SettingAliasAugmented__of_group",
                                 "kind": "INTERFACE"
                             },
                         ],
@@ -2222,7 +2222,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     },
                     {
                         "name": "nulls",
-                        "defaultValue": '"SMALLEST"',
+                        "defaultValue": 'SMALLEST',  # TODO(tailhook) not sure
                         "type": {
                             "name": "nullsOrderingEnum",
                             "kind": "ENUM",

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -1209,8 +1209,8 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                                 "description": None,
                                 "type": {
                                     "__typename": "__Type",
-                                    "name":
-                                        "SettingAliasAugmented__of_group",
+                                    "name": "_edb__"
+                                            "SettingAliasAugmented__of_group",
                                     "kind": "INTERFACE",
                                     "ofType": None
                                 },
@@ -1254,103 +1254,6 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                             {
                                 "__typename": "__Type",
                                 "name": "SettingAliasAugmented",
-                                "kind": "INTERFACE"
-                            },
-                        ],
-                        "possibleTypes": None,
-                        "enumValues": None,
-                        "inputFields": None,
-                        "ofType": None
-                    },
-                    {
-                        "__typename": "__Type",
-                        "kind": "OBJECT",
-                        "name": "SettingAliasAugmented__of_group_Type",
-                        "description": None,
-                        "fields": [
-                            {
-                                "__typename": "__Field",
-                                "name": "id",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "NON_NULL",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": "ID",
-                                        "kind": "SCALAR"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "name",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "NON_NULL",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": "String",
-                                        "kind": "SCALAR"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "name_upper",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": "String",
-                                    "kind": "SCALAR"
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "settings",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "LIST",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": None,
-                                        "kind": "NON_NULL"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            }
-                        ],
-                        "interfaces": [
-                            {
-                                "__typename": "__Type",
-                                "name": "NamedObject",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "Object",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "SettingAliasAugmented__of_group",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "UserGroup",
                                 "kind": "INTERFACE"
                             },
                         ],
@@ -1753,6 +1656,104 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                             {
                                 "__typename": "__Type",
                                 "name": "User",
+                                "kind": "INTERFACE"
+                            },
+                        ],
+                        "possibleTypes": None,
+                        "enumValues": None,
+                        "inputFields": None,
+                        "ofType": None
+                    },
+                    {
+                        "__typename": "__Type",
+                        "kind": "OBJECT",
+                        "name": "_edb__SettingAliasAugmented__of_group_Type",
+                        "description": None,
+                        "fields": [
+                            {
+                                "__typename": "__Field",
+                                "name": "id",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "ID",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "name",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": "String",
+                                        "kind": "SCALAR"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "name_upper",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": "String",
+                                    "kind": "SCALAR"
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            },
+                            {
+                                "__typename": "__Field",
+                                "name": "settings",
+                                "description": None,
+                                "type": {
+                                    "__typename": "__Type",
+                                    "name": None,
+                                    "kind": "LIST",
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "name": None,
+                                        "kind": "NON_NULL"
+                                    }
+                                },
+                                "isDeprecated": False,
+                                "deprecationReason": None
+                            }
+                        ],
+                        "interfaces": [
+                            {
+                                "__typename": "__Type",
+                                "name": "NamedObject",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "Object",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "UserGroup",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
+                                "name": "_edb__"
+                                        "SettingAliasAugmented__of_group",
                                 "kind": "INTERFACE"
                             },
                         ],


### PR DESCRIPTION
Things to note:

1. I strip `__` in front of some names, because new graphql-core doesn't allow them:
    ```
    Name '__SettingAliasAugmented__of_group_Type' must not begin with '__', which is reserved by GraphQL introspection.
    ```
    There should be a better way instead of stripping, but I failed to find one. Need some help. @vpetrovykh ? (FWIW, I don't want to hack graphql-core to allow such names if possible)
2. xfail tests: literal integers are now rejected when float is expected. Looks like it's a feature of the graphql but is not spec-compliant. I'll look into fixing it.
3. I have to double-check that all used class names are referred by their new names (in case some branch is not covered by tests).

But overall the PR is close to be ready for merging. The upside is that one expected failure is now fixed.