### PR TITLE
Strict typing mode for edb.schema.{objects, types}

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -52,6 +52,9 @@ from . import setgen
 from . import stmtctx
 from . import typegen
 
+if TYPE_CHECKING:
+    import uuid
+
 
 @dispatch.compile.register(qlast.FunctionCall)
 def compile_FunctionCall(
@@ -475,6 +478,7 @@ def compile_operator(
         sql_operator = tuple(from_op)
 
     origin_name: Optional[sn.SchemaName]
+    origin_module_id: Optional[uuid.UUID]
     if derivative_op is not None:
         origin_name = oper_name
         origin_module_id = env.schema.get_global(

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -263,6 +263,9 @@ def derive_ptr(
                 # This is a view of a view.  Make sure query-level
                 # computable expressions for pointers are carried over.
                 src_ptr = scls_pointers.get(ctx.env.schema, pn)
+                # mypy somehow loses the type argument in the
+                # "pointers" ObjectIndex.
+                assert isinstance(src_ptr, s_pointers.Pointer)
                 computable_data = ctx.source_map.get(src_ptr)
                 if computable_data is not None:
                     ctx.source_map[ptr] = computable_data

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -958,7 +958,7 @@ class IntrospectionMech:
                 expr_type=s_types.ExprType(r['expr_type']),
                 alias_is_persistent=r['alias_is_persistent'],
                 named=r['named'],
-                element_types=s_obj.ObjectDict.create(
+                element_types=s_obj.ObjectDict[s_types.Type].create(
                     schema, dict(eltypes.iter_subtypes(schema))),
             )
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3120,22 +3120,23 @@ async def generate_views(conn, schema):
             if ptr.is_pure_computable(schema):
                 continue
 
-            field = mcls.get_field(pn)
-            if field is not None and (field.ephemeral or
-                                      not field.introspectable):
+            if mcls.has_field(pn):
+                field = mcls.get_field(pn)
+                if field.ephemeral or not field.introspectable:
+                    field = None
+            else:
                 field = None
 
             refdict = None
             if field is None:
                 fn = classref_attr_aliases.get(pn, pn)
-                refdict = mcls.get_refdict(fn)
-                if refdict is not None and ptr.singular(schema):
-                    # This is nether a field, nor a refdict, that's
-                    # not expected.
-                    raise RuntimeError(
-                        'introspection schema error: {!r} must not be '
-                        'singular'.format(
-                            '(' + schema_cls.name + ')' + '.' + pn))
+                if mcls.has_refdict(fn):
+                    refdict = mcls.get_refdict(fn)
+                    if ptr.singular(schema):
+                        raise RuntimeError(
+                            'introspection schema error: {!r} must not be '
+                            'singular'.format(
+                                '(' + schema_cls.name + ')' + '.' + pn))
 
             if field is None and refdict is None:
                 if pn == 'id':

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -28,7 +28,6 @@ from . import delta as sd
 from . import name as sn
 from . import referencing
 from . import objects as so
-from . import utils
 
 if TYPE_CHECKING:
     from . import schema as s_schema
@@ -232,20 +231,9 @@ class CreateAnnotationValue(
 
         attr: Annotation = schema.get(propname)
 
-        cmd.set_attribute_value(
-            'annotation',
-            utils.reduce_to_typeref(schema, attr),
-        )
-
-        cmd.set_attribute_value(
-            'value',
-            value,
-        )
-
-        cmd.set_attribute_value(
-            'is_final',
-            not attr.get_inheritable(schema),
-        )
+        cmd.set_attribute_value('annotation', attr)
+        cmd.set_attribute_value('value', value)
+        cmd.set_attribute_value('is_final', not attr.get_inheritable(schema))
 
         assert isinstance(cmd, CreateAnnotationValue)
         return cmd

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -239,19 +239,18 @@ class CastCommand(sd.QualifiedObjectCommand[Cast],
         assert isinstance(astnode, qlast.CastCommand)
         modaliases = context.modaliases
 
-        from_type = utils.resolve_typeref(
-            utils.ast_to_typeref(astnode.from_type, modaliases=modaliases,
-                                 schema=schema),
-            schema=schema
+        from_type = utils.ast_to_type(
+            astnode.from_type,
+            modaliases=modaliases,
+            schema=schema,
         )
 
-        to_type = utils.resolve_typeref(
-            utils.ast_to_typeref(astnode.to_type, modaliases=modaliases,
-                                 schema=schema),
-            schema=schema
+        to_type = utils.ast_to_type(
+            astnode.to_type,
+            modaliases=modaliases,
+            schema=schema,
         )
-        assert isinstance(from_type, s_types.Type)
-        assert isinstance(to_type, s_types.Type)
+
         return get_cast_fullname(schema, 'std', from_type, to_type)
 
 
@@ -290,7 +289,7 @@ class CreateCast(CastCommand, sd.CreateObject[Cast]):
 
         cmd.set_attribute_value(
             'from_type',
-            utils.ast_to_typeref(
+            utils.ast_to_type(
                 astnode.from_type,
                 modaliases=modaliases,
                 schema=schema,
@@ -299,7 +298,7 @@ class CreateCast(CastCommand, sd.CreateObject[Cast]):
 
         cmd.set_attribute_value(
             'to_type',
-            utils.ast_to_typeref(
+            utils.ast_to_type(
                 astnode.to_type,
                 modaliases=modaliases,
                 schema=schema,

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -749,7 +749,7 @@ class CreateConstraint(
         if cmd.get_attribute_value('return_type') is None:
             cmd.set_attribute_value(
                 'return_type',
-                utils.reduce_to_typeref(schema, schema.get('std::bool')),
+                schema.get('std::bool'),
             )
 
         if cmd.get_attribute_value('return_typemod') is None:

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -320,7 +320,7 @@ class Constraint(referencing.ReferencedInheritingObject,
         old: Optional[so.Object],
         new: so.Object,
         *,
-        context: so.ComparisonContext = None,
+        context: so.ComparisonContext,
         old_schema: Optional[s_schema.Schema],
         new_schema: s_schema.Schema,
     ) -> None:

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -316,7 +316,7 @@ class Constraint(referencing.ReferencedInheritingObject,
     @classmethod
     def delta_properties(
         cls,
-        delta: sd.ObjectCommand[Constraint],
+        delta: sd.ObjectCommand[so.Object],
         old: Optional[so.Object],
         new: so.Object,
         *,
@@ -368,7 +368,7 @@ class ConsistencySubject(
         ref_cls=Constraint)
 
     constraints = so.SchemaField(
-        so.ObjectIndexByFullname,
+        so.ObjectIndexByFullname[Constraint],
         inheritable=False, ephemeral=True, coerce=True, compcoef=0.887,
         default=so.DEFAULT_CONSTRUCTOR
     )
@@ -395,7 +395,9 @@ class ConsistencySubjectCommandContext:
     pass
 
 
-class ConsistencySubjectCommand(inheriting.InheritingObjectCommand):
+class ConsistencySubjectCommand(
+    inheriting.InheritingObjectCommand[so.InheritingObjectT],
+):
     pass
 
 
@@ -549,8 +551,8 @@ class ConstraintCommand(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
-        refcls: so.InheritingObject,
-        implicit_bases: List[so.InheritingObject]
+        refcls: Constraint,
+        implicit_bases: List[Constraint],
     ) -> sd.Command:
         mcls = type(self.scls)
         ref_rebase_cmd = sd.ObjectCommandMeta.get_command_class_or_die(
@@ -849,13 +851,12 @@ class CreateConstraint(
         schema: s_schema.Schema,
         astnode: qlast.ObjectDDL,
         context: sd.CommandContext,
-    ) -> so.ObjectList[so.InheritingObject]:
+    ) -> so.ObjectList[Constraint]:
         if isinstance(astnode, qlast.CreateConcreteConstraint):
             classname = cls._classname_from_ast(schema, astnode, context)
             base_name = sn.shortname_from_fullname(classname)
-            base: so.Object = schema.get(base_name)
-            return so.ObjectList.create(
-                schema, [utils.reduce_to_typeref(schema, base)])
+            base = schema.get(base_name, type=Constraint)
+            return so.ObjectList.create(schema, [base])
         else:
             return super()._classbases_from_ast(schema, astnode, context)
 
@@ -919,6 +920,8 @@ class DeleteConstraint(
     referenced_astnode = qlast.DropConcreteConstraint
 
 
-class RebaseConstraint(ConstraintCommand,
-                       inheriting.RebaseInheritingObject):
+class RebaseConstraint(
+    ConstraintCommand,
+    inheriting.RebaseInheritingObject[Constraint],
+):
     pass

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1148,7 +1148,7 @@ class ObjectCommand(
         *,
         name: Optional[str] = None,
         default: None = None,
-    ) -> Optional[so.Object]:
+    ) -> Optional[so.Object_T]:
         ...
 
     def get_object(  # NoQA: F811
@@ -1158,7 +1158,7 @@ class ObjectCommand(
         *,
         name: Optional[str] = None,
         default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
-    ) -> Optional[so.Object]:
+    ) -> Optional[so.Object_T]:
         metaclass = self.get_schema_metaclass()
         if name is None:
             name = self.classname
@@ -1963,8 +1963,7 @@ class AlterSpecialObjectProperty(Command):
         new_value: Any = astnode.value
 
         if field.type is s_expr.Expression:
-            orig_expr_field = parent_cls.get_field(f'orig_{field.name}')
-            if orig_expr_field:
+            if parent_cls.has_field(f'orig_{field.name}'):
                 orig_text = cls.get_orig_expr_text(
                     schema, parent_op.qlast, field.name)
             else:
@@ -2058,8 +2057,7 @@ class AlterObjectProperty(Command):
         new_value: Any
 
         if field.type is s_expr.Expression:
-            orig_expr_field = parent_cls.get_field(f'orig_{field.name}')
-            if orig_expr_field:
+            if parent_cls.has_field(f'orig_{field.name}'):
                 orig_text = cls.get_orig_expr_text(
                     schema, parent_op.qlast, field.name)
             else:
@@ -2207,7 +2205,7 @@ class AlterObjectProperty(Command):
             astcls = qlast.SetField
 
         parent_cls = parent_op.get_schema_metaclass()
-        has_shadow = parent_cls.get_field(f'orig_{field.name}') is not None
+        has_shadow = parent_cls.has_field(f'orig_{field.name}')
 
         if context.descriptive_mode:
             # When generating AST for DESCRIBE AS TEXT, we want

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1703,7 +1703,7 @@ class AlterObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
             for astcmd in astnode.commands:
                 if isinstance(astcmd, qlast.AlterDropInherit):
                     dropped_bases.extend(
-                        utils.ast_to_typeref(
+                        utils.ast_to_object(
                             b,
                             metaclass=cls.get_schema_metaclass(),
                             modaliases=context.modaliases,
@@ -1714,7 +1714,7 @@ class AlterObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
 
                 elif isinstance(astcmd, qlast.AlterAddInherit):
                     bases = [
-                        utils.ast_to_typeref(
+                        utils.ast_to_object(
                             b,
                             metaclass=cls.get_schema_metaclass(),
                             modaliases=context.modaliases,

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -137,10 +137,11 @@ class ParameterDesc(ParameterLike):
             paramd = expr.Expression.compiled(
                 defexpr, schema, modaliases=modaliases, as_fragment=True)
 
-        paramt = utils.resolve_typeref(
-            utils.ast_to_typeref(
-                astnode.type, modaliases=modaliases, schema=schema),
-            schema)
+        paramt = utils.ast_to_type(
+            astnode.type,
+            modaliases=modaliases,
+            schema=schema,
+        )
 
         if astnode.kind is ft.ParameterKind.VARIADIC:
             paramt = s_types.Array.from_subtypes(schema, (paramt,))
@@ -205,13 +206,8 @@ class ParameterDesc(ParameterLike):
         )
 
         cmd = CreateParameter(classname=param_name)
-
         cmd.set_attribute_value('name', param_name)
-
-        cmd.set_attribute_value(
-            'type',
-            utils.reduce_to_typeref(schema, self.type),
-        )
+        cmd.set_attribute_value('type', self.type)
 
         if self.type.is_collection() and not self.type.is_polymorphic(schema):
             s_types.ensure_schema_collection(
@@ -734,11 +730,11 @@ class CreateCallableObject(CallableCommand, sd.CreateObject):
         if hasattr(astnode, 'returning'):
             modaliases = context.modaliases
 
-            return_type_ref = utils.ast_to_typeref(
-                astnode.returning, modaliases=modaliases, schema=schema)
-
-            return_type = utils.resolve_typeref(
-                return_type_ref, schema=schema)
+            return_type = utils.ast_to_type(
+                astnode.returning,
+                modaliases=modaliases,
+                schema=schema,
+            )
 
             if (return_type.is_collection()
                     and not return_type.is_polymorphic(schema)):
@@ -749,7 +745,7 @@ class CreateCallableObject(CallableCommand, sd.CreateObject):
                 )
 
             cmd.set_attribute_value(
-                'return_type', return_type_ref)
+                'return_type', return_type)
             cmd.set_attribute_value(
                 'return_typemod', astnode.returning_typemod)
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1011,7 +1011,7 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
         *,
         our_schema: s_schema.Schema,
         their_schema: s_schema.Schema,
-        context: Optional[ComparisonContext],
+        context: ComparisonContext,
     ) -> float:
         comparator = getattr(field.type, 'compare_values', None)
         if callable(comparator):
@@ -1034,13 +1034,13 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
 
     @classmethod
     def compare_values(
-        cls,
-        ours: Optional[Object],
-        theirs: Optional[Object],
+        cls: Type[Object_T],
+        ours: Optional[Object_T],
+        theirs: Optional[Object_T],
         *,
         our_schema: s_schema.Schema,
         their_schema: s_schema.Schema,
-        context: Optional[ComparisonContext],
+        context: ComparisonContext,
         compcoef: float,
     ) -> float:
         """Compare two values and return a coefficient of similarity.
@@ -1074,7 +1074,7 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
         old: Optional[Object],
         new: Optional[Object],
         *,
-        context: ComparisonContext = None,
+        context: Optional[ComparisonContext] = None,
         old_schema: Optional[s_schema.Schema],
         new_schema: s_schema.Schema,
     ) -> sd.ObjectCommand[Object]:
@@ -1273,7 +1273,7 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
         old: Optional[Object],
         new: Object,
         *,
-        context: ComparisonContext = None,
+        context: ComparisonContext,
         old_schema: Optional[s_schema.Schema],
         new_schema: s_schema.Schema,
     ) -> None:
@@ -2291,8 +2291,9 @@ class InheritingObject(SubclassableObject):
         return self.get_bases(schema).names(schema)
 
     def get_topmost_concrete_base(
-        self, schema: s_schema.Schema
-    ) -> InheritingObject:
+        self: InheritingObjectT,
+        schema: s_schema.Schema
+    ) -> InheritingObjectT:
         """Get the topmost non-abstract base."""
         lineage = [self]
         lineage.extend(self.get_ancestors(schema).objects(schema))

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -599,7 +599,7 @@ class PointerCommandOrFragment:
                             'declared_overloaded', True
                         )
 
-                target = utils.reduce_to_typeref(schema, target_t)
+                target = target_t
 
             elif isinstance(target_ref, s_types.Collection):
                 srcctx = self.get_attribute_source_context('target')

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -18,7 +18,6 @@
 
 
 from __future__ import annotations
-
 from typing import *
 
 from edgedb import scram
@@ -58,7 +57,7 @@ class RoleCommandContext(
 
 
 class RoleCommand(sd.GlobalObjectCommand,
-                  inheriting.InheritingObjectCommand,
+                  inheriting.InheritingObjectCommand[Role],
                   s_anno.AnnotationSubjectCommand,
                   schema_metaclass=Role,
                   context_class=RoleCommandContext):
@@ -82,17 +81,15 @@ class RoleCommand(sd.GlobalObjectCommand,
         schema: s_schema.Schema,
         astnode: qlast.ObjectDDL,
         context: sd.CommandContext,
-    ) -> so.ObjectList[so.InheritingObject]:
+    ) -> so.ObjectList[Role]:
         result = []
         for b in getattr(astnode, 'bases', None) or []:
-            result.append(
-                schema.get_global(cls.get_schema_metaclass(), b.maintype.name)
-            )
+            result.append(schema.get_global(Role, b.maintype.name))
 
         return so.ObjectList.create(schema, result)
 
 
-class CreateRole(RoleCommand, inheriting.CreateInheritingObject):
+class CreateRole(RoleCommand, inheriting.CreateInheritingObject[Role]):
     astnode = qlast.CreateRole
 
     @classmethod
@@ -129,7 +126,7 @@ class CreateRole(RoleCommand, inheriting.CreateInheritingObject):
         super()._apply_field_ast(schema, context, node, op)
 
 
-class RebaseRole(RoleCommand, inheriting.RebaseInheritingObject):
+class RebaseRole(RoleCommand, inheriting.RebaseInheritingObject[Role]):
     pass
 
 
@@ -137,7 +134,7 @@ class RenameRole(RoleCommand, sd.RenameObject):
     pass
 
 
-class AlterRole(RoleCommand, inheriting.AlterInheritingObject):
+class AlterRole(RoleCommand, inheriting.AlterInheritingObject[Role]):
     astnode = qlast.AlterRole
 
     @classmethod
@@ -152,5 +149,5 @@ class AlterRole(RoleCommand, inheriting.AlterInheritingObject):
         return cmd
 
 
-class DeleteRole(RoleCommand, inheriting.DeleteInheritingObject):
+class DeleteRole(RoleCommand, inheriting.DeleteInheritingObject[Role]):
     astnode = qlast.DropRole

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -198,8 +198,8 @@ class ScalarTypeCommandContext(sd.ObjectCommandContext[ScalarType],
 
 
 class ScalarTypeCommand(
-    s_types.InheritingTypeCommand,
-    constraints.ConsistencySubjectCommand,
+    s_types.InheritingTypeCommand[ScalarType],
+    constraints.ConsistencySubjectCommand[ScalarType],
     s_anno.AnnotationSubjectCommand,
     schema_metaclass=ScalarType,
     context_class=ScalarTypeCommandContext,
@@ -221,15 +221,15 @@ class ScalarTypeCommand(
     def _validate_base_refs(
         cls,
         schema: s_schema.Schema,
-        base_refs: List[so.Object],
+        base_refs: Iterable[ScalarType],
         astnode: qlast.ObjectDDL,
         context: sd.CommandContext,
-    ) -> so.ObjectList[so.InheritingObject]:
+    ) -> so.ObjectList[ScalarType]:
         has_enums = any(isinstance(br, AnonymousEnumTypeRef)
                         for br in base_refs)
 
         if has_enums:
-            if len(base_refs) > 1:
+            if len(tuple(base_refs)) > 1:
                 assert isinstance(astnode, qlast.BasesMixin)
                 raise errors.SchemaError(
                     f'invalid scalar type definition, enumeration must be the '
@@ -240,7 +240,10 @@ class ScalarTypeCommand(
         return super()._validate_base_refs(schema, base_refs, astnode, context)
 
 
-class CreateScalarType(ScalarTypeCommand, inheriting.CreateInheritingObject):
+class CreateScalarType(
+    ScalarTypeCommand,
+    inheriting.CreateInheritingObject[ScalarType],
+):
     astnode = qlast.CreateScalarType
 
     @classmethod
@@ -332,7 +335,10 @@ class RenameScalarType(ScalarTypeCommand, sd.RenameObject):
     pass
 
 
-class RebaseScalarType(ScalarTypeCommand, inheriting.RebaseInheritingObject):
+class RebaseScalarType(
+    ScalarTypeCommand,
+    inheriting.RebaseInheritingObject[ScalarType],
+):
 
     def apply(
         self,
@@ -405,10 +411,15 @@ class RebaseScalarType(ScalarTypeCommand, inheriting.RebaseInheritingObject):
         return schema
 
 
-class AlterScalarType(ScalarTypeCommand,
-                      inheriting.AlterInheritingObject):
+class AlterScalarType(
+    ScalarTypeCommand,
+    inheriting.AlterInheritingObject[ScalarType],
+):
     astnode = qlast.AlterScalarType
 
 
-class DeleteScalarType(ScalarTypeCommand, inheriting.DeleteInheritingObject):
+class DeleteScalarType(
+    ScalarTypeCommand,
+    inheriting.DeleteInheritingObject[ScalarType],
+):
     astnode = qlast.DropScalarType

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -87,8 +87,8 @@ class ScalarType(
     def _to_nonpolymorphic(
         self,
         schema: s_schema.Schema,
-        concrete_type: s_types.Type,
-    ) -> s_types.Type:
+        concrete_type: ScalarType,
+    ) -> ScalarType:
         if (not concrete_type.is_polymorphic(schema) and
                 concrete_type.issubclass(schema, self)):
             return concrete_type
@@ -148,7 +148,7 @@ class ScalarType(
         self,
         other: s_types.Type,
         schema: s_schema.Schema,
-    ) -> Optional[s_types.Type]:
+    ) -> Optional[ScalarType]:
 
         if not isinstance(other, ScalarType):
             return None
@@ -158,13 +158,14 @@ class ScalarType(
 
         left = self.get_topmost_concrete_base(schema)
         right = other.get_topmost_concrete_base(schema)
-        assert isinstance(left, ScalarType)
-        assert isinstance(right, ScalarType)
 
         if left == right:
             return left
         else:
-            return s_casts.find_common_castable_type(schema, left, right)
+            return cast(
+                Optional[ScalarType],
+                s_casts.find_common_castable_type(schema, left, right),
+            )
 
     def get_base_for_cast(self, schema: s_schema.Schema) -> so.Object:
         if self.is_enum(schema):

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -242,13 +242,60 @@ def typeref_to_ast(schema: s_schema.Schema,
     return result
 
 
-def reduce_to_typeref(schema: s_schema.Schema, t: so.Object) -> so.Object:
-    ref, _ = t._reduce_to_ref(schema)
-    return ref
-
-
 def resolve_typeref(ref: so.Object, schema: s_schema.Schema) -> so.Object:
     return ref._resolve_ref(schema)
+
+
+def ast_to_object(
+    node: qlast.TypeName, *,
+    metaclass: Optional[so.ObjectMeta] = None,
+    modaliases: Mapping[Optional[str], str],
+    schema: s_schema.Schema,
+) -> so.Object:
+
+    ref = ast_to_typeref(
+        node,
+        metaclass=metaclass,
+        modaliases=modaliases,
+        schema=schema,
+    )
+
+    return resolve_typeref(ref, schema)
+
+
+@overload
+def ast_to_type(  # NoQA: F811
+    node: qlast.TypeName, *,
+    metaclass: Type[s_types.TypeT],
+    modaliases: Mapping[Optional[str], str],
+    schema: s_schema.Schema,
+) -> s_types.TypeT:
+    ...
+
+
+@overload
+def ast_to_type(  # NoQA: F811
+    node: qlast.TypeName, *,
+    metaclass: None = None,
+    modaliases: Mapping[Optional[str], str],
+    schema: s_schema.Schema,
+) -> s_types.Type:
+    ...
+
+
+def ast_to_type(  # NoQA: F811
+    node: qlast.TypeName, *,
+    metaclass: Optional[Type[s_types.TypeT]] = None,
+    modaliases: Mapping[Optional[str], str],
+    schema: s_schema.Schema,
+) -> s_types.TypeT:
+
+    return ast_to_object(
+        node,
+        metaclass=metaclass,
+        modaliases=modaliases,
+        schema=schema,
+    )
 
 
 def is_nontrivial_container(value: Any) -> Optional[collections.abc.Iterable]:

--- a/mypy.ini
+++ b/mypy.ini
@@ -239,6 +239,18 @@ ignore_errors = False
 [mypy-edb.schema.objects.*]
 follow_imports = True
 ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
 
 [mypy-edb.schema.ordering.*]
 follow_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -275,6 +275,18 @@ no_implicit_reexport = True
 [mypy-edb.schema.types.*]
 follow_imports = True
 ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
 
 [mypy-edb.schema._types.*]
 follow_imports = True

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 78.23)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 83.08)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 78.17)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 78.23)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 76.28)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 78.17)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)


### PR DESCRIPTION
This enables strict type checking for `edb.schema.objects` and `edb.schema.types`.  As usual,
this uncovered some class hierarchy wrongness and other infidelities, so there's associated code movement. This also improves the mypy plugin, most notably fixing support for the explicit typing annotations on fields.