### PR TITLE
Fix typing errors in edb.schema.utils

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -279,7 +279,7 @@ class BaseConstant(Expr):
 class StringConstant(BaseConstant):
 
     @classmethod
-    def from_python(cls, s: str):
+    def from_python(cls, s: str) -> StringConstant:
         return cls(value=s)
 
 
@@ -312,7 +312,7 @@ class BytesConstant(BaseConstant):
     value: bytes
 
     @classmethod
-    def from_python(cls, s: bytes):
+    def from_python(cls, s: bytes) -> BytesConstant:
         return cls(value=s)
 
 

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -54,12 +54,12 @@ class ObjectType(
 ):
 
     union_of = so.SchemaField(
-        so.ObjectSet,
+        so.ObjectSet["ObjectType"],
         default=so.DEFAULT_CONSTRUCTOR,
         coerce=True)
 
     intersection_of = so.SchemaField(
-        so.ObjectSet,
+        so.ObjectSet["ObjectType"],
         default=so.DEFAULT_CONSTRUCTOR,
         coerce=True)
 
@@ -266,7 +266,7 @@ def get_or_create_union_type(
     *,
     opaque: bool = False,
     module: Optional[str] = None,
-) -> ObjectType:
+) -> Tuple[s_schema.Schema, ObjectType, bool]:
 
     type_id, name = s_types.get_union_type_id(
         schema,
@@ -307,7 +307,7 @@ def get_or_create_intersection_type(
     components: Iterable[ObjectType],
     *,
     module: Optional[str] = None,
-) -> ObjectType:
+) -> Tuple[s_schema.Schema, ObjectType, bool]:
 
     type_id, name = s_types.get_intersection_type_id(
         schema,

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -334,9 +334,9 @@ class Type(
         return False
 
     def get_intersection_of(
-        self,
+        self: TypeT,
         schema: s_schema.Schema,
-    ) -> Optional[so.ObjectSet[Type]]:
+    ) -> Optional[so.ObjectSet[TypeT]]:
         return None
 
     def material_type(

--- a/mypy.ini
+++ b/mypy.ini
@@ -373,7 +373,7 @@ warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
 
-[mypy-edb.schema.util]
+[mypy-edb.schema.utils]
 follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 42.41)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 42.58)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
The typing pass in #1074 had a typo in the module name in mypy.ini,
which resulted in the module not being checked in strict mode.  This
fixes the remaining issues.