### PR TITLE
Reimplement schema object shell mechanism

### DIFF
--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -261,7 +261,7 @@ def __infer_anytyperef(
     ir: irast.AnyTypeRef,
     env: context.Environment,
 ) -> s_types.Type:
-    return s_pseudo.Any.instance()
+    return s_pseudo.Any.get(env.schema)
 
 
 @_infer_type.register
@@ -269,7 +269,7 @@ def __infer_anytupleref(
     ir: irast.AnyTupleRef,
     env: context.Environment,
 ) -> s_types.Type:
-    return s_pseudo.AnyTuple.instance()
+    return s_pseudo.AnyTuple.get(env.schema)
 
 
 @_infer_type.register
@@ -448,7 +448,7 @@ def __infer_index(
                 node_type.get_name(env.schema) == 'std::anyscalar') and
             (index_type.implicitly_castable_to(int_t, env.schema) or
                 index_type.implicitly_castable_to(str_t, env.schema))):
-        result = s_pseudo.Any.instance()
+        result = s_pseudo.Any.get(env.schema)
 
     else:
         raise errors.QueryError(
@@ -472,7 +472,7 @@ def __infer_array(
             raise errors.QueryError('could not determine array type',
                                     context=ir.context)
     else:
-        element_type = s_pseudo.Any.instance()
+        element_type = s_pseudo.Any.get(env.schema)
 
     return s_types.Array.create(env.schema, element_type=element_type)
 

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -61,9 +61,9 @@ def get_schema_object(
         module = name.module
         name = name.name
     elif isinstance(name, qlast.AnyType):
-        return s_pseudo.Any.instance()
+        return s_pseudo.Any.get(ctx.env.schema)
     elif isinstance(name, qlast.AnyTuple):
-        return s_pseudo.AnyTuple.instance()
+        return s_pseudo.AnyTuple.get(ctx.env.schema)
     elif isinstance(name, qlast.BaseObjectRef):
         raise AssertionError(f"Unhandled BaseObjectRef subclass: {name!r}")
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -79,7 +79,7 @@ def new_empty_set(*, stype: Optional[s_types.Type]=None, alias: str,
                   srcctx: Optional[
                       parsing.ParserContext]=None) -> irast.Set:
     if stype is None:
-        stype = s_pseudo.Any.create()
+        stype = s_pseudo.Any.get(ctx.env.schema)
         if srcctx is not None:
             ctx.env.type_origins[stype] = srcctx
 
@@ -164,7 +164,7 @@ def new_array_set(
     if elements:
         stype = inference.infer_type(arr, env=ctx.env)
     else:
-        anytype = s_pseudo.Any.create()
+        anytype = s_pseudo.Any.get(ctx.env.schema)
         stype = s_types.Array.from_subtypes(ctx.env.schema, [anytype])
         if srcctx is not None:
             ctx.env.type_origins[anytype] = srcctx

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -291,10 +291,10 @@ def ir_typeref_to_type(
         given *typeref*.
     """
     if is_anytuple(typeref):
-        return s_pseudo.AnyTuple.instance()
+        return s_pseudo.AnyTuple.get(schema)
 
     elif is_any(typeref):
-        return s_pseudo.Any.instance()
+        return s_pseudo.Any.get(schema)
 
     elif is_tuple(typeref):
         named = False

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -544,17 +544,17 @@ class IntrospectionMech:
             scls = coll_type.from_subtypes(schema, st, typemods=typemods)
 
         elif t['maintype'] == 'anytype':
-            scls = s_pseudo.Any.instance()
+            scls = s_pseudo.Any.get(schema)
 
         elif t['maintype'] == 'anytuple':
-            scls = s_pseudo.AnyTuple.instance()
+            scls = s_pseudo.AnyTuple.get(schema)
 
         else:
             type_id = t['maintype']
             if type_id == s_obj.get_known_type_id('anytype'):
-                scls = s_pseudo.Any.instance()
+                scls = s_pseudo.Any.get(schema)
             elif type_id == s_obj.get_known_type_id('anytuple'):
-                scls = s_pseudo.AnyTuple.instance()
+                scls = s_pseudo.AnyTuple.get(schema)
             else:
                 scls = schema.get_by_id(t['maintype'])
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -2033,7 +2033,7 @@ def get_interesting_metaclasses():
     metaclasses = []
 
     for mcls in s_obj.ObjectMeta.get_schema_metaclasses():
-        if issubclass(mcls, (s_obj.ObjectRef, s_db.Database)):
+        if issubclass(mcls, s_db.Database):
             continue
 
         if isinstance(mcls, adapter.Adapter):

--- a/edb/schema/abc.py
+++ b/edb/schema/abc.py
@@ -23,8 +23,6 @@ import typing
 
 
 if typing.TYPE_CHECKING:
-    from . import schema as s_schema
-
     ObjectContainer_T = typing.TypeVar(
         'ObjectContainer_T', bound='ObjectContainer'
     )
@@ -39,10 +37,7 @@ class Object:
 
 
 class ObjectContainer:
-    def _reduce_to_ref(
-        self: ObjectContainer_T, schema: s_schema.Schema
-    ) -> typing.Tuple[ObjectContainer_T, typing.Any]:
-        raise NotImplementedError
+    pass
 
 
 class Database(Object):

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -135,7 +135,7 @@ class Constraint(referencing.ReferencedInheritingObject,
     ) -> Optional[s_pseudo.Any]:
         # Point subject placeholder to a dummy pointer to make EdgeQL
         # pipeline happy.
-        return s_pseudo.Any.instance()
+        return s_pseudo.Any.get(schema)
 
     @classmethod
     def get_concrete_constraint_attrs(
@@ -612,7 +612,7 @@ class CreateConstraint(
             num=param_offset,
             name='__subject__',
             default=None,
-            type=s_pseudo.Any.instance(),
+            type=s_pseudo.Any.get(schema),
             typemod=ft.TypeModifier.SINGLETON,
             kind=ft.ParameterKind.POSITIONAL,
         ))

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -223,6 +223,7 @@ def delta_schemas(
             result.add(create)
 
     objects = sd.DeltaRoot(canonical=True)
+    context = so.ComparisonContext()
 
     for sclass in get_global_dep_order():
         filters: List[Callable[[s_schema.Schema, so.Object], bool]] = []
@@ -259,8 +260,15 @@ def delta_schemas(
             extra_filters=filters + schema_a_filters,
         )
 
-        objects.add(so.Object.delta_sets(
-            old, new, old_schema=schema_a, new_schema=schema_b))
+        objects.add(
+            so.Object.delta_sets(
+                old,
+                new,
+                old_schema=schema_a,
+                new_schema=schema_b,
+                context=context,
+            )
+        )
 
     if linearize_delta:
         objects = s_ordering.linearize_delta(

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -152,13 +152,6 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
             result.add(mcls.adapt(op))
         return result
 
-    def _resolve_type_ref(
-        self,
-        ref: so.Object,
-        schema: s_schema.Schema,
-    ) -> so.Object:
-        return utils.resolve_typeref(ref, schema)
-
     def _resolve_attr_value(
         self,
         value: Any,
@@ -171,7 +164,7 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
         if isinstance(value, so.Shell):
             value = value.resolve(schema)
         else:
-            if isinstance(ftype, so.ObjectMeta):
+            if isinstance(ftype, so.ObjectMeta) and False:
                 value = self._resolve_type_ref(value, schema)
 
             elif issubclass(ftype, checked.CheckedDict):

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2078,9 +2078,11 @@ class AlterObjectProperty(Command):
 
             elif isinstance(astnode.value, qlast.ObjectRef):
 
-                new_value = utils.ast_objref_to_objref(
-                    astnode.value, modaliases=context.modaliases,
-                    schema=schema)
+                new_value = utils.ast_to_object(
+                    astnode.value,
+                    modaliases=context.modaliases,
+                    schema=schema,
+                )
 
             elif (isinstance(astnode.value, qlast.Set)
                     and not astnode.value.elements):

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -215,6 +215,49 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer, s_abc.Expression):
             ) if self.refs is not None else None
         ), self
 
+    def as_shell(self, schema: s_schema.Schema) -> ExpressionShell:
+        return ExpressionShell(
+            text=self.text,
+            origtext=self.origtext,
+            refs=(
+                r.as_shell(schema) for r in self.refs.objects(schema)
+            ) if self.refs is not None else None,
+            _qlast=self._qlast,
+        )
+
+
+class ExpressionShell(so.Shell):
+
+    def __init__(
+        self,
+        *,
+        text: str,
+        origtext: Optional[str],
+        refs: Optional[Iterable[so.ObjectShell]],
+        _qlast: Optional[qlast_.Base] = None,
+    ) -> None:
+        self.text = text
+        self.origtext = origtext
+        self.refs = tuple(refs) if refs is not None else None
+        self._qlast = _qlast
+
+    def resolve(self, schema: s_schema.Schema) -> Expression:
+        return Expression(
+            text=self.text,
+            origtext=self.origtext,
+            refs=so.ObjectSet.create(
+                schema,
+                (s.resolve(schema) for s in self.refs),
+            ) if self.refs is not None else None,
+            _qlast=self._qlast,
+        )
+
+    @property
+    def qlast(self) -> qlast_.Base:
+        if self._qlast is None:
+            self._qlast = qlparser.parse_fragment(self.text)
+        return self._qlast
+
 
 class ExpressionList(checked.FrozenCheckedList[Expression]):
 

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -202,19 +202,6 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer, s_abc.Expression):
             _irast=expr._irast,
         )
 
-    def _reduce_to_ref(self,
-                       schema: s_schema.Schema) -> Tuple[Expression,
-                                                         Expression]:
-        return type(self)(
-            text=self.text,
-            origtext=self.origtext,
-            refs=so.ObjectSet.create(
-                schema,
-                (scls._reduce_to_ref(schema)[0]
-                 for scls in self.refs.objects(schema))
-            ) if self.refs is not None else None
-        ), self
-
     def as_shell(self, schema: s_schema.Schema) -> ExpressionShell:
         return ExpressionShell(
             text=self.text,

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -91,7 +91,7 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer, s_abc.Expression):
                        *,
                        our_schema: s_schema.Schema,
                        their_schema: s_schema.Schema,
-                       context: Any,
+                       context: so.ComparisonContext,
                        compcoef: float) -> float:
         if not ours and not theirs:
             return 1.0

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -564,38 +564,51 @@ class CallableObject(
         old: Optional[so.Object],
         new: Optional[so.Object],
         *,
-        context: Optional[so.ComparisonContext] = None,
+        context: so.ComparisonContext,
         old_schema: Optional[s_schema.Schema],
         new_schema: s_schema.Schema,
     ) -> sd.ObjectCommand[so.Object]:
-        context = context or so.ComparisonContext()
 
         def param_is_inherited(schema: s_schema.Schema, func, param):
             qualname = sn.get_specialized_name(
                 param.get_shortname(schema), func.get_name(schema))
             return qualname != param.get_name(schema).name
 
-        with context(old, new):
-            delta = super().delta(old, new, context=context,
-                                  old_schema=old_schema, new_schema=new_schema)
+        delta = super().delta(
+            old,
+            new,
+            context=context,
+            old_schema=old_schema,
+            new_schema=new_schema,
+        )
 
-            if old:
-                old_params = old.get_params(old_schema).objects(old_schema)
-                oldcoll = [p for p in old_params
-                           if not param_is_inherited(old_schema, old, p)]
-            else:
-                oldcoll = []
+        if old:
+            old_params = old.get_params(old_schema).objects(old_schema)
+            oldcoll = [
+                p for p in old_params
+                if not param_is_inherited(old_schema, old, p)
+            ]
+        else:
+            oldcoll = []
 
-            if new:
-                new_params = new.get_params(new_schema).objects(new_schema)
-                newcoll = [p for p in new_params
-                           if not param_is_inherited(new_schema, new, p)]
-            else:
-                newcoll = []
+        if new:
+            new_params = new.get_params(new_schema).objects(new_schema)
+            newcoll = [
+                p for p in new_params
+                if not param_is_inherited(new_schema, new, p)
+            ]
+        else:
+            newcoll = []
 
-            delta.add(cls.delta_sets(
-                oldcoll, newcoll, context,
-                old_schema=old_schema, new_schema=new_schema))
+        delta.add(
+            cls.delta_sets(
+                oldcoll,
+                newcoll,
+                context=context,
+                old_schema=old_schema,
+                new_schema=new_schema,
+            )
+        )
 
         return delta
 

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -373,8 +373,7 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
 
         base_refs: List[so.InheritingObjectT] = []
         for b in getattr(astnode, 'bases', None) or []:
-            obj = utils.ast_to_typeref(b, modaliases=modaliases, schema=schema)
-            # assert isinstance(obj, so.InheritingObject)
+            obj = utils.ast_to_type(b, modaliases=modaliases, schema=schema)
             base_refs.append(cast(so.InheritingObjectT, obj))
 
         return cls._validate_base_refs(schema, base_refs, astnode, context)

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -680,7 +680,7 @@ class CreateInheritingObject(
                 base_names.append(b.name)
         else:
             assert isinstance(bases, so.ObjectList)
-            base_names = list(bases.names(schema, allow_unresolved=True))
+            base_names = list(bases.names(schema))
 
         # Filter out implicit bases
         explicit_bases = [

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -317,10 +317,10 @@ class CreateLink(
                         node.target = expr.qlast
                     else:
                         t = op.new_value
-                        assert isinstance(t, so.Object)
+                        assert isinstance(t, (so.Object, so.ObjectShell))
                         node.target = utils.typeref_to_ast(schema, t)
             else:
-                assert isinstance(op.new_value, so.Object)
+                assert isinstance(op.new_value, (so.Object, so.ObjectShell))
                 node.commands.append(
                     qlast.SetLinkType(
                         type=utils.typeref_to_ast(schema, op.new_value)
@@ -345,7 +345,6 @@ class CreateLink(
         parent_ctx = self.get_referrer_context(context)
         if parent_ctx is None:
             return cmd
-        source_name = parent_ctx.op.classname
 
         base_prop_name = sn.Name('std::source')
         s_name = sn.get_specialized_name(
@@ -360,15 +359,15 @@ class CreateLink(
         src_prop.set_attribute_value('name', src_prop_name)
         src_prop.set_attribute_value(
             'bases',
-            so.ObjectList.create(schema, [so.ObjectRef(name=base_prop_name)]),
+            so.ObjectList.create(schema, [schema.get(base_prop_name)]),
         )
         src_prop.set_attribute_value(
             'source',
-            so.ObjectRef(name=self.classname),
+            self.scls,
         )
         src_prop.set_attribute_value(
             'target',
-            so.ObjectRef(name=source_name),
+            parent_ctx.op.scls,
         )
         src_prop.set_attribute_value('required', True)
         src_prop.set_attribute_value('readonly', True)
@@ -392,11 +391,11 @@ class CreateLink(
         tgt_prop.set_attribute_value('name', tgt_prop_name)
         tgt_prop.set_attribute_value(
             'bases',
-            so.ObjectList.create(schema, [so.ObjectRef(name=base_prop_name)]),
+            so.ObjectList.create(schema, [schema.get(base_prop_name)]),
         )
         tgt_prop.set_attribute_value(
             'source',
-            so.ObjectRef(name=self.classname),
+            self.scls,
         )
         tgt_prop.set_attribute_value(
             'target',

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -189,7 +189,7 @@ class LinkCommand(lproperties.PropertySourceCommand,
         schema: s_schema.Schema,
         astnode: qlast.CreateConcreteLink,
         context: sd.CommandContext,
-        target_ref: so.ObjectRef,
+        target_ref: Union[so.Object, so.ObjectShell],
     ) -> None:
         assert astnode.target is not None
         slt = SetLinkType(classname=self.classname, type=target_ref)

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -125,7 +125,7 @@ class Link(sources.Source, pointers.Pointer, s_abc.Link,
         *,
         our_schema: s_schema.Schema,
         their_schema: s_schema.Schema,
-        context: Optional[so.ComparisonContext] = None,
+        context: so.ComparisonContext,
     ) -> float:
         if not isinstance(other, Link):
             if isinstance(other, pointers.Pointer):

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -71,7 +71,7 @@ class Property(pointers.Pointer, s_abc.Property,
 
         return schema, ptr
 
-    def compare(self, other, *, our_schema, their_schema, context=None):
+    def compare(self, other, *, our_schema, their_schema, context):
         if not isinstance(other, Property):
             if isinstance(other, pointers.Pointer):
                 return 0.0

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -248,7 +248,11 @@ class ObjectType(
             return None
         else:
             return type(self).delta(
-                None, self, old_schema=schema, new_schema=schema,
+                None,
+                self,
+                old_schema=schema,
+                new_schema=schema,
+                context=so.ComparisonContext(),
             )
 
     def allow_ref_propagation(

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -207,37 +207,6 @@ class ObjectType(
 
         return False
 
-    def _reduce_to_ref(self, schema):
-        union_of = self.get_union_of(schema)
-        if union_of:
-            my_name = self.get_name(schema)
-            return (
-                s_types.ExistingUnionTypeRef(
-                    components=[
-                        c._reduce_to_ref(schema)[0]
-                        for c in union_of.objects(schema)
-                    ],
-                    name=my_name,
-                ),
-                my_name,
-            )
-
-        intersection_of = self.get_intersection_of(schema)
-        if intersection_of:
-            my_name = self.get_name(schema)
-            return (
-                s_types.ExistingIntersectionTypeRef(
-                    components=[
-                        c._reduce_to_ref(schema)[0]
-                        for c in intersection_of.objects(schema)
-                    ],
-                    name=my_name,
-                ),
-                my_name,
-            )
-
-        return super()._reduce_to_ref(schema)
-
     def as_create_delta_for_compound_type(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -258,6 +258,11 @@ def _trace_op(
             new_value_name = op.new_value.get_name(new_schema)
             deps.add(('create', new_value_name))
             deps.add(('alter', new_value_name))
+        elif isinstance(op.new_value, so.ObjectShell):
+            nvn = op.new_value.name
+            if nvn is not None:
+                deps.add(('create', nvn))
+                deps.add(('alter', nvn))
 
         parent_op = opstack[-2]
         assert isinstance(parent_op, sd.ObjectCommand)

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -622,7 +622,12 @@ class PointerCommandOrFragment:
 
         return schema
 
-    def _parse_computable(self, expr, schema, context) -> so.ObjectRef:
+    def _parse_computable(
+        self,
+        expr: qlast.Base,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> Tuple[s_types.Type, Optional[Pointer]]:
         from edb.ir import ast as irast
         from edb.ir import typeutils as irtyputils
 

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -123,6 +123,9 @@ class Any(PseudoType):
     def _reduce_to_ref(self, schema):
         return AnyObjectRef(), sn.UnqualifiedName('anytype')
 
+    def as_shell(self, schema):
+        return AnyTypeShell()
+
 
 class AnyObjectRef(so.ObjectRef):
 
@@ -130,6 +133,15 @@ class AnyObjectRef(so.ObjectRef):
         super().__init__(name=name)
 
     def _resolve_ref(self, schema: s_schema.Schema) -> Any:
+        return Any.get(schema)
+
+
+class AnyTypeShell(s_types.TypeShell):
+
+    def __init__(self, *, name=sn.UnqualifiedName('anytype')):
+        super().__init__(name=name)
+
+    def resolve(self, schema: s_schema.Schema) -> Any:
         return Any.get(schema)
 
 
@@ -176,6 +188,9 @@ class AnyTuple(PseudoType):
     ) -> s_types.Type:
         return concrete_type
 
+    def as_shell(self, schema):
+        return AnyTupleShell()
+
 
 class AnyTupleRef(so.ObjectRef):
 
@@ -183,6 +198,15 @@ class AnyTupleRef(so.ObjectRef):
         super().__init__(name=name)
 
     def _resolve_ref(self, schema: s_schema.Schema) -> AnyTuple:
+        return AnyTuple.get(schema)
+
+
+class AnyTupleShell(s_types.TypeShell):
+
+    def __init__(self, *, name=sn.UnqualifiedName('anytuple')):
+        super().__init__(name=name)
+
+    def resolve(self, schema: s_schema.Schema) -> AnyTuple:
         return AnyTuple.get(schema)
 
 

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 # Cannot import * from typing because of name conflicts in this file.
-from typing import Optional, TypeVar, Tuple, TYPE_CHECKING
+from typing import Optional, TypeVar, TYPE_CHECKING
 
 from . import name as sn
 from . import objects as so
@@ -120,20 +120,8 @@ class Any(PseudoType):
         else:
             return s_types.MAX_TYPE_DISTANCE
 
-    def _reduce_to_ref(self, schema):
-        return AnyObjectRef(), sn.UnqualifiedName('anytype')
-
     def as_shell(self, schema):
         return AnyTypeShell()
-
-
-class AnyObjectRef(so.ObjectRef):
-
-    def __init__(self, *, name=sn.UnqualifiedName('anytype')):
-        super().__init__(name=name)
-
-    def _resolve_ref(self, schema: s_schema.Schema) -> Any:
-        return Any.get(schema)
 
 
 class AnyTypeShell(s_types.TypeShell):
@@ -164,12 +152,6 @@ class AnyTuple(PseudoType):
     ) -> bool:
         return other.is_anytuple()
 
-    def _reduce_to_ref(
-        self,
-        schema: s_schema.Schema
-    ) -> Tuple[AnyTupleRef, sn.UnqualifiedName]:
-        return AnyTupleRef(), sn.UnqualifiedName('anytuple')
-
     def _resolve_polymorphic(
         self,
         schema: s_schema.Schema,
@@ -190,15 +172,6 @@ class AnyTuple(PseudoType):
 
     def as_shell(self, schema):
         return AnyTupleShell()
-
-
-class AnyTupleRef(so.ObjectRef):
-
-    def __init__(self, *, name=sn.UnqualifiedName('anytuple')) -> None:
-        super().__init__(name=name)
-
-    def _resolve_ref(self, schema: s_schema.Schema) -> AnyTuple:
-        return AnyTuple.get(schema)
 
 
 class AnyTupleShell(s_types.TypeShell):

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -941,7 +941,7 @@ class CreateReferencedInheritingObject(
             ]
         else:
             assert isinstance(bases, so.ObjectList)
-            base_names = list(bases.names(schema, allow_unresolved=True))
+            base_names = list(bases.names(schema))
 
         # Filter out explicit bases
         implicit_bases = [

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -299,9 +299,11 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase[ReferencedT]):
             base_name: str
 
             try:
-                base_ref = utils.ast_to_typeref(
+                base_ref = utils.ast_to_type(
                     qlast.TypeName(maintype=astnode.name),
-                    modaliases=context.modaliases, schema=schema)
+                    modaliases=context.modaliases,
+                    schema=schema,
+                )
             except errors.InvalidReferenceError:
                 base_name = sn.Name(name)
             else:

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -626,7 +626,7 @@ class Collection(Type, s_abc.Collection):
         *,
         our_schema: s_schema.Schema,
         their_schema: s_schema.Schema,
-        context: Optional[so.ComparisonContext],
+        context: so.ComparisonContext,
         compcoef: float,
     ) -> float:
         if ours is None and theirs is None:
@@ -1889,9 +1889,15 @@ class TypeCommand(sd.ObjectCommand[Type]):
                 context=context,
             )
 
-        derived_delta.add(so.Object.delta_sets(
-            prev_expr_aliases, expr_aliases,
-            old_schema=old_schema, new_schema=new_schema))
+        derived_delta.add(
+            so.Object.delta_sets(
+                prev_expr_aliases,
+                expr_aliases,
+                old_schema=old_schema,
+                new_schema=new_schema,
+                context=so.ComparisonContext(),
+            )
+        )
 
         if prev_ir is not None:
             for vt in prev_coll_expr_aliases:

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -43,6 +43,7 @@ from edb.schema import database as s_db
 from edb.schema import ddl as s_ddl
 from edb.schema import delta as sd
 from edb.schema import modules as s_mod
+from edb.schema import pseudo as s_pseudo
 from edb.schema import schema as s_schema
 from edb.schema import std as s_std
 
@@ -288,6 +289,7 @@ async def _make_stdlib(
 ) -> Tuple[s_schema.Schema, str, Set[uuid.UUID]]:
     schema = s_schema.Schema()
     schema, _ = s_mod.Module.create_in_schema(schema, name='__derived__')
+    schema = s_pseudo.populate_types(schema)
 
     current_block = None
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1275,7 +1275,7 @@ class Compiler(BaseCompiler):
 
         schema_ddl = s_ddl.ddl_text_from_schema(schema)
 
-        all_objects = schema.get_objects(excluded_modules=s_schema.STD_MODULES)
+        all_objects = schema.get_objects(exclude_stdlib=True)
         ids = []
         for obj in all_objects:
             if isinstance(obj, s_obj.QualifiedObject):
@@ -1291,7 +1291,7 @@ class Compiler(BaseCompiler):
 
         objtypes = schema.get_objects(
             type=s_objtypes.ObjectType,
-            excluded_modules=s_schema.STD_MODULES,
+            exclude_stdlib=True,
         )
         descriptors = []
 

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -38,6 +38,7 @@ from edb.server import defines
 from edb.schema import ddl as s_ddl
 from edb.schema import delta as sd
 from edb.schema import migrations as s_migrations  # noqa
+from edb.schema import pseudo as s_pseudo
 from edb.schema import schema as s_schema
 from edb.schema import std as s_std
 
@@ -231,6 +232,7 @@ def _load_std_schema():
 
         if schema is None:
             schema = s_schema.Schema()
+            schema = s_pseudo.populate_types(schema)
             for modname in s_schema.STD_LIB + ('stdgraphql',):
                 schema = s_std.load_std_module(schema, modname)
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1681,7 +1681,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_function_19(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidReferenceError,
-                r"schema item 'std::anytype' does not exist"):
+                r"type 'std::anytype' does not exist"):
 
             await self.con.execute(r'''
                 CREATE FUNCTION test::ddlf_19(f: std::anytype) -> int64

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 85.22)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 84.95)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 84.84)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 85.22)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 84.95)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 84.84)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 84.98)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 84.93)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 84.93)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 84.95)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)


### PR DESCRIPTION
There are cases when schema objects cannot be referred to directly from a
schema delta: forward references and deltas resulting from schema 
comparison.  In these cases we replace schema object references with 
isntances of `ObjectRef` (or its numerous subclasses) that are a 
schema-independent way of describing a schema object in *some* schema. For
most objects it's just a name.

The current implementation of `ObjectRef` is problematic because it tries
to masquerade as a regular schema `Object` (mostly for historical typing
reasons), but since it's not a real object, the schema code is peppered
with checks in places where `ObjectRef` is not expected, and, since it
masquerades as an `Object` the typing doesn't help much (or, worse, gets in
the way).

Luckily, with the current state of things, the use cases for object shells
are much more limited, and the above mentioned masquerading is not
necessary.  This commit adds a new implementation of `ObjectShell`
(and `TypeShell`, etc.) that does the necessary minimum in a much cleaner
way.

(The PR contains multiple independent commits, please review separately.)