### PR TITLE
Rust cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 /.local
 /perf.data*
 /build
+/target
+/tmp
 __pycache__/
 .d8_history
 /.eggs
@@ -30,4 +32,4 @@ docs/_build
 /.vscode
 /.pytest_cache
 /.mypy_cache
-
+/.vagga

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "edb/server/pgproto"]
 	path = edb/server/pgproto
 	url = https://github.com/MagicStack/py-pgproto.git
-[submodule "edgedb-rust"]
-	path = edgedb-rust
-	url = https://github.com/edgedb/edgedb-rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,8 +33,9 @@ dependencies = [
 
 [[package]]
 name = "cpython"
-version = "0.3.0"
-source = "git+git://github.com/dgrunwald/rust-cpython?rev=dabc06c#dabc06c035800514b9a4ccf2f8e1726ce3023c17"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfaf3847ab963e40c4f6dd8d6be279bdf74007ae2413786a0dcbb28c52139a95"
 dependencies = [
  "libc",
  "num-traits",
@@ -103,8 +104,9 @@ dependencies = [
 
 [[package]]
 name = "python3-sys"
-version = "0.3.0"
-source = "git+git://github.com/dgrunwald/rust-cpython?rev=dabc06c#dabc06c035800514b9a4ccf2f8e1726ce3023c17"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90af11779515a1e530af60782d273b59ac79d33b0e253c071a728563957c76d4"
 dependencies = [
  "libc",
  "regex",

--- a/edb/edgeql-rust/Cargo.toml
+++ b/edb/edgeql-rust/Cargo.toml
@@ -10,8 +10,8 @@ edgeql-parser = {path = "../edgeql-parser"}
 combine = "4.0.0-beta.1"
 
 [dependencies.cpython]
-git = "git://github.com/dgrunwald/rust-cpython"
-rev = "dabc06c"
+name = "cpython"
+version = "0.4.1"
 features = ["extension-module"]
 
 [lib]

--- a/edb/edgeql-rust/src/errors.rs
+++ b/edb/edgeql-rust/src/errors.rs
@@ -22,7 +22,10 @@ impl cpython::PythonObjectWithCheckedDowncast for TokenizerError {
         if TokenizerError::type_object(py).is_instance(py, &obj) {
             Ok(unsafe { PythonObject::unchecked_downcast_from(obj) })
         } else {
-            Err(cpython::PythonObjectDowncastError(py))
+            Err(cpython::PythonObjectDowncastError::new(py,
+                "TokenizerError",
+                TokenizerError::type_object(py),
+            ))
         }
     }
 
@@ -33,7 +36,10 @@ impl cpython::PythonObjectWithCheckedDowncast for TokenizerError {
         if TokenizerError::type_object(py).is_instance(py, obj) {
             Ok(unsafe { PythonObject::unchecked_downcast_borrow_from(obj) })
         } else {
-            Err(cpython::PythonObjectDowncastError(py))
+            Err(cpython::PythonObjectDowncastError::new(py,
+                "TokenizerError",
+                TokenizerError::type_object(py),
+            ))
         }
     }
 }


### PR DESCRIPTION
1. Remove already unused git submodule
2. Add `/target` folder to `.gitignore` (the latter is used when you run `cargo test` or any other cargo command on your own, not through `setup.py`)
3. Upgrade cpython crate to 0.4.1 (instead of some git revision)