### PR TITLE
Add annotations for schema functions

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -811,10 +811,6 @@ class CallableObject(ObjectDDL):
     params: typing.List[FuncParam]
 
 
-class AlterCallableObject(AlterObject, CallableObject):
-    pass
-
-
 class CreateConstraint(CreateExtendingObject, CallableObject):
     subjectexpr: typing.Optional[Expr]
     is_abstract: bool = True

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -811,6 +811,10 @@ class CallableObject(ObjectDDL):
     params: typing.List[FuncParam]
 
 
+class AlterCallableObject(AlterObject, CallableObject):
+    pass
+
+
 class CreateConstraint(CreateExtendingObject, CallableObject):
     subjectexpr: typing.Optional[Expr]
     is_abstract: bool = True

--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -603,7 +603,7 @@ def get_param_anchors_for_callable(
 
     pg_params = s_func.PgParams.from_params(schema, params)
     for pi, p in enumerate(pg_params.params):
-        p_shortname = p.get_shortname(schema)
+        p_shortname = p.get_parameter_name(schema)
         anchors[p_shortname] = irast.Parameter(
             name=p_shortname,
             typeref=irtyputils.type_to_typeref(schema, p.get_type(schema)))

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -624,7 +624,7 @@ def finalize_args(
 
         if param_mod is not ft.TypeModifier.SET_OF:
             arg_scope = pathctx.get_set_scope(arg, ctx=ctx)
-            param_shortname = param.get_shortname(ctx.env.schema)
+            param_shortname = param.get_parameter_name(ctx.env.schema)
 
             # Arg was wrapped for scope fencing purposes,
             # but that fence has been removed above, so unwrap it.

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -264,7 +264,7 @@ def try_bind_call_args(
 
         pi += 1
 
-        param_shortname = param.get_shortname(schema)
+        param_shortname = param.get_parameter_name(schema)
         param_type = param.get_type(schema)
         if param_shortname in kwargs:
             matched_kwargs += 1
@@ -376,7 +376,7 @@ def try_bind_call_args(
                         f'failed to resolve the parameter for the arg #{i}')
 
                 param = barg.param
-                param_shortname = param.get_shortname(schema)
+                param_shortname = param.get_parameter_name(schema)
                 null_args.add(param_shortname)
 
                 defaults_mask |= 1 << i

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -82,12 +82,14 @@ def index_parameters(
         if variadic and variadic_num == i:
             assert varargs is None
             varargs = []
-            result[p.get_shortname(schema)] = qlast.Array(elements=varargs)
+            result[p.get_parameter_name(schema)] = qlast.Array(
+                elements=varargs
+            )
 
         if varargs is not None:
             varargs.append(e)
         else:
-            result[p.get_shortname(schema)] = e
+            result[p.get_parameter_name(schema)] = e
 
     return result
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -581,7 +581,7 @@ class FunctionCommand:
             if compile_defaults and param_default is not None:
                 default = self.compile_default(func, param_default, schema)
 
-            args.append((param.get_shortname(schema), pg_at, default))
+            args.append((param.get_parameter_name(schema), pg_at, default))
 
         return args
 
@@ -733,7 +733,7 @@ class OperatorCommand(FunctionCommand):
 
         for param in pg_params.params:
             pg_at = self.get_pgtype(oper, param.get_type(schema), schema)
-            args.append((param.get_shortname(schema), pg_at))
+            args.append((param.get_parameter_name(schema), pg_at))
 
         return args
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -500,9 +500,14 @@ class ConstraintCommand(
             params = self._get_params(schema, context)
 
             anchors: Dict[str, Any] = {}
+            # type ignore below, because so.ObjectList[Parameter]
+            # is in practice s_func.ParameterLikeList
             param_anchors, _ = (
                 qlcompiler.get_param_anchors_for_callable(
-                    params, schema, inlined_defaults=False)
+                    params,  # type: ignore
+                    schema,
+                    inlined_defaults=False
+                )
             )
             anchors.update(param_anchors)
             referrer_ctx = self.get_referrer_context(context)
@@ -511,12 +516,14 @@ class ConstraintCommand(
                 assert isinstance(referrer_ctx.op, sd.ObjectCommand)
                 anchors['__subject__'] = referrer_ctx.op.scls
 
+            # type ignore below, because so.ObjectList[Parameter]
+            # is in practice s_func.ParameterLikeList
             return s_expr.Expression.compiled(
                 value,
                 schema=schema,
                 modaliases=context.modaliases,
                 anchors=anchors,
-                func_params=params,
+                func_params=params,  # type: ignore
                 allow_generic_type_output=True,
                 parent_object_type=self.get_schema_metaclass(),
             )

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -703,20 +703,6 @@ class CallableCommand(sd.QualifiedObjectCommand[CallableObject]):
             params.append(param)
         return FuncParameterList.create(schema, params)
 
-    def _alter_innards(
-        self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-    ) -> s_schema.Schema:
-        # type ignore below, because CallableCommand is used as mixin,
-        # in classes where super()._alter_innards is bound
-        schema = super()._alter_innards(schema, context)  # type: ignore
-
-        for op in self.get_subcommands(metaclass=Parameter):
-            schema = op.apply(schema, context=context)
-
-        return schema
-
     @classmethod
     def _get_param_desc_from_ast(
         cls,
@@ -754,6 +740,23 @@ class CallableCommand(sd.QualifiedObjectCommand[CallableObject]):
             params.append(param)
 
         return schema, params
+
+
+class AlterCallableObject(CallableCommand,
+                          sd.AlterObject[CallableObject]):
+    astnode = qlast.AlterCallableObject
+
+    def _alter_innards(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = super()._alter_innards(schema, context)
+
+        for op in self.get_subcommands(metaclass=Parameter):
+            schema = op.apply(schema, context=context)
+
+        return schema
 
 
 class CreateCallableObject(CallableCommand, sd.CreateObject[CallableObject]):

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 
 def param_as_str(
     schema: s_schema.Schema,
-    param: Union[ParameterDesc, Parameter]
+    param: Union[ParameterDesc, Parameter],
 ) -> str:
     ret = []
     kind = param.get_kind(schema)
@@ -134,7 +134,7 @@ class ParameterDesc(ParameterLike):
         schema: s_schema.Schema,
         modaliases: Mapping[Optional[str], str],
         num: int,
-        astnode: qlast.FuncParam
+        astnode: qlast.FuncParam,
     ) -> ParameterDesc:
 
         paramd = None
@@ -199,7 +199,7 @@ class ParameterDesc(ParameterLike):
         cls,
         schema: s_schema.Schema,
         context: sd.CommandContext,
-        cmd: CreateParameter
+        cmd: CreateParameter,
     ) -> Tuple[s_schema.Schema, ParameterDesc]:
         props = cmd.get_attributes(schema, context)
         props['name'] = Parameter.paramname_from_fullname(props['name'])
@@ -221,7 +221,7 @@ class ParameterDesc(ParameterLike):
         schema: s_schema.Schema,
         func_fqname: sn.Name,
         *,
-        context: sd.CommandContext
+        context: sd.CommandContext,
     ) -> sd.Command:
         CreateParameter = sd.ObjectCommandMeta.get_command_class_or_die(
             sd.CreateObject, Parameter)
@@ -250,7 +250,7 @@ class ParameterDesc(ParameterLike):
         schema: s_schema.Schema,
         func_fqname: sn.Name,
         *,
-        context: sd.CommandContext
+        context: sd.CommandContext,
     ) -> sd.Command:
         DeleteParameter = sd.ObjectCommandMeta.get_command_class_or_die(
             sd.DeleteObject, Parameter)
@@ -309,7 +309,7 @@ class Parameter(so.ObjectFragment, ParameterLike):
         self,
         schema: s_schema.Schema,
         *,
-        with_parent: bool=False
+        with_parent: bool = False,
     ) -> str:
         vn = super().get_verbosename(schema)
         if with_parent:
@@ -406,7 +406,7 @@ class PgParams(NamedTuple):
     def from_params(
         cls,
         schema: s_schema.Schema,
-        params: Union[Sequence[ParameterLike], ParameterLikeList]
+        params: Union[Sequence[ParameterLike], ParameterLikeList],
     ) -> PgParams:
         pg_params = []
         named = []
@@ -450,7 +450,7 @@ class ParameterLikeList(abc.ABC):
     def get_by_name(
         self,
         schema: s_schema.Schema,
-        name: str
+        name: str,
     ) -> Optional[ParameterLike]:
         raise NotImplementedError
 
@@ -465,7 +465,7 @@ class ParameterLikeList(abc.ABC):
     @abc.abstractmethod
     def find_named_only(
         self,
-        schema: s_schema.Schema
+        schema: s_schema.Schema,
     ) -> Mapping[str, ParameterLike]:
         raise NotImplementedError
 
@@ -508,7 +508,7 @@ class FuncParameterList(so.ObjectList[Parameter], ParameterLikeList):
 
     def find_named_only(
         self,
-        schema: s_schema.Schema
+        schema: s_schema.Schema,
     ) -> Mapping[str, Parameter]:
         named = {}
         for param in self.objects(schema):
@@ -696,7 +696,7 @@ class CallableCommand(sd.QualifiedObjectCommand[CallableObject]):
     def _get_params(
         self,
         schema: s_schema.Schema,
-        context: sd.CommandContext
+        context: sd.CommandContext,
     ) -> so.ObjectList[Parameter]:
         params = []
         for cr_param in self.get_subcommands(type=ParameterCommand):
@@ -711,7 +711,7 @@ class CallableCommand(sd.QualifiedObjectCommand[CallableObject]):
         modaliases: Mapping[Optional[str], str],
         astnode: qlast.ObjectDDL,
         *,
-        param_offset: int=0
+        param_offset: int=0,
     ) -> List[ParameterDesc]:
         params = []
         if not hasattr(astnode, 'params'):
@@ -732,7 +732,7 @@ class CallableCommand(sd.QualifiedObjectCommand[CallableObject]):
         cls,
         schema: s_schema.Schema,
         context: sd.CommandContext,
-        cmd: sd.Command
+        cmd: sd.Command,
     ) -> Tuple[s_schema.Schema, List[ParameterDesc]]:
         params = []
         for subcmd in cmd.get_subcommands(type=CreateParameter):
@@ -830,7 +830,7 @@ class DeleteCallableObject(CallableCommand,
         cls,
         schema: s_schema.Schema,
         astnode: qlast.DDLOperation,
-        context: sd.CommandContext
+        context: sd.CommandContext,
     ) -> sd.Command:
         assert isinstance(astnode, qlast.ObjectDDL)
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
@@ -893,7 +893,8 @@ class Function(CallableObject, VolatilitySubject, s_abc.Function,
     def get_verbosename(
         self,
         schema: s_schema.Schema,
-        *, with_parent: bool=False,
+        *,
+        with_parent: bool=False,
     ) -> str:
         params = self.get_params(schema)
         sn = self.get_shortname(schema)
@@ -1124,7 +1125,7 @@ class CreateFunction(CreateCallableObject, FunctionCommand):
         cls,
         schema: s_schema.Schema,
         astnode: qlast.DDLOperation,
-        context: sd.CommandContext
+        context: sd.CommandContext,
     ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
         assert isinstance(astnode, qlast.CreateFunction)

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -751,7 +751,6 @@ class CallableCommand(sd.QualifiedObjectCommand[CallableObject]):
 
 class AlterCallableObject(CallableCommand,
                           sd.AlterObject[CallableObject]):
-    astnode = qlast.AlterCallableObject
 
     def _alter_innards(
         self,
@@ -1224,7 +1223,8 @@ class RenameFunction(sd.RenameObject, FunctionCommand):
     pass
 
 
-class AlterFunction(sd.AlterObject[Function], FunctionCommand):
+class AlterFunction(AlterCallableObject,
+                    FunctionCommand):
     astnode = qlast.AlterFunction
 
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -362,10 +362,10 @@ class ParameterCommandContext(sd.ObjectCommandContext[Parameter]):
     pass
 
 
-# type ignore below, because adding [Parameter] and consequently making
-# Parameter a referencing.ReferencedObject breaks the code
+# type ignore below, because making Parameter
+# a referencing.ReferencedObject breaks the code
 class ParameterCommand(
-    referencing.StronglyReferencedObjectCommand,  # type: ignore
+    referencing.StronglyReferencedObjectCommand[Parameter],  # type: ignore
     schema_metaclass=Parameter,
     context_class=ParameterCommandContext,
     referrer_context_class=CallableCommandContext
@@ -699,7 +699,7 @@ class CallableCommand(sd.QualifiedObjectCommand[CallableObject]):
     ) -> so.ObjectList[Parameter]:
         params = []
         for cr_param in self.get_subcommands(type=ParameterCommand):
-            param: Parameter = schema.get(cr_param.classname)
+            param = schema.get(cr_param.classname, type=Parameter)
             params.append(param)
         return FuncParameterList.create(schema, params)
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1084,7 +1084,6 @@ class CreateFunction(CreateCallableObject, FunctionCommand):
                     f'invalid default value {p_default.text!r} of parameter '
                     f'{p.get_displayname(schema)!r}: {ex}',
                     context=self.source_context)
-            # 024
             assert isinstance(ir_default, irast.Statement)
 
             check_default_type = True
@@ -1124,7 +1123,6 @@ class CreateFunction(CreateCallableObject, FunctionCommand):
         context: sd.CommandContext
     ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
-        # 002
         assert isinstance(astnode, qlast.CreateFunction)
 
         if astnode.code is not None:

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -172,6 +172,7 @@ class CreateOperator(s_func.CreateCallableObject, OperatorCommand):
         fullname = self.scls.get_name(schema)
         shortname = sn.shortname_from_fullname(fullname)
         return_typemod = self.scls.get_return_typemod(schema)
+        assert isinstance(self.scls, Operator)
         recursive = self.scls.get_recursive(schema)
         derivative_of = self.scls.get_derivative_of(schema)
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2083,7 +2083,7 @@ def ensure_schema_collection(
 def cleanup_schema_collection(
     schema: s_schema.Schema,
     coll_type: Type,
-    parent: Type,
+    parent: so.Object,
     parent_cmd: sd.Command,
     *,
     src_context: Optional[parsing.ParserContext] = None,

--- a/mypy.ini
+++ b/mypy.ini
@@ -580,3 +580,19 @@ no_implicit_optional = True
 warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
+
+[mypy-edb.schema.functions]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 85.11)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 87.41)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.43)

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 87.41)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 87.44)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.43)


### PR DESCRIPTION
Adds annotations for schema functions, including a small refactoring of how `get_shortname` is used in `Parameter` class: its signature is made consistent with the one inherited from `QualifiedObject`, and replaces the places where it is used with a new function `get_parameter_name`.