### PR TITLE
Fix implicit limit injection in non-computed multi pointer in shape

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -317,7 +317,8 @@ def _normalize_view_ptr_expr(
                 shape_el.offset or shape_el.limit or
                 base_ptr_is_computable or
                 is_polymorphic or
-                target_typexpr is not None):
+                target_typexpr is not None or
+                ctx.implicit_limit):
 
             if target_typexpr is None:
                 qlexpr = qlast.Path(steps=[source, lexpr])

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2548,6 +2548,19 @@ class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):
                 r"""
                     WITH MODULE test
                     SELECT FL_B {
+                        a,
+                    } ORDER BY .n
+                """,
+                __limit__=2
+            )
+
+            self.assertEqual(len(result), 2)
+            self.assertEqual(len(result[0].a), 2)
+
+            result = await self.con._fetchall(
+                r"""
+                    WITH MODULE test
+                    SELECT FL_B {
                         a ORDER BY .n,
                         a_arr := array_agg(.a)
                     } ORDER BY .n


### PR DESCRIPTION
This fixes another case of missed implicit limit injection in cases
like:

    SELECT Foo { ptr }

where `ptr` is a multi link or property.

Per report from @jaclarke