### PR TITLE
Make Parametric compatible with Generic types

### DIFF
--- a/edb/common/checked.py
+++ b/edb/common/checked.py
@@ -41,7 +41,9 @@ K = TypeVar("K")
 V = TypeVar("V")
 
 
-class ParametricContainer(parametric.ParametricType):
+class ParametricContainer:
+
+    types: ClassVar[Optional[Tuple[type, ...]]] = None
 
     def __reduce__(self) -> Tuple[Any, ...]:
         assert self.types is not None, f'missing parameters in {type(self)}'
@@ -113,7 +115,7 @@ class AbstractCheckedList(Generic[T]):
 
 class FrozenCheckedList(
     ParametricContainer,
-    parametric.SingleParameter,
+    parametric.SingleParametricType[T],
     AbstractCheckedList[T],
     Sequence[T],
 ):
@@ -166,7 +168,7 @@ class FrozenCheckedList(
 
 class CheckedList(
     ParametricContainer,
-    parametric.SingleParameter,
+    parametric.SingleParametricType[T],
     AbstractCheckedList[T],
     MutableSequence[T],
 ):
@@ -323,7 +325,7 @@ class AbstractCheckedSet(AbstractSet[T]):
 
 class FrozenCheckedSet(
     ParametricContainer,
-    parametric.SingleParameter,
+    parametric.SingleParametricType[T],
     AbstractCheckedSet[T],
 ):
     def __init__(self, iterable: Iterable[T] = ()) -> None:
@@ -397,7 +399,7 @@ class FrozenCheckedSet(
 
 class CheckedSet(
     ParametricContainer,
-    parametric.SingleParameter,
+    parametric.SingleParametricType[T],
     AbstractCheckedSet[T],
     MutableSet[T],
 ):
@@ -554,7 +556,7 @@ class AbstractCheckedDict(Generic[K, V]):
 
 class CheckedDict(
     ParametricContainer,
-    parametric.KeyValueParameter,
+    parametric.KeyValueParametricType[K, V],
     AbstractCheckedDict[K, V],
     MutableMapping[K, V],
 ):

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -958,7 +958,7 @@ class IntrospectionMech:
                 expr_type=s_types.ExprType(r['expr_type']),
                 alias_is_persistent=r['alias_is_persistent'],
                 named=r['named'],
-                element_types=s_obj.ObjectDict[s_types.Type].create(
+                element_types=s_obj.ObjectDict[str, s_types.Type].create(
                     schema, dict(eltypes.iter_subtypes(schema))),
             )
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1511,7 +1511,7 @@ class BaseTuple(Collection, s_abc.Tuple):
         ct.set_attribute_value('named', self.is_named(schema))
         ct.set_attribute_value(
             'element_types',
-            so.ObjectDict[Type].create(
+            so.ObjectDict[str, Type].create(
                 schema,
                 dict(self.iter_subtypes(schema)),
             ))
@@ -1610,7 +1610,7 @@ class Tuple(EphemeralCollection, BaseTuple):
             id=self.id,
             name=str(self.id),
             named=self.named,
-            element_types=so.ObjectDict[Type].create(schema, el_types),
+            element_types=so.ObjectDict[str, Type].create(schema, el_types),
         )
 
     def __getstate__(self) -> Dict[str, Any]:
@@ -1632,7 +1632,7 @@ class BaseSchemaTuple(SchemaCollection, BaseTuple):
     )
 
     element_types = so.SchemaField(  # type: ignore
-        so.ObjectDict[Type],
+        so.ObjectDict[str, Type],
         coerce=True,
         # We want a low compcoef so that tuples are *never* altered.
         compcoef=0,
@@ -1647,12 +1647,10 @@ class BaseSchemaTuple(SchemaCollection, BaseTuple):
     def iter_subtypes(
         self, schema: s_schema.Schema
     ) -> Iterator[typing.Tuple[str, Type]]:
-        # TODO: SchemaFields need to be made generic in the Mypy plugin
-        yield from self.get_element_types(schema).items(schema)  # type: ignore
+        yield from self.get_element_types(schema).items(schema)
 
     def get_subtypes(self, schema: s_schema.Schema) -> typing.Tuple[Type, ...]:
-        # TODO: SchemaFields need to be made generic in the Mypy plugin
-        return self.get_element_types(schema).values(schema)  # type: ignore
+        return self.get_element_types(schema).values(schema)
 
         if self.element_types:
             return self.element_types.objects(schema)

--- a/tests/common/test_checked.py
+++ b/tests/common/test_checked.py
@@ -70,7 +70,7 @@ class CheckedDictTests(EnsureTypeChecking, unittest.TestCase):
         with self.assertRaises(ValueError):
             StrDict(**{"foo": "bar"})
 
-        with self.assertRaisesRegex(TypeError, "expects two type parameters"):
+        with self.assertRaisesRegex(TypeError, "expects 2 type parameters"):
             # no value type given
             CheckedDict[int]
 
@@ -203,7 +203,7 @@ class CheckedListTestBase(EnsureTypeChecking):
         with self.assertRaisesRegex(TypeError, "must be parametrized"):
             self.BaseList()
 
-        with self.assertRaisesRegex(TypeError, "expects one type parameter"):
+        with self.assertRaisesRegex(TypeError, "expects 1 type parameter"):
             self.BaseList[int, int]()
 
         with self.assertRaisesRegex(TypeError, "already parametrized"):

--- a/tests/common/test_parametric.py
+++ b/tests/common/test_parametric.py
@@ -1,0 +1,98 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2011-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+from typing import *  # NoQA
+
+import unittest
+
+from edb.common.parametric import ParametricType
+
+T = TypeVar("T")
+K = TypeVar("K")
+Z = TypeVar("Z")
+A = TypeVar("A")
+B = TypeVar("B")
+
+
+class ParametricTypeTests(unittest.TestCase):
+
+    def test_common_parametric_basics(self) -> None:
+
+        with self.assertRaisesRegex(
+            TypeError,
+            'must be declared as Generic'
+        ):
+            class Foo(ParametricType):
+                pass
+
+        with self.assertRaisesRegex(
+            TypeError,
+            'P1: missing ClassVar for generic parameter ~T'
+        ):
+            class P1(ParametricType, Generic[T]):
+                pass
+
+        class P2(ParametricType, Generic[T]):
+            random_class_var: ClassVar[int]
+            another_class_var: ClassVar[Type[str]]
+            not_class_var: int
+            t: ClassVar[Type[T]]
+
+        self.assertTrue(issubclass(P2[int].t, int))
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "type 'P2' expects 1 type parameter, got 2"
+        ):
+            P2[int, str]
+
+        with self.assertRaisesRegex(
+            TypeError,
+            "P3: missing one or more type arguments for base 'P2'"
+        ):
+            class P3(P2, Generic[K]):
+                pass
+
+        class P4(P2[Z], Generic[K, Z]):
+            pass
+
+        self.assertTrue(issubclass(P4[str, int].t, int))
+
+        class Bar:
+            pass
+
+        class P5(P4[A, B], Bar):
+            pass
+
+        self.assertTrue(issubclass(P5[float, str].t, str))
+
+        # Note the origin class error below is imperfect because we
+        # rely on __orig_bases__ in the subclass check and that elides
+        # P5.
+        with self.assertRaisesRegex(
+            TypeError,
+            "P6: missing one or more type arguments for base 'P4'"
+        ):
+            class P6(P5):
+                pass
+
+        class P7(P5[int, float]):
+            pass
+
+        self.assertTrue(issubclass(P7.t, float))

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -197,7 +197,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "cli", 36.67)
 
     def test_cqa_type_coverage_common(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "common", 34.79)
+        self.assertFunctionCoverage(EDB_DIR / "common", 35.16)
 
     def test_cqa_type_coverage_common_ast(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "common" / "ast", 7.58)


### PR DESCRIPTION
In most cases, the number of generic type variables in a subclass of
`Parametric` would match the number `Parametric` expects.  However, 
sometimes it is useful to be able to declare extra type vars that are
_not_ managed by `Parametric`, and this commit makes this possible.

Bonus: `ObjectDict` now has properly parametrized keys.