### PR TITLE
Always derive collection types via schema

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -505,6 +505,7 @@ def compile_func_to_ir(
     )
 
     assert isinstance(ir, irast.Statement)
+    schema = ir.schema
 
     return_type = func.get_return_type(schema)
     if (not ir.stype.issubclass(schema, return_type)

--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -33,6 +33,7 @@ from . import context
 from . import dispatch
 from . import inference
 from . import polyres
+from . import schemactx
 from . import setgen
 from . import stmtctx
 
@@ -97,8 +98,8 @@ def compile_orderby_clause(
                     kwargs={},
                     ctx=exprctx)
                 if len(matched) != 1:
-                    sort_type_name = sort_type.material_type(env.schema) \
-                                              .get_displayname(env.schema)
+                    sort_type_name = schemactx.get_material_type(
+                        sort_type, ctx=ctx).get_displayname(env.schema)
                     if len(matched) == 0:
                         raise errors.QueryError(
                             f'type {sort_type_name!r} cannot be used in '

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -150,6 +150,9 @@ class Environment:
     schema: s_schema.Schema
     """A Schema instance to use for class resolution."""
 
+    orig_schema: s_schema.Schema
+    """A Schema as it was at the start of the compilation."""
+
     parent_object_type: Optional[s_obj.ObjectMeta]
     """The type of a schema object, if the expression is part of its def."""
 
@@ -231,6 +234,7 @@ class Environment:
         func_params: Optional[s_func.ParameterLikeList]=None,
     ) -> None:
         self.schema = schema
+        self.orig_schema = schema
         self.path_scope = path_scope
         self.schema_view_cache = {}
         self.query_parameters = {}

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -586,7 +586,9 @@ def compile_type_check_op(
                 f'type checks on non-primitive collections are not supported'
             )
 
-        test_type = irtyputils.ir_typeref_to_type(ctx.env.schema, typeref)
+        ctx.env.schema, test_type = (
+            irtyputils.ir_typeref_to_type(ctx.env.schema, typeref)
+        )
         result = ltype.issubclass(ctx.env.schema, test_type)
 
     return irast.TypeCheckOp(

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -373,8 +373,8 @@ def compile_operator(
         matched_call = matched[0]
     else:
         if len(args) == 2:
-            ltype = args[0][0].material_type(env.schema)
-            rtype = args[1][0].material_type(env.schema)
+            ltype = schemactx.get_material_type(args[0][0], ctx=ctx)
+            rtype = schemactx.get_material_type(args[1][0], ctx=ctx)
 
             types = (
                 f'{ltype.get_displayname(env.schema)!r} and '
@@ -382,7 +382,8 @@ def compile_operator(
         else:
             types = ', '.join(
                 repr(
-                    a[0].material_type(env.schema).get_displayname(env.schema)
+                    schemactx.get_material_type(
+                        a[0], ctx=ctx).get_displayname(env.schema)
                 ) for a in args
             )
 
@@ -456,10 +457,14 @@ def compile_operator(
         else:
             larg, _, rarg = (a.expr for a in final_args)
 
-        left_type = setgen.get_set_type(larg, ctx=ctx).material_type(
-            ctx.env.schema)
-        right_type = setgen.get_set_type(rarg, ctx=ctx).material_type(
-            ctx.env.schema)
+        left_type = schemactx.get_material_type(
+            setgen.get_set_type(larg, ctx=ctx),
+            ctx=ctx,
+        )
+        right_type = schemactx.get_material_type(
+            setgen.get_set_type(rarg, ctx=ctx),
+            ctx=ctx,
+        )
 
         if left_type.issubclass(env.schema, right_type):
             rtype = right_type

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -53,8 +53,10 @@ def get_tuple_indirection_path_id(
         element_type: s_types.Type, *,
         ctx: context.ContextLevel) -> irast.PathId:
 
+    ctx.env.schema, src_t = irtyputils.ir_typeref_to_type(
+        ctx.env.schema, tuple_path_id.target)
     ptrcls = irast.TupleIndirectionLink(
-        irtyputils.ir_typeref_to_type(ctx.env.schema, tuple_path_id.target),
+        src_t,
         element_type,
         element_name=element_name,
     )

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -179,8 +179,12 @@ def try_bind_call_args(
             if resolved_poly_base_type == resolved:
                 return s_types.MAX_TYPE_DISTANCE if is_abstract else 0
 
-            ct = resolved_poly_base_type.find_common_implicitly_castable_type(
-                resolved, ctx.env.schema)
+            ctx.env.schema, ct = (
+                resolved_poly_base_type.find_common_implicitly_castable_type(
+                    resolved,
+                    ctx.env.schema,
+                )
+            )
 
             if ct is not None:
                 # If we found a common implicitly castable type, we
@@ -445,8 +449,8 @@ def try_bind_call_args(
 
     if return_type.is_polymorphic(schema):
         if resolved_poly_base_type is not None:
-            return_type = return_type.to_nonpolymorphic(
-                schema, resolved_poly_base_type)
+            ctx.env.schema, return_type = return_type.to_nonpolymorphic(
+                ctx.env.schema, resolved_poly_base_type)
         elif not in_polymorphic_func:
             return None
 
@@ -455,10 +459,11 @@ def try_bind_call_args(
     if resolved_poly_base_type is not None:
         for i, barg in enumerate(bound_param_args):
             if barg.param_type.is_polymorphic(schema):
+                ctx.env.schema, ptype = barg.param_type.to_nonpolymorphic(
+                    ctx.env.schema, resolved_poly_base_type)
                 bound_param_args[i] = BoundArg(
                     barg.param,
-                    barg.param_type.to_nonpolymorphic(
-                        schema, resolved_poly_base_type),
+                    ptype,
                     barg.val,
                     barg.valtype,
                     barg.cast_distance,

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -348,6 +348,16 @@ def get_intersection_type(
     return intersection
 
 
+def get_material_type(
+    t: s_types.TypeT,
+    *,
+    ctx: context.ContextLevel,
+) -> s_types.TypeT:
+
+    ctx.env.schema, mtype = t.material_type(ctx.env.schema)
+    return mtype
+
+
 class TypeIntersectionResult(NamedTuple):
 
     stype: s_types.Type
@@ -475,8 +485,8 @@ def is_type_compatible(
     ctx: context.ContextLevel,
 ) -> bool:
 
-    material_type_a = type_a.material_type(ctx.env.schema)
-    material_type_b = type_b.material_type(ctx.env.schema)
+    material_type_a = get_material_type(type_a, ctx=ctx)
+    material_type_b = get_material_type(type_b, ctx=ctx)
 
     compatible = material_type_b.issubclass(ctx.env.schema, material_type_a)
     if compatible:

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -165,7 +165,8 @@ def new_array_set(
         stype = inference.infer_type(arr, env=ctx.env)
     else:
         anytype = s_pseudo.Any.get(ctx.env.schema)
-        stype = s_types.Array.from_subtypes(ctx.env.schema, [anytype])
+        ctx.env.schema, stype = s_types.Array.from_subtypes(
+            ctx.env.schema, [anytype])
         if srcctx is not None:
             ctx.env.type_origins[anytype] = srcctx
 
@@ -718,7 +719,7 @@ def type_intersection_set(
         # route link property references accordingly.
         for component in rptr.ptrref.union_components:
             component_endpoint_ref = component.dir_target
-            component_endpoint = irtyputils.ir_typeref_to_type(
+            ctx.env.schema, component_endpoint = irtyputils.ir_typeref_to_type(
                 ctx.env.schema, component_endpoint_ref)
             if component_endpoint.issubclass(ctx.env.schema, stype):
                 assert isinstance(component, irast.PointerRef)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -288,15 +288,18 @@ def compile_InsertQuery(
         stmt_subject_stype = setgen.get_set_type(subject, ctx=ictx)
 
         result = setgen.class_set(
-            stmt_subject_stype.material_type(ctx.env.schema),
-            path_id=stmt.subject.path_id, ctx=ctx)
+            schemactx.get_material_type(stmt_subject_stype, ctx=ctx),
+            path_id=stmt.subject.path_id,
+            ctx=ctx,
+        )
 
         stmt.result = compile_query_subject(
             result,
             view_scls=ctx.view_scls,
             view_name=ctx.toplevel_result_view_name,
             compile_views=ictx.stmt is ictx.toplevel_stmt,
-            ctx=ictx)
+            ctx=ictx,
+        )
 
         result = fini_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 
@@ -349,15 +352,18 @@ def compile_UpdateQuery(
         stmt_subject_stype = setgen.get_set_type(subject, ctx=ictx)
 
         result = setgen.class_set(
-            stmt_subject_stype.material_type(ctx.env.schema),
-            path_id=stmt.subject.path_id, ctx=ctx)
+            schemactx.get_material_type(stmt_subject_stype, ctx=ctx),
+            path_id=stmt.subject.path_id,
+            ctx=ctx,
+        )
 
         stmt.result = compile_query_subject(
             result,
             view_scls=ctx.view_scls,
             view_name=ctx.toplevel_result_view_name,
             compile_views=ictx.stmt is ictx.toplevel_stmt,
-            ctx=ictx)
+            ctx=ictx,
+        )
 
         result = fini_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 
@@ -433,15 +439,18 @@ def compile_DeleteQuery(
 
         stmt_subject_stype = setgen.get_set_type(subject, ctx=ictx)
         result = setgen.class_set(
-            stmt_subject_stype.material_type(ctx.env.schema),
-            path_id=stmt.subject.path_id, ctx=ctx)
+            schemactx.get_material_type(stmt_subject_stype, ctx=ctx),
+            path_id=stmt.subject.path_id,
+            ctx=ctx,
+        )
 
         stmt.result = compile_query_subject(
             result,
             view_scls=ctx.view_scls,
             view_name=ctx.toplevel_result_view_name,
             compile_views=ictx.stmt is ictx.toplevel_stmt,
-            ctx=ictx)
+            ctx=ictx,
+        )
 
         result = fini_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -480,12 +480,13 @@ def _normalize_view_ptr_expr(
                 # paths.
                 src_path_id = path_id.src_path()
                 assert src_path_id is not None
+                ctx.env.schema, src_t = irtyputils.ir_typeref_to_type(
+                    shape_expr_ctx.env.schema,
+                    src_path_id.target,
+                )
                 prefix_rptr = irast.Pointer(
                     source=setgen.class_set(
-                        irtyputils.ir_typeref_to_type(
-                            shape_expr_ctx.env.schema,
-                            src_path_id.target,
-                        ),
+                        src_t,
                         path_id=src_path_id,
                         ctx=shape_expr_ctx,
                     ),
@@ -514,8 +515,10 @@ def _normalize_view_ptr_expr(
         ptr_cardinality = None
         ptr_target = inference.infer_type(irexpr, ctx.env)
 
-        if (isinstance(ptr_target, s_types.Collection)
-                and not ctx.env.schema.get_by_id(ptr_target.id, default=None)):
+        if (
+            isinstance(ptr_target, s_types.Collection)
+            and not ctx.env.orig_schema.get_by_id(ptr_target.id, default=None)
+        ):
             # Record references to implicitly defined collection types,
             # so that the alias delta machinery can pick them up.
             ctx.env.created_schema_objects.add(ptr_target)

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -960,8 +960,7 @@ class GQLCoreSchema:
 
         else:
             edb_base = name
-            edb_base_name = edb_base.get_name(self.edb_schema)
-            name = f'{edb_base_name.module}::{edb_base_name.name}'
+            name = edb_base.get_name(self.edb_schema)
 
         if not name.startswith('stdgraphql::'):
             if edb_base is None:
@@ -1017,7 +1016,7 @@ class GQLBaseType(metaclass=GQLTypeMeta):
 
         # __typename
         if name is None:
-            self._name = f'{edb_base_name.module}::{edb_base_name.name}'
+            self._name = edb_base_name
         else:
             self._name = name
         # determine module from name if not already specified

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -232,7 +232,7 @@ def cast_const_to_python(
         ir: irast.TypeCast,
         schema: s_schema.Schema) -> Any:
 
-    stype = irtyputils.ir_typeref_to_type(schema, ir.to_type)
+    schema, stype = irtyputils.ir_typeref_to_type(schema, ir.to_type)
     pytype = scalar_type_to_python_type(stype, schema)
     sval = evaluate_to_python_val(ir.expr, schema=schema)
     return pytype(sval)

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -353,7 +353,7 @@ def get_backend_name(schema, obj, catenate=True, *, aspect=None):
         return get_constraint_backend_name(
             obj.id, module.id, catenate, aspect=aspect)
 
-    elif isinstance(obj, s_types.BaseTuple):
+    elif isinstance(obj, s_types.Tuple):
         return get_tuple_backend_name(
             obj.id, catenate, aspect=aspect)
 

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 
 from typing import *
 
+from edb.ir import typeutils as irtyputils
+
 from edb.pgsql import ast as pgast
 from edb.pgsql import types as pg_types
 
@@ -79,7 +81,7 @@ def tuple_getattr(
 
     set_expr: pgast.BaseExpr
 
-    if tuple_typeref.in_schema:
+    if irtyputils.is_persistent_tuple(tuple_typeref):
         set_expr = pgast.Indirection(
             arg=tuple_val,
             indirection=[

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -88,7 +88,7 @@ def array_as_json_object(
 
             json_args.append(val)
 
-            if not el_type.in_schema:
+            if not irtyputils.is_persistent_tuple(el_type):
                 # Column definition list is only allowed for functions
                 # returning "record", i.e. an anonymous tuple, which
                 # would not be the case for schema-persistent tuple types.
@@ -168,7 +168,7 @@ def unnamed_tuple_as_json_object(
 ) -> pgast.BaseExpr:
     vals: List[pgast.BaseExpr] = []
 
-    if styperef.in_schema:
+    if irtyputils.is_persistent_tuple(styperef):
         for el_idx, el_type in enumerate(styperef.subtypes):
             val: pgast.BaseExpr = pgast.Indirection(
                 arg=expr,
@@ -243,7 +243,7 @@ def named_tuple_as_json_object(
 ) -> pgast.BaseExpr:
     keyvals: List[pgast.BaseExpr] = []
 
-    if styperef.in_schema:
+    if irtyputils.is_persistent_tuple(styperef):
         for el_type in styperef.subtypes:
             keyvals.append(pgast.StringConstant(val=el_type.element_name))
             val: pgast.BaseExpr = pgast.Indirection(
@@ -370,7 +370,7 @@ def output_as_value(
 
         if (expr.typeref is not None
                 and not env.singleton_mode
-                and expr.typeref.in_schema):
+                and irtyputils.is_persistent_tuple(expr.typeref)):
             pg_type = pgtypes.pg_type_from_ir_typeref(expr.typeref)
             val = pgast.TypeCast(
                 arg=val,

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -597,13 +597,13 @@ def finalize_optional_rel(
 
 def get_set_rel_alias(ir_set: irast.Set, *,
                       ctx: context.CompilerContextLevel) -> str:
+    _, _, dname = ir_set.path_id.target_name_hint.rpartition('::')
     if ir_set.rptr is not None and ir_set.rptr.source.typeref is not None:
         alias_hint = '{}_{}'.format(
-            ir_set.rptr.source.typeref.name_hint.name,
+            dname,
             ir_set.rptr.ptrref.shortname.name
         )
     else:
-        _, _, dname = ir_set.path_id.target_name_hint.rpartition('::')
         alias_hint = dname.replace('~', '-')
 
     return alias_hint

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -34,7 +34,6 @@ from edb.common import uuidgen
 
 from edb.edgeql import qltypes
 
-from edb.schema import abc as s_abc
 from edb.schema import constraints as s_constraints
 from edb.schema import database as s_db
 from edb.schema import expr as s_expr
@@ -43,7 +42,6 @@ from edb.schema import modules as s_mod
 from edb.schema import name as sn
 from edb.schema import objects as s_obj
 from edb.schema import pseudo as s_pseudo
-from edb.schema import types as s_types
 
 from edb.server import defines
 
@@ -2039,10 +2037,6 @@ def get_interesting_metaclasses():
         if isinstance(mcls, adapter.Adapter):
             continue
 
-        if (issubclass(mcls, s_abc.Collection)
-                and not issubclass(mcls, s_types.SchemaCollection)):
-            continue
-
         metaclasses.append(mcls)
 
     return metaclasses
@@ -2529,24 +2523,6 @@ def _generate_type_element_view(schema, type_fields):
             types AS q
         WHERE
             q.position IS NOT NULL
-
-        UNION ALL
-
-        SELECT
-            st.id           AS id,
-            (SELECT id FROM edgedb.Object
-                 WHERE name = 'schema::TypeElement')
-                            AS __type__,
-            st.maintype     AS type,
-            st.name         AS name,
-            st.position     AS num
-        FROM
-            edgedb.TupleExprAlias AS q,
-            LATERAL UNNEST ((q.element_types).types) AS st(
-                id, maintype, name, position
-            )
-        WHERE
-            st.position IS NOT NULL
     '''
 
     return dbops.View(name=tabname(schema, TypeElement), query=view_query)

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -76,16 +76,18 @@ class ConstraintMech:
             rptr = ref.rptr
             if rptr is not None:
                 ptrref = ref.rptr.ptrref
-                ptr = irtyputils.ptrcls_from_ptrref(ptrref, schema=schema)
+                schema, ptr = irtyputils.ptrcls_from_ptrref(
+                    ptrref, schema=schema)
                 if ptr.is_link_property(schema):
                     srcref = ref.rptr.source.rptr.ptrref
-                    src = irtyputils.ptrcls_from_ptrref(srcref, schema=schema)
+                    schema, src = irtyputils.ptrcls_from_ptrref(
+                        srcref, schema=schema)
                     if src.get_is_derived(schema):
                         # This specialized pointer was derived specifically
                         # for the purposes of constraint expr compilation.
                         src = src.get_bases(schema).first(schema)
                 else:
-                    src = irtyputils.ir_typeref_to_type(
+                    schema, src = irtyputils.ir_typeref_to_type(
                         schema, ref.rptr.source.typeref)
                 ref_ptrs[ref] = (ptr, src)
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -612,7 +612,7 @@ class CreateConstraint(
             num=param_offset,
             name='__subject__',
             default=None,
-            type=s_pseudo.Any.get(schema),
+            type=s_pseudo.AnyTypeShell(),
             typemod=ft.TypeModifier.SINGLETON,
             kind=ft.ParameterKind.POSITIONAL,
         ))

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -63,8 +63,8 @@ def get_global_dep_order() -> Tuple[Type[so.Object], ...]:
         constraints.Constraint,
         scalars.ScalarType,
         # schema arrays and tuples are UnqualifiedObject
-        types.SchemaArray,
-        types.SchemaTuple,
+        types.Array,
+        types.Tuple,
         # aliases are treated separately because they are not UnqualifiedObject
         types.ArrayExprAlias,
         types.TupleExprAlias,

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -84,9 +84,9 @@ class AliasCommand(
 
             if isinstance(scls, s_scalars.ScalarType):
                 mapping = cls._scalar_cmd_map
-            elif isinstance(scls, s_types.BaseTuple):
+            elif isinstance(scls, s_types.Tuple):
                 mapping = cls._tuple_cmd_map
-            elif isinstance(scls, s_types.BaseArray):
+            elif isinstance(scls, s_types.Array):
                 mapping = cls._array_cmd_map
             elif isinstance(scls, s_objtypes.ObjectType):
                 mapping = cls._objtype_cmd_map

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -86,7 +86,7 @@ class ObjectType(
 
     def get_displayname(self, schema):
         if self.is_view(schema) and not self.get_alias_is_persistent(schema):
-            mtype = self.material_type(schema)
+            schema, mtype = self.material_type(schema)
         else:
             mtype = self
 
@@ -143,9 +143,14 @@ class ObjectType(
         return self.issubclass(schema, other)
 
     def find_common_implicitly_castable_type(
-            self, other: s_types.Type,
-            schema) -> Optional[s_types.Type]:
-        return utils.get_class_nearest_common_ancestor(schema, [self, other])
+        self,
+        other: s_types.Type,
+        schema: s_schema.Schema,
+    ) -> Tuple[s_schema.Schema, Optional[s_types.Type]]:
+        return (
+            schema,
+            utils.get_class_nearest_common_ancestor(schema, [self, other]),
+        )
 
     @classmethod
     def get_root_classes(cls):
@@ -206,23 +211,6 @@ class ObjectType(
                 )
 
         return False
-
-    def as_create_delta_for_compound_type(
-        self,
-        schema: s_schema.Schema,
-    ) -> Optional[CreateObjectType]:
-
-        if (not self.get_union_of(schema)
-                and not self.get_intersection_of(schema)):
-            return None
-        else:
-            return type(self).delta(
-                None,
-                self,
-                old_schema=schema,
-                new_schema=schema,
-                context=so.ComparisonContext(),
-            )
 
     def allow_ref_propagation(
         self,

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 from typing import *
 
 import collections
-import uuid
 
 from edb.common import topological
 
@@ -368,11 +367,13 @@ def get_object(
 ) -> so.Object:
     metaclass = op.get_schema_metaclass()
 
-    if issubclass(metaclass, s_types.SchemaCollection):
+    if issubclass(metaclass, s_types.Collection):
         if sn.Name.is_qualified(name):
             return schema.get(name)
         else:
-            return schema.get_by_id(uuid.UUID(name))
+            t_id = s_types.type_id_from_name(name)
+            assert t_id is not None
+            return schema.get_by_id(t_id)
     elif not issubclass(metaclass, so.QualifiedObject):
         return schema.get_global(metaclass, name)
     else:

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -438,7 +438,10 @@ class CreateReferencedObject(
 
             cmd.set_attribute_value(
                 refdict.backref_attr,
-                so.ObjectShell(name=referrer_name),
+                so.ObjectShell(
+                    name=referrer_name,
+                    schemaclass=referrer_class,
+                ),
             )
 
             cmd.set_attribute_value('is_local', True)

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -89,10 +89,10 @@ class ScalarType(
         self,
         schema: s_schema.Schema,
         concrete_type: ScalarType,
-    ) -> ScalarType:
+    ) -> Tuple[s_schema.Schema, ScalarType]:
         if (not concrete_type.is_polymorphic(schema) and
                 concrete_type.issubclass(schema, self)):
-            return concrete_type
+            return schema, concrete_type
         raise TypeError(
             f'cannot interpret {concrete_type.get_name(schema)} '
             f'as {self.get_name(schema)}')
@@ -149,23 +149,26 @@ class ScalarType(
         self,
         other: s_types.Type,
         schema: s_schema.Schema,
-    ) -> Optional[ScalarType]:
+    ) -> Tuple[s_schema.Schema, Optional[ScalarType]]:
 
         if not isinstance(other, ScalarType):
-            return None
+            return schema, None
 
         if self.is_polymorphic(schema) and other.is_polymorphic(schema):
-            return self
+            return schema, self
 
         left = self.get_topmost_concrete_base(schema)
         right = other.get_topmost_concrete_base(schema)
 
         if left == right:
-            return left
+            return schema, left
         else:
-            return cast(
-                Optional[ScalarType],
-                s_casts.find_common_castable_type(schema, left, right),
+            return (
+                schema,
+                cast(
+                    Optional[ScalarType],
+                    s_casts.find_common_castable_type(schema, left, right),
+                )
             )
 
     def get_base_for_cast(self, schema: s_schema.Schema) -> so.Object:

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -408,14 +408,14 @@ class Compiler(BaseCompiler):
                             array_params.append(
                                 (idx, el_type.get_backend_id(ir.schema)))
 
-                params_type = s_types.Tuple.create(
+                ir.schema, params_type = s_types.Tuple.create(
                     ir.schema,
                     element_types=collections.OrderedDict(subtypes),
                     named=named)
                 if array_params:
                     in_array_backend_tids = {p[0]: p[1] for p in array_params}
             else:
-                params_type = s_types.Tuple.create(
+                ir.schema, params_type = s_types.Tuple.create(
                     ir.schema, element_types={}, named=False)
 
             in_type_data, in_type_id = sertypes.TypeSerializer.describe(
@@ -1317,7 +1317,7 @@ class Compiler(BaseCompiler):
         ptrdesc: List[DumpBlockDescriptor] = []
 
         if isinstance(source, s_props.Property):
-            prop_tuple = s_types.Tuple.from_subtypes(
+            schema, prop_tuple = s_types.Tuple.from_subtypes(
                 schema,
                 {
                     'source': schema.get('std::uuid'),
@@ -1369,7 +1369,7 @@ class Compiler(BaseCompiler):
 
                 props[ptr.get_shortname(schema).name] = ptr.get_target(schema)
 
-            link_tuple = s_types.Tuple.from_subtypes(
+            schema, link_tuple = s_types.Tuple.from_subtypes(
                 schema,
                 props,
                 {'named': True},

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -31,6 +31,7 @@ from edb.common import uuidgen
 
 from edb.schema import links as s_links
 from edb.schema import objects as s_obj
+from edb.schema import scalars as s_scalars
 from edb.schema import types as s_types
 
 
@@ -133,7 +134,7 @@ class TypeSerializer:
                                             view_shapes_metadata)
                         for st in t.get_subtypes(self.schema)]
 
-            if t.named:
+            if t.is_named(self.schema):
                 element_names = list(t.get_element_names(self.schema))
                 assert len(element_names) == len(subtypes)
 
@@ -194,7 +195,7 @@ class TypeSerializer:
 
         elif view_shapes.get(t):
             # This is a view
-            mt = t.material_type(self.schema)
+            self.schema, mt = t.material_type(self.schema)
             base_type_id = mt.id
 
             subtypes = []
@@ -287,10 +288,10 @@ class TypeSerializer:
             self._register_type_id(type_id)
             return type_id
 
-        elif t.is_scalar():
+        elif isinstance(t, s_scalars.ScalarType):
             # This is a scalar type
 
-            mt = t.material_type(self.schema)
+            self.schema, mt = t.material_type(self.schema)
             type_id = mt.id
             if type_id in self.uuid_to_pos:
                 # already described

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_02_15_00_00
+EDGEDB_CATALOG_VERSION = 2020_03_30_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1939,7 +1939,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.InvalidOperatorDefinitionError,
                 r'cannot create the '
-                r'`test::=\(l: std::array<anytype>, r: std::str\)` operator: '
+                r'`test::=\(l: array<anytype>, r: std::str\)` operator: '
                 r'operands of a recursive operator must either be '
                 r'all arrays or all tuples'):
             await self.con.execute('''
@@ -1954,7 +1954,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.InvalidOperatorDefinitionError,
                 r'cannot create the '
-                r'`test::=\(l: std::array<anytype>, r: anytuple\)` operator: '
+                r'`test::=\(l: array<anytype>, r: anytuple\)` operator: '
                 r'operands of a recursive operator must either be '
                 r'all arrays or all tuples'):
             await self.con.execute('''
@@ -1969,8 +1969,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.InvalidOperatorDefinitionError,
                 r'cannot create the non-recursive '
-                r'`std::=\(l: std::array<std::int64>, '
-                r'r: std::array<std::int64>\)` operator: '
+                r'`std::=\(l: array<std::int64>, '
+                r'r: array<std::int64>\)` operator: '
                 r'overloading a recursive operator '
                 r'`array<anytype> = array<anytype>` with a non-recursive one '
                 r'is not allowed'):
@@ -1987,8 +1987,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.InvalidOperatorDefinitionError,
                 r'cannot create the recursive '
-                r'`test::=\(l: std::array<std::int64>, '
-                r'r: std::array<std::int64>\)` operator: '
+                r'`test::=\(l: array<std::int64>, '
+                r'r: array<std::int64>\)` operator: '
                 r'overloading a non-recursive operator '
                 r'`array<anytype> = array<anytype>` with a recursive one '
                 r'is not allowed'):

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 42.58)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 42.63)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 100.00)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 46.57)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 46.53)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 84.95)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 85.11)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.43)


### PR DESCRIPTION
Currently, collection types (`Tuple` and `Array`) are a weird special
case, whereby collection type instances are normally not tracked by a
schema, except when used by another schema object.  This duality
requires a complex web of classes with lots of hacks to circumvent
typing violations.  The complexity of this implementation far outweighs
any possible benefit of deriving ephemeral collection types outside of the
schema.

This commit reworks the whole thing so that there are now only one class
for each collection kind with the usual traits of the schema object.
The changes are mostly about changing a bunch of functions that may
derive new collection types to return the modified schema object.