### PR TITLE
Graphql rewrite stage 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "edb-graphql-parser"
 version = "0.3.0"
-source = "git+https://github.com/edgedb/graphql-parser#12607994ccba9ac655ce0397749402659b21f7e7"
+source = "git+https://github.com/edgedb/graphql-parser#0aa4ba2ebcd77c61c80d9b59092568213acf4673"
 dependencies = [
  "combine 3.8.1",
  "num-bigint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "edb-graphql-parser"
 version = "0.3.0"
-source = "git+https://github.com/edgedb/graphql-parser#0aa4ba2ebcd77c61c80d9b59092568213acf4673"
+source = "git+https://github.com/edgedb/graphql-parser#562996e30cc77148e419a69734058c792697ac3f"
 dependencies = [
  "combine 3.8.1",
  "num-bigint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "edb-graphql-parser"
 version = "0.3.0"
-source = "git+https://github.com/edgedb/graphql-parser#562996e30cc77148e419a69734058c792697ac3f"
+source = "git+https://github.com/edgedb/graphql-parser#12607994ccba9ac655ce0397749402659b21f7e7"
 dependencies = [
  "combine 3.8.1",
  "num-bigint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "bigdecimal"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460825c9e21708024d67c07057cd5560e5acdccac85de0de624a81d3de51bacb"
+checksum = "1374191e2dd25f9ae02e3aa95041ed5d747fc77b3c102b49fe2dd9a8117a6244"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c875843236b5e2eb535fd0b696387bfb623f896479b10ed626cf442b836e8032"
+checksum = "9d79eb8c0bfd05a68f8b6195b27c4f2e042f86d52da032817f89a3847e0495ed"
 dependencies = [
  "bytes",
  "memchr",
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c5e5ac752e18207b12e16b10631ae5f7f68f8805f335f9b817ead83d9ffce1"
+checksum = "cf6b25ee9ac1995c54d7adb2eff8cfffb7260bc774fb63c601ec65467f43cd9d"
 dependencies = [
  "quote",
  "syn",
@@ -112,7 +112,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "edb-graphql-parser"
 version = "0.3.0"
-source = "git+https://github.com/edgedb/graphql-parser#562996e30cc77148e419a69734058c792697ac3f"
+source = "git+https://github.com/edgedb/graphql-parser#12607994ccba9ac655ce0397749402659b21f7e7"
 dependencies = [
  "combine 3.8.1",
  "num-bigint",
@@ -123,7 +123,7 @@ dependencies = [
 [[package]]
 name = "edgedb-protocol"
 version = "0.1.0"
-source = "git+https://github.com/edgedb/edgedb-rust#2f722174e8e6b8fa9089117ce570c609d2c1ad8c"
+source = "git+https://github.com/edgedb/edgedb-rust#75f5f9a67ad49c003e0b5b219bf58fab06c414a6"
 dependencies = [
  "bigdecimal",
  "bytes",
@@ -137,7 +137,7 @@ dependencies = [
 name = "edgeql-parser"
 version = "0.1.0"
 dependencies = [
- "combine 4.0.1",
+ "combine 4.1.0",
  "snafu",
  "twoway",
 ]
@@ -148,7 +148,7 @@ version = "0.1.0"
 dependencies = [
  "bigdecimal",
  "bytes",
- "combine 4.0.1",
+ "combine 4.1.0",
  "cpython",
  "edgedb-protocol",
  "edgeql-parser",
@@ -182,9 +182,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 
 [[package]]
 name = "memchr"
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
+checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -323,18 +323,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
+checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
+checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/edb/graphql-rewrite/src/entry_point.rs
+++ b/edb/graphql-rewrite/src/entry_point.rs
@@ -171,8 +171,8 @@ pub fn visit_directives<'x>(key_vars: &mut BTreeSet<String>,
 {
     for dir in oper.selection_set.visit::<Directive<_>>() {
         if dir.name == "include" || dir.name == "skip" {
-            for (_, value) in &dir.arguments {
-                match value {
+            for arg in &dir.arguments {
+                match arg.value {
                     GqlValue::Variable(vname) => {
                         key_vars.insert(vname.to_string());
                     }

--- a/edb/graphql-rewrite/src/entry_point.rs
+++ b/edb/graphql-rewrite/src/entry_point.rs
@@ -23,7 +23,7 @@ pub enum Value {
     Int32(i32),
     Int64(i64),
     BigInt(String),
-    Float(f64),
+    Decimal(String),
     Boolean(bool),
 }
 
@@ -258,7 +258,10 @@ pub fn rewrite(operation: Option<&str>, s: &str) -> Result<Entry, Error> {
                     BigInt(s.as_bigint().to_string())
                 }
                 (G::Float(s), Some("Float")) => {
-                    Float(*s)
+                    Decimal(s.clone())
+                }
+                (G::Float(s), Some("Decimal")) => {
+                    Decimal(s.clone())
                 }
                 (G::Boolean(s), Some("Boolean")) => {
                     Boolean(*s)
@@ -374,10 +377,9 @@ pub fn rewrite(operation: Option<&str>, s: &str) -> Result<Entry, Error> {
                 });
                 variables.push(Variable {
                     token: PyToken::new(&(*token, *pos))?,
-                    value: Value::Float(token.value.parse().map_err(
-                        |_| Error::Assertion("can't parse float".into()))?),
+                    value: Value::Decimal(token.value.to_string()),
                 });
-                push_var_definition(&mut args, &var_name, "Float");
+                push_var_definition(&mut args, &var_name, "Decimal");
                 continue;
             }
             Name if token.value == "true" || token.value == "false" => {

--- a/edb/graphql-rewrite/src/entry_point.rs
+++ b/edb/graphql-rewrite/src/entry_point.rs
@@ -39,6 +39,7 @@ pub enum Error {
     Syntax(ParseError),
     NotFound(String),
     Assertion(String),
+    Query(String),
 }
 
 
@@ -226,6 +227,10 @@ pub fn rewrite(operation: Option<&str>, s: &str) -> Result<Entry, Error> {
     visit_directives(&mut key_vars, &mut value_positions, &oper);
 
     for var in &oper.variable_definitions {
+        if var.name.starts_with("_edb_arg__") {
+            return Err(Error::Query(
+                "Variables starting with '_edb_arg__' are prohibited".into()));
+        }
         if let Some(ref dvalue) = var.default_value {
             let value = match (&dvalue.value, type_name(&var.var_type)) {
                 (G::String(ref s), Some("String")) => Str(s.clone()),

--- a/edb/graphql-rewrite/src/pyentry.rs
+++ b/edb/graphql-rewrite/src/pyentry.rs
@@ -164,7 +164,13 @@ fn rewrite(py: Python<'_>, operation: Option<&PyString>, text: &PyString)
                     var.token.position.map(|x| x.column),
                 ).to_py_object(py).into_object())?;
             }
-            // TODO(tailhook) insert defaults
+            for (name, var) in &entry.defaults {
+                vars.set_item(py, name.to_py_object(py),
+                    match var.value {
+                        Value::Str(ref s) => PyString::new(py, s),
+                        _ => todo!(),
+                    })?;
+            }
             Entry::create_instance(py,
                 PyString::new(py, &entry.key),
                 vars,

--- a/edb/graphql-rewrite/src/pyentry.rs
+++ b/edb/graphql-rewrite/src/pyentry.rs
@@ -5,6 +5,7 @@ use edb_graphql_parser::common::{unquote_string, unquote_block_string};
 use edb_graphql_parser::position::Pos;
 
 use crate::pyerrors::{LexingError, SyntaxError, NotFoundError, AssertionError};
+use crate::pyerrors::{QueryError};
 use crate::entry_point::{Value, Error};
 use crate::pytoken::PyToken;
 use crate::entry_point;
@@ -207,6 +208,7 @@ fn rewrite(py: Python<'_>, operation: Option<&PyString>, text: &PyString)
         Err(Error::Lexing(e)) => Err(LexingError::new(py, e.to_string())),
         Err(Error::Syntax(e)) => Err(SyntaxError::new(py, e.to_string())),
         Err(Error::NotFound(e)) => Err(NotFoundError::new(py, e.to_string())),
+        Err(Error::Query(e)) => Err(QueryError::new(py, e.to_string())),
         Err(Error::Assertion(e))
         => Err(AssertionError::new(py, e.to_string())),
     }
@@ -224,5 +226,6 @@ py_module_initializer!(
         m.add(py, "SyntaxError", py.get_type::<SyntaxError>())?;
         m.add(py, "NotFoundError", py.get_type::<NotFoundError>())?;
         m.add(py, "AssertionError", py.get_type::<AssertionError>())?;
+        m.add(py, "QueryError", py.get_type::<QueryError>())?;
         Ok(())
     });

--- a/edb/graphql-rewrite/src/pyentry.rs
+++ b/edb/graphql-rewrite/src/pyentry.rs
@@ -12,12 +12,16 @@ use crate::entry_point;
 
 py_class!(pub class Entry |py| {
     data _key: PyString;
+    data _key_vars: PyList;
     data _variables: PyDict;
     data _substitutions: PyDict;
     data _tokens: Vec<PyToken>;
     data _end_pos: Pos;
     def key(&self) -> PyResult<PyString> {
         Ok(self._key(py).clone_ref(py))
+    }
+    def key_vars(&self) -> PyResult<PyList> {
+        Ok(self._key_vars(py).clone_ref(py))
     }
     def variables(&self) -> PyResult<PyDict> {
         Ok(self._variables(py).clone_ref(py))
@@ -187,8 +191,13 @@ fn rewrite(py: Python<'_>, operation: Option<&PyString>, text: &PyString)
                         _ => todo!(),
                     })?;
             }
+            let key_vars = PyList::new(py,
+                &entry.key_vars.iter()
+                .map(|v| v.to_py_object(py).into_object())
+                .collect::<Vec<_>>());
             Entry::create_instance(py,
                 PyString::new(py, &entry.key),
+                key_vars,
                 vars,
                 substitutions,
                 entry.tokens,

--- a/edb/graphql-rewrite/src/pyerrors.rs
+++ b/edb/graphql-rewrite/src/pyerrors.rs
@@ -8,11 +8,13 @@ pub struct LexingError(PyObject);
 pub struct SyntaxError(PyObject);
 pub struct NotFoundError(PyObject);
 pub struct AssertionError(PyObject);
+pub struct QueryError(PyObject);
 
 pyobject_newtype!(LexingError);
 pyobject_newtype!(SyntaxError);
 pyobject_newtype!(NotFoundError);
 pyobject_newtype!(AssertionError);
+pyobject_newtype!(QueryError);
 
 impl LexingError {
     pub fn new<'p, T: ToPyObject>(py: Python<'p>, args: T) -> PyErr {
@@ -229,6 +231,62 @@ impl cpython::PythonObjectWithTypeObject for AssertionError {
                 TYPE_OBJECT = PyErr::new_type(
                     py,
                     "edb._graphql_rewrite.AssertionError",
+                    Some(PythonObject::into_object(py.get_type::<Exception>())),
+                    None).as_type_ptr();
+            }
+
+            PyType::from_type_ptr(py, TYPE_OBJECT)
+        }
+    }
+}
+
+impl QueryError {
+    pub fn new<'p, T: ToPyObject>(py: Python<'p>, args: T) -> PyErr {
+        PyErr::new::<QueryError, T>(py, args)
+    }
+}
+
+impl cpython::PythonObjectWithCheckedDowncast for QueryError {
+    #[inline]
+    fn downcast_from<'p>(py: Python<'p>, obj: PyObject)
+        -> Result<QueryError, cpython::PythonObjectDowncastError<'p>>
+    {
+        if QueryError::type_object(py).is_instance(py, &obj) {
+            Ok(unsafe { PythonObject::unchecked_downcast_from(obj) })
+        } else {
+            Err(cpython::PythonObjectDowncastError::new(py,
+                "QueryError",
+                QueryError::type_object(py),
+            ))
+        }
+    }
+
+    #[inline]
+    fn downcast_borrow_from<'a, 'p>(py: Python<'p>, obj: &'a PyObject)
+        -> Result<&'a QueryError, cpython::PythonObjectDowncastError<'p>>
+    {
+        if QueryError::type_object(py).is_instance(py, obj) {
+            Ok(unsafe { PythonObject::unchecked_downcast_borrow_from(obj) })
+        } else {
+            Err(cpython::PythonObjectDowncastError::new(py,
+                "QueryError",
+                QueryError::type_object(py),
+            ))
+        }
+    }
+}
+
+impl cpython::PythonObjectWithTypeObject for QueryError {
+    #[inline]
+    fn type_object(py: Python) -> PyType {
+        unsafe {
+            static mut TYPE_OBJECT: *mut cpython::_detail::ffi::PyTypeObject
+                = 0 as *mut cpython::_detail::ffi::PyTypeObject;
+
+            if TYPE_OBJECT.is_null() {
+                TYPE_OBJECT = PyErr::new_type(
+                    py,
+                    "edb._graphql_rewrite.QueryError",
                     Some(PythonObject::into_object(py.get_type::<Exception>())),
                     None).as_type_ptr();
             }

--- a/edb/graphql-rewrite/src/pytoken.rs
+++ b/edb/graphql-rewrite/src/pytoken.rs
@@ -39,7 +39,8 @@ pub struct PyToken {
 }
 
 impl PyToken {
-    pub fn new((token, position): (Token<'_>, Pos)) -> Result<PyToken, Error> {
+    pub fn new((token, position): &(Token<'_>, Pos)) -> Result<PyToken, Error>
+    {
         use edb_graphql_parser::tokenizer::Kind::*;
         use PyTokenKind as T;
 
@@ -67,7 +68,7 @@ impl PyToken {
         };
         Ok(PyToken {
             kind, value,
-            position: Some(position),
+            position: Some(*position),
         })
     }
 }

--- a/edb/graphql-rewrite/src/token_vec.rs
+++ b/edb/graphql-rewrite/src/token_vec.rs
@@ -3,33 +3,35 @@ use edb_graphql_parser::position::Pos;
 
 
 pub struct TokenVec<'a> {
-    tokens: Vec<(Token<'a>, Pos)>,
+    tokens: &'a Vec<(Token<'a>, Pos)>,
     consumed: usize,
 }
 
 
 impl<'a> TokenVec<'a> {
-    pub fn new(tokens: Vec<(Token<'a>, Pos)>) -> TokenVec {
+    pub fn new(tokens: &'a Vec<(Token<'a>, Pos)>) -> TokenVec {
         TokenVec {
             tokens,
             consumed: 0,
         }
     }
     pub fn drain<'x>(&'x mut self, n: usize)
-        -> impl Iterator<Item=(Token, Pos)> + 'x
+        -> impl Iterator<Item=&(Token, Pos)> + 'x
     {
+        let pos = self.consumed;
         self.consumed += n;
         assert!(n <= self.tokens.len(), "attempt to more tokens than exist");
-        self.tokens.drain(..n)
+        self.tokens[pos..][..n].iter()
     }
     pub fn drain_to<'x>(&'x mut self, end: usize)
-        -> impl Iterator<Item=(Token, Pos)> + 'x
+        -> impl Iterator<Item=&(Token, Pos)> + 'x
     {
         let n = end.checked_sub(self.consumed)
             .expect("drain_to with index smaller than current");
         self.drain(n)
     }
     pub fn len(&self) -> usize {
-        self.tokens.len()
+        self.tokens.len().checked_sub(self.consumed)
+            .expect("consumed more tokens than exists")
     }
 }

--- a/edb/graphql-rewrite/tests/rewrite.rs
+++ b/edb/graphql-rewrite/tests/rewrite.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
 use edb_graphql_parser::{Pos};
-use num_bigint::BigInt;
 
 use graphql_rewrite::{rewrite, Variable, Value};
 use graphql_rewrite::{PyToken, PyTokenKind};
@@ -342,5 +341,72 @@ fn test_bigint() {
             },
             value: Value::BigInt("171234567901234567890".into()),
         }
+    ]);
+}
+
+#[test]
+fn test_first_1() {
+    let entry = rewrite(None, r###"
+        query {
+            object(filter: {field: {eq: 1}}, first: 1) {
+                field
+            }
+        }
+    "###).unwrap();
+    assert_eq!(entry.key, "\
+        query($_edb_arg__0:Int!){\
+            object(filter:{field:{eq:$_edb_arg__0}}first:1){\
+                field\
+            }\
+        }\
+    ");
+    assert_eq!(entry.variables, vec![
+        Variable {
+            token: PyToken {
+                kind: PyTokenKind::Int,
+                value: r#"1"#.into(),
+                position: Some(Pos { line: 3, column: 41,
+                                     character: 57, token: 12 }),
+            },
+            value: Value::Int32(1),
+        }
+    ]);
+}
+
+#[test]
+fn test_first_2() {
+    let entry = rewrite(None, r###"
+        query {
+            object(filter: {field: {eq: 1}}, first: 2) {
+                field
+            }
+        }
+    "###).unwrap();
+    assert_eq!(entry.key, "\
+        query($_edb_arg__0:Int!$_edb_arg__1:Int!){\
+            object(filter:{field:{eq:$_edb_arg__0}}first:$_edb_arg__1){\
+                field\
+            }\
+        }\
+    ");
+    assert_eq!(entry.variables, vec![
+        Variable {
+            token: PyToken {
+                kind: PyTokenKind::Int,
+                value: r#"1"#.into(),
+                position: Some(Pos { line: 3, column: 41,
+                                     character: 57, token: 12 }),
+            },
+            value: Value::Int32(1),
+        },
+        Variable {
+            token: PyToken {
+                kind: PyTokenKind::Int,
+                value: r#"2"#.into(),
+                position: Some(Pos { line: 3, column: 53,
+                                     character: 69, token: 17 }),
+            },
+            value: Value::Int32(2),
+        },
     ]);
 }

--- a/edb/graphql-rewrite/tests/rewrite.rs
+++ b/edb/graphql-rewrite/tests/rewrite.rs
@@ -459,7 +459,7 @@ fn test_float() {
         }
     "###).unwrap();
     assert_eq!(entry.key, "\
-        query($_edb_arg__0:Float!){\
+        query($_edb_arg__0:Decimal!){\
             object(filter:{field:{eq:$_edb_arg__0}}){\
                 field\
             }\
@@ -473,7 +473,7 @@ fn test_float() {
                 position: Some(Pos { line: 3, column: 41,
                                      character: 57, token: 12 }),
             },
-            value: Value::Float(17.25),
+            value: Value::Decimal("17.25".into()),
         }
     ]);
 }
@@ -496,7 +496,7 @@ fn test_defaults_float() {
     ");
     let mut defaults = BTreeMap::new();
     defaults.insert("x".to_owned(), Variable {
-        value: Value::Float(123.25),
+        value: Value::Decimal("123.25".into()),
         token: PyToken {
             kind: PyTokenKind::Equals,
             value: "=".into(),
@@ -505,7 +505,7 @@ fn test_defaults_float() {
         },
     });
     defaults.insert("y".to_owned(), Variable {
-        value: Value::Float(1234.75),
+        value: Value::Decimal("1234.75".into()),
         token: PyToken {
             kind: PyTokenKind::Equals,
             value: "=".into(),

--- a/edb/graphql-rewrite/tests/rewrite.rs
+++ b/edb/graphql-rewrite/tests/rewrite.rs
@@ -410,3 +410,41 @@ fn test_first_2() {
         },
     ]);
 }
+
+#[test]
+fn test_defaults_int() {
+    let entry = rewrite(Some("Hello"), r###"
+        query Hello($x: Int = 123, $y: Int! = 1234) {
+            object(x: $x, y: $y) {
+                field
+            }
+        }
+    "###).unwrap();
+    assert_eq!(entry.key, "\
+        query Hello($x:Int!$y:Int!){\
+            object(x:$x y:$y){\
+                field\
+            }\
+        }\
+    ");
+    let mut defaults = BTreeMap::new();
+    defaults.insert("x".to_owned(), Variable {
+        value: Value::Int32(123),
+        token: PyToken {
+            kind: PyTokenKind::Equals,
+            value: "=".into(),
+            position: Some(Pos { line: 2, column: 29,
+                                 character: 29, token: 7 }),
+        },
+    });
+    defaults.insert("y".to_owned(), Variable {
+        value: Value::Int32(1234),
+        token: PyToken {
+            kind: PyTokenKind::Equals,
+            value: "=".into(),
+            position: Some(Pos { line: 2, column: 45,
+                                 character: 45, token: 14 }),
+        }
+    });
+    assert_eq!(entry.defaults, defaults);
+}

--- a/edb/graphql-rewrite/tests/rewrite.rs
+++ b/edb/graphql-rewrite/tests/rewrite.rs
@@ -448,3 +448,70 @@ fn test_defaults_int() {
     });
     assert_eq!(entry.defaults, defaults);
 }
+
+#[test]
+fn test_float() {
+    let entry = rewrite(None, r###"
+        query {
+            object(filter: {field: {eq: 17.25}}) {
+                field
+            }
+        }
+    "###).unwrap();
+    assert_eq!(entry.key, "\
+        query($_edb_arg__0:Float!){\
+            object(filter:{field:{eq:$_edb_arg__0}}){\
+                field\
+            }\
+        }\
+    ");
+    assert_eq!(entry.variables, vec![
+        Variable {
+            token: PyToken {
+                kind: PyTokenKind::Float,
+                value: r#"17.25"#.into(),
+                position: Some(Pos { line: 3, column: 41,
+                                     character: 57, token: 12 }),
+            },
+            value: Value::Float(17.25),
+        }
+    ]);
+}
+
+#[test]
+fn test_defaults_float() {
+    let entry = rewrite(Some("Hello"), r###"
+        query Hello($x: Float = 123.25, $y: Float! = 1234.75) {
+            object(x: $x, y: $y) {
+                field
+            }
+        }
+    "###).unwrap();
+    assert_eq!(entry.key, "\
+        query Hello($x:Float!$y:Float!){\
+            object(x:$x y:$y){\
+                field\
+            }\
+        }\
+    ");
+    let mut defaults = BTreeMap::new();
+    defaults.insert("x".to_owned(), Variable {
+        value: Value::Float(123.25),
+        token: PyToken {
+            kind: PyTokenKind::Equals,
+            value: "=".into(),
+            position: Some(Pos { line: 2, column: 31,
+                                 character: 31, token: 7 }),
+        },
+    });
+    defaults.insert("y".to_owned(), Variable {
+        value: Value::Float(1234.75),
+        token: PyToken {
+            kind: PyTokenKind::Equals,
+            value: "=".into(),
+            position: Some(Pos { line: 2, column: 52,
+                                 character: 52, token: 14 }),
+        }
+    });
+    assert_eq!(entry.defaults, defaults);
+}

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -73,8 +73,8 @@ _IMPLICIT_CONVERSIONS = {
     ("Int64", "Bigint!"),
     ("Int64", "Decimal"),
     ("Int64", "Decimal!"),
-    ("Float", "Decimal"),
-    ("Float", "Decimal!"),
+    ("Decimal", "Float"),
+    ("Decimal", "Float!"),
 }
 INT_FLOAT_ERROR = re.compile(
     r"Variable '\$[^']+' of type 'Int!?'"

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -377,10 +377,7 @@ class GraphQLTranslator:
 
                 if isinstance(cond, gql_ast.VariableNode):
                     varname = cond.name.value
-                    var = self._context.vars[varname]
-                    # mark the variable as critical
-                    self._context.vars[varname] = var._replace(critical=True)
-                    value = var.val
+                    value = self._context.vars[varname].val
 
                     if value is None:
                         raise g_errors.GraphQLValidationError(

--- a/edb/server/http_graphql_port/compiler.py
+++ b/edb/server/http_graphql_port/compiler.py
@@ -45,7 +45,7 @@ class CompiledOperation:
     sql_args: List[str]
     dbver: int
     cacheable: bool
-    cache_deps_vars: Dict
+    cache_deps_vars: Optional[FrozenSet[str]]
     variables: Dict
 
 

--- a/edb/server/http_graphql_port/protocol.pyx
+++ b/edb/server/http_graphql_port/protocol.pyx
@@ -17,10 +17,11 @@
 #
 
 
+import cython
 import json
 import logging
 import urllib.parse
-from typing import Any, Dict, Tuple, List, Optional
+from typing import Any, Dict, Tuple, List, Optional, Union
 
 from graphql.language import lexer as gql_lexer
 
@@ -45,6 +46,16 @@ _USER_ERRORS = (
     _graphql_rewrite.SyntaxError,
     _graphql_rewrite.NotFoundError,
 )
+
+@cython.final
+cdef class CacheRedirect:
+    cdef public list key_vars  # List[str],  must be sorted
+
+    def __init__(self, key_vars: List[str]):
+        self.key_vars = key_vars
+
+
+CacheEntry = Union[CacheRedirect, compiler.CompiledOperation]
 
 
 cdef class Protocol(http.HttpProtocol):
@@ -200,8 +211,9 @@ cdef class Protocol(http.HttpProtocol):
             vars = rewritten.variables().copy()
             if variables:
                 vars.update(variables)
+            key_var_names = rewritten.key_vars()
             # on bad queries the following line can trigger KeyError
-            key_vars = tuple(vars[k] for k in rewritten.key_vars())
+            key_vars = tuple(vars[k] for k in key_var_names)
         except _graphql_rewrite.QueryError as e:
             raise errors.QueryError(e.args[0])
         except Exception as e:
@@ -213,6 +225,7 @@ cdef class Protocol(http.HttpProtocol):
             rewrite_error = e
             prepared_query = query
             vars = variables.copy() if variables else {}
+            key_var_names = []
             key_vars = ()
         else:
             prepared_query = rewritten.key()
@@ -220,16 +233,20 @@ cdef class Protocol(http.HttpProtocol):
             if debug.flags.graphql_compile:
                 debug.header('GraphQL optimized query')
                 print(rewritten.key())
-                print(f'key_vars: {key_vars}')
+                print(f'key_vars: {key_var_names}')
                 print(f'variables: {vars}')
 
         cache_key = (prepared_query, key_vars, operation_name, dbver)
         use_prep_stmt = False
 
-        op: compiler.CompiledOperation = self.query_cache.get(
-            cache_key, None)
+        entry: CacheEntry = self.query_cache.get(cache_key, None)
 
-        if op is None:
+        if isinstance(entry, CacheRedirect):
+            key_vars2 = tuple(vars[k] for k in entry.key_vars)
+            cache_key2 = (prepared_query, key_vars2, operation_name, dbver)
+            entry = self.query_cache.get(cache_key2, None)
+
+        if entry is None:
             if rewritten is not None:
                 op = await self.compile(
                     dbver, query,
@@ -239,18 +256,23 @@ cdef class Protocol(http.HttpProtocol):
             else:
                 op = await self.compile(
                     dbver, query, None, None, operation_name, vars)
-            self.query_cache[cache_key] = op
-        else:
-            if op.cache_deps_vars:
-                op = await self.compile(dbver,
-                    query,
-                    rewritten.tokens(gql_lexer.TokenKind),
-                    rewritten.substitutions(),
-                    operation_name, vars)
+
+            key_var_set = set(key_var_names)
+            if op.cache_deps_vars and op.cache_deps_vars != key_var_set:
+                key_var_set.update(op.cache_deps_vars)
+                key_var_names = sorted(key_var_set)
+                redir = CacheRedirect(key_vars=key_var_names)
+                self.query_cache[cache_key] = redir
+                key_vars2 = tuple(vars[k] for k in key_var_names)
+                cache_key2 = (prepared_query, key_vars2, operation_name, dbver)
+                self.query_cache[cache_key2] = op
             else:
-                # This is at least the second time this query is used
-                # and it's safe to cache.
-                use_prep_stmt = True
+                self.query_cache[cache_key] = op
+        else:
+            op = entry
+            # This is at least the second time this query is used
+            # and it's safe to cache.
+            use_prep_stmt = True
 
         args = []
         if op.sql_args:

--- a/edb/server/http_graphql_port/protocol.pyx
+++ b/edb/server/http_graphql_port/protocol.pyx
@@ -183,6 +183,12 @@ cdef class Protocol(http.HttpProtocol):
     async def execute(self, query, operation_name, variables):
         dbver = self.server.get_dbver()
 
+        if variables:
+            for var_name in variables:
+                if var_name.startswith('_edb_arg__'):
+                    raise errors.QueryError(
+                        f"Variables starting with '_edb_arg__' are prohibited")
+
         if debug.flags.graphql_compile:
             debug.header('Input graphql')
             print(query)
@@ -196,6 +202,8 @@ cdef class Protocol(http.HttpProtocol):
                 vars.update(variables)
             # on bad queries the following line can trigger KeyError
             key_vars = tuple(vars[k] for k in rewritten.key_vars())
+        except _graphql_rewrite.QueryError as e:
+            raise errors.QueryError(e.args[0])
         except Exception as e:
             if isinstance(e, _USER_ERRORS):
                 logger.info("Error rewriting graphql query: %s", e)

--- a/edb/server/http_graphql_port/protocol.pyx
+++ b/edb/server/http_graphql_port/protocol.pyx
@@ -190,6 +190,12 @@ cdef class Protocol(http.HttpProtocol):
 
         try:
             rewritten = _graphql_rewrite.rewrite(operation_name, query)
+
+            vars = rewritten.variables().copy()
+            if variables:
+                vars.update(variables)
+            # on bad queries the following line can trigger KeyError
+            key_vars = tuple(vars[k] for k in rewritten.key_vars())
         except Exception as e:
             if isinstance(e, _USER_ERRORS):
                 logger.info("Error rewriting graphql query: %s", e)
@@ -199,18 +205,16 @@ cdef class Protocol(http.HttpProtocol):
             rewrite_error = e
             prepared_query = query
             vars = variables.copy() if variables else {}
+            key_vars = ()
         else:
             prepared_query = rewritten.key()
-            vars = rewritten.variables().copy()
-            if variables:
-                vars.update(variables)
 
             if debug.flags.graphql_compile:
                 debug.header('GraphQL optimized query')
                 print(rewritten.key())
                 print(f'variables: {vars}')
 
-        cache_key = (prepared_query, operation_name, dbver)
+        cache_key = (prepared_query, key_vars, operation_name, dbver)
         use_prep_stmt = False
 
         op: compiler.CompiledOperation = self.query_cache.get(

--- a/edb/server/http_graphql_port/protocol.pyx
+++ b/edb/server/http_graphql_port/protocol.pyx
@@ -212,6 +212,7 @@ cdef class Protocol(http.HttpProtocol):
             if debug.flags.graphql_compile:
                 debug.header('GraphQL optimized query')
                 print(rewritten.key())
+                print(f'key_vars: {key_vars}')
                 print(f'variables: {vars}')
 
         cache_key = (prepared_query, key_vars, operation_name, dbver)

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -18,6 +18,7 @@
 
 
 import asyncio
+import decimal
 import codecs
 import hashlib
 import json
@@ -294,7 +295,6 @@ cdef class PGProto:
             WriteBuffer bind_buf
             WriteBuffer execute_buf
             WriteBuffer buf
-            char *str
             ssize_t size
             bint parse = 1
             bint store_stmt = 0
@@ -325,7 +325,10 @@ cdef class PGProto:
         bind_buf.write_int16(<int16_t><uint16_t>(len(args)))
 
         for arg in args:
-            jarg = json.dumps(arg)
+            if isinstance(arg, decimal.Decimal):
+                jarg = str(arg)
+            else:
+                jarg = json.dumps(arg)
             pgproto.jsonb_encode(DEFAULT_CODEC_CONTEXT, bind_buf, jarg)
 
         bind_buf.write_int32(0x00010001)  # binary for the output

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -2809,6 +2809,30 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                 }
             """)
 
+    def test_graphql_functional_variables_41(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r"Variables starting with '_edb_arg__' are prohibited"):
+            self.graphql_query(r"""
+                query($_edb_arg__1: Int!) {
+                    User(limit: $_edb_arg__1) {
+                        id,
+                    }
+                }
+            """, variables={'_edb_arg__1': 1})
+
+    def test_graphql_functional_variables_42(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r"Variables starting with '_edb_arg__' are prohibited"):
+            self.graphql_query(r"""
+                query($_edb_arg__1: Int = 1) {
+                    User(limit: $_edb_arg__1) {
+                        id,
+                    }
+                }
+            """)
+
     def test_graphql_functional_enum_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,


### PR DESCRIPTION
1. Implement Int/Float/Boolean variables extraction (excluding `first: 1` as a special case)
2. implement extraction of variable's default values
2. Extract variables from `@include(if:$var)` and `@skip(if:$var)` (previously they were detected too late, so were effectively disabling query cache)