### PR TITLE
Represent EdgeQL function bodies as Expressions

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -879,6 +879,7 @@ class Language(s_enum.StrEnum):
 class FunctionCode(Clause):
     language: Language
     code: typing.Optional[str]
+    nativecode: typing.Optional[Expr]
     from_function: typing.Optional[str]
     from_expr: bool
 
@@ -886,6 +887,7 @@ class FunctionCode(Clause):
 class CreateFunction(CreateObject, CallableObject):
     returning: TypeExpr
     code: FunctionCode
+    nativecode: typing.Optional[Expr]
     returning_typemod: qltypes.TypeModifier = qltypes.TypeModifier.SINGLETON
 
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1476,9 +1476,15 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 self.write(from_clause)
                 self.write(f'{node.code.from_function!r}')
             elif node.code.language is qlast.Language.EdgeQL:
-                assert node.code.code
-                self._write_keywords('USING')
-                self.write(f' ({node.code.code})')
+                if node.nativecode:
+                    self._write_keywords('USING')
+                    self.write(' (')
+                    self.visit(node.nativecode)
+                    self.write(')')
+                else:
+                    assert node.code.code
+                    self._write_keywords('USING')
+                    self.write(f' ({node.code.code})')
             else:
                 from_clause = f'USING {node.code.language} '
                 if self.sdlmode:

--- a/edb/pgsql/datasources/schema/functions.py
+++ b/edb/pgsql/datasources/schema/functions.py
@@ -35,6 +35,7 @@ async def fetch(
                 f.return_typemod,
                 f.language,
                 f.code,
+                f.nativecode,
                 f.from_function,
                 f.from_expr,
                 f.force_return_cast,

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -422,6 +422,11 @@ class IntrospectionMech:
             else:
                 initial_value = None
 
+            if row['nativecode']:
+                nativecode = self.unpack_expr(row['nativecode'], schema)
+            else:
+                nativecode = None
+
             func_data = {
                 'id': row['id'],
                 'name': name,
@@ -434,6 +439,7 @@ class IntrospectionMech:
                 'sql_func_has_out_params': row['sql_func_has_out_params'],
                 'error_on_null_result': row['error_on_null_result'],
                 'code': row['code'],
+                'nativecode': nativecode,
                 'initial_value': initial_value,
                 'session_only': row['session_only'],
                 'volatility': row['volatility'],

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -810,10 +810,7 @@ class CreateConstraint(
 
             node.params = [p[1] for p in params]
 
-    def get_ast_attr_for_field(
-        self,
-        field: so.Field[str],
-    ) -> Optional[str]:
+    def get_ast_attr_for_field(self, field: str) -> Optional[str]:
         if field == 'subjectexpr':
             return 'subjectexpr'
         else:

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1084,7 +1084,7 @@ class ObjectCommand(
             if subnode is not None:
                 node.commands.append(subnode)
 
-    def get_ast_attr_for_field(self, field: so.Field[Any]) -> Optional[str]:
+    def get_ast_attr_for_field(self, field: str) -> Optional[str]:
         return None
 
     @classmethod

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -138,6 +138,7 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer, s_abc.Expression):
         allow_generic_type_output: bool = False,
         func_params: Optional[s_func.ParameterLikeList] = None,
         singletons: Sequence[s_types.Type] = (),
+        session_mode: bool = False,
     ) -> Expression:
 
         from edb.edgeql import compiler as qlcompiler
@@ -162,6 +163,7 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer, s_abc.Expression):
                 parent_object_type=parent_object_type,
                 allow_generic_type_output=allow_generic_type_output,
                 singletons=singletons,
+                session_mode=session_mode,
             )
 
         assert isinstance(ir, irast_.Statement)
@@ -222,11 +224,13 @@ class ExpressionShell(so.Shell):
         origtext: Optional[str],
         refs: Optional[Iterable[so.ObjectShell]],
         _qlast: Optional[qlast_.Base] = None,
+        _irast: Optional[irast_.Command] = None,
     ) -> None:
         self.text = text
         self.origtext = origtext
         self.refs = tuple(refs) if refs is not None else None
         self._qlast = _qlast
+        self._irast = _irast
 
     def resolve(self, schema: s_schema.Schema) -> Expression:
         return Expression(
@@ -237,6 +241,7 @@ class ExpressionShell(so.Shell):
                 (s.resolve(schema) for s in self.refs),
             ) if self.refs is not None else None,
             _qlast=self._qlast,
+            _irast=self._irast,
         )
 
     @property

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -212,7 +212,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 VARIADIC a: int64
             ) -> int64
                 USING EdgeQL $$
-                    SELECT <int64>sum(array_unpack(a));;
+                    SELECT <int64>sum(array_unpack(a))
                 $$;
         ''')
 
@@ -520,16 +520,16 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             CREATE FUNCTION test::inner(
                 a: anytype
             ) -> int64
-                USING EdgeQL $$
-                    SELECT 1;
-                $$;
+                USING (
+                    SELECT 1
+                );
 
             CREATE FUNCTION test::call13(
                 a: anytype
             ) -> int64
-                USING EdgeQL $$
+                USING (
                     SELECT test::inner(a)
-                $$;
+                );
         ''')
 
         await self.assert_query_result(
@@ -557,7 +557,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
                 a: str
             ) -> int64
                 USING EdgeQL $$
-                    SELECT 2;
+                    SELECT 2
                 $$;
 
             CREATE FUNCTION test::call13_2(

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -3122,7 +3122,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }
 
             function str_upper(val: str) -> str {
-                using (SELECT '^^' ++ str_upper(val) ++ '^^');
+                using (SELECT '^^' ++ std::str_upper(val) ++ '^^');
             }
         """)
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1497,15 +1497,16 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_function_10(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'parameter `sum` is not callable'):
+                r'parameter `sum` is not callable',
+                _line=6, _col=39):
 
             await self.con.execute('''
                 CREATE FUNCTION test::ddlf_10(
                     sum: int64
                 ) -> int64
-                    USING EdgeQL $$
+                    USING (
                         SELECT <int64>sum(sum)
-                    $$;
+                    );
             ''')
 
     async def test_edgeql_ddl_function_11(self):
@@ -1690,8 +1691,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_function_20(self):
         with self.assertRaisesRegex(
-                edgedb.InvalidFunctionDefinitionError,
-                r'functions can only contain one statement'):
+                edgedb.EdgeQLSyntaxError,
+                r"Unexpected ';'"):
 
             await self.con.execute(r'''
                 CREATE FUNCTION test::ddlf_20(f: int64) -> int64
@@ -4264,7 +4265,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             };
             CREATE SCALAR TYPE test::dropint EXTENDING int64;
             CREATE FUNCTION test::dropfunc(a: test::dropint) -> int64
-                USING EdgeQL $$ SELECT a; $$;
+                USING EdgeQL $$ SELECT a $$;
         """)
 
         async with self.assertRaisesRegexTx(

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -18,7 +18,6 @@
 
 
 import os.path
-import textwrap
 
 from edb.testbase import server as tb
 from edb.tools import test
@@ -1327,56 +1326,3 @@ class TestIntrospection(tb.QueryTestCase):
         """)
 
         self.assertGreater(res, 0)
-
-    async def test_edgeql_introspection_describe_01(self):
-        # Test that things like "\1" are serialized correctly
-        # by the DESCRIBE command as they would in a raw string.
-        async with self.con.transaction():
-            await self.con.execute(r'''
-                CREATE FUNCTION bad() -> str
-                    USING ( SELECT r'\1' );
-            ''')
-
-            desc = await self.con.fetchone('''
-                DESCRIBE OBJECT bad AS TEXT
-            ''')
-
-        self.assertEqual(
-            desc,
-            r"function default::bad() ->  std::str "
-            r"using ( SELECT r'\1' );"
-        )
-
-    async def test_edgeql_introspection_describe_02(self):
-        # Test that things like "\1" are serialized correctly
-        # by the DESCRIBE command as they would in a raw string.
-
-        output = await self.con.fetchone('''
-            DESCRIBE OBJECT test::User AS TEXT VERBOSE
-        ''')
-
-        expected = textwrap.dedent('''\
-            type test::User extending test::Dictionary {
-                index on (__subject__.name);
-                required single link __type__ -> schema::Type {
-                    readonly := true;
-                };
-                multi link todo -> test::Issue {
-                    single property rank -> std::int64 {
-                        default := 42;
-                    };
-                };
-                required single property id -> std::uuid {
-                    readonly := true;
-                    constraint std::exclusive;
-                };
-                required single property name -> std::str {
-                    constraint std::exclusive;
-                };
-            };''')
-
-        self.assertEqual(
-            output,
-            expected,
-            f'output:\n\n{output}\n\nIS NOT EQUAL TO EXPECTED:\n\n{expected}'
-        )

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 89.84)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 89.88)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.43)


### PR DESCRIPTION
Currently, function bodies are always parsed and stored as string
literals, which are only compiled when the `CreateFunction` delta
command is applied.  This has obvious downsides: validation happens too
late, and there's no dependency tracing for objects referenced in the
function body, not to mention the ugly hacks in the parser that deparse
the `USING (<expr>)` form back to a string.

Co-authored-by: Paul Colomiets (@tailhook)