### PR TITLE
Use token list in compile_eql rather than a string

### DIFF
--- a/edb/edgeql/__init__.py
+++ b/edb/edgeql/__init__.py
@@ -22,5 +22,6 @@ from __future__ import annotations
 from . import ast  # NOQA
 from .codegen import generate_source  # NOQA
 from .parser import parse, parse_fragment, parse_block  # NOQA
+from .parser import parse_block_tokens  # NOQA
 from .parser.grammar import keywords  # NOQA
 from .rewriter import rewrite_refs  # NOQA

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -19,8 +19,13 @@
 
 from __future__ import annotations
 
+from typing import *
+
 from . import parser as ql_parser
 from .. import ast as qlast
+
+if TYPE_CHECKING:
+    from edb import _edgeql_rust
 
 
 def parse_fragment(expr):
@@ -54,7 +59,12 @@ def parse(expr, module_aliases=None):
     return tree
 
 
-def parse_block(expr):
+def parse_block_tokens(eql_tokens: List[_edgeql_rust.Token]):
+    parser = ql_parser.EdgeQLBlockParser()
+    return parser.parse(eql_tokens)
+
+
+def parse_block(expr: str):
     parser = ql_parser.EdgeQLBlockParser()
     return parser.parse(expr)
 

--- a/edb/edgeql/parser/grammar/rust_lexer.py
+++ b/edb/edgeql/parser/grammar/rust_lexer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Deque, Optional
+from typing import Deque, Optional, Union, List
 from collections import deque
 from edb._edgeql_rust import tokenize as _tokenize, Token
 
@@ -14,10 +14,15 @@ class EdgeQLLexer(object):
     def __init__(self):
         self.filename = None  # TODO
 
-    def setinputstr(self, text: str) -> None:
-        self.inputstr = text
-        self.tokens = deque(_tokenize(text))
-        self.end_of_input = self.tokens[-1].end()
+    def setinputstr(self, text: Union[str, List[Token]]) -> None:
+        if isinstance(text, str):
+            self.inputstr = text
+            self.tokens = deque(_tokenize(text))
+            self.end_of_input = self.tokens[-1].end()
+        else:
+            self.inputstr = None
+            self.tokens = deque(text)
+            self.end_of_input = self.tokens[-1].end()
 
     def token(self) -> Token:
         if self.tokens:

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -73,7 +73,8 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
     _attrs: Mapping[str, str]
 
     def __init__(self, msg: str=None, *,
-                 hint: str=None, details: str=None, context=None,
+                 hint: str=None, details: str=None,
+                 context=None, position: Optional[Tuple[int, int, int]] = None,
                  token=None):
         if type(self) is EdgeDBError:
             raise RuntimeError(
@@ -119,6 +120,11 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
         if context.start is not None:
             self._attrs[FIELD_POSITION_START] = str(context.start.pointer)
             self._attrs[FIELD_POSITION_END] = str(context.end.pointer)
+
+    def set_position(self, line: int, column: int, pointer: int):
+        self.set_linecol(line, column)
+        self._attrs[FIELD_POSITION_START] = str(pointer)
+        self._attrs[FIELD_POSITION_END] = str(pointer)
 
     @property
     def line(self):

--- a/edb/server/http_edgeql_port/protocol.pyx
+++ b/edb/server/http_edgeql_port/protocol.pyx
@@ -29,6 +29,7 @@ from edb.common import debug
 from edb.common import markup
 
 from edb.server import compiler
+from edb.server import tokenizer
 from edb.server.compiler import IoFormat
 from edb.server.http import http
 from edb.server.http cimport http
@@ -129,9 +130,9 @@ cdef class Protocol(http.HttpProtocol):
         comp = await self.server.compilers.get()
         try:
             units = await comp.call(
-                'compile_eql',
+                'compile_eql_tokens',
                 dbver,
-                query,
+                tokenizer.tokenize(query),
                 None,           # modaliases
                 None,           # session config
                 IoFormat.JSON,  # json mode

--- a/edb/server/tokenizer.pyx
+++ b/edb/server/tokenizer.pyx
@@ -1,0 +1,33 @@
+import re
+
+from typing import Optional, List, Tuple
+
+from edb._edgeql_rust import tokenize as _tokenize, TokenizerError, Token
+
+from edb.errors import base as base_errors, EdgeQLSyntaxError
+
+
+cdef object TRAILING_WS_IN_CONTINUATION = re.compile(r'\\ \s+\n')
+
+
+def tokenize(eql: bytes) -> List[Token]:
+    try:
+        eql_str = eql.decode()
+        return _tokenize(eql_str)
+    except TokenizerError as e:
+        message, position = e.args
+        hint = _derive_hint(eql_str, message, position)
+        raise EdgeQLSyntaxError(
+            message, position=position, hint=hint) from e
+
+
+def _derive_hint(
+    input: str,
+    message: str,
+    position: Tuple[int, int, int],
+) -> Optional[str]:
+    _, _, off = position
+    if message == r"invalid string literal: invalid escape sequence '\ '":
+        if TRAILING_WS_IN_CONTINUATION.search(input[off:]):
+            return "consider removing trailing whitespace"
+

--- a/setup.py
+++ b/setup.py
@@ -545,6 +545,12 @@ setuptools.setup(
             extra_link_args=EXT_LDFLAGS),
 
         distutils_extension.Extension(
+            "edb.server.tokenizer",
+            ["edb/server/tokenizer.pyx"],
+            extra_compile_args=EXT_CFLAGS,
+            extra_link_args=EXT_LDFLAGS),
+
+        distutils_extension.Extension(
             "edb.server.mng_port.edgecon",
             ["edb/server/mng_port/edgecon.pyx"],
             extra_compile_args=EXT_CFLAGS,

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 43.49)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 43.45)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
This is a prerequisite for constant extraction PR. Not sure if this needs to be merged separately