### PR TITLE
Break the schema/compiler import loop and organize compiler options

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -128,55 +128,61 @@ dispatch.py
 from __future__ import annotations
 from typing import *
 
+# WARNING: this package is in a tight import loop with various modules
+# in edb.schema, so no direct imports from either this package or
+# edb.schema are allowed at the top-level.  If absolutely necessary,
+# use the lazy-loading mechanism.
+
+import functools
+
 from edb import errors
 
-from edb.edgeql import parser as ql_parser
+from edb.edgeql import ast as qlast
+from edb.edgeql import parser as qlparser
 
 from edb.common import debug
-from edb.common import markup  # NOQA
 
-from edb.schema import functions as s_func
-from edb.schema import types as s_types
-
-from edb.edgeql import ast as qlast
-from edb.ir import ast as irast
-from edb.ir import staeval as ireval
-
-from . import dispatch
-from . import inference
-from . import setgen
-from . import stmtctx
-
-from . import expr as _expr_compiler  # NOQA
-from . import config as _config_compiler  # NOQA
-from . import stmt as _stmt_compiler  # NOQA
+from .options import CompilerOptions as CompilerOptions  # "as" for reexport
 
 if TYPE_CHECKING:
-    from edb.schema import name as s_name
-    from edb.schema import objects as s_obj
     from edb.schema import schema as s_schema
+    from edb.schema import types as s_types
+
+    from edb.ir import ast as irast
+    from edb.ir import staeval as ireval
+
+    from . import dispatch as dispatch_mod
+    from . import inference as inference_mod
+    from . import stmtctx as stmtctx_mod
+else:
+    # Modules will be loaded lazily in _load().
+    dispatch_mod = None
+    inference_mod = None
+    irast = None
+    ireval = None
+    stmtctx_mod = None
 
 
+#: Compiler modules lazy-load guard.
+_LOADED = False
+
+
+def compiler_entrypoint(func: Callable[..., Any]) -> Callable[..., Any]:
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if not _LOADED:
+            _load()
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@compiler_entrypoint
 def compile_ast_to_ir(
     tree: qlast.Base,
     schema: s_schema.Schema,
     *,
-    modaliases: Optional[Mapping[Optional[str], str]] = None,
-    anchors: Optional[Mapping[str, Any]] = None,
-    path_prefix_anchor: Optional[str] = None,
-    singletons: Sequence[s_types.Type] = (),
-    func_params: Optional[s_func.ParameterLikeList] = None,
-    result_view_name: Optional[s_name.SchemaName] = None,
-    derived_target_module: Optional[str] = None,
-    parent_object_type: Optional[s_obj.ObjectMeta] = None,
-    implicit_limit: int = 0,
-    implicit_id_in_shapes: bool = False,
-    implicit_tid_in_shapes: bool = False,
-    schema_view_mode: bool = False,
-    session_mode: bool = False,
-    disable_constant_folding: bool = False,
-    json_parameters: bool = False,
-    allow_generic_type_output: bool = False,
+    options: Optional[CompilerOptions] = None,
 ) -> irast.Command:
     """Compile given EdgeQL AST into EdgeDB IR.
 
@@ -191,114 +197,27 @@ def compile_ast_to_ir(
             Schema instance.  Must contain definitions for objects
             referenced by the AST *tree*.
 
-        modaliases:
-            Module name resolution table.  Useful when this EdgeQL
-            expression is part of some other construct, such as a
-            DDL statement.
-
-        anchors:
-            Predefined symbol table.  Maps identifiers
-            (or ``qlast.SpecialAnchor`` instances) to specified
-            schema objects or IR fragments.
-
-        path_prefix_anchor:
-            Symbol name used to resolve the prefix of abbreviated
-            path expressions by default.  The symbol must be present
-            in *anchors*.
-
-        singletons:
-            An optional set of schema types that should be treated
-            as singletons in the context of this compilation.
-
-        func_params:
-            When compiling a function body, specifies function parameter
-            definitions.
-
-        result_view_name:
-            Optionally defines the name of the topmost generated view type.
-            Useful when compiling schema views.
-
-        derived_target_module:
-            The name of the module where derived types and pointers should
-            be placed.  When compiling a schema view, this would be the
-            name of the module where the view is defined.  By default,
-            the special ``__derived__`` module is used.
-
-        parent_object_type:
-            Optionaly specifies the class of the schema object, in the
-            context of which this expression is compiled.  Used in schema
-            definitions.
-
-        implicit_limit:
-            If set to a non-zero integer value, this will be injected
-            as an implicit `LIMIT` clause into each read query.
-
-        implicit_id_in_shapes:
-            Whether to include object id property in shapes by default.
-
-        implicit_tid_in_shapes:
-            Whether to implicitly include object type id in shapes as
-            the ``__tid__`` computable.
-
-        schema_view_mode:
-            When compiling a schema view, set this to ``True``.
-
-        session_mode:
-            When ``True``, assumes that the expression is compiled in
-            the presence of a persistent database session.  Otherwise,
-            the use of functions and other constructs that require a
-            persistent session will trigger an error.
-
-        disable_constant_folding:
-            When ``True``, the compile-time evaluation and substitution
-            of constant expressions is disabled.
-
-        json_parameters:
-            When ``True``, the argument values are assumed to be in JSON
-            format.
-
-        allow_generic_type_output:
-            If ``True``, allows the expression to return a generic type.
-            By default, expressions must resolve into concrete types.
+        options:
+            An optional :class:`edgeql.compiler.options.CompilerOptions`
+            instance specifying compilation options.
 
     Returns:
         An instance of :class:`ir.ast.Command`.  Most frequently, this
         would be an instance of :class:`ir.ast.Statement`.
     """
+    if options is None:
+        options = CompilerOptions()
 
     if debug.flags.edgeql_compile:
         debug.header('EdgeQL AST')
         debug.dump(tree, schema=schema)
+        debug.header('Compiler Options')
+        debug.dump(options.__dict__)
 
-    ctx = stmtctx.init_context(
-        schema=schema,
-        anchors=anchors,
-        singletons=singletons,
-        modaliases=modaliases,
-        func_params=func_params,
-        derived_target_module=derived_target_module,
-        result_view_name=result_view_name,
-        implicit_limit=implicit_limit,
-        implicit_id_in_shapes=implicit_id_in_shapes,
-        implicit_tid_in_shapes=implicit_tid_in_shapes,
-        schema_view_mode=schema_view_mode,
-        disable_constant_folding=disable_constant_folding,
-        json_parameters=json_parameters,
-        session_mode=session_mode,
-        allow_generic_type_output=allow_generic_type_output,
-        parent_object_type=parent_object_type,
-    )
+    ctx = stmtctx_mod.init_context(schema=schema, options=options)
 
-    if path_prefix_anchor is not None:
-        assert anchors is not None
-        path_prefix = anchors[path_prefix_anchor]
-        assert isinstance(path_prefix, s_types.Type)
-        ctx.partial_path_prefix = setgen.class_set(path_prefix, ctx=ctx)
-        ctx.partial_path_prefix.anchor = path_prefix_anchor
-        ctx.partial_path_prefix.show_as_anchor = path_prefix_anchor
-
-    ir_set = dispatch.compile(tree, ctx=ctx)
-    ir_expr = stmtctx.fini_expression(ir_set, ctx=ctx)
+    ir_set = dispatch_mod.compile(tree, ctx=ctx)
+    ir_expr = stmtctx_mod.fini_expression(ir_set, ctx=ctx)
 
     if ctx.env.query_parameters:
         first_argname = next(iter(ctx.env.query_parameters))
@@ -324,13 +243,12 @@ def compile_ast_to_ir(
     return ir_expr
 
 
+@compiler_entrypoint
 def compile_ast_fragment_to_ir(
     tree: qlast.Base,
     schema: s_schema.Schema,
     *,
-    modaliases: Optional[Mapping[Optional[str], str]] = None,
-    anchors: Optional[Mapping[str, Any]] = None,
-    path_prefix_anchor: Optional[str] = None,
+    options: Optional[CompilerOptions] = None,
 ) -> irast.Statement:
     """Compile given EdgeQL AST fragment into EdgeDB IR.
 
@@ -346,46 +264,32 @@ def compile_ast_fragment_to_ir(
             Schema instance.  Must contain definitions for objects
             referenced by the AST *tree*.
 
-        modaliases:
-            Module name resolution table.  Useful when this EdgeQL
-            expression is part of some other construct, such as a
-            DDL statement.
-
-        anchors:
-            Predefined symbol table.  Maps identifiers
-            (or ``qlast.SpecialAnchor`` instances) to specified
-            schema objects or IR fragments.
-
-        path_prefix_anchor:
-            Symbol name used to resolve the prefix of abbreviated
-            path expressions by default.  The symbol must be present
-            in *anchors*.
+        options:
+            An optional :class:`edgeql.compiler.options.CompilerOptions`
+            instance specifying compilation options.
 
     Returns:
         An instance of :class:`ir.ast.Statement`.
     """
-    ctx = stmtctx.init_context(
-        schema=schema, anchors=anchors, modaliases=modaliases)
-    if path_prefix_anchor is not None:
-        assert anchors is not None
-        path_prefix = anchors[path_prefix_anchor]
-        assert isinstance(path_prefix, s_types.Type)
-        ctx.partial_path_prefix = setgen.class_set(path_prefix, ctx=ctx)
-        ctx.partial_path_prefix.anchor = path_prefix_anchor
-        ctx.partial_path_prefix.show_as_anchor = path_prefix_anchor
+    if options is None:
+        options = CompilerOptions()
 
-    ir_set = dispatch.compile(tree, ctx=ctx)
+    ctx = stmtctx_mod.init_context(schema=schema, options=options)
+    ir_set = dispatch_mod.compile(tree, ctx=ctx)
 
     result_type: Optional[s_types.Type]
     try:
-        result_type = inference.infer_type(ir_set, ctx.env)
+        result_type = inference_mod.infer_type(ir_set, ctx.env)
     except errors.QueryError:
         # Not all fragments can be resolved into a concrete type,
         # that's OK.
         result_type = None
 
-    return irast.Statement(expr=ir_set, schema=ctx.env.schema,
-                           stype=result_type)
+    return irast.Statement(
+        expr=ir_set,
+        schema=ctx.env.schema,
+        stype=result_type,
+    )
 
 
 def evaluate_to_python_val(
@@ -417,7 +321,7 @@ def evaluate_to_python_val(
         the const evaluator, the function will raise
         :exc:`ir.staeval.UnsupportedExpressionError`.
     """
-    tree = ql_parser.parse_fragment(expr)
+    tree = qlparser.parse_fragment(expr)
     return evaluate_ast_to_python_val(tree, schema, modaliases=modaliases)
 
 
@@ -450,16 +354,24 @@ def evaluate_ast_to_python_val(
         the const evaluator, the function will raise
         :exc:`ir.staeval.UnsupportedExpressionError`.
     """
-    ir = compile_ast_fragment_to_ir(tree, schema, modaliases=modaliases)
+    if modaliases is None:
+        modaliases = {}
+    ir = compile_ast_fragment_to_ir(
+        tree,
+        schema,
+        options=CompilerOptions(
+            modaliases=modaliases,
+        ),
+    )
     return ireval.evaluate_to_python_val(ir.expr, schema=ir.schema)
 
 
+@compiler_entrypoint
 def compile_constant_tree_to_ir(
     const: qlast.BaseConstant,
     schema: s_schema.Schema,
     *,
     styperef: Optional[irast.TypeRef] = None,
-    modaliases: Optional[Mapping[Optional[str], str]] = None,
 ) -> irast.Expr:
     """Compile an EdgeQL constant into an IR ConstExpr.
 
@@ -476,24 +388,15 @@ def compile_constant_tree_to_ir(
             ConstExpr.  If not specified, the inferred type of the constant
             is used.
 
-        modaliases:
-            Module name resolution table.  Useful when this EdgeQL
-            expression is part of some other construct, such as a
-            DDL statement.
-
     Returns:
         An instance of :class:`ir.ast.ConstExpr` representing the
         constant.
     """
-    ctx = stmtctx.init_context(
-        schema=schema,
-        modaliases=modaliases,
-    )
-
+    ctx = stmtctx_mod.init_context(schema=schema, options=CompilerOptions())
     if not isinstance(const, qlast.BaseConstant):
         raise ValueError(f'unexpected input: {const!r} is not a constant')
 
-    ir_set = dispatch.compile(const, ctx=ctx)
+    ir_set = dispatch_mod.compile(const, ctx=ctx)
     assert isinstance(ir_set, irast.Set)
     result = ir_set.expr
     assert isinstance(result, irast.BaseConstant)
@@ -501,3 +404,28 @@ def compile_constant_tree_to_ir(
         result = type(result)(value=result.value, typeref=styperef)
 
     return result
+
+
+def _load() -> None:
+    """Load the compiler modules.  This is done once per process."""
+
+    global _LOADED
+    global dispatch_mod, inference_mod, irast, ireval, stmtctx_mod
+
+    from edb.ir import ast as _irast
+    from edb.ir import staeval as _ireval
+
+    from . import expr as _expr_compiler  # NOQA
+    from . import config as _config_compiler  # NOQA
+    from . import stmt as _stmt_compiler  # NOQA
+
+    from . import dispatch
+    from . import inference
+    from . import stmtctx
+
+    dispatch_mod = dispatch
+    inference_mod = inference
+    irast = _irast
+    ireval = _ireval
+    stmtctx_mod = stmtctx
+    _LOADED = True

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -63,8 +63,12 @@ def compile_FunctionCall(
     env = ctx.env
 
     if isinstance(expr.func, str):
-        if (ctx.env.func_params is not None
-                and ctx.env.func_params.get_by_name(env.schema, expr.func)):
+        if (
+            ctx.env.options.func_params is not None
+            and ctx.env.options.func_params.get_by_name(
+                env.schema, expr.func
+            )
+        ):
             raise errors.QueryError(
                 f'parameter `{expr.func}` is not callable',
                 context=expr.context)
@@ -81,13 +85,13 @@ def compile_FunctionCall(
             context=expr.context)
 
     in_polymorphic_func = (
-        ctx.env.func_params is not None and
-        ctx.env.func_params.has_polymorphic(env.schema)
+        ctx.env.options.func_params is not None and
+        ctx.env.options.func_params.has_polymorphic(env.schema)
     )
 
     in_abstract_constraint = (
         in_polymorphic_func and
-        ctx.env.parent_object_type is s_constr.Constraint
+        ctx.env.options.schema_object_context is s_constr.Constraint
     )
 
     args, kwargs = compile_call_args(expr, funcname, ctx=ctx)
@@ -110,7 +114,7 @@ def compile_FunctionCall(
     assert isinstance(func, s_func.Function)
     func_name = func.get_shortname(env.schema)
 
-    if not ctx.env.session_mode and func.get_session_only(env.schema):
+    if not ctx.env.options.session_mode and func.get_session_only(env.schema):
         raise errors.QueryError(
             f'{func_name}() cannot be called in a non-session context',
             context=expr.context)
@@ -356,13 +360,13 @@ def compile_operator(
         matched = polyres.find_callable(opers, args=args, kwargs={}, ctx=ctx)
 
     in_polymorphic_func = (
-        ctx.env.func_params is not None and
-        ctx.env.func_params.has_polymorphic(env.schema)
+        ctx.env.options.func_params is not None and
+        ctx.env.options.func_params.has_polymorphic(env.schema)
     )
 
     in_abstract_constraint = (
         in_polymorphic_func and
-        ctx.env.parent_object_type is s_constr.Constraint
+        ctx.env.options.schema_object_context is s_constr.Constraint
     )
 
     if not in_polymorphic_func:

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -1,0 +1,93 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+"""EdgeQL compiler options."""
+
+
+from __future__ import annotations
+from typing import *
+
+from dataclasses import dataclass, field as dc_field
+
+if TYPE_CHECKING:
+    from edb.schema import functions as s_func
+    from edb.schema import objects as s_obj
+    from edb.schema import name as s_name
+    from edb.schema import types as s_types
+
+
+@dataclass
+class GlobalCompilerOptions:
+    """Compiler toggles that affect compilation as a whole."""
+
+    #: Whether to allow the expression to be of a generic type.
+    allow_generic_type_output: bool = False
+
+    #: Enables constant folding optimization (enabled by default).
+    constant_folding: bool = True
+
+    #: Force types of all parameters to std::json
+    json_parameters: bool = False
+
+    #: Whether there is a specific session.
+    session_mode: bool = False
+
+    #: Use material types for pointer targets in schema views.
+    schema_view_mode: bool = False
+
+    #: If the expression is being processed in the context of a certain
+    #: schema object, i.e. a constraint expression, or a pointer default,
+    #: this contains the type of the schema object.
+    schema_object_context: Optional[Type[s_obj.Object]] = None
+
+    #: When compiling a function body, specifies function parameter
+    #: definitions.
+    func_params: Optional[s_func.ParameterLikeList] = None
+
+
+@dataclass
+class CompilerOptions(GlobalCompilerOptions):
+
+    #: Module name aliases.
+    modaliases: Mapping[Optional[str], str] = dc_field(default_factory=dict)
+
+    #: External symbol table.
+    anchors: Mapping[str, Any] = dc_field(default_factory=dict)
+
+    #: The symbol to assume as the prefix for abbreviated paths.
+    path_prefix_anchor: Optional[str] = None
+
+    #: Module to put derived schema objects to.
+    derived_target_module: Optional[str] = None
+
+    #: The name to use for the top-level type variant.
+    result_view_name: Optional[s_name.SchemaName] = None
+
+    #: If > 0, Inject implicit LIMIT to every SELECT query.
+    implicit_limit: int = 0
+
+    #: Include id property in every shape implicitly.
+    implicit_id_in_shapes: bool = False
+
+    #: Include __tid__ computable (.__type__.id) in every shape implicitly.
+    implicit_tid_in_shapes: bool = False
+
+    #: A set of schema types that should be treated
+    #: as singletons in the context of this compilation.
+    singletons: FrozenSet[s_types.Type] = frozenset()

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -203,8 +203,8 @@ def try_bind_call_args(
     schema = ctx.env.schema
 
     in_polymorphic_func = (
-        ctx.env.func_params is not None and
-        ctx.env.func_params.has_polymorphic(schema)
+        ctx.env.options.func_params is not None and
+        ctx.env.options.func_params.has_polymorphic(schema)
     )
 
     has_empty_variadic = False

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -101,7 +101,7 @@ def _process_view(
         is_update: bool=False,
         ctx: context.ContextLevel) -> s_objtypes.ObjectType:
 
-    if (view_name is None and ctx.env.schema_view_mode
+    if (view_name is None and ctx.env.options.schema_view_mode
             and view_rptr is not None):
         # Make sure persistent schema expression aliases have properly formed
         # names as opposed to the usual mangled form of the ephemeral

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     import uuid
 
     from edb.schema import schema as s_schema
-    from edb.edgeql.compiler import context as ql_compiler_ctx
+    from edb.edgeql.compiler import context as qlcompiler_ctx
 
 
 class WeakNamespace(str):
@@ -132,7 +132,7 @@ class PathId:
         schema: s_schema.Schema,
         t: s_types.Type,
         *,
-        env: Optional[ql_compiler_ctx.Environment] = None,
+        env: Optional[qlcompiler_ctx.Environment] = None,
         namespace: AbstractSet[AnyNamespace] = frozenset(),
         typename: Optional[s_name.Name] = None,
     ) -> PathId:

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -31,7 +31,7 @@ from edb import errors
 
 from edb.common import uuidgen
 from edb.edgeql import ast as qlast
-from edb.edgeql import compiler as ql_compiler
+from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import qltypes
 
 from edb.ir import ast as irast
@@ -145,7 +145,7 @@ def evaluate_OperatorCall(
     # in question is always a StringConstant.
     qlconst = qlast.StringConstant.from_python(value)
 
-    result = ql_compiler.compile_constant_tree_to_ir(
+    result = qlcompiler.compile_constant_tree_to_ir(
         qlconst, styperef=opcall.typeref, schema=schema)
 
     assert isinstance(result, irast.ConstExpr), 'expected ConstExpr'
@@ -317,7 +317,7 @@ def object_type_to_python_type(
             if p.get_required(schema):
                 default = dataclasses.MISSING
         else:
-            default = ql_compiler.evaluate_to_python_val(
+            default = qlcompiler.evaluate_to_python_val(
                 default.text, schema=schema)
             if is_multi and not isinstance(default, frozenset):
                 default = frozenset((default,))

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -29,6 +29,7 @@ from edb import errors
 
 from edb.edgeql import ast as ql_ast
 from edb.edgeql import qltypes as ql_ft
+from edb.edgeql import compiler as qlcompiler
 
 from edb.schema import annos as s_anno
 from edb.schema import casts as s_casts
@@ -1790,11 +1791,13 @@ class CreateIndex(IndexCommand, CreateObject, adapts=s_indexes.CreateIndex):
             index_expr = type(index_expr).compiled(
                 index_expr,
                 schema=schema,
-                modaliases=context.modaliases,
-                parent_object_type=self.get_schema_metaclass(),
-                anchors={ql_ast.Subject().name: subject},
-                path_prefix_anchor=path_prefix_anchor,
-                singletons=singletons,
+                options=qlcompiler.CompilerOptions(
+                    modaliases=context.modaliases,
+                    schema_object_context=self.get_schema_metaclass(),
+                    anchors={ql_ast.Subject().name: subject},
+                    path_prefix_anchor=path_prefix_anchor,
+                    singletons=singletons,
+                ),
             )
             ir = index_expr.irast
 

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -27,7 +27,7 @@ from edb.ir import ast as irast
 from edb.ir import astexpr as irastexpr
 from edb.ir import typeutils as irtyputils
 from edb.ir import utils as ir_utils
-from edb.edgeql import compiler as ql_compiler
+from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import ast as qlast
 from edb.edgeql import parser as ql_parser
 from edb.edgeql.compiler import astutils as ql_astutils
@@ -211,10 +211,12 @@ class ConstraintMech:
             cls, subject, constraint, schema):
         assert constraint.get_subject(schema) is not None
 
-        ir = ql_compiler.compile_ast_to_ir(
+        ir = qlcompiler.compile_ast_to_ir(
             constraint.get_finalexpr(schema).qlast,
             schema,
-            anchors={qlast.Subject().name: subject},
+            options=qlcompiler.CompilerOptions(
+                anchors={qlast.Subject().name: subject},
+            ),
         )
 
         terminal_refs = ir_utils.get_longest_paths(ir.expr.expr.result)
@@ -414,7 +416,7 @@ def ptr_default_to_col_default(schema, ptr, expr):
                 expr=eql,
             )
         )
-        ir = ql_compiler.compile_ast_to_ir(eql, schema)
+        ir = qlcompiler.compile_ast_to_ir(eql, schema)
     except errors.SchemaError:
         # Reference errors mean that is is a non-constant default
         # referring to a not-yet-existing objects.

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from typing import *
 
 from edb.edgeql import ast as qlast
+from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import qltypes
 
 from . import delta as sd
@@ -216,7 +217,6 @@ class CreateAnnotationValue(
         astnode: qlast.DDLOperation,
         context: sd.CommandContext
     ) -> CreateAnnotationValue:
-        from edb.edgeql import compiler as qlcompiler
 
         assert isinstance(astnode, qlast.CreateAnnotationValue)
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
@@ -265,8 +265,6 @@ class AlterAnnotationValue(
         astnode: qlast.DDLOperation,
         context: sd.CommandContext
     ) -> AlterAnnotationValue:
-        from edb.edgeql import compiler as qlcompiler
-
         assert isinstance(astnode, qlast.AlterAnnotationValue)
 
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -24,6 +24,7 @@ from edb import errors
 
 from edb import edgeql
 from edb.edgeql import ast as qlast
+from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import qltypes as ft
 
 from . import abc as s_abc
@@ -239,8 +240,10 @@ class Constraint(referencing.ReferencedInheritingObject,
         final_expr = s_expr.Expression.compiled(
             s_expr.Expression.from_ast(expr_ql, schema, module_aliases),
             schema=schema,
-            modaliases=module_aliases,
-            anchors={qlast.Subject().name: subject},
+            options=qlcompiler.CompilerOptions(
+                modaliases=module_aliases,
+                anchors={qlast.Subject().name: subject},
+            ),
         )
 
         bool_t: s_scalars.ScalarType = schema.get('std::bool')
@@ -514,11 +517,13 @@ class ConstraintCommand(
             return s_expr.Expression.compiled(
                 value,
                 schema=schema,
-                modaliases=context.modaliases,
-                anchors=anchors,
-                func_params=params,
-                allow_generic_type_output=True,
-                parent_object_type=self.get_schema_metaclass(),
+                options=qlcompiler.CompilerOptions(
+                    modaliases=context.modaliases,
+                    anchors=anchors,
+                    func_params=params,
+                    allow_generic_type_output=True,
+                    schema_object_context=self.get_schema_metaclass(),
+                ),
             )
         else:
             return super().compile_expr_field(schema, context, field, value)

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -28,11 +28,16 @@ import uuid
 from edb import errors
 
 from edb.common import adapter
+from edb.common import checked
+from edb.common import markup
+from edb.common import ordered
 from edb.common import parsing
+from edb.common import struct
+
 from edb.edgeql import ast as qlast
+from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import qltypes
 
-from edb.common import checked, markup, ordered, struct
 
 from . import expr as s_expr
 from . import name as sn
@@ -434,8 +439,6 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
         astnode: qlast.DDLOperation,
         name: str,
     ) -> Optional[str]:
-        from edb.edgeql import compiler as qlcompiler
-
         orig_text_expr = qlast.get_ddl_field_value(astnode, f'orig_{name}')
         if orig_text_expr:
             orig_text = qlcompiler.evaluate_ast_to_python_val(
@@ -2043,7 +2046,6 @@ class AlterObjectProperty(Command):
         astnode: qlast.DDLOperation,
         context: CommandContext,
     ) -> AlterObjectProperty:
-        from edb.edgeql import compiler as qlcompiler
         assert isinstance(astnode, qlast.BaseSetField)
 
         propname = astnode.name

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -18,6 +18,7 @@
 
 
 from __future__ import annotations
+from typing import *
 
 import copy
 
@@ -26,17 +27,15 @@ from edb.common import struct
 
 from edb.edgeql import ast as qlast_
 from edb.edgeql import codegen as qlcodegen
+from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import parser as qlparser
-from typing import *
 
 from . import abc as s_abc
 from . import objects as so
 
 
 if TYPE_CHECKING:
-    from edb.schema import types as s_types
     from edb.schema import schema as s_schema
-    from edb.schema import functions as s_func
     from edb.ir import ast as irast_
 
 
@@ -130,40 +129,23 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer, s_abc.Expression):
         expr: Expression,
         schema: s_schema.Schema,
         *,
+        options: Optional[qlcompiler.CompilerOptions] = None,
         as_fragment: bool = False,
-        modaliases: Optional[Mapping[Optional[str], str]] = None,
-        parent_object_type: Optional[so.ObjectMeta] = None,
-        anchors: Optional[Mapping[str, Any]] = None,
-        path_prefix_anchor: Optional[str] = None,
-        allow_generic_type_output: bool = False,
-        func_params: Optional[s_func.ParameterLikeList] = None,
-        singletons: Sequence[s_types.Type] = (),
-        session_mode: bool = False,
     ) -> Expression:
 
-        from edb.edgeql import compiler as qlcompiler
         from edb.ir import ast as irast_
 
         if as_fragment:
             ir: irast_.Command = qlcompiler.compile_ast_fragment_to_ir(
                 expr.qlast,
                 schema=schema,
-                modaliases=modaliases,
-                anchors=anchors,
-                path_prefix_anchor=path_prefix_anchor,
+                options=options,
             )
         else:
             ir = qlcompiler.compile_ast_to_ir(
                 expr.qlast,
                 schema=schema,
-                modaliases=modaliases,
-                anchors=anchors,
-                path_prefix_anchor=path_prefix_anchor,
-                func_params=func_params,
-                parent_object_type=parent_object_type,
-                allow_generic_type_output=allow_generic_type_output,
-                singletons=singletons,
-                session_mode=session_mode,
+                options=options,
             )
 
         assert isinstance(ir, irast_.Statement)

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -23,6 +23,7 @@ from typing import *
 from edb import edgeql
 from edb import errors
 from edb.edgeql import ast as qlast
+from edb.edgeql import compiler as qlcompiler
 
 from . import abc as s_abc
 from . import annos as s_anno
@@ -208,11 +209,13 @@ class CreateIndex(
             return type(value).compiled(
                 value,
                 schema=schema,
-                modaliases=context.modaliases,
-                parent_object_type=self.get_schema_metaclass(),
-                anchors={qlast.Subject().name: subject},
-                path_prefix_anchor=path_prefix_anchor,
-                singletons=singletons,
+                options=qlcompiler.CompilerOptions(
+                    modaliases=context.modaliases,
+                    schema_object_context=self.get_schema_metaclass(),
+                    anchors={qlast.Subject().name: subject},
+                    path_prefix_anchor=path_prefix_anchor,
+                    singletons=singletons,
+                ),
             )
         else:
             return super().compile_expr_field(schema, context, field, value)

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -20,11 +20,13 @@ from __future__ import annotations
 
 from typing import *
 
-from edb.edgeql import ast as qlast
-from edb.edgeql import qltypes
+from edb import errors
+
 from edb.common import enum
 
-from edb import errors
+from edb.edgeql import ast as qlast
+from edb.edgeql import compiler as qlcompiler
+from edb.edgeql import qltypes
 
 from . import abc as s_abc
 from . import annos as s_anno
@@ -653,10 +655,12 @@ class PointerCommandOrFragment(sd.ObjectCommand[Pointer]):
         expr = s_expr.Expression.compiled(
             s_expr.Expression.from_ast(expr, schema, context.modaliases),
             schema=schema,
-            modaliases=context.modaliases,
-            anchors={qlast.Source().name: source},
-            path_prefix_anchor=qlast.Source().name,
-            singletons=[source],
+            options=qlcompiler.CompilerOptions(
+                modaliases=context.modaliases,
+                anchors={qlast.Source().name: source},
+                path_prefix_anchor=qlast.Source().name,
+                singletons=[source],
+            ),
         )
 
         base = None
@@ -942,11 +946,13 @@ class PointerCommand(
             return type(value).compiled(
                 value,
                 schema=schema,
-                modaliases=context.modaliases,
-                parent_object_type=self.get_schema_metaclass(),
-                anchors=anchors,
-                path_prefix_anchor=path_prefix_anchor,
-                singletons=singletons,
+                options=qlcompiler.CompilerOptions(
+                    modaliases=context.modaliases,
+                    schema_object_context=self.get_schema_metaclass(),
+                    anchors=anchors,
+                    path_prefix_anchor=path_prefix_anchor,
+                    singletons=singletons,
+                ),
             )
         else:
             return super().compile_expr_field(schema, context, field, value)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -31,6 +31,7 @@ from edb.common import checked
 from edb.common import uuidgen
 
 from edb.edgeql import ast as qlast
+from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import qltypes
 
 from . import abc as s_abc
@@ -1742,8 +1743,6 @@ class TypeCommand(sd.ObjectCommand[Type]):
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> irast.Statement:
-        from edb.edgeql import compiler as qlcompiler
-
         cached: Optional[irast.Statement] = (
             context.get_cached((expr, classname)))
         if cached is not None:
@@ -1753,11 +1752,14 @@ class TypeCommand(sd.ObjectCommand[Type]):
             expr = qlast.SelectQuery(result=expr)
 
         ir = qlcompiler.compile_ast_to_ir(
-            expr, schema,
-            derived_target_module=classname.module,
-            result_view_name=classname,
-            modaliases=context.modaliases,
-            schema_view_mode=True,
+            expr,
+            schema,
+            options=qlcompiler.CompilerOptions(
+                derived_target_module=classname.module,
+                result_view_name=classname,
+                modaliases=context.modaliases,
+                schema_view_mode=True,
+            ),
         )
 
         context.cache_value((expr, classname), ir)

--- a/edb/server/http_graphql_port/compiler.py
+++ b/edb/server/http_graphql_port/compiler.py
@@ -26,7 +26,7 @@ from edb import errors
 from edb import graphql
 
 from edb.common import debug
-from edb.edgeql import compiler as ql_compiler
+from edb.edgeql import compiler as qlcompiler
 from edb.pgsql import compiler as pg_compiler
 from edb.server import compiler
 
@@ -81,10 +81,13 @@ class Compiler(compiler.BaseCompiler):
             substitutions=substitutions,
             operation_name=operation_name)
 
-        ir = ql_compiler.compile_ast_to_ir(
+        ir = qlcompiler.compile_ast_to_ir(
             op.edgeql_ast,
             schema=db.schema,
-            json_parameters=True)
+            options=qlcompiler.CompilerOptions(
+                json_parameters=True,
+            ),
+        )
 
         if ir.cardinality.is_multi():
             raise errors.ResultCardinalityMismatchError(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3643,7 +3643,9 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             stmt = qlcompiler.compile_ast_to_ir(
                 qltree,
                 schema,
-                modaliases={None: 'test'},
+                options=qlcompiler.CompilerOptions(
+                    modaliases={None: 'test'},
+                ),
             )
 
             output = self.uuid_re.sub(

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,9 +206,9 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 43.45)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 43.59)
 
-    def test_cqa_type_coverage_edgeql_compiler(self) -> None:
+    def test_cqa_type_coverage_edgeqlcompiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)
 
     def test_cqa_type_coverage_edgeql_parser(self) -> None:
@@ -232,7 +232,7 @@ class TypeCoverageTests(unittest.TestCase):
     def test_cqa_type_coverage_pgsql(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql", 46.53)
 
-    def test_cqa_type_coverage_pgsql_compiler(self) -> None:
+    def test_cqa_type_coverage_pgsqlcompiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)
 
     def test_cqa_type_coverage_pgsql_datasources(self) -> None:


### PR DESCRIPTION
This is a long overdue cleanup that makes `edb.edgeql.compiler` properly
importable from schema modules by making its entrypoint imports lazy.

Another cleanup organizes compilation options into a separate dataclass.
The number of options has grown rather large to keep passing them
around as regular kwargs anymore.