### PR TITLE
Implement volatility inference

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -187,6 +187,11 @@ class Environment:
         qltypes.Cardinality]
     """A dictionary of all expressions and their inferred cardinality."""
 
+    inferred_volatility: Dict[
+        irast.Base,
+        qltypes.Volatility]
+    """A dictionary of expressions and their inferred volatility."""
+
     view_shapes: Dict[
         Union[s_types.Type, s_pointers.PointerLike],
         List[s_pointers.Pointer]
@@ -225,6 +230,7 @@ class Environment:
         self.type_origins = {}
         self.inferred_types = {}
         self.inferred_cardinality = {}
+        self.inferred_volatility = {}
         self.view_shapes = collections.defaultdict(list)
         self.view_shapes_metadata = collections.defaultdict(
             irast.ViewShapeMetadata)

--- a/edb/edgeql/compiler/inference/__init__.py
+++ b/edb/edgeql/compiler/inference/__init__.py
@@ -19,7 +19,13 @@
 
 from __future__ import annotations
 
-__all__ = ('amend_empty_set_type', 'infer_cardinality', 'infer_type',)
+__all__ = (
+    'amend_empty_set_type',
+    'infer_cardinality',
+    'infer_type',
+    'infer_volatility',
+)
 
 from .cardinality import infer_cardinality  # NOQA
 from .types import amend_empty_set_type, infer_type  # NOQA
+from .volatility import infer_volatility  # NOQA

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -1,0 +1,316 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+from typing import *
+
+import functools
+
+from edb import errors
+
+from edb.edgeql import qltypes
+
+from edb.ir import ast as irast
+
+from .. import context
+
+
+IMMUTABLE = qltypes.Volatility.IMMUTABLE
+STABLE = qltypes.Volatility.STABLE
+VOLATILE = qltypes.Volatility.VOLATILE
+
+
+def _max_volatility(args: Iterable[qltypes.Volatility]) -> qltypes.Volatility:
+    # We rely on a happy coincidence that the lexical
+    # order of volatility constants coincides with the volatility
+    # level.
+    arg_list = list(args)
+    if not arg_list:
+        return IMMUTABLE
+    else:
+        return max(arg_list)
+
+
+def _common_volatility(
+    args: Iterable[irast.Base],
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return _max_volatility(
+        infer_volatility(a, env) for a in args)
+
+
+@functools.singledispatch
+def _infer_volatility(
+    ir: irast.Base,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    raise ValueError(f'infer_volatility: cannot handle {ir!r}')
+
+
+@_infer_volatility.register(type(None))
+def __infer_none(
+    ir: None,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    # Here for debugging purposes.
+    raise ValueError('invalid infer_volatility(None, schema) call')
+
+
+@_infer_volatility.register
+def __infer_statement(
+    ir: irast.Statement,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return infer_volatility(ir.expr, env)
+
+
+@_infer_volatility.register
+def __infer_config_insert(
+    ir: irast.ConfigInsert,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return infer_volatility(ir.expr, env)
+
+
+@_infer_volatility.register
+def __infer_emptyset(
+    ir: irast.EmptySet,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return IMMUTABLE
+
+
+@_infer_volatility.register
+def __infer_typeref(
+    ir: irast.TypeRef,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return IMMUTABLE
+
+
+@_infer_volatility.register
+def __infer_type_introspection(
+    ir: irast.TypeIntrospection,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return IMMUTABLE
+
+
+@_infer_volatility.register
+def __infer_set(
+    ir: irast.Set,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    if ir.rptr is not None:
+        return infer_volatility(ir.rptr.source, env)
+    elif ir.expr is not None:
+        return infer_volatility(ir.expr, env)
+    else:
+        return STABLE
+
+
+@_infer_volatility.register
+def __infer_func_call(
+    ir: irast.FunctionCall,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    if ir.args:
+        return _max_volatility([
+            _common_volatility((arg.expr for arg in ir.args), env),
+            ir.volatility
+        ])
+    else:
+        return ir.volatility
+
+
+@_infer_volatility.register
+def __infer_oper_call(
+    ir: irast.OperatorCall,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    if ir.args:
+        return _max_volatility([
+            _common_volatility((arg.expr for arg in ir.args), env),
+            ir.volatility
+        ])
+    else:
+        return ir.volatility
+
+
+@_infer_volatility.register
+def __infer_const(
+    ir: irast.BaseConstant,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return IMMUTABLE
+
+
+@_infer_volatility.register
+def __infer_param(
+    ir: irast.Parameter,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return IMMUTABLE
+
+
+@_infer_volatility.register
+def __infer_const_set(
+    ir: irast.ConstantSet,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return IMMUTABLE
+
+
+@_infer_volatility.register
+def __infer_typecheckop(
+    ir: irast.TypeCheckOp,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return infer_volatility(ir.left, env)
+
+
+@_infer_volatility.register
+def __infer_typecast(
+    ir: irast.TypeCast,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return infer_volatility(ir.expr, env)
+
+
+@_infer_volatility.register
+def __infer_select_stmt(
+    ir: irast.SelectStmt,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    components = []
+
+    if ir.iterator_stmt is not None:
+        components.append(ir.iterator_stmt)
+
+    components.append(ir.result)
+
+    if ir.where is not None:
+        components.append(ir.where)
+
+    if ir.orderby:
+        components.extend(o.expr for o in ir.orderby)
+
+    if ir.offset is not None:
+        components.append(ir.offset)
+
+    if ir.limit is not None:
+        components.append(ir.limit)
+
+    return _common_volatility(components, env)
+
+
+@_infer_volatility.register
+def __infer_group_stmt(
+    ir: irast.GroupStmt,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    raise NotImplementedError
+
+
+@_infer_volatility.register
+def __infer_insert_stmt(
+    ir: irast.InsertStmt,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return VOLATILE
+
+
+@_infer_volatility.register
+def __infer_update_stmt(
+    ir: irast.UpdateStmt,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return VOLATILE
+
+
+@_infer_volatility.register
+def __infer_delete_stmt(
+    ir: irast.DeleteStmt,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return VOLATILE
+
+
+@_infer_volatility.register
+def __infer_slice(
+    ir: irast.SliceIndirection,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    # slice indirection volatility depends on the volatility of
+    # the base expression and the slice index expressions
+    args = [ir.expr]
+    if ir.start is not None:
+        args.append(ir.start)
+    if ir.stop is not None:
+        args.append(ir.stop)
+
+    return _common_volatility(args, env)
+
+
+@_infer_volatility.register
+def __infer_index(
+    ir: irast.IndexIndirection,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    # index indirection volatility depends on both the volatility of
+    # the base expression and the index expression
+    return _common_volatility([ir.expr, ir.index], env)
+
+
+@_infer_volatility.register
+def __infer_array(
+    ir: irast.Array,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return _common_volatility(ir.elements, env)
+
+
+@_infer_volatility.register
+def __infer_tuple(
+    ir: irast.Tuple,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    return _common_volatility(
+        [el.val for el in ir.elements], env)
+
+
+def infer_volatility(
+    ir: irast.Base,
+    env: context.Environment,
+) -> qltypes.Volatility:
+    result = env.inferred_volatility.get(ir)
+    if result is not None:
+        return result
+
+    result = _infer_volatility(ir, env)
+
+    if result not in {VOLATILE, STABLE, IMMUTABLE}:
+        raise errors.QueryError(
+            'could not determine the volatility of '
+            'set produced by expression',
+            context=ir.context)
+
+    env.inferred_volatility[ir] = result
+
+    return result

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -137,6 +137,8 @@ def fini_expression(
     else:
         cardinality = qltypes.Cardinality.AT_MOST_ONE
 
+    volatility = inference.infer_volatility(ir, env=ctx.env)
+
     if ctx.env.options.schema_view_mode:
         for view in ctx.view_nodes.values():
             if view.is_collection():
@@ -201,6 +203,7 @@ def fini_expression(
         source_map=ctx.source_map,
         scope_tree=ctx.path_scope,
         cardinality=cardinality,
+        volatility=volatility,
         stype=expr_type,
         view_shapes=ctx.env.view_shapes,
         view_shapes_metadata=ctx.env.view_shapes_metadata,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -411,6 +411,7 @@ class Statement(Command):
     views: typing.Dict[sn.Name, s_types.Type]
     params: typing.Dict[str, s_types.Type]
     cardinality: qltypes.Cardinality
+    volatility: qltypes.Volatility
     stype: s_types.Type
     view_shapes: typing.Dict[so.Object, typing.List[s_pointers.Pointer]]
     view_shapes_metadata: typing.Dict[so.Object, ViewShapeMetadata]

--- a/tests/test_edgeql_ir_volatility_inference.py
+++ b/tests/test_edgeql_ir_volatility_inference.py
@@ -1,0 +1,147 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2012-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os.path
+import textwrap
+
+from edb.testbase import lang as tb
+
+from edb.edgeql import compiler
+from edb.edgeql import qltypes
+from edb.edgeql import parser as qlparser
+
+
+class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
+    """Unit tests for volatility inference."""
+
+    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
+                          'cards.esdl')
+
+    def run_test(self, *, source, spec, expected):
+        qltree = qlparser.parse(source)
+        ir = compiler.compile_ast_to_ir(qltree, self.schema)
+
+        expected_volatility = qltypes.Volatility(
+            textwrap.dedent(expected).strip(' \n'))
+        self.assertEqual(ir.volatility, expected_volatility,
+                         'unexpected volatility:\n' + source)
+
+    def test_edgeql_ir_volatility_inference_00(self):
+        """
+        WITH MODULE test
+        SELECT Card
+% OK %
+        STABLE
+        """
+
+    def test_edgeql_ir_volatility_inference_01(self):
+        """
+        WITH
+            MODULE test,
+            foo := random()
+        SELECT
+            foo
+% OK %
+        VOLATILE
+        """
+
+    def test_edgeql_ir_volatility_inference_02(self):
+        """
+        WITH
+            MODULE test
+        SELECT
+            Card
+        FILTER
+            random() > 0.9
+% OK %
+        VOLATILE
+        """
+
+    def test_edgeql_ir_volatility_inference_03(self):
+        """
+        WITH
+            MODULE test
+        SELECT
+            Card
+        ORDER BY
+            random()
+% OK %
+        VOLATILE
+        """
+
+    def test_edgeql_ir_volatility_inference_04(self):
+        """
+        WITH
+            MODULE test
+        SELECT
+            Card
+        LIMIT
+            <int64>random()
+% OK %
+        VOLATILE
+        """
+
+    def test_edgeql_ir_volatility_inference_05(self):
+        """
+        WITH
+            MODULE test
+        SELECT
+            Card
+        OFFSET
+            <int64>random()
+% OK %
+        VOLATILE
+        """
+
+    def test_edgeql_ir_volatility_inference_06(self):
+        """
+        WITH
+            MODULE test
+        INSERT
+            Card {
+                name := 'foo',
+                element := 'fire',
+                cost := 1,
+            }
+% OK %
+        VOLATILE
+        """
+
+    def test_edgeql_ir_volatility_inference_07(self):
+        """
+        WITH
+            MODULE test
+        UPDATE
+            Card
+        SET {
+                name := 'foo',
+        }
+% OK %
+        VOLATILE
+        """
+
+    def test_edgeql_ir_volatility_inference_08(self):
+        """
+        WITH
+            MODULE test
+        DELETE
+            Card
+% OK %
+        VOLATILE
+        """

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -24,6 +24,7 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import tracer
 from edb.edgeql.compiler.inference import cardinality
 from edb.edgeql.compiler.inference import types
+from edb.edgeql.compiler.inference import volatility
 from edb.ir import ast as irast
 from edb.server.compiler import status
 
@@ -91,3 +92,19 @@ class TestTracer(unittest.TestCase):
                 if dispatcher.dispatch(astcls) is not_implemented:
                     self.fail(
                         f'_infer_type for {name} is not implemented')
+
+    def test_infer_volatility_dispatch(self):
+        dispatcher = volatility._infer_volatility
+        not_implemented = dispatcher.registry[object]
+
+        for name, astcls in inspect.getmembers(irast, inspect.isclass):
+            # Expr and Stmt need cardinality inference.
+            if (issubclass(astcls, (irast.Expr, irast.Stmt,
+                                    # ConfigInsert is the only config
+                                    # command needing volatility inference.
+                                    irast.ConfigInsert))
+                    and not astcls.__abstract_node__):
+
+                if dispatcher.dispatch(astcls) is not_implemented:
+                    self.fail(
+                        f'_infer_volatility for {name} is not implemented')

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 43.59)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 43.87)
 
     def test_cqa_type_coverage_edgeqlcompiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
This adds the ability to infer expression volatility in the EdgeQL
compiler.  The implementation is very similar to cardinality inference.