### PR TITLE
Add annotations for schema pointers

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1021,7 +1021,7 @@ class Schema(SDL):
 #
 
 
-def get_targets(target: TypeExpr):
+def get_targets(target: typing.Union[None, TypeExpr, Expr]):
     if target is None:
         return []
     elif isinstance(target, TypeOp):

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -244,8 +244,8 @@ def derive_ptr(
     ctx.env.schema, derived = ptr.derive_ref(
         ctx.env.schema,
         source,
-        target,
         *qualifiers,
+        target=target,
         name=derived_name,
         inheritance_merge=inheritance_merge,
         refdict_whitelist={'pointers'},
@@ -445,7 +445,7 @@ def derive_dummy_ptr(
         ctx.env.schema, derived = ptr.derive_ref(
             ctx.env.schema,
             derived_obj,
-            derived_obj,
+            target=derived_obj,
             attrs={
                 'cardinality': qltypes.SchemaCardinality.MANY,
             },

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -602,6 +602,7 @@ def extend_path(
     else:
         if direction is not s_pointers.PointerDirection.Inbound:
             source = ptrcls.get_near_endpoint(ctx.env.schema, direction)
+            assert isinstance(source, s_types.Type)
             stype = get_set_type(source_set, ctx=ctx)
             if not stype.issubclass(ctx.env.schema, source):
                 # Polymorphic link reference
@@ -616,6 +617,7 @@ def extend_path(
         ns=ctx.path_id_namespace, ctx=ctx)
 
     target = ptrcls.get_far_endpoint(ctx.env.schema, direction)
+    assert isinstance(target, s_types.Type)
     target_set = new_set(stype=target, path_id=path_id, ctx=ctx)
 
     ptr = irast.Pointer(

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     import uuid
 
     from edb.schema import name as s_name
+    from edb.schema import objects as s_objects
     from edb.schema import schema as s_schema
 
     PtrRefCacheKey = Tuple[s_pointers.PointerLike, s_pointers.PointerDirection]
@@ -398,6 +399,13 @@ def ptrref_from_ptrcls(
 
     ircls: Type[irast.BasePointerRef]
 
+    source_ref: Union[Optional[irast.TypeRef],
+                      Optional[s_objects.Object]]
+    target_ref: Union[Optional[irast.TypeRef],
+                      Optional[s_objects.Object]]
+    out_source: Union[Optional[irast.TypeRef],
+                      Optional[s_objects.Object]]
+
     if isinstance(ptrcls, irast.TupleIndirectionLink):
         ircls = irast.TupleIndirectionPointerRef
     elif isinstance(ptrcls, irast.TypeIntersectionLink):
@@ -414,8 +422,6 @@ def ptrref_from_ptrcls(
             s_mod.Module, name.module).id
     else:
         raise AssertionError(f'unexpected pointer class: {ptrcls}')
-
-    out_source: Optional[irast.TypeRef]
 
     target = ptrcls.get_far_endpoint(schema, direction)
     if isinstance(target, s_types.Type):
@@ -473,6 +479,7 @@ def ptrref_from_ptrcls(
         union_ptrs = set()
 
         for component in union_of.objects(schema):
+            assert isinstance(component, s_pointers.Pointer)
             material_comp = component.material_type(schema)
             union_ptrs.add(material_comp)
 
@@ -607,6 +614,7 @@ def cardinality_from_ptrcls(
         out_cardinality = None
         dir_cardinality = None
     else:
+        assert isinstance(out_card, qltypes.SchemaCardinality)
         out_cardinality = qltypes.Cardinality.from_schema_value(
             required, out_card)
         # Determine the cardinality of a given endpoint set.

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -39,7 +39,6 @@ if TYPE_CHECKING:
     import uuid
 
     from edb.schema import name as s_name
-    from edb.schema import objects as s_objects
     from edb.schema import schema as s_schema
 
     PtrRefCacheKey = Tuple[s_pointers.PointerLike, s_pointers.PointerDirection]
@@ -399,12 +398,9 @@ def ptrref_from_ptrcls(
 
     ircls: Type[irast.BasePointerRef]
 
-    source_ref: Union[Optional[irast.TypeRef],
-                      Optional[s_objects.Object]]
-    target_ref: Union[Optional[irast.TypeRef],
-                      Optional[s_objects.Object]]
-    out_source: Union[Optional[irast.TypeRef],
-                      Optional[s_objects.Object]]
+    source_ref: Optional[irast.TypeRef]
+    target_ref: Optional[irast.TypeRef]
+    out_source: Optional[irast.TypeRef]
 
     if isinstance(ptrcls, irast.TupleIndirectionLink):
         ircls = irast.TupleIndirectionPointerRef
@@ -424,7 +420,8 @@ def ptrref_from_ptrcls(
         raise AssertionError(f'unexpected pointer class: {ptrcls}')
 
     target = ptrcls.get_far_endpoint(schema, direction)
-    if isinstance(target, s_types.Type):
+    if target is not None and not isinstance(target, irast.TypeRef):
+        assert isinstance(target, s_types.Type)
         target_ref = type_to_typeref(schema, target, cache=typeref_cache)
     else:
         target_ref = target
@@ -443,8 +440,11 @@ def ptrref_from_ptrcls(
         )
         source_ref = None
     else:
-        if isinstance(source, s_types.Type):
-            source_ref = type_to_typeref(schema, source, cache=typeref_cache)
+        if source is not None and not isinstance(source, irast.TypeRef):
+            assert isinstance(source, s_types.Type)
+            source_ref = type_to_typeref(schema,
+                                         source,
+                                         cache=typeref_cache)
         else:
             source_ref = source
         source_ptr = None

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -40,7 +40,7 @@ from . import sources
 from . import utils
 
 if TYPE_CHECKING:
-    from . import objtypes as s_objtypes
+    from . import types as s_types
     from . import schema as s_schema
 
 
@@ -140,7 +140,7 @@ class Link(sources.Source, pointers.Pointer, s_abc.Link,
     def set_target(
         self,
         schema: s_schema.Schema,
-        target: s_objtypes.ObjectType,
+        target: s_types.Type,
     ) -> s_schema.Schema:
         schema = super().set_target(schema, target)
         tgt_prop = self.getptr(schema, 'target')

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -187,7 +187,7 @@ class LinkCommand(lproperties.PropertySourceCommand,
     def _set_pointer_type(
         self,
         schema: s_schema.Schema,
-        astnode: qlast.CreateConcreteLink,
+        astnode: qlast.CreateConcretePointer,
         context: sd.CommandContext,
         target_ref: Union[so.Object, so.ObjectShell],
     ) -> None:
@@ -273,6 +273,7 @@ class CreateLink(
     ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
         if isinstance(astnode, qlast.CreateConcreteLink):
+            assert isinstance(cmd, pointers.PointerCommand)
             cmd._process_create_or_alter_ast(schema, astnode, context)
         else:
             # this is an abstract property then
@@ -472,6 +473,7 @@ class AlterLink(
     ) -> referencing.AlterReferencedInheritingObject[Link]:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
         if isinstance(astnode, qlast.CreateConcreteLink):
+            assert isinstance(cmd, pointers.PointerCommand)
             cmd._process_create_or_alter_ast(schema, astnode, context)
         assert isinstance(cmd, referencing.AlterReferencedInheritingObject)
         return cmd

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -58,7 +58,7 @@ class Property(pointers.Pointer, s_abc.Property,
             target = self.get_target(schema)
 
         schema, ptr = super().derive_ref(
-            schema, source, target, attrs=attrs, **kwargs)
+            schema, source, target=target, attrs=attrs, **kwargs)
 
         ptr_sn = ptr.get_shortname(schema)
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -43,7 +43,7 @@ from . import utils
 
 
 if TYPE_CHECKING:
-    from . import sources as s_sources
+    from . import objtypes as s_objtypes
 
 
 class PointerDirection(enum.StrEnum):
@@ -54,8 +54,8 @@ class PointerDirection(enum.StrEnum):
 MAX_NAME_LENGTH = 63
 
 
-def merge_cardinality(target: Pointer, sources: List[so.Object],
-                      field_name: str, *, schema: s_schema.Schema) -> object:
+def merge_cardinality(target: Pointer, sources: List[Pointer],
+                      field_name: str, *, schema: s_schema.Schema) -> Any:
     current = None
     current_from = None
 
@@ -83,8 +83,8 @@ def merge_cardinality(target: Pointer, sources: List[so.Object],
     return current
 
 
-def merge_readonly(target: Pointer, sources: List[so.Object],
-                   field_name: str, *, schema: s_schema.Schema) -> object:
+def merge_readonly(target: Pointer, sources: List[Pointer],
+                   field_name: str, *, schema: s_schema.Schema) -> Any:
 
     current = None
     current_from = None
@@ -108,6 +108,8 @@ def merge_readonly(target: Pointer, sources: List[so.Object],
                 current = nextval
                 current_from = source
             elif current is not nextval:
+                assert current_from is not None
+
                 tgt_repr = target.get_verbosename(
                     schema, with_parent=True)
                 cf_repr = current_from.get_verbosename(
@@ -125,8 +127,13 @@ def merge_readonly(target: Pointer, sources: List[so.Object],
     return current
 
 
-def merge_target(ptr: Pointer, bases: List[so.Pointer],
-                 field_name: str, *, schema) -> Pointer:
+def merge_target(
+    ptr: Pointer,
+    bases: List[Pointer],
+    field_name: str,
+    *,
+    schema: s_schema.Schema,
+) -> Optional[s_types.Type]:
 
     target = None
 
@@ -203,12 +210,12 @@ class Pointer(referencing.ReferencedInheritingObject,
         merge_fn=merge_cardinality)
 
     union_of = so.SchemaField(
-        so.ObjectSet,
+        so.ObjectSet[so.Object],
         default=None,
         coerce=True)
 
     intersection_of = so.SchemaField(
-        so.ObjectSet,
+        so.ObjectSet[so.Object],
         default=None,
         coerce=True)
 
@@ -218,21 +225,28 @@ class Pointer(referencing.ReferencedInheritingObject,
     def is_type_intersection(self) -> bool:
         return False
 
-    def get_displayname(self, schema) -> str:
+    def get_displayname(self, schema: s_schema.Schema) -> str:
         sn = self.get_shortname(schema)
         if self.generic(schema):
             return sn
         else:
             return sn.name
 
-    def get_verbosename(self, schema, *, with_parent: bool=False) -> str:
+    def get_verbosename(
+        self,
+        schema: s_schema.Schema,
+        *,
+        with_parent: bool=False,
+    ) -> str:
         is_abstract = self.generic(schema)
         vn = super().get_verbosename(schema)
         if is_abstract:
             return f'abstract {vn}'
         else:
             if with_parent:
-                pvn = self.get_source(schema).get_verbosename(
+                source = self.get_source(schema)
+                assert source is not None
+                pvn = source.get_verbosename(
                     schema, with_parent=True)
                 return f'{vn} of {pvn}'
             else:
@@ -241,30 +255,50 @@ class Pointer(referencing.ReferencedInheritingObject,
     def is_scalar(self) -> bool:
         return False
 
-    def material_type(self, schema):
+    def material_type(self, schema: s_schema.Schema) -> Pointer:
         non_derived_parent = self.get_nearest_non_derived_parent(schema)
         if non_derived_parent.generic(schema):
             return self
         else:
             return non_derived_parent
 
-    def get_near_endpoint(self, schema, direction):
+    def get_near_endpoint(
+        self,
+        schema: s_schema.Schema,
+        direction: PointerDirection,
+    ) -> Optional[so.Object]:
         if direction == PointerDirection.Outbound:
             return self.get_source(schema)
         else:
             return self.get_target(schema)
 
-    def get_far_endpoint(self, schema, direction):
+    def get_far_endpoint(
+        self,
+        schema: s_schema.Schema,
+        direction: PointerDirection,
+    ) -> Optional[so.Object]:
         if direction == PointerDirection.Outbound:
             return self.get_target(schema)
         else:
             return self.get_source(schema)
 
-    def set_target(self, schema, target):
+    def set_target(
+        self,
+        schema: s_schema.Schema,
+        target: s_objtypes.ObjectType,
+    ) -> s_schema.Schema:
         return self.set_field_value(schema, 'target', target)
 
     @classmethod
-    def merge_targets(cls, schema, ptr, t1, t2, *, allow_contravariant=False):
+    def merge_targets(
+        cls,
+        schema: s_schema.Schema,
+        ptr: Pointer,
+        t1: s_types.Type,
+        t2: s_types.Type,
+        *,
+        allow_contravariant: bool = False,
+    ) -> Tuple[s_schema.Schema, Optional[s_types.Type]]:
         if t1 is t2:
             return schema, t1
 
@@ -300,6 +334,9 @@ class Pointer(referencing.ReferencedInheritingObject,
             return schema, t1
 
         else:
+            assert isinstance(t1, so.SubclassableObject)
+            assert isinstance(t2, so.SubclassableObject)
+
             if t2.issubclass(schema, t1):
                 # The new target is a subclass of the current target, so
                 # it is a more specific requirement.
@@ -322,8 +359,16 @@ class Pointer(referencing.ReferencedInheritingObject,
 
             return schema, current_target
 
-    def get_derived(self, schema, source, target, *,
-                    derived_name_base=None, **kwargs):
+    def get_derived(
+        self,
+        schema: s_schema.Schema,
+        source: so.Object,
+        target: s_types.Type,
+        *,
+        derived_name_base: str = None,
+        **kwargs: Any
+    ) -> Tuple[s_schema.Schema, Pointer]:
+        assert isinstance(source, so.QualifiedObject)
         fqname = self.derive_name(
             schema, source, derived_name_base=derived_name_base)
         ptr = schema.get(fqname, default=None)
@@ -337,24 +382,24 @@ class Pointer(referencing.ReferencedInheritingObject,
                 schema, ptr = self.derive_ref(
                     schema, source, target,
                     derived_name_base=derived_name_base, **kwargs)
-
+        assert isinstance(ptr, Pointer)
         return schema, ptr
 
     def get_derived_name_base(self, schema: s_schema.Schema) -> sn.Name:
         shortname = self.get_shortname(schema)
         return sn.Name(module='__', name=shortname.name)
 
-    def derive_ref(
-        self: referencing.ReferencedT,
+    def derive_ref(  # type: ignore
+        self,
         schema: s_schema.Schema,
-        source: s_sources.Source,
+        source: so.QualifiedObject,
         target: Optional[s_types.Type] = None,
         *qualifiers: str,
         mark_derived: bool = False,
-        attrs: Optional[Mapping[str, Any]] = None,
+        attrs: Optional[Dict[str, Any]] = None,
         dctx: Optional[sd.CommandContext] = None,
         **kwargs: Any,
-    ) -> Tuple[s_schema.Schema, referencing.ReferencedT]:
+    ) -> Tuple[s_schema.Schema, Pointer]:
 
         if target is None:
             if attrs and 'target' in attrs:
@@ -376,13 +421,16 @@ class Pointer(referencing.ReferencedInheritingObject,
         return bool(self.get_expr(schema))
 
     def is_id_pointer(self, schema: s_schema.Schema) -> bool:
-        std_id = schema.get('std::Object').getptr(schema, 'id')
-        std_target = schema.get('std::target')
+        from edb.schema import sources as s_sources
+        std_id = schema.get('std::Object',
+                            type=s_sources.Source).getptr(schema, 'id')
+        std_target = schema.get('std::target', type=so.SubclassableObject)
+        assert isinstance(std_id, so.SubclassableObject)
         return self.issubclass(schema, (std_id, std_target))
 
     def is_endpoint_pointer(self, schema: s_schema.Schema) -> bool:
-        std_source = schema.get('std::source')
-        std_target = schema.get('std::target')
+        std_source = schema.get('std::source', type=so.SubclassableObject)
+        std_target = schema.get('std::target', type=so.SubclassableObject)
         return self.issubclass(schema, (std_source, std_target))
 
     def is_special_pointer(self, schema: s_schema.Schema) -> bool:
@@ -402,14 +450,14 @@ class Pointer(referencing.ReferencedInheritingObject,
     def generic(self, schema: s_schema.Schema) -> bool:
         return self.get_source(schema) is None
 
-    def get_referrer(self, schema):
+    def get_referrer(self, schema: s_schema.Schema) -> Optional[so.Object]:
         return self.get_source(schema)
 
     def is_exclusive(self, schema: s_schema.Schema) -> bool:
         if self.generic(schema):
             raise ValueError(f'{self!r} is generic')
 
-        exclusive = schema.get('std::exclusive')
+        exclusive = schema.get('std::exclusive', type=constraints.Constraint)
 
         ptr = self.get_nearest_non_derived_parent(schema)
 
@@ -443,7 +491,7 @@ class Pointer(referencing.ReferencedInheritingObject,
             if b.get_source(schema) != my_source
         ]
 
-    def has_user_defined_properties(self, schema):
+    def has_user_defined_properties(self, schema: s_schema.Schema) -> bool:
         return False
 
     def allow_ref_propagation(
@@ -452,7 +500,11 @@ class Pointer(referencing.ReferencedInheritingObject,
         constext: sd.CommandContext,
         refdict: so.RefDict,
     ) -> bool:
-        return not self.get_source(schema).is_view(schema)
+        from edb.schema import objtypes as s_objtypes
+
+        object_type = self.get_source(schema)
+        assert isinstance(object_type, s_objtypes.ObjectType)
+        return not object_type.is_view(schema)
 
 
 class PseudoPointer(s_abc.Pointer):
@@ -465,19 +517,19 @@ class PseudoPointer(s_abc.Pointer):
     def is_type_intersection(self) -> bool:
         return False
 
-    def get_bases(self, schema):
+    def get_bases(self, schema: s_schema.Schema) -> so.ObjectList[Pointer]:
         return so.ObjectList.create(schema, [])
 
-    def get_ancestors(self, schema):
+    def get_ancestors(self, schema: s_schema.Schema) -> so.ObjectList[Pointer]:
         return so.ObjectList.create(schema, [])
 
-    def get_name(self, schema):
+    def get_name(self, schema: s_schema.Schema) -> str:
         raise NotImplementedError
 
-    def get_shortname(self, schema):
+    def get_shortname(self, schema: s_schema.Schema) -> str:
         return self.get_name(schema)
 
-    def get_displayname(self, schema):
+    def get_displayname(self, schema: s_schema.Schema) -> str:
         return self.get_name(schema)
 
     def has_user_defined_properties(self, schema: s_schema.Schema) -> bool:
@@ -486,10 +538,13 @@ class PseudoPointer(s_abc.Pointer):
     def get_required(self, schema: s_schema.Schema) -> bool:
         return True
 
-    def get_cardinality(self, schema):
+    def get_cardinality(
+        self,
+        schema: s_schema.Schema
+    ) -> qltypes.SchemaCardinality:
         raise NotImplementedError
 
-    def get_path_id_name(self, schema):
+    def get_path_id_name(self, schema: s_schema.Schema) -> str:
         return self.get_name(schema)
 
     def get_is_derived(self, schema: s_schema.Schema) -> bool:
@@ -498,22 +553,32 @@ class PseudoPointer(s_abc.Pointer):
     def get_is_local(self, schema: s_schema.Schema) -> bool:
         return True
 
-    def get_union_of(self, schema):
+    def get_union_of(
+        self,
+        schema: s_schema.Schema,
+    ) -> Optional[so.ObjectSet[s_types.Type]]:
         return None
 
-    def get_default(self, schema):
+    def get_default(
+        self,
+        schema: s_schema.Schema,
+    ) -> Optional[s_expr.Expression]:
         return None
 
-    def get_expr(self, schema):
+    def get_expr(self, schema: s_schema.Schema) -> Optional[s_expr.Expression]:
         return None
 
-    def get_source(self, schema) -> so.Object:
+    def get_source(self, schema: s_schema.Schema) -> so.Object:
         raise NotImplementedError
 
-    def get_target(self, schema) -> s_types.Type:
+    def get_target(self, schema: s_schema.Schema) -> s_types.Type:
         raise NotImplementedError
 
-    def get_near_endpoint(self, schema, direction):
+    def get_near_endpoint(
+        self,
+        schema: s_schema.Schema,
+        direction: PointerDirection,
+    ) -> so.Object:
         if direction is PointerDirection.Outbound:
             return self.get_source(schema)
         else:
@@ -521,7 +586,11 @@ class PseudoPointer(s_abc.Pointer):
                 f'inbound direction is not valid for {type(self)}'
             )
 
-    def get_far_endpoint(self, schema, direction):
+    def get_far_endpoint(
+        self,
+        schema: s_schema.Schema,
+        direction: PointerDirection,
+    ) -> so.Object:
         if direction is PointerDirection.Outbound:
             return self.get_target(schema)
         else:
@@ -542,13 +611,13 @@ class PseudoPointer(s_abc.Pointer):
     ) -> bool:
         raise NotImplementedError
 
-    def scalar(self):
+    def scalar(self) -> bool:
         raise NotImplementedError
 
-    def material_type(self, schema):
+    def material_type(self, schema: s_schema.Schema) -> PseudoPointer:
         return self
 
-    def is_pure_computable(self, schema: s_schema.Schema,) -> bool:
+    def is_pure_computable(self, schema: s_schema.Schema) -> bool:
         return False
 
     def is_exclusive(self, schema: s_schema.Schema) -> bool:
@@ -561,17 +630,21 @@ PointerLike = Union[Pointer, PseudoPointer]
 class ComputableRef(so.Object):
     """A shell for a computed target type."""
 
-    def __init__(self, expr: str) -> None:
+    expr: qlast.Expr
+
+    def __init__(self, expr: qlast.Base):
         super().__init__(_private_init=True)
         self.__dict__['expr'] = expr
 
 
-class PointerCommandContext(sd.ObjectCommandContext,
+class PointerCommandContext(sd.ObjectCommandContext[Pointer],
                             s_anno.AnnotationSubjectCommandContext):
     pass
 
 
-class PointerCommandOrFragment(sd.ObjectCommand[Pointer]):
+class PointerCommandOrFragment(
+    referencing.ReferencedObjectCommandBase[Pointer]
+):
 
     def resolve_refs(
         self,
@@ -643,30 +716,35 @@ class PointerCommandOrFragment(sd.ObjectCommand[Pointer]):
         expr: qlast.Base,
         schema: s_schema.Schema,
         context: sd.CommandContext,
-    ) -> Tuple[s_schema.Schema, s_types.Type, Optional[Pointer]]:
+    ) -> Tuple[s_schema.Schema, s_types.Type, Union[None,
+                                                    PseudoPointer,
+                                                    Pointer]]:
         from edb.ir import ast as irast
         from edb.ir import typeutils as irtyputils
+        from edb.schema import objtypes as s_objtypes
 
         # "source" attribute is set automatically as a refdict back-attr
         parent_ctx = self.get_referrer_context(context)
+        assert parent_ctx is not None
         source_name = parent_ctx.op.classname
 
-        source = schema.get(source_name)
-        expr = s_expr.Expression.compiled(
+        source = schema.get(source_name, type=s_objtypes.ObjectType)
+        expression = s_expr.Expression.compiled(
             s_expr.Expression.from_ast(expr, schema, context.modaliases),
             schema=schema,
             options=qlcompiler.CompilerOptions(
                 modaliases=context.modaliases,
                 anchors={qlast.Source().name: source},
                 path_prefix_anchor=qlast.Source().name,
-                singletons=[source],
+                singletons=frozenset([source]),
             ),
         )
 
+        assert isinstance(expression.irast, irast.Statement)
         base = None
-        target = expr.irast.stype
+        target = expression.irast.stype
 
-        result_expr = expr.irast.expr.expr
+        result_expr = expression.irast.expr.expr
 
         if (isinstance(result_expr, irast.SelectStmt)
                 and result_expr.result.rptr is not None):
@@ -683,8 +761,8 @@ class PointerCommandOrFragment(sd.ObjectCommand[Pointer]):
                     expr_rptr.ptrref, schema=schema
                 )
 
-        self.set_attribute_value('expr', expr)
-        required, card = expr.irast.cardinality.to_schema_value()
+        self.set_attribute_value('expr', expression)
+        required, card = expression.irast.cardinality.to_schema_value()
         spec_required = self.get_attribute_value('required')
         spec_card = self.get_attribute_value('cardinality')
 
@@ -734,27 +812,49 @@ class PointerCommandOrFragment(sd.ObjectCommand[Pointer]):
 
 
 class PointerCommand(
-    referencing.ReferencedInheritingObjectCommand,
-    constraints.ConsistencySubjectCommand,
+    referencing.ReferencedInheritingObjectCommand[Pointer],
+    constraints.ConsistencySubjectCommand[Pointer],
     s_anno.AnnotationSubjectCommand,
     PointerCommandOrFragment,
 ):
 
-    def _create_begin(self, schema, context):
+    def _set_pointer_type(
+        self,
+        schema: s_schema.Schema,
+        astnode: qlast.CreateConcretePointer,
+        context: sd.CommandContext,
+        target_ref: Union[so.Object, so.ObjectShell],
+    ) -> None:
+        return None
+
+    def _create_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
         schema = super()._create_begin(schema, context)
 
         if not context.canonical:
             self._validate_pointer_def(schema, context)
         return schema
 
-    def _alter_begin(self, schema, context):
+    def _alter_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
         schema = super()._alter_begin(schema, context)
         if not context.canonical:
             self._validate_pointer_def(schema, context)
         return schema
 
-    def _validate_pointer_def(self, schema, context):
+    def _validate_pointer_def(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> None:
         """Check that pointer definition is sound."""
+        from edb.ir import ast as irast
 
         referrer_ctx = self.get_referrer_context(context)
         if referrer_ctx is None:
@@ -769,8 +869,14 @@ class PointerCommand(
         if default_expr is not None:
             if default_expr.irast is None:
                 default_expr = default_expr.compiled(default_expr, schema)
+
+            assert isinstance(default_expr.irast, irast.Statement)
+
             default_type = default_expr.irast.stype
+            assert default_type is not None
             ptr_target = scls.get_target(schema)
+            assert ptr_target is not None
+
             source_context = self.get_attribute_source_context('default')
             if not default_type.assignment_castable_to(ptr_target, schema):
                 raise errors.SchemaDefinitionError(
@@ -797,11 +903,17 @@ class PointerCommand(
                 )
 
     @classmethod
-    def _classname_from_ast(cls, schema, astnode, context):
+    def _classname_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.NamedDDL,
+        context: sd.CommandContext,
+    ) -> sn.Name:
         referrer_ctx = cls.get_referrer_context(context)
         if referrer_ctx is not None:
 
             referrer_name = referrer_ctx.op.classname
+            assert isinstance(referrer_name, sn.Name)
 
             shortname = sn.Name(
                 module='__',
@@ -827,7 +939,12 @@ class PointerCommand(
         return name
 
     @classmethod
-    def _cmd_tree_from_ast(cls, schema, astnode, context):
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
         referrer_ctx = cls.get_referrer_context(context)
         if referrer_ctx is not None:
@@ -835,7 +952,12 @@ class PointerCommand(
                 cmd.set_attribute_value('declared_overloaded', True)
         return cmd
 
-    def _process_create_or_alter_ast(self, schema, astnode, context):
+    def _process_create_or_alter_ast(
+        self,
+        schema: s_schema.Schema,
+        astnode: qlast.CreateConcretePointer,
+        context: sd.CommandContext,
+    ) -> None:
         """Handle the CREATE {PROPERTY|LINK} AST node.
 
         This may be called in the context of either Create or Alter.
@@ -847,13 +969,17 @@ class PointerCommand(
             self.set_attribute_value('cardinality', astnode.cardinality)
 
         parent_ctx = self.get_referrer_context(context)
+        assert parent_ctx is not None
         source_name = parent_ctx.op.classname
         self.set_attribute_value('source', so.ObjectShell(name=source_name))
 
         # FIXME: this is an approximate solution
         targets = qlast.get_targets(astnode.target)
+        target_ref: Union[None, s_types.TypeShell, ComputableRef]
 
         if len(targets) > 1:
+            assert isinstance(source_name, sn.Name)
+
             new_targets = [
                 utils.ast_to_type_shell(
                     t,
@@ -888,6 +1014,7 @@ class PointerCommand(
             target_ref = None
 
         if isinstance(target_ref, s_types.CollectionTypeShell):
+            assert astnode.target is not None
             s_types.ensure_schema_collection(
                 schema,
                 target_ref,
@@ -897,6 +1024,7 @@ class PointerCommand(
             )
 
         if isinstance(self, sd.CreateObject):
+            assert astnode.target is not None
             self.set_attribute_value(
                 'target',
                 target_ref,
@@ -917,33 +1045,43 @@ class PointerCommand(
         elif target_ref is not None:
             self._set_pointer_type(schema, astnode, context, target_ref)
 
-    @classmethod
-    def _extract_union_operands(cls, expr, operands):
-        if expr.op == 'UNION':
-            cls._extract_union_operands(expr.op_larg, operands)
-            cls._extract_union_operands(expr.op_rarg, operands)
-        else:
-            operands.append(expr)
-
-    def compile_expr_field(self, schema, context, field, value):
+#    @classmethod
+#    def _extract_union_operands(cls, expr, operands):
+#        if expr.op == 'UNION':
+#            cls._extract_union_operands(expr.op_larg, operands)
+#            cls._extract_union_operands(expr.op_rarg, operands)
+#        else:
+#            operands.append(expr)
+#
+    def compile_expr_field(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        field: so.Field[Any],
+        value: Any,
+    ) -> s_expr.Expression:
         from . import sources as s_sources
 
         if field.name in {'default', 'expr'}:
-            singletons = []
+            singletons: List[s_types.Type] = []
             path_prefix_anchor = None
-            anchors = {}
+            anchors: Dict[str, Any] = {}
 
             if field.name == 'expr':
                 parent_ctx = context.get_ancestor(
-                    s_sources.SourceCommandContext, self)
+                    s_sources.SourceCommandContext,   # type: ignore
+                    self
+                )
+                assert parent_ctx is not None
                 source_name = parent_ctx.op.classname
                 source = schema.get(source_name, default=None)
                 anchors[qlast.Source().name] = source
                 if not isinstance(source, Pointer):
+                    assert source is not None
                     singletons = [source]
                     path_prefix_anchor = qlast.Source().name
 
-            return type(value).compiled(
+            expression = type(value).compiled(
                 value,
                 schema=schema,
                 options=qlcompiler.CompilerOptions(
@@ -951,13 +1089,21 @@ class PointerCommand(
                     schema_object_context=self.get_schema_metaclass(),
                     anchors=anchors,
                     path_prefix_anchor=path_prefix_anchor,
-                    singletons=singletons,
+                    singletons=frozenset(singletons),
                 ),
             )
+            assert isinstance(expression, s_expr.Expression)
+            return expression
         else:
             return super().compile_expr_field(schema, context, field, value)
 
-    def _apply_field_ast(self, schema, context, node, op):
+    def _apply_field_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        node: qlast.DDLOperation,
+        op: sd.AlterObjectProperty,
+    ) -> None:
         if context.descriptive_mode:
             # When generating AST for DESCRIBE AS TEXT, we want to
             # omit 'readonly' flag if it's inherited and it actually
@@ -965,6 +1111,7 @@ class PointerCommand(
             if op.property == 'readonly':
                 pointer_obj = self.get_object(schema, context)
                 field = type(pointer_obj).get_field('readonly')
+                assert isinstance(field, so.SchemaField)
                 dval = field.default
 
                 if op.source == 'inheritance' and op.new_value is dval:
@@ -974,11 +1121,15 @@ class PointerCommand(
 
 
 class SetPointerType(
-        referencing.ReferencedInheritingObjectCommand,
-        inheriting.AlterInheritingObjectFragment,
+        referencing.ReferencedInheritingObjectCommand[Pointer],
+        inheriting.AlterInheritingObjectFragment[Pointer],
         PointerCommandOrFragment):
 
-    def _alter_begin(self, schema, context):
+    def _alter_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
         schema = super()._alter_begin(schema, context)
         scls = self.scls
 
@@ -998,7 +1149,9 @@ class SetPointerType(
 
             tgt = scls.get_target(schema)
             for base in set(implicit_bases) - context.altered_targets:
+                assert tgt is not None
                 base_tgt = base.get_target(schema)
+                assert isinstance(base_tgt, so.SubclassableObject)
                 if not tgt.issubclass(schema, base_tgt):
                     non_altered_bases.append(base)
 
@@ -1024,7 +1177,10 @@ class SetPointerType(
             if context.enable_recursion:
                 tgt = self.get_attribute_value('target')
 
-                def _set_type(alter_cmd, refname):
+                def _set_type(
+                    alter_cmd: sd.Command,
+                    refname: Any
+                ) -> None:
                     s_t = type(self)(
                         classname=alter_cmd.classname,
                     )
@@ -1041,14 +1197,26 @@ class SetPointerType(
         return schema
 
     @classmethod
-    def _cmd_from_ast(cls, schema, astnode, context):
+    def _cmd_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.ObjectCommand[Pointer]:
         return cls(classname=context.current().op.classname)
 
     @classmethod
-    def _cmd_tree_from_ast(cls, schema, astnode, context):
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.Command:
+        assert isinstance(astnode, qlast.SetPointerType)
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
 
         targets = qlast.get_targets(astnode.type)
+        target_ref: s_types.TypeShell
 
         if len(targets) > 1:
             new_targets = [
@@ -1078,11 +1246,12 @@ class SetPointerType(
 
 
 def get_or_create_union_pointer(
-    schema,
+    schema: s_schema.Schema,
     ptrname: str,
-    source,
+    source: so.Object,
     direction: PointerDirection,
-    components: Iterable[Pointer], *,
+    components: Iterable[Pointer],
+    *,
     opaque: bool = False,
     modname: Optional[str] = None,
 ) -> Tuple[s_schema.Schema, Pointer]:
@@ -1093,7 +1262,13 @@ def get_or_create_union_pointer(
     if len(components) == 1 and direction is PointerDirection.Outbound:
         return schema, components[0]
 
-    targets = [p.get_far_endpoint(schema, direction) for p in components]
+    far_endpoints = [p.get_far_endpoint(schema, direction)
+                     for p in components]
+    targets: List[s_types.Type] = [p for p in far_endpoints
+                                   if isinstance(p, s_types.Type)]
+
+    target: so.Object
+
     schema, target = utils.get_union_type(
         schema, targets, opaque=opaque, module=modname)
 
@@ -1104,7 +1279,9 @@ def get_or_create_union_pointer(
             break
 
     metacls = type(components[0])
-    genptr = schema.get(metacls.get_default_base_name())
+    default_base_name = metacls.get_default_base_name()
+    assert default_base_name is not None
+    genptr = schema.get(default_base_name, type=Pointer)
 
     if direction is PointerDirection.Inbound:
         source, target = target, source
@@ -1123,9 +1300,11 @@ def get_or_create_union_pointer(
     )
 
     if isinstance(result, s_sources.Source):
+        # cast below, because in this case the list of Pointer
+        # is also a list of Source (links.Link)
         schema = s_sources.populate_pointer_set_for_source_union(
             schema,
-            components,
+            cast(List[s_sources.Source], components),
             result,
             modname=modname,
         )
@@ -1134,9 +1313,9 @@ def get_or_create_union_pointer(
 
 
 def get_or_create_intersection_pointer(
-    schema,
+    schema: s_schema.Schema,
     ptrname: str,
-    source,
+    source: s_objtypes.ObjectType,
     components: Iterable[Pointer], *,
     modname: Optional[str] = None,
 ) -> Tuple[s_schema.Schema, Pointer]:
@@ -1144,9 +1323,9 @@ def get_or_create_intersection_pointer(
     components = list(components)
 
     if len(components) == 1:
-        return components[0]
+        return schema, components[0]
 
-    targets = [p.get_target(schema) for p in components]
+    targets = list(filter(None, [p.get_target(schema) for p in components]))
     schema, target = utils.get_intersection_type(
         schema, targets, module=modname)
 
@@ -1157,7 +1336,9 @@ def get_or_create_intersection_pointer(
             break
 
     metacls = type(components[0])
-    genptr = schema.get(metacls.get_default_base_name())
+    default_base_name = metacls.get_default_base_name()
+    assert default_base_name is not None
+    genptr = schema.get(default_base_name, type=Pointer)
 
     schema, result = genptr.get_derived(
         schema,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -553,7 +553,7 @@ class PseudoPointer(s_abc.Pointer):
     def get_union_of(
         self,
         schema: s_schema.Schema,
-    ) -> Optional[so.ObjectSet[s_types.Type]]:
+    ) -> None:
         return None
 
     def get_default(

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -74,7 +74,7 @@ def populate_pointer_set_for_source_union(
     components: Iterable[Source],
     union: Source,
     *,
-    modname: str = '__derived__',
+    modname: Optional[str] = '__derived__',
 ) -> s_schema.Schema:
 
     union_pointers = {}

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -74,8 +74,10 @@ def populate_pointer_set_for_source_union(
     components: Iterable[Source],
     union: Source,
     *,
-    modname: Optional[str] = '__derived__',
+    modname: Optional[str] = None,
 ) -> s_schema.Schema:
+    if modname is None:
+        modname = '__derived__'
 
     union_pointers = {}
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -596,3 +596,19 @@ no_implicit_optional = True
 warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
+
+[mypy-edb.schema.pointers]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 89.88)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 93.99)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.43)


### PR DESCRIPTION
Adds annotations for schema pointers, include refactoring of Pointer.derive_ref method to make it compatible with its ancestor class ReferencedObject.