### PR TITLE
Prohibit database names longer than 63 characters.

### DIFF
--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -29,6 +29,7 @@ from edb.common import uuidgen
 from edb.schema import abc as s_abc
 from edb.schema import casts as s_casts
 from edb.schema import constraints as s_constr
+from edb.schema import defines as s_def
 from edb.schema import functions as s_func
 from edb.schema import modules as s_mod
 from edb.schema import name as s_name
@@ -136,7 +137,7 @@ def _edgedb_name_to_pg_name(name: str, prefix_length: int = 0) -> str:
         name[:prefix_length] +
         hashed +
         ':' +
-        name[-(63 - prefix_length - 1 - len(hashed)):]
+        name[-(s_def.MAX_NAME_LENGTH - prefix_length - 1 - len(hashed)):]
     )
 
 
@@ -148,12 +149,12 @@ def edgedb_name_to_pg_name(name: str, prefix_length: int = 0) -> str:
     @param name: EdgeDB name to convert
     @return: PostgreSQL column name
     """
-    if not (0 <= prefix_length < 63):
+    if not (0 <= prefix_length < s_def.MAX_NAME_LENGTH):
         raise ValueError('supplied name is too long '
                          'to be kept in original form')
 
     name = str(name)
-    if len(name) <= 63 - prefix_length:
+    if len(name) <= s_def.MAX_NAME_LENGTH - prefix_length:
         return name
 
     return _edgedb_name_to_pg_name(name, prefix_length)

--- a/edb/schema/defines.py
+++ b/edb/schema/defines.py
@@ -1,0 +1,24 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+
+# Maximum length of column name in Postgres. This limits the database
+# name length and affects column name mangling.
+MAX_NAME_LENGTH = 63

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -27,6 +27,7 @@ from edb.common import enum
 from edb.edgeql import ast as qlast
 from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import qltypes
+from edb.schema import defines as s_def
 
 from . import abc as s_abc
 from . import annos as s_anno
@@ -50,9 +51,6 @@ if TYPE_CHECKING:
 class PointerDirection(enum.StrEnum):
     Outbound = '>'
     Inbound = '<'
-
-
-MAX_NAME_LENGTH = 63
 
 
 def merge_cardinality(target: Pointer, sources: List[Pointer],
@@ -926,10 +924,10 @@ class PointerCommand(
             name = super()._classname_from_ast(schema, astnode, context)
 
         shortname = sn.shortname_from_fullname(name)
-        if len(shortname.name) > MAX_NAME_LENGTH:
+        if len(shortname.name) > s_def.MAX_NAME_LENGTH:
             raise errors.SchemaDefinitionError(
                 f'link or property name length exceeds the maximum of '
-                f'{MAX_NAME_LENGTH} characters',
+                f'{s_def.MAX_NAME_LENGTH} characters',
                 context=astnode.context)
         return name
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -19,6 +19,7 @@
 
 import edgedb
 
+from edb.schema import defines as s_def
 from edb.testbase import server as tb
 
 
@@ -45,3 +46,10 @@ class TestDatabase(tb.ConnectedTestCase):
             await conn.aclose()
         finally:
             await self.con.execute('DROP DATABASE mytestdb;')
+
+    async def test_database_create_02(self):
+        with self.assertRaisesRegex(edgedb.SchemaDefinitionError,
+                                    r'Database names longer than \d+ '
+                                    r'characters are not supported'):
+            await self.con.execute(
+                f'CREATE DATABASE mytestdb_{"x" * s_def.MAX_NAME_LENGTH};')


### PR DESCRIPTION
 Fixes: #1158