### PR TITLE
Stop special-casing the definition of pseudo types

### DIFF
--- a/edb/edgeql-rust/src/tokenizer.rs
+++ b/edb/edgeql-rust/src/tokenizer.rs
@@ -15,7 +15,7 @@ use crate::errors::TokenizerError;
 
 static mut TOKENS: Option<Tokens> = None;
 
-const UNRESERVED_KEYWORDS: [&str; 76] = [
+const UNRESERVED_KEYWORDS: [&str; 77] = [
     "abstract",
     "after",
     "alias",
@@ -65,6 +65,7 @@ const UNRESERVED_KEYWORDS: [&str; 76] = [
     "postfix",
     "prefix",
     "property",
+    "pseudo",
     "read",
     "rename",
     "required",

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -715,6 +715,10 @@ class DropAnnotation(DropObject):
     pass
 
 
+class CreatePseudoType(CreateObject):
+    pass
+
+
 class CreateScalarType(CreateExtendingObject):
     pass
 

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -93,7 +93,7 @@ def compile_cast(
         return _cast_array_literal(
             ir_set, orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
 
-    elif orig_stype.is_tuple():
+    elif orig_stype.is_tuple(ctx.env.schema):
         return _cast_tuple(
             ir_set, orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
 
@@ -374,7 +374,7 @@ def _cast_tuple(
         return _cast_to_ir(
             new_tuple, direct_cast, orig_stype, new_stype, ctx=ctx)
 
-    if not new_stype.is_tuple():
+    if not new_stype.is_tuple(ctx.env.schema):
         raise errors.QueryError(
             f'cannot cast {orig_stype.get_displayname(ctx.env.schema)!r} '
             f'to {new_stype.get_displayname(ctx.env.schema)!r}',

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -409,7 +409,7 @@ def compile_TypeCast(
         pt = typegen.ql_typeexpr_to_type(expr.type, ctx=ctx)
 
         if (
-            (pt.is_tuple() or pt.is_anytuple())
+            (pt.is_tuple(ctx.env.schema) or pt.is_anytuple(ctx.env.schema))
             and not ctx.env.options.func_params
         ):
             raise errors.QueryError(

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -270,7 +270,7 @@ def __infer_anytyperef(
     ir: irast.AnyTypeRef,
     env: context.Environment,
 ) -> s_types.Type:
-    return s_pseudo.Any.get(env.schema)
+    return s_pseudo.PseudoType.get(env.schema, 'anytype')
 
 
 @_infer_type.register
@@ -278,7 +278,7 @@ def __infer_anytupleref(
     ir: irast.AnyTupleRef,
     env: context.Environment,
 ) -> s_types.Type:
-    return s_pseudo.AnyTuple.get(env.schema)
+    return s_pseudo.PseudoType.get(env.schema, 'anytuple')
 
 
 @_infer_type.register
@@ -368,7 +368,7 @@ def __infer_slice(
         base_name = 'bytes'
     elif isinstance(node_type, s_abc.Array):
         base_name = 'array'
-    elif node_type.is_any():
+    elif node_type.is_any(env.schema):
         base_name = 'anytype'
     else:
         # the base type is not valid
@@ -452,12 +452,12 @@ def __infer_index(
 
         result = node_type.get_subtypes(env.schema)[0]
 
-    elif (node_type.is_any() or
+    elif (node_type.is_any(env.schema) or
             (node_type.is_scalar() and
                 node_type.get_name(env.schema) == 'std::anyscalar') and
             (index_type.implicitly_castable_to(int_t, env.schema) or
                 index_type.implicitly_castable_to(str_t, env.schema))):
-        result = s_pseudo.Any.get(env.schema)
+        result = s_pseudo.PseudoType.get(env.schema, 'anytype')
 
     else:
         raise errors.QueryError(
@@ -482,7 +482,7 @@ def __infer_array(
             raise errors.QueryError('could not determine array type',
                                     context=ir.context)
     else:
-        element_type = s_pseudo.Any.get(env.schema)
+        element_type = s_pseudo.PseudoType.get(env.schema, 'anytype')
 
     env.schema, arr_t = s_types.Array.create(
         env.schema,

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -395,7 +395,7 @@ def try_bind_call_args(
                 if empty_default:
                     default_type = None
 
-                    if param_type.is_any():
+                    if param_type.is_any(schema):
                         if resolved_poly_base_type is None:
                             raise errors.QueryError(
                                 f'could not resolve "anytype" type for the '

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -61,9 +61,9 @@ def get_schema_object(
         module = name.module
         name = name.name
     elif isinstance(name, qlast.AnyType):
-        return s_pseudo.Any.get(ctx.env.schema)
+        return s_pseudo.PseudoType.get(ctx.env.schema, 'anytype')
     elif isinstance(name, qlast.AnyTuple):
-        return s_pseudo.AnyTuple.get(ctx.env.schema)
+        return s_pseudo.PseudoType.get(ctx.env.schema, 'anytuple')
     elif isinstance(name, qlast.BaseObjectRef):
         raise AssertionError(f"Unhandled BaseObjectRef subclass: {name!r}")
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -79,7 +79,7 @@ def new_empty_set(*, stype: Optional[s_types.Type]=None, alias: str,
                   srcctx: Optional[
                       parsing.ParserContext]=None) -> irast.Set:
     if stype is None:
-        stype = s_pseudo.Any.get(ctx.env.schema)
+        stype = s_pseudo.PseudoType.get(ctx.env.schema, 'anytype')
         if srcctx is not None:
             ctx.env.type_origins[stype] = srcctx
 
@@ -164,7 +164,7 @@ def new_array_set(
     if elements:
         stype = inference.infer_type(arr, env=ctx.env)
     else:
-        anytype = s_pseudo.Any.get(ctx.env.schema)
+        anytype = s_pseudo.PseudoType.get(ctx.env.schema, 'anytype')
         ctx.env.schema, stype = s_types.Array.from_subtypes(
             ctx.env.schema, [anytype])
         if srcctx is not None:
@@ -860,7 +860,7 @@ def ensure_set(
         stype = type_override
 
     if (isinstance(ir_set, irast.EmptySet)
-            and (stype is None or stype.is_any())
+            and (stype is None or stype.is_any(ctx.env.schema))
             and typehint is not None):
         inference.amend_empty_set_type(ir_set, typehint, env=ctx.env)
         stype = get_set_type(ir_set, ctx=ctx)

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -107,6 +107,10 @@ class WithDDLStmt(Nonterm):
 # DDL statements that are allowed inside CREATE DATABASE and CREATE MIGRATION
 #
 class InnerDDLStmt(Nonterm):
+
+    def reduce_CreatePseudoTypeStmt(self, *kids):
+        self.val = kids[0].val
+
     def reduce_CreateScalarTypeStmt(self, *kids):
         self.val = kids[0].val
 
@@ -730,6 +734,30 @@ class DropConcreteConstraintStmt(Nonterm):
             name=kids[2].val,
             args=kids[3].val,
             subjectexpr=kids[4].val,
+        )
+
+
+#
+# CREATE PSEUDO TYPE
+#
+
+commands_block(
+    'CreatePseudoType',
+    SetFieldStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
+)
+
+
+class CreatePseudoTypeStmt(Nonterm):
+
+    def reduce_CreatePseudoTypeStmt(self, *kids):
+        r"""%reduce
+            CREATE PSEUDO TYPE NodeName OptCreatePseudoTypeCommandsBlock
+        """
+        self.val = qlast.CreatePseudoType(
+            name=kids[3].val,
+            commands=kids[4].val,
         )
 
 

--- a/edb/edgeql/parser/grammar/keywords.py
+++ b/edb/edgeql/parser/grammar/keywords.py
@@ -74,6 +74,7 @@ unreserved_keywords = frozenset([
     "postfix",
     "prefix",
     "property",
+    "pseudo",
     "read",
     "rename",
     "required",

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -304,7 +304,7 @@ class GQLCoreSchema:
             if name in self._gql_enums:
                 target = self._gql_enums.get(name)
 
-        elif edb_target.is_tuple():
+        elif edb_target.is_tuple(self.edb_schema):
             edb_typename = edb_target.get_verbosename(self.edb_schema)
             raise g_errors.GraphQLCoreError(
                 f"Could not convert {edb_typename} to a GraphQL type.")

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -155,12 +155,12 @@ def type_to_typeref(
             if cached_result.name_hint == t.get_name(schema):
                 return cached_result
 
-    if t.is_anytuple():
+    if t.is_anytuple(schema):
         result = irast.AnyTupleRef(
             id=t.id,
             name_hint=typename or t.get_name(schema),
         )
-    elif t.is_any():
+    elif t.is_any(schema):
         result = irast.AnyTypeRef(
             id=t.id,
             name_hint=typename or t.get_name(schema),
@@ -325,10 +325,10 @@ def ir_typeref_to_type(
         given *typeref*.
     """
     if is_anytuple(typeref):
-        return schema, s_pseudo.AnyTuple.get(schema)
+        return schema, s_pseudo.PseudoType.get(schema, 'anytuple')
 
     elif is_any(typeref):
-        return schema, s_pseudo.Any.get(schema)
+        return schema, s_pseudo.PseudoType.get(schema, 'anytype')
 
     elif is_tuple(typeref):
         named = False

--- a/edb/lib/std/10-scalars.edgeql
+++ b/edb/lib/std/10-scalars.edgeql
@@ -17,6 +17,10 @@
 #
 
 
+CREATE PSEUDO TYPE `anytype`;
+
+CREATE PSEUDO TYPE `anytuple`;
+
 CREATE ABSTRACT SCALAR TYPE std::anyscalar;
 
 CREATE SCALAR TYPE std::bool EXTENDING std::anyscalar;

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -48,6 +48,7 @@ from edb.schema import name as sn
 from edb.schema import objects as s_obj
 from edb.schema import operators as s_opers
 from edb.schema import pointers as s_pointers
+from edb.schema import pseudo as s_pseudo
 from edb.schema import referencing as s_referencing
 from edb.schema import roles as s_roles
 from edb.schema import sources as s_sources
@@ -361,6 +362,22 @@ class AlterObjectProperty(MetaCommand, adapts=sd.AlterObjectProperty):
     pass
 
 
+class PseudoTypeCommand(ObjectMetaCommand):
+
+    _table = metaschema.get_metaclass_table(s_pseudo.PseudoType)
+
+    def get_table(self, schema):
+        return self._table
+
+
+class CreatePseudoType(
+    PseudoTypeCommand,
+    CreateObject,
+    adapts=s_pseudo.CreatePseudoType,
+):
+    pass
+
+
 class TupleCommand(ObjectMetaCommand):
 
     pass
@@ -523,7 +540,7 @@ class FunctionCommand:
         return common.get_backend_name(schema, func, catenate=False)
 
     def get_pgtype(self, func: s_funcs.Function, obj, schema):
-        if obj.is_any():
+        if obj.is_any(schema):
             return ('anyelement',)
 
         try:

--- a/edb/pgsql/intromech.py
+++ b/edb/pgsql/intromech.py
@@ -551,17 +551,17 @@ class IntrospectionMech:
             )
 
         elif t['maintype'] == 'anytype':
-            scls = s_pseudo.Any.get(schema)
+            scls = s_pseudo.PseudoType.get(schema, 'anytype')
 
         elif t['maintype'] == 'anytuple':
-            scls = s_pseudo.AnyTuple.get(schema)
+            scls = s_pseudo.PseudoType.get(schema, 'anytuple')
 
         else:
             type_id = t['maintype']
             if type_id == s_obj.get_known_type_id('anytype'):
-                scls = s_pseudo.Any.get(schema)
+                scls = s_pseudo.PseudoType.get(schema, 'anytype')
             elif type_id == s_obj.get_known_type_id('anytuple'):
-                scls = s_pseudo.AnyTuple.get(schema)
+                scls = s_pseudo.PseudoType.get(schema, 'anytuple')
             else:
                 scls = schema.get_by_id(t['maintype'])
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -41,7 +41,6 @@ from edb.schema import migrations  # NoQA
 from edb.schema import modules as s_mod
 from edb.schema import name as sn
 from edb.schema import objects as s_obj
-from edb.schema import pseudo as s_pseudo
 
 from edb.server import defines
 
@@ -2098,22 +2097,6 @@ def get_metaclass_table(mcls):
     return metaclass_tables[mcls]
 
 
-def make_register_any_command():
-    pseudo_type_table = get_metaclass_table(s_pseudo.PseudoType)
-
-    anytype = pseudo_type_table.record
-    anytype.ancestors = None
-    anytype.id = s_obj.get_known_type_id('anytype')
-    anytype.name = 'anytype'
-
-    anytuple = pseudo_type_table.record
-    anytuple.ancestors = None
-    anytuple.id = s_obj.get_known_type_id('anytuple')
-    anytuple.name = 'anytuple'
-
-    return dbops.Insert(table=pseudo_type_table, records=[anytype, anytuple])
-
-
 async def bootstrap(conn):
     commands = dbops.CommandGroup()
     commands.add_commands([
@@ -2194,9 +2177,6 @@ async def bootstrap(conn):
         dbops.CreateFunction(SysVersionFunction()),
         dbops.CreateFunction(SysGetTransactionIsolation()),
     ])
-
-    # Register "any" pseudo-type.
-    commands.add_command(make_register_any_command())
 
     block = dbops.PLTopBlock(disable_ddl_triggers=True)
     commands.generate(block)

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -149,7 +149,7 @@ def pg_type_from_object(
     if isinstance(obj, s_scalars.ScalarType):
         return pg_type_from_scalar(schema, obj)
 
-    elif obj.is_type() and obj.is_anytuple():
+    elif obj.is_type() and obj.is_anytuple(schema):
         return ('record',)
 
     elif isinstance(obj, s_abc.Tuple):
@@ -173,7 +173,7 @@ def pg_type_from_object(
     elif isinstance(obj, s_objtypes.ObjectType):
         return ('uuid',)
 
-    elif obj.is_type() and obj.is_any():
+    elif obj.is_type() and obj.is_any(schema):
         return ('anyelement',)
 
     else:
@@ -264,7 +264,7 @@ class _PointerStorageInfo:
         if pointer_target is not None:
             if pointer_target.is_object_type():
                 column_type = ('uuid',)
-            elif pointer_target.is_tuple():
+            elif pointer_target.is_tuple(schema):
                 column_type = common.get_backend_name(schema, pointer_target,
                                                       catenate=False)
             else:
@@ -567,12 +567,12 @@ class TypeDesc:
                     maintype=t.id, name=tn, collection=t.schema_name,
                     subtypes=subtypes, dimensions=dimensions,
                     position=i if not is_root else None)
-            elif t.is_type() and t.is_any():
+            elif t.is_type() and t.is_any(schema):
                 desc = TypeDescNode(
                     maintype=t.id, name=tn, collection=None,
                     subtypes=[], dimensions=[],
                     position=i if not is_root else None)
-            elif t.is_type() and t.is_anytuple():
+            elif t.is_type() and t.is_anytuple(schema):
                 desc = TypeDescNode(
                     maintype=t.id, name=tn, collection=None,
                     subtypes=[], dimensions=[],

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -133,10 +133,10 @@ class Constraint(referencing.ReferencedInheritingObject,
     def _dummy_subject(
         cls,
         schema: s_schema.Schema,
-    ) -> Optional[s_pseudo.Any]:
+    ) -> Optional[s_pseudo.PseudoType]:
         # Point subject placeholder to a dummy pointer to make EdgeQL
         # pipeline happy.
-        return s_pseudo.Any.get(schema)
+        return s_pseudo.PseudoType.get(schema, 'anytype')
 
     @classmethod
     def get_concrete_constraint_attrs(
@@ -617,7 +617,7 @@ class CreateConstraint(
             num=param_offset,
             name='__subject__',
             default=None,
-            type=s_pseudo.AnyTypeShell(),
+            type=s_pseudo.PseudoTypeShell(name='anytype'),
             typemod=ft.TypeModifier.SINGLETON,
             kind=ft.ParameterKind.POSITIONAL,
         ))

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -2210,7 +2210,7 @@ class SubclassableObject(Object):
         if isinstance(parent, tuple):
             return any(self.issubclass(schema, p) for p in parent)
         else:
-            if isinstance(parent, s_types.Type) and parent.is_any():
+            if isinstance(parent, s_types.Type) and parent.is_any(schema):
                 return True
             else:
                 return self._issubclass(schema, parent)

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -189,7 +189,7 @@ class CreateOperator(s_func.CreateCallableObject, OperatorCommand):
         for param in params.objects(schema):
             ptype = param.get_type(schema)
             all_arrays = all_arrays and ptype.is_array()
-            all_tuples = all_tuples and ptype.is_tuple()
+            all_tuples = all_tuples and ptype.is_tuple(schema)
 
         # It's illegal to declare an operator as recursive unless all
         # of its operands are the same basic type of collection.
@@ -236,7 +236,10 @@ class CreateOperator(s_func.CreateCallableObject, OperatorCommand):
                 for param in oper.get_params(schema).objects(schema):
                     ptype = param.get_type(schema)
                     oper_all_arrays = oper_all_arrays and ptype.is_array()
-                    oper_all_tuples = oper_all_tuples and ptype.is_tuple()
+                    oper_all_tuples = (
+                        oper_all_tuples
+                        and ptype.is_tuple(schema)
+                    )
 
                 if (all_arrays == oper_all_arrays and
                         all_tuples == oper_all_tuples):

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -88,8 +88,8 @@ class ScalarType(
     def _to_nonpolymorphic(
         self,
         schema: s_schema.Schema,
-        concrete_type: ScalarType,
-    ) -> Tuple[s_schema.Schema, ScalarType]:
+        concrete_type: s_types.Type,
+    ) -> Tuple[s_schema.Schema, s_types.Type]:
         if (not concrete_type.is_polymorphic(schema) and
                 concrete_type.issubclass(schema, self)):
             return schema, concrete_type
@@ -102,7 +102,7 @@ class ScalarType(
         schema: s_schema.Schema,
         other: s_types.Type,
     ) -> bool:
-        if other.is_any():
+        if other.is_any(schema):
             return True
         else:
             return self.issubclass(schema, other)

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -215,11 +215,11 @@ def ast_to_type_shell(
 
     elif isinstance(node.maintype, qlast.AnyType):
         from . import pseudo as s_pseudo
-        return s_pseudo.AnyTypeShell()
+        return s_pseudo.PseudoTypeShell(name='anytype')
 
     elif isinstance(node.maintype, qlast.AnyTuple):
         from . import pseudo as s_pseudo
-        return s_pseudo.AnyTupleShell()
+        return s_pseudo.PseudoTypeShell(name='anytuple')
 
     assert isinstance(node.maintype, qlast.ObjectRef)
 
@@ -287,9 +287,9 @@ def typeref_to_ast(
     result: qlast.TypeExpr
     components: Tuple[so.Object, ...]
 
-    if t.is_type() and cast(s_types.Type, t).is_any():
+    if t.is_type() and cast(s_types.Type, t).is_any(schema):
         result = qlast.TypeName(name=_name, maintype=qlast.AnyType())
-    elif t.is_type() and cast(s_types.Type, t).is_anytuple():
+    elif t.is_type() and cast(s_types.Type, t).is_anytuple(schema):
         result = qlast.TypeName(name=_name, maintype=qlast.AnyTuple())
     elif isinstance(t, s_types.Tuple) and t.is_named(schema):
         result = qlast.TypeName(

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -43,7 +43,6 @@ from edb.schema import database as s_db
 from edb.schema import ddl as s_ddl
 from edb.schema import delta as sd
 from edb.schema import modules as s_mod
-from edb.schema import pseudo as s_pseudo
 from edb.schema import schema as s_schema
 from edb.schema import std as s_std
 
@@ -289,7 +288,6 @@ async def _make_stdlib(
 ) -> Tuple[s_schema.Schema, str, Set[uuid.UUID]]:
     schema = s_schema.Schema()
     schema, _ = s_mod.Module.create_in_schema(schema, name='__derived__')
-    schema = s_pseudo.populate_types(schema)
 
     current_block = None
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_04_06_00_00
+EDGEDB_CATALOG_VERSION = 2020_04_10_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -38,7 +38,6 @@ from edb.server import defines
 from edb.schema import ddl as s_ddl
 from edb.schema import delta as sd
 from edb.schema import migrations as s_migrations  # noqa
-from edb.schema import pseudo as s_pseudo
 from edb.schema import schema as s_schema
 from edb.schema import std as s_std
 
@@ -232,7 +231,6 @@ def _load_std_schema():
 
         if schema is None:
             schema = s_schema.Schema()
-            schema = s_pseudo.populate_types(schema)
             for modname in s_schema.STD_LIB + ('stdgraphql',):
                 schema = s_std.load_std_module(schema, modname)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -597,6 +597,22 @@ warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
 
+[mypy-edb.schema.pseudo]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+
 [mypy-edb.schema.pointers]
 follow_imports = True
 ignore_errors = False

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -304,3 +304,10 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
             ''',
             {'123_HELLO'},
         )
+
+    async def test_edgeql_userddl_23(self):
+        with self.assertRaisesRegex(
+            edgedb.UnsupportedFeatureError,
+            'user-defined pseudotypes are not supported'
+        ):
+            await self.con.execute('CREATE PSEUDO TYPE foo;')

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 43.59)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 43.52)
 
     def test_cqa_type_coverage_edgeqlcompiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 93.99)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 94.24)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.43)


### PR DESCRIPTION
Remove the remaining special handling around how `anytype` and
`anytuple` are defined.  This adds a std-only `CREATE PSEUDO TYPE`
syntax and other bits necessary to treat pseudo types like any other
schema type.