### PR TITLE
Move the curried constraint parameter value to the params link in introspection

### DIFF
--- a/docs/edgeql/introspection/constraints.rst
+++ b/docs/edgeql/introspection/constraints.rst
@@ -69,7 +69,7 @@ Introspection of the scalar ``maxex_100`` with focus on the constraint:
     ...         expr,
     ...         annotations: { name, @value },
     ...         subject: { name },
-    ...         args: { name, @value, type: { name } },
+    ...         params: { name, @value, type: { name } },
     ...         return_typemod,
     ...         return_type: { name },
     ...         errmessage,
@@ -85,7 +85,7 @@ Introspection of the scalar ``maxex_100`` with focus on the constraint:
                     expr: '(__subject__ <= max)',
                     annotations: {},
                     subject: Object { name: 'default::maxex_100' },
-                    args: {
+                    params: {
                         Object {
                             name: 'max',
                             type: Object { name: 'anytype' },

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -167,8 +167,7 @@ CREATE ABSTRACT TYPE schema::VolatilitySubject {
 CREATE TYPE schema::Constraint
     EXTENDING schema::CallableObject, schema::InheritingObject
 {
-    CREATE MULTI LINK args -> schema::Parameter {
-        CREATE CONSTRAINT std::exclusive;
+    ALTER LINK params {
         CREATE PROPERTY value -> std::str;
     };
     CREATE PROPERTY expr -> std::str;

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -703,7 +703,7 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
             r'''
                 SELECT schema::Constraint {
                     name,
-                    args: {
+                    params: {
                         num,
                         name,
                         kind,
@@ -720,7 +720,7 @@ class TestConstraintsDDL(tb.NonIsolatedDDLTestCase):
             [
                 {
                     "name": 'test::mymax_ext1',
-                    "args": [
+                    "params": [
                         {
                             "num": 1,
                             "kind": 'POSITIONAL',

--- a/tests/test_dump01.py
+++ b/tests/test_dump01.py
@@ -508,10 +508,10 @@ class TestDump01(tb.QueryTestCase, tb.CLITestCaseMixin):
                     } ORDER BY @index,
                     constraints: {
                         name,
-                        args: {
+                        params: {
                             name,
                             @value,
-                        },
+                        } FILTER .name != '__subject__',
                     },
                 }
                 FILTER
@@ -538,7 +538,7 @@ class TestDump01(tb.QueryTestCase, tb.CLITestCaseMixin):
                     'constraints': [
                         {
                             'name': 'default::user_int_constr',
-                            'args': [{'name': 'x', '@value': '5'}],
+                            'params': [{'name': 'x', '@value': '5'}],
                         },
                     ],
                 },
@@ -551,7 +551,7 @@ class TestDump01(tb.QueryTestCase, tb.CLITestCaseMixin):
                     'constraints': [
                         {
                             'name': 'std::max_len_value',
-                            'args': [{'name': 'max', '@value': '5'}],
+                            'params': [{'name': 'max', '@value': '5'}],
                         },
                     ],
                 },
@@ -568,10 +568,10 @@ class TestDump01(tb.QueryTestCase, tb.CLITestCaseMixin):
                         name,
                         constraints: {
                             name,
-                            args: {
+                            params: {
                                 name,
                                 @value,
-                            },
+                            } FILTER .name != '__subject__',
                         },
                     }
                     FILTER .name IN {'m0', 'm1'}
@@ -589,7 +589,7 @@ class TestDump01(tb.QueryTestCase, tb.CLITestCaseMixin):
                             'constraints': [
                                 {
                                     'name': 'default::user_int_constr',
-                                    'args': [{'name': 'x', '@value': '3'}],
+                                    'params': [{'name': 'x', '@value': '3'}],
                                 },
                             ],
                         },
@@ -598,7 +598,7 @@ class TestDump01(tb.QueryTestCase, tb.CLITestCaseMixin):
                             'constraints': [
                                 {
                                     'name': 'std::max_len_value',
-                                    'args': [{'name': 'max', '@value': '3'}],
+                                    'params': [{'name': 'max', '@value': '3'}],
                                 },
                             ],
                         }

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -515,10 +515,11 @@ class TestIntrospection(tb.QueryTestCase):
                     subject: {
                         name
                     },
-                    args: {
+                    params: {
                         num,
                         @value
-                    } ORDER BY .num
+                    } FILTER .name != '__subject__'
+                      ORDER BY .num
                 }
                 FILTER
                     .subject.name = 'body'
@@ -530,7 +531,7 @@ class TestIntrospection(tb.QueryTestCase):
                 'subject': {
                     'name': 'body'
                 },
-                'args': [{
+                'params': [{
                     'num': 1,
                     '@value': '10000'
                 }]
@@ -550,7 +551,11 @@ class TestIntrospection(tb.QueryTestCase):
                             expr,
                             annotations: { name, @value },
                             subject: { name },
-                            args: { name, @value, type: { name } },
+                            params: {
+                                name,
+                                @value,
+                                type: { name }
+                            } FILTER .name != '__subject__',
                             return_typemod,
                             return_type: { name },
                             errmessage,
@@ -570,7 +575,7 @@ class TestIntrospection(tb.QueryTestCase):
                                 'expr': '(__subject__ <= max)',
                                 'annotations': {},
                                 'subject': {'name': 'body'},
-                                'args': [
+                                'params': [
                                     {
                                         'name': 'max',
                                         'type': {'name': 'std::int64'},
@@ -593,7 +598,7 @@ class TestIntrospection(tb.QueryTestCase):
                                 'expr': 'std::_is_exclusive(__subject__)',
                                 'annotations': {},
                                 'subject': {'name': 'id'},
-                                'args': {},
+                                'params': {},
                                 'return_typemod': 'SINGLETON',
                                 'return_type': {'name': 'std::bool'},
                                 'errmessage':
@@ -617,7 +622,11 @@ class TestIntrospection(tb.QueryTestCase):
                         expr,
                         annotations: { name, @value },
                         subject: { name },
-                        args: { name, @value, type: { name } },
+                        params: {
+                            name,
+                            @value,
+                            type: { name }
+                        } FILTER .name != '__subject__',
                         return_typemod,
                         return_type: { name },
                         errmessage,
@@ -634,7 +643,7 @@ class TestIntrospection(tb.QueryTestCase):
                         'expr': 'contains(vals, __subject__)',
                         'annotations': {},
                         'subject': {'name': 'test::EmulatedEnum'},
-                        'args': [
+                        'params': [
                             {
                                 'name': 'vals',
                                 'type': {'name': 'array'},


### PR DESCRIPTION
Currently, we expose the applied constraint args in the `args` link of
the `schema::Constraint` type.  But it already has the `params` link it
inherits from `CallableObject`, so it makes sense to use that link
instead.