### PR TITLE
Separate used-defined and system object type hierarchies

### DIFF
--- a/docs/cheatsheet/repl.rst
+++ b/docs/cheatsheet/repl.rst
@@ -50,7 +50,7 @@ Describe an object type:
 .. code-block:: edgeql-repl
 
     db> \d std::Object
-    abstract type std::Object {
+    abstract type std::Object extending std::BaseObject {
         required single link __type__ -> schema::Type {
             readonly := true;
         };

--- a/docs/datamodel/objects.rst
+++ b/docs/datamodel/objects.rst
@@ -25,10 +25,12 @@ than one type <ref_eql_sdl_object_types_inheritance>` - that's called
 *multiple inheritance*. This mechanism allows building complex object
 types out of combinations of more basic types.
 
-``std::Object`` is the root of the object type hierarchy and all object
-types in EdgeDB extend ``std::Object`` directly or indirectly.
+``std::BaseObject`` is the root of the object type hierarchy and all
+object types in EdgeDB, including system types, extend ``std::BaseObject``
+directly or indirectly.  User-defined object types extend from ``std::Object``,
+which is a subtype of ``std::BaseObject``.
 
-.. eql:type:: std::Object
+.. eql:type:: std::BaseObject
 
     Root object type.
 
@@ -36,13 +38,23 @@ types in EdgeDB extend ``std::Object`` directly or indirectly.
 
     .. code-block:: sdl
 
-        abstract type Object {
+        abstract type std::BaseObject {
             # Universally unique object identifier
             required readonly property id -> uuid;
 
             # Object type in the information schema.
             required readonly link __type__ -> schema::ObjectType;
         }
+
+.. eql:type:: std::Object
+
+    Root object type for user-defined types.
+
+    Definition:
+
+    .. code-block:: sdl
+
+        abstract type std::Object extending std::BaseObject;
 
 
 See Also

--- a/docs/edgeql/introspection/objects.rst
+++ b/docs/edgeql/introspection/objects.rst
@@ -98,6 +98,7 @@ Introspection of ``User``:
             is_final: false,
             bases: {Object { name: 'default::Addressable' }},
             ancestors: {
+                Object { name: 'std::BaseObject' },
                 Object { name: 'std::Object' },
                 Object { name: 'default::Addressable' }
             },

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -516,7 +516,7 @@ def compile_Introspect(
         typeref = typegen.type_to_typeref(
             typing.cast(
                 s_objtypes.ObjectType,
-                ctx.env.schema.get('std::Object'),
+                ctx.env.schema.get('std::BaseObject'),
             ),
             env=ctx.env,
         )

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -427,7 +427,7 @@ def derive_dummy_ptr(
     *,
     ctx: context.ContextLevel,
 ) -> s_pointers.Pointer:
-    stdobj = cast(s_objtypes.ObjectType, ctx.env.schema.get('std::Object'))
+    stdobj = cast(s_objtypes.ObjectType, ctx.env.schema.get('std::BaseObject'))
     derived_obj_name = stdobj.get_derived_name(
         ctx.env.schema, stdobj, module='__derived__')
     derived_obj = ctx.env.schema.get(derived_obj_name, None)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -190,7 +190,7 @@ def compile_GroupQuery(
 
         typename = s_name.Name(
             module='__group__', name=ctx.aliases.get('Group'))
-        obj = ctx.env.get_track_schema_object('std::Object')
+        obj = ctx.env.get_track_schema_object('std::BaseObject')
         stmt.group_path_id = pathctx.get_path_id(
             obj, typename=typename, ctx=ictx)
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -157,11 +157,11 @@ def fini_expression(
                 tgt = vptr.get_target(ctx.env.schema)
                 if (tgt.is_union_type(ctx.env.schema)
                         and tgt.get_is_opaque_union(ctx.env.schema)):
-                    # Opaque unions should manifest as std::Object
+                    # Opaque unions should manifest as std::BaseObject
                     # in schema views.
                     ctx.env.schema = vptr.set_target(
                         ctx.env.schema,
-                        ctx.env.schema.get('std::Object'),
+                        ctx.env.schema.get('std::BaseObject'),
                     )
 
                 if not hasattr(vptr, 'get_pointers'):

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -476,7 +476,7 @@ def trace_Function(node: qlast.CreateFunction, *, ctx: DepTraceContext):
             param_t = ctx.get_ref_name(param.type.maintype)
             params[param.name] = param_t
         else:
-            params[param.name] = 'std::Object'
+            params[param.name] = 'std::BaseObject'
 
     if node.nativecode is not None:
         deps.append((node.nativecode, params))

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -27,8 +27,9 @@ CREATE ABSTRACT ANNOTATION cfg::internal;
 CREATE ABSTRACT ANNOTATION cfg::requires_restart;
 CREATE ABSTRACT ANNOTATION cfg::system;
 
+CREATE ABSTRACT TYPE cfg::ConfigObject EXTENDING std::BaseObject;
 
-CREATE TYPE cfg::Port {
+CREATE TYPE cfg::Port EXTENDING cfg::ConfigObject {
     CREATE REQUIRED PROPERTY port -> std::int64 {
         CREATE CONSTRAINT std::exclusive;
         SET readonly := true;
@@ -57,12 +58,12 @@ CREATE TYPE cfg::Port {
 };
 
 
-CREATE ABSTRACT TYPE cfg::AuthMethod;
+CREATE ABSTRACT TYPE cfg::AuthMethod EXTENDING cfg::ConfigObject;
 CREATE TYPE cfg::Trust EXTENDING cfg::AuthMethod;
 CREATE TYPE cfg::SCRAM EXTENDING cfg::AuthMethod;
 
 
-CREATE TYPE cfg::Auth {
+CREATE TYPE cfg::Auth EXTENDING cfg::ConfigObject {
     CREATE REQUIRED PROPERTY priority -> std::int64 {
         CREATE CONSTRAINT std::exclusive;
         SET readonly := true;
@@ -83,7 +84,7 @@ CREATE TYPE cfg::Auth {
 };
 
 
-CREATE TYPE cfg::Config {
+CREATE TYPE cfg::Config extending cfg::ConfigObject {
     CREATE REQUIRED PROPERTY listen_port -> std::int16 {
         CREATE ANNOTATION cfg::system := 'true';
         SET default := 5656;

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -38,7 +38,7 @@ CREATE SCALAR TYPE schema::Volatility
     EXTENDING enum<'IMMUTABLE', 'STABLE', 'VOLATILE'>;
 
 # Base type for all schema entities.
-CREATE ABSTRACT TYPE schema::Object {
+CREATE ABSTRACT TYPE schema::Object EXTENDING std::BaseObject {
     CREATE REQUIRED PROPERTY name -> std::str;
 };
 
@@ -53,7 +53,7 @@ ALTER TYPE schema::Type {
 };
 
 
-ALTER TYPE std::Object {
+ALTER TYPE std::BaseObject {
     CREATE LINK __type__ -> schema::Type {
         SET readonly := True;
     };
@@ -133,7 +133,7 @@ CREATE ABSTRACT TYPE schema::InheritingObject EXTENDING schema::Object {
 };
 
 
-CREATE TYPE schema::Parameter {
+CREATE TYPE schema::Parameter EXTENDING std::BaseObject {
     CREATE REQUIRED LINK type -> schema::Type;
     CREATE REQUIRED PROPERTY typemod -> std::str;
     CREATE REQUIRED PROPERTY kind -> std::str;
@@ -155,7 +155,7 @@ CREATE ABSTRACT TYPE schema::CallableObject
 };
 
 
-CREATE ABSTRACT TYPE schema::VolatilitySubject {
+CREATE ABSTRACT TYPE schema::VolatilitySubject EXTENDING schema::Object {
     CREATE REQUIRED PROPERTY volatility -> schema::Volatility {
         # NOTE: this default indicates the default value in the python
         # implementation, but is not itself a source of truth

--- a/edb/lib/std/60-baseobject.edgeql
+++ b/edb/lib/std/60-baseobject.edgeql
@@ -30,14 +30,19 @@ CREATE ABSTRACT PROPERTY std::target;
 
 CREATE ABSTRACT LINK std::link;
 
-CREATE ABSTRACT TYPE std::Object {
+CREATE ABSTRACT TYPE std::BaseObject {
     CREATE REQUIRED PROPERTY id EXTENDING std::id -> std::uuid {
         SET default := (SELECT std::uuid_generate_v1mc());
         SET readonly := True;
         CREATE CONSTRAINT std::exclusive;
     };
+    CREATE ANNOTATION std::description := 'Root object type.'
 };
 
+CREATE ABSTRACT TYPE std::Object EXTENDING std::BaseObject {
+    CREATE ANNOTATION std::description :=
+        'Root object type for user-defined types';
+};
 
 # 'USING SQL EXPRESSION' creates an EdgeDB Operator for purposes of
 # introspection and validation by the EdgeQL compiler. However, no
@@ -54,63 +59,69 @@ CREATE ABSTRACT TYPE std::Object {
 # On the other hand, if we use "USING SQL OPERATOR", we will end up
 # clashing with the operators for uuid in Postgres.
 CREATE INFIX OPERATOR
-std::`=` (l: std::Object, r: std::Object) -> std::bool {
+std::`=` (l: std::BaseObject, r: std::BaseObject) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
-std::`?=` (l: OPTIONAL std::Object, r: OPTIONAL std::Object) -> std::bool {
+std::`?=` (
+    l: OPTIONAL std::BaseObject,
+    r: OPTIONAL std::BaseObject
+) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
-std::`!=` (l: std::Object, r: std::Object) -> std::bool {
+std::`!=` (l: std::BaseObject, r: std::BaseObject) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
-std::`?!=` (l: OPTIONAL std::Object, r: OPTIONAL std::Object) -> std::bool {
+std::`?!=` (
+    l: OPTIONAL std::BaseObject,
+    r: OPTIONAL std::BaseObject
+) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
-std::`>=` (l: std::Object, r: std::Object) -> std::bool {
+std::`>=` (l: std::BaseObject, r: std::BaseObject) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
-std::`>` (l: std::Object, r: std::Object) -> std::bool {
+std::`>` (l: std::BaseObject, r: std::BaseObject) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
-std::`<=` (l: std::Object, r: std::Object) -> std::bool {
+std::`<=` (l: std::BaseObject, r: std::BaseObject) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
-std::`<` (l: std::Object, r: std::Object) -> std::bool {
+std::`<` (l: std::BaseObject, r: std::BaseObject) -> std::bool {
     SET volatility := 'IMMUTABLE';
     USING SQL EXPRESSION;
 };
 
 
 # The only possible Object cast is into json.
-CREATE CAST FROM std::Object TO std::json {
+CREATE CAST FROM std::BaseObject TO std::json {
     SET volatility := 'IMMUTABLE';
     USING SQL EXPRESSION;
 };

--- a/edb/lib/stdgraphql.edgeql
+++ b/edb/lib/stdgraphql.edgeql
@@ -23,13 +23,13 @@ CREATE MODULE stdgraphql {
 
 
 # these are just some placeholders for packaging GraphQL queries
-CREATE TYPE stdgraphql::Query;
+CREATE TYPE stdgraphql::Query EXTENDING std::BaseObject;
 ALTER TYPE stdgraphql::Query {
     CREATE PROPERTY __typename := 'Query';
 };
 
 
-CREATE TYPE stdgraphql::Mutation;
+CREATE TYPE stdgraphql::Mutation EXTENDING std::BaseObject;
 ALTER TYPE stdgraphql::Mutation {
     CREATE PROPERTY __typename := 'Mutation';
 };

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -26,14 +26,17 @@ CREATE SCALAR TYPE sys::TransactionIsolation
     EXTENDING enum<'REPEATABLE READ', 'SERIALIZABLE'>;
 
 
-CREATE TYPE sys::Database {
+CREATE ABSTRACT TYPE sys::SystemObject EXTENDING std::BaseObject;
+
+
+CREATE TYPE sys::Database EXTENDING sys::SystemObject {
     CREATE REQUIRED PROPERTY name -> std::str {
         SET readonly := True;
     };
 };
 
 
-CREATE TYPE sys::Role {
+CREATE TYPE sys::Role EXTENDING sys::SystemObject {
     CREATE REQUIRED PROPERTY name -> std::str {
         CREATE CONSTRAINT std::exclusive;
     };

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1981,7 +1981,7 @@ class CreateObjectType(ObjectTypeMetaCommand,
         self.table_name = new_table_name
 
         columns = []
-        if objtype.get_name(schema) == 'std::Object':
+        if objtype.get_name(schema) == 'std::BaseObject':
             token_col = dbops.Column(
                 name='__edb_token', type='uuid', required=False)
             columns.append(token_col)
@@ -2014,7 +2014,7 @@ class CreateObjectType(ObjectTypeMetaCommand,
             cid_col = dbops.Column(
                 name='__type__', type='uuid', required=True)
 
-            if objtype.get_name(schema) == 'std::Object':
+            if objtype.get_name(schema) == 'std::BaseObject':
                 alter_table.add_operation(dbops.AlterTableAddColumn(cid_col))
 
             constraint = dbops.PrimaryKey(

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -93,7 +93,7 @@ class ObjectType(
         union_of = mtype.get_union_of(schema)
         if union_of:
             if self.get_is_opaque_union(schema):
-                std_obj = schema.get('std::Object')
+                std_obj = schema.get('std::BaseObject')
                 return std_obj.get_displayname(schema)
             else:
                 comps = sorted(union_of.objects(schema), key=lambda o: o.id)
@@ -155,7 +155,8 @@ class ObjectType(
     @classmethod
     def get_root_classes(cls):
         return (
-            sn.Name(module='std', name='Object')
+            sn.Name(module='std', name='BaseObject'),
+            sn.Name(module='std', name='Object'),
         )
 
     @classmethod
@@ -240,7 +241,7 @@ def get_or_create_union_type(
     if objtype is None:
         components = list(components)
 
-        std_object = schema.get('std::Object')
+        std_object = schema.get('std::BaseObject')
 
         schema, objtype = std_object.derive_subtype(
             schema,
@@ -281,7 +282,7 @@ def get_or_create_intersection_type(
     if objtype is None:
         components = list(components)
 
-        std_object = schema.get('std::Object')
+        std_object = schema.get('std::BaseObject')
 
         schema, objtype = std_object.derive_subtype(
             schema,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -419,7 +419,7 @@ class Pointer(referencing.ReferencedInheritingObject,
 
     def is_id_pointer(self, schema: s_schema.Schema) -> bool:
         from edb.schema import sources as s_sources
-        std_id = schema.get('std::Object',
+        std_id = schema.get('std::BaseObject',
                             type=s_sources.Source).getptr(schema, 'id')
         std_target = schema.get('std::target', type=so.SubclassableObject)
         assert isinstance(std_id, so.SubclassableObject)

--- a/tests/test_dump01.py
+++ b/tests/test_dump01.py
@@ -674,6 +674,7 @@ class TestDump01(tb.QueryTestCase, tb.CLITestCaseMixin):
                         {'name': 'default::T', '@index': 3},
                         {'name': 'default::R', '@index': 4},
                         {'name': 'std::Object', '@index': 5},
+                        {'name': 'std::BaseObject', '@index': 6},
                     ],
                 }
             ]

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -646,7 +646,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_23(self):
         # Test that an unqualifed reverse link expression
         # as an alias pointer target is handled correctly and
-        # manifests as std::Object.
+        # manifests as std::BaseObject.
         await self.con.execute("""
             SET MODULE test;
 
@@ -673,7 +673,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             [
                 {
                     'target': {
-                        'name': 'std::Object'
+                        'name': 'std::BaseObject'
                     }
                 },
             ],
@@ -2918,6 +2918,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     'name': 'test::ExtA3',
                 }, {
                     'name': 'std::Object',
+                }, {
+                    'name': 'std::BaseObject',
                 }],
             }]
         )
@@ -2940,6 +2942,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     'name': 'test::ExtB3',
                 }, {
                     'name': 'std::Object',
+                }, {
+                    'name': 'std::BaseObject',
                 }],
             }]
         )
@@ -3588,7 +3592,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_alias_03(self):
         await self.con.execute(r"""
             CREATE ALIAS test::RenameAlias03 := (
-                SELECT Object {
+                SELECT BaseObject {
                     alias_computable := 'rename alias 03'
                 }
             );
@@ -3607,12 +3611,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_alias_04(self):
         await self.con.execute(r"""
-            CREATE ALIAS test::DupAlias04_1 := Object {
+            CREATE ALIAS test::DupAlias04_1 := BaseObject {
                 foo := 'hello world 04'
             };
 
             # create an identical alias with a different name
-            CREATE ALIAS test::DupAlias04_2 := Object {
+            CREATE ALIAS test::DupAlias04_2 := BaseObject {
                 foo := 'hello world 04'
             };
         """)

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -323,6 +323,8 @@ class TestIntrospection(tb.QueryTestCase):
                     'name': 'test::Text',
                 }, {
                     'name': 'std::Object',
+                }, {
+                    'name': 'std::BaseObject',
                 }],
             }]
         )
@@ -1051,14 +1053,22 @@ class TestIntrospection(tb.QueryTestCase):
         )
 
     async def test_edgeql_introspection_meta_13(self):
-        # make sure that ALL schema Objects are std::Objects
         res = await self.con.fetchone(r"""
             SELECT count(schema::Object);
         """)
 
+        # make sure that ALL schema Objects are std::BaseObjects
         await self.assert_query_result(
             r"""
-                SELECT schema::Object IS std::Object;
+                SELECT schema::Object IS std::BaseObject;
+            """,
+            [True] * res
+        )
+
+        # ...but not std::Objects
+        await self.assert_query_result(
+            r"""
+                SELECT schema::Object IS NOT std::Object;
             """,
             [True] * res
         )

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1328,7 +1328,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             SELECT
                 (INTROSPECT TYPEOF User.<owner).name;
             ''',
-            ['std::Object']
+            ['std::BaseObject']
         )
 
     async def test_edgeql_select_reverse_link_02(self):

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -338,6 +338,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                 "name": "User_Type",
                 "description": None,
                 "interfaces": [
+                    {"name": "BaseObject"},
                     {"name": "NamedObject"},
                     {"name": "Object"},
                     {"name": "User"},
@@ -1025,6 +1026,11 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                         "interfaces": [
                             {
                                 "__typename": "__Type",
+                                "name": "BaseObject",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
                                 "name": "NamedObject",
                                 "kind": "INTERFACE"
                             },
@@ -1144,6 +1150,11 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                         "interfaces": [
                             {
                                 "__typename": "__Type",
+                                "name": "BaseObject",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
                                 "name": "NamedObject",
                                 "kind": "INTERFACE"
                             },
@@ -1236,6 +1247,11 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                             }
                         ],
                         "interfaces": [
+                            {
+                                "__typename": "__Type",
+                                "name": "BaseObject",
+                                "kind": "INTERFACE"
+                            },
                             {
                                 "__typename": "__Type",
                                 "name": "NamedObject",
@@ -1336,6 +1352,11 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                         "interfaces": [
                             {
                                 "__typename": "__Type",
+                                "name": "BaseObject",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
                                 "name": "NamedObject",
                                 "kind": "INTERFACE"
                             },
@@ -1421,6 +1442,11 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                         "interfaces": [
                             {
                                 "__typename": "__Type",
+                                "name": "BaseObject",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
                                 "name": "NamedObject",
                                 "kind": "INTERFACE"
                             },
@@ -1499,6 +1525,11 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                             }
                         ],
                         "interfaces": [
+                            {
+                                "__typename": "__Type",
+                                "name": "BaseObject",
+                                "kind": "INTERFACE"
+                            },
                             {
                                 "__typename": "__Type",
                                 "name": "NamedObject",
@@ -1645,6 +1676,11 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                         "interfaces": [
                             {
                                 "__typename": "__Type",
+                                "name": "BaseObject",
+                                "kind": "INTERFACE"
+                            },
+                            {
+                                "__typename": "__Type",
                                 "name": "NamedObject",
                                 "kind": "INTERFACE"
                             },
@@ -1740,6 +1776,11 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                             }
                         ],
                         "interfaces": [
+                            {
+                                "__typename": "__Type",
+                                "name": "BaseObject",
+                                "kind": "INTERFACE"
+                            },
                             {
                                 "__typename": "__Type",
                                 "name": "NamedObject",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -808,11 +808,13 @@ _123456789_123456789_123456789 -> str
             type C extending B;
         """)
 
+        BaseObject = schema.get('std::BaseObject')
         Object = schema.get('std::Object')
         A = schema.get('test::A')
         B = schema.get('test::B')
         C = schema.get('test::C')
         std_link = schema.get('std::link')
+        BaseObject__type__ = BaseObject.getptr(schema, '__type__')
         Object__type__ = Object.getptr(schema, '__type__')
         A__type__ = A.getptr(schema, '__type__')
         B__type__ = B.getptr(schema, '__type__')
@@ -823,6 +825,7 @@ _123456789_123456789_123456789 -> str
                 B__type__,
                 A__type__,
                 Object__type__,
+                BaseObject__type__,
                 std_link,
             )
         )
@@ -843,6 +846,7 @@ _123456789_123456789_123456789 -> str
             (
                 B__type__,
                 Object__type__,
+                BaseObject__type__,
                 std_link,
             )
         )


### PR DESCRIPTION
Currently, we use `std::Object` as the root object type for everything,
including the object types defined by the system.  This patch separates
the user-defined and system object hierarchies by adding the new
`std::BaseObject` type which is now the true root type.  `std::Object`
extends from `std::BaseObject` and becomes the default base for
user-defined object types.  All types declared in `schema::', `cfg::`
and `sys::` are made to extend from `BaseObject` directly.