### PR TITLE
Make sure to_intXX and to_floatXX functions don't crash due to inlining

### DIFF
--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -389,7 +389,9 @@ std::to_int64(s: std::str, fmt: OPTIONAL str={}) -> std::int64
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
-            "s"::bigint
+            -- Must use the noninline version to prevent
+            -- the overeager function inliner from crashing
+            edgedb.str_to_int64_noinline("s")
         WHEN "fmt" = '' THEN
             edgedb._raise_specific_exception(
                 'invalid_parameter_value',
@@ -417,7 +419,9 @@ std::to_int32(s: std::str, fmt: OPTIONAL str={}) -> std::int32
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
-            "s"::int
+            -- Must use the noninline version to prevent
+            -- the overeager function inliner from crashing
+            edgedb.str_to_int32_noinline("s")
         WHEN "fmt" = '' THEN
             edgedb._raise_specific_exception(
                 'invalid_parameter_value',
@@ -445,7 +449,9 @@ std::to_int16(s: std::str, fmt: OPTIONAL str={}) -> std::int16
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
-            "s"::smallint
+            -- Must use the noninline version to prevent
+            -- the overeager function inliner from crashing
+            edgedb.str_to_int16_noinline("s")
         WHEN "fmt" = '' THEN
             edgedb._raise_specific_exception(
                 'invalid_parameter_value',
@@ -473,7 +479,7 @@ std::to_float64(s: std::str, fmt: OPTIONAL str={}) -> std::float64
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
-            "s"::float8
+            edgedb.str_to_float64_noinline("s")
         WHEN "fmt" = '' THEN
             edgedb._raise_specific_exception(
                 'invalid_parameter_value',
@@ -501,7 +507,7 @@ std::to_float32(s: std::str, fmt: OPTIONAL str={}) -> std::float32
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
-            "s"::float4
+            edgedb.str_to_float32_noinline("s")
         WHEN "fmt" = '' THEN
             edgedb._raise_specific_exception(
                 'invalid_parameter_value',

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -185,6 +185,114 @@ class StrToDecimal(dbops.Function):
         )
 
 
+class StrToInt64NoInline(dbops.Function):
+    """String-to-int64 cast with noinline guard.
+
+    Adding a LIMIT clause to the function statement makes it
+    uninlinable due to the Postgres inlining heuristic looking
+    for simple SELECT expressions only (i.e. no clauses.)
+
+    This might need to change in the future if the heuristic
+    changes.
+    """
+    text = r'''
+        SELECT
+            "val"::bigint
+        LIMIT
+            1
+        ;
+    '''
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', 'str_to_int64_noinline'),
+            args=[('val', ('text',))],
+            returns=('bigint',),
+            volatility='stable',
+            text=self.text,
+        )
+
+
+class StrToInt32NoInline(dbops.Function):
+    """String-to-int32 cast with noinline guard."""
+    text = r'''
+        SELECT
+            "val"::int
+        LIMIT
+            1
+        ;
+    '''
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', 'str_to_int32_noinline'),
+            args=[('val', ('text',))],
+            returns=('int',),
+            volatility='stable',
+            text=self.text,
+        )
+
+
+class StrToInt16NoInline(dbops.Function):
+    """String-to-int16 cast with noinline guard."""
+    text = r'''
+        SELECT
+            "val"::smallint
+        LIMIT
+            1
+        ;
+    '''
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', 'str_to_int16_noinline'),
+            args=[('val', ('text',))],
+            returns=('smallint',),
+            volatility='stable',
+            text=self.text,
+        )
+
+
+class StrToFloat64NoInline(dbops.Function):
+    """String-to-float64 cast with noinline guard."""
+    text = r'''
+        SELECT
+            "val"::float8
+        LIMIT
+            1
+        ;
+    '''
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', 'str_to_float64_noinline'),
+            args=[('val', ('text',))],
+            returns=('float8',),
+            volatility='stable',
+            text=self.text,
+        )
+
+
+class StrToFloat32NoInline(dbops.Function):
+    """String-to-float32 cast with noinline guard."""
+    text = r'''
+        SELECT
+            "val"::float4
+        LIMIT
+            1
+        ;
+    '''
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', 'str_to_float32_noinline'),
+            args=[('val', ('text',))],
+            returns=('float4',),
+            volatility='stable',
+            text=self.text,
+        )
+
+
 class GetObjectMetadata(dbops.Function):
     """Return EdgeDB metadata associated with a backend object."""
     text = '''
@@ -2147,6 +2255,11 @@ async def bootstrap(conn):
         dbops.CreateDomain(BigintDomain()),
         dbops.CreateFunction(StrToBigint()),
         dbops.CreateFunction(StrToDecimal()),
+        dbops.CreateFunction(StrToInt64NoInline()),
+        dbops.CreateFunction(StrToInt32NoInline()),
+        dbops.CreateFunction(StrToInt16NoInline()),
+        dbops.CreateFunction(StrToFloat64NoInline()),
+        dbops.CreateFunction(StrToFloat32NoInline()),
         dbops.CreateFunction(GetTableDescendantsFunction()),
         dbops.CreateFunction(ParseTriggerConditionFunction()),
         dbops.CreateFunction(NormalizeArrayIndexFunction()),

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_04_10_00_00
+EDGEDB_CATALOG_VERSION = 2020_04_16_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -2155,6 +2155,12 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {987654321},
         )
 
+        await self.assert_query_result(
+            r'''SELECT to_int64('987654321st', <str>$0);''',
+            {987654321},
+            variables=('FM999999999th',),
+        )
+
         with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
@@ -2224,6 +2230,12 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         await self.assert_query_result(
             r'''SELECT to_int32('987654321st', 'FM999999999th');''',
             {987654321},
+        )
+
+        await self.assert_query_result(
+            r'''SELECT to_int32('987654321st', <str>$0);''',
+            {987654321},
+            variables=('FM999999999th',),
         )
 
         with self.assertRaisesRegex(edgedb.InvalidValueError,
@@ -2297,6 +2309,12 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {4321},
         )
 
+        await self.assert_query_result(
+            r'''SELECT to_int16('4321st', <str>$0);''',
+            {4321},
+            variables=('FM999999999th',),
+        )
+
         with self.assertRaisesRegex(edgedb.InvalidValueError,
                                     '"fmt" argument must be'):
             async with self.con.transaction():
@@ -2321,6 +2339,11 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         await self.assert_query_result(
             r'''SELECT to_float64('123.456789', 'FM999.999999999');''',
             {123.456789},
+        )
+        await self.assert_query_result(
+            r'''SELECT to_float64('123.456789', <str>$0);''',
+            {123.456789},
+            variables=('FM999.999999999',)
         )
 
         with self.assertRaisesRegex(edgedb.InvalidValueError,

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 100.00)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 46.53)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 46.76)
 
     def test_cqa_type_coverage_pgsqlcompiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)


### PR DESCRIPTION
In certain situations Postgres might fail to optimize away the `"fmt" is
NULL` branch of `CASE` when inlining the function, triggering the
constant folder to attempt to evaluate an invalid cast.  Fix this by
wrapping the casts into functions formulated in a way that prevents
inlining.