### PR TITLE
Bail out of constant extraction more reliably

### DIFF
--- a/edb/edgeql-rust/src/normalize.rs
+++ b/edb/edgeql-rust/src/normalize.rs
@@ -125,7 +125,7 @@ pub fn normalize<'x>(text: &'x str)
             && (tok.value != "1"
                 || !matches!(rewritten_tokens.last(),
                     Some(CowToken { kind: Kind::Keyword, ref value, .. })
-                    if value == "LIMIT"))
+                    if value.eq_ignore_ascii_case("LIMIT")))
             && tok.value != "9223372036854775808"
             => {
                 push_var(&mut rewritten_tokens, "int64",
@@ -145,7 +145,8 @@ pub fn normalize<'x>(text: &'x str)
             // Kind::DecimalConst => todo!(),
             // Kind::Str => todo!(),
             Kind::Keyword
-            if matches!(&tok.value[..], "CONFIGURE"|"CREATE"|"ALTER"|"DROP")
+            if (matches!(&(&tok.value[..].to_uppercase())[..],
+                "CONFIGURE"|"CREATE"|"ALTER"|"DROP"))
             => {
                 return Ok(Entry {
                     key: serialize_tokens(&tokens),

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -380,8 +380,11 @@ class TestServerConfig(tb.QueryTestCase, tb.CLITestCaseMixin):
         self.assertEqual(conf['value'], 0)
         self.assertEqual(conf['source'], 'default')
 
+        # The "Configure" is spelled the way it's spelled on purpose
+        # to test that we handle keywords in a case-insensitive manner
+        # in constant extraction code.
         await self.con.fetchall('''
-            CONFIGURE SYSTEM SET __internal_testvalue := 1;
+            Configure SYSTEM SET __internal_testvalue := 1;
         ''')
 
         conf = await self.con.fetchone('''


### PR DESCRIPTION
The current normalization code only bails out for upper-cased
CONFIGURE|ALTER|CREATE|DROP queries; fix that to use a case
insensitive comparison.