### PR TITLE
Expose Python CLI as `-m edb.cli`

### DIFF
--- a/edb/cli/__main__.py
+++ b/edb/cli/__main__.py
@@ -1,0 +1,30 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+"""Stub to allow invoking builtin `edgedb` CLI as `python -m edb.cli`."""
+
+from __future__ import annotations
+
+import sys
+
+from edb import cli
+
+
+if __name__ == '__main__':
+    sys.exit(cli.cli(prog_name='edgedb'))


### PR DESCRIPTION
The packaging tooling relies on the availability of CLI for certain
operations, and since we've switched to standalone Rust CLI those bits
have been broken.  Until we figure out how to integrate the standalone
CLI into the build tooling, restore the ability to invoke the original
CLI on production builds via `<bundled-python> -m edb.cli`.