### PR TITLE
Add a debug flag to disable EdgeQL constant extraction

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -81,6 +81,9 @@ class flags(metaclass=FlagsMeta):
     edgeql_compile = Flag(
         doc="Dump EdgeQL/IR/SQL ASTs.")
 
+    edgeql_disable_normalization = Flag(
+        doc="Disable EdgeQL normalization (constant extraction etc)")
+
     graphql_compile = Flag(
         doc="Debug GraphQL compiler.")
 

--- a/edb/server/tokenizer.pyx
+++ b/edb/server/tokenizer.pyx
@@ -1,14 +1,40 @@
 import re
 
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, Dict, Any
 
 from edb._edgeql_rust import tokenize as _tokenize, TokenizerError, Token
 from edb._edgeql_rust import normalize as _normalize, Entry
 
+from edb.common import debug
 from edb.errors import base as base_errors, EdgeQLSyntaxError
 
 
 cdef object TRAILING_WS_IN_CONTINUATION = re.compile(r'\\ \s+\n')
+
+
+class Denormalized:
+
+    def __init__(self, source: str, tokens: List[Token]):
+        self._source = source
+        self._tokens = tokens
+
+    def key(self) -> str:
+        return self._source
+
+    def variables(self) -> Dict[str, Any]:
+        return {}
+
+    def tokens(self) -> List[Token]:
+        return self._tokens
+
+    def first_extra(self) -> Optional[int]:
+        return None
+
+    def extra_count(self) -> int:
+        return 0
+
+    def extra_blob(self) -> bytes:
+        return b''
 
 
 def tokenize(eql: bytes) -> List[Token]:
@@ -23,14 +49,18 @@ def tokenize(eql: bytes) -> List[Token]:
 
 
 def normalize(eql: bytes) -> List[Entry]:
-    try:
+    if debug.flags.edgeql_disable_normalization:
+        return Denormalized(eql.decode(), tokenize(eql))
+    else:
         eql_str = eql.decode()
-        return _normalize(eql_str)
-    except TokenizerError as e:
-        message, position = e.args
-        hint = _derive_hint(eql_str, message, position)
-        raise EdgeQLSyntaxError(
-            message, position=position, hint=hint) from e
+
+        try:
+            return _normalize(eql_str)
+        except TokenizerError as e:
+            message, position = e.args
+            hint = _derive_hint(eql_str, message, position)
+            raise EdgeQLSyntaxError(
+                message, position=position, hint=hint) from e
 
 
 def _derive_hint(
@@ -42,4 +72,3 @@ def _derive_hint(
     if message == r"invalid string literal: invalid escape sequence '\ '":
         if TRAILING_WS_IN_CONTINUATION.search(input[off:]):
             return "consider removing trailing whitespace"
-


### PR DESCRIPTION
This is to test cases when there is a suspected bug in the normalizer,
or the normalization needs to be disabled for any other reason.