### PR TITLE
Unblock linux nightly builds from failures on macOS

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -48,6 +48,7 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
+    continue-on-error: true
 
     strategy:
       max-parallel: 4
@@ -90,7 +91,7 @@ jobs:
         path: artifacts/${{ matrix.target }}
 
   publish-linux:
-    needs: [build-linux, build-macos]
+    needs: [build-linux]
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -158,6 +158,7 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
+    continue-on-error: true
 
     strategy:
       max-parallel: 4
@@ -200,7 +201,7 @@ jobs:
         path: artifacts/${{ matrix.target }}
 
   publish-linux:
-    needs: [build-linux, build-macos]
+    needs: [build-linux]
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4


### PR DESCRIPTION
The macOS build is currently failing, so allow the rest of the jobs to
proceed in the nightly build.