### PR TITLE
Implement status check for the notebook port; return command status

### DIFF
--- a/edb/server/notebook_port/protocol.pxd
+++ b/edb/server/notebook_port/protocol.pxd
@@ -25,3 +25,6 @@ cdef class Protocol(http.HttpProtocol):
     cdef:
         object server
         stmt_cache.StatementsCache query_cache
+
+    cdef handle_error(self, http.HttpRequest request,
+                      http.HttpResponse response, error)

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -62,7 +62,8 @@ class TestHttpNotebook(tb.BaseHttpTest, tb.server.QueryTestCase):
                         'data': [
                             'AAAAAAAAAAAAAAAAAAABBQ==',
                             'AgAAAAAAAAAAAAAAAAAAAQU=',
-                            'RAAAABIAAQAAAAgAAAAAAAAAAQ=='
+                            'RAAAABIAAQAAAAgAAAAAAAAAAQ==',
+                            'U0VMRUNU'
                         ]
                     },
                     {
@@ -70,7 +71,8 @@ class TestHttpNotebook(tb.BaseHttpTest, tb.server.QueryTestCase):
                         'data': [
                             'AAAAAAAAAAAAAAAAAAABAQ==',
                             'AgAAAAAAAAAAAAAAAAAAAQE=',
-                            'RAAAAA4AAQAAAARBQUFB'
+                            'RAAAAA4AAQAAAARBQUFB',
+                            'U0VMRUNU'
                         ]
                     },
                 ]
@@ -94,7 +96,8 @@ class TestHttpNotebook(tb.BaseHttpTest, tb.server.QueryTestCase):
                         'data': [
                             'AAAAAAAAAAAAAAAAAAABBQ==',
                             'AgAAAAAAAAAAAAAAAAAAAQU=',
-                            'RAAAABIAAQAAAAgAAAAAAAAAAQ=='
+                            'RAAAABIAAQAAAAgAAAAAAAAAAQ==',
+                            'U0VMRUNU'
                         ]
                     },
                     {
@@ -138,3 +141,10 @@ class TestHttpNotebook(tb.BaseHttpTest, tb.server.QueryTestCase):
                 ]
             }
         )
+
+    def test_http_notebook_04(self):
+        req = urllib.request.Request(self.http_addr + '/status',
+                                     method='GET')
+        response = urllib.request.urlopen(req)
+        resp_data = json.loads(response.read())
+        self.assertEqual(resp_data, {'kind': 'status', 'status': 'OK'})


### PR DESCRIPTION
* Add `GET /status` URL to the notebook port. Attempts to make a
  query and returns a simple JSON response.

* Return command statuses for EdgeQL commands along with the binary
  data & codecs info.