### PR TITLE
Make sure module schemas are dropped in correct order

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3867,10 +3867,10 @@ class DeleteModule(ModuleMetaCommand, adapts=s_mod.DeleteModule):
         condition = dbops.SchemaExists(name=schema_name)
 
         table = self.get_table(schema)
-        cmd = dbops.CommandGroup()
+        cmd = dbops.CommandGroup(priority=4)
         cmd.add_command(
             dbops.DropSchema(
-                name=schema_name, conditions={condition}, priority=4))
+                name=schema_name, conditions={condition}))
         cmd.add_command(
             dbops.Delete(
                 table=table,


### PR DESCRIPTION
The underlying PostgreSQL schema must be dropped only when all other
objects have been.  The current coding tries to achieve that by placing
a low priority on the `DropSchema` operation, but fails to notice that
the operation is actually within a command group, so the priority should
be applied to the group instead.

Fixes: #1369.