### PR TITLE
Accept `1e100n` as a bigint constant rather than decimal

### DIFF
--- a/edb/edgeql-parser/tests/tokenizer.rs
+++ b/edb/edgeql-parser/tests/tokenizer.rs
@@ -234,11 +234,19 @@ fn bigint() {
     assert_eq!(tok_typ("*0n"), [Mul, BigIntConst]);
     assert_eq!(tok_str("123n"), ["123n"]);
     assert_eq!(tok_typ("123n"), [BigIntConst]);
+    assert_eq!(tok_str("123e3n"), ["123e3n"]);
+    assert_eq!(tok_typ("123e3n"), [BigIntConst]);
+    assert_eq!(tok_str("123e+99n"), ["123e+99n"]);
+    assert_eq!(tok_typ("123e+99n"), [BigIntConst]);
 
     assert_eq!(tok_str("0n "), ["0n"]);
     assert_eq!(tok_typ("0n "), [BigIntConst]);
     assert_eq!(tok_str("123n "), ["123n"]);
     assert_eq!(tok_typ("123n "), [BigIntConst]);
+    assert_eq!(tok_str("123e3n "), ["123e3n"]);
+    assert_eq!(tok_typ("123e3n "), [BigIntConst]);
+    assert_eq!(tok_str("123e+99n "), ["123e+99n"]);
+    assert_eq!(tok_typ("123e+99n "), [BigIntConst]);
     assert_eq!(tok_err("01n"),
         "Unexpected `leading zeros are not allowed in numbers`");
 }
@@ -301,10 +309,6 @@ fn decimal() {
     assert_eq!(tok_typ("123.999e+99n"), [DecimalConst]);
     assert_eq!(tok_str("2345.567e-7n"), ["2345.567e-7n"]);
     assert_eq!(tok_typ("2345.567e-7n"), [DecimalConst]);
-    assert_eq!(tok_str("123e3n"), ["123e3n"]);
-    assert_eq!(tok_typ("123e3n"), [DecimalConst]);
-    assert_eq!(tok_str("123e+99n"), ["123e+99n"]);
-    assert_eq!(tok_typ("123e+99n"), [DecimalConst]);
     assert_eq!(tok_str("2345e-7n"), ["2345e-7n"]);
     assert_eq!(tok_typ("2345e-7n"), [DecimalConst]);
 
@@ -320,10 +324,6 @@ fn decimal() {
     assert_eq!(tok_typ("123.999e+99n "), [DecimalConst]);
     assert_eq!(tok_str("2345.567e-7n "), ["2345.567e-7n"]);
     assert_eq!(tok_typ("2345.567e-7n "), [DecimalConst]);
-    assert_eq!(tok_str("123e3n "), ["123e3n"]);
-    assert_eq!(tok_typ("123e3n "), [DecimalConst]);
-    assert_eq!(tok_str("123e+99n "), ["123e+99n"]);
-    assert_eq!(tok_typ("123e+99n "), [DecimalConst]);
     assert_eq!(tok_str("2345e-7n "), ["2345e-7n"]);
     assert_eq!(tok_typ("2345e-7n "), [DecimalConst]);
 

--- a/edb/edgeql-rust/src/pynormalize.rs
+++ b/edb/edgeql-rust/src/pynormalize.rs
@@ -149,5 +149,9 @@ pub fn normalize(py: Python<'_>, text: &PyString)
         Err(Error::Tokenizer(msg, pos)) => {
             return Err(TokenizerError::new(py, (msg, py_pos(py, &pos))))
         }
+        Err(Error::Assertion(msg, pos)) => {
+            return Err(PyErr::new::<AssertionError, _>(py,
+                format!("{}: {}", pos, msg)));
+        }
     }
 }

--- a/edb/edgeql-rust/tests/normalize.rs
+++ b/edb/edgeql-rust/tests/normalize.rs
@@ -84,6 +84,22 @@ fn test_bigint() {
 }
 
 #[test]
+fn test_bigint_exponent() {
+    let entry = normalize(r###"
+        SELECT 1e10n + 23e13n
+    "###).unwrap();
+    assert_eq!(entry.key, "SELECT(<bigint>$0)+(<bigint>$1)");
+    assert_eq!(entry.variables, vec![
+        Variable {
+            value: Value::BigInt(10000000000u64.into()),
+        },
+        Variable {
+            value: Value::BigInt(230000000000000u64.into()),
+        }
+    ]);
+}
+
+#[test]
 fn test_decimal() {
     let entry = normalize(r###"
         SELECT 1.33n + 23.77n

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -19,6 +19,7 @@
 from datetime import timedelta
 
 import edgedb
+import decimal
 
 from edb.testbase import server as tb
 from edb.tools import test
@@ -404,3 +405,22 @@ class TestEdgeQLDT(tb.QueryTestCase):
                     SELECT <decimal>(<float64>'Infinity' / <float64>'Infinity')
                 '''
             )
+
+    async def test_edgeql_dt_decimal_05(self):
+        await self.assert_query_result(
+            r'''SELECT (INTROSPECT TYPEOF 1e100n).name''',
+            ['std::bigint'],
+        )
+        await self.assert_query_result(
+            r'''SELECT (INTROSPECT TYPEOF 1.0e100n).name''',
+            ['std::decimal'],
+        )
+        await self.assert_query_result(
+            r'''SELECT 1e100n''',
+            [10**100],
+        )
+        await self.assert_query_result(
+            r'''SELECT 1.0e100n''',
+            [10.0**100],
+            [decimal.Decimal('1e100')],
+        )


### PR DESCRIPTION
This commit fixes both tokenizer and normalization (constant
extraction).

This also fixes normalization of some kinds of bigint constants that were failing before (mostly because of updating to https://github.com/edgedb/edgedb-rust/commit/96b8b0cd96661627c822fe6c17a0f9d920ba12f5)

This is part of fixing edgedb/edgedb-cli#33