### PR TITLE
Support of exponential notation for GraphQL Bigint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "edb-graphql-parser"
 version = "0.3.0"
-source = "git+https://github.com/edgedb/graphql-parser#12607994ccba9ac655ce0397749402659b21f7e7"
+source = "git+https://github.com/edgedb/graphql-parser#49f0e0144fac00750db6c448b7050d054e609701"
 dependencies = [
  "combine 3.8.1",
  "num-bigint",
@@ -323,18 +323,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
+checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
+checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -96,6 +96,9 @@ type ScalarTest {
     property p_array_json -> array<json>;
     property p_array_bytes -> array<bytes>;
 }
+type BigIntTest {
+    property value -> bigint;
+}
 
 # Inheritance tests
 type Bar {

--- a/tests/test_http_graphql_mutation.py
+++ b/tests/test_http_graphql_mutation.py
@@ -2442,3 +2442,16 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
         """, {
             "SettingAlias": []
         })
+
+    def test_graphql_mutation_bigint(self):
+        self.assert_graphql_query_result(r"""
+            mutation insert_BigIntTest {
+                insert_BigIntTest(
+                    data: [{value: 1e100}]
+                ) {
+                    value
+                }
+            }
+        """, {
+            "insert_BigIntTest": [{"value": 10**100}]
+        })


### PR DESCRIPTION
Note: this commit adds a test bug the fix have been added to
`edb-graphql-parser` (so lockfile is updated)

This is a follow-up of #1372