### PR TITLE
Switch the nightly macOS build to macos-latest and make errors fatal

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -48,7 +48,6 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
-    continue-on-error: true
 
     strategy:
       max-parallel: 4
@@ -155,7 +154,7 @@ jobs:
 
   publish-macos:
     needs: [build-linux, build-macos]
-    runs-on: macos-10.14
+    runs-on: macos-latest
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -158,7 +158,6 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
-    continue-on-error: true
 
     strategy:
       max-parallel: 4
@@ -380,7 +379,7 @@ jobs:
 
   publish-macos:
     needs: [build-linux, build-macos]
-    runs-on: macos-10.14
+    runs-on: macos-latest
     strategy:
       max-parallel: 4
       matrix:


### PR DESCRIPTION
The `macos-10.14` image is deprecated, switch to `macos-latest`.  Also,
since the build has stabilizied, remove `continue-on-error`.