### PR TITLE
Make sure reconstructing array casts preserve the original order

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1492,7 +1492,7 @@ def process_set_as_tuple_indirection(
 
             rvar = relctx.new_rel_rvar(ir_set, stmt, ctx=subctx)
 
-    return new_simple_set_rvar(ir_set, rvar)
+    return new_simple_set_rvar(ir_set, rvar, aspects=('value',))
 
 
 def process_set_as_type_cast(
@@ -1698,7 +1698,7 @@ def _process_set_func_with_ordinality(
     if arg_is_tuple:
         subtypes = {}
         for i, st in enumerate(inner_rtype.subtypes):
-            colname = st.element_name or str(i)
+            colname = st.element_name or f'_t{i + 1}'
             subtypes[colname] = st
             coldeflist.append(
                 pgast.ColumnDef(
@@ -1718,7 +1718,7 @@ def _process_set_func_with_ordinality(
     fexpr = pgast.FuncCall(name=func_name, args=args, coldeflist=coldeflist)
 
     colnames.append(
-        rtype.subtypes[0].element_name or '0'
+        rtype.subtypes[0].element_name or '_i'
     )
 
     func_rvar = pgast.RangeFunction(

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -454,6 +454,16 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [110, 120],
         )
 
+        await self.assert_query_result(
+            r'''SELECT enumerate(array_unpack([(1, '2')]))''',
+            [[0, [1, '2']]],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT enumerate(array_unpack([(1, '2')])).1.1''',
+            ['2'],
+        )
+
     async def test_edgeql_functions_enumerate_02(self):
         await self.assert_query_result(
             r'''SELECT enumerate(array_unpack([(x:=1)])).1;''',

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -198,6 +198,22 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             [[2, 3, 5]],
         )
 
+    async def test_edgeql_json_cast_07(self):
+        """Check that JSON of array preserves order."""
+
+        await self.assert_query_result(
+            '''WITH MODULE test
+                SELECT <json>array_agg(
+                    (SELECT JSONTest{number}
+                     FILTER .number IN {0, 1}
+                     ORDER BY .j_string)
+                ) = to_json(
+                    '[{"number": 1}, {"number": 0}]'
+                )
+            ''',
+            [True]
+        )
+
     async def test_edgeql_json_accessor_01(self):
         await self.assert_query_result(
             r'''SELECT (to_json('[1, "a", 3]'))[0] = to_json('1');''',


### PR DESCRIPTION
Make sure casts that unpack and reassemble the array do not lose the
array element order.

Per report from @kurtrottmann.