### PR TITLE
Fix erroneous limit injection into singleton properties in shapes

### DIFF
--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2548,6 +2548,8 @@ class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):
                 r"""
                     WITH MODULE test
                     SELECT FL_B {
+                        id,
+                        __type__,
                         a,
                     } ORDER BY .n
                 """,


### PR DESCRIPTION
Implicit limit is only applicable to multi properties and links.  What's
worse, the injection will trigger a false error when protected
properties like `id` are selected:

    db> SELECT Foo {id}
    error: cannot assign to id

Fix this by omitting the implicit limit injection on pointers that are
known to be singletons.

Per report from @RobertoPrevato