### PR TITLE
Docs

### DIFF
--- a/docs/cheatsheet/select.rst
+++ b/docs/cheatsheet/select.rst
@@ -117,3 +117,14 @@ result):
         Movie.title,
         Movie IN User.<author[IS Review].movie
     )
+
+Perform a set intersection of all actors with all directors:
+
+.. code-block:: edgeql
+
+    WITH
+        # get the set of actors and set of directors
+        Actor := Movie.actors,
+        Director := Movie.directors,
+    # set intersection is done via the FILTER clause
+    SELECT Actor FILTER Actor IN Director;

--- a/docs/edgeql/funcops/set.rst
+++ b/docs/edgeql/funcops/set.rst
@@ -26,8 +26,8 @@ Set
     * - :eql:op:`OPTIONAL anytype ?? set <COALESCE>`
       - :eql:op-desc:`COALESCE`
 
-    * - :eql:op:`anytype IN set <IN>`
-      - :eql:op-desc:`IN`
+    * - :eql:op:`anytype [IS type] <ISINTERSECT>`
+      - :eql:op-desc:`ISINTERSECT`
 
     * - :eql:func:`count`
       - :eql:func-desc:`count`
@@ -91,6 +91,8 @@ Set
 .. eql:operator:: IN: anytype IN SET OF anytype -> bool
                       anytype NOT IN SET OF anytype -> bool
 
+    :index: intersection
+
     Test the membership of an element in a set.
 
     Set membership operators :eql:op:`IN` and :eql:op:`NOT IN<IN>`
@@ -106,6 +108,16 @@ Set
 
         db> SELECT {1, 2} IN {1, 3, 5};
         {true, false}
+
+    This operator can also be used to implement set intersection:
+
+    .. code-block:: edgeql-repl
+
+        db> WITH
+        ...     A := {1, 2, 3, 4},
+        ...     B := {2, 4, 6}
+        ... SELECT A FILTER A IN B;
+        {2, 4}
 
 
 ----------

--- a/edb/edgeql/pygments/meta.py
+++ b/edb/edgeql/pygments/meta.py
@@ -112,6 +112,7 @@ class EdgeQL:
         "deferred",
         "delegated",
         "desc",
+        "emit",
         "explicit",
         "expression",
         "final",
@@ -130,6 +131,7 @@ class EdgeQL:
         "named",
         "object",
         "of",
+        "oids",
         "on",
         "only",
         "operator",
@@ -137,6 +139,7 @@ class EdgeQL:
         "postfix",
         "prefix",
         "property",
+        "pseudo",
         "read",
         "rename",
         "repeatable",
@@ -170,6 +173,7 @@ class EdgeQL:
         "true",
     )
     type_builtins = (
+        "BaseObject",
         "Object",
         "anyenum",
         "anyfloat",


### PR DESCRIPTION
Generate the up-to-date grammar file that can be used with docs and
site.

Fix a reference to `[IS Type]` functionality.
Add a description of how to perform set intersection to `IN` and to
cheat sheet.