### PR TITLE
Add support for "set subtract" (-=) operation in UPDATE

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -473,6 +473,7 @@ class SelectClauseMixin(OrderByMixin, OffsetLimitMixin, FilterMixin):
 class ShapeOp(s_enum.StrEnum):
 
     APPEND = 'APPEND'
+    SUBTRACT = 'SUBTRACT'
     ASSIGN = 'ASSIGN'
 
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -561,6 +561,8 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 self.write(' := ')
             elif node.operation.op is qlast.ShapeOp.APPEND:
                 self.write(' += ')
+            elif node.operation.op is qlast.ShapeOp.SUBTRACT:
+                self.write(' -= ')
             else:
                 raise NotImplementedError(
                     f'unexpected shape operation: {node.operation.op!r}'

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1020,12 +1020,18 @@ def computable_ptr_set(
             ctx=ctx,
         )
 
-    stmtctx.enforce_pointer_cardinality(
-        ptrcls,
-        comp_ir_set_copy,
-        singletons={source_path_id},
-        ctx=ctx,
-    )
+    if (
+        pending_cardinality is None
+        or pending_cardinality.shape_op is not qlast.ShapeOp.SUBTRACT
+    ):
+        # When doing subtraction in shapes, the cardinality of the
+        # expression being subtracted does not matter.
+        stmtctx.enforce_pointer_cardinality(
+            ptrcls,
+            comp_ir_set_copy,
+            singletons={source_path_id},
+            ctx=ctx,
+        )
 
     comp_ir_set = new_set_from_set(
         comp_ir_set, path_id=result_path_id, rptr=rptr, ctx=ctx)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -494,6 +494,10 @@ def _infer_pointer_cardinality(
     if shape_op is qlast.ShapeOp.APPEND:
         # += in shape always means MANY
         inferred_card = qltypes.Cardinality.MANY
+    elif shape_op is qlast.ShapeOp.SUBTRACT:
+        # -= does not increase cardinality, but it may result in an empty set,
+        # hence AT_MOST_ONE.
+        inferred_card = qltypes.Cardinality.AT_MOST_ONE
     else:
         inferred_card = infer_expr_cardinality(irexpr=irexpr, ctx=ctx)
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -558,10 +558,17 @@ def _normalize_view_ptr_expr(
             )
             irexpr = dispatch.compile(qlexpr, ctx=shape_expr_ctx)
 
-            if shape_el.operation.op is qlast.ShapeOp.APPEND:
+            if (
+                shape_el.operation.op is qlast.ShapeOp.APPEND
+                or shape_el.operation.op is qlast.ShapeOp.SUBTRACT
+            ):
                 if not is_update:
+                    op = (
+                        '+=' if shape_el.operation.op is qlast.ShapeOp.APPEND
+                        else '-='
+                    )
                     raise errors.EdgeQLSyntaxError(
-                        "unexpected '+='",
+                        f"unexpected '{op}'",
                         context=shape_el.operation.context,
                     )
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -533,6 +533,14 @@ class ComputableShapePointer(Nonterm):
             context=kids[1].context,
         )
 
+    def reduce_SimpleShapePointer_REMASSIGN_Expr(self, *kids):
+        self.val = kids[0].val
+        self.val.compexpr = kids[2].val
+        self.val.operation = qlast.ShapeOperation(
+            op=qlast.ShapeOp.SUBTRACT,
+            context=kids[1].context,
+        )
+
 
 class FilterClause(Nonterm):
     def reduce_FILTER_Expr(self, *kids):

--- a/tests/schemas/updates.esdl
+++ b/tests/schemas/updates.esdl
@@ -61,6 +61,8 @@ type UpdateTest {
     property readonly_note -> str {
         readonly := true;
     }
+
+    multi property str_tags -> str;
 }
 
 type CollectionTest {

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1434,6 +1434,14 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_shape_48(self):
+        """
+        UPDATE Foo
+        SET {
+            foo -= Bar
+        };
+        """
+
     def test_edgeql_syntax_struct_01(self):
         """
         SELECT (

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -208,7 +208,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 44.73)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 44.70)
 
     def test_cqa_type_coverage_edgeqlcompiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)


### PR DESCRIPTION
This implements support for the new `-=` operator for use in the
`UPDATE` shapes:

    UPDATE Foo
    SET {
        bar -= (SELECT Bar FILTER .name = 'bar')
    };

This is largely equivalent to

    UPDATE Foo
    SET {
      bar := (
       SELECT Foo.bar
       FILTER
         Foo.bar NOT IN
           (SELECT Bar FILTER .name = 'bar')
      )
    };

except that `-=` makes life much easier when link propreties are
invoved and is more efficient in the current implementation.

Issue: #165