### PR TITLE
Add static versions of get_{short,display,verbose)name

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -465,7 +465,7 @@ class ConstraintCommand(
     def _classname_quals_from_name(
         cls,
         name: sn.SchemaName
-    ) -> Tuple[str]:
+    ) -> Tuple[str, ...]:
         quals = sn.quals_from_fullname(name)
         return (quals[-1],)
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -363,14 +363,18 @@ class Parameter(so.ObjectFragment, ParameterLike):
         else:
             return vn
 
-    def get_shortname(self, schema: s_schema.Schema) -> sn.Name:
+    @classmethod
+    def get_shortname_static(cls, name: str) -> sn.Name:
+        assert isinstance(name, sn.Name)
         return sn.Name(
-            module=self.get_name(schema).module,
-            name=self.get_parameter_name(schema),
+            module='__',
+            name=cls.paramname_from_fullname(name),
         )
 
-    def get_displayname(self, schema: s_schema.Schema) -> str:
-        return self.get_parameter_name(schema)
+    @classmethod
+    def get_displayname_static(cls, name: str) -> str:
+        shortname = cls.get_shortname_static(name)
+        return shortname.name
 
     def get_parameter_name(self, schema: s_schema.Schema) -> str:
         fullname = self.get_name(schema)
@@ -927,7 +931,7 @@ class Function(CallableObject, VolatilitySubject, s_abc.Function,
     ) -> str:
         params = self.get_params(schema)
         sn = self.get_shortname(schema)
-        return f'function {sn}{params.as_str(schema)}'
+        return f"function '{sn}{params.as_str(schema)}'"
 
 
 class FunctionCommandContext(CallableCommandContext):

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -224,12 +224,13 @@ class Pointer(referencing.ReferencedInheritingObject,
     def is_type_intersection(self) -> bool:
         return False
 
-    def get_displayname(self, schema: s_schema.Schema) -> str:
-        sn = self.get_shortname(schema)
-        if self.generic(schema):
-            return sn
-        else:
+    @classmethod
+    def get_displayname_static(cls, name: str) -> str:
+        sn = cls.get_shortname_static(name)
+        if sn.module == '__':
             return sn.name
+        else:
+            return sn
 
     def get_verbosename(
         self,

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -44,9 +44,6 @@ class PseudoType(so.InheritingObject, s_types.Type):
     def as_shell(self, schema: s_schema.Schema) -> PseudoTypeShell:
         return PseudoTypeShell(name=self.get_name(schema))
 
-    def get_shortname(self, schema: s_schema.Schema) -> str:
-        return self.get_name(schema)
-
     def get_bases(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -189,6 +189,21 @@ class ReferencedObject(so.DerivableObject):
 
         return schema, derived
 
+    def get_verbosename(
+        self,
+        schema: s_schema.Schema,
+        *,
+        with_parent: bool = False,
+    ) -> str:
+        vn = super().get_verbosename(schema)
+        if with_parent:
+            subject = self.get_subject(schema)
+            if subject is not None:
+                pn = subject.get_verbosename(schema, with_parent=True)
+                return f'{vn} of {pn}'
+
+        return vn
+
 
 class ReferencedInheritingObject(
     so.DerivableInheritingObject,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -630,6 +630,8 @@ _123456789_123456789_123456789 -> str
                         constraint max_len_value(10);
                     }
                 }
+
+                index on (.foo)
             };
         """)
 
@@ -661,13 +663,13 @@ _123456789_123456789_123456789 -> str
         fn = list(schema.get_functions('std::json_typeof'))[0]
         self.assertEqual(
             fn.get_verbosename(schema),
-            'function std::json_typeof(json: std::json)',
+            "function 'std::json_typeof(json: std::json)'",
         )
 
         fn_param = fn.get_params(schema).get_by_name(schema, 'json')
         self.assertEqual(
             fn_param.get_verbosename(schema, with_parent=True),
-            "parameter 'json' of function std::json_typeof(json: std::json)",
+            "parameter 'json' of function 'std::json_typeof(json: std::json)'",
         )
 
         op = list(schema.get_operators('std::AND'))[0]
@@ -733,6 +735,13 @@ _123456789_123456789_123456789 -> str
                     schema, with_parent=True),
             "constraint 'std::max_len_value' of property 'bar_prop' of "
             "link 'bar' of object type 'test::Object1'",
+        )
+
+        self.assertEqual(
+            next(iter(obj.get_indexes(
+                schema).objects(schema))).get_verbosename(
+                    schema, with_parent=True),
+            "index 'foo_7770702d' of object type 'test::Object1'",
         )
 
     def test_schema_advanced_types(self):


### PR DESCRIPTION
Currently, `get_shortname()`, and its cousins: `get_displayname()` and
`get_verbosename()` are instance methods, i.e. they require a valid
instance of a schema object to format its name nicely.  Since instances
are not always available or feasible, make a classmethod version for
each of the name formatting methods.  This should help with
fixing #1258.