### PR TITLE
Adapt to the API change in edgedb-python

### DIFF
--- a/edb/testbase/serutils.py
+++ b/edb/testbase/serutils.py
@@ -67,7 +67,7 @@ def _object(o: edgedb.Object):
     for attr in dir(o):
         try:
             link = o[attr]
-        except KeyError:
+        except (KeyError, TypeError):
             link = None
 
         if link:


### PR DESCRIPTION
edgedb/edgedb-python#95 made a change so that index access on objects
now raises `TypeError` instead of `KeyError`.