### PR TITLE
Add `--version` option

### DIFF
--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -515,6 +515,9 @@ _server_options = [
         '--max-protocol', type=str, callback=_protocol_version,
         default='.'.join(map(str, mng_port.CURRENT_PROTOCOL)),
         help='maximum supported and advertized client protocol version'),
+    click.option(
+        '--version', is_flag=True,
+        help='Show the version and exit.')
 ]
 
 
@@ -587,7 +590,10 @@ def server_main(*, insecure=False, **kwargs):
     'EdgeDB Server',
     context_settings=dict(help_option_names=['-h', '--help']))
 @server_options
-def main(**kwargs):
+def main(version=False, **kwargs):
+    if version:
+        print(f"edgedb-server, version {buildmeta.get_version()}")
+        sys.exit(0)
     server_main(**kwargs)
 
 

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -20,12 +20,14 @@
 from __future__ import annotations
 
 import os
+import sys
 
 import click
 
 from edb.common import debug
 from edb.common import devmode as dm
 from edb.server import main as srv_main
+from edb.server import buildmeta
 
 
 @click.group(
@@ -40,10 +42,13 @@ def edbcommands(devmode: bool):
 
 @edbcommands.command()
 @srv_main.server_options
-def server(**kwargs):
+def server(version=False, **kwargs):
+    if version:
+        print(f"edb, version {buildmeta.get_version()}")
+        sys.exit(0)
+
     os.environ['EDGEDB_DEBUG_SERVER'] = '1'
     debug.init_debug_flags()
-
     srv_main.server_main(insecure=True, **kwargs)
 
 


### PR DESCRIPTION
Perhaps, this can make writing tests for `edgedb server` easier. Regardless of that it looks like very expected thing on (almost) any executable.