### PR TITLE
Fix JSON casts on long tuples and shapes

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -747,7 +747,7 @@ class RowExpr(ImmutableBaseExpr):
     """A ROW() expression."""
 
     # The fields.
-    args: typing.List[Base]
+    args: typing.List[BaseExpr]
     # Row expressions, while may contain NULLs, are not NULL themselves.
     nullable: bool = False
 
@@ -756,7 +756,7 @@ class ImplicitRowExpr(ImmutableBaseExpr):
     """A (a, b, c) expression."""
 
     # The fields.
-    args: typing.List[Base]
+    args: typing.List[BaseExpr]
     # Row expressions, while may contain NULLs, are not NULL themselves.
     nullable: bool = False
 

--- a/edb/schema/defines.py
+++ b/edb/schema/defines.py
@@ -22,3 +22,6 @@ from __future__ import annotations
 # Maximum length of column name in Postgres. This limits the database
 # name length and affects column name mangling.
 MAX_NAME_LENGTH = 63
+
+# Maximum number of arguments supported by SQL functions.
+MAX_FUNC_ARG_COUNT = 100

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -232,7 +232,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 100.00)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 46.76)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 46.81)
 
     def test_cqa_type_coverage_pgsqlcompiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)


### PR DESCRIPTION
PostgreSQL has a limit on the maximum number of arguments
passed to a function call, so we must chop input into chunks
if the argument count is greater then the limit.

The max arg limit should also be enforced on EdgeQL functions, but
that's material for another commit.