### PR TITLE
Implement string-splitting function: to_array(str, delim)

### DIFF
--- a/docs/edgeql/funcops/array.rst
+++ b/docs/edgeql/funcops/array.rst
@@ -35,6 +35,9 @@ Array
     * - :eql:func:`to_str`
       - Render an array to a string.
 
+    * - :eql:func:`to_array`
+      - Split a string into an array using a delimiter.
+
     * - :eql:func:`array_agg`
       - :eql:func-desc:`array_agg`
 
@@ -191,3 +194,23 @@ Array
 
         db> SELECT array_unpack([2, 3, 5]);
         {3, 2, 5}
+
+
+----------
+
+.. eql:function:: std::to_array(s: std::str, delimiter: std::str) \
+                                -> array<std::str>
+
+    :index: split str_split explode
+
+    Split string into array elements using the supplied delimiter.
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT to_array('1, 2, 3', ', ');
+        {['1', '2', '3']}
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT to_array('123', '');
+        {['1', '2', '3']}

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -248,6 +248,21 @@ std::to_str(array: array<std::str>, delimiter: std::str) -> std::str
 
 
 CREATE FUNCTION
+std::to_array(s: std::str, delimiter: std::str) -> array<std::str>
+{
+    SET volatility := 'IMMUTABLE';
+    USING SQL $$
+        SELECT (
+            CASE WHEN "delimiter" != ''
+            THEN string_to_array("s", "delimiter")
+            ELSE regexp_split_to_array("s", '')
+            END
+        );
+    $$;
+};
+
+
+CREATE FUNCTION
 std::to_json(str: std::str) -> std::json
 {
     # Casting of jsonb to and from text in PostgreSQL is IMMUTABLE.

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_04_16_00_00
+EDGEDB_CATALOG_VERSION = 2020_05_14_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -2099,6 +2099,27 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [''],
         )
 
+    async def test_edgeql_functions_to_array_01(self):
+        await self.assert_query_result(
+            r'''SELECT to_array('one, two, three', ', ');''',
+            [['one', 'two', 'three']],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT to_array('', ', ');''',
+            [[]],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT to_array('foo', ', ');''',
+            [['foo']],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT to_array('foo', '');''',
+            [['f', 'o', 'o']],
+        )
+
     async def test_edgeql_functions_to_int_01(self):
         await self.assert_query_result(
             r'''SELECT to_int64(' 123456789', '999999999');''',


### PR DESCRIPTION
This implements the reverse of `to_str(array, delim)`:

    db> SELECT to_array('1, 2, 3', ', ');
    {['1', '2', '3']}