### PR TITLE
Rename `to_str(array)` and `to_array(str)` 

### DIFF
--- a/docs/edgeql/funcops/array.rst
+++ b/docs/edgeql/funcops/array.rst
@@ -32,10 +32,10 @@ Array
     * - :eql:func:`find`
       - Find the index of an element in the array.
 
-    * - :eql:func:`to_str`
+    * - :eql:func:`array_join`
       - Render an array to a string.
 
-    * - :eql:func:`to_array`
+    * - :eql:func:`str_split`
       - Split a string into an array using a delimiter.
 
     * - :eql:func:`array_agg`

--- a/docs/edgeql/funcops/array.rst
+++ b/docs/edgeql/funcops/array.rst
@@ -35,9 +35,6 @@ Array
     * - :eql:func:`array_join`
       - Render an array to a string.
 
-    * - :eql:func:`str_split`
-      - Split a string into an array using a delimiter.
-
     * - :eql:func:`array_agg`
       - :eql:func-desc:`array_agg`
 

--- a/docs/edgeql/funcops/string.rst
+++ b/docs/edgeql/funcops/string.rst
@@ -79,6 +79,9 @@ String
     * - :eql:func:`re_test`
       - :eql:func-desc:`re_test`
 
+    * - :eql:func:`str_split`
+      - Split a string into an array using a delimiter.
+
 
 ----------
 

--- a/edb/lib/std/30-strfuncs.edgeql
+++ b/edb/lib/std/30-strfuncs.edgeql
@@ -202,3 +202,13 @@ std::str_trim(s: std::str, tr: std::str=' ') -> std::str
     SET volatility := 'IMMUTABLE';
     USING SQL FUNCTION 'btrim';
 };
+
+
+CREATE FUNCTION
+std::str_split(array: array<std::str>, delimiter: std::str) -> std::str
+{
+    SET volatility := 'STABLE';
+    USING SQL $$
+    SELECT array_to_string("array", "delimiter");
+    $$;
+};

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -238,24 +238,24 @@ std::to_str(json: std::json, fmt: OPTIONAL str={}) -> std::str
 
 
 CREATE FUNCTION
-std::to_str(array: array<std::str>, delimiter: std::str) -> std::str
+std::array_join(array: array<std::str>, delimiter: std::str) -> std::str
 {
     SET volatility := 'STABLE';
     USING SQL $$
-    SELECT array_to_string("array", "delimiter");
+    SELECT array_array_join("array", "delimiter");
     $$;
 };
 
 
 CREATE FUNCTION
-std::to_array(s: std::str, delimiter: std::str) -> array<std::str>
+std::str_split(s: std::str, delimiter: std::str) -> array<std::str>
 {
     SET volatility := 'IMMUTABLE';
     USING SQL $$
         SELECT (
             CASE WHEN "delimiter" != ''
-            THEN string_to_array("s", "delimiter")
-            ELSE regexp_split_to_array("s", '')
+            THEN string_str_split("s", "delimiter")
+            ELSE regexp_split_str_split("s", '')
             END
         );
     $$;

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -238,24 +238,14 @@ std::to_str(json: std::json, fmt: OPTIONAL str={}) -> std::str
 
 
 CREATE FUNCTION
-std::array_join(array: array<std::str>, delimiter: std::str) -> std::str
-{
-    SET volatility := 'STABLE';
-    USING SQL $$
-    SELECT array_array_join("array", "delimiter");
-    $$;
-};
-
-
-CREATE FUNCTION
-std::str_split(s: std::str, delimiter: std::str) -> array<std::str>
+std::array_join(s: std::str, delimiter: std::str) -> array<std::str>
 {
     SET volatility := 'IMMUTABLE';
     USING SQL $$
         SELECT (
             CASE WHEN "delimiter" != ''
-            THEN string_str_split("s", "delimiter")
-            ELSE regexp_split_str_split("s", '')
+            THEN string_to_array("s", "delimiter")
+            ELSE regexp_split_to_array("s", '')
             END
         );
     $$;

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -2083,7 +2083,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                 await self.con.fetchall(
                     r'''SELECT to_str(<cal::local_time>'15:01:22', '');''',)
 
-    async def test_edgeql_functions_to_str_08(self):
+    async def test_edgeql_functions_array_join_01(self):
         await self.assert_query_result(
             r'''SELECT to_str(['one', 'two', 'three'], ', ');''',
             ['one, two, three'],
@@ -2099,7 +2099,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [''],
         )
 
-    async def test_edgeql_functions_to_array_01(self):
+    async def test_edgeql_functions_str_split_01(self):
         await self.assert_query_result(
             r'''SELECT to_array('one, two, three', ', ');''',
             [['one', 'two', 'three']],


### PR DESCRIPTION
Rename `to_str(array)` and `to_array(str)` to `str_split` and `array_join

Fixes #1401