### PR TITLE
Rename `to_str` to `array_join` and `to_array` to `str_split`.

### DIFF
--- a/docs/edgeql/funcops/array.rst
+++ b/docs/edgeql/funcops/array.rst
@@ -32,11 +32,8 @@ Array
     * - :eql:func:`find`
       - Find the index of an element in the array.
 
-    * - :eql:func:`to_str`
+    * - :eql:func:`array_join`
       - Render an array to a string.
-
-    * - :eql:func:`to_array`
-      - Split a string into an array using a delimiter.
 
     * - :eql:func:`array_agg`
       - :eql:func-desc:`array_agg`
@@ -198,19 +195,16 @@ Array
 
 ----------
 
-.. eql:function:: std::to_array(s: std::str, delimiter: std::str) \
-                                -> array<std::str>
 
-    :index: split str_split explode
+.. eql:function:: std::array_join(array: array<str>, delimiter: str) -> str
 
-    Split string into array elements using the supplied delimiter.
+    :index: join array_to_string implode
 
-    .. code-block:: edgeql-repl
+    Render an array to a string.
 
-        db> SELECT to_array('1, 2, 3', ', ');
-        {['1', '2', '3']}
+    Join a string array into a single string using a specified *delimiter*:
 
     .. code-block:: edgeql-repl
 
-        db> SELECT to_array('123', '');
-        {['1', '2', '3']}
+        db> SELECT to_str(['one', 'two', 'three'], ', ');
+        {'one, two, three'}

--- a/docs/edgeql/funcops/string.rst
+++ b/docs/edgeql/funcops/string.rst
@@ -67,6 +67,9 @@ String
     * - :eql:func:`str_repeat`
       - :eql:func-desc:`str_repeat`
 
+    * - :eql:func:`str_split`
+      - Split a string into an array using a delimiter.
+
     * - :eql:func:`re_match`
       - :eql:func-desc:`re_match`
 
@@ -375,6 +378,27 @@ String
 ----------
 
 
+.. eql:function:: std::str_split(s: std::str, delimiter: std::str) \
+                                 -> array<std::str>
+
+    :index: split str_split explode
+
+    Split string into array elements using the supplied delimiter.
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT str_split('1, 2, 3', ', ');
+        {['1', '2', '3']}
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT str_split('123', '');
+        {['1', '2', '3']}
+
+
+----------
+
+
 .. eql:function:: std::re_match(pattern: str, \
                                 string: str) -> array<str>
 
@@ -469,7 +493,6 @@ String
                   std::to_str(val: bigint, fmt: OPTIONAL str={}) -> str
                   std::to_str(val: decimal, fmt: OPTIONAL str={}) -> str
                   std::to_str(val: json, fmt: OPTIONAL str={}) -> str
-                  std::to_str(array: array<str>, delimiter: str) -> str
                   std::to_str(val: cal::local_datetime, \
                               fmt: OPTIONAL str={}) -> str
                   std::to_str(val: cal::local_date, \

--- a/edb/lib/std/30-arrayfuncs.edgeql
+++ b/edb/lib/std/30-arrayfuncs.edgeql
@@ -57,6 +57,16 @@ std::array_get(
 };
 
 
+CREATE FUNCTION
+std::array_join(array: array<std::str>, delimiter: std::str) -> std::str
+{
+    SET volatility := 'STABLE';
+    USING SQL $$
+    SELECT array_to_string("array", "delimiter");
+    $$;
+};
+
+
 ## Array operators
 
 

--- a/edb/lib/std/30-strfuncs.edgeql
+++ b/edb/lib/std/30-strfuncs.edgeql
@@ -202,3 +202,18 @@ std::str_trim(s: std::str, tr: std::str=' ') -> std::str
     SET volatility := 'IMMUTABLE';
     USING SQL FUNCTION 'btrim';
 };
+
+
+CREATE FUNCTION
+std::str_split(s: std::str, delimiter: std::str) -> array<std::str>
+{
+    SET volatility := 'IMMUTABLE';
+    USING SQL $$
+        SELECT (
+            CASE WHEN "delimiter" != ''
+            THEN string_to_array("s", "delimiter")
+            ELSE regexp_split_to_array("s", '')
+            END
+        );
+    $$;
+};

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -203,6 +203,17 @@ std::to_str(d: std::decimal, fmt: OPTIONAL str={}) -> std::str
 };
 
 
+# TODO: This converter function is deprecated and
+# is scheduled to be removed before 1.0.
+# Use std::array_join() instead.
+CREATE FUNCTION
+std::to_str(array: array<std::str>, delimiter: std::str) -> std::str
+{
+    SET volatility := 'STABLE';
+    USING (
+        SELECT std::array_join(array, delimiter)
+    );
+};
 
 
 # JSON can be prettified by specifying 'pretty' as the format, any
@@ -233,31 +244,6 @@ std::to_str(json: std::json, fmt: OPTIONAL str={}) -> std::str
             )
         END
     )
-    $$;
-};
-
-
-CREATE FUNCTION
-std::to_str(array: array<std::str>, delimiter: std::str) -> std::str
-{
-    SET volatility := 'STABLE';
-    USING SQL $$
-    SELECT array_to_string("array", "delimiter");
-    $$;
-};
-
-
-CREATE FUNCTION
-std::to_array(s: std::str, delimiter: std::str) -> array<std::str>
-{
-    SET volatility := 'IMMUTABLE';
-    USING SQL $$
-        SELECT (
-            CASE WHEN "delimiter" != ''
-            THEN string_to_array("s", "delimiter")
-            ELSE regexp_split_to_array("s", '')
-            END
-        );
     $$;
 };
 

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -175,7 +175,8 @@ sys::get_version_as_str() -> std::str
             ++ '.' ++ <str>v.minor
             ++ (('-' ++ <str>v.stage ++ '.' ++ <str>v.stage_no)
                 IF v.stage != <sys::version_stage>'final' ELSE '')
-            ++ (('+' ++ std::to_str(v.local, '.')) IF len(v.local) > 0 ELSE '')
+            ++ (('+' ++ std::array_join(v.local, '.')) IF len(v.local) > 0
+                ELSE '')
     );
 };
 

--- a/edb/repl/__init__.py
+++ b/edb/repl/__init__.py
@@ -686,7 +686,7 @@ class Cli:
             WITH MODULE schema
             SELECT ScalarType {
                 name,
-                `extending` := to_str(array_agg(.bases.name), ', '),
+                `extending` := array_join(array_agg(.bases.name), ', '),
                 kind := (
                     'enum' IF 'std::anyenum' IN .ancestors.name ELSE
                     'sequence' IF 'std::sequence' IN .ancestors.name ELSE
@@ -757,7 +757,7 @@ class Cli:
             WITH MODULE schema
             SELECT ObjectType {
                 name,
-                `extending` := to_str(array_agg(.ancestors.name), ', '),
+                `extending` := array_join(array_agg(.ancestors.name), ', '),
             }
         '''
 

--- a/tests/schemas/dump01_default.esdl
+++ b/tests/schemas/dump01_default.esdl
@@ -30,7 +30,7 @@ function user_func_0(x: int64) -> str {
 
 function user_func_1(x: array<int64>, y: str) -> str {
     using (
-        SELECT to_str(<array<str>>x, y)
+        SELECT array_join(<array<str>>x, y)
     );
     volatility := 'IMMUTABLE';
 };
@@ -172,7 +172,7 @@ type I {
     };
     required link i2 -> C {
         default := (
-            SELECT C FILTER .val = to_str(['D', '0', '2'], '') LIMIT 1
+            SELECT C FILTER .val = array_join(['D', '0', '2'], '') LIMIT 1
         );
     };
 }
@@ -184,7 +184,7 @@ type J {
         SELECT C FILTER .val = 'D0' ++ user_func_0(1)[-1] LIMIT 1
     );
     link j2 := (
-        SELECT C FILTER .val = to_str(['D', '0', '2'], '') LIMIT 1
+        SELECT C FILTER .val = array_join(['D', '0', '2'], '') LIMIT 1
     );
 }
 

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -2083,40 +2083,40 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                 await self.con.fetchall(
                     r'''SELECT to_str(<cal::local_time>'15:01:22', '');''',)
 
-    async def test_edgeql_functions_to_str_08(self):
+    async def test_edgeql_functions_array_join_01(self):
         await self.assert_query_result(
-            r'''SELECT to_str(['one', 'two', 'three'], ', ');''',
+            r'''SELECT array_join(['one', 'two', 'three'], ', ');''',
             ['one, two, three'],
         )
 
         await self.assert_query_result(
-            r'''SELECT to_str(['one', 'two', 'three'], '');''',
+            r'''SELECT array_join(['one', 'two', 'three'], '');''',
             ['onetwothree'],
         )
 
         await self.assert_query_result(
-            r'''SELECT to_str(<array<str>>[], ', ');''',
+            r'''SELECT array_join(<array<str>>[], ', ');''',
             [''],
         )
 
-    async def test_edgeql_functions_to_array_01(self):
+    async def test_edgeql_functions_str_split_01(self):
         await self.assert_query_result(
-            r'''SELECT to_array('one, two, three', ', ');''',
+            r'''SELECT str_split('one, two, three', ', ');''',
             [['one', 'two', 'three']],
         )
 
         await self.assert_query_result(
-            r'''SELECT to_array('', ', ');''',
+            r'''SELECT str_split('', ', ');''',
             [[]],
         )
 
         await self.assert_query_result(
-            r'''SELECT to_array('foo', ', ');''',
+            r'''SELECT str_split('foo', ', ');''',
             [['foo']],
         )
 
         await self.assert_query_result(
-            r'''SELECT to_array('foo', '');''',
+            r'''SELECT str_split('foo', '');''',
             [['f', 'o', 'o']],
         )
 

--- a/tests/test_edgeql_tree.py
+++ b/tests/test_edgeql_tree.py
@@ -590,7 +590,7 @@ class TestTree(tb.QueryTestCase):
                 WITH MODULE test
                 UPDATE Tree
                 SET {
-                    val := to_str(
+                    val := array_join(
                         [.val, 'c'] ++ array_agg((
                             SELECT _ := .children.val
                             ORDER BY _
@@ -657,7 +657,7 @@ class TestTree(tb.QueryTestCase):
                 WITH MODULE test
                 UPDATE Eert
                 SET {
-                    val := to_str(
+                    val := array_join(
                         [.val, 'c'] ++ array_agg((
                             SELECT _ := .children.val
                             ORDER BY _


### PR DESCRIPTION
Rename `to_str(array, delimiter)` and `to_array(str, delimiter)` to more
discoverable and familiar `array_join(array, delimiter)` and
`str_split(str, delimiter)` respectively.

Fixes #1401

Co-authored-by: Shankar Jha <shankarj67@gmail.com>