### PR TITLE
Better numeric constants

### DIFF
--- a/docs/edgeql/lexical.rst
+++ b/docs/edgeql/lexical.rst
@@ -367,9 +367,6 @@ an explicit cast can be used to convert them to :eql:type:`float32`:
     db> SELECT 0.1;
     {0.1}
 
-    db> SELECT 12.;
-    {12.0}
-
     db> SELECT 12.3;
     {12.3}
 

--- a/edb/edgeql-rust/src/normalize.rs
+++ b/edb/edgeql-rust/src/normalize.rs
@@ -134,7 +134,7 @@ pub fn normalize<'x>(text: &'x str)
                     next_var(variables.len()),
                     tok.start, tok.end);
                 variables.push(Variable {
-                    value: Value::Int(tok.value.parse()
+                    value: Value::Int(tok.value.replace("_", "").parse()
                         .map_err(|e| Error::Tokenizer(
                             format!("can't parse integer: {}", e),
                             tok.start))?),
@@ -146,7 +146,7 @@ pub fn normalize<'x>(text: &'x str)
                     next_var(variables.len()),
                     tok.start, tok.end);
                 variables.push(Variable {
-                    value: Value::Float(tok.value.parse()
+                    value: Value::Float(tok.value.replace("_", "").parse()
                         .map_err(|e| Error::Tokenizer(
                             format!("can't parse float: {}", e),
                             tok.start))?),
@@ -157,7 +157,8 @@ pub fn normalize<'x>(text: &'x str)
                 push_var(&mut rewritten_tokens, "__std__::bigint",
                     next_var(variables.len()),
                     tok.start, tok.end);
-                let dec: BigDecimal = tok.value[..tok.value.len()-1].parse()
+                let dec: BigDecimal = tok.value[..tok.value.len()-1]
+                        .replace("_", "").parse()
                         .map_err(|e| Error::Tokenizer(
                             format!("can't parse bigint: {}", e),
                             tok.start))?;
@@ -176,6 +177,7 @@ pub fn normalize<'x>(text: &'x str)
                 variables.push(Variable {
                     value: Value::Decimal(
                         tok.value[..tok.value.len()-1]
+                        .replace("_", "")
                         .parse()
                         .map_err(|e| Error::Tokenizer(
                             format!("can't parse decimal: {}", e),

--- a/edb/edgeql-rust/src/tokenizer.rs
+++ b/edb/edgeql-rust/src/tokenizer.rs
@@ -495,12 +495,12 @@ fn convert(py: Python, tokens: &Tokens, cache: &mut Cache,
             Ok((tokens.nfconst.clone_ref(py),
                 PyString::new(py, value),
                 cache.decimal(py)?.call(py,
-                    (&value[..value.len()-1],), None)?))
+                    (&value[..value.len()-1].replace("_", ""),), None)?))
         }
         FloatConst => {
             Ok((tokens.fconst.clone_ref(py),
                 PyString::new(py, value),
-                f64::from_str(value)
+                f64::from_str(&value.replace("_", ""))
                 .map_err(|e| TokenizerError::new(py,
                     (format!("error reading float: {}", e),
                      py_pos(py, &token.start))))?
@@ -516,7 +516,7 @@ fn convert(py: Python, tokens: &Tokens, cache: &mut Cache,
                 // i64 as absolute (positive) value.
                 // Python has no problem of representing such a positive
                 // value, though.
-                u64::from_str(value)
+                u64::from_str(&value.replace("_", ""))
                 .map_err(|e| TokenizerError::new(py,
                     (format!("error reading int: {}", e),
                      py_pos(py, &token.start))))?
@@ -527,7 +527,7 @@ fn convert(py: Python, tokens: &Tokens, cache: &mut Cache,
             Ok((tokens.niconst.clone_ref(py),
                 PyString::new(py, value),
                 py.get_type::<PyInt>().call(py,
-                    (&value[..value.len()-1],), None)?))
+                    (&value[..value.len()-1].replace("_", ""),), None)?))
         }
         BinStr => {
             Ok((tokens.bconst.clone_ref(py),

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -176,7 +176,8 @@ def compile_BaseConstant(
         std_type = 'std::str'
         node_cls = irast.StringConstant
     elif isinstance(expr, qlast.IntegerConstant):
-        int_value = int(expr.value)
+        value = value.replace("_", "")
+        int_value = int(value)
         if expr.is_negative:
             int_value = -int_value
             value = f'-{value}'
@@ -184,20 +185,21 @@ def compile_BaseConstant(
         std_type = 'std::int64'
         node_cls = irast.IntegerConstant
     elif isinstance(expr, qlast.FloatConstant):
+        value = value.replace("_", "")
         if expr.is_negative:
             value = f'-{value}'
         std_type = 'std::float64'
         node_cls = irast.FloatConstant
     elif isinstance(expr, qlast.DecimalConstant):
         assert value[-1] == 'n'
-        value = value[:-1]
+        value = value[:-1].replace("_", "")
         if expr.is_negative:
             value = f'-{value}'
         std_type = 'std::decimal'
         node_cls = irast.DecimalConstant
     elif isinstance(expr, qlast.BigintConstant):
         assert value[-1] == 'n'
-        value = value[:-1]
+        value = value[:-1].replace("_", "")
         if expr.is_negative:
             value = f'-{value}'
         std_type = 'std::bigint'

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 
-
 import edgedb
 
 from edb.testbase import server as tb

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -380,6 +380,11 @@ class TestExpressions(tb.QueryTestCase):
                     r'''SELECT <int64>'3689348814741900000000000' ''',
                 )
 
+        with self.assertRaisesRegex(edgedb.EdgeQLSyntaxError,
+                                    'expected digit after dot'):
+            async with self.con.transaction():
+                await self.con.fetchone('SELECT 0. ')
+
     async def test_edgeql_expr_op_02(self):
         await self.assert_query_result(
             r'''SELECT 40 ^ 2;''',

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -17,6 +17,7 @@
 #
 
 
+import decimal
 import re
 import unittest  # NOQA
 
@@ -109,6 +110,7 @@ class TestEdgeQLParser(EdgeQLSyntaxTest):
         SELECT +7;
         SELECT -7;
         SELECT 551;
+        SELECT 1_024;
         """
 
     def test_edgeql_syntax_constants_02(self):
@@ -145,7 +147,9 @@ class TestEdgeQLParser(EdgeQLSyntaxTest):
         SELECT 3.5432e20;
         SELECT 3.5432e+20;
         SELECT 3.5432e-20;
+        SELECT 3.543_2e-20;
         SELECT 354.32e-20;
+        SELECT 2_354.32e-20;
 
 % OK %
 
@@ -155,7 +159,9 @@ class TestEdgeQLParser(EdgeQLSyntaxTest):
         SELECT 3.5432e20;
         SELECT 3.5432e+20;
         SELECT 3.5432e-20;
+        SELECT 3.543_2e-20;
         SELECT 354.32e-20;
+        SELECT 2_354.32e-20;
         """
 
     def test_edgeql_syntax_constants_05(self):
@@ -181,6 +187,8 @@ class TestEdgeQLParser(EdgeQLSyntaxTest):
         SELECT 02;
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError, 'expected digit after dot',
+                  line=2, col=16)
     def test_edgeql_syntax_constants_08(self):
         """
         SELECT 1.;
@@ -449,12 +457,15 @@ aa';
         SELECT -1n;
         SELECT 100000n;
         SELECT -100000n;
+        SELECT 100_000n;
+        SELECT -100_000n;
         SELECT -354.32n;
         SELECT 35400000000000.32n;
         SELECT -35400000000000000000.32n;
         SELECT 3.5432e20n;
         SELECT -3.5432e+20n;
         SELECT 3.5432e-20n;
+        SELECT 3.543_2e-20n;
         SELECT 354.32e-20n;
 
 % OK %
@@ -465,12 +476,15 @@ aa';
         SELECT -1n;
         SELECT 100000n;
         SELECT -100000n;
+        SELECT 100_000n;
+        SELECT -100_000n;
         SELECT -354.32n;
         SELECT 35400000000000.32n;
         SELECT -35400000000000000000.32n;
         SELECT 3.5432e20n;
         SELECT -3.5432e+20n;
         SELECT 3.5432e-20n;
+        SELECT 3.543_2e-20n;
         SELECT 354.32e-20n;
         """
 
@@ -3459,6 +3473,54 @@ aa';
         ) ->
             std::int64 USING SQL FUNCTION 'aaa';
         """
+
+    async def test_edgeql_syntax_ddl_function_49(self):
+        # This test checks constants, but we have to do DDLs to test them
+        # with constant extraction disabled
+        await self.con.execute('''
+            CREATE FUNCTION test::constant_int() -> std::int64 {
+                USING (SELECT 1_024);
+            };
+            CREATE FUNCTION test::constant_bigint() -> std::bigint {
+                USING (SELECT 1_024n);
+            };
+            CREATE FUNCTION test::constant_float() -> std::float64 {
+                USING (SELECT 1_024.1_250);
+            };
+            CREATE FUNCTION test::constant_decimal() -> std::decimal {
+                USING (SELECT 1_024.1_024n);
+            };
+        ''')
+        try:
+            await self.assert_query_result(
+                r'''
+                    SELECT (
+                        int := test::constant_int(),
+                        bigint := test::constant_bigint(),
+                        float := test::constant_float(),
+                        decimal := test::constant_decimal(),
+                    )
+                ''',
+                [{
+                    "int": 1024,
+                    "bigint": 1024,
+                    "float": 1024.125,
+                    "decimal": 1024.1024,
+                }],
+                [{
+                    "int": 1024,
+                    "bigint": 1024,
+                    "float": 1024.125,
+                    "decimal": decimal.Decimal('1024.1024'),
+                }],
+            )
+        finally:
+            await self.con.execute("""
+                DROP FUNCTION test::constant_int();
+                DROP FUNCTION test::constant_float();
+                DROP FUNCTION test::constant_bigint();
+                DROP FUNCTION test::constant_decimal();
+            """)
 
     def test_edgeql_syntax_ddl_property_01(self):
         """


### PR DESCRIPTION
This PR removes `0.` support and adds `1_024` support.

The underscore semantics mostly adheres to rust semantics: allow arbitrary number underscores between digits and at the end of the integer, fractional part or exponent, but not at the start of the integer or decimal part. Unlike in Rust starting exponent with underscore (`1e_10` is **not** allowed).