### PR TITLE
Fix error reporting for incorrect use of slice.

### DIFF
--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -374,7 +374,7 @@ def __infer_slice(
         # the base type is not valid
         raise errors.QueryError(
             f'{node_type.get_verbosename(env.schema)} cannot be sliced',
-            context=ir.start.context)
+            context=ir.expr.context)
 
     for index in [ir.start, ir.stop]:
         if index is not None:
@@ -463,7 +463,7 @@ def __infer_index(
         raise errors.QueryError(
             f'index indirection cannot be applied to '
             f'{node_type.get_verbosename(env.schema)}',
-            context=ir.index.context)
+            context=ir.expr.context)
 
     return result
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4498,3 +4498,40 @@ aa \
             ''',
             [[1, 3], [2, 1], [3, 2]]
         )
+
+    async def test_edgeql_expr_slice_01(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r"scalar type 'std::int64' cannot be sliced"):
+
+            await self.con.execute("""
+                SELECT 1[1:3];
+            """)
+
+    async def test_edgeql_expr_slice_02(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r"scalar type 'std::int64' cannot be sliced"):
+
+            await self.con.execute("""
+                SELECT 1[:3];
+            """)
+
+    async def test_edgeql_expr_slice_03(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r"scalar type 'std::int64' cannot be sliced"):
+
+            await self.con.execute("""
+                SELECT 1[1:];
+            """)
+
+    async def test_edgeql_expr_index_01(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r"index indirection cannot be applied to scalar type "
+                r"'std::int64'"):
+
+            await self.con.execute("""
+                SELECT 1[1];
+            """)


### PR DESCRIPTION
The error message for incorrect use of slice was tied to the context of
the slice start expression, which may not be present. The expression
being sliced is guaranteed to be present, though, so the error can be
anchored to that.

Fixes #1135