### PR TITLE
Prohibit indexes on non-single expressions.

### DIFF
--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5113,3 +5113,41 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ''',
             [1],
         )
+
+    async def test_edgeql_ddl_index_01(self):
+        with self.assertRaisesRegex(
+            edgedb.ResultCardinalityMismatchError,
+            r"possibly more than one element returned by the index expression"
+        ):
+            await self.con.execute(r"""
+                CREATE TYPE Foo {
+                    CREATE MULTI PROPERTY a -> int64;
+                    CREATE INDEX ON (.a);
+                }
+            """)
+
+    async def test_edgeql_ddl_index_02(self):
+        with self.assertRaisesRegex(
+            edgedb.ResultCardinalityMismatchError,
+            r"possibly more than one element returned by the index expression"
+        ):
+            await self.con.execute(r"""
+                CREATE TYPE Foo {
+                    CREATE PROPERTY a -> int64;
+                    CREATE PROPERTY b -> int64;
+                    CREATE INDEX ON ({.a, .b});
+                }
+            """)
+
+    async def test_edgeql_ddl_index_03(self):
+        with self.assertRaisesRegex(
+            edgedb.ResultCardinalityMismatchError,
+            r"possibly more than one element returned by the index expression"
+        ):
+            await self.con.execute(r"""
+                CREATE TYPE Foo {
+                    CREATE PROPERTY a -> int64;
+                    CREATE PROPERTY b -> int64;
+                    CREATE INDEX ON (array_unpack([.a, .b]));
+                }
+            """)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3751,11 +3751,11 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             type Parent {
                 multi property name -> str;
-                index on (.name);
             }
 
             type Parent2 {
                 link foo -> Foo;
+                index on (.foo);
             }
 
             type Child extending Parent, Parent2 {
@@ -3789,7 +3789,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             """
             type test::Child extending test::Parent, test::Parent2 {
                 annotation test::anno := 'annotated';
-                index on (.name);
+                index on (.foo);
                 required single link __type__ -> schema::Type {
                     readonly := true;
                 };


### PR DESCRIPTION
Ensure that the index expression cardinality is never more than ONE.

Fixes: #1320