### PR TITLE
Unbreak non-dev-mode builds

### DIFF
--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -254,6 +254,7 @@ def _load_reflection_schema():
     if _refl_schema is None:
         std_dirs_hash = devmode.hash_dirs(s_std.CACHE_SRC_DIRS)
 
+        cache = None
         if devmode.is_in_dev_mode():
             cache = devmode.read_dev_mode_cache(
                 std_dirs_hash, 'transient-reflschema.pickle')


### PR DESCRIPTION
Current nightly build is broken and rebuilding nightly fails too: https://github.com/edgedb/edgedb/runs/711330064?check_suite_focus=true#step:21:284
This should fix new builds. 