### PR TITLE
Adds built-in function to convert unix timestamp to datetime

### DIFF
--- a/docs/edgeql/funcops/datetime.rst
+++ b/docs/edgeql/funcops/datetime.rst
@@ -386,6 +386,7 @@ Date and Time
                   std::to_datetime(year: int64, month: int64, day: int64, \
                     hour: int64, min: int64, sec: float64, timezone: str) \
                     -> datetime
+                  std::to_datetime(epochseconds: float64) -> datetime
 
     :index: parse datetime
 
@@ -416,7 +417,7 @@ Date and Time
         ...   <cal::local_datetime>'January 1, 2019 12:00AM', 'HKT');
         {<datetime>'2018-12-31T16:00:00+00:00'}
 
-    Yet another way to construct a the :eql:type:`datetime` value
+    Another way to construct a the :eql:type:`datetime` value
     is to specify it in terms of its component parts: *year*, *month*,
     *day*, *hour*, *min*, *sec*, and *timezone*
 
@@ -426,6 +427,13 @@ Date and Time
         ...     2018, 5, 7, 15, 1, 22.306916, 'UTC');
         {<datetime>'2018-05-07T15:01:22.306916+00:00'}
 
+    Finally, it is also possible to convert a Unix timestamp to a
+    :eql:type:`datetime`
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT to_datetime(1590595184.584);
+        {<datetime>'2020-05-27T15:59:44.584000000Z'}
 
 ------------
 

--- a/docs/edgeql/funcops/datetime.rst
+++ b/docs/edgeql/funcops/datetime.rst
@@ -386,7 +386,9 @@ Date and Time
                   std::to_datetime(year: int64, month: int64, day: int64, \
                     hour: int64, min: int64, sec: float64, timezone: str) \
                     -> datetime
+                  std::to_datetime(epochseconds: decimal) -> datetime
                   std::to_datetime(epochseconds: float64) -> datetime
+                  std::to_datetime(epochseconds: int64) -> datetime
 
     :index: parse datetime
 

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -328,6 +328,16 @@ std::to_datetime(epochseconds: std::float64) -> std::datetime
 
 
 CREATE FUNCTION
+std::to_datetime(epochseconds: std::int64) -> std::datetime
+{
+    SET volatility := 'STABLE';
+    USING SQL $$
+    SELECT to_timestamp("epochseconds")
+    $$;
+};
+
+
+CREATE FUNCTION
 std::to_datetime(epochseconds: std::decimal) -> std::datetime
 {
     SET volatility := 'STABLE';

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -328,6 +328,16 @@ std::to_datetime(epochseconds: std::float64) -> std::datetime
 
 
 CREATE FUNCTION
+std::to_datetime(epochseconds: std::decimal) -> std::datetime
+{
+    SET volatility := 'STABLE';
+    USING SQL $$
+    SELECT to_timestamp("epochseconds")
+    $$;
+};
+
+
+CREATE FUNCTION
 std::to_duration(
         NAMED ONLY hours: std::int64=0,
         NAMED ONLY minutes: std::int64=0,

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -318,6 +318,16 @@ std::to_datetime(year: std::int64, month: std::int64, day: std::int64,
 
 
 CREATE FUNCTION
+std::to_datetime(epochseconds: std::float64) -> std::datetime
+{
+    SET volatility := 'STABLE';
+    USING SQL $$
+    SELECT to_timestamp("epochseconds")
+    $$;
+};
+
+
+CREATE FUNCTION
 std::to_duration(
         NAMED ONLY hours: std::int64=0,
         NAMED ONLY minutes: std::int64=0,

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -984,6 +984,12 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         )
         self.assertEqual('1986-05-30T00:00:00+00:00', dt)
 
+    async def test_edgeql_functions_unix_to_datetime_04(self):
+        dt = await self.con.fetchone(
+            'SELECT <str>to_datetime(517795200.00n);'
+        )
+        self.assertEqual('1986-05-30T00:00:00+00:00', dt)
+
     async def test_edgeql_functions_datetime_current_01(self):
         # make sure that datetime as a str gets serialized to a
         # particular format

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -966,6 +966,24 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [True],
         )
 
+    async def test_edgeql_functions_unix_to_datetime_01(self):
+        dt = await self.con.fetchone(
+            'SELECT <str>to_datetime(1590595184.584);'
+        )
+        self.assertEqual('2020-05-27T15:59:44.584+00:00', dt)
+
+    async def test_edgeql_functions_unix_to_datetime_02(self):
+        dt = await self.con.fetchone(
+            'SELECT <str>to_datetime(1590595184);'
+        )
+        self.assertEqual('2020-05-27T15:59:44+00:00', dt)
+
+    async def test_edgeql_functions_unix_to_datetime_03(self):
+        dt = await self.con.fetchone(
+            'SELECT <str>to_datetime(517795200);'
+        )
+        self.assertEqual('1986-05-30T00:00:00+00:00', dt)
+
     async def test_edgeql_functions_datetime_current_01(self):
         # make sure that datetime as a str gets serialized to a
         # particular format


### PR DESCRIPTION
* Internally it uses the PostgreSQL function `to_timestamp`.
* Adds tests
* Adds description in documentation together with other datetime converters

Should close #1183 