### PR TITLE
Fix restoring dumps with schema objects with camelCased/complex names

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1631,7 +1631,7 @@ class Compiler(BaseCompiler):
                     link_bias=True,
                 )
 
-                cols.append(pg_common.quote_ident(stor_info.column_name))
+                cols.append(stor_info.column_name)
 
                 props[ptr.get_shortname(schema).name] = ptr.get_target(schema)
 
@@ -1661,7 +1661,7 @@ class Compiler(BaseCompiler):
                 )
 
                 if stor_info.table_type == 'ObjectType':
-                    cols.append(pg_common.quote_ident(stor_info.column_name))
+                    cols.append(stor_info.column_name)
                     shape.append(ptr)
 
                 link_stor_info = pg_types.get_pointer_storage_info(
@@ -1687,7 +1687,8 @@ class Compiler(BaseCompiler):
         )
 
         stmt = (
-            f'COPY {table_name} ({", ".join(c for c in cols)}) '
+            f'COPY {table_name} '
+            f'({", ".join(pg_common.quote_ident(c) for c in cols)}) '
             f'TO STDOUT WITH BINARY'
         ).encode()
 
@@ -1761,7 +1762,7 @@ class Compiler(BaseCompiler):
                         link_bias=True,
                     )
 
-                    cols.append(pg_common.quote_ident(stor_info.column_name))
+                    cols.append(stor_info.column_name)
 
                 if set(desc_cols) != set(cols):
                     raise RuntimeError(
@@ -1783,8 +1784,7 @@ class Compiler(BaseCompiler):
                     )
 
                     if stor_info.table_type == 'ObjectType':
-                        cols.append(pg_common.quote_ident(
-                            stor_info.column_name))
+                        cols.append(stor_info.column_name)
 
                 if set(desc_cols) != set(cols):
                     raise RuntimeError(
@@ -1794,7 +1794,8 @@ class Compiler(BaseCompiler):
                 schema, obj, catenate=True)
 
             stmt = (
-                f'COPY {table_name} ({", ".join(c for c in desc_cols)}) '
+                f'COPY {table_name} '
+                f'({", ".join(pg_common.quote_ident(c) for c in desc_cols)}) '
                 f'FROM STDIN WITH BINARY'
             ).encode()
 

--- a/tests/schemas/dump02_default.esdl
+++ b/tests/schemas/dump02_default.esdl
@@ -1,0 +1,25 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+type `S p a M` {
+    required property `🚀` -> int32;
+}
+
+type A {
+    required link `s p A m 🤞` -> `S p a M`;
+}

--- a/tests/schemas/dump02_setup.edgeql
+++ b/tests/schemas/dump02_setup.edgeql
@@ -1,0 +1,28 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+SET MODULE default;
+
+INSERT `S p a M` {
+    `🚀` := 42
+};
+
+INSERT A {
+    `s p A m 🤞` := (SELECT `S p a M` FILTER .`🚀` = 42)
+};

--- a/tests/test_dump02.py
+++ b/tests/test_dump02.py
@@ -1,0 +1,90 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os.path
+import tempfile
+
+from edb.testbase import server as tb
+
+
+class TestDump02(tb.QueryTestCase, tb.CLITestCaseMixin):
+
+    SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
+                                  'dump02_default.esdl')
+
+    SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
+                         'dump02_setup.edgeql')
+
+    ISOLATED_METHODS = False
+    SERIALIZED = True
+
+    async def test_dump02_basic(self):
+        await self.ensure_schema_data_integrity()
+
+    async def test_dump02_dump_restore(self):
+        assert type(self).__name__.startswith('Test')
+        # The name of the database created for this test case by
+        # the test runner:
+        dbname = type(self).__name__[4:].lower()
+
+        with tempfile.NamedTemporaryFile() as f:
+            self.run_cli('-d', dbname, 'dump', f.name)
+
+            await self.con.execute(f'CREATE DATABASE {dbname}_restored')
+            try:
+                self.run_cli('-d', f'{dbname}_restored', 'restore', f.name)
+                con2 = await self.connect(database=f'{dbname}_restored')
+            except Exception:
+                await self.con.execute(f'DROP DATABASE {dbname}_restored')
+                raise
+
+        oldcon = self.con
+        self.__class__.con = con2
+        try:
+            await self.ensure_schema_data_integrity()
+        finally:
+            self.__class__.con = oldcon
+            await con2.aclose()
+            await self.con.execute(f'DROP DATABASE {dbname}_restored')
+
+    async def ensure_schema_data_integrity(self):
+        tx = self.con.transaction()
+        await tx.start()
+        try:
+            await self._ensure_schema_data_integrity()
+        finally:
+            await tx.rollback()
+
+    async def _ensure_schema_data_integrity(self):
+        await self.assert_query_result(
+            r'''
+                SELECT A {
+                    `s p A m 🤞`: {
+                        `🚀`
+                    }
+                }
+            ''',
+            [
+                {
+                    's p A m 🤞': {
+                        '🚀': 42
+                    }
+                }
+            ]
+        )


### PR DESCRIPTION
This fix allows to restore dumps made with EdgeDB 1.0a2 that have
schema objects with complex names. The fix is forward and backward
compatible.

Fixes #1292.