### PR TITLE
Support bootstrap cache in production mode

### DIFF
--- a/edb/pgsql/dbops/views.py
+++ b/edb/pgsql/dbops/views.py
@@ -35,12 +35,23 @@ class View(base.DBObject):
 
 
 class CreateView(ddl.SchemaObjectOperation):
-    def __init__(self, view, *,
-                 conditions=None, neg_conditions=None, priority=0):
+    def __init__(
+        self,
+        view,
+        *,
+        conditions=None,
+        neg_conditions=None,
+        or_replace=False,
+        priority=0,
+    ):
         super().__init__(view.name, conditions=conditions,
                          neg_conditions=neg_conditions, priority=priority)
         self.view = view
+        self.or_replace = or_replace
 
     def code(self, block: base.PLBlock) -> str:
         query = textwrap.indent(textwrap.dedent(self.view.query), '    ')
-        return f'CREATE VIEW {qn(*self.view.name)} AS\n{query}'
+        return (
+            f'CREATE {"OR REPLACE" if self.or_replace else ""}'
+            f' VIEW {qn(*self.view.name)} AS\n{query}'
+        )

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -2425,7 +2425,7 @@ async def generate_support_views(conn, schema):
             name=('edgedb', f'_Schema{schema_obj.get_name(schema).name}'),
             query=(f'SELECT * FROM {q(*bn)}')
         )
-        commands.add_command(dbops.CreateView(alias_view))
+        commands.add_command(dbops.CreateView(alias_view, or_replace=True))
 
     InhObject = schema.get('schema::InheritingObject')
     InhObject_ancestors = InhObject.getptr(schema, 'ancestors')
@@ -2437,20 +2437,20 @@ async def generate_support_views(conn, schema):
         name=('edgedb', f'_SchemaInheritingObject__ancestors'),
         query=(f'SELECT * FROM {q(*bn)}')
     )
-    commands.add_command(dbops.CreateView(alias_view))
+    commands.add_command(dbops.CreateView(alias_view, or_replace=True))
 
     conf = schema.get('cfg::Config')
     cfg_views, _ = _generate_config_type_view(schema, conf, path=[], rptr=None)
     commands.add_commands([
-        dbops.CreateView(dbops.View(name=tn, query=q))
+        dbops.CreateView(dbops.View(name=tn, query=q), or_replace=True)
         for tn, q in cfg_views
     ])
 
     for dbview in _generate_database_views(schema):
-        commands.add_command(dbops.CreateView(dbview))
+        commands.add_command(dbops.CreateView(dbview, or_replace=True))
 
     for roleview in _generate_role_views(schema):
-        commands.add_command(dbops.CreateView(roleview))
+        commands.add_command(dbops.CreateView(roleview, or_replace=True))
 
     block = dbops.PLTopBlock(disable_ddl_triggers=True)
     commands.generate(block)

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -33,6 +33,7 @@ from edb import edgeql
 from edb.edgeql import ast as qlast
 from edb.edgeql import parser as qlparser
 
+from edb.server import buildmeta
 from edb.server import defines
 from edb.server import compiler as edbcompiler
 
@@ -226,11 +227,11 @@ _schema_class_layout = None
 def _load_std_schema():
     global _std_schema
     if _std_schema is None:
-        std_dirs_hash = devmode.hash_dirs(s_std.CACHE_SRC_DIRS)
+        std_dirs_hash = buildmeta.hash_dirs(s_std.CACHE_SRC_DIRS)
         schema = None
 
         if devmode.is_in_dev_mode():
-            schema = devmode.read_dev_mode_cache(
+            schema = buildmeta.read_data_cache(
                 std_dirs_hash, 'transient-stdschema.pickle')
 
         if schema is None:
@@ -239,7 +240,7 @@ def _load_std_schema():
                 schema = s_std.load_std_module(schema, modname)
 
         if devmode.is_in_dev_mode():
-            devmode.write_dev_mode_cache(
+            buildmeta.write_data_cache(
                 schema, std_dirs_hash, 'transient-stdschema.pickle')
 
         _std_schema = schema
@@ -252,11 +253,11 @@ def _load_reflection_schema():
     global _schema_class_layout
 
     if _refl_schema is None:
-        std_dirs_hash = devmode.hash_dirs(s_std.CACHE_SRC_DIRS)
+        std_dirs_hash = buildmeta.hash_dirs(s_std.CACHE_SRC_DIRS)
 
         cache = None
         if devmode.is_in_dev_mode():
-            cache = devmode.read_dev_mode_cache(
+            cache = buildmeta.read_data_cache(
                 std_dirs_hash, 'transient-reflschema.pickle')
 
         if cache is not None:
@@ -269,7 +270,7 @@ def _load_reflection_schema():
             reflschema = refldelta.apply(std_schema, context)
 
             if devmode.is_in_dev_mode():
-                devmode.write_dev_mode_cache(
+                buildmeta.write_data_cache(
                     (reflschema, classlayout),
                     std_dirs_hash,
                     'transient-reflschema.pickle',


### PR DESCRIPTION
Bootstrap cache makes complete sense in production builds also, so
enable it in `--no-devmode`.