### PR TITLE
Fix handling of optional query parameters

### DIFF
--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -124,7 +124,10 @@ def compile_Parameter(
     is_decimal: bool = expr.name.isdecimal()
 
     if not is_decimal and ctx.env.use_named_params:
-        result = pgast.NamedParamRef(name=expr.name)
+        result = pgast.NamedParamRef(
+            name=expr.name,
+            nullable=not expr.required,
+        )
     else:
         try:
             index = ctx.argmap[expr.name].index
@@ -142,7 +145,7 @@ def compile_Parameter(
                     index=index,
                     required=expr.required,
                 )
-        result = pgast.ParamRef(number=index)
+        result = pgast.ParamRef(number=index, nullable=not expr.required)
 
     return pgast.TypeCast(
         arg=result,

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -949,6 +949,25 @@ class TestExpressions(tb.QueryTestCase):
                     variables={'x': [123]},
                 )
 
+    async def test_edgeql_expr_variables_06(self):
+        await self.assert_query_result(
+            f'''SELECT <OPTIONAL int64>$x + <int64>$y;''',
+            [5],
+            variables={'x': 2, 'y': 3},
+        )
+
+        await self.assert_query_result(
+            f'''SELECT <OPTIONAL int64>$x + <int64>$y;''',
+            [],
+            variables={'x': None, 'y': 3},
+        )
+
+        await self.assert_query_result(
+            f'''SELECT len(<OPTIONAL str>$x);''',
+            [],
+            variables={'x': None},
+        )
+
     async def _test_boolop(self, left, right, op, not_op, result):
         if isinstance(result, bool):
             # this operation should be valid and produce opposite


### PR DESCRIPTION
Currently, the compiler incorrectly assumes all parameters to be
non-nullable, which is obviously not the case if a parameter is
`OPTIONAL`.

Fixes: #1435