### PR TITLE
Add more unicode features to the dump test.

### DIFF
--- a/tests/schemas/dump02_default.esdl
+++ b/tests/schemas/dump02_default.esdl
@@ -18,12 +18,14 @@
 
 abstract annotation `🍿`;
 
+abstract constraint `🚀🍿` extending max_len_value;
+
 function `💯`(NAMED ONLY `🙀`: int64) -> int64 {
     using (
         SELECT 100 - `🙀`
     );
 
-    annotation `🍿` := 'fun!';
+    annotation `🍿` := 'fun!🚀';
     volatility := 'IMMUTABLE';
 }
 
@@ -34,4 +36,24 @@ type `S p a M` {
 
 type A {
     required link `s p A m 🤞` -> `S p a M`;
+}
+
+scalar type 你好 extending str;
+
+scalar type مرحبا extending 你好;
+    # constraint `🚀🍿`(10);
+
+scalar type `🚀🚀🚀` extending مرحبا;
+
+type Łukasz {
+    required property `Ł🤞` -> `🚀🚀🚀` {
+        default := <`🚀🚀🚀`>'你好🤞'
+    }
+    index on (.`Ł🤞`);
+
+    link `Ł💯` -> A {
+        property `🙀🚀🚀🚀🙀` -> `🚀🚀🚀`;
+        property `🙀مرحبا🙀` -> مرحبا;
+            # constraint `🚀🍿`(2);
+    };
 }

--- a/tests/schemas/dump02_setup.edgeql
+++ b/tests/schemas/dump02_setup.edgeql
@@ -19,10 +19,36 @@
 
 SET MODULE default;
 
+# Not sure if the esdl filename will handle this on all systems, so
+# I'm adding stuff here.
+CREATE MODULE `💯💯💯`;
+
+CREATE FUNCTION `💯💯💯`::`🚀🙀🚀`(`🤞`: default::`🚀🚀🚀`) -> `🚀🚀🚀`
+USING (
+    SELECT <`🚀🚀🚀`>(`🤞` ++ 'Ł🙀')
+);
+# end of DDL
+
 INSERT `S p a M` {
     `🚀` := 42
 };
 
 INSERT A {
     `s p A m 🤞` := (SELECT `S p a M` FILTER .`🚀` = 42)
+};
+
+INSERT Łukasz;
+
+INSERT Łukasz {
+    `Ł🤞` := 'simple 🚀',
+    `Ł💯` := (
+        SELECT A
+        # {
+        #     `🙀🚀🚀🚀🙀`:= 'Łink prop 🙀🚀🚀🚀🙀',
+        #     `🙀مرحبا🙀`:=
+        #         `💯💯💯`::`🚀🙀🚀`('Łink prop 🙀مرحبا🙀'),
+        # }
+        FILTER .`s p A m 🤞`.`🚀` = 42
+        LIMIT 1
+    )
 };


### PR DESCRIPTION
Test non-trivial unicode names for:
- annotation
- scalar type
- type
- property
- link
- link property
- index (on a property with unicode name)
- function (including parameters and type)
- module
- constraint
- database