### PR TITLE
Use lxml 4.5.1

### DIFF
--- a/edb/tools/docs/eql.py
+++ b/edb/tools/docs/eql.py
@@ -1045,8 +1045,9 @@ class StatementTransform(s_transforms.SphinxTransform):
 
     def apply(self):
         for section in self.document.traverse(d_nodes.section):
-            parser = lxml.etree.XMLParser(recover=True)
-            x = lxml.etree.parse(io.StringIO(section.asdom().toxml()), parser)
+            xml_str = section.asdom().toxml()
+            parser = lxml.etree.XMLParser(recover=True, encoding="UTF-8")
+            x = lxml.etree.parse(io.StringIO(xml_str), parser)
 
             fields = set(x.xpath('field_list/field/field_name/text()'))
             title = x.xpath('title/text()')[0]

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ CYTHON_DEPENDENCY = 'Cython==0.29.14'
 
 DOCS_DEPS = [
     'Sphinx~=2.3.1',
-    'lxml~=4.4.2',
+    'lxml~=4.5.1',
     'sphinxcontrib-asyncio~=0.2.0',
 ]
 


### PR DESCRIPTION
The 4.4 series bundled an outdated libxml2 and the full build was failing for
me on Python 3.8 running on macOS Catalina due to the emoji in
internals/protocol/dataformats.rst.