### PR TITLE
Fix `IndexCommand.get_object()`

### DIFF
--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -185,14 +185,35 @@ class IndexCommand(
         quals = sn.quals_from_fullname(name)
         return tuple(quals[-2:])
 
-    # type ignore below, because parent class defines a compatible overload
-    def get_object(  # type: ignore
+    @overload
+    def get_object(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
         *,
         name: Optional[str] = None,
-        default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
+        default: Union[Index, so.NoDefaultT] = so.NoDefault,
+    ) -> Index:
+        ...
+
+    @overload
+    def get_object(  # NoQA: F811
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        *,
+        name: Optional[str] = None,
+        default: None = None,
+    ) -> Optional[Index]:
+        ...
+
+    def get_object( # NoQA: F811
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        *,
+        name: Optional[str] = None,
+        default: Union[Index, so.NoDefaultT, None] = so.NoDefault,
     ) -> Optional[Index]:
         try:
             return super().get_object(

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -207,7 +207,7 @@ class IndexCommand(
     ) -> Optional[Index]:
         ...
 
-    def get_object( # NoQA: F811
+    def get_object(  # NoQA: F811
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -192,9 +192,12 @@ class IndexCommand(
         context: sd.CommandContext,
         *,
         name: Optional[str] = None,
+        default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
     ) -> Optional[Index]:
         try:
-            return super().get_object(schema, context, name=name)
+            return super().get_object(
+                schema, context, name=name, default=default
+            )
         except errors.InvalidReferenceError:
             referrer_ctx = self.get_referrer_context_or_die(context)
             referrer = referrer_ctx.scls

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -311,3 +311,20 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
             'user-defined pseudotypes are not supported'
         ):
             await self.con.execute('CREATE PSEUDO TYPE foo;')
+
+    async def test_edgeql_userddl_24(self):
+        await self.con.execute('''
+            CREATE SCALAR TYPE Slug EXTENDING str {
+                CREATE CONSTRAINT regexp(r'^[a-z0-9][.a-z0-9-]+$')
+            };
+            CREATE ABSTRACT TYPE Named {
+                CREATE REQUIRED PROPERTY name -> Slug
+            };
+            CREATE TYPE User EXTENDING Named;
+        ''')
+
+        await self.con.execute('''
+            ALTER TYPE Named {
+                CREATE INDEX ON (__subject__.name)
+            };
+        ''')


### PR DESCRIPTION
Without this change, altering a type to add an index to it results in:

```
TypeError: get_object() got an unexpected keyword argument 'default'
```