### PR TITLE
Add a __std__ alias for 'std'; fix constant extraction

### DIFF
--- a/edb/edgeql-parser/src/keywords.rs
+++ b/edb/edgeql-parser/src/keywords.rs
@@ -122,6 +122,7 @@ pub const CURRENT_RESERVED_KEYWORDS: &[&str] = &[
     "__source__",
     "__subject__",
     "__type__",
+    "__std__",
     "alter",
     "and",
     "anytuple",

--- a/edb/edgeql-parser/src/tokenizer.rs
+++ b/edb/edgeql-parser/src/tokenizer.rs
@@ -776,6 +776,7 @@ pub fn is_keyword(s: &str) -> bool {
         | "__source__"
         | "__subject__"
         | "__type__"
+        | "__std__"
         | "alter"
         | "and"
         | "anytuple"

--- a/edb/edgeql-rust/src/normalize.rs
+++ b/edb/edgeql-rust/src/normalize.rs
@@ -130,7 +130,7 @@ pub fn normalize<'x>(text: &'x str)
                     if value.eq_ignore_ascii_case("LIMIT")))
             && tok.value != "9223372036854775808"
             => {
-                push_var(&mut rewritten_tokens, "std::int64",
+                push_var(&mut rewritten_tokens, "__std__::int64",
                     next_var(variables.len()),
                     tok.start, tok.end);
                 variables.push(Variable {
@@ -142,7 +142,7 @@ pub fn normalize<'x>(text: &'x str)
                 continue;
             }
             Kind::FloatConst => {
-                push_var(&mut rewritten_tokens, "std::float64",
+                push_var(&mut rewritten_tokens, "__std__::float64",
                     next_var(variables.len()),
                     tok.start, tok.end);
                 variables.push(Variable {
@@ -154,7 +154,7 @@ pub fn normalize<'x>(text: &'x str)
                 continue;
             }
             Kind::BigIntConst => {
-                push_var(&mut rewritten_tokens, "std::bigint",
+                push_var(&mut rewritten_tokens, "__std__::bigint",
                     next_var(variables.len()),
                     tok.start, tok.end);
                 let dec: BigDecimal = tok.value[..tok.value.len()-1].parse()
@@ -170,7 +170,7 @@ pub fn normalize<'x>(text: &'x str)
                 continue;
             }
             Kind::DecimalConst => {
-                push_var(&mut rewritten_tokens, "std::decimal",
+                push_var(&mut rewritten_tokens, "__std__::decimal",
                     next_var(variables.len()),
                     tok.start, tok.end);
                 variables.push(Variable {
@@ -184,7 +184,7 @@ pub fn normalize<'x>(text: &'x str)
                 continue;
             }
             Kind::Str => {
-                push_var(&mut rewritten_tokens, "std::str",
+                push_var(&mut rewritten_tokens, "__std__::str",
                     next_var(variables.len()),
                     tok.start, tok.end);
                 variables.push(Variable {

--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -25,10 +25,6 @@ from typing import *
 
 from edb.edgeql import ast as qlast
 
-from edb.schema import schema as s_schema
-from edb.schema import types as s_types
-from edb.schema import utils as s_utils
-
 
 def extend_binop(
     binop: Optional[qlast.Expr],
@@ -76,8 +72,3 @@ def is_ql_path(qlexpr: qlast.Expr) -> bool:
     start = qlexpr.steps[0]
 
     return isinstance(start, (qlast.Source, qlast.ObjectRef, qlast.Ptr))
-
-
-def type_to_ql_typeref(t: s_types.Type, *,
-                       schema: s_schema.Schema) -> qlast.TypeExpr:
-    return s_utils.typeref_to_ast(schema, t)

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -453,7 +453,7 @@ def _cast_array(
             subctx.anchors[source_alias] = ir_set
 
             unpacked = qlast.FunctionCall(
-                func=('std', 'array_unpack'),
+                func=('__std__', 'array_unpack'),
                 args=[
                     qlast.Path(
                         steps=[qlast.ObjectRef(name=source_alias)],
@@ -464,7 +464,7 @@ def _cast_array(
             enumerated = setgen.ensure_set(
                 dispatch.compile(
                     qlast.FunctionCall(
-                        func=('std', 'enumerate'),
+                        func=('__std__', 'enumerate'),
                         args=[unpacked],
                     ),
                     ctx=subctx,
@@ -479,7 +479,7 @@ def _cast_array(
             )
 
             elements = qlast.FunctionCall(
-                func=('std', 'array_agg'),
+                func=('__std__', 'array_agg'),
                 args=[
                     qlast.SelectQuery(
                         result=qlast.TypeCast(

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1002,8 +1002,8 @@ def computable_ptr_set(
         assert target_scls is not None
         if not target_scls.is_object_type():
             schema_qlexpr = qlast.TypeCast(
-                type=astutils.type_to_ql_typeref(
-                    target_scls, schema=ctx.env.schema),
+                type=typegen.type_to_ql_typeref(
+                    target_scls, ctx=ctx),
                 expr=schema_qlexpr,
             )
         qlexpr = astutils.ensure_qlstmt(schema_qlexpr)

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -33,10 +33,10 @@ from edb.ir import utils as irutils
 from edb.schema import abc as s_abc
 from edb.schema import pointers as s_pointers
 from edb.schema import types as s_types
+from edb.schema import utils as s_utils
 
 from edb.edgeql import ast as qlast
 
-from . import astutils
 from . import context
 from . import dispatch
 from . import schemactx
@@ -49,8 +49,11 @@ def type_to_ql_typeref(
     _name: Optional[str] = None,
     ctx: context.ContextLevel,
 ) -> qlast.TypeExpr:
-
-    return astutils.type_to_ql_typeref(t, schema=ctx.env.schema)
+    return s_utils.typeref_to_ast(
+        ctx.env.schema,
+        t,
+        disambiguate_std='std' in ctx.modaliases,
+    )
 
 
 def ql_typeexpr_to_ir_typeref(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -679,8 +679,7 @@ def _normalize_view_ptr_expr(
                     )
                 ):
                     qlexpr = astutils.ensure_qlstmt(qlast.TypeCast(
-                        type=astutils.type_to_ql_typeref(
-                            base_target, schema=ctx.env.schema),
+                        type=typegen.type_to_ql_typeref(base_target, ctx=ctx),
                         expr=compexpr,
                     ))
                     ptr_target = base_target

--- a/edb/edgeql/quote.py
+++ b/edb/edgeql/quote.py
@@ -70,7 +70,7 @@ def needs_quoting(string: str, allow_reserved: bool) -> bool:
     string = string.lower()
 
     is_reserved = (
-        string != '__type__'
+        string not in {'__type__', '__std__'}
         and string in keywords.by_type[keywords.RESERVED_KEYWORD]
     )
 

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -33,6 +33,7 @@ from edb.edgeql import parser as ql_parser
 from edb.edgeql.compiler import astutils as ql_astutils
 
 from edb.schema import scalars as s_scalars
+from edb.schema import utils as s_utils
 
 from edb.common import ast
 
@@ -411,8 +412,8 @@ def ptr_default_to_col_default(schema, ptr, expr):
         eql = ql_parser.parse(expr.text)
         eql = ql_astutils.ensure_qlstmt(
             qlast.TypeCast(
-                type=ql_astutils.type_to_ql_typeref(
-                    ptr.get_target(schema), schema=schema),
+                type=s_utils.typeref_to_ast(
+                    schema, ptr.get_target(schema)),
                 expr=eql,
             )
         )

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -513,6 +513,14 @@ class Schema(s_abc.Schema):
         name, module, shortname = sn.split_name(name)
         implicit_builtins = module is None
 
+        if module == '__std__':
+            fqname = sn.SchemaName(shortname, 'std')
+            result = getter(self, fqname)
+            if result is not None:
+                return result
+            else:
+                return default
+
         if module_aliases is not None:
             fq_module = module_aliases.get(module)
             if fq_module is not None:

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -1385,6 +1385,37 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             [[[1.0]]],
         )
 
+    async def test_edgeql_casts_collections_02(self):
+        await self.assert_query_result(
+            R'''
+                WITH
+                    std AS MODULE math,
+                    foo := (SELECT [1, 2, 3])
+                SELECT <array<str>>foo;
+            ''',
+            [['1', '2', '3']],
+        )
+
+        await self.assert_query_result(
+            R'''
+                WITH
+                    std AS MODULE math,
+                    foo := (SELECT [<int32>1, <int32>2, <int32>3])
+                SELECT <array<str>>foo;
+            ''',
+            [['1', '2', '3']],
+        )
+
+        await self.assert_query_result(
+            R'''
+                WITH
+                    std AS MODULE math,
+                    foo := (SELECT [(1,), (2,), (3,)])
+                SELECT <array<tuple<str>>>foo;
+            ''',
+            [[['1'], ['2'], ['3']]],
+        )
+
     # casting into an abstract scalar should be illegal
     async def test_edgeql_casts_illegal_01(self):
         with self.assertRaisesRegex(

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2373,6 +2373,16 @@ class TestExpressions(tb.QueryTestCase):
             [{'a': 'foo', 'b': 42}],
         )
 
+        await self.assert_query_result(
+            r'''SELECT <tuple<__std__::str, int64>> ('foo', 42);''',
+            [['foo', 42]],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT <__std__::int16>1;''',
+            [1],
+        )
+
     async def test_edgeql_expr_implicit_cast_01(self):
         await self.assert_query_result(
             r'''SELECT (INTROSPECT TYPEOF(<int32>1 + 3)).name;''',

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -2503,7 +2503,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
-            r'''SELECT len({'hello', 'world'});''',
+            r'''SELECT __std__::len({'hello', 'world'});''',
             [5, 5]
         )
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2036,6 +2036,24 @@ aa';
         SELECT Bar;
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=21)
+    def test_edgeql_syntax_with_10(self):
+        """
+        WITH MODULE __std__ SELECT Foo;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=26)
+    def test_edgeql_syntax_with_11(self):
+        """
+        WITH a AS MODULE __std__ SELECT Foo;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=26)
+    def test_edgeql_syntax_with_12(self):
+        """
+        WITH a AS MODULE `__std__` SELECT Foo;
+        """
+
     def test_edgeql_syntax_detached_01(self):
         """
         WITH F := DETACHED Foo
@@ -3433,6 +3451,15 @@ aa';
             std::int64 USING SQL FUNCTION 'aaa';
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=32)
+    def test_edgeql_syntax_ddl_function_48(self):
+        """
+        CREATE FUNCTION __std__(
+            f: int64
+        ) ->
+            std::int64 USING SQL FUNCTION 'aaa';
+        """
+
     def test_edgeql_syntax_ddl_property_01(self):
         """
         CREATE ABSTRACT PROPERTY std::property {
@@ -3488,6 +3515,30 @@ aa';
         CREATE MODULE foo;
         CREATE MODULE `foo.bar`;
         CREATE MODULE `all.abstract.bar`;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=23)
+    def test_edgeql_syntax_ddl_module_02(self):
+        """
+        CREATE MODULE __subject__;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=23)
+    def test_edgeql_syntax_ddl_module_03(self):
+        """
+        CREATE MODULE __std__.a;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=25)
+    def test_edgeql_syntax_ddl_module_04(self):
+        """
+        CREATE MODULE a.__std__;
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=23)
+    def test_edgeql_syntax_ddl_module_05(self):
+        """
+        CREATE MODULE `__std__`;
         """
 
     def test_edgeql_syntax_ddl_type_01(self):

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -703,9 +703,6 @@ class TestServerProto(tb.QueryTestCase):
                 ('1', 1, 1.1, decimal.Decimal('1.1'), 1)
             )
 
-    @test.xfail('''
-        Overriding the 'std' module breaks things.
-    ''')
     async def test_server_proto_args_09(self):
         async with self._run_and_rollback():
             self.assertEqual(


### PR DESCRIPTION
Add a '__std__' alias for the 'std' module.

This fixes constant extraction in queries wit a
'WITH std AS MODULE ...' clause.

Issue #1457.