### PR TITLE
Allow explit OPTIONAL qualifiers in DDL and SDL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: docs cython postgres postgres-ext pygments
+.PHONY: build docs cython postgres postgres-ext pygments
+.DEFAULT_GOAL := build
 
 SPHINXOPTS:="-W -n"
 
@@ -22,5 +23,5 @@ pygments:
 		echo "$$out" > edb/edgeql/pygments/meta.py
 
 
-update:
-	pip install -Ue .[test]
+build:
+	pip install -Ue .[docs,test]

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,7 @@ postgres:
 pygments:
 	out=$$(edb gen-meta-grammars edgeql) && \
 		echo "$$out" > edb/edgeql/pygments/meta.py
+
+
+update:
+	pip install -Ue .[test]

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -765,7 +765,7 @@ class DropProperty(DropObject):
 
 
 class CreateConcretePointer(CreateObject, BasesMixin):
-    is_required: bool = False
+    is_required: typing.Optional[bool] = None
     declared_overloaded: bool = False
     target: typing.Optional[typing.Union[Expr, TypeExpr]]
     cardinality: qltypes.SchemaCardinality

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1225,8 +1225,14 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         keywords = []
         if self.sdlmode and node.declared_overloaded:
             keywords.append('OVERLOADED')
-        if node.is_required:
-            keywords.append('REQUIRED')
+            if node.is_required:
+                keywords.append('REQUIRED')
+        else:
+            if node.is_required is True:
+                keywords.append('REQUIRED')
+            elif node.is_required is False:
+                keywords.append('OPTIONAL')
+            # else: `is_required` is None
         if node.cardinality:
             keywords.append(node.cardinality.as_ptr_qual().upper())
         keywords.append('PROPERTY')
@@ -1265,12 +1271,19 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
         for command in node.commands:
             if isinstance(command, qlast.SetSpecialField):
-                kw = self._process_SetSpecialField(command)
-                specials.add(command)
-                if kw[0] == 'SET':
-                    keywords.append(kw[1])
+                if command.name == "required":
+                    if command.value is True:
+                        keywords.append("REQUIRED")
+                    elif command.value is False:
+                        keywords.append("OPTIONAL")
+                    # else: command.value is None
+                else:
+                    kw = self._process_SetSpecialField(command)
+                    specials.add(command)
+                    if kw[0] == 'SET':
+                        keywords.append(kw[1])
 
-        order = ['REQUIRED', 'SINGLE', 'MULTI']
+        order = ['OPTIONAL', 'REQUIRED', 'SINGLE', 'MULTI']
         keywords.sort(key=lambda i: order.index(i))
 
         return keywords, frozenset(specials)
@@ -1333,8 +1346,14 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
         if self.sdlmode and node.declared_overloaded:
             keywords.append('OVERLOADED')
-        if node.is_required:
-            keywords.append('REQUIRED')
+            if node.is_required:
+                keywords.append('REQUIRED')
+        else:
+            if node.is_required is True:
+                keywords.append("REQUIRED")
+            elif node.is_required is False:
+                keywords.append("OPTIONAL")
+            # else: node.is_required is None
         if node.cardinality:
             keywords.append(node.cardinality.as_ptr_qual().upper())
         keywords.append('LINK')

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -437,6 +437,9 @@ class PtrQualsSpec(typing.NamedTuple):
 
 
 class PtrQuals(Nonterm):
+    def reduce_OPTIONAL(self, *kids):
+        self.val = PtrQualsSpec(required=False)
+
     def reduce_REQUIRED(self, *kids):
         self.val = PtrQualsSpec(required=True)
 
@@ -445,6 +448,14 @@ class PtrQuals(Nonterm):
 
     def reduce_MULTI(self, *kids):
         self.val = PtrQualsSpec(cardinality=qltypes.SchemaCardinality.MANY)
+
+    def reduce_OPTIONAL_SINGLE(self, *kids):
+        self.val = PtrQualsSpec(
+            required=False, cardinality=qltypes.SchemaCardinality.ONE)
+
+    def reduce_OPTIONAL_MULTI(self, *kids):
+        self.val = PtrQualsSpec(
+            required=False, cardinality=qltypes.SchemaCardinality.MANY)
 
     def reduce_REQUIRED_SINGLE(self, *kids):
         self.val = PtrQualsSpec(
@@ -469,6 +480,15 @@ class OptPtrQuals(Nonterm):
 # are followed by an ident in this case (unlike in DDL, where it is followed
 # by a keyword).
 class ComputableShapePointer(Nonterm):
+
+    def reduce_OPTIONAL_SimpleShapePointer_ASSIGN_Expr(self, *kids):
+        self.val = kids[1].val
+        self.val.compexpr = kids[3].val
+        self.val.required = False
+        self.val.operation = qlast.ShapeOperation(
+            op=qlast.ShapeOp.ASSIGN,
+            context=kids[2].context,
+        )
 
     def reduce_REQUIRED_SimpleShapePointer_ASSIGN_Expr(self, *kids):
         self.val = kids[1].val
@@ -495,6 +515,26 @@ class ComputableShapePointer(Nonterm):
         self.val.operation = qlast.ShapeOperation(
             op=qlast.ShapeOp.ASSIGN,
             context=kids[2].context,
+        )
+
+    def reduce_OPTIONAL_MULTI_SimpleShapePointer_ASSIGN_Expr(self, *kids):
+        self.val = kids[2].val
+        self.val.compexpr = kids[4].val
+        self.val.required = False
+        self.val.cardinality = qltypes.SchemaCardinality.MANY
+        self.val.operation = qlast.ShapeOperation(
+            op=qlast.ShapeOp.ASSIGN,
+            context=kids[3].context,
+        )
+
+    def reduce_OPTIONAL_SINGLE_SimpleShapePointer_ASSIGN_Expr(self, *kids):
+        self.val = kids[2].val
+        self.val.compexpr = kids[4].val
+        self.val.required = False
+        self.val.cardinality = qltypes.SchemaCardinality.ONE
+        self.val.operation = qlast.ShapeOperation(
+            op=qlast.ShapeOp.ASSIGN,
+            context=kids[3].context,
         )
 
     def reduce_REQUIRED_MULTI_SimpleShapePointer_ASSIGN_Expr(self, *kids):

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -442,8 +442,7 @@ def generate_structure(
                         schema = _run_ddl(
                             f'''
                                 ALTER TYPE {rschema_name} {{
-                                    CREATE
-                                    {'REQUIRED' if field.required else ''}
+                                    CREATE {qual}
                                     {ptrkind} {pn} -> {ptrtype};
                                 }}
                             ''',
@@ -521,7 +520,7 @@ def generate_structure(
                 schema = _run_ddl(
                     f'''
                         ALTER TYPE {rschema_name} {{
-                            CREATE MULTI LINK {shadow_pn}
+                            CREATE OPTIONAL MULTI LINK {shadow_pn}
                             EXTENDING schema::reference
                              -> {get_schema_name_for_pycls(ref_cls)} {{
                                  ON TARGET DELETE ALLOW;
@@ -541,7 +540,7 @@ def generate_structure(
                 schema = _run_ddl(
                     f'''
                         ALTER TYPE {rschema_name} {{
-                            CREATE MULTI LINK {refdict.attr}
+                            CREATE OPTIONAL MULTI LINK {refdict.attr}
                             EXTENDING schema::reference
                              -> {ptr_type} {{
                                  ON TARGET DELETE ALLOW;
@@ -599,11 +598,12 @@ def generate_structure(
             for fn, storage in {**props, **extra_props}.items():
                 prop_ptr = ref_ptr.getptr(schema, fn)
                 if prop_ptr is None:
+                    pty = storage.ptrtype
                     schema = _run_ddl(
                         f'''
                             ALTER TYPE {rschema_name} {{
                                 ALTER LINK {refdict.attr} {{
-                                    CREATE PROPERTY {fn} -> {storage.ptrtype};
+                                    CREATE OPTIONAL PROPERTY {fn} -> {pty};
                                 }}
                             }}
                         ''',
@@ -617,12 +617,12 @@ def generate_structure(
                 for fn, storage in props.items():
                     prop_ptr = shadow_ref_ptr.getptr(schema, fn)
                     if prop_ptr is None:
+                        pty = storage.ptrtype
                         schema = _run_ddl(
                             f'''
                                 ALTER TYPE {rschema_name} {{
                                     ALTER LINK {shadow_pn} {{
-                                        CREATE PROPERTY {fn} ->
-                                            {storage.ptrtype};
+                                        CREATE OPTIONAL PROPERTY {fn} -> {pty};
                                     }}
                                 }}
                             ''',

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -418,11 +418,12 @@ def generate_structure(
             ptr = schema_objtype.getptr(schema, fn)
 
             if fn in ownfields:
+                qual = "REQUIRED" if field.required else "OPTIONAL"
                 if ptr is None:
                     schema = _run_ddl(
                         f'''
                             ALTER TYPE {rschema_name} {{
-                                CREATE {'REQUIRED' if field.required else ''}
+                                CREATE {qual}
                                 {storage.ptrkind} {fn} -> {storage.ptrtype};
                             }}
                         ''',

--- a/tests/schemas/issues.esdl
+++ b/tests/schemas/issues.esdl
@@ -68,7 +68,7 @@ scalar type issue_num_t extending std::str;
 
 type Comment extending Text, Owned {
     required link issue -> Issue;
-    link parent -> Comment;
+    optional link parent -> Comment;
 }
 
 type Issue extending Named, Owned, Text {
@@ -84,9 +84,9 @@ type Issue extending Named, Owned, Text {
 
     link priority -> Priority;
 
-    multi link watchers -> User;
+    optional multi link watchers -> User;
 
-    property time_estimate -> int64;
+    optional property time_estimate -> int64;
 
     multi link time_spent_log -> LogEntry;
 
@@ -118,8 +118,8 @@ type Publication {
     property title1 := (SELECT ident(.title));
     required property title2 := (SELECT ident(.title));
     required single property title3 := (SELECT ident(.title));
-    single property title4 := (SELECT ident(.title));
-    multi property title5 := (SELECT ident(.title));
+    optional single property title4 := (SELECT ident(.title));
+    optional multi property title5 := (SELECT ident(.title));
     required multi property title6 := (SELECT ident(.title));
 
     multi link authors -> User {

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -755,6 +755,11 @@ aa';
         SELECT REQUIRED (User.groups.description);
         """
 
+    def test_edgeql_syntax_optional_01(self):
+        """
+        SELECT OPTIONAL (User.groups.description);
+        """
+
     def test_edgeql_syntax_list_01(self):
         """
         SELECT (some_list_fn())[2];

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -755,11 +755,6 @@ aa';
         SELECT REQUIRED (User.groups.description);
         """
 
-    def test_edgeql_syntax_optional_01(self):
-        """
-        SELECT OPTIONAL (User.groups.description);
-        """
-
     def test_edgeql_syntax_list_01(self):
         """
         SELECT (some_list_fn())[2];

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3956,7 +3956,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     constraint std::exclusive {
                         annotation test::anno := 'annotated constraint';
                     };
-                    single property p -> test::int_t {
+                    optional single property p -> test::int_t {
                         constraint std::max_value(10);
                     };
                 };
@@ -3964,7 +3964,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     readonly := true;
                     constraint std::exclusive;
                 };
-                multi property name -> std::str;
+                optional multi property name -> std::str;
             };
             """,
 
@@ -3976,12 +3976,12 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     readonly := true;
                 };
                 overloaded single link foo extending test::f -> test::Foo {
-                    single property p -> test::int_t;
+                    optional single property p -> test::int_t;
                 };
                 required single property id -> std::uuid {
                     readonly := true;
                 };
-                multi property name -> std::str;
+                optional multi property name -> std::str;
             };
             """,
 
@@ -4048,12 +4048,12 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             [
                 """
                 type test::Spam {
-                    single link foobar -> (test::Foo | test::Bar);
+                    optional single link foobar -> (test::Foo | test::Bar);
                 };
                 """,
                 """
                 type test::Spam {
-                    single link foobar -> (test::Bar | test::Foo);
+                    optional single link foobar -> (test::Bar | test::Foo);
                 };
                 """,
             ]
@@ -4212,7 +4212,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     constraint std::exclusive;
                 };
                 required single property image -> std::str;
-                single property name -> std::str;
+                optional single property name -> std::str;
             };
             """,
 
@@ -4227,7 +4227,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     readonly := true;
                 };
                 required single property image -> std::str;
-                single property name -> std::str;
+                optional single property name -> std::str;
             };
             """,
 
@@ -4235,7 +4235,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::User extending test::HasImage {
-                single property name -> std::str;
+                optional single property name -> std::str;
             };
             ''',
 
@@ -4361,7 +4361,8 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::UniqueName {
-                single link translated_label extending test::translated_label
+                optional single link translated_label
+                extending test::translated_label
                         -> test::Label {
                     constraint std::exclusive on (WITH
                         MODULE test
@@ -4389,11 +4390,12 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 required single link __type__ -> schema::Type {
                     readonly := true;
                 };
-                single link translated_label extending test::translated_label
+                optional single link translated_label
+                extending test::translated_label
                     -> test::Label
                 {
-                    single property lang -> std::str;
-                    single property prop1 -> std::str;
+                    optional single property lang -> std::str;
+                    optional single property prop1 -> std::str;
                 };
                 required single property id -> std::uuid {
                     readonly := true;
@@ -4408,14 +4410,15 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 required single link __type__ -> schema::Type {
                     readonly := true;
                 };
-                single link translated_label extending test::translated_label
+                optional single link translated_label
+                extending test::translated_label
                     -> test::Label
                 {
                     constraint std::exclusive on (__subject__@prop1);
                     constraint std::exclusive on (
                         (__subject__@source, __subject__@lang));
-                    single property lang -> std::str;
-                    single property prop1 -> std::str;
+                    optional single property lang -> std::str;
+                    optional single property prop1 -> std::str;
                 };
                 required single property id -> std::uuid {
                     readonly := true;
@@ -4478,7 +4481,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE SINGLE PROPERTY bar -> std::str {
+                CREATE OPTIONAL SINGLE PROPERTY bar -> std::str {
                     SET readonly := false;
                 };
             };
@@ -4487,7 +4490,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Foo {
-                single property bar -> std::str {
+                optional single property bar -> std::str {
                     readonly := false;
                 };
             };
@@ -4509,7 +4512,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             """
             CREATE MODULE test IF NOT EXISTS;
             CREATE TYPE test::Foo {
-                CREATE SINGLE PROPERTY name -> std::str;
+                CREATE OPTIONAL SINGLE PROPERTY name -> std::str;
             };
             CREATE ALIAS test::Bar :=
                 (WITH
@@ -4541,7 +4544,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             """
             CREATE MODULE test IF NOT EXISTS;
             CREATE TYPE test::Foo {
-                CREATE SINGLE PROPERTY name -> std::str;
+                CREATE OPTIONAL SINGLE PROPERTY name -> std::str;
             };
             CREATE ALIAS test::Bar {
                 USING (WITH
@@ -4620,11 +4623,11 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             """
             CREATE MODULE test IF NOT EXISTS;
             CREATE TYPE test::Foo {
-                CREATE SINGLE PROPERTY annotated_compprop {
+                CREATE OPTIONAL SINGLE PROPERTY annotated_compprop {
                     USING ('foo');
                     CREATE ANNOTATION std::title := 'compprop';
                 };
-                CREATE SINGLE LINK annotated_link {
+                CREATE OPTIONAL SINGLE LINK annotated_link {
                     USING (WITH
                         MODULE test
                     SELECT
@@ -4634,7 +4637,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     );
                     CREATE ANNOTATION std::title := 'complink';
                 };
-                CREATE SINGLE LINK complink := (WITH
+                CREATE OPTIONAL SINGLE LINK complink := (WITH
                     MODULE test
                 SELECT
                     Foo
@@ -4667,11 +4670,11 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE SINGLE PROPERTY annotated_compprop {
+                CREATE OPTIONAL SINGLE PROPERTY annotated_compprop {
                     USING ('foo');
                     CREATE ANNOTATION std::title := 'compprop';
                 };
-                CREATE SINGLE LINK annotated_link {
+                CREATE OPTIONAL SINGLE LINK annotated_link {
                     USING (WITH
                         MODULE test
                     SELECT
@@ -4681,7 +4684,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     );
                     CREATE ANNOTATION std::title := 'complink';
                 };
-                CREATE SINGLE LINK complink := (WITH
+                CREATE OPTIONAL SINGLE LINK complink := (WITH
                     MODULE test
                 SELECT
                     Foo
@@ -4709,15 +4712,16 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                       schema::Type,
                       schema::Source
             {
-                CREATE MULTI LINK intersection_of -> schema::ObjectType;
-                CREATE MULTI LINK union_of -> schema::ObjectType;
-                CREATE SINGLE PROPERTY is_compound_type := (
+                CREATE OPTIONAL MULTI LINK intersection_of
+                    -> schema::ObjectType;
+                CREATE OPTIONAL MULTI LINK union_of -> schema::ObjectType;
+                CREATE OPTIONAL SINGLE PROPERTY is_compound_type := (
                     (EXISTS (.union_of) OR EXISTS (.intersection_of))
                 );
-                CREATE MULTI LINK links := (
+                CREATE OPTIONAL MULTI LINK links := (
                     .pointers[IS schema::Link]
                 );
-                CREATE MULTI LINK properties := (
+                CREATE OPTIONAL MULTI LINK properties := (
                     .pointers[IS schema::Property]
                 );
             };
@@ -4733,11 +4737,13 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     schema::Type,
                     schema::Source
             {
-                multi link intersection_of -> schema::ObjectType;
-                multi link links := (.pointers[IS schema::Link]);
-                multi link properties := (.pointers[IS schema::Property]);
-                multi link union_of -> schema::ObjectType;
-                single property is_compound_type := (
+                optional multi link intersection_of -> schema::ObjectType;
+                optional multi link links := (.pointers[IS schema::Link]);
+                optional multi link properties := (
+                    .pointers[IS schema::Property]
+                );
+                optional multi link union_of -> schema::ObjectType;
+                optional single property is_compound_type := (
                     (EXISTS (.union_of) OR EXISTS (.intersection_of))
                 );
             };
@@ -4773,7 +4779,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE SINGLE LINK bar -> std::Object {
+                CREATE OPTIONAL SINGLE LINK bar -> std::Object {
                     ON TARGET DELETE ALLOW;
                 };
             };
@@ -4783,7 +4789,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Foo {
-                single link bar -> std::Object {
+                optional single link bar -> std::Object {
                     on target delete  allow;
                 };
             };
@@ -4796,7 +4802,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 required single link __type__ -> schema::Type {
                     readonly := true;
                 };
-                single link bar -> std::Object {
+                optional single link bar -> std::Object {
                     on target delete  allow;
                 };
                 required single property id -> std::uuid {


### PR DESCRIPTION
Also makes DESCRIBE output OPTIONAL by default in both DDL and SDL.

Fixes #1342