### PR TITLE
Fix handling of ROLE commands on RDS

### DIFF
--- a/edb/pgsql/dbops/base.py
+++ b/edb/pgsql/dbops/base.py
@@ -18,11 +18,12 @@
 
 
 from __future__ import annotations
+from typing import *
 
 import collections
+import enum
 import numbers
 import textwrap
-from typing import *
 
 from edb.common import markup
 from edb.common import struct
@@ -32,6 +33,13 @@ from ..common import quote_ident as qi
 from ..common import quote_literal as ql
 from ..common import quote_type as qt
 from ..common import qname as qn
+
+
+class NotSpecifiedT(enum.Enum):
+    NotSpecified = 0
+
+
+NotSpecified: Final = NotSpecifiedT.NotSpecified
 
 
 def encode_value(val: Any) -> str:

--- a/edb/pgsql/dbops/roles.py
+++ b/edb/pgsql/dbops/roles.py
@@ -34,11 +34,11 @@ class Role(base.DBObject):
         self,
         name: str,
         *,
-        allow_login: bool = False,
-        allow_createdb: bool = False,
-        allow_createrole: bool = False,
-        password: Optional[str] = None,
-        is_superuser: bool = False,
+        allow_login: Union[bool, base.NotSpecifiedT] = base.NotSpecified,
+        allow_createdb: Union[bool, base.NotSpecifiedT] = base.NotSpecified,
+        allow_createrole: Union[bool, base.NotSpecifiedT] = base.NotSpecified,
+        password: Union[None, str, base.NotSpecifiedT] = base.NotSpecified,
+        is_superuser: Union[bool, base.NotSpecifiedT] = base.NotSpecified,
         membership: Optional[Iterable[str]] = None,
         metadata: Optional[Mapping[str, Any]] = None,
     ) -> None:
@@ -87,15 +87,18 @@ class RoleCommand:
         }
 
         for objattr, stmtattr in attrmap.items():
-            if getattr(self.object, objattr):
+            attr = getattr(self.object, objattr)
+            if attr is base.NotSpecified:
+                continue
+            elif attr:
                 attrs.append(stmtattr)
             else:
                 attrs.append(f'NO{stmtattr}')
 
-        if self.object.password:
-            attrs.append(f'PASSWORD {ql(self.object.password)}')
-        else:
+        if self.object.password is None:
             attrs.append('PASSWORD NULL')
+        elif self.object.password is not base.NotSpecified:
+            attrs.append(f'PASSWORD {ql(self.object.password)}')
 
         return f'ROLE {self.object.get_id()} {" ".join(attrs)}'
 
@@ -147,3 +150,17 @@ class AlterRoleDropMember(ddl.SchemaObjectOperation):
 
     def code(self, block: base.PLBlock) -> str:
         return f'REVOKE {qi(self.name)} FROM {qi(self.member)}'
+
+
+class AlterRoleAddMembership(ddl.SchemaObjectOperation):
+
+    def __init__(
+            self, name, membership, *, conditions=None,
+            neg_conditions=None, priority=0):
+        super().__init__(name, conditions=conditions,
+                         neg_conditions=neg_conditions, priority=priority)
+        self.membership = membership
+
+    def code(self, block: base.PLBlock) -> str:
+        roles = ', '.join(qi(m) for m in self.membership)
+        return f'GRANT {roles} TO {qi(self.name)}'

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -642,7 +642,8 @@ class CommandContext:
         descriptive_mode: bool = False,
         schema_object_ids: Optional[
             Mapping[Tuple[str, Optional[str]], uuid.UUID]
-        ] = None
+        ] = None,
+        backend_superuser_role: Optional[str] = None,
     ) -> None:
         self.stack: List[CommandContextToken[Command]] = []
         self._cache: Dict[Hashable, Any] = {}
@@ -658,6 +659,7 @@ class CommandContext:
         self.renamed_objs: Set[so.Object] = set()
         self.altered_targets: Set[so.Object] = set()
         self.schema_object_ids = schema_object_ids
+        self.backend_superuser_role = backend_superuser_role
 
     @property
     def modaliases(self) -> Mapping[Optional[str], str]:

--- a/edb/server/baseport.py
+++ b/edb/server/baseport.py
@@ -57,6 +57,14 @@ class Port:
     def get_compiler_worker_cls(self):
         raise NotImplementedError
 
+    def get_compiler_worker_args(self):
+        return {
+            'connect_args': self._pg_addr,
+            'backend_instance_params': (
+                self.get_server().get_backend_instance_params()
+            ),
+        }
+
     def get_compiler_worker_name(self):
         raise NotImplementedError
 
@@ -76,7 +84,7 @@ class Port:
 
         self._compiler_manager = await procpool.create_manager(
             runstate_dir=self._internal_runstate_dir,
-            worker_args=(self._pg_addr,),
+            worker_args=self.get_compiler_worker_args(),
             worker_cls=self.get_compiler_worker_cls(),
             name=self.get_compiler_worker_name(),
         )

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -116,7 +116,7 @@ async def _ensure_edgedb_role(
         if superuser_role:
             # If the cluster is exposing an explicit superuser role,
             # become a member of that instead of creating a superuser
-            # role directly,
+            # role directly.
             membership.add(superuser_role)
             superuser_flag = False
         else:
@@ -576,7 +576,11 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
             stdlib,
         )
         await conn.execute(testmode_sql)
-        await metaschema.generate_support_views(conn, stdlib.reflschema)
+        await metaschema.generate_support_views(
+            cluster,
+            conn,
+            stdlib.reflschema,
+        )
 
     # Make sure that schema backend_id properties are in sync with
     # the database.
@@ -640,7 +644,7 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
         json.dumps(stdlib.introquery),
     )
 
-    await metaschema.generate_support_views(conn, stdlib.reflschema)
+    await metaschema.generate_support_views(cluster, conn, stdlib.reflschema)
     await metaschema.generate_support_functions(conn, stdlib.reflschema)
 
     compiler = edbcompiler.new_compiler(

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -23,6 +23,7 @@ from .compiler import Compiler, BaseCompiler, CompilerDatabaseState
 from .compiler import compile_edgeql_script
 from .compiler import load_std_schema
 from .compiler import new_compiler, new_compiler_context
+from .compiler import BackendInstanceParams
 from .dbstate import QueryUnit
 from .enums import Capability, CompileStatementMode, ResultCardinality
 from .enums import IoFormat
@@ -30,6 +31,7 @@ from .enums import IoFormat
 
 __all__ = (
     'Compiler', 'BaseCompiler', 'CompilerDatabaseState',
+    'BackendInstanceParams',
     'QueryUnit',
     'Capability', 'CompileStatementMode', 'ResultCardinality', 'IoFormat',
     'compile_edgeql_script',

--- a/edb/server/procpool/pool.py
+++ b/edb/server/procpool/pool.py
@@ -239,7 +239,7 @@ class Manager:
 
 
 async def create_manager(*, runstate_dir: str, name: str,
-                         worker_cls: type, worker_args: tuple) -> Manager:
+                         worker_cls: type, worker_args: dict) -> Manager:
 
     loop = asyncio.get_running_loop()
     pool = Manager(

--- a/edb/server/procpool/worker.py
+++ b/edb/server/procpool/worker.py
@@ -50,7 +50,7 @@ async def worker(cls, cls_args, sockname):
 
     con = await amsg.worker_connect(sockname)
     try:
-        worker = cls(*cls_args)
+        worker = cls(**cls_args)
 
         while True:
             try:

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -30,6 +30,7 @@ from edb.common import taskgroup
 from edb.edgeql import parser as ql_parser
 
 from edb.server import config
+from edb.server import compiler as edbcompiler
 from edb.server import defines
 from edb.server import http_edgeql_port
 from edb.server import http_graphql_port
@@ -336,3 +337,8 @@ class Server:
 
     async def get_instance_data(self, conn, key):
         return await self._dbindex.get_instance_data(conn, key)
+
+    def get_backend_instance_params(self) -> edbcompiler.BackendInstanceParams:
+        return edbcompiler.BackendInstanceParams(
+            explicit_superuser_role=self._cluster.get_superuser_role(),
+        )


### PR DESCRIPTION
Although bootstrap on RDS accounts for the Postgres role configuration
specifics on RDS, `CREATE ROLE` and `ALTER ROLE` currently fail, because
the compiler and the DDL subsystem have no knowledge of those specifics.
Fix this.

Fixes: #1472