### PR TITLE
Make postgres port integer

### DIFF
--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -586,7 +586,7 @@ class Cluster(BaseCluster):
             # daemon run.
             return None
 
-        portnum = lines[3]
+        portnum = int(lines[3])
         sockdir = lines[4]
         hostaddr = lines[5]
 


### PR DESCRIPTION
Previously was inconsistent: integer when using postgres-dsn, string
otherwise.

Fixes edgedb/edgedb-cli#79