### PR TITLE
Aliases

### DIFF
--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1545,7 +1545,11 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self._visit_AlterObject(node, 'FUNCTION', after_name=after_name)
 
     def visit_DropFunction(self, node: qlast.DropFunction) -> None:
-        self._visit_DropObject(node, 'FUNCTION')
+        def after_name() -> None:
+            self.write('(')
+            self.visit_list(node.params, newlines=False)
+            self.write(')')
+        self._visit_DropObject(node, 'FUNCTION', after_name=after_name)
 
     def visit_FuncParam(self, node: qlast.FuncParam) -> None:
         kind = node.kind.to_edgeql()

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -535,14 +535,18 @@ def ptr_step_set(
 
 
 def resolve_ptr(
-        near_endpoint: s_obj.Object,
-        pointer_name: str, *,
-        far_endpoints: Iterable[s_obj.Object] = (),
-        direction: s_pointers.PointerDirection=(
-            s_pointers.PointerDirection.Outbound
-        ),
-        source_context: Optional[parsing.ParserContext]=None,
-        ctx: context.ContextLevel) -> s_pointers.Pointer:
+    near_endpoint: s_obj.Object,
+    pointer_name: str,
+    *,
+    far_endpoints: Iterable[s_obj.Object] = (),
+    direction: s_pointers.PointerDirection = (
+        s_pointers.PointerDirection.Outbound
+    ),
+    source_context: Optional[parsing.ParserContext] = None,
+    track_ref: bool = True,
+    ctx: context.ContextLevel,
+) -> s_pointers.Pointer:
+
     if not isinstance(near_endpoint, s_sources.Source):
         # Reference to a property on non-object
         msg = 'invalid property reference on a primitive type expression'
@@ -555,16 +559,18 @@ def resolve_ptr(
 
         if ptr is not None:
             ref = ptr.get_nearest_non_derived_parent(ctx.env.schema)
-            ctx.env.schema_refs.add(ref)
+            if track_ref:
+                ctx.env.schema_refs.add(ref)
 
     else:
         ptrs = near_endpoint.getrptrs(ctx.env.schema, pointer_name,
                                       sources=far_endpoints)
         if ptrs:
-            ctx.env.schema_refs.update(
-                p.get_nearest_non_derived_parent(ctx.env.schema)
-                for p in ptrs
-            )
+            if track_ref:
+                ctx.env.schema_refs.update(
+                    p.get_nearest_non_derived_parent(ctx.env.schema)
+                    for p in ptrs
+                )
 
             opaque = (
                 direction is s_pointers.PointerDirection.Inbound

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -153,6 +153,11 @@ def fini_expression(
             view_own_pointers = view.get_pointers(ctx.env.schema)
             for vptr in view_own_pointers.objects(ctx.env.schema):
                 _elide_derived_ancestors(vptr, ctx=ctx)
+                ctx.env.schema = vptr.set_field_value(
+                    ctx.env.schema,
+                    'is_from_alias',
+                    True,
+                )
 
                 tgt = vptr.get_target(ctx.env.schema)
                 assert tgt is not None
@@ -175,6 +180,11 @@ def fini_expression(
                 )
                 for vlprop in vptr_own_pointers.objects(ctx.env.schema):
                     _elide_derived_ancestors(vlprop, ctx=ctx)
+                    ctx.env.schema = vlprop.set_field_value(
+                        ctx.env.schema,
+                        'is_from_alias',
+                        True,
+                    )
 
     expr_type = inference.infer_type(ir, ctx.env)
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -567,7 +567,12 @@ def _normalize_view_ptr_expr(
             )
 
             try:
-                ptrcls = setgen.resolve_ptr(ptrsource, ptrname, ctx=ctx)
+                ptrcls = setgen.resolve_ptr(
+                    ptrsource,
+                    ptrname,
+                    track_ref=False,
+                    ctx=ctx,
+                )
 
                 base_ptrcls = ptrcls.get_bases(
                     ctx.env.schema).first(ctx.env.schema)
@@ -655,6 +660,10 @@ def _normalize_view_ptr_expr(
             if base_ptrcls is None:
                 base_ptrcls = shape_expr_ctx.view_rptr.base_ptrcls
                 base_ptrcls_is_alias = shape_expr_ctx.view_rptr.ptrcls_is_alias
+
+            if ptrcls is not None:
+                ctx.env.schema = ptrcls.set_field_value(
+                    ctx.env.schema, 'is_local', True)
 
         ptr_cardinality = None
         ptr_target = inference.infer_type(irexpr, ctx.env)
@@ -830,6 +839,12 @@ def _normalize_view_ptr_expr(
         ctx.env.schema = ptrcls.set_field_value(
             ctx.env.schema,
             'computable',
+            True,
+        )
+
+        ctx.env.schema = ptrcls.set_field_value(
+            ctx.env.schema,
+            'is_local',
             True,
         )
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3338,7 +3338,8 @@ class UpdateEndpointDeleteActions(MetaCommand):
         for link_op, link, orig_schema in self.link_ops:
             if isinstance(link_op, DeleteLink):
                 if (link.generic(orig_schema)
-                        or not link.get_is_local(orig_schema)):
+                        or not link.get_is_local(orig_schema)
+                        or link.is_pure_computable(orig_schema)):
                     continue
                 source = link.get_source(orig_schema)
                 current_source = orig_schema.get_by_id(source.id, None)
@@ -3351,7 +3352,11 @@ class UpdateEndpointDeleteActions(MetaCommand):
                     affected_targets.add(current_target)
                 deletions = True
             else:
-                if link.generic(schema) or not link.get_is_local(schema):
+                if (
+                    link.generic(schema)
+                    or not link.get_is_local(schema)
+                    or link.is_pure_computable(schema)
+                ):
                     continue
                 source = link.get_source(schema)
                 if source.is_view(schema):
@@ -3403,6 +3408,9 @@ class UpdateEndpointDeleteActions(MetaCommand):
                                              field_name='target'):
                 if (not link.get_is_local(schema)
                         or link.is_pure_computable(schema)):
+                    continue
+                source = link.get_source(schema)
+                if source.is_view(schema):
                     continue
                 ptr_stor_info = types.get_pointer_storage_info(
                     link, schema=schema)

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -2871,8 +2871,6 @@ async def _execute_block(conn, block):
     try:
         await conn.execute(sql_text)
     except Exception as e:
-        import edb.common.debug
-        edb.common.debug.dump(e.__dict__)
         position = getattr(e, 'position', None)
         internal_position = getattr(e, 'internal_position', None)
         context = getattr(e, 'context', '')

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -239,16 +239,6 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
         else:
             return None
 
-    def get_attribute_source_context(
-        self,
-        attr_name: str,
-    ) -> Optional[parsing.ParserContext]:
-        op = self.get_attribute_set_cmd(attr_name)
-        if op is not None:
-            return op.source_context
-        else:
-            return None
-
     def get_orig_attribute_value(
         self,
         attr_name: str,
@@ -256,6 +246,16 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
         op = self.get_attribute_set_cmd(attr_name)
         if op is not None:
             return op.old_value
+        else:
+            return None
+
+    def get_attribute_source_context(
+        self,
+        attr_name: str,
+    ) -> Optional[parsing.ParserContext]:
+        op = self.get_attribute_set_cmd(attr_name)
+        if op is not None:
+            return op.source_context
         else:
             return None
 
@@ -1043,6 +1043,23 @@ class ObjectCommand(
         # a List[Type[DDLOperation]]
         return type(self).astnode  # type: ignore
 
+    def _deparse_name(
+        self,
+        schema: s_schema.Schema,
+        context: CommandContext,
+        name: str,
+    ) -> qlast.ObjectRef:
+        qlclass = self.get_schema_metaclass().get_ql_class()
+
+        if isinstance(name, sn.Name):
+            nname = sn.shortname_from_fullname(name)
+            ref = qlast.ObjectRef(
+                module=nname.module, name=nname.name, itemclass=qlclass)
+        else:
+            ref = qlast.ObjectRef(module='', name=name, itemclass=qlclass)
+
+        return ref
+
     def _get_ast(
         self,
         schema: s_schema.Schema,
@@ -1051,17 +1068,11 @@ class ObjectCommand(
         parent_node: Optional[qlast.DDLOperation] = None,
     ) -> Optional[qlast.DDLOperation]:
         astnode = self._get_ast_node(schema, context)
-        qlclass = self.get_schema_metaclass().get_ql_class()
-        if isinstance(self.classname, sn.Name):
-            nname = sn.shortname_from_fullname(self.classname)
-            name = qlast.ObjectRef(module=nname.module, name=nname.name,
-                                   itemclass=qlclass)
-        else:
-            name = qlast.ObjectRef(module='', name=self.classname,
-                                   itemclass=qlclass)
 
         if astnode.get_field('name'):
-            op = astnode(name=name)
+            op = astnode(
+                name=self._deparse_name(schema, context, self.classname),
+            )
         else:
             op = astnode()
 
@@ -1266,6 +1277,18 @@ class ObjectCommand(
         for attr in self.enumerate_attributes():
             result[attr] = self.get_resolved_attribute_value(
                 attr, schema=schema, context=context)
+
+        return result
+
+    def get_orig_attributes(
+        self,
+        schema: s_schema.Schema,
+        context: CommandContext,
+    ) -> Dict[str, Any]:
+        result = {}
+
+        for attr in self.enumerate_attributes():
+            result[attr] = self.get_orig_attribute_value(attr)
 
         return result
 
@@ -1570,6 +1593,10 @@ class AlterObjectFragment(ObjectCommand[so.Object]):
         assert isinstance(op, ObjectCommand)
         scls = op.scls
         self.scls = scls
+
+        for op in self.get_prerequisites():
+            schema = op.apply(schema, context)
+
         schema = self._alter_begin(schema, context)
         schema = self._alter_innards(schema, context)
         schema = self._alter_finalize(schema, context)
@@ -1674,8 +1701,13 @@ class RenameObject(AlterObjectFragment):
         parent_node: Optional[qlast.DDLOperation] = None,
     ) -> Optional[qlast.DDLOperation]:
         astnode = self._get_ast_node(schema, context)
-        ref = qlast.ObjectRef(name=self.new_name)
-        return astnode(new_name=ref)
+        ref = self._deparse_name(schema, context, self.new_name)
+        ref.itemclass = None
+        orig_ref = self._deparse_name(schema, context, self.classname)
+        if (orig_ref.module, orig_ref.name) != (ref.module, ref.name):
+            return astnode(new_name=ref)
+        else:
+            return None
 
     @classmethod
     def _cmd_from_ast(
@@ -1985,16 +2017,19 @@ class DeleteObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
 
         if not context.canonical:
             refs = schema.get_referrers(self.scls)
+            ctx = context.current()
+            assert ctx is not None
+            orig_schema = ctx.original_schema
             if refs:
                 for ref in refs:
                     if (not context.is_deleting(ref)
-                            and ref.is_blocking_ref(schema, self.scls)):
+                            and ref.is_blocking_ref(orig_schema, self.scls)):
                         ref_strs.append(
-                            ref.get_verbosename(schema, with_parent=True))
+                            ref.get_verbosename(orig_schema, with_parent=True))
 
             if ref_strs:
-                vn = self.scls.get_verbosename(schema, with_parent=True)
-                dn = self.scls.get_displayname(schema)
+                vn = self.scls.get_verbosename(orig_schema, with_parent=True)
+                dn = self.scls.get_displayname(orig_schema)
                 detail = '; '.join(f'{ref_str} depends on {dn}'
                                    for ref_str in ref_strs)
                 raise errors.SchemaError(

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -22,6 +22,7 @@ from typing import *
 
 import collections
 import collections.abc
+import contextlib
 import itertools
 import uuid
 
@@ -826,6 +827,13 @@ class CommandContext:
 
     def get_value(self, key: Hashable) -> Any:
         return self._values.get(key)
+
+    @contextlib.contextmanager
+    def suspend_dep_verification(self):
+        dep_ver = self.disable_dep_verification
+        self.disable_dep_verification = True
+        yield self
+        self.disable_dep_verification = dep_ver
 
     def __call__(
         self,

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -437,53 +437,6 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
 
         return bases
 
-    def _apply_rebase_ast(
-        self,
-        context: sd.CommandContext,
-        node: qlast.ObjectDDL,
-        op: Any
-    ) -> Any:
-        rebase = next(iter(self.get_subcommands(type=RebaseInheritingObject)))
-
-        dropped = rebase.removed_bases
-        added = rebase.added_bases
-
-        if dropped:
-            node.commands.append(
-                qlast.AlterDropInherit(
-                    bases=[
-                        qlast.ObjectRef(
-                            module=b.classname.module,
-                            name=b.classname.name
-                        )
-                        for b in dropped
-                    ]
-                )
-            )
-
-        for bases, pos in added:
-            if isinstance(pos, tuple):
-                pos_node = qlast.Position(
-                    position=pos[0],
-                    ref=qlast.ObjectRef(
-                        module=pos[1].classname.module,
-                        name=pos[1].classname.name))
-            else:
-                pos_node = qlast.Position(position=pos)
-
-            node.commands.append(
-                qlast.AlterAddInherit(
-                    bases=[
-                        qlast.ObjectRef(
-                            module=b.classname.module,
-                            name=b.classname.name
-                        )
-                        for b in bases
-                    ],
-                    position=pos_node
-                )
-            )
-
     def _apply_field_ast(
         self,
         schema: s_schema.Schema,
@@ -499,8 +452,6 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
                     value=op.new_value
                 )
             )
-        elif op.property == 'bases':
-            self._apply_rebase_ast(context, node, op)
         else:
             super()._apply_field_ast(schema, context, node, op)
 
@@ -952,3 +903,53 @@ class RebaseInheritingObject(
             bases = [default_base]
 
         return so.ObjectList[so.InheritingObjectT].create(schema, bases)
+
+    def _get_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        *,
+        parent_node: Optional[qlast.DDLOperation] = None,
+    ) -> Optional[qlast.DDLOperation]:
+        assert parent_node is not None
+
+        dropped = self._get_bases_for_ast(schema, context, self.removed_bases)
+
+        if dropped:
+            parent_node.commands.append(
+                qlast.AlterDropInherit(
+                    bases=[utils.typeref_to_ast(schema, b) for b in dropped],
+                )
+            )
+
+        for bases, pos in self.added_bases:
+            bases = self._get_bases_for_ast(schema, context, bases)
+            if not bases:
+                continue
+
+            if isinstance(pos, tuple):
+                pos_node = qlast.Position(
+                    position=pos[0],
+                    ref=utils.typeref_to_ast(schema, pos[1]),
+                )
+            else:
+                pos_node = qlast.Position(position=pos)
+
+            parent_node.commands.append(
+                qlast.AlterAddInherit(
+                    bases=[utils.typeref_to_ast(schema, b) for b in bases],
+                    position=pos_node,
+                )
+            )
+
+        return None
+
+    def _get_bases_for_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        bases: Tuple[so.ObjectShell, ...],
+    ) -> Tuple[so.ObjectShell, ...]:
+        mcls = self.get_schema_metaclass()
+        roots = set(mcls.get_root_classes())
+        return tuple(b for b in bases if b.name not in roots)

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -398,12 +398,11 @@ class AlterProperty(
     ) -> None:
         if op.property == 'target':
             if op.new_value:
-                node.commands.append(qlast.SetLinkType(
-                    type=qlast.ObjectRef(
-                        name=op.new_value.classname.name,  # type: ignore
-                        module=op.new_value.classname.module  # type: ignore
-                    )
-                ))
+                node.commands.append(
+                    qlast.SetPropertyType(
+                        type=utils.typeref_to_ast(schema, op.new_value),
+                    ),
+                )
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -86,11 +86,11 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
         return cmd
 
 
-class AlterMigration(MigrationCommand):
+class AlterMigration(MigrationCommand, sd.AlterObject[Migration]):
     astnode = qlast.AlterMigration
 
 
-class DeleteMigration(MigrationCommand):
+class DeleteMigration(MigrationCommand, sd.DeleteObject[Migration]):
     astnode = qlast.DropMigration
 
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1030,13 +1030,10 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
             if field.compcoef is None:
                 continue
 
-            our_value = self.get_field_value(our_schema, field_name)
-            their_value = other.get_field_value(their_schema, field_name)
-
-            fcoef = cls.compare_field_value(
+            fcoef = cls.compare_obj_field_value(
                 field,
-                our_value,
-                their_value,
+                self,
+                other,
                 our_schema=our_schema,
                 their_schema=their_schema,
                 context=context,
@@ -1052,7 +1049,7 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
         return True
 
     @classmethod
-    def compare_field_value(
+    def _compare_field_value(
         cls,
         field: Field[Type[T]],
         our_value: T,
@@ -1080,6 +1077,35 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
             return field.compcoef
         else:
             return 1.0
+
+    @classmethod
+    def compare_obj_field_value(
+        cls: Type[Object_T],
+        field: Field[Type[T]],
+        ours: Optional[Object_T],
+        theirs: Optional[Object_T],
+        *,
+        our_schema: s_schema.Schema,
+        their_schema: s_schema.Schema,
+        context: ComparisonContext,
+        explicit: bool = False,
+    ) -> float:
+        fname = field.name
+        if explicit:
+            our_value = ours.get_explicit_field_value(our_schema, fname, None)
+            their_value = theirs.get_explicit_field_value(their_schema, fname, None)
+        else:
+            our_value = ours.get_field_value(our_schema, fname)
+            their_value = theirs.get_field_value(their_schema, fname)
+
+        return cls._compare_field_value(
+            field,
+            our_value,
+            their_value,
+            our_schema=our_schema,
+            their_schema=their_schema,
+            context=context,
+        )
 
     @classmethod
     def compare_values(
@@ -1338,18 +1364,23 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
                     new_v = newattr_v
 
                 if f.compcoef is not None:
-                    fcoef = cls.compare_field_value(
+                    fcoef = cls.compare_obj_field_value(
                         f,
-                        oldattr_v,
-                        newattr_v,
+                        old,
+                        new,
                         our_schema=old_schema,
                         their_schema=new_schema,
-                        context=context)
+                        context=context,
+                        explicit=True,
+                    )
 
                     if fcoef != 1.0:
-                        delta.set_attribute_value(
+                        cls.delta_property(
+                            new_schema,
+                            new,
+                            delta,
                             fn,
-                            new_v,
+                            value=new_v,
                             orig_value=old_v,
                         )
         elif new:
@@ -1395,8 +1426,9 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
         delta: sd.ObjectCommand[Object],
         fname: str,
         value: Any,
+        orig_value: Any = None,
     ) -> None:
-        delta.set_attribute_value(fname, value)
+        delta.set_attribute_value(fname, value, orig_value=orig_value)
 
     @classmethod
     def delta_rename(
@@ -1440,8 +1472,6 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
                                       new_schema=new_schema))
             return adds_mods
         elif new is None:
-            if old is None:
-                raise ValueError("`old` and `new` cannot be both None.")
             for o in old:
                 dels.add(o.delta(o, None, context=context,
                                  old_schema=old_schema,
@@ -2553,14 +2583,56 @@ class InheritingObject(SubclassableObject):
         delta: sd.Command,
         fname: str,
         value: Any,
+        orig_value: Any = None,
     ) -> None:
         assert isinstance(scls, InheritingObject)
         inherited_fields = scls.get_inherited_fields(schema)
         delta.set_attribute_value(
             fname,
             value,
+            orig_value=orig_value,
             inherited=fname in inherited_fields,
         )
+
+    @classmethod
+    def compare_obj_field_value(
+        cls: Type[Object_T],
+        field: Field[Type[T]],
+        ours: Optional[Object_T],
+        theirs: Optional[Object_T],
+        *,
+        our_schema: s_schema.Schema,
+        their_schema: s_schema.Schema,
+        context: ComparisonContext,
+        explicit: bool = False,
+    ) -> float:
+        fname = field.name
+        if explicit:
+            our_value = ours.get_explicit_field_value(our_schema, fname, None)
+            their_value = theirs.get_explicit_field_value(their_schema, fname, None)
+        else:
+            our_value = ours.get_field_value(our_schema, fname)
+            their_value = theirs.get_field_value(their_schema, fname)
+
+        similarity = cls._compare_field_value(
+            field,
+            our_value,
+            their_value,
+            our_schema=our_schema,
+            their_schema=their_schema,
+            context=context,
+        )
+
+        # Check to see if this field's inherited status has changed.
+        # If so, this is defintely a change.
+        our_ifs = ours.get_inherited_fields(our_schema)
+        their_ifs = theirs.get_inherited_fields(their_schema)
+
+        if (fname in our_ifs) != (fname in their_ifs):
+            # The change in inherited status decreases the similarity.
+            similarity *= 0.5
+
+        return similarity
 
 
 DerivableInheritingObjectT = TypeVar(

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -440,6 +440,16 @@ class AlterObjectType(ObjectTypeCommand,
         cmd = cls._handle_view_op(schema, cmd, astnode, context)
         return cmd
 
+    def _get_ast_node(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext
+    ) -> Type[qlast.DDLOperation]:
+        if self.get_attribute_value('expr'):
+            return qlast.AlterAlias
+        else:
+            return super()._get_ast_node(schema, context)
+
 
 class DeleteObjectType(ObjectTypeCommand,
                        inheriting.DeleteInheritingObject[ObjectType]):

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -437,7 +437,15 @@ class AlterObjectType(ObjectTypeCommand,
         assert isinstance(astnode, qlast.ObjectDDL)
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
         assert isinstance(cmd, sd.QualifiedObjectCommand)
-        cmd = cls._handle_view_op(schema, cmd, astnode, context)
+
+        if isinstance(astnode, qlast.AlterAlias):
+            # Need to disable dependency verification in order to allow
+            # force-recreating a new aliased type.
+            with context.suspend_dep_verification():
+                cmd = cls._handle_view_op(schema, cmd, astnode, context)
+        else:
+            cmd = cls._handle_view_op(schema, cmd, astnode, context)
+
         return cmd
 
     def _get_ast_node(

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -267,6 +267,32 @@ class Pointer(referencing.ReferencedInheritingObject,
             else:
                 return vn
 
+    @classmethod
+    def delta_properties(
+        cls,
+        delta: sd.ObjectCommand[so.Object],
+        old: Optional[so.Object],
+        new: Optional[so.Object],
+        *,
+        context: so.ComparisonContext,
+        old_schema: Optional[s_schema.Schema],
+        new_schema: s_schema.Schema,
+    ) -> None:
+        super().delta_properties(
+            delta, old, new, context=context,
+            old_schema=old_schema, new_schema=new_schema)
+
+        # If we have an alter, make sure to retain 'is_from_alias'.
+        if old and new:
+            assert isinstance(new, Pointer)
+
+            newattr_v = new.get_explicit_field_value(
+                new_schema, 'is_from_alias', None)
+            delta.set_attribute_value(
+                'is_from_alias',
+                newattr_v,
+            )
+
     def is_scalar(self) -> bool:
         return False
 

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -116,8 +116,7 @@ class ReferencedObject(so.DerivableObject):
             derived_attrs.update(attrs)
 
         derived_attrs['name'] = derived_name
-        derived_attrs['bases'] = so.ObjectList.create(
-            schema, [self])
+        derived_attrs['bases'] = so.ObjectList.create(schema, [self])
 
         mcls = type(self)
         referrer_class = type(referrer)
@@ -692,6 +691,41 @@ class ReferencedInheritingObjectCommand(
                     context=self.source_context,
                 )
 
+    def get_implicit_bases(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        bases: Any,
+    ) -> Sequence[str]:
+
+        mcls = self.get_schema_metaclass()
+        default_base = mcls.get_default_base_name()
+
+        if isinstance(bases, so.ObjectCollectionShell):
+            base_names = [
+                b.name for b in bases.items if b.name is not None
+            ]
+        elif isinstance(bases, so.ObjectList):
+            base_names = list(bases.names(schema))
+        else:
+            # assume regular iterable of shells
+            base_names = [
+                b.name for b in bases
+            ]
+
+        # Filter out explicit bases
+        implicit_bases = [
+            b
+            for b in base_names
+            if (
+                b != default_base
+                and isinstance(b, sn.SchemaName)
+                and sn.shortname_from_fullname(b) != b
+            )
+        ]
+
+        return implicit_bases
+
     def _propagate_ref_op(self,
                           schema: s_schema.Schema,
                           context: sd.CommandContext,
@@ -751,7 +785,10 @@ class CreateReferencedInheritingObject(
     ) -> Optional[qlast.DDLOperation]:
         refctx = type(self).get_referrer_context(context)
         if refctx is not None:
-            if not self.get_attribute_value('is_local'):
+            if self.get_attribute_value('is_from_alias'):
+                return None
+
+            elif not self.get_attribute_value('is_local'):
                 if context.descriptive_mode:
                     astnode = super()._get_ast(
                         schema,
@@ -927,37 +964,6 @@ class CreateReferencedInheritingObject(
 
         return schema
 
-    def get_implicit_bases(
-        self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-        bases: Any,
-    ) -> Sequence[str]:
-
-        mcls = self.get_schema_metaclass()
-        default_base = mcls.get_default_base_name()
-
-        if isinstance(bases, so.ObjectCollectionShell):
-            base_names = [
-                b.name for b in bases.items if b.name is not None
-            ]
-        else:
-            assert isinstance(bases, so.ObjectList)
-            base_names = list(bases.names(schema))
-
-        # Filter out explicit bases
-        implicit_bases = [
-            b
-            for b in base_names
-            if (
-                b != default_base
-                and isinstance(b, sn.SchemaName)
-                and sn.shortname_from_fullname(b) != b
-            )
-        ]
-
-        return implicit_bases
-
 
 class AlterReferencedInheritingObject(
     ReferencedInheritingObjectCommand[ReferencedInheritingObjectT],
@@ -1034,6 +1040,16 @@ class RebaseReferencedInheritingObject(
             self.removed_bases = removed_bases
 
         return super().apply(schema, context)
+
+    def _get_bases_for_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        bases: Tuple[so.ObjectShell, ...],
+    ) -> Tuple[so.ObjectShell, ...]:
+        bases = super()._get_bases_for_ast(schema, context, bases)
+        implicit_bases = set(self.get_implicit_bases(schema, context, bases))
+        return tuple(b for b in bases if b.name not in implicit_bases)
 
 
 class RenameReferencedInheritingObject(
@@ -1228,3 +1244,19 @@ class DeleteReferencedInheritingObject(
         schema = cmd.apply(schema, context)
 
         return schema, cmd
+
+    def _get_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        *,
+        parent_node: Optional[qlast.DDLOperation] = None,
+    ) -> Optional[qlast.DDLOperation]:
+        refctx = type(self).get_referrer_context(context)
+        if (
+            refctx is not None
+            and not self.get_orig_attribute_value('is_local')
+        ):
+            return None
+        else:
+            return super()._get_ast(schema, context, parent_node=parent_node)

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -970,6 +970,23 @@ class AlterReferencedInheritingObject(
     inheriting.AlterInheritingObject[ReferencedInheritingObjectT],
 ):
 
+    def _get_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        *,
+        parent_node: Optional[qlast.DDLOperation] = None,
+    ) -> Optional[qlast.DDLOperation]:
+        if self.get_attribute_value('is_from_alias'):
+            return None
+        else:
+            r = super()._get_ast(schema, context, parent_node=parent_node)
+
+            # from edb.common.markup import dump
+            # dump(r, marker='referencing.py:986')
+
+            return r
+
     @classmethod
     def _cmd_tree_from_ast(
         cls,

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -442,6 +442,11 @@ class Schema(s_abc.Schema):
         name = data['name']
 
         if name in self._name_to_id:
+
+            from edb.common.markup import dump
+            dump(self.get(name), schema=self, marker='schema.py:446')
+            dump(self.get(name).is_view(self), schema=self, marker='schema.py:447')
+
             raise errors.SchemaError(
                 f'{type(scls).__name__} {name!r} is already present '
                 f'in the schema {self!r}')

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -323,8 +323,8 @@ class BaseSchemaTest(BaseDocTest):
                 ddl_plan = s_ddl.compile_migration(
                     ddl_plan, target_schema, current_schema)
 
-            elif isinstance(stmt, qlast.Delta):
-                # APPLY MIGRATION
+            elif isinstance(stmt, qlast.CommitMigration):
+                # COMMIT MIGRATION
                 migration_cmd = s_ddl.cmd_from_ddl(
                     stmt, schema=current_schema,
                     modaliases={None: default_module},

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -3457,11 +3457,10 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         )
 
     @test.xfail('''
-        edgedb.errors.InternalServerError: relation
-        "edgedb_f1a94eb6-dbf2-11e9-a3fb-214b780369d9.f20ba958-dbf2-11e9-8884-5764a7d0627a"
-        does not exist
+        The link is preserved, but not the link property value. Which
+        is a bit odd.
 
-        See `test_edgeql_insert_derived_02` first.
+        See also `test_migrations_equivalence_linkprops_08`.
     ''')
     async def test_edgeql_migration_linkprops_08(self):
         await self.con.execute("""
@@ -3507,7 +3506,18 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.assert_query_result(
             r"""
-                SELECT Base {
+                SELECT Derived {
+                    children := count(.child)
+                };
+            """,
+            [{
+                'children': 1,
+            }],
+        )
+
+        await self.assert_query_result(
+            r"""
+                SELECT Derived {
                     child: {
                         @foo,
                     }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1134,12 +1134,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         ddl_plan = migration.get_delta(schema)
         baseline_schema = ddl_plan.apply(schema, context)
-        import edb.common.debug
-        edb.common.debug.dump(ddl_plan)
-
         ddl_text = s_ddl.ddl_text_from_delta(baseline_schema, ddl_plan)
-
-        print(ddl_text)
 
         try:
             test_schema = self.run_ddl(schema, ddl_text)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1122,19 +1122,30 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             },
         )
 
+        from edb.common.markup import dump
+
         migration_cmd = s_ddl.compile_migration(
             migration_cmd,
             self.std_schema,
             base_schema,
         )
 
+        dump(migration_cmd, marker='test_schema.py:1111')
+
         context = s_delta.CommandContext()
         schema = migration_cmd.apply(base_schema, context)
         migration = migration_cmd.scls
 
+        dump(migration, marker='test_schema.py:1117')
+
         ddl_plan = migration.get_delta(schema)
+
+        dump(ddl_plan, marker='test_schema.py:1121')
+
         baseline_schema = ddl_plan.apply(schema, context)
         ddl_text = s_ddl.ddl_text_from_delta(baseline_schema, ddl_plan)
+
+        print(f'AAA ddl_text: {ddl_text}', flush=True)
 
         try:
             test_schema = self.run_ddl(schema, ddl_text)
@@ -1158,7 +1169,9 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         sdl_text = s_ddl.sdl_text_from_schema(baseline_schema)
 
         try:
+            print(f'AAA0: {ddl_text}', flush=True)
             ddl_schema = self.run_ddl(self.std_schema, ddl_text)
+            print(f'AAA1: {sdl_text}', flush=True)
             sdl_schema = self.run_ddl(
                 self.std_schema,
                 f'''


### PR DESCRIPTION
I'm quite puzzled here by what is `_handle_view_op` trying to do. It crashes because even if I remove the alias from the schema so that I can create the new alias, the `prev_ir = cls._compile_view_expr(prev_expr.qlast, classname, schema, context)` dies on the duplicate name bug because it literally tries to re-compile previous view on the old schema, where it exists by definition. This appears to be very wrong. We either need to extract the data necessary for the delta from the schema directly or have some hack that just allows for `_compile_view_expr` to overwrite existing schema objects when given a certain flag.

See `test_migrations_equivalence_42` to trigger this.
