### PR TITLE
Indexes

### DIFF
--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1545,7 +1545,11 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self._visit_AlterObject(node, 'FUNCTION', after_name=after_name)
 
     def visit_DropFunction(self, node: qlast.DropFunction) -> None:
-        self._visit_DropObject(node, 'FUNCTION')
+        def after_name() -> None:
+            self.write('(')
+            self.visit_list(node.params, newlines=False)
+            self.write(')')
+        self._visit_DropObject(node, 'FUNCTION', after_name=after_name)
 
     def visit_FuncParam(self, node: qlast.FuncParam) -> None:
         kind = node.kind.to_edgeql()

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -535,14 +535,18 @@ def ptr_step_set(
 
 
 def resolve_ptr(
-        near_endpoint: s_obj.Object,
-        pointer_name: str, *,
-        far_endpoints: Iterable[s_obj.Object] = (),
-        direction: s_pointers.PointerDirection=(
-            s_pointers.PointerDirection.Outbound
-        ),
-        source_context: Optional[parsing.ParserContext]=None,
-        ctx: context.ContextLevel) -> s_pointers.Pointer:
+    near_endpoint: s_obj.Object,
+    pointer_name: str,
+    *,
+    far_endpoints: Iterable[s_obj.Object] = (),
+    direction: s_pointers.PointerDirection = (
+        s_pointers.PointerDirection.Outbound
+    ),
+    source_context: Optional[parsing.ParserContext] = None,
+    track_ref: bool = True,
+    ctx: context.ContextLevel,
+) -> s_pointers.Pointer:
+
     if not isinstance(near_endpoint, s_sources.Source):
         # Reference to a property on non-object
         msg = 'invalid property reference on a primitive type expression'
@@ -555,16 +559,18 @@ def resolve_ptr(
 
         if ptr is not None:
             ref = ptr.get_nearest_non_derived_parent(ctx.env.schema)
-            ctx.env.schema_refs.add(ref)
+            if track_ref:
+                ctx.env.schema_refs.add(ref)
 
     else:
         ptrs = near_endpoint.getrptrs(ctx.env.schema, pointer_name,
                                       sources=far_endpoints)
         if ptrs:
-            ctx.env.schema_refs.update(
-                p.get_nearest_non_derived_parent(ctx.env.schema)
-                for p in ptrs
-            )
+            if track_ref:
+                ctx.env.schema_refs.update(
+                    p.get_nearest_non_derived_parent(ctx.env.schema)
+                    for p in ptrs
+                )
 
             opaque = (
                 direction is s_pointers.PointerDirection.Inbound

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -153,6 +153,11 @@ def fini_expression(
             view_own_pointers = view.get_pointers(ctx.env.schema)
             for vptr in view_own_pointers.objects(ctx.env.schema):
                 _elide_derived_ancestors(vptr, ctx=ctx)
+                ctx.env.schema = vptr.set_field_value(
+                    ctx.env.schema,
+                    'is_from_alias',
+                    True,
+                )
 
                 tgt = vptr.get_target(ctx.env.schema)
                 assert tgt is not None
@@ -175,6 +180,11 @@ def fini_expression(
                 )
                 for vlprop in vptr_own_pointers.objects(ctx.env.schema):
                     _elide_derived_ancestors(vlprop, ctx=ctx)
+                    ctx.env.schema = vlprop.set_field_value(
+                        ctx.env.schema,
+                        'is_from_alias',
+                        True,
+                    )
 
     expr_type = inference.infer_type(ir, ctx.env)
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -567,7 +567,12 @@ def _normalize_view_ptr_expr(
             )
 
             try:
-                ptrcls = setgen.resolve_ptr(ptrsource, ptrname, ctx=ctx)
+                ptrcls = setgen.resolve_ptr(
+                    ptrsource,
+                    ptrname,
+                    track_ref=False,
+                    ctx=ctx,
+                )
 
                 base_ptrcls = ptrcls.get_bases(
                     ctx.env.schema).first(ctx.env.schema)
@@ -655,6 +660,10 @@ def _normalize_view_ptr_expr(
             if base_ptrcls is None:
                 base_ptrcls = shape_expr_ctx.view_rptr.base_ptrcls
                 base_ptrcls_is_alias = shape_expr_ctx.view_rptr.ptrcls_is_alias
+
+            if ptrcls is not None:
+                ctx.env.schema = ptrcls.set_field_value(
+                    ctx.env.schema, 'is_local', True)
 
         ptr_cardinality = None
         ptr_target = inference.infer_type(irexpr, ctx.env)
@@ -830,6 +839,12 @@ def _normalize_view_ptr_expr(
         ctx.env.schema = ptrcls.set_field_value(
             ctx.env.schema,
             'computable',
+            True,
+        )
+
+        ctx.env.schema = ptrcls.set_field_value(
+            ctx.env.schema,
+            'is_local',
             True,
         )
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3403,7 +3403,8 @@ class UpdateEndpointDeleteActions(MetaCommand):
         for link_op, link, orig_schema in self.link_ops:
             if isinstance(link_op, DeleteLink):
                 if (link.generic(orig_schema)
-                        or not link.get_is_local(orig_schema)):
+                        or not link.get_is_local(orig_schema)
+                        or link.is_pure_computable(orig_schema)):
                     continue
                 source = link.get_source(orig_schema)
                 current_source = orig_schema.get_by_id(source.id, None)
@@ -3416,7 +3417,11 @@ class UpdateEndpointDeleteActions(MetaCommand):
                     affected_targets.add(current_target)
                 deletions = True
             else:
-                if link.generic(schema) or not link.get_is_local(schema):
+                if (
+                    link.generic(schema)
+                    or not link.get_is_local(schema)
+                    or link.is_pure_computable(schema)
+                ):
                     continue
                 source = link.get_source(schema)
                 if source.is_view(schema):
@@ -3468,6 +3473,9 @@ class UpdateEndpointDeleteActions(MetaCommand):
                                              field_name='target'):
                 if (not link.get_is_local(schema)
                         or link.is_pure_computable(schema)):
+                    continue
+                source = link.get_source(schema)
+                if source.is_view(schema):
                     continue
                 ptr_stor_info = types.get_pointer_storage_info(
                     link, schema=schema)

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -2871,8 +2871,6 @@ async def _execute_block(conn, block):
     try:
         await conn.execute(sql_text)
     except Exception as e:
-        import edb.common.debug
-        edb.common.debug.dump(e.__dict__)
         position = getattr(e, 'position', None)
         internal_position = getattr(e, 'internal_position', None)
         context = getattr(e, 'context', '')

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -62,6 +62,7 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer, s_abc.Expression):
         super().__init__(*args, **kwargs)
         self._qlast = _qlast
         self._irast = _irast
+        self._origqlast: Optional[qlast_.Expr] = None
 
     def __getstate__(self) -> Dict[str, Any]:
         return {
@@ -77,6 +78,12 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer, s_abc.Expression):
         if self._qlast is None:
             self._qlast = qlparser.parse_fragment(self.text)
         return self._qlast
+
+    @property
+    def origqlast(self) -> qlast_.Base:
+        if self._origqlast is None:
+            self._origqlast = qlparser.parse_fragment(self.origtext)
+        return self._origqlast
 
     @property
     def irast(self) -> Optional[irast_.Command]:
@@ -215,6 +222,7 @@ class ExpressionShell(so.Shell):
         self.refs = tuple(refs) if refs is not None else None
         self._qlast = _qlast
         self._irast = _irast
+        self._origqlast: Optional[qlast_.Expr] = None
 
     def resolve(self, schema: s_schema.Schema) -> Expression:
         return Expression(
@@ -240,6 +248,12 @@ class ExpressionShell(so.Shell):
         else:
             refs = ', '.join(repr(obj) for obj in self.refs)
         return f'<ExpressionShell {self.origtext} refs=({refs})>'
+
+    @property
+    def origqlast(self) -> qlast_.Base:
+        if self._origqlast is None:
+            self._origqlast = qlparser.parse_fragment(self.origtext)
+        return self._origqlast
 
 
 class ExpressionList(checked.FrozenCheckedList[Expression]):

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -359,6 +359,20 @@ class DeleteIndex(
 ):
     astnode = qlast.DropIndex
 
+    def _apply_fields_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        node: qlast.DDLOperation,
+    ) -> None:
+        # When deleting index the original expression acts as a way to
+        # identify the index, so we must retrieve it and write it as "expr".
+        for fop in self.get_subcommands(type=sd.AlterObjectProperty):
+            if fop.property == 'expr':
+                assert isinstance(fop.old_value, s_expr.Expression)
+                node.expr = fop.old_value.origqlast
+                return
+
     @classmethod
     def _cmd_tree_from_ast(
         cls,

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -398,12 +398,11 @@ class AlterProperty(
     ) -> None:
         if op.property == 'target':
             if op.new_value:
-                node.commands.append(qlast.SetLinkType(
-                    type=qlast.ObjectRef(
-                        name=op.new_value.classname.name,  # type: ignore
-                        module=op.new_value.classname.module  # type: ignore
-                    )
-                ))
+                node.commands.append(
+                    qlast.SetPropertyType(
+                        type=utils.typeref_to_ast(schema, op.new_value),
+                    ),
+                )
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -398,6 +398,7 @@ class AlterProperty(
     ) -> None:
         if op.property == 'target':
             if op.new_value:
+                assert isinstance(op.new_value, so.Object)
                 node.commands.append(
                     qlast.SetPropertyType(
                         type=utils.typeref_to_ast(schema, op.new_value),

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -86,11 +86,11 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
         return cmd
 
 
-class AlterMigration(MigrationCommand):
+class AlterMigration(MigrationCommand, sd.AlterObject[Migration]):
     astnode = qlast.AlterMigration
 
 
-class DeleteMigration(MigrationCommand):
+class DeleteMigration(MigrationCommand, sd.DeleteObject[Migration]):
     astnode = qlast.DropMigration
 
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1240,7 +1240,7 @@ class SetPointerType(
         # alter to the type that is compatible (i.e. does not change)
         # with all expressions it is used in.
         vn = scls.get_verbosename(schema)
-        self._prohibit_if_expr_refs(
+        schema, finalize_ast = self._propagate_if_expr_refs(
             schema, context, action=f'alter the type of {vn}')
 
         if not context.canonical:

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -371,23 +371,25 @@ class Type(
         return not self.is_view(schema)
 
     def as_shell(self, schema: s_schema.Schema) -> TypeShell:
+        name = typing.cast(s_name.Name, self.get_name(schema))
+
         if union_of := self.get_union_of(schema):
             return UnionTypeShell(
                 components=[
                     o.as_shell(schema) for o in union_of.objects(schema)
                 ],
-                module=self.get_name(schema).module,
+                module=name.module,
             )
         elif intersection_of := self.get_intersection_of(schema):
             return IntersectionTypeShell(
                 components=[
                     o.as_shell(schema) for o in intersection_of.objects(schema)
                 ],
-                module=self.get_name(schema).module,
+                module=name.module,
             )
         else:
             return TypeShell(
-                name=self.get_name(schema),
+                name=name,
                 schemaclass=type(self),
                 is_abstract=self.get_is_abstract(schema),
             )

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -323,8 +323,8 @@ class BaseSchemaTest(BaseDocTest):
                 ddl_plan = s_ddl.compile_migration(
                     ddl_plan, target_schema, current_schema)
 
-            elif isinstance(stmt, qlast.Delta):
-                # APPLY MIGRATION
+            elif isinstance(stmt, qlast.CommitMigration):
+                # COMMIT MIGRATION
                 migration_cmd = s_ddl.cmd_from_ddl(
                     stmt, schema=current_schema,
                     modaliases={None: default_module},

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -2013,7 +2013,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         )
 
     async def test_edgeql_migration_37(self):
-        # testing schema aliass
+        # testing schema alias
         await self.con.execute("""
             SET MODULE test;
         """)
@@ -2075,7 +2075,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             """)
 
     async def test_edgeql_migration_38(self):
-        # testing schema aliass
+        # testing schema alias
         await self.con.execute("""
             SET MODULE test;
         """)
@@ -2126,7 +2126,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         )
 
     async def test_edgeql_migration_39(self):
-        # testing schema aliass
+        # testing schema alias
         await self.con.execute("""
             SET MODULE test;
         """)
@@ -2207,7 +2207,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             """)
 
     async def test_edgeql_migration_40(self):
-        # testing schema aliass
+        # testing schema alias
         await self.con.execute("""
             SET MODULE test;
         """)
@@ -2290,7 +2290,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         The error appears to be the same as for test_migrations_equivalence_41
     ''')
     async def test_edgeql_migration_41(self):
-        # testing schema aliass
+        # testing schema alias
         await self.con.execute("""
             SET MODULE test;
         """)
@@ -2393,7 +2393,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         The error appears to be the same as for test_migrations_equivalence_42
     ''')
     async def test_edgeql_migration_42(self):
-        # testing schema aliass
+        # testing schema alias
         await self.con.execute("""
             SET MODULE test;
         """)
@@ -3457,11 +3457,10 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         )
 
     @test.xfail('''
-        edgedb.errors.InternalServerError: relation
-        "edgedb_f1a94eb6-dbf2-11e9-a3fb-214b780369d9.f20ba958-dbf2-11e9-8884-5764a7d0627a"
-        does not exist
+        The link is preserved, but not the link property value. Which
+        is a bit odd.
 
-        See `test_edgeql_insert_derived_02` first.
+        See also `test_migrations_equivalence_linkprops_08`.
     ''')
     async def test_edgeql_migration_linkprops_08(self):
         await self.con.execute("""
@@ -3507,7 +3506,18 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.assert_query_result(
             r"""
-                SELECT Base {
+                SELECT Derived {
+                    children := count(.child)
+                };
+            """,
+            [{
+                'children': 1,
+            }],
+        )
+
+        await self.assert_query_result(
+            r"""
+                SELECT Derived {
                     child: {
                         @foo,
                     }
@@ -4783,7 +4793,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # aliass that don't have arrays
+            # alias that don't have arrays
             alias BaseAlias := Base { bar := Base.foo };
             alias CollAlias := Base.foo;
         """)
@@ -4794,7 +4804,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }
         """)
 
-        # make sure that the aliass initialized correctly
+        # make sure that the alias initialized correctly
         await self.assert_query_result(
             r"""SELECT BaseAlias{bar};""",
             [{'bar': 13.5}],
@@ -4809,7 +4819,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # "same" aliass that now have arrays
+            # "same" alias that now have arrays
             alias BaseAlias := Base { bar := [Base.foo] };
             alias CollAlias := [Base.foo];
         """)
@@ -4833,7 +4843,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # aliass that don't have tuples
+            # alias that don't have tuples
             alias BaseAlias := Base { bar := Base.foo };
             alias CollAlias := Base.foo;
         """)
@@ -4845,7 +4855,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }
         """)
 
-        # make sure that the aliass initialized correctly
+        # make sure that the alias initialized correctly
         await self.assert_query_result(
             r"""SELECT BaseAlias{bar};""",
             [{'bar': 14.5}],
@@ -4861,7 +4871,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # "same" aliass that now have tuples
+            # "same" alias that now have tuples
             alias BaseAlias := Base { bar := (Base.name, Base.foo) };
             alias CollAlias := (Base.name, Base.foo);
         """)
@@ -4886,7 +4896,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # aliass that don't have nested collections
+            # alias that don't have nested collections
             alias BaseAlias := Base { bar := Base.foo };
             alias CollAlias := Base.foo;
         """)
@@ -4899,7 +4909,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }
         """)
 
-        # make sure that the aliass initialized correctly
+        # make sure that the alias initialized correctly
         await self.assert_query_result(
             r"""SELECT BaseAlias{bar};""",
             [{'bar': 15.5}],
@@ -4916,7 +4926,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # "same" aliass that now have nested collections
+            # "same" alias that now have nested collections
             alias BaseAlias := Base {
                 bar := (Base.name, Base.number, [Base.foo])
             };
@@ -4942,7 +4952,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # aliass that don't have named tuples
+            # alias that don't have named tuples
             alias BaseAlias := Base { bar := Base.foo };
             alias CollAlias := Base.foo;
         """)
@@ -4954,7 +4964,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }
         """)
 
-        # make sure that the aliass initialized correctly
+        # make sure that the alias initialized correctly
         await self.assert_query_result(
             r"""SELECT BaseAlias{bar};""",
             [{'bar': 16.5}],
@@ -4970,7 +4980,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # "same" aliass that now have named tuples
+            # "same" alias that now have named tuples
             alias BaseAlias := Base {
                 bar := (a := Base.name, b := Base.foo)
             };
@@ -4996,7 +5006,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property bar -> int32;
             };
 
-            # aliass with array<int32>
+            # alias with array<int32>
             alias BaseAlias := Base { data := [Base.bar] };
             alias CollAlias := [Base.bar];
         """)
@@ -5008,7 +5018,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }
         """)
 
-        # make sure that the aliass initialized correctly
+        # make sure that the alias initialized correctly
         await self.assert_query_result(
             r"""SELECT BaseAlias{data};""",
             [{'data': [17]}],
@@ -5024,7 +5034,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property bar -> int32;
             };
 
-            # aliass with array<flaot32>
+            # alias with array<float32>
             alias BaseAlias := Base { data := [Base.foo] };
             alias CollAlias := [Base.foo];
         """)
@@ -5049,7 +5059,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # aliass with tuple<str, int32>
+            # alias with tuple<str, int32>
             alias BaseAlias := Base {
                 data := (Base.name, Base.number)
             };
@@ -5064,7 +5074,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }
         """)
 
-        # make sure that the aliass initialized correctly
+        # make sure that the alias initialized correctly
         await self.assert_query_result(
             r"""SELECT BaseAlias{data};""",
             [{'data': ['coll_18', 18]}],
@@ -5081,7 +5091,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # aliass with tuple<str, int32, float32>
+            # alias with tuple<str, int32, float32>
             alias BaseAlias := Base {
                 data := (Base.name, Base.number, Base.foo)
             };
@@ -5108,7 +5118,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # aliass with tuple<str, int32>
+            # alias with tuple<str, int32>
             alias BaseAlias := Base {
                 data := (Base.name, Base.number)
             };
@@ -5123,7 +5133,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }
         """)
 
-        # make sure that the aliass initialized correctly
+        # make sure that the alias initialized correctly
         await self.assert_query_result(
             r"""SELECT BaseAlias{data};""",
             [{'data': ['test20', 20]}],
@@ -5140,7 +5150,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # aliass with tuple<str, float32>
+            # alias with tuple<str, float32>
             alias BaseAlias := Base {
                 data := (Base.name, Base.foo)
             };
@@ -5166,7 +5176,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # aliass with tuple<str, float32>
+            # alias with tuple<str, float32>
             alias BaseAlias := Base {
                 data := (Base.name, Base.foo)
             };
@@ -5180,7 +5190,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }
         """)
 
-        # make sure that the aliass initialized correctly
+        # make sure that the alias initialized correctly
         await self.assert_query_result(
             r"""SELECT BaseAlias{data};""",
             [{'data': ['coll_21', 21.5]}],
@@ -5196,7 +5206,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> float32;
             };
 
-            # aliass with named tuple<a: str, b: float32>
+            # alias with named tuple<a: str, b: float32>
             alias BaseAlias := Base {
                 data := (a := Base.name, b := Base.foo)
             };

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -875,23 +875,19 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             """)
 
     async def test_edgeql_ddl_link_target_alter_03(self):
-        with self.assertRaisesRegex(
-                edgedb.SchemaDefinitionError,
-                "cannot alter the type of property 'bar' "
-                "because it is used in an expression"):
-            await self.con.execute("""
-                CREATE TYPE test::Foo {
-                    CREATE PROPERTY bar -> int64;
-                };
+        await self.con.execute("""
+            CREATE TYPE test::Foo {
+                CREATE PROPERTY bar -> int64;
+            };
 
-                CREATE TYPE test::Bar {
-                    CREATE MULTI PROPERTY foo -> int64 {
-                        SET default := (SELECT test::Foo.bar);
-                    }
-                };
+            CREATE TYPE test::Bar {
+                CREATE MULTI PROPERTY foo -> int64 {
+                    SET default := (SELECT test::Foo.bar);
+                }
+            };
 
-                ALTER TYPE test::Foo ALTER PROPERTY bar SET TYPE int32;
-            """)
+            ALTER TYPE test::Foo ALTER PROPERTY bar SET TYPE int32;
+        """)
 
     async def test_edgeql_ddl_link_target_alter_04(self):
         await self.con.execute('''
@@ -3644,21 +3640,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             """)
 
     async def test_edgeql_ddl_rename_07(self):
-        with self.assertRaisesRegex(
-                edgedb.SchemaDefinitionError,
-                "cannot rename object type 'test::Foo' "
-                "because it is used in an expression"):
-            await self.con.execute("""
-                CREATE TYPE test::Foo;
+        await self.con.execute("""
+            CREATE TYPE test::Foo;
 
-                CREATE TYPE test::Bar {
-                    CREATE MULTI LINK foo -> test::Foo {
-                        SET default := (SELECT test::Foo);
-                    }
-                };
+            CREATE TYPE test::Bar {
+                CREATE MULTI LINK foo -> test::Foo {
+                    SET default := (SELECT test::Foo);
+                }
+            };
 
-                ALTER TYPE test::Foo RENAME TO test::FooRenamed;
-            """)
+            ALTER TYPE test::Foo RENAME TO test::FooRenamed;
+        """)
 
     @test.xfail('''
         Fails with the below on "CREATE ALIAS Alias2":


### PR DESCRIPTION
This is generally how I plan to tackle the issue of re-compiling the expressions affected by an alter. `DROP/CREATE` would be performed where currently the check for affecting expressions is made.

See `test_migrations_equivalence_index_03` to trigger this.