### PR TITLE
Log connection and compilation stats

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -120,6 +120,9 @@ class flags(metaclass=FlagsMeta):
     pgserver = Flag(
         doc="Show PostgreSQL server logs and log all statements.")
 
+    telemetry = Flag(
+        doc="Log verbose statistics on connections and compiler behavior.")
+
 
 @contextlib.contextmanager
 def timeit(title='block'):

--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -120,7 +120,7 @@ class flags(metaclass=FlagsMeta):
     pgserver = Flag(
         doc="Show PostgreSQL server logs and log all statements.")
 
-    telemetry = Flag(
+    log_metrics = Flag(
         doc="Log verbose statistics on connections and compiler behavior.")
 
 

--- a/edb/common/windowedsum.py
+++ b/edb/common/windowedsum.py
@@ -1,0 +1,67 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+from typing import *
+
+import collections
+import time
+
+
+class WindowedSum:
+    """Keeps the sum of incremented values from the last minute.
+
+    The sum is kept with second precision.
+
+    >>> s = WindowedSum()
+    >>> s += 1
+    >>> s += 1
+    >>> time.sleep(30)
+    >>> s += 1
+    >>> s += 1
+    >>> int(s)
+    4
+    >>> time.sleep(30)
+    >>> int(s)
+    2
+    """
+
+    def __init__(self) -> None:
+        self._maxlen = 60
+        self._buckets = collections.deque([0], maxlen=self._maxlen)
+        self._last_shift_at = 0
+
+    def __iadd__(self, val: float) -> WindowedSum:
+        self.shift()
+        self._buckets[-1] += val
+        return self
+
+    def __int__(self) -> int:
+        self.shift()
+        return int(sum(self._buckets))
+
+    def __float__(self) -> float:
+        self.shift()
+        return float(sum(self._buckets))
+
+    def shift(self) -> None:
+        now = time.monotonic()
+        shift_by = int(min(now - self._last_shift_at, self._maxlen))
+        if shift_by:
+            self._buckets.extend(shift_by * [0])
+            self._last_shift_at = now

--- a/edb/server/baseport.py
+++ b/edb/server/baseport.py
@@ -44,6 +44,7 @@ class Port:
 
         self._compiler_manager = None
         self._serving = False
+        self._compiler_pool_size = procpool.BUFFER_POOL_SIZE
 
     def in_dev_mode(self):
         return self._devmode
@@ -87,6 +88,7 @@ class Port:
             worker_args=self.get_compiler_worker_args(),
             worker_cls=self.get_compiler_worker_cls(),
             name=self.get_compiler_worker_name(),
+            pool_size=self._compiler_pool_size,
         )
 
     async def stop(self):

--- a/edb/server/http/http.pxd
+++ b/edb/server/http/http.pxd
@@ -39,6 +39,7 @@ cdef class HttpResponse:
 
 cdef class HttpProtocol:
 
+    cdef public object server
     cdef:
         object loop
         object parser

--- a/edb/server/http/http.pyx
+++ b/edb/server/http/http.pyx
@@ -25,7 +25,6 @@ import httptools
 from edb.common import debug
 from edb.common import markup
 
-
 HTTPStatus = http.HTTPStatus
 
 
@@ -44,8 +43,9 @@ cdef class HttpResponse:
 
 cdef class HttpProtocol:
 
-    def __init__(self, loop):
+    def __init__(self, loop, server):
         self.loop = loop
+        self.server = server
         self.transport = None
 
         self.parser = httptools.HttpRequestParser(self)
@@ -95,6 +95,7 @@ cdef class HttpProtocol:
         else:
             self.in_response = True
             self.loop.create_task(self._handle_request(req))
+        self.server.last_minute_requests += 1
 
     cdef close(self):
         self.transport.close()

--- a/edb/server/http/port.py
+++ b/edb/server/http/port.py
@@ -42,6 +42,7 @@ class BaseHttpPort(baseport.Port):
                  **kwargs):
 
         super().__init__(**kwargs)
+        self._compiler_pool_size = 0
 
         if protocol != self.get_proto_name():
             raise RuntimeError(f'unknown protocol {protocol!r}')

--- a/edb/server/http/port.py
+++ b/edb/server/http/port.py
@@ -29,7 +29,7 @@ from edb.server import baseport
 from edb.server import cache
 from edb.server import defines
 
-telemetry = logging.getLogger('edb.server.telemetry')
+log_metrics = logging.getLogger('edb.server.metrics')
 
 
 class BaseHttpPort(baseport.Port):
@@ -151,7 +151,7 @@ class BaseHttpPort(baseport.Port):
         while True:
             current = int(self.last_minute_requests)
             if current != last_seen:
-                telemetry.info(
+                log_metrics.info(
                     "HTTP requests for %s-%s in last minute: %d",
                     self.get_proto_name(),
                     self._netport,

--- a/edb/server/http_edgeql_port/protocol.pxd
+++ b/edb/server/http_edgeql_port/protocol.pxd
@@ -23,5 +23,4 @@ from edb.server.cache cimport stmt_cache
 
 cdef class Protocol(http.HttpProtocol):
     cdef:
-        object server
         stmt_cache.StatementsCache query_cache

--- a/edb/server/http_edgeql_port/protocol.pyx
+++ b/edb/server/http_edgeql_port/protocol.pyx
@@ -38,8 +38,7 @@ from edb.server.http cimport http
 cdef class Protocol(http.HttpProtocol):
 
     def __init__(self, loop, server, query_cache):
-        http.HttpProtocol.__init__(self, loop)
-        self.server = server
+        http.HttpProtocol.__init__(self, loop, server)
         self.query_cache = query_cache
 
     async def handle_request(self, http.HttpRequest request,

--- a/edb/server/http_graphql_port/protocol.pxd
+++ b/edb/server/http_graphql_port/protocol.pxd
@@ -23,5 +23,4 @@ from edb.server.cache cimport stmt_cache
 
 cdef class Protocol(http.HttpProtocol):
     cdef:
-        object server
         stmt_cache.StatementsCache query_cache

--- a/edb/server/http_graphql_port/protocol.pyx
+++ b/edb/server/http_graphql_port/protocol.pyx
@@ -61,8 +61,7 @@ CacheEntry = Union[CacheRedirect, compiler.CompiledOperation]
 cdef class Protocol(http.HttpProtocol):
 
     def __init__(self, loop, server, query_cache):
-        http.HttpProtocol.__init__(self, loop)
-        self.server = server
+        http.HttpProtocol.__init__(self, loop, server)
         self.query_cache = query_cache
 
     async def handle_request(self, http.HttpRequest request,

--- a/edb/server/logsetup.py
+++ b/edb/server/logsetup.py
@@ -171,6 +171,6 @@ def setup_logging(log_level, log_destination):
         warnings.filterwarnings('ignore', category=DeprecationWarning,
                                 module=ignored_module)
 
-    if not debug.flags.telemetry:
-        telemetry = logging.getLogger('edb.server.telemetry')
-        telemetry.setLevel(logging.ERROR)
+    if not debug.flags.log_metrics:
+        log_metrics = logging.getLogger('edb.server.metrics')
+        log_metrics.setLevel(logging.ERROR)

--- a/edb/server/logsetup.py
+++ b/edb/server/logsetup.py
@@ -27,6 +27,7 @@ import logging.handlers
 import sys
 import warnings
 
+from edb.common import debug
 from edb.common import term
 
 
@@ -169,3 +170,7 @@ def setup_logging(log_level, log_destination):
     for ignored_module in IGNORE_DEPRECATIONS_IN:
         warnings.filterwarnings('ignore', category=DeprecationWarning,
                                 module=ignored_module)
+
+    if not debug.flags.telemetry:
+        telemetry = logging.getLogger('edb.server.telemetry')
+        telemetry.setLevel(logging.ERROR)

--- a/edb/server/mng_port/edgecon.pxd
+++ b/edb/server/mng_port/edgecon.pxd
@@ -95,6 +95,7 @@ cdef class EdgeConnection:
 
         tuple protocol_version
         tuple max_protocol
+        object timer
 
         object __weakref__
 
@@ -126,3 +127,11 @@ cdef class EdgeConnection:
     cdef get_backend(self)
 
     cdef uint64_t _parse_implicit_limit(self, bytes v) except <uint64_t>-1
+
+
+@cython.final
+cdef class Timer:
+    cdef:
+        dict _durations
+        dict _last_report_timestamp
+        int _threshold_seconds

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -2045,12 +2045,14 @@ cdef class Timer:
     @contextlib.contextmanager
     def timed(self, operation: str):
         ts_start = time.monotonic()
-        yield
-        ts_end = time.monotonic()
-        duration = ts_end - ts_start
-        series = self._durations.setdefault(operation, [])
-        series.append(duration)
-        self.maybe_log_stats(operation, series=series)
+        try:
+            yield
+        finally:
+            ts_end = time.monotonic()
+            duration = ts_end - ts_start
+            series = self._durations.setdefault(operation, [])
+            series.append(duration)
+            self.maybe_log_stats(operation, series=series)
 
     def maybe_log_stats(
         self, operation: str, *, series: Sequence[float] = ()

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -95,6 +95,7 @@ cdef tuple DUMP_VER_MIN = (0, 7)
 cdef tuple DUMP_VER_MAX = (0, 8)
 
 cdef object logger = logging.getLogger('edb.server')
+cdef object telemetry = logging.getLogger('edb.server.telemetry')
 
 DEF QUERY_OPT_IMPLICIT_LIMIT = 0xFF01
 
@@ -2073,7 +2074,7 @@ cdef class Timer:
             return
 
         p = [0] + statistics.quantiles(series, n=100, method="inclusive")
-        logger.info(
+        telemetry.info(
             "%s stats: count=%d, p99=%.4f; p90=%.4f; p50=%.4f; max=%.4f",
             operation,
             len(series),

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -95,7 +95,7 @@ cdef tuple DUMP_VER_MIN = (0, 7)
 cdef tuple DUMP_VER_MAX = (0, 8)
 
 cdef object logger = logging.getLogger('edb.server')
-cdef object telemetry = logging.getLogger('edb.server.telemetry')
+cdef object log_metrics = logging.getLogger('edb.server.metrics')
 
 DEF QUERY_OPT_IMPLICIT_LIMIT = 0xFF01
 
@@ -2074,7 +2074,7 @@ cdef class Timer:
             return
 
         p = [0] + statistics.quantiles(series, n=100, method="inclusive")
-        telemetry.info(
+        log_metrics.info(
             "%s stats: count=%d, p99=%.4f; p90=%.4f; p50=%.4f; max=%.4f",
             operation,
             len(series),

--- a/edb/server/mng_port/port.py
+++ b/edb/server/mng_port/port.py
@@ -194,7 +194,7 @@ class ManagementPort(baseport.Port):
         action += "d"
         logger.info(
             "%s a connection with ID %d; %d open",
-            action.capitalize() + "ed",
+            action,
             self._edgecon_id,
             self._num_connections,
         )

--- a/edb/server/mng_port/port.py
+++ b/edb/server/mng_port/port.py
@@ -114,9 +114,11 @@ class ManagementPort(baseport.Port):
 
     def on_client_authed(self):
         self._num_connections += 1
+        self._report_connections()
 
     def on_client_disconnected(self):
         self._num_connections -= 1
+        self._report_connections(action="close")
         if not self._num_connections and self._auto_shutdown:
             self._accepting = False
             raise SystemExit
@@ -184,3 +186,15 @@ class ManagementPort(baseport.Port):
                     self._backends.clear()
             finally:
                 await super().stop()
+
+    def _report_connections(self, *, action: str = "open"):
+        action = action.capitalize()
+        if not action.endswith("e"):
+            action += "e"
+        action += "d"
+        logger.info(
+            "%s a connection with ID %d; %d open",
+            action.capitalize() + "ed",
+            self._edgecon_id,
+            self._num_connections,
+        )

--- a/edb/server/mng_port/port.py
+++ b/edb/server/mng_port/port.py
@@ -35,7 +35,7 @@ from . import edgecon
 
 
 logger = logging.getLogger('edb.server')
-telemetry = logging.getLogger('edb.server.telemetry')
+log_metrics = logging.getLogger('edb.server.metrics')
 
 
 class Backend:
@@ -193,7 +193,7 @@ class ManagementPort(baseport.Port):
         if not action.endswith("e"):
             action += "e"
         action += "d"
-        telemetry.info(
+        log_metrics.info(
             "%s a connection with ID %d; open_count=%d",
             action,
             self._edgecon_id,

--- a/edb/server/mng_port/port.py
+++ b/edb/server/mng_port/port.py
@@ -193,7 +193,7 @@ class ManagementPort(baseport.Port):
             action += "e"
         action += "d"
         logger.info(
-            "%s a connection with ID %d; %d open",
+            "%s a connection with ID %d; open_count=%d",
             action,
             self._edgecon_id,
             self._num_connections,

--- a/edb/server/mng_port/port.py
+++ b/edb/server/mng_port/port.py
@@ -35,6 +35,7 @@ from . import edgecon
 
 
 logger = logging.getLogger('edb.server')
+telemetry = logging.getLogger('edb.server.telemetry')
 
 
 class Backend:
@@ -192,7 +193,7 @@ class ManagementPort(baseport.Port):
         if not action.endswith("e"):
             action += "e"
         action += "d"
-        logger.info(
+        telemetry.info(
             "%s a connection with ID %d; open_count=%d",
             action,
             self._edgecon_id,

--- a/edb/server/notebook_port/protocol.pxd
+++ b/edb/server/notebook_port/protocol.pxd
@@ -23,7 +23,6 @@ from edb.server.cache cimport stmt_cache
 
 cdef class Protocol(http.HttpProtocol):
     cdef:
-        object server
         stmt_cache.StatementsCache query_cache
 
     cdef handle_error(self, http.HttpRequest request,

--- a/edb/server/notebook_port/protocol.pyx
+++ b/edb/server/notebook_port/protocol.pyx
@@ -38,8 +38,7 @@ from edb.server.http cimport http
 cdef class Protocol(http.HttpProtocol):
 
     def __init__(self, loop, server, query_cache):
-        http.HttpProtocol.__init__(self, loop)
-        self.server = server
+        http.HttpProtocol.__init__(self, loop, server)
         self.query_cache = query_cache
 
     cdef handle_error(self, http.HttpRequest request,

--- a/edb/server/procpool/__init__.py
+++ b/edb/server/procpool/__init__.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-__all__ = 'create_manager',
+__all__ = ['create_manager', 'BUFFER_POOL_SIZE']
 
 
-from .pool import create_manager
+from .pool import create_manager, BUFFER_POOL_SIZE

--- a/edb/server/procpool/pool.py
+++ b/edb/server/procpool/pool.py
@@ -43,6 +43,7 @@ WORKER_MOD = __name__.rpartition('.')[0] + '.worker'
 
 
 logger = logging.getLogger("edb.server")
+telemetry = logging.getLogger("edb.server.telemetry")
 
 
 # Inherit sys.path so that import system can find worker class
@@ -256,7 +257,7 @@ class Manager:
         if not action.endswith("e"):
             action += "e"
         action += "d"
-        logger.info(
+        telemetry.info(
             "%s a %s worker with PID %d; used=%d; pool=%d;"
             + " spawned=%d; killed=%d",
             action,

--- a/edb/server/procpool/pool.py
+++ b/edb/server/procpool/pool.py
@@ -270,7 +270,8 @@ class Manager:
 
 
 async def create_manager(*, runstate_dir: str, name: str,
-                         worker_cls: type, worker_args: dict) -> Manager:
+                         worker_cls: type, worker_args: dict,
+                         pool_size: int) -> Manager:
 
     loop = asyncio.get_running_loop()
     pool = Manager(
@@ -278,7 +279,8 @@ async def create_manager(*, runstate_dir: str, name: str,
         runstate_dir=runstate_dir,
         worker_cls=worker_cls,
         worker_args=worker_args,
-        name=name)
+        name=name,
+        pool_size=pool_size)
 
     await pool.start()
     return pool

--- a/edb/server/procpool/pool.py
+++ b/edb/server/procpool/pool.py
@@ -43,7 +43,7 @@ WORKER_MOD = __name__.rpartition('.')[0] + '.worker'
 
 
 logger = logging.getLogger("edb.server")
-telemetry = logging.getLogger("edb.server.telemetry")
+log_metrics = logging.getLogger("edb.server.metrics")
 
 
 # Inherit sys.path so that import system can find worker class
@@ -256,7 +256,7 @@ class Manager:
         if not action.endswith("e"):
             action += "e"
         action += "d"
-        telemetry.info(
+        log_metrics.info(
             "%s a %s worker with PID %d; used=%d; pool=%d;"
             + " spawned=%d; killed=%d",
             action,

--- a/edb/server/procpool/pool.py
+++ b/edb/server/procpool/pool.py
@@ -251,7 +251,6 @@ class Manager:
             for worker in workers_to_kill:
                 g.create_task(worker.close())
 
-
     def _report_workers(self, worker: Worker, *, action: str = "spawn"):
         action = action.capitalize()
         if not action.endswith("e"):

--- a/edb/server/procpool/pool.py
+++ b/edb/server/procpool/pool.py
@@ -257,8 +257,8 @@ class Manager:
             action += "e"
         action += "d"
         logger.info(
-            "%s a %s worker with PID %d; %d used, %d in the pool;"
-            + " %d spawned and %d killed so far",
+            "%s a %s worker with PID %d; used=%d; pool=%d;"
+            + " spawned=%d; killed=%d",
             action,
             self._name,
             worker.get_pid(),

--- a/tests/common/test_windowedsum.py
+++ b/tests/common/test_windowedsum.py
@@ -1,0 +1,59 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+from typing import *  # NoQA
+
+import unittest
+import unittest.mock
+
+from edb.common.windowedsum import WindowedSum
+
+
+class ManualClock:
+    def __init__(self, value: float) -> None:
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+
+class WindowedSumTests(unittest.TestCase):
+    def test_common_windowedsum(self) -> None:
+        monotonic = ManualClock(0)
+        with unittest.mock.patch("time.monotonic", monotonic):
+            s = WindowedSum()
+            s += 1
+            self.assertEqual(1, int(s))
+            monotonic.value += 60
+            self.assertEqual(0, int(s))
+            s += 1
+            s += 2
+            s += 3
+            self.assertEqual(6, int(s))
+            monotonic.value += 59
+            self.assertEqual(6, int(s))
+            s += 4
+            self.assertEqual(10, int(s))
+            monotonic.value += 1.5
+            self.assertEqual(4, int(s))
+            monotonic.value += 1.5
+            s += 5
+            self.assertEqual(9, int(s))
+            monotonic.value += 1.5
+            s += 6
+            self.assertEqual(15, int(s))


### PR DESCRIPTION
Includes:
* number of compiler workers
* time of tokenization and compilation
* number of active management port connections

Part of https://github.com/edgedb/cloud/issues/28

Example session:
```
$ edgedb-server -D /tmp/X
INFO 23887 2020-06-22 18:50:59,023 edb.server: EdgeDB server (1.0-alpha.3+dev.258.g8d78f4a2.d20200622) starting in DEV mode.
INFO 23887 2020-06-22 18:51:01,963 edb.server: Spawned a compiler-mng worker with PID 23963; 0 used, 1 in the pool; 4 spawned and 0 killed so far
INFO 23887 2020-06-22 18:51:01,963 edb.server: Spawned a compiler-mng worker with PID 23962; 0 used, 2 in the pool; 4 spawned and 0 killed so far
INFO 23887 2020-06-22 18:51:01,969 edb.server: Spawned a compiler-mng worker with PID 23965; 0 used, 3 in the pool; 4 spawned and 0 killed so far
INFO 23887 2020-06-22 18:51:01,970 edb.server: Spawned a compiler-mng worker with PID 23964; 0 used, 4 in the pool; 4 spawned and 0 killed so far
INFO 23887 2020-06-22 18:51:01,973 edb.server: Serving on 127.0.0.1:5656
INFO 23887 2020-06-22 18:51:01,973 edb.server: Serving on /tmp/X/.s.EDGEDB.5656
INFO 23887 2020-06-22 18:51:01,973 edb.server: Serving admin on /tmp/X/.s.EDGEDB.admin.5656
INFO 23887 2020-06-22 18:51:13,000 edb.server: Spawned a compiler-mng worker with PID 24096; 1 used, 4 in the pool; 5 spawned and 0 killed so far
INFO 23887 2020-06-22 18:51:13,454 edb.server: Openeded a connection with ID 1; 1 open
INFO 23887 2020-06-22 18:51:13,455 edb.server: Normalizing took 0.000088 seconds
INFO 23887 2020-06-22 18:51:13,802 edb.server: Compilation took 0.347334 seconds
INFO 23887 2020-06-22 18:51:17,263 edb.server: Normalizing took 0.000080 seconds
INFO 23887 2020-06-22 18:51:17,269 edb.server: Compilation took 0.005661 seconds
INFO 23887 2020-06-22 18:51:21,956 edb.server: Normalizing took 0.000095 seconds
INFO 23887 2020-06-22 18:51:22,101 edb.server: Compilation took 0.144910 seconds
INFO 23887 2020-06-22 18:51:25,961 edb.server: Spawned a compiler-mng worker with PID 24245; 2 used, 4 in the pool; 6 spawned and 0 killed so far
INFO 23887 2020-06-22 18:51:26,395 edb.server: Openeded a connection with ID 2; 2 open
INFO 23887 2020-06-22 18:51:26,395 edb.server: Normalizing took 0.000053 seconds
INFO 23887 2020-06-22 18:51:30,776 edb.server: Normalizing took 0.000048 seconds
INFO 23887 2020-06-22 18:51:32,181 edb.server: Closeded a connection with ID 2; 1 open
INFO 23887 2020-06-22 18:51:32,182 edb.server: Killed a compiler-mng worker with PID 23962; 1 used, 4 in the pool; 6 spawned and 1 killed so far
INFO 23887 2020-06-22 18:51:36,108 edb.server: Normalizing took 0.000056 seconds
INFO 23887 2020-06-22 18:51:36,114 edb.server: Compilation took 0.005588 seconds
INFO 23887 2020-06-22 18:51:36,862 edb.server: Closeded a connection with ID 2; 0 open
INFO 23887 2020-06-22 18:51:36,862 edb.server: Killed a compiler-mng worker with PID 23963; 0 used, 4 in the pool; 6 spawned and 2 killed so far
INFO 23887 2020-06-22 18:52:06,503 edb.server: Shutting down.
INFO 23887 2020-06-22 18:52:06,505 edb.server: Killed a compiler-mng worker with PID 24245; 0 used, 0 in the pool; 6 spawned and 3 killed so far
INFO 23887 2020-06-22 18:52:06,505 edb.server: Killed a compiler-mng worker with PID 24096; 0 used, 0 in the pool; 6 spawned and 4 killed so far
INFO 23887 2020-06-22 18:52:06,505 edb.server: Killed a compiler-mng worker with PID 23964; 0 used, 0 in the pool; 6 spawned and 5 killed so far
INFO 23887 2020-06-22 18:52:06,505 edb.server: Killed a compiler-mng worker with PID 23965; 0 used, 0 in the pool; 6 spawned and 6 killed so far
$
```