### PR TITLE
Remove most direct references to schema objects at DDL>IR phase

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -37,6 +37,7 @@ from edb.edgeql import qltypes
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
 
+from edb.schema import expraliases as s_aliases
 from edb.schema import functions as s_func
 from edb.schema import name as s_name
 from edb.schema import objects as s_obj
@@ -297,6 +298,20 @@ class Environment:
                                default=default)
         if sobj is not None and sobj is not default:
             self.schema_refs.add(sobj)
+
+            if (
+                isinstance(sobj, s_types.Type)
+                and sobj.get_expr(self.schema) is not None
+            ):
+                # If the type is derived from an ALIAS declaration,
+                # make sure we record the reference to the Alias object
+                # as well for correct delta ordering.
+                alias_objs = self.schema.get_referrers(
+                    sobj,
+                    scls_type=s_aliases.Alias,
+                    field_name='type',
+                )
+                self.schema_refs.update(alias_objs)
 
         return sobj
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1523,6 +1523,10 @@ class SchemaObjectClassValue(typing.NamedTuple):
 
 class SchemaObjectClass(Nonterm):
 
+    def reduce_ALIAS(self, *kids):
+        self.val = SchemaObjectClassValue(
+            itemclass=qltypes.SchemaObjectClass.ALIAS)
+
     def reduce_ANNOTATION(self, *kids):
         self.val = SchemaObjectClassValue(
             itemclass=qltypes.SchemaObjectClass.ANNOTATION)

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -142,6 +142,7 @@ class DescribeLanguage(s_enum.StrEnum):
 
 class SchemaObjectClass(s_enum.StrEnum):
 
+    ALIAS = 'ALIAS'
     ANNOTATION = 'ANNOTATION'
     ARRAY_TYPE = 'ARRAY TYPE'
     CAST = 'CAST'

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -226,6 +226,13 @@ ALTER TYPE schema::Source {
 };
 
 
+CREATE TYPE schema::Alias EXTENDING schema::AnnotationSubject
+{
+    CREATE REQUIRED PROPERTY expr -> std::str;
+    CREATE REQUIRED LINK type -> schema::Type;
+};
+
+
 CREATE TYPE schema::ScalarType
     EXTENDING
         schema::InheritingObject, schema::ConsistencySubject,

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -39,6 +39,7 @@ from edb.schema import constraints as s_constr
 from edb.schema import database as s_db
 from edb.schema import delta as sd
 from edb.schema import expr as s_expr
+from edb.schema import expraliases as s_aliases
 from edb.schema import functions as s_funcs
 from edb.schema import indexes as s_indexes
 from edb.schema import links as s_links
@@ -307,6 +308,42 @@ class DeleteTuple(TupleCommand, adapts=s_types.DeleteTuple):
         return schema
 
 
+class ExprAliasCommand(ObjectMetaCommand):
+    pass
+
+
+class CreateAlias(
+    ExprAliasCommand,
+    CreateObject,
+    adapts=s_aliases.CreateAlias,
+):
+    pass
+
+
+class RenameAlias(
+    ExprAliasCommand,
+    RenameObject,
+    adapts=s_aliases.RenameAlias,
+):
+    pass
+
+
+class AlterAlias(
+    ExprAliasCommand,
+    AlterObject,
+    adapts=s_aliases.AlterAlias,
+):
+    pass
+
+
+class DeleteAlias(
+    ExprAliasCommand,
+    DeleteObject,
+    adapts=s_aliases.DeleteAlias,
+):
+    pass
+
+
 class TupleExprAliasCommand(ObjectMetaCommand):
     pass
 
@@ -314,6 +351,20 @@ class TupleExprAliasCommand(ObjectMetaCommand):
 class CreateTupleExprAlias(
         TupleExprAliasCommand, CreateObject,
         adapts=s_types.CreateTupleExprAlias):
+
+    pass
+
+
+class RenameTupleExprAlias(
+        TupleExprAliasCommand, RenameObject,
+        adapts=s_types.RenameTupleExprAlias):
+
+    pass
+
+
+class AlterTupleExprAlias(
+        TupleExprAliasCommand, AlterObject,
+        adapts=s_types.AlterTupleExprAlias):
 
     pass
 
@@ -361,6 +412,20 @@ class ArrayExprAliasCommand(ObjectMetaCommand):
 class CreateArrayExprAlias(
         ArrayExprAliasCommand, CreateObject,
         adapts=s_types.CreateArrayExprAlias):
+
+    pass
+
+
+class RenameArrayExprAlias(
+        ArrayExprAliasCommand, RenameObject,
+        adapts=s_types.RenameArrayExprAlias):
+
+    pass
+
+
+class AlterArrayExprAlias(
+        ArrayExprAliasCommand, AlterObject,
+        adapts=s_types.AlterArrayExprAlias):
 
     pass
 

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -68,6 +68,7 @@ def get_global_dep_order() -> Tuple[Type[so.Object], ...]:
         # aliases are treated separately because they are not UnqualifiedObject
         types.ArrayExprAlias,
         types.TupleExprAlias,
+        expraliases.Alias,
         lproperties.Property,
         links.Link,
         objtypes.ObjectType,

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -234,6 +234,13 @@ class ExpressionShell(so.Shell):
             self._qlast = qlparser.parse_fragment(self.text)
         return self._qlast
 
+    def __repr__(self) -> str:
+        if self.refs is None:
+            refs = 'N/A'
+        else:
+            refs = ', '.join(repr(obj) for obj in self.refs)
+        return f'<ExpressionShell {self.origtext} refs=({refs})>'
+
 
 class ExpressionList(checked.FrozenCheckedList[Expression]):
 

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -370,22 +370,11 @@ class ObjectTypeCommand(s_types.InheritingTypeCommand[ObjectType],
     pass
 
 
-class CreateObjectType(ObjectTypeCommand,
-                       inheriting.CreateInheritingObject[ObjectType]):
+class CreateObjectType(
+    ObjectTypeCommand,
+    s_types.CreateInheritingType[ObjectType],
+):
     astnode = qlast.CreateObjectType
-
-    @classmethod
-    def _cmd_tree_from_ast(
-        cls,
-        schema: s_schema.Schema,
-        astnode: qlast.DDLOperation,
-        context: sd.CommandContext,
-    ) -> sd.Command:
-        assert isinstance(astnode, qlast.ObjectDDL)
-        cmd = super()._cmd_tree_from_ast(schema, astnode, context)
-        assert isinstance(cmd, sd.QualifiedObjectCommand)
-        cmd = cls._handle_view_op(schema, cmd, astnode, context)
-        return cmd
 
     def _get_ast(
         self,
@@ -426,19 +415,6 @@ class RebaseObjectType(ObjectTypeCommand,
 class AlterObjectType(ObjectTypeCommand,
                       inheriting.AlterInheritingObject[ObjectType]):
     astnode = qlast.AlterObjectType
-
-    @classmethod
-    def _cmd_tree_from_ast(
-        cls,
-        schema: s_schema.Schema,
-        astnode: qlast.DDLOperation,
-        context: sd.CommandContext,
-    ) -> sd.Command:
-        assert isinstance(astnode, qlast.ObjectDDL)
-        cmd = super()._cmd_tree_from_ast(schema, astnode, context)
-        assert isinstance(cmd, sd.QualifiedObjectCommand)
-        cmd = cls._handle_view_op(schema, cmd, astnode, context)
-        return cmd
 
 
 class DeleteObjectType(ObjectTypeCommand,

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -319,19 +319,14 @@ class ReferencedObjectCommand(ReferencedObjectCommandBase[ReferencedT]):
         if parent_ctx is not None:
             assert isinstance(parent_ctx.op, sd.QualifiedObjectCommand)
             referrer_name = parent_ctx.op.classname
-            base_name: str
+            base_ref = utils.ast_to_object_shell(
+                astnode.name,
+                modaliases=context.modaliases,
+                schema=schema,
+                metaclass=cls.get_schema_metaclass(),
+            )
 
-            try:
-                base_ref = utils.ast_to_object(
-                    astnode.name,
-                    modaliases=context.modaliases,
-                    schema=schema,
-                )
-            except errors.InvalidReferenceError:
-                base_name = sn.Name(name)
-            else:
-                base_name = base_ref.get_name(schema)
-
+            base_name = base_ref.name
             quals = cls._classname_quals_from_ast(
                 schema, astnode, base_name, referrer_name, context)
             pnn = sn.get_specialized_name(base_name, referrer_name, *quals)

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -30,6 +30,7 @@ from . import annos as s_anno
 from . import delta as sd
 from . import inheriting
 from . import objects as so
+from . import utils
 
 if TYPE_CHECKING:
     from edb.schema import schema as s_schema
@@ -81,12 +82,17 @@ class RoleCommand(sd.GlobalObjectCommand,
         schema: s_schema.Schema,
         astnode: qlast.ObjectDDL,
         context: sd.CommandContext,
-    ) -> so.ObjectList[Role]:
+    ) -> List[so.ObjectShell]:
         result = []
         for b in getattr(astnode, 'bases', None) or []:
-            result.append(schema.get_global(Role, b.maintype.name))
+            result.append(utils.ast_objref_to_object_shell(
+                b.maintype,
+                metaclass=Role,
+                schema=schema,
+                modaliases=context.modaliases,
+            ))
 
-        return so.ObjectList.create(schema, result)
+        return result
 
 
 class CreateRole(RoleCommand, inheriting.CreateInheritingObject[Role]):

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -366,61 +366,6 @@ def name_to_ast_ref(name: str) -> qlast.ObjectRef:
         )
 
 
-def ast_to_object(
-    node: Union[qlast.TypeName, qlast.ObjectRef],
-    *,
-    metaclass: Optional[Type[so.Object]] = None,
-    modaliases: Mapping[Optional[str], str],
-    schema: s_schema.Schema,
-) -> so.Object:
-
-    ref = ast_to_object_shell(
-        node,
-        metaclass=metaclass,
-        modaliases=modaliases,
-        schema=schema,
-    )
-
-    return ref.resolve(schema)
-
-
-@overload
-def ast_to_type(  # NoQA: F811
-    node: qlast.TypeName, *,
-    metaclass: Type[s_types.TypeT],
-    modaliases: Mapping[Optional[str], str],
-    schema: s_schema.Schema,
-) -> s_types.TypeT:
-    ...
-
-
-@overload
-def ast_to_type(  # NoQA: F811
-    node: qlast.TypeName, *,
-    metaclass: None = None,
-    modaliases: Mapping[Optional[str], str],
-    schema: s_schema.Schema,
-) -> s_types.Type:
-    ...
-
-
-def ast_to_type(  # NoQA: F811
-    node: qlast.TypeName, *,
-    metaclass: Optional[Type[s_types.TypeT]] = None,
-    modaliases: Mapping[Optional[str], str],
-    schema: s_schema.Schema,
-) -> s_types.TypeT:
-
-    ref = ast_to_type_shell(
-        node,
-        metaclass=metaclass,
-        modaliases=modaliases,
-        schema=schema,
-    )
-
-    return ref.resolve(schema)  # type: ignore
-
-
 def is_nontrivial_container(value: Any) -> Optional[Iterable[Any]]:
     trivial_classes = (str, bytes, bytearray, memoryview)
     if (isinstance(value, collections.abc.Iterable) and

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -398,7 +398,7 @@ class Compiler(BaseCompiler):
         schema = current_tx.get_schema()
 
         if debug.flags.delta_plan:
-            debug.header('Delta Plan')
+            debug.header('Canonical Delta Plan')
             debug.dump(delta, schema=schema)
 
         delta = pg_delta.CommandMeta.adapt(delta)

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_06_15_00_00
+EDGEDB_CATALOG_VERSION = 2020_06_23_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2698,6 +2698,7 @@ class TestExpressions(tb.QueryTestCase):
                 ORDER BY _;
             """,
             [
+                'schema::Alias',
                 'schema::Annotation',
                 'schema::AnnotationSubject',
                 'schema::Array',

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1475,28 +1475,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
-    @test.xfail('''
-        AssertionError: unexpected difference in schema produced by
-        COMMIT MIGRATION and DDL obtained from GET MIGRATION
-        <DeltaRoot source_context=None, canonical=True> (
-            <AlterObjectType classname=default::X ...> (
-                <CreateAnnotationValue
-                 classname=default::std|title@@default|X ...>
-        ...
-
-        DDL text was:
-        CREATE TYPE default::Foo {
-            CREATE SINGLE PROPERTY bar -> std::int64;
-        };
-        CREATE ALIAS default::X {
-            USING (WITH
-                MODULE default
-            SELECT
-                Foo
-            );
-            CREATE ANNOTATION std::title := 'A Foo alias';
-        };
-    ''')
     def test_get_migration_16(self):
         schema = r'''
             type Foo {


### PR DESCRIPTION
The DDL AST -> Delta IR translation phase is not supposed to rely on
objects being present in the schema, and there are a few places where
that still happens, most notably in the handling of Aliases.  The latter
is because `CREATE ALIAS` currently tries to pretend it's really a
`CREATE TYPE ... USING (expr)`, and to know wheter it's `CREATE TYPE` or
`CREATE SCALAR TYPE` it needs to compile the alias expression at AST
translation phase.  Fix this by making aliases into thin wrappers around
the nested type command.  A side-effect of this is that we now have an
explicit `Alias` object in the schema.