### PR TITLE
Describe config

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -66,6 +66,14 @@ class CardinalityModifier(s_enum.StrEnum):
     Required = 'REQUIRED'
 
 
+class DescribeGlobal(s_enum.StrEnum):
+    Schema = 'SCHEMA'
+    SystemConfig = 'SYSTEM CONFIG'
+
+    def to_edgeql(self) -> str:
+        return self.value
+
+
 class Base(ast.AST):
     __abstract_node__ = True
     __ast_hidden__ = {'context'}
@@ -1017,7 +1025,7 @@ class ConfigReset(ConfigOp, FilterMixin):
 class DescribeStmt(Statement):
 
     language: qltypes.DescribeLanguage
-    object: ObjectRef
+    object: typing.Union[ObjectRef, DescribeGlobal]
     options: Options
 
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1659,10 +1659,10 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_DescribeStmt(self, node: qlast.DescribeStmt) -> None:
         self.write(f'DESCRIBE ')
-        if node.object:
-            self.visit(node.object)
+        if isinstance(node.object, qlast.DescribeGlobal):
+            self.write(node.object.to_edgeql())
         else:
-            self.write('SCHEMA')
+            self.visit(node.object)
         if node.language:
             self.write(' AS ', node.language)
         if node.options:

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -483,7 +483,7 @@ def compile_DescribeStmt(
         stmt = irast.SelectStmt()
         init_stmt(stmt, ql, ctx=ictx, parent_ctx=ctx)
 
-        if not ql.object:
+        if ql.object == qlast.DescribeGlobal.Schema:
             if ql.language is qltypes.DescribeLanguage.DDL:
                 # DESCRIBE SCHEMA
                 text = s_ddl.ddl_text_from_schema(
@@ -492,7 +492,31 @@ def compile_DescribeStmt(
             else:
                 raise errors.QueryError(
                     f'cannot describe full schema as {ql.language}')
+
+            ct = typegen.type_to_typeref(
+                ctx.env.get_track_schema_type('std::str'),
+                env=ctx.env,
+            )
+
+            stmt.result = setgen.ensure_set(
+                irast.StringConstant(value=text, typeref=ct),
+                ctx=ictx,
+            )
+
+        elif ql.object == qlast.DescribeGlobal.SystemConfig:
+            if ql.language is qltypes.DescribeLanguage.DDL:
+                function_call = dispatch.compile(
+                    qlast.FunctionCall(
+                        func=('cfg', '_describe_system_config_as_ddl'),
+                    ),
+                    ctx=ictx)
+                assert isinstance(function_call, irast.Set), function_call
+                stmt.result = function_call
+            else:
+                raise errors.QueryError(
+                    f'cannot describe config as {ql.language}')
         else:
+            assert isinstance(ql.object, qlast.ObjectRef), ql.object
             modules = []
             items: DefaultDict[str, List[str]] = defaultdict(list)
             referenced_classes: List[s_obj.ObjectMeta] = []
@@ -654,15 +678,15 @@ def compile_DescribeStmt(
                 masked = textwrap.indent(masked, '# ')
                 text += masked
 
-        ct = typegen.type_to_typeref(
-            ctx.env.get_track_schema_type('std::str'),
-            env=ctx.env,
-        )
+            ct = typegen.type_to_typeref(
+                ctx.env.get_track_schema_type('std::str'),
+                env=ctx.env,
+            )
 
-        stmt.result = setgen.ensure_set(
-            irast.StringConstant(value=text, typeref=ct),
-            ctx=ictx,
-        )
+            stmt.result = setgen.ensure_set(
+                irast.StringConstant(value=text, typeref=ct),
+                ctx=ictx,
+            )
 
         result = fini_stmt(stmt, ql, ctx=ictx, parent_ctx=ctx)
 

--- a/edb/edgeql/parser/grammar/statements.py
+++ b/edb/edgeql/parser/grammar/statements.py
@@ -179,9 +179,17 @@ class DescribeStmt(Nonterm):
     def reduce_DESCRIBE_SCHEMA(self, *kids):
         """%reduce DESCRIBE SCHEMA DescribeFormat"""
         self.val = qlast.DescribeStmt(
-            object=None,
+            object=qlast.DescribeGlobal.Schema,
             language=kids[2].val.language,
             options=kids[2].val.options,
+        )
+
+    def reduce_DESCRIBE_SYSTEM_CONFIG(self, *kids):
+        """%reduce DESCRIBE SYSTEM CONFIG DescribeFormat"""
+        self.val = qlast.DescribeStmt(
+            object=qlast.DescribeGlobal.SystemConfig,
+            language=kids[3].val.language,
+            options=kids[3].val.options,
         )
 
     def reduce_DESCRIBE_SchemaItem(self, *kids):

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -732,7 +732,7 @@ def trace_DescribeStmt(
     ctx: TracerContext,
 ) -> None:
 
-    if node.object:
+    if isinstance(node.object, qlast.ObjectRef):
         fq_name = node.object.name
         if node.object.module:
             fq_name = f'{node.object.module}::{fq_name}'

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -1857,10 +1857,6 @@ class SysConfigFunction(dbops.Function):
         BEGIN
         RETURN QUERY EXECUTE $$
             WITH
-                data_dir AS
-                    (SELECT setting AS dir FROM pg_settings
-                     WHERE name = 'data_directory'),
-
                 config_spec AS
                     (SELECT
                         s.key AS name,

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -308,6 +308,7 @@ def compile_bootstrap_script(
     *,
     single_statement: bool = False,
     expected_cardinality_one: bool = False,
+    output_format: edbcompiler.IoFormat = edbcompiler.IoFormat.JSON,
 ) -> Tuple[s_schema.Schema, str]:
 
     ctx = edbcompiler.new_compiler_context(
@@ -315,7 +316,7 @@ def compile_bootstrap_script(
         single_statement=single_statement,
         expected_cardinality_one=expected_cardinality_one,
         json_parameters=True,
-        output_format=edbcompiler.IoFormat.JSON,
+        output_format=output_format,
     )
 
     return edbcompiler.compile_edgeql_script(compiler, ctx, eql)
@@ -653,6 +654,9 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
         schema_class_layout=stdlib.classlayout,
         bootstrap_mode=True,
     )
+
+    await metaschema.generate_more_support_functions(
+        conn, compiler, stdlib.reflschema)
 
     return schema, stdlib.reflschema, compiler
 

--- a/tests/test_describe_globals.py
+++ b/tests/test_describe_globals.py
@@ -1,0 +1,10 @@
+from edb.testbase import server as tb
+
+
+class TestDescribeRoles(tb.QueryTestCase):
+
+    async def test_describe_system_config(self):
+        result = list(await self.con.fetchall("DESCRIBE SYSTEM CONFIG"))
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], str)
+        self.assertIn('CONFIGURE SYSTEM SET', result[0])

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3923,3 +3923,15 @@ aa';
         """
         DESCRIBE TYPE foo::Bar AS DDL VERBOSE;
         """
+
+    def test_edgeql_syntax_describe_05(self):
+        """
+        DESCRIBE SYSTEM CONFIG;
+% OK %
+        DESCRIBE SYSTEM CONFIG AS DDL;
+        """
+
+    def test_edgeql_syntax_describe_06(self):
+        """
+        DESCRIBE SYSTEM CONFIG AS DDL;
+        """


### PR DESCRIPTION
Adds `DESCRIBE SYSTEM CONFIG`. I'm not sure how to test that. Given that some changes (listen_adresses) interfere with all other tests, some with few tests (`Auth` only blocks auth test, ports blocks more).

Also I'm not sure:
1. Do we need to emit `CONFIG SYSTEM RESET Auth`, as there is a single auth record on empty database, at least in dev mode
2. How to handle "set" parameters like `listen_addresses`. Currently, we can't assign an empty set. But `RESET` may mean a different thing for purposes of dump.

Fixes #1490 