### PR TITLE
Add `make clean`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ docs/_build
 
 !/.coveragerc
 /.vscode
+*.code-workspace
 /.pytest_cache
 /.mypy_cache
 /.vagga

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,7 @@ pygments:
 
 build:
 	pip install -Ue .[docs,test]
+
+
+clean:
+	git clean -Xf -e "!/*.code-workspace" -e "!/*.vscode"


### PR DESCRIPTION
This allows us to clean outdated builds and dependencies from the repo directory, as well as retrigger Cython by removing compiled .c and .h files.