### PR TITLE
Add the syntax of altering a computable to the docs.

### DIFF
--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -153,14 +153,17 @@ Define a new link ``interests`` on the ``User`` object type:
         CREATE MULTI LINK friends -> User
     };
 
-Define a new link ``friends_in_same_town`` as a computable on the
-``User`` object type:
+Define a new link ``special_group`` as a
+:ref:`computable <ref_datamodel_computables>` on the ``User``
+object type, which contains all the friends from the same town:
 
 .. code-block:: edgeql
 
     ALTER TYPE User {
-        CREATE LINK friends_in_same_town := (
-            SELECT __source__.friends FILTER .town = __source__.town)
+        CREATE LINK special_group := (
+            SELECT __source__.friends
+            FILTER .town = __source__.town
+        )
     };
 
 Define a new abstract link ``orderable``, and then a concrete link
@@ -213,6 +216,7 @@ Change the definition of a :ref:`link <ref_datamodel_links>`.
       SET SINGLE
       SET MULTI
       SET TYPE <typename> [, ...]
+      USING (<computable-expr>)
       CREATE ANNOTATION <annotation-name> := <value>
       ALTER ANNOTATION <annotation-name> := <value>
       DROP ANNOTATION <annotation-name>
@@ -286,6 +290,10 @@ The following subcommands are allowed in the ``ALTER LINK`` block:
     Change the target type of the link to the specified type or
     a union of types.  Only valid for concrete links.
 
+:eql:synopsis:`USING (<computable-expr>)`
+    Change the expression of a :ref:`computable <ref_datamodel_computables>`
+    link.  Only valid for concrete links.
+
 :eql:synopsis:`ALTER ANNOTATION <annotation-name>;`
     Alter link annotation :eql:synopsis:`<annotation-name>`.
     See :eql:stmt:`ALTER ANNOTATION <ALTER ANNOTATION>` for details.
@@ -330,22 +338,25 @@ Set the ``title`` annotation of link ``friends`` of object type ``User`` to
         ALTER LINK interests CREATE ANNOTATION title := "Interests";
     };
 
-Add a minimum-length constraint to link ``name`` of object type ``User``:
-
-.. code-block:: edgeql
-
-    ALTER TYPE User {
-        ALTER LINK name {
-            CREATE CONSTRAINT min_len_value(3);
-        };
-    };
-
-
 Rename the abstract link ``orderable`` to ``sorted``:
 
 .. code-block:: edgeql
 
     ALTER ABSTRACT LINK orderable RENAME TO sorted;
+
+Redefine the :ref:`computable <ref_datamodel_computables>` link
+``special_group`` to be those who have some shared interests:
+
+.. code-block:: edgeql
+
+    ALTER TYPE User {
+        CREATE LINK special_group := (
+            SELECT __source__.friends
+            # at least one of the friend's interests
+            # must match the user's
+            FILTER .interests IN __source__.interests
+        )
+    };
 
 
 DROP LINK

--- a/docs/edgeql/ddl/props.rst
+++ b/docs/edgeql/ddl/props.rst
@@ -134,14 +134,15 @@ Define a new link ``address`` on the ``User`` object type:
         CREATE PROPERTY address -> str
     };
 
-Define a new property ``number_of_friends`` as a computable on the
-``User`` object type:
+Define a new property ``number_of_connections`` as a
+:ref:`computable <ref_datamodel_computables>` on the ``User``
+object type counting the number of interests:
 
 .. code-block:: edgeql
 
     ALTER TYPE User {
-        CREATE PROPERTY number_of_friends :=
-            count(__source__.friends)
+        CREATE PROPERTY number_of_connections :=
+            count(.interests)
     };
 
 Define a new abstract link ``orderable`` with ``weight`` property:
@@ -188,6 +189,7 @@ Change the definition of a :ref:`property <ref_datamodel_props>`.
       SET SINGLE
       SET MULTI
       SET TYPE <typename> [, ...]
+      USING (<computable-expr>)
       CREATE ANNOTATION <annotation-name> := <value>
       ALTER ANNOTATION <annotation-name> := <value>
       DROP ANNOTATION <annotation-name>
@@ -268,6 +270,10 @@ The following subcommands are allowed in the ``ALTER LINK`` block:
     Change the target type of the property to the specified type or
     a union of types.  Only valid for concrete properties.
 
+:eql:synopsis:`USING (<computable-expr>)`
+    Change the expression of a :ref:`computable <ref_datamodel_computables>`
+    property.  Only valid for concrete properties.
+
 :eql:synopsis:`ALTER ANNOTATION <annotation-name>;`
     Alter property annotation :eql:synopsis:`<annotation-name>`.
     See :eql:stmt:`ALTER ANNOTATION <ALTER ANNOTATION>` for details.
@@ -318,6 +324,17 @@ Rename the property ``weight`` of link ``orderable`` to ``sort_by``:
 
     ALTER ABSTRACT LINK orderable {
         ALTER PROPERTY weight RENAME TO sort_by;
+    };
+
+Redefine the :ref:`computable <ref_datamodel_computables>` property
+``number_of_connections`` to be the number of friends:
+
+.. code-block:: edgeql
+
+    ALTER TYPE User {
+        ALTER PROPERTY number_of_connections USING (
+            count(.friends)
+        )
     };
 
 


### PR DESCRIPTION
The DDL docs for links and properties now include the syntax for
altering a computable expression and examples of using that syntax.