### PR TITLE
Disable server logging in edb test; plus a couple nit fixes

### DIFF
--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -73,12 +73,15 @@ class Cluster:
     def __init__(
             self, data_dir, *,
             pg_superuser='postgres', port=edgedb_defines.EDGEDB_PORT,
-            runstate_dir=None, env=None, testmode=False):
+            runstate_dir=None, env=None, testmode=False, log_level=None):
         self._pg_dsn = None
         self._data_dir = data_dir
         self._location = data_dir
         self._edgedb_cmd = [sys.executable, '-m', 'edb.server.main',
                             '-D', self._data_dir]
+
+        if log_level:
+            self._edgedb_cmd.extend(['--log-level', log_level])
 
         if devmode.is_in_dev_mode():
             self._edgedb_cmd.append('--devmode')
@@ -276,12 +279,12 @@ class Cluster:
 class TempCluster(Cluster):
     def __init__(
             self, *, data_dir_suffix=None, data_dir_prefix=None,
-            data_dir_parent=None, env=None, testmode=False):
+            data_dir_parent=None, env=None, testmode=False, log_level=None):
         tempdir = tempfile.mkdtemp(
             suffix=data_dir_suffix, prefix=data_dir_prefix,
             dir=data_dir_parent)
         super().__init__(data_dir=tempdir, runstate_dir=tempdir, env=env,
-                         testmode=testmode)
+                         testmode=testmode, log_level=log_level)
 
 
 class RunningCluster(Cluster):

--- a/edb/server/http_graphql_port/protocol.pyx
+++ b/edb/server/http_graphql_port/protocol.pyx
@@ -217,9 +217,9 @@ cdef class Protocol(http.HttpProtocol):
             raise errors.QueryError(e.args[0])
         except Exception as e:
             if isinstance(e, _USER_ERRORS):
-                logger.info("Error rewriting graphql query: %s", e)
+                logger.info("Error rewriting graphql query: %r", e)
             else:
-                logger.warning("Error rewriting graphql query: %s", e)
+                logger.warning("Error rewriting graphql query: %r", e)
             rewritten = None
             rewrite_error = e
             prepared_query = query

--- a/edb/server/logsetup.py
+++ b/edb/server/logsetup.py
@@ -134,6 +134,9 @@ def setup_logging(log_level, log_destination):
         raise RuntimeError('Invalid logging level {!r}'.format(log_level))
 
     if log_level == 'SILENT':
+        logger = logging.getLogger()
+        logger.disabled = True
+        logger.setLevel(logging.CRITICAL)
         return
 
     if log_destination == 'syslog':

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -202,10 +202,12 @@ def _init_cluster(data_dir=None, *, cleanup_atexit=True, init_settings=None):
         _env = {}
 
     if data_dir is None:
-        cluster = edgedb_cluster.TempCluster(env=_env, testmode=True)
+        cluster = edgedb_cluster.TempCluster(
+            env=_env, testmode=True, log_level='s')
         destroy = True
     else:
-        cluster = edgedb_cluster.Cluster(data_dir=data_dir, env=_env)
+        cluster = edgedb_cluster.Cluster(
+            data_dir=data_dir, env=_env, log_level='s')
         destroy = False
 
     if cluster.get_status() == 'not-initialized':

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -659,7 +659,10 @@ class ParallelTextTestResult(unittest.result.TestResult):
             self.errors.append((subtest, self._exc_info_to_string(err, test)))
             self._mirrorOutput = True
 
-            self.ren.report(subtest, Markers.errored)
+            self.ren.report(
+                subtest,
+                Markers.errored,
+                currently_running=list(self.currently_running))
             if self.failfast:
                 self.suite.stop_requested = True
 


### PR DESCRIPTION
Server logging in `edb test` is pointless as it's hidden. All it currently can do is to break tests rendering. Later on we'll need to find a way to capture logging for every test.