### PR TITLE
Allow empty set as a valid value for multi configuration properties

### DIFF
--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -402,10 +402,6 @@ class Set(Base):
         return f'<ir.Set \'{self.path_id}\' at 0x{id(self):x}>'
 
 
-class EmptySet(Set):
-    pass
-
-
 class Command(Base):
     __abstract_node__ = True
 
@@ -453,12 +449,16 @@ class TypeIntrospection(ImmutableExpr):
     typeref: TypeRef
 
 
-class ConstExpr(ImmutableExpr):
+class ConstExpr(Expr):
     __abstract_node__ = True
     typeref: TypeRef
 
 
-class BaseConstant(ConstExpr):
+class EmptySet(Set, ConstExpr):
+    pass
+
+
+class BaseConstant(ConstExpr, ImmutableExpr):
     __abstract_node__ = True
     value: typing.Any
 
@@ -509,7 +509,7 @@ class BytesConstant(BaseConstant):
     value: bytes
 
 
-class ConstantSet(ConstExpr):
+class ConstantSet(ConstExpr, ImmutableExpr):
 
     elements: typing.Tuple[BaseConstant, ...]
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -81,6 +81,11 @@ ALTER TYPE cfg::Config {
     CREATE MULTI PROPERTY multiprop -> std::str {
         CREATE ANNOTATION cfg::internal := 'true';
     };
+
+    CREATE PROPERTY singleprop -> std::str {
+        CREATE ANNOTATION cfg::internal := 'true';
+        SET default := '';
+    };
 };
 
 

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -740,6 +740,65 @@ class TestServerConfig(tb.QueryTestCase, tb.OldCLITestCaseMixin):
                 CONFIGURE SYSTEM RESET multiprop;
             ''')
 
+    async def test_server_proto_configure_07(self):
+        try:
+            await self.con.execute('''
+                CONFIGURE SESSION SET multiprop := {};
+            ''')
+
+            await self.assert_query_result(
+                '''
+                SELECT _ := cfg::Config.multiprop ORDER BY _
+                ''',
+                [],
+            )
+
+            await self.con.execute('''
+                CONFIGURE SYSTEM SET multiprop := {'4'};
+            ''')
+
+            await self.assert_query_result(
+                '''
+                SELECT _ := cfg::Config.multiprop ORDER BY _
+                ''',
+                [],
+            )
+
+            await self.con.execute('''
+                CONFIGURE SESSION SET multiprop := {'5'};
+            ''')
+
+            await self.assert_query_result(
+                '''
+                SELECT _ := cfg::Config.multiprop ORDER BY _
+                ''',
+                [
+                    '5',
+                ],
+            )
+
+            await self.con.execute('''
+                CONFIGURE SESSION RESET multiprop;
+            ''')
+
+            await self.assert_query_result(
+                '''
+                SELECT _ := cfg::Config.multiprop ORDER BY _
+                ''',
+                [
+                    '4',
+                ],
+            )
+
+        finally:
+            await self.con.execute('''
+                CONFIGURE SESSION RESET multiprop;
+            ''')
+
+            await self.con.execute('''
+                CONFIGURE SYSTEM RESET multiprop;
+            ''')
+
     async def test_server_version(self):
         srv_ver = await self.con.fetchone(r"""
             SELECT sys::get_version()


### PR DESCRIPTION
`CONFIGURE SYSTEM SET multiprop := {}` is currently prohibited for no
good reason, so make amends and fix this.

It's unclear if we should allow empty sets in `single` config properties,
so I didn't touch those.