### PR TITLE
Allow annotations to be renamed.

### DIFF
--- a/docs/edgeql/ddl/annotations.rst
+++ b/docs/edgeql/ddl/annotations.rst
@@ -61,6 +61,72 @@ Declare an annotation ``extrainfo``.
     CREATE ABSTRACT ANNOTATION extrainfo;
 
 
+ALTER ABSTRACT ANNOTATION
+=========================
+
+:eql-statement:
+
+
+Change the definition of an :ref:`annotation <ref_datamodel_annotations>`.
+
+.. eql:synopsis::
+
+    ALTER ABSTRACT ANNOTATION <name>
+    [ "{" ] <subcommand>; [...] [ "}" ];
+
+    # where <subcommand> is one of
+
+      RENAME TO <newname>
+      CREATE ANNOTATION <annotation-name> := <value>
+      ALTER ANNOTATION <annotation-name> := <value>
+      DROP ANNOTATION <annotation-name>
+
+
+Description
+-----------
+
+:eql:synopsis:`ALTER ABSTRACT ANNOTATION` changes the definition of an abstract
+annotation.
+
+
+Parameters
+----------
+
+:eql:synopsis:`<name>`
+    The name (optionally module-qualified) of the annotation to alter.
+
+The following subcommands are allowed in the ``ALTER ABSTRACT ANNOTATION``
+block:
+
+:eql:synopsis:`RENAME TO <newname>`
+    Change the name of the annotation to :eql:synopsis:`<newname>`.
+
+:eql:synopsis:`ALTER ANNOTATION <annotation-name>;`
+    Annotations can also have annotations. Change
+    :eql:synopsis:`<annotation-name>` to a specific
+    :eql:synopsis:`<value>`. See :eql:stmt:`ALTER ANNOTATION` for
+    details.
+
+:eql:synopsis:`DROP ANNOTATION <annotation-name>;`
+    Annotations can also have annotations. Remove annotation
+    :eql:synopsis:`<annotation-name>`.
+    See :eql:stmt:`DROP ANNOTATION <DROP ANNOTATION>` for details.
+
+All the subcommands allowed in the ``CREATE ABSTRACT ANNOTATION``
+block are also valid subcommands for ``ALTER ANNOTATION`` block.
+
+
+Examples
+--------
+
+Rename an annotation:
+
+.. code-block:: edgeql
+
+    ALTER ABSTRACT ANNOTATION extrainfo
+        RENAME TO extra_info;
+
+
 DROP ABSTRACT ANNOTATION
 ========================
 
@@ -83,11 +149,11 @@ necessary in this statement.
 Example
 -------
 
-Drop the annotation ``extrainfo``:
+Drop the annotation ``extra_info``:
 
 .. code-block:: edgeql
 
-    DROP ABSTRACT ANNOTATION extrainfo;
+    DROP ABSTRACT ANNOTATION extra_info;
 
 
 CREATE ANNOTATION

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -759,6 +759,10 @@ class CreateAnnotation(CreateExtendingObject):
     inheritable: bool
 
 
+class AlterAnnotation(AlterObject):
+    pass
+
+
 class DropAnnotation(DropObject):
     pass
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1080,6 +1080,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             tag = 'ABSTRACT ANNOTATION'
         self._visit_CreateObject(node, tag, after_name=after_name)
 
+    def visit_AlterAnnotation(self, node: qlast.AlterAnnotation) -> None:
+        self._visit_AlterObject(node, 'ABSTRACT ANNOTATION')
+
     def visit_DropAnnotation(self, node: qlast.DropAnnotation) -> None:
         self._visit_DropObject(node, 'ABSTRACT ANNOTATION')
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -109,6 +109,9 @@ class InnerDDLStmt(Nonterm):
     def reduce_CreateAnnotationStmt(self, *kids):
         self.val = kids[0].val
 
+    def reduce_AlterAnnotationStmt(self, *kids):
+        self.val = kids[0].val
+
     def reduce_DropAnnotationStmt(self, *kids):
         self.val = kids[0].val
 
@@ -751,25 +754,52 @@ class DropScalarTypeStmt(Nonterm):
 #
 # CREATE ANNOTATION
 #
+commands_block(
+    'CreateAnnotation',
+    CreateAnnotationValueStmt,
+)
+
+
 class CreateAnnotationStmt(Nonterm):
     def reduce_CreateAnnotation(self, *kids):
-        r"""%reduce CREATE ABSTRACT ANNOTATION NodeName OptExtendingSimple \
-                    OptCreateCommandsBlock"""
+        r"""%reduce CREATE ABSTRACT ANNOTATION NodeName \
+                    OptCreateAnnotationCommandsBlock"""
         self.val = qlast.CreateAnnotation(
             name=kids[3].val,
-            bases=kids[4].val,
-            commands=kids[5].val,
+            commands=kids[4].val,
             inheritable=False,
         )
 
     def reduce_CreateInheritableAnnotation(self, *kids):
         r"""%reduce CREATE ABSTRACT INHERITABLE ANNOTATION
-                    NodeName OptExtendingSimple OptCreateCommandsBlock"""
+                    NodeName OptCreateCommandsBlock"""
         self.val = qlast.CreateAnnotation(
             name=kids[4].val,
-            bases=kids[5].val,
-            commands=kids[6].val,
+            commands=kids[5].val,
             inheritable=True,
+        )
+
+
+#
+# ALTER ANNOTATION
+#
+commands_block(
+    'AlterAnnotation',
+    RenameStmt,
+    CreateAnnotationValueStmt,
+    AlterAnnotationValueStmt,
+    DropAnnotationValueStmt,
+    opt=False,
+)
+
+
+class AlterAnnotationStmt(Nonterm):
+    def reduce_AlterAnnotation(self, *kids):
+        r"""%reduce ALTER ABSTRACT ANNOTATION NodeName \
+                    AlterAnnotationCommandsBlock"""
+        self.val = qlast.AlterAnnotation(
+            name=kids[3].val,
+            commands=kids[4].val
         )
 
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -962,6 +962,12 @@ class CreateAnnotation(
     op_priority = 1
 
 
+class RenameAnnotation(
+        AnnotationCommand, RenameObject,
+        adapts=s_anno.RenameAnnotation):
+    pass
+
+
 class AlterAnnotation(
         AnnotationCommand, AlterObject, adapts=s_anno.AlterAnnotation):
     pass

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -168,8 +168,12 @@ class CreateAnnotation(AnnotationCommand, sd.CreateObject[Annotation]):
             super()._apply_field_ast(schema, context, node, op)
 
 
-class AlterAnnotation(AnnotationCommand, sd.AlterObject[Annotation]):
+class RenameAnnotation(AnnotationCommand, sd.RenameObject[Annotation]):
     pass
+
+
+class AlterAnnotation(AnnotationCommand, sd.AlterObject[Annotation]):
+    astnode = qlast.AlterAnnotation
 
 
 class DeleteAnnotation(AnnotationCommand, sd.DeleteObject[Annotation]):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2940,6 +2940,56 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             """)
 
+    async def test_edgeql_ddl_annotation_11(self):
+        await self.con.execute("""
+            CREATE ABSTRACT ANNOTATION test::anno11;
+        """)
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE schema
+                SELECT Annotation {
+                    name,
+                }
+                FILTER
+                    .name LIKE 'test::anno11%';
+            ''',
+            [{"name": "test::anno11"}]
+        )
+
+        await self.con.execute("""
+            ALTER ABSTRACT ANNOTATION test::anno11
+                RENAME TO test::anno11_new_name;
+        """)
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE schema
+                SELECT Annotation {
+                    name,
+                }
+                FILTER
+                    .name LIKE 'test::anno11%';
+            ''',
+            [{"name": "test::anno11_new_name"}]
+        )
+
+        await self.con.execute("""
+            DROP ABSTRACT ANNOTATION test::anno11_new_name;
+        """)
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE schema
+                SELECT Annotation {
+                    name,
+                }
+                FILTER
+                    .name LIKE 'test::anno11%';
+            ''',
+            []
+        )
+
     async def test_edgeql_ddl_anytype_01(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidPropertyTargetError,

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2957,25 +2957,25 @@ aa';
         CREATE SCALAR TYPE myenum EXTENDING enum<'foo', 'bar'>;
         """
 
-    def test_edgeql_syntax_ddl_attribute_01(self):
+    def test_edgeql_syntax_ddl_annotation_01(self):
         """
         CREATE ABSTRACT ANNOTATION std::paramtypes;
         """
 
-    def test_edgeql_syntax_ddl_attribute_02(self):
-        """
-        CREATE ABSTRACT ANNOTATION std::paramtypes EXTENDING std::baseattr;
-        """
-
-    def test_edgeql_syntax_ddl_attribute_03(self):
+    def test_edgeql_syntax_ddl_annotation_02(self):
         """
         CREATE ABSTRACT INHERITABLE ANNOTATION std::paramtypes;
         """
 
-    def test_edgeql_syntax_ddl_attribute_04(self):
+    def test_edgeql_syntax_ddl_annotation_03(self):
         """
-        CREATE ABSTRACT INHERITABLE ANNOTATION std::paramtypes
-            EXTENDING std::foo;
+        DROP ABSTRACT ANNOTATION foo::my_annotation;
+        """
+
+    def test_edgeql_syntax_ddl_annotation_04(self):
+        """
+        ALTER ABSTRACT ANNOTATION foo::my_annotation
+            RENAME TO foo::renamed_annotation;
         """
 
     def test_edgeql_syntax_ddl_constraint_01(self):


### PR DESCRIPTION
Add the syntax for ALTER ABSTRACT ANNOTATION.
Update the documentation.

Fixes #762.