### PR TITLE
Pass target name explicitly to the `describe` action

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -114,6 +114,8 @@ jobs:
     - name: Describe
       id: describe
       uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: << tgt.name >>
 
     - name: Publish
       uses: edgedb/edgedb-pkg/integration/linux/upload/<< tgt.platform >><< "-{}".format(tgt.platform_version) if tgt.platform_version >>@master
@@ -170,6 +172,8 @@ jobs:
     - name: Describe
       id: describe
       uses: edgedb/edgedb-pkg/integration/actions/describe-artifact@master
+      with:
+        target: << tgt.name >>
 
     - name: Publish
       env:


### PR DESCRIPTION
Without this, the package version output does not get populated.