### PR TITLE
Implement "script" output compilation mode

### DIFF
--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -50,10 +50,17 @@ class ShapeFormat(enum.Enum):
 
 
 class OutputFormat(enum.Enum):
+    #: Result data output in PostgreSQL format.
     NATIVE = enum.auto()
+    #: Result data output as a single JSON string.
     JSON = enum.auto()
+    #: Result data output as a single PostgreSQL JSONB type value.
     JSONB = enum.auto()
+    #: Result data output as a JSON string for each element in returned set.
     JSON_ELEMENTS = enum.auto()
+    #: Script mode: query result not returned, cardinality of result set
+    #: is returned instead.
+    SCRIPT = enum.auto()
 
 
 class NoVolatilitySentinel:

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -116,6 +116,7 @@ _IO_FORMAT_MAP = {
     enums.IoFormat.BINARY: pg_compiler.OutputFormat.NATIVE,
     enums.IoFormat.JSON: pg_compiler.OutputFormat.JSON,
     enums.IoFormat.JSON_ELEMENTS: pg_compiler.OutputFormat.JSON_ELEMENTS,
+    enums.IoFormat.SCRIPT: pg_compiler.OutputFormat.SCRIPT,
 }
 
 

--- a/edb/server/compiler/enums.py
+++ b/edb/server/compiler/enums.py
@@ -60,3 +60,4 @@ class IoFormat(strenum.StrEnum):
     BINARY = 'BINARY'
     JSON = 'JSON'
     JSON_ELEMENTS = 'JSON_ELEMENTS'
+    SCRIPT = 'SCRIPT'

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -90,6 +90,7 @@ cdef object CARD_MANY = compiler.ResultCardinality.MANY
 cdef object FMT_BINARY = compiler.IoFormat.BINARY
 cdef object FMT_JSON = compiler.IoFormat.JSON
 cdef object FMT_JSON_ELEMENTS = compiler.IoFormat.JSON_ELEMENTS
+cdef object FMT_SCRIPT = compiler.IoFormat.SCRIPT
 
 cdef tuple DUMP_VER_MIN = (0, 7)
 cdef tuple DUMP_VER_MAX = (0, 8)
@@ -710,7 +711,11 @@ cdef class EdgeConnection:
         with self.timer.timed("Query tokenization"):
             eql_tokens = tokenize(eql)
         with self.timer.timed("Query compilation"):
-            units = await self._compile(eql_tokens, stmt_mode=stmt_mode)
+            units = await self._compile(
+                eql_tokens,
+                io_format=FMT_SCRIPT,
+                stmt_mode=stmt_mode,
+            )
 
         new_type_ids = frozenset()
         for query_unit in units:


### PR DESCRIPTION
When a statement is executed as part of a multi-statement script, or
simply in the situation when the statement output is not needed, it
makes no sense to compile the query to produce `Data` messages to only
have them thrown away.

This adds a new `SCRIPT` output mode to the SQL compiler.  Currently, it
simply produces the cardinality of the result set, but can be extended
to return other statement-identifying information, which, for example,
might be useful to track error context.