### PR TITLE
Bump python version in linter configs

### DIFF
--- a/edb/common/struct.py
+++ b/edb/common/struct.py
@@ -19,7 +19,6 @@
 
 from __future__ import annotations
 from typing import *
-from typing_extensions import Final
 
 import collections
 import enum

--- a/edb/repl/table.py
+++ b/edb/repl/table.py
@@ -19,7 +19,6 @@
 
 from __future__ import annotations
 from typing import *
-from typing_extensions import Literal
 
 import math
 import sys

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -19,13 +19,11 @@
 
 from __future__ import annotations
 from typing import *
-from typing_extensions import Final
 
 import builtins
 import collections
 import collections.abc
 import enum
-import sys
 import uuid
 
 from edb import errors
@@ -48,9 +46,6 @@ if TYPE_CHECKING:
     from edb.schema import objtypes
     from edb.schema import delta as sd
     from edb.schema import schema as s_schema
-
-    if sys.version_info <= (3, 7):
-        from typing_extensions import Protocol  # type: ignore
 
     CovT = TypeVar("CovT", covariant=True)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.8
 plugins = edb.tools.mypy.plugin
 follow_imports = normal
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 79
-target-version = ['py37', 'py38']
+target-version = ['py38']


### PR DESCRIPTION
I've got multiple mypy errors after applying this, not sure if these errors are related:
```sh
~ mypy --version
mypy 0.782
~ python -m mypy .
edb/repl/table.py:22:1: error: Incompatible import of "Literal" (imported name has type "typing_extensions._SpecialForm", local name has type "typing._SpecialForm")
edb/common/struct.py:22:1: error: Incompatible import of "Final" (imported name has type "typing_extensions._SpecialForm", local name has type "typing._SpecialForm")
edb/schema/objects.py:22:1: error: Incompatible import of "Final" (imported name has type "typing_extensions._SpecialForm", local name has type "typing._SpecialForm")
edb/schema/objects.py:53: error: unused 'type: ignore' comment
edb/schema/schema.py:73:15: error: Variable "edb.schema.schema.Refs_T" is not valid as a type
edb/schema/schema.py:73:15: note: See https://mypy.readthedocs.io/en/latest/common_issues.html#variables-vs-type-aliases
edb/schema/schema.py:100:27: error: Variable "edb.schema.schema.Refs_T" is not valid as a type
edb/schema/schema.py:100:27: note: See https://mypy.readthedocs.io/en/latest/common_issues.html#variables-vs-type-aliases
edb/schema/schema.py:348:10: error: Variable "edb.schema.schema.Refs_T" is not valid as a type
edb/schema/schema.py:348:10: note: See https://mypy.readthedocs.io/en/latest/common_issues.html#variables-vs-type-aliases
edb/schema/schema.py:354:14: error: Refs_T? has no attribute "mutate"
edb/schema/schema.py:436:13: error: Returning Any from function declared to return Refs_T?
edb/schema/schema.py:470: error: unused 'type: ignore' comment
edb/schema/schema.py:496: error: unused 'type: ignore' comment
edb/schema/schema.py:647:20: error: Value of type Refs_T? is not indexable
edb/schema/schema.py:683:20: error: Value of type Refs_T? is not indexable
edb/schema/schema.py:774:9: error: Returning Any from function declared to return "Optional[Object]"
edb/schema/schema.py:1007: error: unused 'type: ignore' comment
edb/schema/schema.py:1031:9: error: Return value expected
edb/schema/reflection/reader.py:196:10: error: Refs_T? has no attribute "mutate"
Found 17 errors in 5 files (checked 378 source files)
```