### PR TITLE
Correctly fetch `query_work_mem` from the postgres

### DIFF
--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -205,6 +205,7 @@ def spec_to_json(spec: spec.Spec):
             'system': setting.system,
             'typeid': str(typeid),
             'typemod': str(typemod),
+            'backend_setting': setting.backend_setting,
         }
 
     return json.dumps(dct)

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_07_01_00_00
+EDGEDB_CATALOG_VERSION = 2020_07_13_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -304,6 +304,7 @@ class TestServerConfigUtils(unittest.TestCase):
         self.assertEqual(
             json.loads(j)['bool'],
             {
+                'backend_setting': None,
                 'default': True,
                 'internal': False,
                 'system': False,


### PR DESCRIPTION
Fixes #1553

This makes `query_work_mem` be reported from `backend` (like all similar settings), rather than `system override.

But I'm not sure this fixes the whole problem. Because `system override` probably still contains extra quotes, it's just overlayed by backend after this commit (and before for all other settings).