### PR TITLE
Fix restore all

### DIFF
--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_07_13_00_00
+EDGEDB_CATALOG_VERSION = 2020_07_14_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs


### PR DESCRIPTION
This does two things:
1. It doesn't create a database+user named after unix system user. I don't think think makes sense now.
2. Assumes that `edgedb` user is created (and has no password or extending) in `describe roles`, so it alters it

The (1) fixes issue of database+user being created when we're trying to `restore --all` into that database (so we don't conflict on `CREATE ROLE`, note: we can't know which role will be on target system when generating dump, so can't use alter or drop role statements to fix that).

(2) fixes just `edgedb` since it's always created. I still don't like assymetry of `alter role` for `edgedb` vs `create role` for others in `describe roles` (it's fine in dump, but it kinda weird in statement which is meant to "describe").  