### PR TITLE
Fix handling of invalid unqualified references in DDL

### DIFF
--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -475,8 +475,12 @@ def _delta_from_ddl(
 
     with context(sd.DeltaRootContext(schema=schema, op=delta)):
         cmd = cmd_from_ddl(
-            ddl_stmt, schema=schema, modaliases={},
-            context=context, testmode=testmode)
+            ddl_stmt,
+            schema=schema,
+            modaliases=modaliases,
+            context=context,
+            testmode=testmode,
+        )
         schema = cmd.apply(schema, context)
         delta.add(cmd)
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1642,7 +1642,6 @@ class ObjectShell(Shell):
             return schema.get(
                 self.name,
                 type=self.schemaclass,
-                refname=self.origname,
                 sourcectx=self.sourcectx,
             )
         else:

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -813,7 +813,6 @@ class Schema(s_abc.Schema):
         name: str,
         default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
         *,
-        refname: Optional[str] = None,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
         type: Optional[Type[so.Object_T]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
@@ -828,7 +827,6 @@ class Schema(s_abc.Schema):
         name: str,
         default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
         *,
-        refname: Optional[str] = None,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
         type: Optional[Type[so.Object_T]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
@@ -842,7 +840,6 @@ class Schema(s_abc.Schema):
         name: str,
         default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
         *,
-        refname: Optional[str] = None,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
         type: Optional[Type[so.Object_T]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
@@ -870,11 +867,18 @@ class Schema(s_abc.Schema):
             else:
                 label = 'schema item'
 
-        if refname is None:
-            refname = name
+        refname = name
 
         if type is not None:
-            refname = type.get_displayname_static(refname)
+            if not sn.Name.is_qualified(refname):
+                if module_aliases is not None:
+                    default_module = module_aliases.get(None)
+                    if default_module is not None:
+                        refname = type.get_displayname_static(
+                            f'{default_module}::{refname}',
+                        )
+            else:
+                refname = type.get_displayname_static(refname)
 
         raise errors.InvalidReferenceError(
             f'{label} {refname!r} does not exist',

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -476,7 +476,6 @@ class TypeShell(so.ObjectShell):
         return schema.get(
             self.name,
             type=self.schemaclass,
-            refname=self.origname,
             sourcectx=self.sourcectx,
         )
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -356,7 +356,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_13(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidReferenceError,
-                "object type or alias 'self' does not exist"):
+                "object type or alias 'default::self' does not exist"):
             await self.con.execute(r"""
                 CREATE TYPE test::TestBadContainerLinkObjectType {
                     CREATE PROPERTY foo -> std::str {
@@ -1118,7 +1118,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidReferenceError,
-                r"type 'array' does not exist"):
+                r"type 'default::array' does not exist"):
             await self.con.execute(r"""
                 CREATE TYPE test::Foo {
                     CREATE PROPERTY bar -> array;
@@ -1128,7 +1128,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_bad_02(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidReferenceError,
-                r"type 'tuple' does not exist"):
+                r"type 'default::tuple' does not exist"):
             await self.con.execute(r"""
                 CREATE TYPE test::Foo {
                     CREATE PROPERTY bar -> tuple;
@@ -5661,7 +5661,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                     edgedb.errors.InvalidReferenceError,
-                    "improperly formed name 'blah': module is not specified"):
+                    "object type 'test::blah' does not exist"):
                 await self.con.execute('''
                     WITH MODULE test
                     CREATE TYPE Err1 EXTENDING blah {

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -5534,7 +5534,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_bad_reference_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r"object type or alias 'Usr' does not exist",
+                r"object type or alias 'test::Usr' does not exist",
                 _hint="did you mean one of these: User, URL?"):
 
             await self.con.query("""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -147,7 +147,7 @@ _123456789_123456789_123456789 -> str
         """
 
     @tb.must_fail(errors.InvalidReferenceError,
-                  "type 'int' does not exist",
+                  "type 'test::int' does not exist",
                   position=73,
                   hint='did you mean one of these: int16, int32, int64?')
     def test_schema_bad_type_01(self):

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -350,7 +350,7 @@ class TestServerProto(tb.QueryTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.InvalidReferenceError,
-                "object type or alias 'Tmp' does not exist"):
+                "object type or alias 'default::Tmp' does not exist"):
             await self.con.query('''
                 SELECT count(
                     Tmp FILTER Tmp.tmp = "test_server_set_reset_alias_01");
@@ -376,7 +376,7 @@ class TestServerProto(tb.QueryTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.InvalidReferenceError,
-                "object type or alias 'Tmp' does not exist"):
+                "object type or alias 'default::Tmp' does not exist"):
             await self.con.query('''
                 SELECT count(
                     Tmp FILTER Tmp.tmp = "test_server_set_reset_alias_01");

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -84,7 +84,7 @@ class TestSession(tb.QueryTestCase):
         await self.con.query('SET MODULE foo;')
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                "object type or alias 'User' does not exist"):
+                "object type or alias 'foo::User' does not exist"):
             await self.con.query('SELECT User {name};')
 
     async def test_session_set_command_03(self):


### PR DESCRIPTION
When reporting an `InvalidReferenceError` on an unqualified name, use
the default module alias, if available in the error message to make it
clear where the resolution was attempted.

This fixes an abberration noticed by @tailhook in #1425