### PR TITLE
Update the documentation to use the `edgedb server` tooling

### DIFF
--- a/docs/admin/installation.rst
+++ b/docs/admin/installation.rst
@@ -4,182 +4,33 @@
 Installation
 ============
 
-This section describes the installation of EdgeDB using a packaged
-distribution.
+This section describes the recommended way of installing EdgeDB.
 
+The first step is to install the EdgeDB command line tools.
 
-Binary Packages
-===============
-
-EdgeDB packages are available for common Linux distributions and macOS in
-the official `package repository`_.
-
-.. _`package repository`:
-        https://www.edgedb.com/download/
-
-
----------------------------------
-Red Hat Enterprise Linux / CentOS
----------------------------------
-
-Packages are available for RHEL/CentOS 7 and later.
-
-Step 1. Add the EdgeDB package repository:
+If you are using Linux or macOS, open a terminal and enter the following
+command:
 
 .. code-block:: bash
 
-    sudo tee <<'EOF' /etc/yum.repos.d/edgedb.repo
-    [edgedb]
-    name=edgedb
-    baseurl=https://packages.edgedb.com/rpm/el$releasever/
-    enabled=1
-    gpgcheck=1
-    gpgkey=https://packages.edgedb.com/keys/edgedb.asc
-    EOF
+    $ curl --proto '=https' --tlsv1.2 https://sh.edgedb.com -sSf | sh
 
-Step 2. Install the EdgeDB package:
+Follow the script instructions to complete the CLI installation.
+
+Alternatively, you can install ``edgedb-cli`` using a supported package
+manager as described on the `Downloads <https://www.edgedb.com/download/>`_
+page under the "Other Installation Options" section.
 
 
-.. code-block:: bash
+Server installation
+===================
 
-    sudo yum install edgedb-1-alpha3
-
-
----------------
-Debian / Ubuntu
----------------
-
-Step 1. Import the EdgeDB packaging key:
+Once the ``edgedb`` command-line tool is installed, use the following command
+to install the latest EdgeDB server release:
 
 .. code-block:: bash
 
-    curl https://packages.edgedb.com/keys/edgedb.asc \
-        | sudo apt-key add -
+    $ edgedb server install
 
-Step 2. Add the EdgeDB package repository:
-
-.. code-block:: bash
-
-    dist=$(awk -F"=" '/VERSION_CODENAME=/ {print $2}' /etc/os-release)
-    [ -n "${dist}" ] || \
-        dist=$(awk -F"[)(]+" '/VERSION=/ {print $2}' /etc/os-release)
-    echo deb https://packages.edgedb.com/apt ${dist} main \
-        | sudo tee /etc/apt/sources.list.d/edgedb.list
-
-Step 3. Install the EdgeDB package:
-
-.. code-block:: bash
-
-    apt-get update && apt-get install edgedb-1-alpha3
-
-
------
-macOS
------
-
-You can download and install the `macOS EdgeDB package`_ using the normal
-package installation GUI.
-
-It is also possible to install the package from the command line:
-
-.. code-block:: bash
-
-    sudo installer -pkg /path/to/edgedb-1-alpha3_latest.pkg -target /
-
-Next, download the EdgeDB CLI executable:
-
-.. code-block:: bash
-
-    mkdir -p ~/.edgedb/bin/ \
-    && curl https://packages.edgedb.com/dist/macos-x86_64/edgedb-cli_latest \
-        > ~/.edgedb/bin/edgedb \
-    && chmod +x ~/.edgedb/bin/edgedb
-
-
-.. _`macOS EdgeDB package`:
-      https://packages.edgedb.com/dist/macos-x86_64/
-      edgedb-server-1-alpha3_latest.pkg
-
-
-.. _ref_admin_install_docker:
-
-Docker
-======
-
-Step 1. Pull the EdgeDB server Docker image:
-
-.. code-block:: bash
-
-    docker pull edgedb/edgedb
-
-Step 2.  Run the container (replace ``<datadir>`` with the directory you
-want to persist the data in):
-
-.. code-block:: bash
-
-    docker run -it --rm -p 5656:5656 -p 8888:8888 \
-                -p 8889:8889 --name=edgedb-server \
-                -v <datadir>:/var/lib/edgedb/data \
-                edgedb/edgedb
-
-When configuring extra :ref:`ports <ref_admin_config_connection>`, make
-sure to expose them on the host by adding a corresponding ``-p`` argument to
-the ``docker run`` command. The command above exposes the default ports used by
-:ref:`EdgeQL over binary protocol <ref_protocol_overview>` (5656),
-:ref:`EdgeQL over HTTP <ref_edgeql_index>` (8889), and
-:ref:`GraphQL over HTTP <ref_graphql_index>` (8888).
-
-Step3. Download the EdgeDB CLI executable as described below.
-
-
-CLI Installation
-================
-
-To download the EdgeDB CLI tool, follow the instructions below.
-
------
-Linux
------
-
-Download the executable:
-
-.. code-block:: bash
-
-    mkdir -p ~/.local/bin/ \
-    && curl https://packages.edgedb.com/dist/linux-x86_64/edgedb-cli_latest \
-        > ~/.local/bin/edgedb \
-    && chmod +x ~/.local/bin/edgedb
-
-Add ``~/.local/bin`` to ``$PATH`` in ``~/.bash_profile`` or, if you don't
-use Bash, ``~/.profile``:
-
-.. code-block::
-
-   export PATH="$HOME/.local/bin:$PATH"
-
-Apply the ``$PATH`` change to the current shell by running
-``source ~/.bash_profile`` or ``source ~/.profile``.
-
-
------
-macOS
------
-
-Download the executable:
-
-.. code-block:: bash
-
-    mkdir -p ~/.edgedb/bin/ \
-    && curl https://packages.edgedb.com/dist/macos-x86_64/edgedb-cli_latest \
-        > ~/.edgedb/bin/edgedb \
-    && chmod +x ~/.edgedb/bin/edgedb
-
-Add ``~/.edgedb/bin`` to ``$PATH`` in ``~/.bash_profile`` or, if you don't
-use Bash, ``~/.profile``:
-
-.. code-block::
-
-   export PATH="$HOME/.edgedb/bin:$PATH"
-
-Apply the ``$PATH`` change to the current shell by running
-``source ~/.bash_profile`` or ``source ~/.profile``.
+Refer to the command manual page for more information and installation options
+(``edgedb server install --help``).

--- a/docs/admin/setup.rst
+++ b/docs/admin/setup.rst
@@ -12,26 +12,16 @@ necessary in order to start using it.
 Creating an EdgeDB Instance
 ===========================
 
-.. note::
-
-    If you have installed EdgeDB using a pre-built package, a default
-    system-wide instance would have been created
-    (usually in ``/var/lib/edgedb-N/``, where ``N`` is the major version
-    of EdgeDB).  In this case you can skip this section and refer to
-    the installation section appropriate for your OS.
-
 To use EdgeDB you must first create an *instance*.  An EdgeDB instance
 is a collection of *databases* that is managed by a particular running
 EdgeDB server.  The data managed by the instance is usually stored in
 a single directory, which is called the *data directory*.
 
-The EdgeDB server creates and populates a data directory automatically
-on the first run.  The location of the data directory can be specified
-using the ``-D`` option:
+To create a new EdgeDB instance:
 
 .. code-block:: bash
 
-    $ edgedb-server -D /data/directory/path
+    $ edgedb server init -I<instance-name>
 
 The server would then populate the specified directory with the initial
 databases: ``edgedb`` and ``<user>``, where *<user>* the name of
@@ -49,7 +39,7 @@ a newly created instance:
 
 .. code-block:: bash
 
-    $ edgedb --admin -H <edgedb-host> alter-role <username> --password
+    $ edgedb -I<instance-name> --admin alter-role <username> --password
 
 The ``--admin`` option instructs the ``edgedb`` command to connect to
 the server using a dedicated administrative socket that does not require
@@ -67,46 +57,4 @@ method with the ``trust`` method:
 
 .. code-block:: bash
 
-    $ edgedb --admin -H <edgedb-host> configure insert auth --method=trust
-
-
-Using remote PostgreSQL cluster as a backend
-============================================
-
-By default, EdgeDB creates and manages a local PostgreSQL database instance,
-however it is also possible to use a remote PostgreSQL instance, as long as it
-is version 12 or later.  Superuser access to the cluster is *required*.
-
-To setup EdgeDB using a remote PostgreSQL instance, instead of ``-D``,
-specify the ``--postgres-dsn`` option when starting the EdgeDB server:
-
-.. code-block:: bash
-
-    $ edgedb-server \
-        --postgres-dsn 'postgres://user:password@host:port/database?opt=val'
-
-The format of the connection string generally follows that of
-`libpq`_, including support for specifying the connection parameters
-via `environment variables`_ and reading passwords from `the password
-file`_.  Unlike libpq, EdgeDB will treat unrecognized options as
-`PostgreSQL settings`_ to be used for the connection.  Multiple hosts
-in the connection string are unsupported.
-
-.. note::
-
-    PostgreSQL DBaaS providers normally do not allow direct superuser access
-    to the database instance, which might prevent EdgeDB from working
-    correctly.  At this time, only Amazon RDS for PostgreSQL is supported.
-
-
-.. _libpq:
-    https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-
-.. _environment variables:
-    https://www.postgresql.org/docs/current/libpq-envars.html
-
-.. _the password file:
-    https://www.postgresql.org/docs/current/libpq-pgpass.html
-
-.. _PostgreSQL settings:
-    https://www.postgresql.org/docs/current/static/runtime-config.html
+    $ edgedb -I<instance-name> --admin configure insert auth --method=trust

--- a/docs/tutorial/install.rst
+++ b/docs/tutorial/install.rst
@@ -6,42 +6,32 @@
 .. NOTE this is a good place to mention sublime, atom, vs code and vim
 ..      extensions for EdgeDB
 
-The easiest way to install EdgeDB is to pick one of the pre-built packages
-from the `download page`_.  Please follow the installation instructions
-appropriate for your OS.
+The first step is to install the EdgeDB command line tools.  The easiest
+way to do it is to run the installer as shown below.
 
-In most cases, after a successful installation, EdgeDB would automatically
-start a local system-wide server instance.  If it didn't, and you see
-connection errors, run:
-
-On Linux:
+If you are using Linux or macOS, open a terminal and enter the following
+command:
 
 .. code-block:: bash
 
-    $ sudo systemctl start edgedb-server-1-alpha3
+    $ curl --proto '=https' --tlsv1.2 https://sh.edgedb.com -sSf | sh
 
-On macOS:
-
-.. code-block:: bash
-
-    $ sudo launchctl enable system/com.edgedb.edgedb-server-1-alpha3
-
-Once the installation is complete, we need to set the password for the
-database superuser:
+The command downloads a script and starts the installation of the ``edgedb``
+command line tool.  The script might require elevated privileges and might
+ask you for your password.  Once the ``edgedb`` CLI installation is successful,
+run the following command to configure your current shell to be able to
+run ``edgedb`` commands (you only need to do this once):
 
 .. code-block:: bash
 
-    $ sudo -u edgedb edgedb --admin alter-role edgedb --password
+    $ source /home/elvis/.edgedb/env
 
-With that done we should be able to connect to the EdgeDB server instance
-using the newly set password:
+Then, let's install and configure the EdgeDB server:
 
 .. code-block:: bash
 
-    $ edgedb -u edgedb --password
-
-.. _`download page`:
-        https://www.edgedb.com/download/
+    $ edgedb server install
+    $ edgedb server init
 
 With EdgeDB up and running we're ready to
 :ref:`create a schema <ref_tutorial_createdb>`.


### PR DESCRIPTION
Remove the existing low-level guidance on server installation and
configuration and replace it with `edgedb server` instructions.