### PR TITLE
Fix follow_imports configuration in mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 python_version = 3.7
 plugins = edb.tools.mypy.plugin
-follow_imports = False
+follow_imports = normal
 ignore_missing_imports = True
 ignore_errors = True
 warn_redundant_casts = True
@@ -10,12 +10,10 @@ show_column_numbers = True
 
 # To enable type checks on some package, add a section like those below:
 # [mypy-some.package.*]
-# follow_imports = True
 # ignore_errors = False
 # ... etc.
 
 [mypy-edb.edgeql.compiler.*]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -31,7 +29,6 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.edgeql.codegen]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -47,7 +44,6 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.edgeql.tracer]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -64,7 +60,6 @@ no_implicit_reexport = True
 
 
 [mypy-edb.pgsql.compiler.*]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -80,7 +75,6 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.schema.reflection.*]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -96,7 +90,6 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.common.adapter]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -112,7 +105,6 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.common.checked]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -128,7 +120,6 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.common.compiler]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -144,7 +135,6 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.common.ordered]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -160,7 +150,6 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.common.parametric]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -176,7 +165,6 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.common.struct]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -192,7 +180,6 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.common.uuidgen]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -208,7 +195,6 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.ir.*]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -229,7 +215,6 @@ no_implicit_reexport = True
 no_implicit_reexport = False
 
 [mypy-edb.schema.*]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -245,7 +230,6 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.server.config]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -261,11 +245,9 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.server.bootstrap.*]
-follow_imports = True
 ignore_errors = False
 
 [mypy-edb.server.pgconnparams]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -281,19 +263,15 @@ warn_return_any = True
 no_implicit_reexport = True
 
 [mypy-edb.tools.profiling]
-follow_imports = True
 ignore_errors = False
 
 [mypy-edb.tools.profiling.cli]
-follow_imports = True
 ignore_errors = False
 
 [mypy-edb.tools.profiling.profiler]
-follow_imports = True
 ignore_errors = False
 
 [mypy-edb.repl.*]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True
@@ -310,7 +288,6 @@ no_implicit_reexport = True
 
 # edbperf lives under https://github.com/edgedb/edgedb-perf
 [mypy-edbperf.*]
-follow_imports = True
 ignore_errors = False
 # Equivalent of --strict on the command line:
 disallow_subclassing_any = True


### PR DESCRIPTION
True and False are not actually valid values for follow_imports, but
mypy apparently only checks this when they are passed on the command line.
(Fix submitted to mypy: https://github.com/python/mypy/pull/9165).
This leads to unusual and inconsistent mypy behavior.

The intended values for follow_imports here are 'normal' and 'skip',
but it turns out that we do just fine if we set it to normal
everywhere, so do that.