### PR TITLE
Proper implementation of DROP OWNED

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -618,6 +618,26 @@ class AlterDropInherit(DDLOperation, BasesMixin):
     pass
 
 
+class AlterOwned(DDLOperation):
+    owned: bool
+
+
+class AlterPropertyOwned(AlterOwned):
+    pass
+
+
+class AlterLinkOwned(AlterOwned):
+    pass
+
+
+class AlterConstraintOwned(AlterOwned):
+    pass
+
+
+class AlterIndexOwned(AlterOwned):
+    pass
+
+
 class OnTargetDelete(DDLOperation):
     cascade: qltypes.LinkTargetDeleteAction
 
@@ -1096,3 +1116,14 @@ def get_ddl_field_value(
             return cmd.value
 
     return None
+
+
+def has_ddl_subcommand(
+    ddlcmd: DDLOperation,
+    cmdtype: typing.Type[DDLOperation],
+) -> bool:
+    for cmd in ddlcmd.commands:
+        if isinstance(cmd, cmdtype):
+            return True
+    else:
+        return False

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -954,8 +954,6 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             keywords.append('FINAL')
         elif fname == 'required':
             keywords.append('REQUIRED')
-        elif fname == 'is_owned':
-            keywords.append('OWNED')
         elif fname == 'cardinality':
             if node.value:
                 keywords.append(node.value.as_ptr_qual().upper())
@@ -1439,6 +1437,21 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
     def visit_SetLinkType(self, node: qlast.SetLinkType) -> None:
         self.write('SET TYPE ')
         self.visit(node.type)
+
+    def visit_AlterPropertyOwned(self, node: qlast.AlterPropertyOwned) -> None:
+        self.write('SET OWNED' if node.owned else 'DROP OWNED')
+
+    def visit_AlterLinkOwned(self, node: qlast.AlterLinkOwned) -> None:
+        self.write('SET OWNED' if node.owned else 'DROP OWNED')
+
+    def visit_AlterConstraintOwned(
+        self,
+        node: qlast.AlterConstraintOwned,
+    ) -> None:
+        self.write('SET OWNED' if node.owned else 'DROP OWNED')
+
+    def visit_AlterIndexOwned(self, node: qlast.AlterIndexOwned) -> None:
+        self.write('SET OWNED' if node.owned else 'DROP OWNED')
 
     def visit_OnTargetDelete(self, node: qlast.OnTargetDelete) -> None:
         self._write_keywords('ON TARGET DELETE ', node.cascade)

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -365,14 +365,6 @@ class AlterFinal(Nonterm):
             name='is_final', value=True)
 
 
-class AlterOwned(Nonterm):
-    def reduce_DROP_OWNED(self, *kids):
-        self.val = qlast.SetSpecialField(name='is_owned', value=False)
-
-    def reduce_SET_OWNED(self, *kids):
-        self.val = qlast.SetSpecialField(name='is_owned', value=True)
-
-
 class OptInheritPosition(Nonterm):
     def reduce_BEFORE_NodeName(self, *kids):
         self.val = qlast.Position(ref=kids[1].val, position='BEFORE')
@@ -611,12 +603,20 @@ class SetDelegatedStmt(Nonterm):
         )
 
 
+class AlterConstraintOwned(Nonterm):
+    def reduce_DROP_OWNED(self, *kids):
+        self.val = qlast.AlterConstraintOwned(owned=False)
+
+    def reduce_SET_OWNED(self, *kids):
+        self.val = qlast.AlterConstraintOwned(owned=True)
+
+
 commands_block(
     'AlterConcreteConstraint',
     RenameStmt,
     SetFieldStmt,
     SetDelegatedStmt,
-    AlterOwned,
+    AlterConstraintOwned,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -823,10 +823,18 @@ class DropAnnotationStmt(Nonterm):
         )
 
 
+class AlterIndexOwned(Nonterm):
+    def reduce_DROP_OWNED(self, *kids):
+        self.val = qlast.AlterIndexOwned(owned=False)
+
+    def reduce_SET_OWNED(self, *kids):
+        self.val = qlast.AlterIndexOwned(owned=True)
+
+
 commands_block(
     'AlterIndex',
     SetFieldStmt,
-    AlterOwned,
+    AlterIndexOwned,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -1047,12 +1055,20 @@ class SetRequiredStmt(Nonterm):
         )
 
 
+class AlterPropertyOwned(Nonterm):
+    def reduce_DROP_OWNED(self, *kids):
+        self.val = qlast.AlterPropertyOwned(owned=False)
+
+    def reduce_SET_OWNED(self, *kids):
+        self.val = qlast.AlterPropertyOwned(owned=True)
+
+
 commands_block(
     'AlterConcreteProperty',
     UsingStmt,
     RenameStmt,
     SetFieldStmt,
-    AlterOwned,
+    AlterPropertyOwned,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -1258,12 +1274,20 @@ class CreateConcreteLinkStmt(Nonterm):
         )
 
 
+class AlterLinkOwned(Nonterm):
+    def reduce_DROP_OWNED(self, *kids):
+        self.val = qlast.AlterLinkOwned(owned=False)
+
+    def reduce_SET_OWNED(self, *kids):
+        self.val = qlast.AlterLinkOwned(owned=True)
+
+
 commands_block(
     'AlterConcreteLink',
     UsingStmt,
     RenameStmt,
     SetFieldStmt,
-    AlterOwned,
+    AlterLinkOwned,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1077,6 +1077,14 @@ class RenameConstraint(
     pass
 
 
+class AlterConstraintOwned(
+    ConstraintCommand,
+    AlterObject,
+    adapts=s_constr.AlterConstraintOwned,
+):
+    pass
+
+
 class AlterConstraint(
         ConstraintCommand, AlterObject,
         adapts=s_constr.AlterConstraint):
@@ -1773,6 +1781,14 @@ class RenameIndex(IndexCommand, RenameObject, adapts=s_indexes.RenameIndex):
         self.pgops.add(rename)
 
         return schema
+
+
+class AlterIndexOwned(
+    IndexCommand,
+    AlterObject,
+    adapts=s_indexes.AlterIndexOwned,
+):
+    pass
 
 
 class AlterIndex(IndexCommand, AlterObject, adapts=s_indexes.AlterIndex):
@@ -2623,6 +2639,14 @@ class SetLinkType(LinkMetaCommand, adapts=s_links.SetLinkType):
         return LinkMetaCommand.apply(self, schema, context)
 
 
+class AlterLinkOwned(
+    LinkMetaCommand,
+    AlterObject,
+    adapts=s_links.AlterLinkOwned,
+):
+    pass
+
+
 class AlterLink(LinkMetaCommand, adapts=s_links.AlterLink):
     def apply(
         self,
@@ -2952,6 +2976,14 @@ class SetPropertyType(
     ) -> s_schema.Schema:
         schema = s_props.SetPropertyType.apply(self, schema, context)
         return PropertyMetaCommand.apply(self, schema, context)
+
+
+class AlterPropertyOwned(
+    PropertyMetaCommand,
+    AlterObject,
+    adapts=s_props.AlterPropertyOwned,
+):
+    pass
 
 
 class AlterProperty(

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -1030,6 +1030,13 @@ class RenameConstraint(ConstraintCommand, sd.RenameObject[Constraint]):
     pass
 
 
+class AlterConstraintOwned(
+    ConstraintCommand,
+    referencing.AlterOwned[Constraint],
+):
+    astnode = qlast.AlterConstraintOwned
+
+
 class AlterConstraint(
     ConstraintCommand,
     referencing.AlterReferencedInheritingObject[Constraint],

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -249,8 +249,12 @@ class ExpressionList(checked.FrozenCheckedList[Expression]):
                      sources: Sequence[so.Object],
                      field_name: str,
                      *,
+                     ignore_local: bool = False,
                      schema: s_schema.Schema) -> Any:
-        result = target.get_explicit_field_value(schema, field_name, None)
+        if not ignore_local:
+            result = target.get_explicit_field_value(schema, field_name, None)
+        else:
+            result = None
         for source in sources:
             theirs = source.get_explicit_field_value(schema, field_name, None)
             if theirs:

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -386,6 +386,10 @@ class RenameIndex(
         )
 
 
+class AlterIndexOwned(IndexCommand, referencing.AlterOwned[Index]):
+    astnode = qlast.AlterIndexOwned
+
+
 class AlterIndex(
     IndexCommand,
     referencing.AlterReferencedInheritingObject[Index],

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -834,9 +834,6 @@ class RebaseInheritingObject(
 
         assert isinstance(scls, so.InheritingObject)
 
-        for op in self.get_subcommands(type=sd.ObjectCommand):
-            schema = op.apply(schema, context)
-
         if not context.canonical:
             bases = self._apply_base_delta(schema, context, scls)
             schema = scls.set_field_value(schema, 'bases', bases)

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -52,9 +52,13 @@ def merge_actions(
     sources: List[so.Object],
     field_name: str,
     *,
+    ignore_local: bool = False,
     schema: s_schema.Schema,
 ) -> Any:
-    ours = target.get_explicit_local_field_value(schema, field_name, None)
+    if not ignore_local:
+        ours = target.get_explicit_local_field_value(schema, field_name, None)
+    else:
+        ours = None
     if ours is None:
         current = None
         current_from = None
@@ -443,6 +447,14 @@ class SetLinkType(pointers.SetPointerType,
                   referrer_context_class=LinkSourceCommandContext):
 
     astnode = qlast.SetLinkType
+
+
+class AlterLinkOwned(
+    referencing.AlterOwned[Link],
+    schema_metaclass=Link,
+    referrer_context_class=LinkSourceCommandContext,
+):
+    astnode = qlast.AlterLinkOwned
 
 
 class SetTargetDeletePolicy(sd.Command):

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -364,6 +364,14 @@ class SetPropertyType(pointers.SetPointerType,
     astnode = qlast.SetPropertyType
 
 
+class AlterPropertyOwned(
+    referencing.AlterOwned[Property],
+    schema_metaclass=Property,
+    referrer_context_class=PropertySourceContext,
+):
+    astnode = qlast.AlterPropertyOwned
+
+
 class AlterProperty(
     PropertyCommand,
     referencing.AlterReferencedInheritingObject[Property],

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -523,17 +523,20 @@ def minimize_class_set_by_least_generic(
     return result
 
 
-def merge_reduce(target: so.InheritingObjectT,
-                 sources: Iterable[so.InheritingObjectT],
-                 field_name: str,
-                 *,
-                 schema: s_schema.Schema,
-                 f: Callable[[List[Any]], so.InheritingObjectT]) \
-        -> Optional[so.InheritingObjectT]:
+def merge_reduce(
+    target: so.InheritingObjectT,
+    sources: Iterable[so.InheritingObjectT],
+    field_name: str,
+    *,
+    ignore_local: bool,
+    schema: s_schema.Schema,
+    f: Callable[[List[Any]], so.InheritingObjectT],
+) -> Optional[so.InheritingObjectT]:
     values = []
-    ours = target.get_explicit_local_field_value(schema, field_name, None)
-    if ours is not None:
-        values.append(ours)
+    if not ignore_local:
+        ours = target.get_explicit_local_field_value(schema, field_name, None)
+        if ours is not None:
+            values.append(ours)
     for source in sources:
         theirs = source.get_explicit_field_value(schema, field_name, None)
         if theirs is not None:
@@ -545,22 +548,40 @@ def merge_reduce(target: so.InheritingObjectT,
         return None
 
 
-def merge_sticky_bool(target: so.InheritingObjectT,
-                      sources: Iterable[so.InheritingObjectT],
-                      field_name: str,
-                      *,
-                      schema: s_schema.Schema) \
-        -> Optional[so.InheritingObjectT]:
-    return merge_reduce(target, sources, field_name, schema=schema, f=max)
+def merge_sticky_bool(
+    target: so.InheritingObjectT,
+    sources: Iterable[so.InheritingObjectT],
+    field_name: str,
+    *,
+    ignore_local: bool,
+    schema: s_schema.Schema
+) -> Optional[so.InheritingObjectT]:
+    return merge_reduce(
+        target,
+        sources,
+        field_name,
+        ignore_local=ignore_local,
+        schema=schema,
+        f=max,
+    )
 
 
-def merge_weak_bool(target: so.InheritingObjectT,
-                    sources: Iterable[so.InheritingObjectT],
-                    field_name: str,
-                    *,
-                    schema: s_schema.Schema) \
-        -> Optional[so.InheritingObjectT]:
-    return merge_reduce(target, sources, field_name, schema=schema, f=min)
+def merge_weak_bool(
+    target: so.InheritingObjectT,
+    sources: Iterable[so.InheritingObjectT],
+    field_name: str,
+    *,
+    ignore_local: bool,
+    schema: s_schema.Schema,
+) -> Optional[so.InheritingObjectT]:
+    return merge_reduce(
+        target,
+        sources,
+        field_name,
+        ignore_local=ignore_local,
+        schema=schema,
+        f=min,
+    )
 
 
 def get_nq_name(schema: s_schema.Schema,


### PR DESCRIPTION
The syntax for `SET|DROP OWNED` was added in c6cc25da9c46d0, however the 
implementation of `DROP OWNED` there is incomplete.  `DROP OWNED` basically
means "revert this object to its pristine inherited state", and that means
resetting all attributes and dropping all owned refs.