### PR TITLE
Add a new header to the Prepare message to implicitly inline type names

### DIFF
--- a/docs/internals/protocol/messages.rst
+++ b/docs/internals/protocol/messages.rst
@@ -215,6 +215,16 @@ Use:
 * ``JSON_ELEMENTS`` to return a single JSON string per top-level set element.
   This can be used to iterate over a large result set efficiently.
 
+Known headers:
+
+* 0xFF01 ``IMPLICIT_LIMIT`` -- implicit limit for objects returned.
+  Valid format: decimal number encoded as UTF-8 text. Not set by default.
+
+* 0xFF02 ``INLINE_TYPENAMES`` -- if set to "true" all returned objects have
+  a ``__tname__`` property set to their type name (equivalent to having
+  an implicit "__tname__ := .__type__.name" computable.)
+
+
 .. eql:struct:: edb.testbase.protocol.Cardinality
 
 
@@ -403,7 +413,7 @@ Known headers:
 
 * 101 ``BLOCK_TYPE`` -- block type, always "I"
 * 102 ``SERVER_TIME`` -- server time when dump is started as a floating point
-                       unix timestamp stringified
+  unix timestamp stringified
 * 103 ``SERVER_VERSION`` -- full version of server as string
 
 

--- a/docs/internals/protocol/typedesc.rst
+++ b/docs/internals/protocol/typedesc.rst
@@ -275,17 +275,38 @@ Enumeration Type Descriptor
     };
 
 
+Scalar Type Name Annotation
+===========================
+
+Part of the type descriptor when the :ref:`ref_protocol_msg_prepare`
+client message has the ``INLINE_TYPENAMES`` header set.  Every non-builtin
+base scalar type and all enum types would have their full schema name
+provided via this annotation.
+
+.. code-block:: c
+
+    struct TypeAnnotationDescriptor {
+        uint8        type = 0xff;
+
+        // ID of the scalar type.
+        uuid         id;
+
+        // Type name.
+        string       type_name;
+    };
+
+
 Type Annotation Descriptor
 ==========================
 
-Drivers should ignore unknown type annotations.
+Drivers must ignore unknown type annotations.
 
 .. code-block:: c
 
     struct TypeAnnotationDescriptor {
         // Indicates that this is an
         // Type Annotation descriptor.
-        uint8        type = 0xf0..0xff;
+        uint8        type = 0x7f..0xfe;
 
         // ID of the descriptor the
         // annotation is for.

--- a/edb/api/types.txt
+++ b/edb/api/types.txt
@@ -16,55 +16,7 @@
 # limitations under the License.
 #
 
-
-# IMPORTANT: synchronize any changes with docs/internal/protocol/types.rst.
-
-
-# Types encoding in EdgeDB binary protocol:
-#
-#    set:           <type=0> <uuid> <pos>
-#
-#    shape:         <type=1> <uuid>
-#                            <count> [<flags> <str> <pos>]+
-#
-#                   -- where <flags> is 1 byte;
-#                      * 1 << 0 bit: the field wasn't explicitly requested
-#                                    (e.g. "id" or "__type__")
-#                      * 1 << 1 bit: the field is a link property
-#                      * 1 << 2 bit: the field is a link
-#
-#    base scalar:   <type=2> <uuid>
-#
-#    scalar:        <type=3> <uuid> <pos>
-#
-#    tuple:         <type=4> <uuid> <count> [<pos>]*
-#
-#    namedtuple:    <type=5> <uuid> <count> [<str> <pos>]+
-#
-#    array:         <type=6> <uuid> <pos> <count> <int32>+
-#
-#                   -- where <count> specifies the number of dimensions
-#                      and must be >= 1, it is followed by <count> of
-#                      int32 values specifying the cardinality of each
-#                      dimension (-1 means an unbounded dimension).
-#
-#    enum:          <type=7> <uuid> <count> <str>+
-#
-#    type_anno      <type=f0..ff> <uuid> <str>
-#
-#                   -- A type annotation;  0xf0 <= <type> <= 0xff.
-#                      Drivers should ignore unknown type annotations.
-#
-#
-# where:
-#
-#    <pos>         2 bytes (uint16) position of the type in the description
-#    <type>        1 byte  (uint8)
-#    <count>       2 bytes (uint16)
-#    <str>         2 bytes (uint16) length; followed by chars
-
-
-# Base scalar types:
+# Base Scalar Types
 
 00000000-0000-0000-0000-000000000001 anytype
 00000000-0000-0000-0000-000000000002 anytuple

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -127,6 +127,7 @@ def compile_cast(
             with ctx.new() as subctx:
                 subctx.implicit_id_in_shapes = False
                 subctx.implicit_tid_in_shapes = False
+                subctx.implicit_tname_in_shapes = False
                 viewgen.compile_view_shapes(ir_set, ctx=subctx)
         elif (orig_stype.issubclass(ctx.env.schema, json_t)
               and new_stype.is_enum(ctx.env.schema)):

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -450,6 +450,10 @@ class ContextLevel(compiler.ContextLevel):
     implicit_tid_in_shapes: bool
     """Whether to include the type id property in object shapes implicitly."""
 
+    implicit_tname_in_shapes: bool
+    """Whether to include the type name property in object shapes
+       implicitly."""
+
     implicit_limit: int
     """Implicit LIMIT clause in SELECT statements."""
 
@@ -531,6 +535,7 @@ class ContextLevel(compiler.ContextLevel):
             self.toplevel_result_view_name = None
             self.implicit_id_in_shapes = False
             self.implicit_tid_in_shapes = False
+            self.implicit_tname_in_shapes = False
             self.implicit_limit = 0
             self.inhibit_implicit_limit = False
             self.special_computables_in_mutation_shape = frozenset()
@@ -576,6 +581,7 @@ class ContextLevel(compiler.ContextLevel):
             self.toplevel_stmt = prevlevel.toplevel_stmt
             self.implicit_id_in_shapes = prevlevel.implicit_id_in_shapes
             self.implicit_tid_in_shapes = prevlevel.implicit_tid_in_shapes
+            self.implicit_tname_in_shapes = prevlevel.implicit_tname_in_shapes
             self.implicit_limit = prevlevel.implicit_limit
             self.inhibit_implicit_limit = prevlevel.inhibit_implicit_limit
             self.special_computables_in_mutation_shape = \

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -105,6 +105,9 @@ class CompilerOptions(GlobalCompilerOptions):
     #: Include __tid__ computable (.__type__.id) in every shape implicitly.
     implicit_tid_in_shapes: bool = False
 
+    #: Include __tname__ computable (.__type__.name) in every shape implicitly.
+    implicit_tname_in_shapes: bool = False
+
     #: A set of schema types that should be treated
     #: as singletons in the context of this compilation.
     singletons: FrozenSet[s_types.Type] = frozenset()

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -374,6 +374,7 @@ def compile_InsertQuery(
 
             bodyctx.implicit_id_in_shapes = False
             bodyctx.implicit_tid_in_shapes = False
+            bodyctx.implicit_tname_in_shapes = False
             bodyctx.implicit_limit = 0
 
             stmt.subject = compile_query_subject(
@@ -455,6 +456,7 @@ def compile_UpdateQuery(
         with ictx.new() as bodyctx:
             bodyctx.implicit_id_in_shapes = False
             bodyctx.implicit_tid_in_shapes = False
+            bodyctx.implicit_tname_in_shapes = False
             bodyctx.implicit_limit = 0
 
             stmt.subject = compile_query_subject(
@@ -558,6 +560,7 @@ def compile_DeleteQuery(
         with ictx.new() as bodyctx:
             bodyctx.implicit_id_in_shapes = False
             bodyctx.implicit_tid_in_shapes = False
+            bodyctx.implicit_tname_in_shapes = False
             stmt.subject = compile_query_subject(
                 subject,
                 shape=None,
@@ -1118,7 +1121,7 @@ def compile_query_subject(
 
     if (
         ctx.expr_exposed
-        and viewgen.has_implicit_tid(
+        and viewgen.has_implicit_type_computables(
             expr_stype,
             is_mutation=is_insert or is_update or is_delete,
             ctx=ctx,

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -95,6 +95,7 @@ def init_context(
     ctx.toplevel_result_view_name = options.result_view_name
     ctx.implicit_id_in_shapes = options.implicit_id_in_shapes
     ctx.implicit_tid_in_shapes = options.implicit_tid_in_shapes
+    ctx.implicit_tname_in_shapes = options.implicit_tname_in_shapes
     ctx.implicit_limit = options.implicit_limit
 
     return ctx

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -101,6 +101,8 @@ class CompileContext:
     json_parameters: bool = False
     schema_reflection_mode: bool = False
     implicit_limit: int = 0
+    inline_typeids: bool = False
+    inline_typenames: bool = False
     schema_object_ids: Optional[Mapping[str, uuid.UUID]] = None
     source: Optional[edgeql.Source] = None
     backend_instance_params: BackendInstanceParams = BackendInstanceParams()
@@ -581,7 +583,7 @@ class Compiler(BaseCompiler):
 
         single_stmt_mode = ctx.stmt_mode is enums.CompileStatementMode.SINGLE
 
-        implicit_fields = (
+        can_have_implicit_fields = (
             native_out_format and
             single_stmt_mode
         )
@@ -601,8 +603,13 @@ class Compiler(BaseCompiler):
             schema=current_tx.get_schema(),
             options=qlcompiler.CompilerOptions(
                 modaliases=current_tx.get_modaliases(),
-                implicit_tid_in_shapes=implicit_fields,
-                implicit_id_in_shapes=implicit_fields,
+                implicit_tid_in_shapes=(
+                    can_have_implicit_fields and ctx.inline_typeids
+                ),
+                implicit_tname_in_shapes=(
+                    can_have_implicit_fields and ctx.inline_typenames
+                ),
+                implicit_id_in_shapes=can_have_implicit_fields,
                 constant_folding=not disable_constant_folding,
                 json_parameters=ctx.json_parameters,
                 implicit_limit=ctx.implicit_limit,
@@ -1613,6 +1620,8 @@ class Compiler(BaseCompiler):
         stmt_mode: Optional[enums.CompileStatementMode],
         capability: enums.Capability,
         implicit_limit: int=0,
+        inline_typeids: bool=False,
+        inline_typenames: bool=False,
         json_parameters: bool=False,
         schema: Optional[s_schema.Schema] = None,
         schema_object_ids: Optional[Mapping[str, uuid.UUID]] = None,
@@ -1650,6 +1659,8 @@ class Compiler(BaseCompiler):
             output_format=io_format,
             expected_cardinality_one=expect_one,
             implicit_limit=implicit_limit,
+            inline_typeids=inline_typeids,
+            inline_typenames=inline_typenames,
             stmt_mode=stmt_mode,
             json_parameters=json_parameters,
             schema_object_ids=schema_object_ids,
@@ -1667,6 +1678,8 @@ class Compiler(BaseCompiler):
         io_format: enums.IoFormat,
         expect_one: bool,
         implicit_limit: int,
+        inline_typeids: bool,
+        inline_typenames: bool,
         stmt_mode: enums.CompileStatementMode,
     ):
         state = self._load_state(txid)
@@ -1676,6 +1689,8 @@ class Compiler(BaseCompiler):
             output_format=io_format,
             expected_cardinality_one=expect_one,
             implicit_limit=implicit_limit,
+            inline_typeids=inline_typeids,
+            inline_typenames=inline_typenames,
             stmt_mode=stmt_mode,
             source=source,
         )
@@ -1742,6 +1757,7 @@ class Compiler(BaseCompiler):
             io_format=enums.IoFormat.BINARY,
             expect_one=False,
             implicit_limit=implicit_limit,
+            inline_typenames=True,
             modaliases=DEFAULT_MODULE_ALIASES_MAP,
             session_config=EMPTY_MAP,
             stmt_mode=enums.CompileStatementMode.SINGLE,
@@ -1768,6 +1784,8 @@ class Compiler(BaseCompiler):
                     io_format=enums.IoFormat.BINARY,
                     expect_one=False,
                     implicit_limit=implicit_limit,
+                    inline_typeids=False,
+                    inline_typenames=True,
                     stmt_mode=enums.CompileStatementMode.SINGLE,
                 )
 
@@ -1797,6 +1815,8 @@ class Compiler(BaseCompiler):
         io_format: enums.IoFormat,
         expect_one: bool,
         implicit_limit: int,
+        inline_typeids: bool,
+        inline_typenames: bool,
         stmt_mode: enums.CompileStatementMode,
         capability: enums.Capability,
         json_parameters: bool=False,
@@ -1808,6 +1828,8 @@ class Compiler(BaseCompiler):
             io_format=io_format,
             expect_one=expect_one,
             implicit_limit=implicit_limit,
+            inline_typeids=inline_typeids,
+            inline_typenames=inline_typenames,
             modaliases=sess_modaliases,
             session_config=sess_config,
             stmt_mode=enums.CompileStatementMode(stmt_mode),
@@ -1824,6 +1846,8 @@ class Compiler(BaseCompiler):
         io_format: enums.IoFormat,
         expect_one: bool,
         implicit_limit: int,
+        inline_typeids: bool,
+        inline_typenames: bool,
         stmt_mode: enums.CompileStatementMode,
     ) -> List[dbstate.QueryUnit]:
 
@@ -1833,6 +1857,8 @@ class Compiler(BaseCompiler):
             io_format=io_format,
             expect_one=expect_one,
             implicit_limit=implicit_limit,
+            inline_typeids=inline_typeids,
+            inline_typenames=inline_typenames,
             stmt_mode=enums.CompileStatementMode(stmt_mode),
         )
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -644,7 +644,8 @@ class Compiler(BaseCompiler):
             if native_out_format:
                 out_type_data, out_type_id = sertypes.TypeSerializer.describe(
                     ir.schema, ir.stype,
-                    ir.view_shapes, ir.view_shapes_metadata)
+                    ir.view_shapes, ir.view_shapes_metadata,
+                    inline_typenames=ctx.inline_typenames)
             else:
                 out_type_data, out_type_id = \
                     sertypes.TypeSerializer.describe_json()

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -45,6 +45,7 @@ EMPTY_TUPLE_ID = s_obj.get_known_type_id('empty-tuple').bytes
 EMPTY_TUPLE_DESC = b'\x04' + EMPTY_TUPLE_ID + b'\x00\x00'
 
 UUID_TYPE_ID = s_obj.get_known_type_id('std::uuid')
+STR_TYPE_ID = s_obj.get_known_type_id('std::str')
 
 NULL_TYPE_ID = b'\x00' * 16
 NULL_TYPE_DESC = b''
@@ -274,6 +275,12 @@ class TypeSerializer:
                     if el_type != UUID_TYPE_ID:
                         raise errors.InternalServerError(
                             f"{el_name!r} is expected to be a 'std::uuid' "
+                            f"singleton")
+                    flags |= self.EDGE_POINTER_IS_IMPLICIT
+                elif el_name == '__tname__':
+                    if el_type != STR_TYPE_ID:
+                        raise errors.InternalServerError(
+                            f"{el_name!r} is expected to be a 'std::str' "
                             f"singleton")
                     flags |= self.EDGE_POINTER_IS_IMPLICIT
                 if el_l:

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -463,7 +463,7 @@ class TypeSerializer:
             return ArrayDesc(
                 tid=tid, dim_len=dim_len, subtype=codecs_list[pos])
 
-        elif (t >= 0xf0 and t <= 0xff):
+        elif (t >= 0x7f and t <= 0xff):
             # Ignore all type annotations.
             desc.read_len32_prefixed_bytes()
 

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -83,11 +83,8 @@ cdef class DatabaseConnectionView:
     cdef in_tx(self)
     cdef in_tx_error(self)
 
-    cdef cache_compiled_query(self, str eql, object io_format,
-                              bint expect_one, int implicit_limit,
-                              query_unit)
-    cdef lookup_compiled_query(self, str eql, object io_format,
-                               bint expect_one, int implicit_limit)
+    cdef cache_compiled_query(self, object key, object query_unit)
+    cdef lookup_compiled_query(self, object key)
 
     cdef tx_error(self)
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -174,28 +174,23 @@ cdef class DatabaseConnectionView:
     cdef in_tx_error(self):
         return self._tx_error
 
-    cdef cache_compiled_query(self, str eql, object io_format,
-                              bint expect_one, int implicit_limit, query_unit):
-
+    cdef cache_compiled_query(self, object key, object query_unit):
         assert query_unit.cacheable
 
-        key = (eql, io_format, expect_one, implicit_limit,
-               self._modaliases, self._config)
+        key = (key, self._modaliases, self._config)
 
         if self._in_tx_with_ddl:
             self._eql_to_compiled[key] = query_unit
         else:
             self._db._cache_compiled_query(key, query_unit)
 
-    cdef lookup_compiled_query(self, str eql, object io_format,
-                               bint expect_one, int implicit_limit):
+    cdef lookup_compiled_query(self, object key):
         if (self._tx_error or
                 not self._query_cache_enabled or
                 self._in_tx_with_ddl):
             return None
 
-        key = (eql, io_format, expect_one, implicit_limit,
-               self._modaliases, self._config)
+        key = (key, self._modaliases, self._config)
 
         if self._in_tx_with_ddl or self._in_tx_with_set:
             query_unit = self._eql_to_compiled.get(key)

--- a/edb/server/http_edgeql_port/protocol.pyx
+++ b/edb/server/http_edgeql_port/protocol.pyx
@@ -137,6 +137,8 @@ cdef class Protocol(http.HttpProtocol):
                 IoFormat.JSON,  # json mode
                 False,          # expected cardinality is MANY
                 0,              # no implicit limit
+                False,          # no inlining of type IDs
+                False,          # no inlining of type names
                 compiler.CompileStatementMode.SINGLE,
                 compiler.Capability.QUERY,
                 True,           # json parameters

--- a/edb/server/mng_port/consts.pxi
+++ b/edb/server/mng_port/consts.pxi
@@ -17,11 +17,8 @@
 #
 
 
-DEF PROTO_VER_MAJOR = 0
-DEF PROTO_VER_MINOR = 8
-
 cpdef tuple MIN_PROTOCOL = (0, 7)
-cpdef tuple CURRENT_PROTOCOL = (0, 8)
+cpdef tuple CURRENT_PROTOCOL = (0, 9)
 
 DEF DUMP_BLOCK_SIZE = 1024 * 1024 * 10
 

--- a/edb/server/mng_port/edgecon.pxd
+++ b/edb/server/mng_port/edgecon.pxd
@@ -51,6 +51,18 @@ cdef enum EdgeConnectionStatus:
 
 
 @cython.final
+cdef class QueryRequestInfo:
+    cdef public object source  # edgeql.Source
+    cdef public object io_format
+    cdef public bint expect_one
+    cdef public int implicit_limit
+    cdef public bint inline_typeids
+    cdef public bint inline_typenames
+
+    cdef int cached_hash
+
+
+@cython.final
 cdef class CompiledQuery:
     cdef public object query_unit
     cdef public object first_extra  # Optional[int]
@@ -99,8 +111,9 @@ cdef class EdgeConnection:
 
         object __weakref__
 
-    cdef _parse_io_format(self, bytes mode)
+    cdef parse_io_format(self, bytes mode)
     cdef parse_cardinality(self, bytes card)
+    cdef parse_prepare_query_part(self, bint account_for_stmt_name)
     cdef char render_cardinality(self, query_unit) except -1
 
     cdef write(self, WriteBuffer buf)

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -92,7 +92,7 @@ cdef object FMT_JSON_ELEMENTS = compiler.IoFormat.JSON_ELEMENTS
 cdef object FMT_SCRIPT = compiler.IoFormat.SCRIPT
 
 cdef tuple DUMP_VER_MIN = (0, 7)
-cdef tuple DUMP_VER_MAX = (0, 8)
+cdef tuple DUMP_VER_MAX = (0, 9)
 
 cdef object logger = logging.getLogger('edb.server')
 cdef object log_metrics = logging.getLogger('edb.server.metrics')

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -98,6 +98,51 @@ cdef object logger = logging.getLogger('edb.server')
 cdef object log_metrics = logging.getLogger('edb.server.metrics')
 
 DEF QUERY_OPT_IMPLICIT_LIMIT = 0xFF01
+DEF QUERY_OPT_INLINE_TYPENAMES = 0xFF02
+DEF QUERY_OPT_INLINE_TYPEIDS = 0xFF03
+
+
+@cython.final
+cdef class QueryRequestInfo:
+
+    def __cinit__(
+        self,
+        source: edgeql.Source,
+        io_format: object,
+        expect_one: bint,
+        implicit_limit: int,
+        inline_typeids: bint,
+        inline_typenames: bint,
+    ):
+        self.source = source
+        self.io_format = io_format
+        self.expect_one = expect_one
+        self.implicit_limit = implicit_limit
+        self.inline_typeids = inline_typeids
+        self.inline_typenames = inline_typenames
+
+        self.cached_hash = hash((
+            self.source.text(),
+            self.io_format,
+            self.expect_one,
+            self.implicit_limit,
+            self.inline_typeids,
+            self.inline_typenames,
+        ))
+
+    def __hash__(self):
+        return self.cached_hash
+
+    def __eq__(self, other: QueryRequestInfo) -> bool:
+        return (
+            self.source.text() == other.source.text() and
+            self.io_format == other.io_format and
+            self.expect_one == other.expect_one and
+            self.implicit_limit == other.implicit_limit and
+            self.inline_typeids == other.inline_typeids and
+            self.inline_typenames == other.inline_typenames
+        )
+
 
 @cython.final
 cdef class CompiledQuery:
@@ -658,12 +703,9 @@ cdef class EdgeConnection:
 
     async def _compile(
         self,
-        source: edgeql.Source,
+        query_req: QueryRequestInfo,
         *,
-        io_format: compiler.IoFormat = FMT_BINARY,
-        expect_one: bint = False,
         stmt_mode: str = 'single',
-        implicit_limit: uint64_t = 0,
     ):
         if self.dbview.in_tx_error():
             self.dbview.raise_in_tx_error()
@@ -672,10 +714,52 @@ cdef class EdgeConnection:
             return await self.get_backend().compiler.call(
                 'compile_in_tx',
                 self.dbview.txid,
+                query_req.source,
+                query_req.io_format,
+                query_req.expect_one,
+                query_req.implicit_limit,
+                query_req.inline_typeids,
+                query_req.inline_typenames,
+                stmt_mode,
+            )
+        else:
+            return await self.get_backend().compiler.call(
+                'compile',
+                self.dbview.dbver,
+                query_req.source,
+                self.dbview.modaliases,
+                self.dbview.get_session_config(),
+                query_req.io_format,
+                query_req.expect_one,
+                query_req.implicit_limit,
+                query_req.inline_typeids,
+                query_req.inline_typenames,
+                stmt_mode,
+                CAP_ALL,
+            )
+
+    async def _compile_script(
+        self,
+        query: bytes,
+        *,
+        stmt_mode: str = 'single',
+    ):
+        with self.timer.timed("Query tokenization"):
+            source = edgeql.Source.from_string(query.decode('utf-8'))
+
+        if self.dbview.in_tx_error():
+            self.dbview.raise_in_tx_error()
+
+        if self.dbview.in_tx():
+            return await self.get_backend().compiler.call(
+                'compile_in_tx',
+                self.dbview.txid,
                 source,
-                io_format,
-                expect_one,
-                implicit_limit,
+                FMT_SCRIPT,
+                False,
+                0,
+                False,
+                False,
                 stmt_mode,
             )
         else:
@@ -685,9 +769,11 @@ cdef class EdgeConnection:
                 source,
                 self.dbview.modaliases,
                 self.dbview.get_session_config(),
-                io_format,
-                expect_one,
-                implicit_limit,
+                FMT_SCRIPT,
+                False,
+                0,
+                False,
+                False,
                 stmt_mode,
                 CAP_ALL,
             )
@@ -758,14 +844,8 @@ cdef class EdgeConnection:
 
     async def _simple_query(self, eql: bytes):
         stmt_mode = 'all'
-        with self.timer.timed("Query tokenization"):
-            source = edgeql.Source.from_string(eql.decode('utf-8'))
         with self.timer.timed("Query compilation"):
-            units = await self._compile(
-                source,
-                io_format=FMT_SCRIPT,
-                stmt_mode=stmt_mode,
-            )
+            units = await self._compile_script(eql, stmt_mode=stmt_mode)
 
         new_type_ids = frozenset()
         for query_unit in units:
@@ -831,23 +911,19 @@ cdef class EdgeConnection:
     async def _parse(
         self,
         bytes eql,
-        object io_format,
-        bint expect_one,
-        uint64_t implicit_limit,
+        QueryRequestInfo query_req,
     ) -> CompiledQuery:
+        source = query_req.source
+
         if self.debug:
             self.debug_print('PARSE', eql)
-
-        with self.timer.timed("Query tokenization"):
-            source = self._tokenize(eql)
 
         if self.debug:
             self.debug_print('Cache key', source.text())
             self.debug_print('Extra variables', source.variables(),
                              'after', source.first_extra())
 
-        query_unit = self.dbview.lookup_compiled_query(
-            source.text(), io_format, expect_one, implicit_limit)
+        query_unit = self.dbview.lookup_compiled_query(query_req)
         cached = True
         if query_unit is None:
             # Cache miss; need to compile this query.
@@ -865,11 +941,8 @@ cdef class EdgeConnection:
             else:
                 with self.timer.timed("Query compilation"):
                     query_unit = await self._compile(
-                        source,
-                        io_format=io_format,
-                        expect_one=expect_one,
+                        query_req,
                         stmt_mode='single',
-                        implicit_limit=implicit_limit,
                     )
                 query_unit = query_unit[0]
         elif self.dbview.in_tx_error():
@@ -891,9 +964,7 @@ cdef class EdgeConnection:
         )
 
         if not cached and query_unit.cacheable:
-            self.dbview.cache_compiled_query(
-                source.text(), io_format, expect_one,
-                implicit_limit, query_unit)
+            self.dbview.cache_compiled_query(query_req, query_unit)
 
         return CompiledQuery(
             query_unit=query_unit,
@@ -925,7 +996,7 @@ cdef class EdgeConnection:
             raise errors.InternalServerError(
                 f'unknown cardinality {query_unit.cardinality!r}')
 
-    cdef _parse_io_format(self, bytes mode):
+    cdef parse_io_format(self, bytes mode):
         if mode == b'j':
             return FMT_JSON
         elif mode == b'J':
@@ -935,6 +1006,60 @@ cdef class EdgeConnection:
         else:
             raise errors.BinaryProtocolError(
                 f'unknown output mode "{repr(mode)[2:-1]}"')
+
+    cdef parse_prepare_query_part(self, parse_stmt_name: bint):
+        cdef:
+            object io_format
+            bytes eql
+            dict headers
+            uint64_t implicit_limit = 0
+            bint inline_typeids = False
+            bint inline_typenames = False
+            bytes stmt_name = b''
+
+        headers = self.parse_headers()
+        if headers:
+            for k, v in headers.items():
+                if k == QUERY_OPT_IMPLICIT_LIMIT:
+                    implicit_limit = self._parse_implicit_limit(v)
+                elif k == QUERY_OPT_INLINE_TYPEIDS:
+                    inline_typeids = v.lower() == b'true'
+                elif k == QUERY_OPT_INLINE_TYPENAMES:
+                    inline_typenames = v.lower() == b'true'
+                else:
+                    raise errors.BinaryProtocolError(
+                        f'unexpected message header: {k}'
+                    )
+
+        io_format = self.parse_io_format(self.buffer.read_byte())
+        expect_one = (
+            self.parse_cardinality(self.buffer.read_byte()) is CARD_ONE
+        )
+
+        if parse_stmt_name:
+            stmt_name = self.buffer.read_len_prefixed_bytes()
+            if stmt_name:
+                raise errors.UnsupportedFeatureError(
+                    'prepared statements are not yet supported')
+
+        eql = self.buffer.read_len_prefixed_bytes()
+        if not eql:
+            raise errors.BinaryProtocolError('empty query')
+
+        with self.timer.timed("Query normalization"):
+            source = self._tokenize(eql)
+
+        query_req = QueryRequestInfo(
+            source,
+            io_format,
+            expect_one,
+            implicit_limit,
+            inline_typeids,
+            inline_typenames,
+        )
+
+        return eql, query_req, stmt_name
+
 
     cdef inline reject_headers(self):
         cdef int16_t nheaders = self.buffer.read_int16()
@@ -985,39 +1110,13 @@ cdef class EdgeConnection:
 
     async def parse(self):
         cdef:
-            object io_format
             bytes eql
-            dict headers
-            uint64_t implicit_limit = 0
+            QueryRequestInfo query_req
 
         self._last_anon_compiled = None
 
-        headers = self.parse_headers()
-        if headers:
-            for k, v in headers.items():
-                if k == QUERY_OPT_IMPLICIT_LIMIT:
-                    implicit_limit = self._parse_implicit_limit(v)
-                else:
-                    raise errors.BinaryProtocolError(
-                        f'unexpected message header: {k}'
-                    )
-
-        io_format = self._parse_io_format(self.buffer.read_byte())
-        expect_one = (
-            self.parse_cardinality(self.buffer.read_byte()) is CARD_ONE
-        )
-
-        stmt_name = self.buffer.read_len_prefixed_bytes()
-        if stmt_name:
-            raise errors.UnsupportedFeatureError(
-                'prepared statements are not yet supported')
-
-        eql = self.buffer.read_len_prefixed_bytes()
-        if not eql:
-            raise errors.BinaryProtocolError('empty query')
-
-        compiled_query = await self._parse(
-            eql, io_format, expect_one, implicit_limit)
+        eql, query_req, stmt_name = self.parse_prepare_query_part(True)
+        compiled_query = await self._parse(eql, query_req)
 
         buf = WriteBuffer.new_message(b'1')  # ParseComplete
         buf.write_int16(0)  # no headers
@@ -1277,54 +1376,38 @@ cdef class EdgeConnection:
     async def optimistic_execute(self):
         cdef:
             WriteBuffer bound_args_buf
+
+            bytes query
+            QueryRequestInfo query_req
+
             bint process_sync
             bytes in_tid
             bytes out_tid
             bytes bound_args
-            uint64_t implicit_limit = 0
 
         self._last_anon_compiled = None
 
-        headers = self.parse_headers()
-        if headers:
-            for k, v in headers.items():
-                if k == QUERY_OPT_IMPLICIT_LIMIT:
-                    implicit_limit = self._parse_implicit_limit(v)
-                else:
-                    raise errors.BinaryProtocolError(
-                        f'unexpected message header: {k}'
-                    )
+        query, query_req, _ = self.parse_prepare_query_part(False)
 
-        io_format = self._parse_io_format(self.buffer.read_byte())
-        expect_one = (
-            self.parse_cardinality(self.buffer.read_byte()) is CARD_ONE
-        )
-        query = self.buffer.read_len_prefixed_bytes()
         in_tid = self.buffer.read_bytes(16)
         out_tid = self.buffer.read_bytes(16)
         bind_args = self.buffer.read_len_prefixed_bytes()
         self.buffer.finish_message()
 
-        if not query:
-            raise errors.BinaryProtocolError('empty query')
-
-        source = self._tokenize(query)
-        query_unit = self.dbview.lookup_compiled_query(
-            source.text(), io_format, expect_one, implicit_limit)
+        query_unit = self.dbview.lookup_compiled_query(query_req)
         if query_unit is None:
             if self.debug:
                 self.debug_print('OPTIMISTIC EXECUTE /REPARSE', query)
 
-            compiled = await self._parse(
-                query, io_format, expect_one, implicit_limit)
+            compiled = await self._parse(query, query_req)
             self._last_anon_compiled = compiled
             query_unit = compiled.query_unit
         else:
             compiled = CompiledQuery(
                 query_unit=query_unit,
-                first_extra=source.first_extra(),
-                extra_count=source.extra_count(),
-                extra_blob=source.extra_blob(),
+                first_extra=query_req.source.first_extra(),
+                extra_count=query_req.source.extra_count(),
+                extra_blob=query_req.source.extra_blob(),
             )
 
         if (query_unit.in_type_id != in_tid or
@@ -1339,8 +1422,7 @@ cdef class EdgeConnection:
             # "last anonymous statement" *in Postgres*.
             # Otherwise the `await self._execute` below would execute
             # some other query.
-            compiled = await self._parse(
-                query, io_format, expect_one, implicit_limit)
+            compiled = await self._parse(query, query_req)
             self._last_anon_compiled = compiled
             return
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -204,6 +204,29 @@ class TestCase(unittest.TestCase, metaclass=TestCaseMeta):
                                 f'{expected_val!r})') from e
                 raise
 
+    def __getstate__(self):
+        # TestCases get pickled when run in in separate OS processes
+        # via `edb test -jN`. If they reference any unpickleable objects,
+        # the test engine crashes with no indication why and on what test.
+        # That said, most of the TestCases' guts are not needed for the
+        # test results renderer, so we only keep the essential attributes
+        # here.
+
+        outcome = self._outcome
+        if outcome is not None and outcome.errors:
+            # We don't use `test._outcome` to render errors in
+            # our renderers.
+            outcome.errors = []
+
+        return {
+            '_testMethodName': self._testMethodName,
+            '_outcome': outcome,
+            '_testMethodDoc': self._testMethodDoc,
+            '_subtest': self._subtest,
+            '_cleanups': [],
+            '_type_equality_funcs': self._type_equality_funcs,
+        }
+
 
 _default_cluster = None
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -396,11 +396,14 @@ class ConnectedTestCaseMixin:
             exp_result_binary = exp_result_json
 
         typenames = random.choice([True, False])
+        typeids = random.choice([True, False])
+
         try:
             res = await self.con._fetchall(
                 query,
                 *fetch_args,
                 __typenames__=typenames,
+                __typeids__=typeids,
                 **fetch_kw
             )
             res = serutils.serialize(res)
@@ -409,7 +412,9 @@ class ConnectedTestCaseMixin:
             self._assert_data_shape(res, exp_result_binary, message=msg)
         except Exception:
             self.add_fail_notes(
-                serialization='binary', __typenames__=typenames)
+                serialization='binary',
+                __typenames__=typenames,
+                __typeids__=typeids)
             raise
 
     def _sort_results(self, results, sort):

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -32,6 +32,7 @@ import math
 import os
 import pathlib
 import pprint
+import random
 import re
 import subprocess
 import sys
@@ -394,14 +395,21 @@ class ConnectedTestCaseMixin:
             # The expected result is the same
             exp_result_binary = exp_result_json
 
+        typenames = random.choice([True, False])
         try:
-            res = await self.con.query(query, *fetch_args, **fetch_kw)
+            res = await self.con._fetchall(
+                query,
+                *fetch_args,
+                __typenames__=typenames,
+                **fetch_kw
+            )
             res = serutils.serialize(res)
             if sort is not None:
                 self._sort_results(res, sort)
             self._assert_data_shape(res, exp_result_binary, message=msg)
         except Exception:
-            self.add_fail_notes(serialization='binary')
+            self.add_fail_notes(
+                serialization='binary', __typenames__=typenames)
             raise
 
     def _sort_results(self, results, sort):

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -166,7 +166,14 @@ class ChannelingTestResultMeta(type):
                 error_text = self._exc_info_to_string(args[-1], args[0])
                 args[-1] = error_text
 
-            self._queue.put((meth, args, kwargs))
+            try:
+                self._queue.put((meth, args, kwargs))
+            except Exception:
+                print(
+                    f'!!! Test worker child process: '
+                    f'failed to serialize arguments for {meth}: '
+                    f'*args={args} **kwargs={kwargs} !!!')
+                raise
         return _wrapper
 
     def __new__(mcls, name, bases, dct):

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ RUNTIME_DEPS = [
     'graphql-core~=3.0.3',
     'promise~=2.2.0',
 
-    'edgedb>=0.9.0a1',
+    'edgedb>=0.12.0a1',
 ]
 
 CYTHON_DEPENDENCY = 'Cython==0.29.21'

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -248,14 +248,17 @@ class TestDelete(tb.QueryTestCase):
             }],
         )
 
-        deleted = await self.con.query(
+        deleted = await self.con._fetchall(
             r"""
                 WITH MODULE test
                 DELETE DeleteTest2;
             """,
+            __typeids__=True,
+            __typenames__=True
         )
 
         self.assertTrue(hasattr(deleted[0], '__tid__'))
+        self.assertEqual(deleted[0].__tname__, 'test::DeleteTest2')
 
     async def test_edgeql_delete_returning_04(self):
         await self.con.execute(r"""

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -569,7 +569,7 @@ class TestInsert(tb.QueryTestCase):
             [3],
         )
 
-        obj = await self.con.query_one(
+        obj = await self.con._fetchall(
             '''
                 WITH MODULE test
                 INSERT DefaultTest1 {
@@ -577,10 +577,13 @@ class TestInsert(tb.QueryTestCase):
                     num := 1,
                 };
             ''',
+            __typeids__=True,
+            __typenames__=True,
         )
 
-        self.assertTrue(hasattr(obj, 'id'))
-        self.assertTrue(hasattr(obj, '__tid__'))
+        self.assertTrue(hasattr(obj[0], 'id'))
+        self.assertTrue(hasattr(obj[0], '__tid__'))
+        self.assertEqual(obj[0].__tname__, 'test::DefaultTest1')
 
     async def test_edgeql_insert_returning_03(self):
         await self.con.execute('''

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -438,7 +438,7 @@ class TestUpdate(tb.QueryTestCase):
                 ],
             )
 
-            objs = await self.con.query(
+            objs = await self.con._fetchall(
                 r"""
                     WITH MODULE test
                     UPDATE UpdateTest
@@ -446,10 +446,12 @@ class TestUpdate(tb.QueryTestCase):
                     SET {
                         name := 'new ' ++ UpdateTest.name
                     };
-                """
+                """,
+                __typenames__=True,
+                __typeids__=True
             )
-
             self.assertTrue(hasattr(objs[0], '__tid__'))
+            self.assertEqual(objs[0].__tname__, 'test::UpdateTest')
 
         finally:
             await self.con.execute(r"""

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -268,18 +268,17 @@ class TestServerProto(tb.QueryTestCase):
                 r = await self.con.query_json(q)
                 self.assertEqual(r, '[]')
 
-        for q in qs:
-            with self.assertRaisesRegex(
-                    edgedb.InterfaceError,
-                    r'cannot be executed with query_one\(\).*'
-                    r'not return'):
-                await self.con.query_one(q)
+        with self.assertRaisesRegex(
+                edgedb.InterfaceError,
+                r'cannot be executed with query_one\(\).*'
+                r'not return'):
+            await self.con.query_one('START TRANSACTION')
 
-            with self.assertRaisesRegex(
-                    edgedb.InterfaceError,
-                    r'cannot be executed with query_one_json\(\).*'
-                    r'not return'):
-                await self.con.query_one_json(q)
+        with self.assertRaisesRegex(
+                edgedb.InterfaceError,
+                r'cannot be executed with query_one_json\(\).*'
+                r'not return'):
+            await self.con.query_one_json('START TRANSACTION')
 
     async def test_server_proto_fetch_single_command_04(self):
         with self.assertRaisesRegex(edgedb.ProtocolError,


### PR DESCRIPTION
The Prepare protocol message now has a new header to make the compiler
implicitly inline a "__tname__ := .__type__.name" computable.  This is
especially useful for REPL-like applications.