### PR TITLE
Make the error message less cryptic.

### DIFF
--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -1473,6 +1473,11 @@ class GraphQLTranslator:
             vartype = vartype.type
             optional = False
 
+        if vartype.name.value not in gt.GQL_TO_EDB_SCALARS_MAP:
+            raise errors.QueryError(
+                f"Only scalar input variables are allowed. "
+                f"Variable {varname!r} has non-scalar value.")
+
         casttype = qlast.TypeName(
             maintype=qlast.ObjectRef(
                 name=gt.GQL_TO_EDB_SCALARS_MAP[vartype.name.value])

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -2833,6 +2833,19 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                 }
             """)
 
+    def test_graphql_functional_variables_43(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r"Only scalar input variables are allowed\. "
+                r"Variable 'f' has non-scalar value\."):
+            self.graphql_query(r"""
+                query user($f: FilterUser!) {
+                    User(filter: $f) {
+                        name
+                    }
+                }
+            """, variables={"f": {"name": {"eq": "Alice"}}})
+
     def test_graphql_functional_enum_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,


### PR DESCRIPTION
Currently we can only support scalar values for input variables, which
the error message now explicitly states.

Issue: #1241