### PR TITLE
Improve RENAME DDL reconstruction from schema diff

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -312,12 +312,12 @@ class ConstraintCommand(
     ) -> None:
         # check that 'subject' and 'subjectexpr' are not set as annotations
         for command in astnode.commands:
-            assert isinstance(command, (qlast.NamedDDL, qlast.BaseSetField))
-            cname = command.name
-            if cname in {'subject', 'subjectexpr'}:
-                raise errors.InvalidConstraintDefinitionError(
-                    f'{cname} is not a valid constraint annotation',
-                    context=command.context)
+            if isinstance(command, qlast.BaseSetField):
+                cname = command.name
+                if cname in {'subject', 'subjectexpr'}:
+                    raise errors.InvalidConstraintDefinitionError(
+                        f'{cname} is not a valid constraint annotation',
+                        context=command.context)
 
     @classmethod
     def _classname_quals_from_ast(

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -757,15 +757,20 @@ class CallableCommand(sd.QualifiedObjectCommand[CallableObjectT]):
         context: sd.CommandContext,
     ) -> FuncParameterList:
         params = self.get_attribute_value('params')
+        result: Any
         if params is None:
             param_list = []
             for cr_param in self.get_subcommands(type=ParameterCommand):
                 param = schema.get(cr_param.classname, type=Parameter)
                 param_list.append(param)
-            params = FuncParameterList.create(schema, param_list)
+            result = FuncParameterList.create(schema, param_list)
+        elif isinstance(params, so.ObjectCollectionShell):
+            result = params.resolve(schema)
+        else:
+            result = params
 
-        assert isinstance(params, FuncParameterList)
-        return params
+        assert isinstance(result, FuncParameterList)
+        return result
 
     @classmethod
     def _get_param_desc_from_ast(

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -26,8 +26,10 @@ from . import annos as s_anno
 from . import delta as sd
 
 
-class Module(s_anno.AnnotationSubject,
-             qlkind=qltypes.SchemaObjectClass.MODULE):
+class Module(
+    s_anno.AnnotationSubject,
+    qlkind=qltypes.SchemaObjectClass.MODULE,
+):
     pass
 
 


### PR DESCRIPTION
This makes it so that parent object renames are processed before child
object alteration is considered, which correctly skips delta hunks that
resulted in rename propagation, as well as reassembles the delta tree in
a way that results in only a single DDL command.