### PR TITLE
Add explicit declarations for casts from json to collections

### DIFF
--- a/edb/lib/std/30-jsonfuncs.edgeql
+++ b/edb/lib/std/30-jsonfuncs.edgeql
@@ -153,12 +153,24 @@ CREATE CAST FROM anytuple TO std::json {
 };
 
 
+CREATE CAST FROM std::json TO anytuple {
+    SET volatility := 'STABLE';
+    USING SQL EXPRESSION;
+};
+
+
 CREATE CAST FROM std::json TO array<json> {
     SET volatility := 'IMMUTABLE';
     USING SQL $$
         SELECT array_agg(j)
         FROM jsonb_array_elements(val) AS j
     $$;
+};
+
+
+CREATE CAST FROM std::json TO array<anytype> {
+    SET volatility := 'STABLE';
+    USING SQL EXPRESSION;
 };
 
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_07_14_14_00
+EDGEDB_CATALOG_VERSION = 2020_07_23_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs


### PR DESCRIPTION
This is to explicitly indicate support for the newly added `std::json`
casts.