### PR TITLE
Fix handling of literal empty sets of object types

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -61,15 +61,20 @@ if TYPE_CHECKING:
 PtrDir = s_pointers.PointerDirection
 
 
-def new_set(*, stype: s_types.Type, ctx: context.ContextLevel,
-            **kwargs: Any) -> irast.Set:
+def new_set(
+    *,
+    stype: s_types.Type,
+    ctx: context.ContextLevel,
+    ircls: Type[irast.Set] = irast.Set,
+    **kwargs: Any,
+) -> irast.Set:
     """Create a new ir.Set instance with given attributes.
 
     Absolutely all ir.Set instances must be created using this
     constructor.
     """
     typeref = typegen.type_to_typeref(stype, env=ctx.env)
-    ir_set = irast.Set(typeref=typeref, **kwargs)
+    ir_set = ircls(typeref=typeref, **kwargs)
     ctx.env.set_types[ir_set] = stype
     return ir_set
 
@@ -125,7 +130,8 @@ def new_set_from_set(
         expr=ir_set.expr,
         rptr=rptr,
         context=ir_set.context,
-        ctx=ctx
+        ircls=type(ir_set),
+        ctx=ctx,
     )
 
 

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -3797,6 +3797,42 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 } ORDER BY .number;
                 """)
 
+    async def test_edgeql_select_empty_object_01(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE test
+            SELECT <Issue>{}
+            ''',
+            [],
+        )
+
+    async def test_edgeql_select_empty_object_02(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE test
+            SELECT NOT EXISTS (<Issue>{})
+            ''',
+            [True],
+        )
+
+    async def test_edgeql_select_empty_object_03(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE test
+            SELECT ((SELECT Issue FILTER false) ?= <Issue>{})
+            ''',
+            [True],
+        )
+
+    async def test_edgeql_select_empty_object_04(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE test
+            SELECT count(<Issue>{}) = 0
+            ''',
+            [True],
+        )
+
     async def test_edgeql_select_cross_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
Literal empty set of object type (i.e. `<Foo>{}`) is currently
erroneously returning an entire set of `Foo` instead of an empty set.

Fixes: #1589