### PR TITLE
Disallow empty set literals in FOR ... UNION statements

### DIFF
--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -112,7 +112,7 @@ class ByExprList(ListNonterm, element=ByExpr, separator=tokens.T_COMMA):
 
 class SimpleFor(Nonterm):
     def reduce_For(self, *kids):
-        r"%reduce FOR Identifier IN Set \
+        r"%reduce FOR Identifier IN NonEmptySet \
                   UNION OptionallyAliasedExpr"
         self.val = qlast.ForQuery(
             iterator_alias=kids[1].val,
@@ -956,6 +956,11 @@ class NamedTupleElementList(ListNonterm, element=NamedTupleElement,
     pass
 
 
+class NonEmptySet(Nonterm):
+    def reduce_LBRACE_TrailingCommaExprList_RBRACE(self, *kids):
+        self.val = qlast.Set(elements=kids[1].val)
+
+
 class Set(Nonterm):
     def reduce_LBRACE_OptExprList_RBRACE(self, *kids):
         self.val = qlast.Set(elements=kids[1].val)
@@ -976,6 +981,14 @@ class OptExprList(Nonterm):
 
     def reduce_empty(self, *kids):
         self.val = []
+
+
+class TrailingCommaExprList(Nonterm):
+    def reduce_ExprList_COMMA(self, *kids):
+        self.val = kids[0].val
+
+    def reduce_ExprList(self, *kids):
+        self.val = kids[0].val
 
 
 class ExprList(ListNonterm, element=Expr, separator=tokens.T_COMMA):

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2609,6 +2609,14 @@ aa';
         UNION (UPDATE Foo FILTER (Foo.id = x.0) SET {bar := x.1});
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Unexpected '}'",
+                  line=2, col=27)
+    def test_edgeql_syntax_empty_for_01(self):
+        """
+        SELECT (FOR x in {} UNION ());
+        """
+
     def test_edgeql_syntax_coalesce_01(self):
         """
         SELECT (a ?? x);


### PR DESCRIPTION
They don't do anything useful and some internals can't handle them.
Fixes #1585.