### PR TITLE
Handle nested aliased types in GraphQL.

### DIFF
--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -564,12 +564,12 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             {
                 "SettingAlias": [
                     {
-                        "__typename": "SettingAlias_Type",
+                        "__typename": "SettingAlias",
                         "name": "perks",
                         "value": "full",
                     },
                     {
-                        "__typename": "SettingAlias_Type",
+                        "__typename": "SettingAlias",
                         "name": "template",
                         "value": "blue",
                     },
@@ -608,7 +608,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             {
                 "SettingAlias": [
                     {
-                        "__typename": "SettingAlias_Type",
+                        "__typename": "SettingAlias",
                         "name": "perks",
                         "value": "full",
                         "of_group": {
@@ -617,7 +617,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                         }
                     },
                     {
-                        "__typename": "SettingAlias_Type",
+                        "__typename": "SettingAlias",
                         "name": "template",
                         "value": "blue",
                         "of_group": {
@@ -649,23 +649,23 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             {
                 "SettingAliasAugmented": [
                     {
-                        "__typename": "SettingAliasAugmented_Type",
+                        "__typename": "SettingAliasAugmented",
                         "name": "perks",
                         "value": "full",
                         "of_group": {
                             "__typename":
-                                "__SettingAliasAugmented__of_group_Type",
+                                "__SettingAliasAugmented__of_group",
                             "name": "upgraded",
                             "name_upper": "UPGRADED",
                         }
                     },
                     {
-                        "__typename": "SettingAliasAugmented_Type",
+                        "__typename": "SettingAliasAugmented",
                         "name": "template",
                         "value": "blue",
                         "of_group": {
                             "__typename":
-                                "__SettingAliasAugmented__of_group_Type",
+                                "__SettingAliasAugmented__of_group",
                             "name": "upgraded",
                             "name_upper": "UPGRADED",
                         }
@@ -693,7 +693,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             {
                 "ProfileAlias": [
                     {
-                        "__typename": "ProfileAlias_Type",
+                        "__typename": "ProfileAlias",
                         "name": "Alice profile",
                         "value": "special",
                         "owner": [
@@ -727,6 +727,72 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         """, {
             'User': [{'name': 'Alice'}]
         })
+
+    def test_graphql_functional_alias_05(self):
+        self.assert_graphql_query_result(
+            r"""
+                {
+                    SettingAliasAugmented(
+                        filter: {of_group: {name_upper: {eq: "UPGRADED"}}}
+                    ) {
+                        name
+                        of_group {
+                            name
+                            name_upper
+                        }
+                    }
+                }
+            """,
+            {
+                "SettingAliasAugmented": [
+                    {
+                        "name": "perks",
+                        "of_group": {
+                            "name": "upgraded",
+                            "name_upper": "UPGRADED",
+                        }
+                    },
+                    {
+                        "name": "template",
+                        "of_group": {
+                            "name": "upgraded",
+                            "name_upper": "UPGRADED",
+                        }
+                    },
+                ],
+            },
+            sort=lambda x: x['name']
+        )
+
+    def test_graphql_functional_alias_06(self):
+        self.assert_graphql_query_result(
+            r"""
+                {
+                    SettingAliasAugmented(
+                        filter: {name: {eq: "perks"}}
+                    ) {
+                        name
+                        of_group(
+                            filter: {name_upper: {gt: "U"}}
+                        ) {
+                            name
+                            name_upper
+                        }
+                    }
+                }
+            """,
+            {
+                "SettingAliasAugmented": [
+                    {
+                        "name": "perks",
+                        "of_group": {
+                            "name": "upgraded",
+                            "name_upper": "UPGRADED",
+                        }
+                    },
+                ],
+            },
+        )
 
     def test_graphql_functional_arguments_01(self):
         result = self.graphql_query(r"""

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -1177,213 +1177,6 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     {
                         "__typename": "__Type",
                         "kind": "OBJECT",
-                        "name": "SettingAliasAugmented_Type",
-                        "description": None,
-                        "fields": [
-                            {
-                                "__typename": "__Field",
-                                "name": "id",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "NON_NULL",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": "ID",
-                                        "kind": "SCALAR"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "name",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "NON_NULL",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": "String",
-                                        "kind": "SCALAR"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "of_group",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": "_edb__"
-                                            "SettingAliasAugmented__of_group",
-                                    "kind": "INTERFACE",
-                                    "ofType": None
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "value",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "NON_NULL",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": "String",
-                                        "kind": "SCALAR"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            }
-                        ],
-                        "interfaces": [
-                            {
-                                "__typename": "__Type",
-                                "name": "BaseObject",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "NamedObject",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "Object",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "Setting",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "SettingAliasAugmented",
-                                "kind": "INTERFACE"
-                            },
-                        ],
-                        "possibleTypes": None,
-                        "enumValues": None,
-                        "inputFields": None,
-                        "ofType": None
-                    },
-                    {
-                        "__typename": "__Type",
-                        "kind": "OBJECT",
-                        "name": "SettingAlias_Type",
-                        "description": None,
-                        "fields": [
-                            {
-                                "__typename": "__Field",
-                                "name": "id",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "NON_NULL",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": "ID",
-                                        "kind": "SCALAR"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "name",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "NON_NULL",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": "String",
-                                        "kind": "SCALAR"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "of_group",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": 'UserGroup',
-                                    "kind": "INTERFACE",
-                                    "ofType": None
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "value",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "NON_NULL",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": "String",
-                                        "kind": "SCALAR"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            }
-                        ],
-                        "interfaces": [
-                            {
-                                "__typename": "__Type",
-                                "name": "BaseObject",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "NamedObject",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "Object",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "Setting",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "SettingAlias",
-                                "kind": "INTERFACE"
-                            },
-                        ],
-                        "possibleTypes": None,
-                        "enumValues": None,
-                        "inputFields": None,
-                        "ofType": None
-                    },
-                    {
-                        "__typename": "__Type",
-                        "kind": "OBJECT",
                         "name": "Setting_Type",
                         "description": None,
                         "fields": [
@@ -1692,114 +1485,6 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                             {
                                 "__typename": "__Type",
                                 "name": "User",
-                                "kind": "INTERFACE"
-                            },
-                        ],
-                        "possibleTypes": None,
-                        "enumValues": None,
-                        "inputFields": None,
-                        "ofType": None
-                    },
-                    {
-                        "__typename": "__Type",
-                        "kind": "OBJECT",
-                        "name": "_edb__SettingAliasAugmented__of_group_Type",
-                        "description": None,
-                        "fields": [
-                            {
-                                "__typename": "__Field",
-                                "name": "id",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "NON_NULL",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": "ID",
-                                        "kind": "SCALAR"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "name",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "NON_NULL",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": "String",
-                                        "kind": "SCALAR"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "name_upper",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "NON_NULL",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": "String",
-                                        "kind": "SCALAR"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            },
-                            {
-                                "__typename": "__Field",
-                                "name": "settings",
-                                "description": None,
-                                "type": {
-                                    "__typename": "__Type",
-                                    "name": None,
-                                    "kind": "LIST",
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "name": None,
-                                        "kind": "NON_NULL"
-                                    }
-                                },
-                                "isDeprecated": False,
-                                "deprecationReason": None
-                            }
-                        ],
-                        "interfaces": [
-                            {
-                                "__typename": "__Type",
-                                "name": "BaseObject",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "NamedObject",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "Object",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "UserGroup",
-                                "kind": "INTERFACE"
-                            },
-                            {
-                                "__typename": "__Type",
-                                "name": "_edb__"
-                                        "SettingAliasAugmented__of_group",
                                 "kind": "INTERFACE"
                             },
                         ],
@@ -2523,5 +2208,156 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                 "name": "other__Foo_Type",
                 "__typename": "__Type",
                 "description": 'Test type "Foo"',
+            }
+        })
+
+    def test_graphql_schema_type_18(self):
+        self.assert_graphql_query_result(r"""
+            fragment _t on __Type {
+                __typename
+                name
+                kind
+            }
+
+            fragment _f on __Type {
+                fields {
+                    __typename
+                    name
+                    description
+                    type {
+                        ..._t
+                        ofType {
+                            ..._t
+                        }
+                    }
+                    isDeprecated
+                    deprecationReason
+                }
+            }
+
+            fragment _T on __Type {
+                        __typename
+                        kind
+                        name
+                        description
+                        ..._f
+                        interfaces {
+                            ..._t
+                        }
+                        possibleTypes {
+                            name
+                        }
+                        enumValues {
+                            name
+                        }
+                        inputFields {
+                            name
+                        }
+                        ofType {
+                            name
+                        }
+            }
+
+            query {
+                __type(name: "SettingAliasAugmented") {
+                    __typename
+                    kind
+                    name
+                    description
+                    ..._f
+                    interfaces {
+                        ..._T
+                    }
+                    possibleTypes {
+                        ..._T
+                    }
+                    enumValues {
+                        name
+                    }
+                    inputFields {
+                        name
+                    }
+                    ofType {
+                        name
+                    }
+                }
+            }
+        """, {
+            "__type": {
+                "kind": "OBJECT",
+                "name": "SettingAliasAugmented",
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": None,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "ID",
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "__typename": "__Field",
+                        "description": None,
+                        "isDeprecated": False,
+                        "deprecationReason": None,
+                    },
+                    {
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": None,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "__typename": "__Field",
+                        "description": None,
+                        "isDeprecated": False,
+                        "deprecationReason": None,
+                    },
+                    {
+                        "name": "of_group",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "_edb__SettingAliasAugmented__of_group",
+                            "ofType": None,
+                            "__typename": "__Type"
+                        },
+                        "__typename": "__Field",
+                        "description": None,
+                        "isDeprecated": False,
+                        "deprecationReason": None,
+                    },
+                    {
+                        "name": "value",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": None,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "__typename": "__Field",
+                        "description": None,
+                        "isDeprecated": False,
+                        "deprecationReason": None,
+                    },
+                ],
+                "ofType": None,
+                "__typename": "__Type",
+                "enumValues": None,
+                "interfaces": [],
+                "description": None,
+                "inputFields": None,
+                "possibleTypes": None,
             }
         })


### PR DESCRIPTION
Aliased types have layout similar to their original tpyes, but with
potentially additional links or properties. This means that the GraphQL
reflected fields must have additional arguments on them. This, in turn,
means that the aliased type cannot be simply derived from the original
type's interface because the arguments would then have to match as well.
So aliased types are reflected without attempting to preserve inheritance,
but instead the focus is on making all the fields accessible.

Fixes #722.