### PR TITLE
Make the debug dump print sequence-specific brackets

### DIFF
--- a/edb/common/markup/elements/lang.py
+++ b/edb/common/markup/elements/lang.py
@@ -62,6 +62,7 @@ class Object(BaseObject):
 class List(BaseObject):
     items = Field(base.MarkupList, default=base.MarkupList, coerce=True)
     trimmed = Field(bool, default=False)
+    brackets = Field(str, default="[]")
 
 
 class Dict(BaseObject):

--- a/edb/common/markup/renderers/terminal.py
+++ b/edb/common/markup/renderers/terminal.py
@@ -367,7 +367,7 @@ class LangRenderer(BaseRenderer):
 
     def _render_lang_List(self, element):
         with self.buffer.foldable_lines():
-            self.buffer.write('[', style=self.styles.bracket)
+            self.buffer.write(element.brackets[0], style=self.styles.bracket)
 
             item_count = len(element.items)
             if item_count:
@@ -382,7 +382,7 @@ class LangRenderer(BaseRenderer):
             if element.trimmed:
                 self.buffer.write('...')
 
-            self.buffer.write(']', style=self.styles.bracket)
+            self.buffer.write(element.brackets[1], style=self.styles.bracket)
 
     def _render_mapping_(self, mapping, trimmed=False):
         self.buffer.write('{', style=self.styles.bracket)

--- a/edb/common/markup/serializer/base.py
+++ b/edb/common/markup/serializer/base.py
@@ -304,12 +304,22 @@ def serialize_sequence(obj, *, ctx, trim_at=100):
     els = []
     cnt = 0
     trim = ctx.trim
+
+    if isinstance(obj, tuple):
+        brackets = "()"
+    elif isinstance(obj,
+                    (collections.abc.Set, weakref.WeakSet, set, frozenset)):
+        brackets = "{}"
+    else:
+        brackets = "[]"
+
     for cnt, item in enumerate(obj):
         els.append(serialize(item, ctx=ctx))
         if trim and cnt >= trim_at:
             break
     return elements.lang.List(
-        items=els, id=id(obj), trimmed=(trim and cnt >= trim_at))
+        items=els, id=id(obj), brackets=brackets,
+        trimmed=(trim and cnt >= trim_at))
 
 
 @serializer.register(dict)

--- a/tests/common/test_markup.py
+++ b/tests/common/test_markup.py
@@ -64,7 +64,7 @@ class MarkupTests(unittest.TestCase):
         assert markup.dumps('123') == "'123'"
 
         expected = \
-            "[\n    '123',\n    1,\n    1.1,\n    {\n        foo: []\n    }\n]"
+            "[\n    '123',\n    1,\n    1.1,\n    {\n        foo: ()\n    }\n]"
         expected = expected.replace(' ', '')
         assert markup.dumps(['123', 1, 1.1, {'foo': ()}]).replace(
             ' ', '') == expected


### PR DESCRIPTION
So tuples get '() and sets get '{}'.

I was initially confused by my tuples having brackets, and so made
this tweak. Mostly I just like the output more.

*shrug*