### PR TITLE
Reimplement the pointer optionality qualifier check as a merge function

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2433,41 +2433,11 @@ class AlterSpecialObjectProperty(Command):
                 context.modaliases,
                 orig_text=orig_text,
             )
-        elif field.name == 'required' and not new_value:
-            # disallow dropping required that is not locally set
-            parent_obj = parent_op.get_object(schema, context, default=None)
-            errmsg = None
-
-            if parent_obj:
-                local_required = parent_obj.get_explicit_local_field_value(
-                    schema, 'required', None)
-
-                if not local_required:
-                    parent_repr = parent_obj.get_verbosename(
-                        schema, with_parent=True)
-                    errmsg = (
-                        f'cannot drop required qualifier because it is not '
-                        f'defined directly on {parent_repr}'
-                    )
-            else:
-                # We don't have a parent object which means we're in
-                # the process of creating it.
-                shortname = sn.shortname_from_fullname(
-                    parent_op.classname).name
-
-                parent_classname = parent_cls.get_schema_class_displayname()
-
-                errmsg = (
-                    f'cannot drop required qualifier of an '
-                    f'inherited {parent_classname} {shortname!r}'
-                )
-
-            if errmsg:
-                raise errors.SchemaError(errmsg, context=astnode.context)
 
         return AlterObjectProperty(
             property=astnode.name,
-            new_value=new_value
+            new_value=new_value,
+            source_context=astnode.context,
         )
 
 

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
     from . import schema as s_schema
     from . import types as s_types
 
+    T = TypeVar('T')
+
 
 def ast_objref_to_object_shell(
     node: qlast.ObjectRef, *,
@@ -530,8 +532,9 @@ def merge_reduce(
     *,
     ignore_local: bool,
     schema: s_schema.Schema,
-    f: Callable[[List[Any]], so.InheritingObjectT],
-) -> Optional[so.InheritingObjectT]:
+    f: Callable[[List[T]], T],
+    type: Type[T],
+) -> Optional[T]:
     values = []
     if not ignore_local:
         ours = target.get_explicit_local_field_value(schema, field_name, None)
@@ -546,42 +549,6 @@ def merge_reduce(
         return f(values)
     else:
         return None
-
-
-def merge_sticky_bool(
-    target: so.InheritingObjectT,
-    sources: Iterable[so.InheritingObjectT],
-    field_name: str,
-    *,
-    ignore_local: bool,
-    schema: s_schema.Schema
-) -> Optional[so.InheritingObjectT]:
-    return merge_reduce(
-        target,
-        sources,
-        field_name,
-        ignore_local=ignore_local,
-        schema=schema,
-        f=max,
-    )
-
-
-def merge_weak_bool(
-    target: so.InheritingObjectT,
-    sources: Iterable[so.InheritingObjectT],
-    field_name: str,
-    *,
-    ignore_local: bool,
-    schema: s_schema.Schema,
-) -> Optional[so.InheritingObjectT]:
-    return merge_reduce(
-        target,
-        sources,
-        field_name,
-        ignore_local=ignore_local,
-        schema=schema,
-        f=min,
-    )
 
 
 def get_nq_name(schema: s_schema.Schema,

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4973,7 +4973,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test that read-only flag must be consistent in the
         # inheritance hierarchy.
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
+                edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'foo' of "
                 "object type 'test::Derived': it is defined as True in "
                 "property 'foo' of object type 'test::Derived' and as "
@@ -4995,7 +4995,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test that read-only flag must be consistent in the
         # inheritance hierarchy.
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
+                edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'foo' of "
                 "object type 'test::Derived': it is defined as False in "
                 "property 'foo' of object type 'test::Derived' and as "
@@ -5019,7 +5019,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test that read-only flag must be consistent in the
         # inheritance hierarchy.
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
+                edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'foo' of "
                 "object type 'test::Derived': it is defined as False in "
                 "property 'foo' of object type 'test::Base0' and as "
@@ -5057,7 +5057,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # of the Derived with Base1, whereas the more accurate error
         # message would refer to Base0 and Base1.
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
+                edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'foo' of "
                 "object type 'test::Derived': it is defined as False in "
                 "property 'foo' of object type 'test::Derived' and as "
@@ -5074,7 +5074,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test that read-only flag must be consistent in the
         # inheritance hierarchy.
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
+                edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of link 'foo' of "
                 "object type 'test::Derived': it is defined as True in "
                 "link 'foo' of object type 'test::Derived' and as "
@@ -5096,7 +5096,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test that read-only flag must be consistent in the
         # inheritance hierarchy.
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
+                edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of link 'foo' of "
                 "object type 'test::Derived': it is defined as False in "
                 "link 'foo' of object type 'test::Derived' and as "
@@ -5120,7 +5120,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test that read-only flag must be consistent in the
         # inheritance hierarchy.
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
+                edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of link 'foo' of "
                 "object type 'test::Derived': it is defined as False in "
                 "link 'foo' of object type 'test::Base0' and as "
@@ -5158,7 +5158,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # of the Derived with Base1, whereas the more accurate error
         # message would refer to Base0 and Base1.
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
+                edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of link 'foo' of "
                 "object type 'test::Derived': it is defined as False in "
                 "link 'foo' of object type 'test::Derived' and as "
@@ -5175,7 +5175,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test that read-only flag must be consistent in the
         # inheritance hierarchy.
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
+                edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'bar' of "
                 "link 'foo' of object type 'test::Derived': it is defined "
                 "as True in property 'bar' of link 'foo' of object type "
@@ -5202,7 +5202,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test that read-only flag must be consistent in the
         # inheritance hierarchy.
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
+                edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'bar' of "
                 "link 'foo' of object type 'test::Derived': it is defined "
                 "as False in property 'bar' of link 'foo' of object type "
@@ -5231,7 +5231,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test that read-only flag must be consistent in the
         # inheritance hierarchy.
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
+                edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'bar' of "
                 "link 'foo' of object type 'test::Derived': it is defined "
                 "as False in property 'bar' of link 'foo' of object type "
@@ -5278,7 +5278,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # of the Derived with Base1, whereas the more accurate error
         # message would refer to Base0 and Base1.
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
+                edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'bar' of "
                 "link 'foo' of object type 'test::Derived': it is defined "
                 "as False in property 'bar' of link 'foo' of object type "
@@ -5298,14 +5298,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test that required qualifier cannot be dropped if it was not
         # actually set on the particular property.
         with self.assertRaisesRegex(
-                edgedb.SchemaError, "cannot drop required"):
+            edgedb.SchemaDefinitionError,
+            "cannot make.*optional",
+        ):
             await self.con.execute('''
                 SET MODULE test;
 
                 CREATE TYPE Base {
-                    CREATE PROPERTY foo -> str;
+                    CREATE REQUIRED PROPERTY foo -> str;
                 };
-                ALTER TYPE Base {
+                CREATE TYPE Derived EXTENDING Base;
+                ALTER TYPE Derived {
                     ALTER PROPERTY foo {
                         DROP REQUIRED;
                     };
@@ -5316,26 +5319,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test that required qualifier cannot be dropped if it was not
         # actually set on the particular property.
         with self.assertRaisesRegex(
-                edgedb.SchemaError, "cannot drop required"):
-            await self.con.execute('''
-                SET MODULE test;
-
-                CREATE TYPE Base {
-                    CREATE REQUIRED PROPERTY foo -> str;
-                };
-                CREATE TYPE Derived EXTENDING Base;
-                ALTER TYPE Derived {
-                    ALTER PROPERTY foo {
-                        DROP REQUIRED;
-                    };
-                };
-            ''')
-
-    async def test_edgeql_ddl_required_03(self):
-        # Test that required qualifier cannot be dropped if it was not
-        # actually set on the particular property.
-        with self.assertRaisesRegex(
-                edgedb.SchemaError, "cannot drop required"):
+            edgedb.SchemaDefinitionError,
+            "cannot make.*optional",
+        ):
             await self.con.execute('''
                 SET MODULE test;
 
@@ -5349,18 +5335,41 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             ''')
 
-    async def test_edgeql_ddl_required_04(self):
+    async def test_edgeql_ddl_required_03(self):
         # Test that required qualifier cannot be dropped if it was not
         # actually set on the particular link.
         with self.assertRaisesRegex(
-                edgedb.SchemaError, "cannot drop required"):
+            edgedb.SchemaDefinitionError,
+            "cannot make.*optional",
+        ):
             await self.con.execute('''
                 SET MODULE test;
 
                 CREATE TYPE Base {
-                    CREATE LINK foo -> Object;
+                    CREATE REQUIRED LINK foo -> Object;
                 };
-                ALTER TYPE Base {
+                CREATE TYPE Derived EXTENDING Base;
+                ALTER TYPE Derived {
+                    ALTER LINK foo {
+                        DROP REQUIRED;
+                    };
+                };
+            ''')
+
+    async def test_edgeql_ddl_required_04(self):
+        # Test that required qualifier cannot be dropped if it was not
+        # actually set on the particular link.
+        with self.assertRaisesRegex(
+            edgedb.SchemaDefinitionError,
+            "cannot make.*optional",
+        ):
+            await self.con.execute('''
+                SET MODULE test;
+
+                CREATE TYPE Base {
+                    CREATE REQUIRED LINK foo -> Object;
+                };
+                CREATE TYPE Derived EXTENDING Base {
                     ALTER LINK foo {
                         DROP REQUIRED;
                     };
@@ -5371,57 +5380,21 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test that required qualifier cannot be dropped if it was not
         # actually set on the particular link.
         with self.assertRaisesRegex(
-                edgedb.SchemaError, "cannot drop required"):
+            edgedb.SchemaDefinitionError,
+            "cannot make.*optional",
+        ):
             await self.con.execute('''
                 SET MODULE test;
 
                 CREATE TYPE Base {
+                    CREATE OPTIONAL LINK foo -> Object;
+                };
+                CREATE TYPE Base2 {
                     CREATE REQUIRED LINK foo -> Object;
                 };
-                CREATE TYPE Derived EXTENDING Base;
-                ALTER TYPE Derived {
+                CREATE TYPE Derived EXTENDING Base, Base2 {
                     ALTER LINK foo {
                         DROP REQUIRED;
-                    };
-                };
-            ''')
-
-    async def test_edgeql_ddl_required_06(self):
-        # Test that required qualifier cannot be dropped if it was not
-        # actually set on the particular link.
-        with self.assertRaisesRegex(
-                edgedb.SchemaError, "cannot drop required"):
-            await self.con.execute('''
-                SET MODULE test;
-
-                CREATE TYPE Base {
-                    CREATE REQUIRED LINK foo -> Object;
-                };
-                CREATE TYPE Derived EXTENDING Base {
-                    ALTER LINK foo {
-                        DROP REQUIRED;
-                    };
-                };
-            ''')
-
-    async def test_edgeql_ddl_required_07(self):
-        # Test that required qualifier cannot be dropped if it was not
-        # actually set on the particular link property.
-        with self.assertRaisesRegex(
-                edgedb.SchemaError, "cannot drop required"):
-            await self.con.execute('''
-                SET MODULE test;
-
-                CREATE TYPE Base {
-                    CREATE LINK foo -> Object {
-                        CREATE PROPERTY bar -> str;
-                    };
-                };
-                CREATE TYPE Derived EXTENDING Base {
-                    ALTER LINK foo {
-                        ALTER PROPERTY bar {
-                            DROP REQUIRED;
-                        };
                     };
                 };
             ''')
@@ -5570,24 +5543,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ''',
             [1],
         )
-
-    async def test_edgeql_ddl_required_10(self):
-        # Test that required qualifier cannot be dropped if it was not
-        # actually set on the particular property.
-        with self.assertRaisesRegex(
-                edgedb.SchemaError, "cannot drop required"):
-            await self.con.execute('''
-                SET MODULE test;
-
-                CREATE TYPE Base {
-                    CREATE OPTIONAL PROPERTY foo -> str;
-                };
-                ALTER TYPE Base {
-                    ALTER PROPERTY foo {
-                        DROP REQUIRED;
-                    };
-                };
-            ''')
 
     async def test_edgeql_ddl_index_01(self):
         with self.assertRaisesRegex(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -277,6 +277,42 @@ _123456789_123456789_123456789 -> str
             }
         """
 
+    @tb.must_fail(errors.SchemaDefinitionError,
+                  "cannot make property 'title' of object type 'test::B' "
+                  "optional: its parent property 'title' of object type "
+                  "'test::A' is defined as required",
+                  line=7, col=17)
+    def test_schema_optionality_consistency_check_01(self):
+        """
+            type A {
+                required property title -> str;
+            }
+
+            type B extending A {
+                overloaded optional property title -> str;
+            }
+        """
+
+    @tb.must_fail(errors.SchemaDefinitionError,
+                  "cannot make property 'title' of object type 'test::C' "
+                  "optional: its parent property 'title' of object type "
+                  "'test::B' is defined as required",
+                  line=11, col=17)
+    def test_schema_optionality_consistency_check_02(self):
+        """
+            type A {
+                optional property title -> str;
+            }
+
+            type B {
+                required property title -> str;
+            }
+
+            type C extending A, B {
+                overloaded optional property title -> str;
+            }
+        """
+
     def test_schema_refs_01(self):
         schema = self.load_schema("""
             type Object1;


### PR DESCRIPTION
Current `REQUIRED` qualifier consistency check is done at an awkward
point in DDL AST visitor, which produces false positives when
`DROP REQUIRED` is actually a nop.  More importantly, though, the
current check does not prevent doing the wrong thing in the current
implementation of SDL.

Fix this by reimplementing the check as a field merge function, like
`cardinality` and `readonly`.