### PR TITLE
Do not confuse default link base as "derived base"

### DIFF
--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -541,13 +541,17 @@ def ptrref_from_ptrcls(
     base_ptr: Optional[irast.BasePointerRef]
     if is_derived:
         base_ptrcls = ptrcls.get_bases(schema).first(schema)
-        base_ptr = ptrref_from_ptrcls(
-            ptrcls=base_ptrcls,
-            direction=direction,
-            schema=schema,
-            cache=cache,
-            typeref_cache=typeref_cache,
-        )
+        top_ptr_name = type(base_ptrcls).get_default_base_name()
+        if base_ptrcls.get_name(schema) != top_ptr_name:
+            base_ptr = ptrref_from_ptrcls(
+                ptrcls=base_ptrcls,
+                direction=direction,
+                schema=schema,
+                cache=cache,
+                typeref_cache=typeref_cache,
+            )
+        else:
+            base_ptr = None
     else:
         base_ptr = None
 

--- a/tests/schemas/cards_aliases_setup.edgeql
+++ b/tests/schemas/cards_aliases_setup.edgeql
@@ -82,7 +82,9 @@ CREATE ALIAS test::AliasedFriends := (
 CREATE ALIAS test::AwardAlias := (
     test::Award {
         # this should be a single link, because awards are exclusive
-        winner := test::Award.<awards[IS test::User]
+        winner := test::Award.<awards[IS test::User] {
+            name_upper := str_upper(.name)
+        }
     }
 );
 

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -710,6 +710,24 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             ],
         )
 
+    async def test_edgeql_aliases_nested_03(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test
+                SELECT AwardAlias {
+                    winner: {
+                        name_upper
+                    }
+                }
+                FILTER
+                    .winner.name_upper = 'ALICE';
+            """,
+            [
+                {'winner': {'name_upper': 'ALICE'}},
+                {'winner': {'name_upper': 'ALICE'}},
+            ],
+        )
+
     async def test_edgeql_aliases_deep_01(self):
         # fetch the result we will compare to
         res = await self.con.query_json(r"""


### PR DESCRIPTION
When handling computable pointers, make sure that we're not peeling
the derived pointer to the top `std::link` or `std::pointer`.  In
fact, `PointerRef.base_ptr` should never contain the top pointer.

Fixes: #1614.