### PR TITLE
Make sure delayed inference work is not missed in FOR aliases (part 2)

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -148,6 +148,11 @@ def compile_ForQuery(
             view_scope_info = scopectx.path_scope_map[iterator_view]
             iterator_scope = view_scope_info.path_scope
 
+            for cb in view_scope_info.tentative_work:
+                stmtctx.at_stmt_fini(cb, ctx=ctx)
+
+            view_scope_info.tentative_work[:] = []
+
         pathctx.register_set_in_scope(
             iterator_stmt,
             path_scope=iterator_scope_parent,

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -3996,6 +3996,15 @@ aa \
             [],
         )
 
+    async def test_edgeql_expr_if_else_09(self):
+        await self.assert_query_result(
+            r"""
+                FOR _ IN {<str>{'1'} IF false ELSE <str>{}}
+                UNION ();
+            """,
+            [],
+        )
+
     async def test_edgeql_expr_setop_01(self):
         await self.assert_query_result(
             r"""SELECT EXISTS <str>{};""",


### PR DESCRIPTION
This is a followup to 602cca6ecc, which missed a case when the iterator
variable is not actually referenced in the `FOR` body.

Fixes: #1594.