### PR TITLE
Optimize handling of singleton right operand in ??

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -707,13 +707,9 @@ def finalize_args(
             arg = casts.compile_cast(
                 arg, paramtype, srcctx=None, ctx=ctx)
 
-        if param_mod is not ft.TypeModifier.SET_OF:
-            call_arg = irast.CallArg(expr=arg,
-                                     cardinality=ft.Cardinality.ONE)
-        else:
-            call_arg = irast.CallArg(expr=arg, cardinality=None)
-            stmtctx.get_expr_cardinality_later(
-                target=call_arg, field='cardinality', irexpr=arg, ctx=ctx)
+        call_arg = irast.CallArg(expr=arg, cardinality=None)
+        stmtctx.get_expr_cardinality_later(
+            target=call_arg, field='cardinality', irexpr=arg, ctx=ctx)
 
         args.append(call_arg)
 

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -95,6 +95,8 @@ class Cardinality(s_enum.StrEnum):
     MANY = 'MANY'
     # [1, inf)
     AT_LEAST_ONE = 'AT_LEAST_ONE'
+    # Sentinel
+    UNKNOWN = 'UNKNOWN'
 
     def is_single(self) -> bool:
         return self in {Cardinality.AT_MOST_ONE, Cardinality.ONE}

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -563,7 +563,7 @@ class CallArg(ImmutableBase):
     __ast_mutable_fields__ = frozenset(('cardinality',))
 
     expr: Set
-    cardinality: qltypes.Cardinality = qltypes.Cardinality.ONE
+    cardinality: qltypes.Cardinality = qltypes.Cardinality.UNKNOWN
 
 
 class Call(ImmutableExpr):

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1328,18 +1328,65 @@ def process_set_as_coalesce(
         left_ir, right_ir = (a.expr for a in expr.args)
         left_card, right_card = (a.cardinality for a in expr.args)
 
-        if right_card.is_single():
-            # Singleton RHS, simply use scalar COALESCE.
+        if right_card is qltypes.Cardinality.ONE:
+            # Non-optional singleton RHS, simply use scalar COALESCE
+            # without any precautions.
             left = dispatch.compile(left_ir, ctx=newctx)
-
-            with newctx.new() as rightctx:
-                rightctx.force_optional.add(right_ir.path_id)
-                right = dispatch.compile(right_ir, ctx=rightctx)
-
+            right = dispatch.compile(right_ir, ctx=newctx)
             set_expr = pgast.CoalesceExpr(args=[left, right])
+            pathctx.put_path_value_var(
+                stmt,
+                ir_set.path_id,
+                set_expr,
+                env=newctx.env,
+            )
 
-            pathctx.put_path_value_var_if_not_exists(
-                stmt, ir_set.path_id, set_expr, env=ctx.env)
+        elif right_card is qltypes.Cardinality.AT_MOST_ONE:
+            # Optional singleton RHS, use scalar COALESCE, but
+            # be careful not to JOIN the RHS as-is and instead
+            # turn it into a value and make sure to filter out
+            # the potential NULL result if both sides turn out
+            # to be empty:
+            #     SELECT
+            #         q.v
+            #     FROM
+            #         (SELECT
+            #             COALESCE(<lhs>, (SELECT (<rhs>))) AS v
+            #         ) AS q
+            #     WHERE
+            #         q.v IS NOT NULL
+            with newctx.subrel() as subctx:
+                left = dispatch.compile(left_ir, ctx=subctx)
+
+                with newctx.subrel() as rightctx:
+                    dispatch.compile(right_ir, ctx=rightctx)
+                    pathctx.get_path_value_output(
+                        rightctx.rel,
+                        right_ir.path_id,
+                        env=rightctx.env,
+                    )
+                    right = rightctx.rel
+
+                set_expr = pgast.CoalesceExpr(args=[left, right])
+
+                pathctx.put_path_value_var_if_not_exists(
+                    subctx.rel, ir_set.path_id, set_expr, env=ctx.env)
+
+                sub_rvar = relctx.rvar_for_rel(
+                    subctx.rel,
+                    lateral=True,
+                    ctx=subctx,
+                )
+
+                relctx.include_rvar(stmt, sub_rvar, ir_set.path_id, ctx=subctx)
+
+            rvar = pathctx.get_path_value_var(
+                stmt, path_id=ir_set.path_id, env=ctx.env)
+
+            stmt.where_clause = astutils.extend_binop(
+                stmt.where_clause,
+                pgast.NullTest(arg=rvar, negated=True),
+            )
         else:
             # Things become tricky in cases where the RHS is a non-singleton.
             # We cannot use the regular scalar COALESCE over a JOIN,

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -471,3 +471,13 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         subtitle: ONE
         """
+
+    def test_edgeql_ir_card_inference_46(self):
+        """
+        WITH MODULE test
+        SELECT Named {
+            as_card := Named[IS Card]
+        }
+% OK %
+        as_card: AT_MOST_ONE
+        """


### PR DESCRIPTION
When the cardinality of the right operand in ?? is known to be exactly
`ONE`, we can use a scalar SQL `COALESCE` without any precautions.  If
it's `AT_MOST_ONE`, use a fact that `(SELECT (<empty_rel>))` is `NULL`
to avoid using `force_optional`, because the latter largely defeats the
optimization.

This also fixes cardinality inference of certain type intersection
paths.