### PR TITLE
Use ddl_identity for annotation refs in annotation value commands

### DIFF
--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -246,14 +246,15 @@ class IndexCommand(
         assert isinstance(astnode, qlast.IndexOp)
         cmd = super()._cmd_from_ast(schema, astnode, context)
         orig_text = cls.get_orig_expr_text(schema, astnode, 'expr')
-        cmd.ddl_identity = {
-            'expr': s_expr.Expression.from_ast(
+        cmd.set_ddl_identity(
+            'expr',
+            s_expr.Expression.from_ast(
                 astnode.expr,
                 schema,
                 context.modaliases,
                 orig_text=orig_text,
             ),
-        }
+        )
         return cmd
 
     def get_ast_attr_for_field(self, field: str) -> Optional[str]:

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -195,7 +195,8 @@ class Field(struct.ProtoField, Generic[T]):
     #: command in DDL.
     allow_ddl_set: bool
     #: Whether the field is used to identify the object
-    #: in DDL operations.
+    #: in DDL operations and schema reflection when object
+    #: name is insufficient.
     ddl_identity: bool
     #: Used for fields holding references to objects.  If True,
     #: the reference is considered "weak", i.e. not essential for

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -799,12 +799,12 @@ class PointerCommandOrFragment(
     referencing.ReferencedObjectCommandBase[Pointer]
 ):
 
-    def resolve_refs(
+    def canonicalize_attributes(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> s_schema.Schema:
-        schema = super().resolve_refs(schema, context)
+        schema = super().canonicalize_attributes(schema, context)
         target_ref = self.get_local_attribute_value('target')
 
         if target_ref is not None:

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -750,7 +750,12 @@ def _update_lprops(
         target_link = mcls.get_reflection_link()
         assert target_link is not None
         target_field = mcls.get_field(target_link)
-        target_obj = cmd.get_orig_attribute_value(target_link)
+        target_obj = cmd.get_ddl_identity(target_link)
+        if target_obj is None:
+            raise AssertionError(
+                f'cannot find link target in ddl_identity of a command for '
+                f'schema class reflected as link: {cmd!r}'
+            )
         target_ref = target_obj.get_name(schema)
         target_clsname = target_field.type.__name__
     else:


### PR DESCRIPTION
Currently, reflection of annotation value commands relies on the
`annotation` reference to be present in the command, which is not always
the case, such as when only the annotation value is altered.  Use the
new DDL identity mechanism to always guarantee that the reference is
there in a canonical representation of a command.  While at it, do some
minor refactoring to make DDL identity handling sligtly more formal and
general.

Fixes: #1618.