### PR TITLE
Allow empty curly-braced blocks in DDL and SDL

### DIFF
--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -226,7 +226,7 @@ class ProductionHelper:
     def _singleton_list(self, cmd):
         self.val = [cmd.val]
 
-    def _empty(self):
+    def _empty(self, *kids):
         self.val = []
 
     def _block(self, lbrace, cmdlist, sc2, rbrace):
@@ -263,6 +263,8 @@ def commands_block(parent, *commands, opt=True):
     clsdict['reduce_LBRACE_Semicolons_' + cmdlist.__name__ +
             '_OptSemicolons_RBRACE'] = \
         ProductionHelper._block2
+    clsdict['reduce_LBRACE_OptSemicolons_RBRACE'] = \
+        ProductionHelper._empty
     if not opt:
         #
         #   | Command

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -180,7 +180,7 @@ class SDLProductionHelper:
     def _singleton_list(self, cmd):
         self.val = [cmd.val]
 
-    def _empty(self):
+    def _empty(self, *kids):
         self.val = []
 
     def _block(self, lbrace, sc1, cmdl, rbrace):
@@ -249,6 +249,8 @@ def sdl_commands_block(parent, *commands, opt=True):
     clsdict[f'reduce_LBRACE_OptSemicolons_{cmdlist.__name__}_OptSemicolons_' +
             f'{cmd_s.__name__}_RBRACE'] = \
         SDLProductionHelper._block3
+    clsdict[f'reduce_LBRACE_OptSemicolons_RBRACE'] = \
+        SDLProductionHelper._empty
     _new_nonterm(f'{parent}SDLCommandsBlock', clsdict=clsdict)
 
     if opt is False:

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3818,6 +3818,124 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_empty_01(self):
+        """
+        CREATE TYPE Foo { };
+
+% OK %
+
+        CREATE TYPE Foo;
+        """
+
+    def test_edgeql_syntax_ddl_empty_02(self):
+        """
+        CREATE TYPE Foo { CREATE PROPERTY bar -> str { } };
+
+% OK %
+
+        CREATE TYPE Foo {
+            CREATE PROPERTY bar -> str;
+        };
+        """
+
+    def test_edgeql_syntax_sdl_empty_01(self):
+        """
+        START MIGRATION to {
+            type default::User {
+
+            };
+        };
+
+% OK %
+
+        START MIGRATION to {
+            type default::User;
+        };
+        """
+
+    def test_edgeql_syntax_sdl_empty_02(self):
+        """
+        START MIGRATION to {
+            type default::User {
+                property name -> str {
+
+                };
+            };
+        };
+
+% OK %
+
+        START MIGRATION to {
+            type default::User {
+                property name -> str;
+            };
+        };
+        """
+
+    def test_edgeql_syntax_ddl_semi_01(self):
+        """
+        CREATE TYPE Foo { ;;; };
+
+% OK %
+
+        CREATE TYPE Foo;
+        """
+
+    def test_edgeql_syntax_ddl_semi_02(self):
+        """
+        CREATE TYPE Foo {
+            ;;;
+            CREATE PROPERTY bar -> str
+            ;;;
+            CREATE PROPERTY baz -> int64;
+            ;;;
+        };
+
+% OK %
+
+        CREATE TYPE Foo {
+            CREATE PROPERTY bar -> str;
+            CREATE PROPERTY baz -> int64;
+        };
+        """
+
+    def test_edgeql_syntax_sdl_semi_01(self):
+        """
+        START MIGRATION to {
+            type default::User {
+                ;;;;
+            };
+        };
+
+% OK %
+
+        START MIGRATION to {
+            type default::User;
+        };
+        """
+
+    def test_edgeql_syntax_sdl_semi_02(self):
+        """
+        START MIGRATION to {
+            type default::User {
+                ;;;
+                property bar -> int64;
+                ;;;
+                property name -> str;
+                ;;;
+            };
+        };
+
+% OK %
+
+        START MIGRATION to {
+            type default::User {
+                property bar -> int64;
+                property name -> str;
+            };
+        };
+        """
+
     def test_edgeql_syntax_transaction_01(self):
         """
         START TRANSACTION;


### PR DESCRIPTION
Currently, `CREATE User {}` is a syntax error, and likewise in SDL.
This is merely an artifact of how the parser productions are arranged,
not a deliberate restriction, so add the missing productions to allow
empty blocks in the name of better UX.

Fixes: #1626.