### PR TITLE
Make query normalization use same variable for same constants

### DIFF
--- a/edb/edgeql-rust/src/pynormalize.rs
+++ b/edb/edgeql-rust/src/pynormalize.rs
@@ -43,7 +43,7 @@ py_class!(pub class Entry |py| {
                 match var.value {
                     Value::Int(ref v) => v.to_py_object(py).into_object(),
                     Value::Str(ref v) => v.to_py_object(py).into_object(),
-                    Value::Float(ref v) => v.to_py_object(py).into_object(),
+                    Value::Float(ref v) => v.0.to_py_object(py).into_object(),
                     Value::BigInt(ref v) => {
                         py.get_type::<PyInt>()
                         .call(py,
@@ -103,7 +103,7 @@ pub fn serialize_extra(variables: &[Variable]) -> Result<Bytes, String> {
                     .map_err(|e| format!("str cannot be encoded: {}", e))?;
             }
             Value::Float(ref v) => {
-                codec::Float64.encode(&mut buf, &P::Float64(f64::from_bits(*v)))
+                codec::Float64.encode(&mut buf, &P::Float64(v.0))
                     .map_err(|e| format!("float cannot be encoded: {}", e))?;
             }
             Value::BigInt(ref v) => {

--- a/edb/edgeql-rust/src/pynormalize.rs
+++ b/edb/edgeql-rust/src/pynormalize.rs
@@ -103,7 +103,7 @@ pub fn serialize_extra(variables: &[Variable]) -> Result<Bytes, String> {
                     .map_err(|e| format!("str cannot be encoded: {}", e))?;
             }
             Value::Float(ref v) => {
-                codec::Float64.encode(&mut buf, &P::Float64(v.clone()))
+                codec::Float64.encode(&mut buf, &P::Float64(f64::from_bits(*v)))
                     .map_err(|e| format!("float cannot be encoded: {}", e))?;
             }
             Value::BigInt(ref v) => {

--- a/edb/edgeql-rust/tests/normalize.rs
+++ b/edb/edgeql-rust/tests/normalize.rs
@@ -60,10 +60,10 @@ fn test_float() {
         "SELECT(<__std__::float64>$0)+(<__std__::float64>$1)");
     assert_eq!(entry.variables, vec![
         Variable {
-            value: Value::Float(1.5),
+            value: Value::Float((1.5_f64).to_bits()),
         },
         Variable {
-            value: Value::Float(23.25),
+            value: Value::Float((23.25_f64).to_bits()),
         }
     ]);
 }
@@ -168,6 +168,45 @@ fn test_tuple_access() {
     assert_eq!(entry.variables, vec![
         Variable {
             value: Value::Int(2),
+        },
+    ]);
+}
+
+#[test]
+fn test_matching_int() {
+    let entry = normalize(r###"
+        SELECT 1 + 1
+    "###).unwrap();
+    assert_eq!(entry.key, "SELECT(<__std__::int64>$0)+(<__std__::int64>$0)");
+    assert_eq!(entry.variables, vec![
+        Variable {
+            value: Value::Int(1),
+        },
+    ]);
+}
+
+#[test]
+fn test_matching_str() {
+    let entry = normalize(r###"
+        SELECT "foo" ++ "foo"
+    "###).unwrap();
+    assert_eq!(entry.key, "SELECT(<__std__::str>$0)++(<__std__::str>$0)");
+    assert_eq!(entry.variables, vec![
+        Variable {
+            value: Value::Str("foo".into()),
+        },
+    ]);
+}
+
+#[test]
+fn test_matching_float() {
+    let entry = normalize(r###"
+        SELECT 3.14 + 3.14
+    "###).unwrap();
+    assert_eq!(entry.key, "SELECT(<__std__::float64>$0)+(<__std__::float64>$0)");
+    assert_eq!(entry.variables, vec![
+        Variable {
+            value: Value::Float((3.14_f64).to_bits()),
         },
     ]);
 }

--- a/edb/edgeql-rust/tests/normalize.rs
+++ b/edb/edgeql-rust/tests/normalize.rs
@@ -1,4 +1,4 @@
-use edgeql_rust::normalize::{normalize, Value, Variable};
+use edgeql_rust::normalize::{normalize, Value, Variable, FloatWrapper};
 
 
 #[test]
@@ -60,10 +60,10 @@ fn test_float() {
         "SELECT(<__std__::float64>$0)+(<__std__::float64>$1)");
     assert_eq!(entry.variables, vec![
         Variable {
-            value: Value::Float((1.5_f64).to_bits()),
+            value: Value::Float(FloatWrapper(1.5)),
         },
         Variable {
-            value: Value::Float((23.25_f64).to_bits()),
+            value: Value::Float(FloatWrapper(23.25)),
         }
     ]);
 }
@@ -206,7 +206,7 @@ fn test_matching_float() {
     assert_eq!(entry.key, "SELECT(<__std__::float64>$0)+(<__std__::float64>$0)");
     assert_eq!(entry.variables, vec![
         Variable {
-            value: Value::Float((3.14_f64).to_bits()),
+            value: Value::Float(FloatWrapper(3.14)),
         },
     ]);
 }

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -384,25 +384,20 @@ class TestConstraintsSchema(tb.QueryTestCase):
                 """)
 
     async def test_select_coalesce_insert_01(self):
-        # We use parameters here because normalization prevents
-        # constants from appearing the same.
-        # TODO: Fix normalization and update this test.
         query = r'''
         SELECT
-         ((SELECT test::UniqueName_2 FILTER .name = <str>$0)
-          ?? (INSERT test::UniqueName_2 {name := <str>$0})) {name};
+         ((SELECT test::UniqueName_2 FILTER .name = "test")
+          ?? (INSERT test::UniqueName_2 {name := "test"})) {name};
         '''
 
         await self.assert_query_result(
             query,
             [{"name": "test"}],
-            variables=("test",)
         )
 
         await self.assert_query_result(
             query,
             [{"name": "test"}],
-            variables=("test",)
         )
 
         query2 = r'''


### PR DESCRIPTION
This is needed to make select-or-insert work when using constants,
since otherwise this hides the equality of constants from the
compiler.

Work on #684.