### PR TITLE
Bring the CREATE MIGRATION syntax in line with RFC 1000 edits

### DIFF
--- a/edb/edgeql-parser/src/keywords.rs
+++ b/edb/edgeql-parser/src/keywords.rs
@@ -46,6 +46,7 @@ pub const UNRESERVED_KEYWORDS: &[&str] = &[
     "oids",
     "on",
     "only",
+    "onto",
     "operator",
     "overloaded",
     "owned",

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1011,6 +1011,12 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_CreateMigration(self, node: qlast.CreateMigration) -> None:
         self.write('CREATE MIGRATION')
+        if node.name is not None:
+            self.write(' ')
+            self.write(ident_to_str(node.name.name))
+            if node.parent is not None:
+                self.write(' ONTO ')
+                self.write(ident_to_str(node.parent.name))
         if node.commands:
             self._ddl_visit_body(node.commands)
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2882,6 +2882,48 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_create_migration_01(self):
+        """
+        CREATE MIGRATION {};
+
+% OK %
+
+        CREATE MIGRATION;
+        """
+
+    def test_edgeql_syntax_ddl_create_migration_02(self):
+        """
+        CREATE MIGRATION { ;;; CREATE TYPE Foo ;;; CREATE TYPE Bar ;;; };
+
+% OK %
+
+        CREATE MIGRATION {
+            CREATE TYPE Foo;
+            CREATE TYPE Bar;
+        };
+        """
+
+    def test_edgeql_syntax_ddl_create_migration_03(self):
+        """
+        CREATE MIGRATION {
+            CREATE TYPE Foo;
+        };
+        """
+
+    def test_edgeql_syntax_ddl_create_migration_04(self):
+        """
+        CREATE MIGRATION m123123123 {
+            CREATE TYPE Foo;
+        };
+        """
+
+    def test_edgeql_syntax_ddl_create_migration_05(self):
+        """
+        CREATE MIGRATION m123123123 ONTO m134134134 {
+            CREATE TYPE Foo;
+        };
+        """
+
     # TODO: remove this test once the entire grammar is converted
     def test_edgeql_syntax_ddl_aggregate_00(self):
         """


### PR DESCRIPTION
This adds the syntax to allow passing an explicit migration name and
parent.  Both are used purely for sanity purposes so that the frontend
and the server are in agreement about the migration sequence.