### PR TITLE
Accept CREATE MIGRATION commands from the client

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -769,7 +769,10 @@ class Compiler(BaseCompiler):
         current_tx = ctx.state.current_tx()
         schema = current_tx.get_schema()
 
-        if isinstance(ql, qlast.StartMigration):
+        if isinstance(ql, qlast.CreateMigration):
+            query = self._compile_and_apply_ddl_stmt(ctx, ql)
+
+        elif isinstance(ql, qlast.StartMigration):
             if current_tx.is_implicit():
                 savepoint_name = None
                 tx_cmd = qlast.StartTransaction()

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5837,3 +5837,24 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     WITH MODULE test
                     DROP FUNCTION foo___1(a: int64);
                 ''')
+
+    async def test_edgeql_ddl_create_migration_01(self):
+        await self.con.execute(f'''
+            CREATE MIGRATION
+            {{
+                CREATE TYPE Type1 {{
+                    CREATE PROPERTY field1 -> str;
+                }};
+            }};
+        ''')
+
+        await self.assert_query_result(
+            '''
+            SELECT schema::ObjectType {
+                name
+            } FILTER .name = 'default::Type1'
+            ''',
+            [{
+                'name': 'default::Type1',
+            }]
+        )


### PR DESCRIPTION
Although the internals of `CREATE MIGRATION` are implemented, the
compiler frontend doesn't actually currently accept `CREATE MIGRATION`
commands from the client.  Fix this.