### PR TITLE
Make DESCRIBE CURRENT MIGRATION AS JSON conform to the RFC

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -880,7 +880,12 @@ class Compiler(BaseCompiler):
 
                 desc = json.dumps({
                     'confirmed': confirmed,
-                    'proposed': proposed,
+                    'proposed': [{
+                        'statements': [{
+                            'text': proposed[0],
+                        }],
+                        'confidence': 1.0,
+                    }],
                 }).encode('unicode_escape').decode('utf-8')
 
                 desc_ql = edgeql.parse(


### PR DESCRIPTION
The `DESCRIBE CURRENT MIGRATION AS JSON` output now matches that
specified in the RFC.  There's no support for alternatives and user
input inquiries yet, but this is enough to drive simple migrations.