### PR TITLE
Fix issues with nested inserts

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -317,11 +317,6 @@ def compile_InsertQuery(
         )
 
     with ctx.subquery() as ictx:
-        # Disallow nested INSERTs inside the shape in SELECT-or-INSERT.
-        # TODO: Support this.
-        if conditioned_on:
-            ictx.in_conditional = expr.context
-
         stmt = irast.InsertStmt()
         init_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -161,6 +161,11 @@ class CompilerContextLevel(compiler.ContextLevel):
         ]
     ]
 
+    #: The ir statement and CTE of any enclosing insert currently being
+    #: compiled.
+    enclosing_insert: Optional[
+        Tuple[irast.MutatingStmt, pgast.CommonTableExpr]]
+
     def __init__(
         self,
         prevlevel: Optional[CompilerContextLevel],
@@ -199,6 +204,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.scope_tree = scope_tree
             self.type_rel_overlays = collections.defaultdict(list)
             self.ptr_rel_overlays = collections.defaultdict(list)
+            self.enclosing_insert = None
 
         else:
             self.env = prevlevel.env
@@ -227,6 +233,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.scope_tree = prevlevel.scope_tree
             self.type_rel_overlays = prevlevel.type_rel_overlays
             self.ptr_rel_overlays = prevlevel.ptr_rel_overlays
+            self.enclosing_insert = prevlevel.enclosing_insert
 
             if mode in {ContextSwitchMode.SUBREL, ContextSwitchMode.NEWREL,
                         ContextSwitchMode.SUBSTMT}:

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1241,21 +1241,6 @@ def process_link_values(
                 row_query, ir_stmt.subject.path_id, env=input_rel_ctx.env)
             dispatch.visit(ir_expr, ctx=input_rel_ctx)
 
-            if is_insert:
-                target_rvar = pathctx.get_path_rvar(
-                    input_rel,
-                    ir_expr.path_id,
-                    aspect='identity',
-                    env=input_rel_ctx.env,
-                )
-                pathctx.put_path_rvar(
-                    input_rel,
-                    ir_stmt.subject.path_id,
-                    rvar=target_rvar,
-                    aspect='identity',
-                    env=input_rel_ctx.env,
-                )
-
             if (
                 isinstance(ir_expr.expr, irast.Stmt)
                 and ir_expr.expr.iterator_stmt is not None
@@ -1271,21 +1256,6 @@ def process_link_values(
                         inner_iterator_cte = cte
                         break
                 if inner_iterator_cte is not None:
-                    target_rvar = pathctx.get_path_rvar(
-                        input_rel,
-                        ir_expr.path_id,
-                        aspect='identity',
-                        env=input_rel_ctx.env,
-                    )
-
-                    pathctx.put_path_rvar(
-                        input_rel,
-                        inner_iterator_path_id,
-                        rvar=target_rvar,
-                        aspect='identity',
-                        env=input_rel_ctx.env,
-                    )
-
                     inner_iterator_rvar = relctx.rvar_for_rel(
                         inner_iterator_cte, lateral=True, ctx=subrelctx)
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1238,7 +1238,7 @@ def process_link_values(
         with subrelctx.newscope() as sctx, sctx.subrel() as input_rel_ctx:
             input_rel = input_rel_ctx.rel
             if iterator is not None:
-                input_rel_ctx.path_scope[iterator[1].query.path_id] = \
+                input_rel_ctx.path_scope[iterator[0].query.path_id] = \
                     row_query
             input_rel_ctx.expr_exposed = False
             input_rel_ctx.volatility_ref = pathctx.get_path_identity_var(

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1238,7 +1238,7 @@ def process_link_values(
         with subrelctx.newscope() as sctx, sctx.subrel() as input_rel_ctx:
             input_rel = input_rel_ctx.rel
             if iterator is not None:
-                input_rel_ctx.path_scope[iterator[0].query.path_id] = \
+                input_rel_ctx.path_scope[iterator[0].path_id] = \
                     row_query
             input_rel_ctx.expr_exposed = False
             input_rel_ctx.volatility_ref = pathctx.get_path_identity_var(

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -82,7 +82,8 @@ def pull_path_namespace(
             if path_id in squery.path_id_mask:
                 continue
 
-            rvar = maybe_get_path_rvar(target, path_id, aspect=aspect, ctx=ctx)
+            rvar = pathctx.maybe_get_path_rvar(
+                target, path_id, aspect=aspect, env=ctx.env)
             if rvar is None:
                 pathctx.put_path_rvar(
                     target, path_id, source, aspect=aspect, env=ctx.env)

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -590,6 +590,19 @@ def ensure_transient_identity_for_set(
                                   id_expr, force=True, env=ctx.env)
     pathctx.put_path_bond(stmt, ir_set.path_id)
 
+    if (ctx.volatility_ref is not None and
+            ctx.volatility_ref is not context.NO_VOLATILITY and
+            isinstance(stmt, pgast.SelectStmt)):
+        # Apply the volatility reference.
+        # See the comment in process_set_as_subquery().
+        stmt.where_clause = astutils.extend_binop(
+            stmt.where_clause,
+            pgast.NullTest(
+                arg=ctx.volatility_ref,
+                negated=True,
+            )
+        )
+
 
 def get_scope(
     ir_set: irast.Set, *,

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -44,6 +44,13 @@ type Note {
     link subject -> Object;
 }
 
+type Person {
+    required single property name -> std::str {
+        constraint std::exclusive;
+    };
+    optional multi link notes -> Note;
+}
+
 type DefaultTest1 {
     property num -> int64 {
         default := 42;


### PR DESCRIPTION
When an enclosing select-or-insert (which will soon become INSERT
UNLESS CONFLICT) conflicts, don't do nested inserts. Also, when there
are nested FORs, the inner inserts need to happen for each nested FOR.

Work on #684.