### PR TITLE
workflows: Bump various standard actions to v2

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -24,7 +24,7 @@ jobs:
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< tgt.name >>
@@ -34,7 +34,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -86,7 +86,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< tgt.name >>
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< tgt.name >>
@@ -116,13 +116,13 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb/edgedb-pkg
 
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< tgt.name >>
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< tgt.name >>
@@ -169,7 +169,7 @@ jobs:
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -193,12 +193,12 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< tgt.name >>
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
         ref: master

--- a/.github/workflows.src/release.tpl.yml
+++ b/.github/workflows.src/release.tpl.yml
@@ -27,7 +27,7 @@ jobs:
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< tgt.name >>
@@ -44,7 +44,7 @@ jobs:
       run: echo ::set-output name=version::${BRANCH#releases/}
       id: whichver
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< tgt.name >>
@@ -126,13 +126,13 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb/edgedb-pkg
 
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< tgt.name >>
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< tgt.name >>
@@ -176,7 +176,7 @@ jobs:
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -200,12 +200,12 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-<< tgt.name >>
         path: artifacts/<< tgt.name >>
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
         ref: master

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
         PKG_PLATFORM_VERSION: "stretch"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-debian-stretch
         path: artifacts/debian-stretch
@@ -42,7 +42,7 @@ jobs:
         PKG_PLATFORM_VERSION: "buster"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-debian-buster
         path: artifacts/debian-buster
@@ -60,7 +60,7 @@ jobs:
         PKG_PLATFORM_VERSION: "xenial"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-ubuntu-xenial
         path: artifacts/ubuntu-xenial
@@ -78,7 +78,7 @@ jobs:
         PKG_PLATFORM_VERSION: "bionic"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-ubuntu-bionic
         path: artifacts/ubuntu-bionic
@@ -96,7 +96,7 @@ jobs:
         PKG_PLATFORM_VERSION: "focal"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-ubuntu-focal
         path: artifacts/ubuntu-focal
@@ -114,7 +114,7 @@ jobs:
         PKG_PLATFORM_VERSION: "7"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-centos-7
         path: artifacts/centos-7
@@ -132,7 +132,7 @@ jobs:
         PKG_PLATFORM_VERSION: "8"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-centos-8
         path: artifacts/centos-8
@@ -142,7 +142,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -194,7 +194,7 @@ jobs:
       run: |
         edgedb-pkg/integration/macos/build.sh
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -205,7 +205,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-debian-stretch
         path: artifacts/debian-stretch
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-debian-buster
         path: artifacts/debian-buster
@@ -241,7 +241,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-ubuntu-xenial
         path: artifacts/ubuntu-xenial
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-ubuntu-bionic
         path: artifacts/ubuntu-bionic
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-ubuntu-focal
         path: artifacts/ubuntu-focal
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-centos-7
         path: artifacts/centos-7
@@ -313,7 +313,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-centos-8
         path: artifacts/centos-8
@@ -332,13 +332,13 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb/edgedb-pkg
 
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -357,7 +357,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-debian-stretch
         path: artifacts/debian-stretch
@@ -385,7 +385,7 @@ jobs:
         PKG_PLATFORM_VERSION: "stretch"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -408,7 +408,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-debian-buster
         path: artifacts/debian-buster
@@ -436,7 +436,7 @@ jobs:
         PKG_PLATFORM_VERSION: "buster"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -448,7 +448,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-ubuntu-xenial
         path: artifacts/ubuntu-xenial
@@ -476,7 +476,7 @@ jobs:
         PKG_PLATFORM_VERSION: "xenial"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -488,7 +488,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-ubuntu-bionic
         path: artifacts/ubuntu-bionic
@@ -516,7 +516,7 @@ jobs:
         PKG_PLATFORM_VERSION: "bionic"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -528,7 +528,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-ubuntu-focal
         path: artifacts/ubuntu-focal
@@ -556,7 +556,7 @@ jobs:
         PKG_PLATFORM_VERSION: "focal"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -568,7 +568,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-centos-7
         path: artifacts/centos-7
@@ -596,7 +596,7 @@ jobs:
         PKG_PLATFORM_VERSION: "7"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -608,7 +608,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-centos-8
         path: artifacts/centos-8
@@ -636,7 +636,7 @@ jobs:
         PKG_PLATFORM_VERSION: "8"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -649,12 +649,12 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
         ref: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         PKG_PLATFORM_VERSION: "stretch"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-debian-stretch
         path: artifacts/debian-stretch
@@ -53,7 +53,7 @@ jobs:
         PKG_PLATFORM_VERSION: "buster"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-debian-buster
         path: artifacts/debian-buster
@@ -79,7 +79,7 @@ jobs:
         PKG_PLATFORM_VERSION: "xenial"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-ubuntu-xenial
         path: artifacts/ubuntu-xenial
@@ -105,7 +105,7 @@ jobs:
         PKG_PLATFORM_VERSION: "bionic"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-ubuntu-bionic
         path: artifacts/ubuntu-bionic
@@ -131,7 +131,7 @@ jobs:
         PKG_PLATFORM_VERSION: "focal"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-ubuntu-focal
         path: artifacts/ubuntu-focal
@@ -157,7 +157,7 @@ jobs:
         PKG_PLATFORM_VERSION: "7"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-centos-7
         path: artifacts/centos-7
@@ -183,7 +183,7 @@ jobs:
         PKG_PLATFORM_VERSION: "8"
         EXTRA_OPTIMIZATIONS: "true"
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: builds-centos-8
         path: artifacts/centos-8
@@ -200,7 +200,7 @@ jobs:
       run: echo ::set-output name=version::${BRANCH#releases/}
       id: whichver
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
         ref: master
@@ -264,7 +264,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-debian-stretch
         path: artifacts/debian-stretch
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-debian-buster
         path: artifacts/debian-buster
@@ -298,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-ubuntu-xenial
         path: artifacts/ubuntu-xenial
@@ -315,7 +315,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-ubuntu-bionic
         path: artifacts/ubuntu-bionic
@@ -332,7 +332,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-ubuntu-focal
         path: artifacts/ubuntu-focal
@@ -349,7 +349,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-centos-7
         path: artifacts/centos-7
@@ -366,7 +366,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-centos-8
         path: artifacts/centos-8
@@ -384,13 +384,13 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
         ref: master
         path: edgedb/edgedb-pkg
 
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
@@ -408,7 +408,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-debian-stretch
         path: artifacts/debian-stretch
@@ -434,7 +434,7 @@ jobs:
         PKG_PLATFORM_VERSION: "stretch"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -457,7 +457,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-debian-buster
         path: artifacts/debian-buster
@@ -483,7 +483,7 @@ jobs:
         PKG_PLATFORM_VERSION: "buster"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -495,7 +495,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-ubuntu-xenial
         path: artifacts/ubuntu-xenial
@@ -521,7 +521,7 @@ jobs:
         PKG_PLATFORM_VERSION: "xenial"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -533,7 +533,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-ubuntu-bionic
         path: artifacts/ubuntu-bionic
@@ -559,7 +559,7 @@ jobs:
         PKG_PLATFORM_VERSION: "bionic"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -571,7 +571,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-ubuntu-focal
         path: artifacts/ubuntu-focal
@@ -597,7 +597,7 @@ jobs:
         PKG_PLATFORM_VERSION: "focal"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -609,7 +609,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-centos-7
         path: artifacts/centos-7
@@ -635,7 +635,7 @@ jobs:
         PKG_PLATFORM_VERSION: "7"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -647,7 +647,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-centos-8
         path: artifacts/centos-8
@@ -673,7 +673,7 @@ jobs:
         PKG_PLATFORM_VERSION: "8"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
@@ -686,12 +686,12 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/download-artifact@v1
+    - uses: actions/download-artifact@v2
       with:
         name: builds-macos-x86_64
         path: artifacts/macos-x86_64
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
         ref: master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,17 +17,17 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 50
         submodules: true
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       id: depcache
       with:
         path: deps
@@ -47,7 +47,7 @@ jobs:
         mkdir -p .tmp
         python setup.py --quiet gen_build_cache_key >.tmp/build_cache_key.txt
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       id: buildcache
       with:
         path: build


### PR DESCRIPTION
Update `checkout`, `cache`, `download-artifact`,
`upload-artifact` and `setup-python` to v2.  This brings
performance improvements and new features for the
aforementioned actions.