### PR TITLE
workflows: Fix target path for actions/checkout

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         repository: edgedb/edgedb-pkg
         ref: master
-        path: edgedb/edgedb-pkg
+        path: edgedb-pkg
 
     - uses: actions/cache@v2
       id: sdk1010cache
@@ -120,7 +120,7 @@ jobs:
       with:
         repository: edgedb/edgedb-pkg
         ref: master
-        path: edgedb/edgedb-pkg
+        path: edgedb-pkg
 
     - uses: actions/download-artifact@v2
       with:
@@ -173,7 +173,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     <% if tgt.name == 'debian-stretch' %>
 
     - name: Publish Docker Image
@@ -202,7 +202,7 @@ jobs:
       with:
         repository: edgedb/edgedb-pkg
         ref: master
-        path: edgedb/edgedb-pkg
+        path: edgedb-pkg
 
     - name: Describe
       id: describe

--- a/.github/workflows.src/release.tpl.yml
+++ b/.github/workflows.src/release.tpl.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         repository: edgedb/edgedb-pkg
         ref: master
-        path: edgedb/edgedb-pkg
+        path: edgedb-pkg
 
     - uses: actions/cache@v2
       id: sdk1010cache
@@ -130,7 +130,7 @@ jobs:
       with:
         repository: edgedb/edgedb-pkg
         ref: master
-        path: edgedb/edgedb-pkg
+        path: edgedb-pkg
 
     - uses: actions/download-artifact@v2
       with:
@@ -180,7 +180,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     <% if tgt.name == 'debian-stretch' %>
 
     - name: Publish Docker Image
@@ -209,7 +209,7 @@ jobs:
       with:
         repository: edgedb/edgedb-pkg
         ref: master
-        path: edgedb/edgedb-pkg
+        path: edgedb-pkg
 
     - name: Describe
       id: describe

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -146,7 +146,7 @@ jobs:
       with:
         repository: edgedb/edgedb-pkg
         ref: master
-        path: edgedb/edgedb-pkg
+        path: edgedb-pkg
 
     - uses: actions/cache@v2
       id: sdk1010cache
@@ -336,7 +336,7 @@ jobs:
       with:
         repository: edgedb/edgedb-pkg
         ref: master
-        path: edgedb/edgedb-pkg
+        path: edgedb-pkg
 
     - uses: actions/download-artifact@v2
       with:
@@ -389,7 +389,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
     - name: Publish Docker Image
@@ -440,7 +440,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
   publish-ubuntu-xenial:
@@ -480,7 +480,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
   publish-ubuntu-bionic:
@@ -520,7 +520,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
   publish-ubuntu-focal:
@@ -560,7 +560,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
   publish-centos-7:
@@ -600,7 +600,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
   publish-centos-8:
@@ -640,7 +640,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
 
@@ -658,7 +658,7 @@ jobs:
       with:
         repository: edgedb/edgedb-pkg
         ref: master
-        path: edgedb/edgedb-pkg
+        path: edgedb-pkg
 
     - name: Describe
       id: describe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,7 @@ jobs:
       with:
         repository: edgedb/edgedb-pkg
         ref: master
-        path: edgedb/edgedb-pkg
+        path: edgedb-pkg
 
     - uses: actions/cache@v2
       id: sdk1010cache
@@ -388,7 +388,7 @@ jobs:
       with:
         repository: edgedb/edgedb-pkg
         ref: master
-        path: edgedb/edgedb-pkg
+        path: edgedb-pkg
 
     - uses: actions/download-artifact@v2
       with:
@@ -438,7 +438,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
     - name: Publish Docker Image
@@ -487,7 +487,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
   publish-ubuntu-xenial:
@@ -525,7 +525,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
   publish-ubuntu-bionic:
@@ -563,7 +563,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
   publish-ubuntu-focal:
@@ -601,7 +601,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
   publish-centos-7:
@@ -639,7 +639,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
   publish-centos-8:
@@ -677,7 +677,7 @@ jobs:
       with:
         repository: edgedb/edgedb-docker
         ref: master
-        path: edgedb/dockerfile
+        path: dockerfile
     
 
 
@@ -695,7 +695,7 @@ jobs:
       with:
         repository: edgedb/edgedb-pkg
         ref: master
-        path: edgedb/edgedb-pkg
+        path: edgedb-pkg
 
     - name: Describe
       id: describe


### PR DESCRIPTION
`actions/checkout@v2` changed how the `path:` argument is handled,
adapt to that.