### PR TITLE
graphql: Add an `exists` filter operation.

### DIFF
--- a/docs/cheatsheet/graphql.rst
+++ b/docs/cheatsheet/graphql.rst
@@ -103,6 +103,24 @@ reviews):
         }
     }
 
+Use the :ref:`MovieAlias <ref_cheatsheet_aliases>` in order to find
+movies that have no reviews:
+
+.. code-block:: graphql
+
+    {
+        MovieAlias(
+            filter: {
+                reviews: {exists: false},
+            }
+        ) {
+            id
+            title
+            year
+            description
+        }
+    }
+
 Use a GraphQL :ref:`mutation <ref_graphql_mutations>` to add a user:
 
 .. code-block:: graphql

--- a/docs/clients/99_graphql/graphql.rst
+++ b/docs/clients/99_graphql/graphql.rst
@@ -73,20 +73,10 @@ Filtering
 Filtering the retrieved data is done by specifying a ``filter``
 argument. The ``filter`` argument is customized to each specific type
 based on the available fields. In case of the sample schema, here's
-what the specification for the available filter arguments:
+what the specification for the available filter arguments for querying
+``Book``:
 
 .. code-block:: graphql-schema
-
-    # this is Author-specific
-    input FilterAuthor {
-        # basic boolean operators that combine conditions
-        and: [FilterAuthor!]
-        or: [FilterAuthor!]
-        not: FilterAuthor
-
-        # fields available for filtering (properties in EdgeQL)
-        name: FilterString
-    }
 
     # this is Book-specific
     input FilterBook {
@@ -99,11 +89,24 @@ what the specification for the available filter arguments:
         title: FilterString
         synopsis: FilterString
         isbn: FilterString
-        author: FilterAuthor
+        author: NestedFilterAuthor
+    }
+
+    # this is Author-specific
+    input NestedFilterAuthor {
+        # instead of boolean operations, "exists" check is available
+        # for links
+        exists: Boolean
+
+        # fields available for filtering (properties in EdgeQL)
+        name: FilterString
     }
 
     # this is generic
     input FilterString {
+        # "exists" check is available for every property, too
+        exists: Boolean
+
         # equality
         eq: String
         neq: String
@@ -182,6 +185,32 @@ example:
     |                 }               |         AND                     |
     |             }                   |         Book.title < 'o';       |
     |         ) {                     |                                 |
+    |             title               |                                 |
+    |         }                       |                                 |
+    |     }                           |                                 |
+    +---------------------------------+---------------------------------+
+
+
+It is possible to search for books that don't specify the author for
+some reason:
+
+.. table::
+    :class: codeblocks
+
+    +---------------------------------+---------------------------------+
+    | GraphQL                         | EdgeQL equivalent               |
+    +=================================+=================================+
+    | .. code-block:: graphql         | .. code-block:: edgeql          |
+    |                                 |                                 |
+    |     {                           |     SELECT                      |
+    |         Book(                   |         Book {                  |
+    |             filter: {           |             id,                 |
+    |                 author: {       |             title               |
+    |                   exists: false |         }                       |
+    |                 }               |     FILTER                      |
+    |             }                   |         NOT EXISTS              |
+    |         ) {                     |             Book.author;        |
+    |             id                  |                                 |
     |             title               |                                 |
     |         }                       |                                 |
     |     }                           |                                 |

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -3227,6 +3227,210 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             ]
         })
 
+    def test_graphql_functional_exists_01(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                User(
+                    filter: {profile: {exists: true}},
+                    order: {name: {dir: ASC}}
+                ) {
+                    name
+                    profile {
+                        name
+                    }
+                }
+            }
+        """, {
+            "User": [
+                {
+                    "name": "Alice",
+                    "profile": {
+                        "name": "Alice profile",
+                    },
+                },
+                {
+                    "name": "Bob",
+                    "profile": {
+                        "name": "Bob profile",
+                    },
+                },
+            ]
+        })
+
+    def test_graphql_functional_exists_02(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                User(
+                    filter: {profile: {exists: false}},
+                    order: {name: {dir: ASC}}
+                ) {
+                    name
+                    profile {
+                        name
+                    }
+                }
+            }
+        """, {
+            "User": [
+                {
+                    "name": "Jane",
+                    "profile": None,
+                },
+                {
+                    "name": "John",
+                    "profile": None,
+                },
+            ]
+        })
+
+    def test_graphql_functional_exists_03(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                User(
+                    filter: {groups: {settings: {exists: false}}},
+                    order: {name: {dir: ASC}}
+                ) {
+                    name
+                    groups {
+                        name
+                        settings {
+                            name
+                        }
+                    }
+                }
+            }
+        """, {
+            "User": [
+                {
+                    "name": "Alice",
+                    "groups": [],
+                },
+                {
+                    "name": "Bob",
+                    "groups": [],
+                },
+                {
+                    "name": "John",
+                    "groups": [
+                        {
+                            "name": "basic",
+                            "settings": [],
+                        }
+                    ],
+                },
+            ]
+        })
+
+    def test_graphql_functional_exists_04(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                User(
+                    filter: {groups: {settings: {exists: true}}}
+                ) {
+                    name
+                    groups {
+                        name
+                        settings(order: {name: {dir: ASC}}) {
+                            name
+                        }
+                    }
+                }
+            }
+        """, {
+            "User": [
+                {
+                    "name": "Jane",
+                    "groups": [
+                        {
+                            "name": "upgraded",
+                            "settings": [
+                                {
+                                    "name": "perks",
+                                },
+                                {
+                                    "name": "template",
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ]
+        })
+
+    def test_graphql_functional_exists_05(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                User(
+                    filter: {groups: {settings: {id: {exists: false}}}},
+                    order: {name: {dir: ASC}}
+                ) {
+                    name
+                    groups {
+                        name
+                        settings {
+                            name
+                        }
+                    }
+                }
+            }
+        """, {
+            "User": [
+                {
+                    "name": "Alice",
+                    "groups": [],
+                },
+                {
+                    "name": "Bob",
+                    "groups": [],
+                },
+                {
+                    "name": "John",
+                    "groups": [
+                        {
+                            "name": "basic",
+                            "settings": [],
+                        }
+                    ],
+                },
+            ]
+        })
+
+    def test_graphql_functional_exists_06(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                User(
+                    filter: {groups: {settings: {id: {exists: true}}}}
+                ) {
+                    name
+                    groups {
+                        name
+                        settings(order: {name: {dir: ASC}}) {
+                            name
+                        }
+                    }
+                }
+            }
+        """, {
+            "User": [
+                {
+                    "name": "Jane",
+                    "groups": [
+                        {
+                            "name": "upgraded",
+                            "settings": [
+                                {
+                                    "name": "perks",
+                                },
+                                {
+                                    "name": "template",
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ]
+        })
+
 
 class TestGraphQLInit(tb.GraphQLTestCase):
     """Test GraphQL initialization on an empty database."""


### PR DESCRIPTION
The `exists` filter operation appears at every nested level regardless
of whether the level represents a link or a property. The operation
takes either a `true` or `false`, which translates to `EXISTS` and `NOT
EXISTS` EdgeQL respectively.

Fixes #1655