### PR TITLE
Fix quoting of identifiers in SQL.

### DIFF
--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -81,7 +81,10 @@ def needs_quoting(string):
                string.replace('_', 'a').isalnum())
     return (
         not isalnum or
-        string.lower() in pg_keywords.by_type[pg_keywords.RESERVED_KEYWORD] or
+        string.lower() in pg_keywords.by_type[
+            pg_keywords.RESERVED_KEYWORD] or
+        string.lower() in pg_keywords.by_type[
+            pg_keywords.TYPE_FUNC_NAME_KEYWORD] or
         string.lower() != string
     )
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -879,6 +879,21 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 ALTER TYPE Child ALTER LINK target DROP OWNED;
             """)
 
+    async def test_edgeql_ddl_27(self):
+        # Test that identifiers that are SQL keywords get quoted.
+        # Issue 1667
+        await self.con.execute("""
+            CREATE TYPE test::Foo {
+                CREATE PROPERTY left -> str;
+                CREATE PROPERTY smallint -> str;
+                CREATE PROPERTY natural -> str;
+                CREATE PROPERTY null -> str;
+                CREATE PROPERTY `like` -> str;
+                CREATE PROPERTY `create` -> str;
+                CREATE PROPERTY `link` -> str;
+            };
+        """)
+
     async def test_edgeql_ddl_default_01(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,


### PR DESCRIPTION
EdgeQL identifiers that are the same as SQL keywords should be quoted.
Unreserved SQL keywords are exempt from this rule.

Fixes #1667.