### PR TITLE
Fix handling of savepoints inside migration blocks

### DIFF
--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -314,6 +314,7 @@ class Transaction:
                 modaliases=self.get_modaliases(),
                 config=self.get_session_config(),
                 cached_reflection=self.get_cached_reflection(),
+                migration_state=self.get_migration_state(),
             ),
         )
 
@@ -326,6 +327,7 @@ class Transaction:
                 modaliases=self.get_modaliases(),
                 config=self.get_session_config(),
                 cached_reflection=self.get_cached_reflection(),
+                migration_state=self.get_migration_state(),
             ),
         )
 


### PR DESCRIPTION
Savepoints currently forget to pass the migration state along due to an
oversight.

Fixes: #1678