### PR TITLE
wip

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -293,6 +293,7 @@ def compile_ast_fragment_to_ir(
         expr=ir_set,
         schema=ctx.env.schema,
         stype=result_type,
+        has_dml=ir_set.has_dml,
     )
 
 

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -211,7 +211,17 @@ def compile_FunctionCall(
         tuple_path_ids=tuple_path_ids,
     )
 
-    return setgen.ensure_set(fcall, typehint=rtype, path_id=path_id, ctx=ctx)
+    result = setgen.ensure_set(fcall, typehint=rtype, path_id=path_id, ctx=ctx)
+    result.has_dml = func.get_mutating_stmts(env.schema)
+
+    # top-level statement or at least current statement should be
+    # marked as having DML
+    if ctx.toplevel_stmt:
+        ctx.toplevel_stmt.has_dml = True
+    elif ctx.stmt:
+        ctx.stmt.has_dml = True
+
+    return result
 
 
 #: A dictionary of conditional callables and the indices

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -232,6 +232,7 @@ def fini_expression(
             t for t in ctx.env.created_schema_objects
             if isinstance(t, s_types.Collection) and t != expr_type
         ),
+        has_dml=ir.has_dml,
     )
     return result
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -89,9 +89,10 @@ def new_scope_tree() -> ScopeTreeNode:
 
 class Base(ast.AST):
     __abstract_node__ = True
-    __ast_hidden__ = {'context'}
+    __ast_hidden__ = {'context', 'has_dml'}
 
     context: parsing.ParserContext
+    has_dml: bool = False
 
     def __repr__(self) -> str:
         return (

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -979,6 +979,9 @@ class Function(CallableObject, VolatilitySubject, s_abc.Function,
     error_on_null_result = so.SchemaField(
         str, default=None, compcoef=0.9, introspectable=False)
 
+    mutating_stmts = so.SchemaField(
+        bool, default=False, allow_ddl_set=True, ephemeral=True)
+
     initial_value = so.SchemaField(
         expr.Expression, default=None, compcoef=0.4, coerce=True)
 
@@ -1137,6 +1140,9 @@ class FunctionCommand(
         ir = compiled.irast
         assert isinstance(ir, irast.Statement)
         schema = ir.schema
+
+        # Record whether the function has any mutations
+        self.set_attribute_value('mutating_stmts', ir.has_dml)
 
         return_type = self._get_attribute_value(schema, context, 'return_type')
         if (not ir.stype.issubclass(schema, return_type)


### PR DESCRIPTION
The `has_dml` and `mutating_stmts` flags should be sufficient to keep track of DML usage within function bodies as well as potentially track that in default expressions and computables. It's probably a good idea to restrict DML in the majority of the DDL expressions, actually.

Please look over this and I'll set up a test suite that checks this flag (similar to how cardinality is tested in a separate test suite).