### PR TITLE
Fix broken errors in some correlated set cases

### DIFF
--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -89,14 +89,11 @@ def register_set_in_scope(
     if path_scope is None:
         path_scope = ctx.path_scope
 
-    try:
-        return path_scope.attach_path(
-            ir_set.path_id,
-            fence_points=fence_points,
-        )
-    except irast.InvalidScopeConfiguration as e:
-        raise errors.QueryError(
-            e.args[0], context=ir_set.context) from e
+    return path_scope.attach_path(
+        ir_set.path_id,
+        fence_points=fence_points,
+        context=ir_set.context,
+    )
 
 
 def assign_set_scope(

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -779,12 +779,9 @@ def compile_Shape(
             f'shapes cannot be applied to '
             f'{expr_stype.get_verbosename(ctx.env.schema)}'
         )
-    try:
-        view_type = viewgen.process_view(
-            stype=expr_stype, path_id=expr.path_id,
-            elements=shape.elements, ctx=ctx)
-    except irast.InvalidScopeConfiguration as e:
-        raise errors.QueryError(e.args[0], context=shape.context) from e
+    view_type = viewgen.process_view(
+        stype=expr_stype, path_id=expr.path_id,
+        elements=shape.elements, parser_context=shape.context, ctx=ctx)
 
     return setgen.ensure_set(expr, type_override=view_type, ctx=ctx)
 
@@ -1044,20 +1041,18 @@ def compile_query_subject(
                 f'{expr_stype.get_verbosename(ctx.env.schema)}'
             )
 
-        try:
-            view_scls = viewgen.process_view(
-                stype=expr_stype,
-                path_id=expr.path_id,
-                elements=shape,
-                view_rptr=view_rptr,
-                view_name=view_name,
-                is_insert=is_insert,
-                is_update=is_update,
-                is_delete=is_delete,
-                ctx=ctx,
-            )
-        except irast.InvalidScopeConfiguration as e:
-            raise errors.QueryError(e.args[0], context=expr.context) from e
+        view_scls = viewgen.process_view(
+            stype=expr_stype,
+            path_id=expr.path_id,
+            elements=shape,
+            view_rptr=view_rptr,
+            view_name=view_name,
+            is_insert=is_insert,
+            is_update=is_update,
+            is_delete=is_delete,
+            parser_context=expr.context,
+            ctx=ctx,
+        )
 
     if view_scls is not None:
         expr = setgen.ensure_set(expr, type_override=view_scls, ctx=ctx)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -779,9 +779,12 @@ def compile_Shape(
             f'shapes cannot be applied to '
             f'{expr_stype.get_verbosename(ctx.env.schema)}'
         )
-    view_type = viewgen.process_view(
-        stype=expr_stype, path_id=expr.path_id,
-        elements=shape.elements, ctx=ctx)
+    try:
+        view_type = viewgen.process_view(
+            stype=expr_stype, path_id=expr.path_id,
+            elements=shape.elements, ctx=ctx)
+    except irast.InvalidScopeConfiguration as e:
+        raise errors.QueryError(e.args[0], context=shape.context) from e
 
     return setgen.ensure_set(expr, type_override=view_type, ctx=ctx)
 
@@ -1041,17 +1044,20 @@ def compile_query_subject(
                 f'{expr_stype.get_verbosename(ctx.env.schema)}'
             )
 
-        view_scls = viewgen.process_view(
-            stype=expr_stype,
-            path_id=expr.path_id,
-            elements=shape,
-            view_rptr=view_rptr,
-            view_name=view_name,
-            is_insert=is_insert,
-            is_update=is_update,
-            is_delete=is_delete,
-            ctx=ctx,
-        )
+        try:
+            view_scls = viewgen.process_view(
+                stype=expr_stype,
+                path_id=expr.path_id,
+                elements=shape,
+                view_rptr=view_rptr,
+                view_name=view_name,
+                is_insert=is_insert,
+                is_update=is_update,
+                is_delete=is_delete,
+                ctx=ctx,
+            )
+        except irast.InvalidScopeConfiguration as e:
+            raise errors.QueryError(e.args[0], context=expr.context) from e
 
     if view_scls is not None:
         expr = setgen.ensure_set(expr, type_override=view_scls, ctx=ctx)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -80,7 +80,7 @@ def init_context(
         # the necessary fashion.
         for singleton in options.singletons:
             path_id = pathctx.get_path_id(singleton, ctx=ctx)
-            ctx.env.path_scope.attach_path(path_id)
+            ctx.env.path_scope.attach_path(path_id, context=None)
 
         ctx.path_scope = ctx.env.path_scope.attach_fence()
 

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -152,6 +152,10 @@ class InvalidPropertyTargetError(InvalidTargetError):
     _code = 0x_04_02_01_02
 
 
+class InvalidScopeConfigurationError(InvalidTypeError):
+    _code = 0x_04_02_02_00
+
+
 class InvalidReferenceError(QueryError):
     _code = 0x_04_03_00_00
 

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -152,10 +152,6 @@ class InvalidPropertyTargetError(InvalidTargetError):
     _code = 0x_04_02_01_02
 
 
-class InvalidScopeConfigurationError(InvalidTypeError):
-    _code = 0x_04_02_02_00
-
-
 class InvalidReferenceError(QueryError):
     _code = 0x_04_03_00_00
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -80,7 +80,7 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
 from .pathid import PathId, AnyNamespace, WeakNamespace  # noqa
-from .scopetree import InvalidScopeConfiguration, ScopeTreeNode  # noqa
+from .scopetree import ScopeTreeNode  # noqa
 
 
 def new_scope_tree() -> ScopeTreeNode:

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -25,16 +25,9 @@ from typing import *
 import textwrap
 import weakref
 
+from edb import errors
+from edb.common import context as pctx
 from . import pathid
-
-
-class InvalidScopeConfiguration(Exception):
-    def __init__(self, msg: str, *,
-                 offending_node: ScopeTreeNode,
-                 existing_node: ScopeTreeNode) -> None:
-        super().__init__(msg)
-        self.offending_node = offending_node
-        self.existing_node = existing_node
 
 
 class FenceInfo(NamedTuple):
@@ -311,7 +304,8 @@ class ScopeTreeNode:
             node = node.parent
         return node
 
-    def attach_child(self, node: ScopeTreeNode) -> None:
+    def attach_child(self, node: ScopeTreeNode,
+                     context: Optional[pctx.ParserContext]=None) -> None:
         """Attach a child node to this node.
 
         This is a low-level operation, no tree validation is
@@ -320,10 +314,9 @@ class ScopeTreeNode:
         if node.path_id is not None:
             for child in self.children:
                 if child.path_id == node.path_id:
-                    raise InvalidScopeConfiguration(
+                    raise errors.InvalidScopeConfigurationError(
                         f'{node.path_id} is already present in {self!r}',
-                        existing_node=child,
-                        offending_node=node,
+                        context=context,
                     )
 
         if node.unique_id is not None:
@@ -349,6 +342,7 @@ class ScopeTreeNode:
         self,
         path_id: pathid.PathId,
         *,
+        context: Optional[pctx.ParserContext],
         fence_points: FrozenSet[pathid.PathId] = frozenset(),
     ) -> List[ScopeTreeNode]:
         """Attach a scope subtree representing *path_id*."""
@@ -406,10 +400,11 @@ class ScopeTreeNode:
                 parent.attach_child(fence)
                 parent = fence
 
-        self.attach_subtree(subtree)
+        self.attach_subtree(subtree, context=context)
         return fences
 
-    def attach_subtree(self, node: ScopeTreeNode) -> None:
+    def attach_subtree(self, node: ScopeTreeNode,
+                       context: Optional[pctx.ParserContext]=None) -> None:
         """Attach a subtree to this node.
 
         *node* is expected to be a balanced scope tree and may be modified
@@ -436,11 +431,10 @@ class ScopeTreeNode:
                     # scope and cannot be factored out, such as
                     # a reference to a correlated set inside a DML
                     # statement.
-                    raise InvalidScopeConfiguration(
+                    raise errors.InvalidScopeConfigurationError(
                         f'cannot reference correlated set '
                         f'{path_id.pformat()!r} here',
-                        offending_node=descendant,
-                        existing_node=visible,
+                        context=context,
                     )
 
                 # This path is already present in the tree, discard,
@@ -464,11 +458,10 @@ class ScopeTreeNode:
                     # scope and cannot be factored out, such as
                     # a reference to a correlated set inside a DML
                     # statement.
-                    raise InvalidScopeConfiguration(
+                    raise errors.InvalidScopeConfigurationError(
                         f'cannot reference correlated set '
                         f'{path_id.pformat()!r} here',
-                        offending_node=descendant,
-                        existing_node=existing,
+                        context=context,
                     )
 
                 unnest_fence = False
@@ -510,14 +503,13 @@ class ScopeTreeNode:
 
                             assert offending_node.path_id is not None
 
-                            raise InvalidScopeConfiguration(
+                            raise errors.InvalidScopeConfigurationError(
                                 f'reference to '
                                 f'{offending_node.path_id.pformat()!r} '
                                 f'changes the interpretation of '
                                 f'{existing.path_id.pformat()!r} '
                                 f'elsewhere in the query',
-                                offending_node=offending_node,
-                                existing_node=existing
+                                context=context,
                             )
 
                         parent_fence.remove_descendants(path_id)

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -314,7 +314,7 @@ class ScopeTreeNode:
         if node.path_id is not None:
             for child in self.children:
                 if child.path_id == node.path_id:
-                    raise errors.InvalidScopeConfigurationError(
+                    raise errors.InvalidReferenceError(
                         f'{node.path_id} is already present in {self!r}',
                         context=context,
                     )
@@ -431,7 +431,7 @@ class ScopeTreeNode:
                     # scope and cannot be factored out, such as
                     # a reference to a correlated set inside a DML
                     # statement.
-                    raise errors.InvalidScopeConfigurationError(
+                    raise errors.InvalidReferenceError(
                         f'cannot reference correlated set '
                         f'{path_id.pformat()!r} here',
                         context=context,
@@ -458,7 +458,7 @@ class ScopeTreeNode:
                     # scope and cannot be factored out, such as
                     # a reference to a correlated set inside a DML
                     # statement.
-                    raise errors.InvalidScopeConfigurationError(
+                    raise errors.InvalidReferenceError(
                         f'cannot reference correlated set '
                         f'{path_id.pformat()!r} here',
                         context=context,
@@ -503,7 +503,7 @@ class ScopeTreeNode:
 
                             assert offending_node.path_id is not None
 
-                            raise errors.InvalidScopeConfigurationError(
+                            raise errors.InvalidReferenceError(
                                 f'reference to '
                                 f'{offending_node.path_id.pformat()!r} '
                                 f'changes the interpretation of '

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1718,6 +1718,18 @@ class TestInsert(tb.QueryTestCase):
                 );
             ''')
 
+    async def test_edgeql_insert_correlated_bad_03(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                "cannot reference correlated set 'Person' here"):
+            await self.con.execute(r'''
+                WITH MODULE test
+                SELECT (
+                    Person,
+                    (INSERT Person {name := 'insert bad'}),
+                )
+            ''')
+
     async def test_edgeql_insert_unless_conflict_01(self):
         query = r'''
         SELECT

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -1880,6 +1880,18 @@ class TestUpdate(tb.QueryTestCase):
                 );
             ''')
 
+    async def test_edgeql_update_correlated_bad_03(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                "cannot reference correlated set 'UpdateTest' here"):
+            await self.con.execute(r'''
+                WITH MODULE test
+                SELECT (
+                    UpdateTest,
+                    (UPDATE UpdateTest SET {name := 'update bad'}),
+                )
+            ''')
+
     async def test_edgeql_update_protect_readonly_01(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,


### PR DESCRIPTION
InvalidScopeConfiguration carries references to ScopeTreeNodes in it,
which causes grief because those fail to pickle due to the weakrefs in
them. (Though pickling them doesn't seem like the right thing to do
even if it wasn't for the weakref.)

Handle this in the same way that it is handled for the current cases
of this message that work: by catching it and reraising. (See
`register_set_in_scope`).

Other solutions to this might be better: we could just drop the nodes
from InvalidScopeConfiguration, since it doesn't seem like we ever
make use of them in any way.

Catching and rethrowing has the advantage that we can provide a better
source context, though, since one does not seem to be available in the
places InvalidScopeConfiguration is thrown. (Though that could also be
changed.)