### PR TITLE
Fix derived name mangling in schema

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        fetch-depth: 0
+        submodules: false
+
+    - uses: actions/checkout@v2
+      with:
         fetch-depth: 50
         submodules: true
 

--- a/edb/common/verutils.py
+++ b/edb/common/verutils.py
@@ -1,0 +1,111 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+from typing import *
+
+import enum
+import re
+
+
+VERSION_PATTERN = re.compile(r"""
+    ^
+    (?P<release>[0-9]+(?:\.[0-9]+)*)
+    (?P<pre>
+        [-]?
+        (?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))
+        [\.]?
+        (?P<pre_n>[0-9]+)?
+    )?
+    (?P<dev>
+        [\.]?
+        (?P<dev_l>dev)
+        [\.]?
+        (?P<dev_n>[0-9]+)?
+    )?
+    (?:\+(?P<local>[a-z0-9]+(?:[\.][a-z0-9]+)*))?
+    $
+""", re.X)
+
+
+class VersionStage(enum.IntEnum):
+
+    DEV = 0
+    ALPHA = 10
+    BETA = 20
+    RC = 30
+    FINAL = 40
+
+
+class Version(NamedTuple):
+
+    major: int
+    minor: int
+    stage: VersionStage
+    stage_no: int
+    local: Tuple[str, ...]
+
+    def __str__(self):
+        ver = f'{self.major}.{self.minor}'
+        if self.stage is not VersionStage.FINAL:
+            ver += f'-{self.stage.name.lower()}.{self.stage_no}'
+        if self.local:
+            ver += f'{("+" + ".".join(self.local)) if self.local else ""}'
+
+        return ver
+
+
+def parse_version(ver: str) -> Version:
+    v = VERSION_PATTERN.match(ver)
+    if v is None:
+        raise ValueError(f'cannot parse version: {ver}')
+    local = []
+    if v.group('pre'):
+        pre_l = v.group('pre_l')
+        if pre_l in {'a', 'alpha'}:
+            stage = VersionStage.ALPHA
+        elif pre_l == {'b', 'beta'}:
+            stage = VersionStage.BETA
+        elif pre_l == {'c', 'rc'}:
+            stage = VersionStage.RC
+        else:
+            raise ValueError(f'cannot determine release stage from {ver}')
+
+        stage_no = int(v.group('pre_n'))
+        if v.group('dev'):
+            local.extend(['dev', v.group('dev_n')])
+    elif v.group('dev'):
+        stage = VersionStage.DEV
+        stage_no = int(v.group('dev_n'))
+    else:
+        stage = VersionStage.FINAL
+        stage_no = 0
+
+    if v.group('local'):
+        local.extend(v.group('local').split('.'))
+
+    release = [int(r) for r in v.group('release').split('.')]
+
+    return Version(
+        major=release[0],
+        minor=release[1],
+        stage=stage,
+        stage_no=stage_no,
+        local=tuple(local),
+    )

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -700,17 +700,17 @@ class IsinstanceFunction(dbops.Function):
 class NormalizeNameFunction(dbops.Function):
     text = '''
         SELECT
-            CASE WHEN strpos(name, '@@') = 0 THEN
+            CASE WHEN strpos(name, '@') = 0 THEN
                 name
             ELSE
                 CASE WHEN strpos(name, '::') = 0 THEN
-                    replace(split_part(name, '@@', 1), '|', '::')
+                    replace(split_part(name, '@', 1), '|', '::')
                 ELSE
                     replace(
                         split_part(
                             -- "reverse" calls are to emulate "rsplit"
                             reverse(split_part(reverse(name), '::', 1)),
-                            '@@', 1),
+                            '@', 1),
                         '|', '::')
                 END
             END;

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -39,6 +39,8 @@ from . import schema as s_schema
 if TYPE_CHECKING:
     import uuid
 
+    from edb.common import verutils
+
 
 def delta_schemas(
     schema_a: Optional[s_schema.Schema],
@@ -424,10 +426,17 @@ def delta_from_ddl(
     schema_object_ids: Optional[
         Mapping[Tuple[str, Optional[str]], uuid.UUID]
     ]=None,
+    compat_ver: verutils.Version = None,
 ) -> sd.DeltaRoot:
-    _, cmd = _delta_from_ddl(ddl_stmt, schema=schema, modaliases=modaliases,
-                             stdmode=stdmode, testmode=testmode,
-                             schema_object_ids=schema_object_ids)
+    _, cmd = _delta_from_ddl(
+        ddl_stmt,
+        schema=schema,
+        modaliases=modaliases,
+        stdmode=stdmode,
+        testmode=testmode,
+        schema_object_ids=schema_object_ids,
+        compat_ver=compat_ver,
+    )
     return cmd
 
 
@@ -441,6 +450,7 @@ def _delta_from_ddl(
     schema_object_ids: Optional[
         Mapping[Tuple[str, Optional[str]], uuid.UUID]
     ]=None,
+    compat_ver: verutils.Version = None,
 ) -> Tuple[s_schema.Schema, sd.DeltaRoot]:
     delta = sd.DeltaRoot()
     context = sd.CommandContext(
@@ -449,6 +459,7 @@ def _delta_from_ddl(
         stdmode=stdmode,
         testmode=testmode,
         schema_object_ids=schema_object_ids,
+        compat_ver=compat_ver,
     )
 
     with context(sd.DeltaRootContext(schema=schema, op=delta)):

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -349,7 +349,7 @@ class Parameter(so.ObjectFragment, ParameterLike):
 
     @classmethod
     def paramname_from_fullname(cls, fullname: sn.Name) -> str:
-        parts = str(fullname.name).split('@@', 1)
+        parts = str(fullname.name).split('@', 1)
         if len(parts) == 2:
             return sn.unmangle_name(parts[0])
         elif '::' in fullname:

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -1884,11 +1884,13 @@ cdef class EdgeConnection:
 
         # Now parse the embedded dump header message:
 
-        # Ignore headers
+        dump_server_ver_str = None
         headers_num = self.buffer.read_int16()
         for _ in range(headers_num):
-            self.buffer.read_int16()
-            self.buffer.read_len_prefixed_bytes()
+            hdrname = self.buffer.read_int16()
+            hdrval = self.buffer.read_len_prefixed_bytes()
+            if hdrname == DUMP_HEADER_SERVER_VER:
+                dump_server_ver_str = hdrval.decode('utf-8')
 
         proto_major = self.buffer.read_int16()
         proto_minor = self.buffer.read_int16()
@@ -1939,6 +1941,7 @@ cdef class EdgeConnection:
                 await self.get_backend().compiler.call(
                     'describe_database_restore',
                     tx_snapshot_id,
+                    dump_server_ver_str,
                     schema_ddl,
                     schema_ids,
                     blocks,

--- a/setup.py
+++ b/setup.py
@@ -539,78 +539,8 @@ else:
 
 
 def custom_scm_version():
-    posint = r'(0|[1-9]\d*)'
-    pep440_version_re = re.compile(
-        rf"""
-        ^
-        (?P<major>{posint})
-        \.
-        (?P<minor>{posint})
-        (
-            \.
-            (?P<micro>{posint})
-        )?
-        (
-            (?P<prekind>a|b|rc)
-            (?P<preval>{posint})
-        )?
-        $
-        """,
-        re.X,
-    )
-
-    proc = subprocess.run(
-        ['git', 'tag', '--list', 'v*'],
-        stdout=subprocess.PIPE,
-        universal_newlines=True,
-        check=True,
-    )
-    versions = proc.stdout.split('\n')
-    latest_version = max(versions)
-
-    proc = subprocess.run(
-        ['git', 'tag', '--points-at', 'HEAD'],
-        stdout=subprocess.PIPE,
-        universal_newlines=True,
-        check=True,
-    )
-    tags = proc.stdout.split('\n')
-    exact_tags = set(versions) & set(tags)
-
-    proc = subprocess.run(
-        ['git', 'rev-list', '--count', 'HEAD'],
-        stdout=subprocess.PIPE,
-        universal_newlines=True,
-        check=True,
-    )
-    commits_on_branch = proc.stdout.strip()
-
-    def version_scheme(version):
-        if exact_tags:
-            return exact_tags.pop()[1:]
-
-        m = pep440_version_re.match(latest_version[1:])
-        if not m:
-            return f'{latest_version[1:]}.dev{commits_on_branch}'
-
-        major = m.group('major')
-        minor = m.group('minor')
-        micro = m.group('micro') or ''
-        microkind = '.' if micro else ''
-        prekind = m.group('prekind') or ''
-        preval = m.group('preval') or ''
-
-        if prekind and preval:
-            preval = str(int(preval) + 1)
-        elif micro:
-            micro = str(int(micro) + 1)
-        else:
-            minor = str(int(minor) + 1)
-
-        incremented_ver = f'{major}.{minor}{microkind}{micro}{prekind}{preval}'
-        return f'{incremented_ver}.dev{commits_on_branch}'
-
-    return {'version_scheme': version_scheme}
+    from edb.server import buildmeta
+    return {'version_scheme': buildmeta.scm_version_scheme}
 
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -133,12 +133,9 @@ def _compile_parsers(build_lib, inplace=False):
 
 def _compile_build_meta(build_lib, version, pg_config, runstatedir,
                         shared_dir, version_suffix):
-    import pkg_resources
-    from edb.server import buildmeta
+    from edb.common import verutils
 
-    parsed_version = buildmeta.parse_version(
-        pkg_resources.parse_version(version))
-
+    parsed_version = verutils.parse_version(version)
     vertuple = list(parsed_version._asdict().values())
     vertuple[2] = int(vertuple[2])
     if version_suffix:

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -155,7 +155,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::Card)",
             "(test::User)",
             "FENCE": {
-                "(__derived__::__derived__|U@@w~1)": {
+                "(__derived__::__derived__|U@w~1)": {
                     "FENCE": {
                         "(test::User)"
                     }
@@ -373,7 +373,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         """
 
     def test_edgeql_ir_scope_tree_16(self):
-        # Apparent misplaced "(__derived__::__derived__|U@@w~1)" in the FILTER
+        # Apparent misplaced "(__derived__::__derived__|U@w~1)" in the FILTER
         # fence is due to a alias_map replacement artifact.
         """
         WITH MODULE test,
@@ -391,13 +391,13 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(__derived__::__derived__|U@@w~1).>cards[IS test::Card]\
+            "(__derived__::__derived__|U@w~1).>cards[IS test::Card]\
 .>foo[IS std::float64]": {
                 "BRANCH": {
-                    "(__derived__::__derived__|U@@w~1)\
+                    "(__derived__::__derived__|U@w~1)\
 .>cards[IS test::Card]": {
                         "BRANCH": {
-                            "(__derived__::__derived__|U@@w~1)": {
+                            "(__derived__::__derived__|U@w~1)": {
                                 "FENCE": {
                                     "(test::User)",
                                     "FENCE": {
@@ -409,9 +409,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                         "FENCE": {
                             "(test::Card)",
                             "FENCE": {
-                                "(__derived__::__derived__|U@@w~1)\
+                                "(__derived__::__derived__|U@w~1)\
 .>deck[IS test::Card]": {
-                                    "(__derived__::__derived__|U@@w~1)"
+                                    "(__derived__::__derived__|U@w~1)"
                                 }
                             }
                         }
@@ -483,7 +483,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(__derived__::__derived__|x@@w~1)": {
+            "(__derived__::__derived__|x@w~1)": {
                 "FENCE": {
                     "(test::User).>friends[IS test::User]": {
                         "(test::User)"
@@ -509,7 +509,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 }
             },
             "FENCE": {
-                "(__derived__::__derived__|x@@w~1)\
+                "(__derived__::__derived__|x@w~1)\
 .>0[IS std::float64]"
             }
         }
@@ -611,14 +611,14 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(__derived__::__derived__|x@@w~1)": {
+                "(__derived__::__derived__|x@w~1)": {
                     "FENCE": {
                         "(test::User).>deck[IS test::Card]"
                     }
                 },
                 "(test::User).>deck[IS test::Card]",
                 "FENCE": {
-                    "(__derived__::__derived__|x@@w~1)\
+                    "(__derived__::__derived__|x@w~1)\
 .>name[IS std::str]"
                 }
             }
@@ -634,9 +634,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(__derived__::__derived__|_@@w~2)": {
+            "(__derived__::__derived__|_@w~2)": {
                 "FENCE": {
-                    "(__derived__::__derived__|A@@w~1)",
+                    "(__derived__::__derived__|A@w~1)",
                     "(test::User)"
                 }
             }
@@ -663,7 +663,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(__derived__::__derived__|letter@@w~1)",
+                "(__derived__::__derived__|letter@w~1)",
                 "(test::User).>select_deck[IS test::Card]",
                 "FENCE": {
                     "(test::User).>deck[IS test::Card]",
@@ -698,7 +698,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(__derived__::__derived__|foo@@w~2)": {
+                "(__derived__::__derived__|foo@w~2)": {
                     "FENCE": {
                         "(test::User).>deck[IS test::Card]",
                         "FENCE": {
@@ -707,7 +707,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                         }
                     }
                 },
-                "(__derived__::__derived__|letter@@w~1)",
+                "(__derived__::__derived__|letter@w~1)",
                 "(test::User).>select_deck[IS test::Card]"
             },
             "FENCE": {
@@ -753,16 +753,16 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::Card)",
             "(test::Card).>name[IS std::str]",
             "FENCE": {
-                "(__derived__::__derived__|A@@w~1).>owners[IS test::User]": {
+                "(__derived__::__derived__|A@w~1).>owners[IS test::User]": {
                     "BRANCH": {
-                        "(__derived__::__derived__|A@@w~1)"
+                        "(__derived__::__derived__|A@w~1)"
                     },
                     "FENCE": {
-                        "ns~2@@(__derived__::__derived__|A@@w~1)\
+                        "ns~2@@(__derived__::__derived__|A@w~1)\
 .<deck[IS __derived__::(@SID@)].>indirection[IS test::User]": {
-                            "ns~2@@(__derived__::__derived__|A@@w~1)\
+                            "ns~2@@(__derived__::__derived__|A@w~1)\
 .<deck[IS __derived__::(@SID@)]": {
-                                "(__derived__::__derived__|A@@w~1)"
+                                "(__derived__::__derived__|A@w~1)"
                             }
                         }
                     }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -593,7 +593,7 @@ _123456789_123456789_123456789 -> str
         base_names = constr.get_bases(schema).names(schema)
         self.assertEqual(len(base_names), 1)
         self.assertTrue(base_names[0].startswith(
-            'default::std|exclusive@@default|__|name@@default|Named@'))
+            'default::std|exclusive@default|__||name&default||Named@'))
 
     def test_schema_constraint_inheritance_02(self):
         schema = tb._load_std_schema()
@@ -618,7 +618,7 @@ _123456789_123456789_123456789 -> str
         base_names = constr.get_bases(schema).names(schema)
         self.assertEqual(len(base_names), 1)
         self.assertTrue(base_names[0].startswith(
-            'default::std|exclusive@@default|__|name@@default|Named@'))
+            'default::std|exclusive@default|__||name&default||Named@'))
 
     def test_schema_constraint_inheritance_03(self):
         schema = tb._load_std_schema()


### PR DESCRIPTION
The current mangling schema isn't properly reversible, and we actually rely
on it being so.  Fix this by making sure that
`unmangle(mangle(X)) == X` always holds regardless of the depth of 
mangling.

This creates an incompatibility with earlier dumps, because we carry an 
internal `name -> id` map in them.  Fortunately, it's easy to fix by 
retaining the old mangling code and using it to lookup in schema id maps 
produced by older servers.

*NOTE*: the dump tests are failing because the current version derivation is wrong,
and it seemed wrong to work that around in code.