### PR TITLE
Fix graphql docs to render all subsections

### DIFF
--- a/docs/clients/99_graphql/index.rst
+++ b/docs/clients/99_graphql/index.rst
@@ -36,29 +36,6 @@ Pointing your browser to ``http://127.0.0.1:8888/explore``
 will bring up a `GraphiQL`_ interface to EdgeDB. This interface can be
 used to try out queries and explore the GraphQL capabilities.
 
-
-Known Limitations
-=================
-
-- Due to the differences between EdgeQL and GraphQL syntax
-  :eql:type:`enum <std::enum>` types which have values that cannot be
-  represented as GraphQL identifiers (e.g. ``'N/A'`` or ``'NOT
-  APPLICABLE'``) cannot be properly reflected into GraphQL enums.
-
-- EdgeDB :eql:type:`tuples <std::tuple>` are not supported in GraphQL
-  reflection currently.
-
-- Every non-abstract EdgeDB object type is simultaneously an interface
-  and an object in terms of GraphQL type system, which means that for
-  every one object type name two names are needed in reflected
-  GraphQL. This potentially results in name clashes if the convention
-  of using camel-case names for user types is not followed in EdgeDB.
-
-
-.. __: http://graphql.org/docs/queries/
-
-.. _`GraphiQL`: https://github.com/graphql/graphiql
-
 .. toctree::
     :maxdepth: 2
     :hidden:
@@ -67,3 +44,9 @@ Known Limitations
     mutations
     introspection
     protocol
+    limitations
+
+
+.. __: http://graphql.org/docs/queries/
+
+.. _`GraphiQL`: https://github.com/graphql/graphiql

--- a/docs/clients/99_graphql/limitations.rst
+++ b/docs/clients/99_graphql/limitations.rst
@@ -1,0 +1,19 @@
+.. _ref_graphql_limitations:
+
+=================
+Known Limitations
+=================
+
+- Due to the differences between EdgeQL and GraphQL syntax
+  :eql:type:`enum <std::enum>` types which have values that cannot be
+  represented as GraphQL identifiers (e.g. ``'N/A'`` or ``'NOT
+  APPLICABLE'``) cannot be properly reflected into GraphQL enums.
+
+- EdgeDB :eql:type:`tuples <std::tuple>` are not supported in GraphQL
+  reflection currently.
+
+- Every non-abstract EdgeDB object type is simultaneously an interface
+  and an object in terms of GraphQL type system, which means that for
+  every one object type name two names are needed in reflected
+  GraphQL. This potentially results in name clashes if the convention
+  of using camel-case names for user types is not followed in EdgeDB.


### PR DESCRIPTION
RestructuredText is rather sensitive to where the `.. toctree::` element is attached. Our code only recognizes when it's attached to the topmost level. I'm trying to figure out a way for our Sphinx->XML->JS pipeline to error out in such conditions but I've yet to figure out how to do that. Meanwhile, I decided to fix the problem in edgedb/docs.