### PR TITLE
Add missing qlkind annotation to Index schema object implementation

### DIFF
--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -152,6 +152,7 @@ class SchemaObjectClass(s_enum.StrEnum):
     CONSTRAINT = 'CONSTRAINT'
     DATABASE = 'DATABASE'
     FUNCTION = 'FUNCTION'
+    INDEX = 'INDEX'
     LINK = 'LINK'
     MIGRATION = 'MIGRATION'
     MODULE = 'MODULE'

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -25,6 +25,7 @@ from edb import errors
 from edb.common import ast
 from edb.edgeql import ast as qlast
 from edb.edgeql import compiler as qlcompiler
+from edb.edgeql import qltypes
 
 from . import abc as s_abc
 from . import annos as s_anno
@@ -41,7 +42,11 @@ if TYPE_CHECKING:
     from . import types as s_types
 
 
-class Index(referencing.ReferencedInheritingObject, s_anno.AnnotationSubject):
+class Index(
+    referencing.ReferencedInheritingObject,
+    s_anno.AnnotationSubject,
+    qlkind=qltypes.SchemaObjectClass.INDEX,
+):
 
     subject = so.SchemaField(so.Object)
 


### PR DESCRIPTION
Without this, `DESCRIBE CURRENT MIGRATION` on a migration with indexes
will crash.