### PR TITLE
Add an env variable to force using a cache even if the keys mismatch

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -75,8 +75,8 @@ class flags(metaclass=FlagsMeta):
     bootstrap = Flag(
         doc="Debug server catalog bootstrap.")
 
-    cache_yolo = Flag(
-        doc="Disable consistency check.")
+    bootstrap_cache_yolo = Flag(
+        doc="Disable bootstrap cache consistency check.")
 
     edgeql_parser = Flag(
         doc="Debug EdgeQL parser (rebuild grammar verbosly).")

--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -75,6 +75,9 @@ class flags(metaclass=FlagsMeta):
     bootstrap = Flag(
         doc="Debug server catalog bootstrap.")
 
+    cache_yolo = Flag(
+        doc="Disable consistency check.")
+
     edgeql_parser = Flag(
         doc="Debug EdgeQL parser (rebuild grammar verbosly).")
 

--- a/edb/server/buildmeta.py
+++ b/edb/server/buildmeta.py
@@ -35,6 +35,7 @@ import immutables as immu
 import edb
 from edb.common import devmode
 from edb.common import verutils
+from edb.common import debug
 
 try:
     import setuptools_scm
@@ -137,7 +138,7 @@ def read_data_cache(
     if full_path.exists():
         with open(full_path, 'rb') as f:
             src_hash = f.read(len(cache_key))
-            if src_hash == cache_key:
+            if src_hash == cache_key or debug.flags.cache_yolo:
                 if pickled:
                     data = f.read()
                     try:

--- a/edb/server/buildmeta.py
+++ b/edb/server/buildmeta.py
@@ -138,7 +138,7 @@ def read_data_cache(
     if full_path.exists():
         with open(full_path, 'rb') as f:
             src_hash = f.read(len(cache_key))
-            if src_hash == cache_key or debug.flags.cache_yolo:
+            if src_hash == cache_key or debug.flags.bootstrap_cache_yolo:
                 if pickled:
                     data = f.read()
                     try:


### PR DESCRIPTION
This is useful for speeding up local testing in some cases and for
making it possible to run unit tests when there is an issue that
causes bootstrapping to fail (since failing unit tests are a lot
easier to narrow down).

I can rename the environment variable if somebody has a name they
prefer.