### PR TITLE
Make sure pure aliases don't get confused with physical properties

### DIFF
--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -355,7 +355,10 @@ def get_pointer_storage_info(
         link_bias=False):
     assert not pointer.generic(schema), \
         "only specialized pointers can be stored"
-    material_ptrcls = pointer.material_type(schema)
+    if pointer.get_computable(schema):
+        material_ptrcls = None
+    else:
+        material_ptrcls = pointer.material_type(schema)
     if material_ptrcls is not None:
         pointer = material_ptrcls
     return _PointerStorageInfo(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5686,6 +5686,14 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             [1],
         )
 
+    async def test_edgeql_ddl_prop_alias(self):
+        await self.con.execute("""
+            CREATE TYPE Named {
+                CREATE REQUIRED PROPERTY name -> str;
+                CREATE PROPERTY canonical_name := .name;
+            };
+        """)
+
     async def test_edgeql_ddl_index_01(self):
         with self.assertRaisesRegex(
             edgedb.ResultCardinalityMismatchError,


### PR DESCRIPTION
The following will currently crash with 'column "name" already exists':

    CREATE TYPE Named {
      CREATE REQUIRED PROPERTY name -> str;
      CREATE PROPERTY canonical_name := .name;
    };

This is because `canonical_name` is mistakenly treated as a real column
in table generation.

Fixes: #1716