### PR TITLE
Fix compilation of functions with non-statement bodies

### DIFF
--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -64,6 +64,8 @@ def compile_Set(
             return config.top_output_as_config_op(
                 ir_set, ctx.rel, env=ctx.env)
         else:
+            pathctx.get_path_serialized_output(
+                ctx.rel, ir_set.path_id, env=ctx.env)
             return output.top_output_as_value(ctx.rel, ir_set, env=ctx.env)
     else:
         value = pathctx.get_path_value_var(

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -791,9 +791,8 @@ def get_path_output(
         ptr_info: Optional[pg_types.PointerStorageInfo]=None,
         env: context.Environment) -> pgast.OutputVar:
 
-    view_path_id_map = getattr(rel, 'view_path_id_map', None)
-    if view_path_id_map:
-        path_id = map_path_id(path_id, view_path_id_map)
+    if isinstance(rel, pgast.Query):
+        path_id = map_path_id(path_id, rel.view_path_id_map)
 
     return _get_path_output(rel, path_id=path_id, aspect=aspect,
                             ptr_info=ptr_info, allow_nullable=allow_nullable,
@@ -959,6 +958,7 @@ def get_path_serialized_output(
     # must be kept outside of get_path_output() generic.
     aspect = 'serialized'
 
+    path_id = map_path_id(path_id, rel.view_path_id_map)
     result = rel.path_outputs.get((path_id, aspect))
     if result is not None:
         return result

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -1277,3 +1277,17 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
             r'''SELECT test::call38(C38);''',
             ['yay'],
         )
+
+    async def test_edgeql_calls_39(self):
+        # Test a function taking an object as an argument.
+        await self.con.execute('''
+            CREATE FUNCTION test::call39(
+                foo: str
+            ) -> str
+                USING (foo);
+        ''')
+
+        await self.assert_query_result(
+            r'''SELECT test::call39("identity");''',
+            ['identity'],
+        )


### PR DESCRIPTION
The current top-level output handling assumes that the expression is
always a statement, but that wouldn't always be the case when compiling
the body of a function like the following:

    CREATE FUNCTION identity(arg: str) -> str USING (arg);

Fixes: #1715