### PR TITLE
Forbid usage of DML in some special cases.

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -460,13 +460,13 @@ class ContextLevel(compiler.ContextLevel):
     """Whether to include the type id property in object shapes implicitly."""
 
     implicit_limit: int
-    """Implicit LIMIT clause in SELECT statments."""
+    """Implicit LIMIT clause in SELECT statements."""
 
     inhibit_implicit_limit: bool
     """Whether implicit limit injection should be inhibited."""
 
     special_computables_in_mutation_shape: FrozenSet[str]
-    """A set of "special" compiutable pointers allowed in mutation shape."""
+    """A set of "special" computable pointers allowed in mutation shape."""
 
     empty_result_type_hint: Optional[s_types.Type]
     """Type to use if the statement result expression is an empty set ctor."""

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -66,6 +66,14 @@ class GlobalCompilerOptions:
     #: definitions.
     func_params: Optional[s_func.ParameterLikeList] = None
 
+    #: The name that can be used in a "DML is disallowed in ..."
+    #: error. When this is not None, any DML should cause an error.
+    in_ddl_context_name: Optional[str] = None
+
+    #: Sometimes (like in queries compiled form GraphQL) it may be OK
+    #: to contain DML in the top-level shape computables.
+    allow_top_level_shape_dml: bool = False
+
 
 @dataclass
 class CompilerOptions(GlobalCompilerOptions):

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1577,6 +1577,10 @@ class ObjectCommand(
         mcls = self.get_schema_metaclass()
         return mcls.get_verbosename_static(self.classname)
 
+    def get_displayname(self) -> str:
+        mcls = self.get_schema_metaclass()
+        return mcls.get_displayname_static(self.classname)
+
     @overload
     def get_object(
         self,

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -113,6 +113,7 @@ class AliasCommand(
                 result_view_name=classname,
                 modaliases=context.modaliases,
                 schema_view_mode=True,
+                in_ddl_context_name='alias definition',
             ),
         )
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -870,6 +870,7 @@ class PointerCommandOrFragment(
 
         source = schema.get(source_name, type=s_objtypes.ObjectType)
 
+        ptr_name = self.get_displayname()
         expression = s_expr.Expression.compiled(
             s_expr.Expression.from_ast(expr, schema, context.modaliases),
             schema=schema,
@@ -878,6 +879,7 @@ class PointerCommandOrFragment(
                 anchors={qlast.Source().name: source},
                 path_prefix_anchor=qlast.Source().name,
                 singletons=frozenset([source]),
+                in_ddl_context_name=f'computable {ptr_name!r}',
             ),
         )
 
@@ -931,8 +933,6 @@ class PointerCommandOrFragment(
             spec_card = self.scls.get_cardinality(schema)
 
         if spec_required and not required:
-            ptr_name = sn.shortname_from_fullname(
-                self.get_attribute_value('name')).name
             srcctx = self.get_attribute_source_context('target')
             raise errors.SchemaDefinitionError(
                 f'possibly an empty set returned by an '
@@ -946,8 +946,6 @@ class PointerCommandOrFragment(
             spec_card in {None, qltypes.SchemaCardinality.ONE} and
             card is not qltypes.SchemaCardinality.ONE
         ):
-            ptr_name = sn.shortname_from_fullname(
-                self.get_attribute_value('name')).name
             srcctx = self.get_attribute_source_context('target')
             raise errors.SchemaDefinitionError(
                 f'possibly more than one element returned by an '

--- a/edb/server/http_graphql_port/compiler.py
+++ b/edb/server/http_graphql_port/compiler.py
@@ -98,6 +98,7 @@ class Compiler(compiler.BaseCompiler):
             schema=db.schema,
             options=qlcompiler.CompilerOptions(
                 json_parameters=True,
+                allow_top_level_shape_dml=True,
             ),
         )
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1658,6 +1658,115 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             """)
 
+    async def test_edgeql_ddl_bad_07(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                r"invalid mutation in computable 'foo'"):
+            async with self.con.transaction():
+                await self.con.execute(r"""
+                    CREATE TYPE test::Foo;
+
+                    CREATE TYPE test::Bar {
+                        CREATE LINK foo := (INSERT test::Foo);
+                    };
+                """)
+
+    async def test_edgeql_ddl_bad_08(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                r"invalid mutation in computable 'foo'"):
+            async with self.con.transaction():
+                await self.con.execute(r"""
+                    CREATE TYPE test::Foo;
+
+                    CREATE TYPE test::Bar {
+                        CREATE LINK foo := (
+                            WITH x := (INSERT test::Foo)
+                            SELECT x
+                        );
+                    };
+                """)
+
+    async def test_edgeql_ddl_bad_09(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                r"invalid mutation in computable 'foo'"):
+            async with self.con.transaction():
+                await self.con.execute(r"""
+                    CREATE TYPE test::Foo;
+
+                    CREATE TYPE test::Bar {
+                        CREATE PROPERTY foo := (INSERT test::Foo).id;
+                    };
+                """)
+
+    async def test_edgeql_ddl_bad_10(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                r"invalid mutation in alias definition"):
+            async with self.con.transaction():
+                await self.con.execute(r"""
+                    CREATE TYPE test::Foo;
+                    CREATE TYPE test::Bar;
+
+                    CREATE ALIAS test::Baz := test::Bar {
+                        foo := (INSERT test::Foo)
+                    };
+                """)
+
+    async def test_edgeql_ddl_bad_11(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                r"invalid mutation in alias definition"):
+            async with self.con.transaction():
+                await self.con.execute(r"""
+                    CREATE TYPE test::Foo;
+                    CREATE TYPE test::Bar;
+
+                    CREATE ALIAS test::Baz := test::Bar {
+                        foo := (INSERT test::Foo).id
+                    };
+                """)
+
+    async def test_edgeql_ddl_bad_12(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                r"invalid mutation in alias definition"):
+            async with self.con.transaction():
+                await self.con.execute(r"""
+                    CREATE TYPE test::Foo;
+                    CREATE TYPE test::Bar {
+                        CREATE LINK foo -> test::Foo;
+                    };
+
+                    CREATE ALIAS test::Baz := test::Bar {
+                        foo: {
+                            fuz := (INSERT test::Foo)
+                        }
+                    };
+                """)
+
+    async def test_edgeql_ddl_bad_13(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                r"invalid mutation in alias definition"):
+            async with self.con.transaction():
+                await self.con.execute(r"""
+                    CREATE TYPE test::Foo;
+                    CREATE TYPE test::Bar {
+                        CREATE LINK foo -> test::Foo;
+                    };
+
+                    CREATE ALIAS test::Baz := (
+                        WITH x := (INSERT test::Foo)
+                        SELECT test::Bar {
+                            foo: {
+                                fuz := x
+                            }
+                        }
+                    );
+                """)
+
     async def test_edgeql_ddl_link_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
@@ -1701,7 +1810,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     };
                 """)
 
-    async def test_edgeql_ddl_prop_bad_01(self):
+    async def test_edgeql_ddl_property_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 f'link or property name length exceeds the maximum'):

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -1663,21 +1663,22 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_cardinality_02(self):
         await self.assert_query_result(r'''
-            WITH MODULE test
+            WITH
+                MODULE test,
+                x1 := (
+                    UPDATE UpdateTest
+                    FILTER .name = 'update-test1'
+                    SET {
+                        status := (
+                            SELECT Status
+                            # the ID is non-existent
+                            FILTER .id = <uuid>
+                                '10000000-aaaa-bbbb-cccc-d00000000000'
+                        )
+                    }
+                )
             SELECT stdgraphql::Query {
                 multi x0 := (
-                    WITH x1 := (
-                        UPDATE UpdateTest
-                        FILTER .name = 'update-test1'
-                        SET {
-                            status := (
-                                SELECT Status
-                                # the ID is non-existent
-                                FILTER .id = <uuid>
-                                    '10000000-aaaa-bbbb-cccc-d00000000000'
-                            )
-                        }
-                    )
                     SELECT x1 {
                         name,
                         status: {


### PR DESCRIPTION
DML is forbidden in shapes, aliased types, and computable definitions.

Issue #1688