### PR TITLE
Fix handling of collections of newly created types

### DIFF
--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -166,14 +166,10 @@ class AliasCommand(
         derived_delta = sd.DeltaRoot()
 
         for ref in ir.new_coll_types:
-            s_types.ensure_schema_collection(
-                # not "new_schema", because that already contains this
-                # collection type.
-                schema,
-                ref.as_shell(new_schema),
-                derived_delta,
-                context=context,
-            )
+            colltype_shell = ref.as_shell(new_schema)
+            # not "new_schema", because that already contains this
+            # collection type.
+            derived_delta.add(colltype_shell.as_create_delta(schema))
 
         if is_alter:
             assert old_schema is not None

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -288,10 +288,6 @@ class ParameterDesc(ParameterLike):
         cmd.set_attribute_value('name', param_name)
         cmd.set_attribute_value('type', self.type)
 
-        if isinstance(self.type, s_types.CollectionTypeShell):
-            s_types.ensure_schema_collection(
-                schema, self.type, cmd, context=context)
-
         for attr in ('num', 'typemod', 'kind', 'default'):
             cmd.set_attribute_value(attr, getattr(self, attr))
 
@@ -316,14 +312,9 @@ class ParameterDesc(ParameterLike):
         cmd = DeleteParameter(classname=param_name)
 
         if isinstance(self.type, s_types.CollectionTypeShell):
-            param = schema.get(param_name, type=Parameter)
-            s_types.cleanup_schema_collection(
-                schema,
-                self.type.resolve(schema),
-                param,
-                cmd,
-                context=context,
-            )
+            colltype = self.type.resolve(schema)
+            assert isinstance(colltype, s_types.Collection)
+            cmd.add(colltype.as_colltype_delete_delta(schema))
 
         return cmd
 
@@ -437,7 +428,15 @@ class ParameterCommand(
     context_class=ParameterCommandContext,
     referrer_context_class=CallableCommandContext
 ):
-    pass
+
+    def canonicalize_attributes(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = super().canonicalize_attributes(schema, context)
+        return s_types.materialize_type_in_attribute(
+            schema, context, self, 'type')
 
 
 class CreateParameter(ParameterCommand, sd.CreateObject[Parameter]):
@@ -811,6 +810,15 @@ class CallableCommand(sd.QualifiedObjectCommand[CallableObjectT]):
 
         return schema, params
 
+    def canonicalize_attributes(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = super().canonicalize_attributes(schema, context)
+        return s_types.materialize_type_in_attribute(
+            schema, context, self, 'return_type')
+
 
 class AlterCallableObject(
     CallableCommand[CallableObjectT],
@@ -883,13 +891,6 @@ class CreateCallableObject(
                 schema=schema,
             )
 
-            if isinstance(return_type, s_types.CollectionTypeShell):
-                s_types.ensure_schema_collection(
-                    schema, return_type, cmd,
-                    src_context=astnode.returning.context,
-                    context=context,
-                )
-
             cmd.set_attribute_value(
                 'return_type', return_type)
             cmd.set_attribute_value(
@@ -937,10 +938,8 @@ class DeleteCallableObject(
             sourcectx=astnode.context)
 
         return_type = obj.get_return_type(schema)
-        if return_type.is_collection():
-            s_types.cleanup_schema_collection(
-                schema, return_type, obj, cmd, context=context,
-                src_context=astnode.context)
+        if isinstance(return_type, s_types.Collection):
+            cmd.add(return_type.as_colltype_delete_delta(schema))
 
         return cmd
 

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -446,10 +446,8 @@ class DeleteProperty(
             prop = schema.get(cmd.classname, type=Property)
             target = prop.get_target(schema)
 
-            if target is not None and target.is_collection():
-                s_types.cleanup_schema_collection(
-                    schema, target, prop, cmd, context=context,
-                    src_context=astnode.context)
+            if target is not None and isinstance(target, s_types.Collection):
+                cmd.add(target.as_colltype_delete_delta(schema))
 
         return cmd
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4010,6 +4010,36 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         """])
 
+    def test_schema_migrations_equivalence_collections_23(self):
+        self._assert_migration_equivalence([r"""
+            scalar type MyScalar extending str;
+
+            type User {
+                required property tup -> tuple<x:MyScalar>;
+            };
+        """, r"""
+            scalar type MyScalar extending str;
+
+            type User {
+                required property tup -> array<x:MyScalar>;
+            };
+        """])
+
+    def test_schema_migrations_equivalence_collections_24(self):
+        self._assert_migration_equivalence([r"""
+            scalar type MyScalar extending str;
+
+            type User {
+                required property arr -> array<x:MyScalar>;
+            };
+        """, r"""
+            scalar type MyScalar extending str;
+
+            type User {
+                required property arr -> tuple<x:MyScalar>;
+            };
+        """])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
When a collection type is defined in terms of one or more *new* types
that were defined in the same migration, the DDL compilation would crash
because collection types currently assume that their consituent types
exist at the time of DDL AST processing, which isn't always true.

Fix this by not attempting to resolve component types too early.  Also,
while at it, clean up the implementation of implicit collection type
creation and cleanup by using conditional commands instead of the
current `ensure_collection_type` hack.

Fixes: #1730