### PR TITLE
Overhaul how FOR interacts with iterators

### DIFF
--- a/edb/common/ast/visitor.py
+++ b/edb/common/ast/visitor.py
@@ -59,7 +59,7 @@ def find_children(node, test_func, *args, force_traversal=False,
 
                     if field_spec.child_traverse or force_traversal:
                         _n = _find_children(n, test_func)
-                        if _n is not None:
+                        if _n:
                             result.extend(_n)
                             if terminate_early:
                                 return result
@@ -76,7 +76,7 @@ def find_children(node, test_func, *args, force_traversal=False,
 
                 if field_spec.child_traverse or force_traversal:
                     _n = _find_children(value, test_func)
-                    if _n is not None:
+                    if _n:
                         result.extend(_n)
                         if terminate_early:
                             return result

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -438,6 +438,9 @@ class ContextLevel(compiler.ContextLevel):
     iterator_ctx: Optional[ContextLevel]
     """The context of the statement where all iterators should be placed."""
 
+    iterator_path_ids: FrozenSet[irast.PathId]
+    """The path ids of all in scope iterator variables"""
+
     scope_id_ctr: compiler.SimpleCounter
     """Path scope id counter."""
 
@@ -528,6 +531,7 @@ class ContextLevel(compiler.ContextLevel):
             self.path_scope = irast.new_scope_tree()
             self.path_scope_map = {}
             self.iterator_ctx = None
+            self.iterator_path_ids = frozenset()
             self.scope_id_ctr = compiler.SimpleCounter()
             self.view_scls = None
             self.expr_exposed = False
@@ -565,6 +569,7 @@ class ContextLevel(compiler.ContextLevel):
             self.shape_type_cache = prevlevel.shape_type_cache
 
             self.iterator_ctx = prevlevel.iterator_ctx
+            self.iterator_path_ids = prevlevel.iterator_path_ids
             self.path_id_namespace = prevlevel.path_id_namespace
             self.pending_stmt_own_path_id_namespace = \
                 prevlevel.pending_stmt_own_path_id_namespace
@@ -625,6 +630,7 @@ class ContextLevel(compiler.ContextLevel):
                 self.banned_paths = set()
 
                 self.iterator_ctx = None
+                self.iterator_path_ids = frozenset()
 
                 self.view_rptr = None
                 self.view_scls = None

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -169,6 +169,7 @@ def compile_ForQuery(
         # scope.
         iterator_scope_parent.factoring_allowlist.add(
             stmt.iterator_stmt.path_id)
+        sctx.iterator_path_ids |= {stmt.iterator_stmt.path_id}
         node = iterator_scope_parent.find_descendant(iterator_stmt.path_id)
         if node is not None:
             node.attach_subtree(iterator_scope)
@@ -864,6 +865,7 @@ def init_stmt(
 
     if isinstance(irstmt, irast.MutatingStmt):
         ctx.path_scope.factoring_fence = True
+        parent_ctx.path_scope.factoring_allowlist.update(ctx.iterator_path_ids)
         ctx.iterator_ctx = None
 
     irstmt.parent_stmt = parent_ctx.stmt

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -290,3 +290,12 @@ def get_iterator_sets(stmt: irast.Stmt) -> Sequence[irast.Set]:
         iterators.extend(stmt.hoisted_iterators)
 
     return iterators
+
+
+def contains_dml(stmt: irast.Stmt) -> bool:
+    """Check whether a statement contains any DML in a subtree."""
+    # If this ends up being a perf problem, we can use a visitor
+    # directly and cache.
+    res = ast.find_children(stmt, lambda x: isinstance(x, irast.MutatingStmt),
+                            terminate_early=True)
+    return bool(res)

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -818,3 +818,9 @@ class Set(ImmutableBaseExpr):
 
     name: str
     value: BaseExpr
+
+
+class IteratorCTE(typing.NamedTuple):
+    # ... Do we really need the Set, or this at all?
+    set: irast.Set
+    cte: CommonTableExpr

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -820,8 +820,7 @@ class Set(ImmutableBaseExpr):
     value: BaseExpr
 
 
-class IteratorCTE(typing.NamedTuple):
-    # ... Do we really need the Set, or this at all?
-    set: irast.Set
+class IteratorCTE(ImmutableBase):
+    path_id: irast.PathId
     cte: CommonTableExpr
-    all_ids: typing.FrozenSet[irast.PathId]
+    parent: typing.Optional[IteratorCTE]

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -824,3 +824,4 @@ class IteratorCTE(ImmutableBase):
     path_id: irast.PathId
     cte: CommonTableExpr
     parent: typing.Optional[IteratorCTE]
+    is_dml_pseudo_iterator: bool = False

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -824,3 +824,4 @@ class IteratorCTE(typing.NamedTuple):
     # ... Do we really need the Set, or this at all?
     set: irast.Set
     cte: CommonTableExpr
+    all_ids: typing.FrozenSet[irast.PathId]

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -161,10 +161,10 @@ class CompilerContextLevel(compiler.ContextLevel):
         ]
     ]
 
-    #: The ir statement and CTE of any enclosing insert/update currently
-    #: being compiled.
-    enclosing_dml: Optional[
-        Tuple[irast.Set, pgast.CommonTableExpr]]
+    #: The ir statement and CTE of any enclosing iterator-like
+    #: construct (which includes iterators, insert/update, and INSERT
+    #: ELSE select clauses) currently being compiled.
+    enclosing_cte_iterator: Optional[pgast.IteratorCTE]
 
     def __init__(
         self,
@@ -204,7 +204,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.scope_tree = scope_tree
             self.type_rel_overlays = collections.defaultdict(list)
             self.ptr_rel_overlays = collections.defaultdict(list)
-            self.enclosing_dml = None
+            self.enclosing_cte_iterator = None
 
         else:
             self.env = prevlevel.env
@@ -233,7 +233,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.scope_tree = prevlevel.scope_tree
             self.type_rel_overlays = prevlevel.type_rel_overlays
             self.ptr_rel_overlays = prevlevel.ptr_rel_overlays
-            self.enclosing_dml = prevlevel.enclosing_dml
+            self.enclosing_cte_iterator = prevlevel.enclosing_cte_iterator
 
             if mode in {ContextSwitchMode.SUBREL, ContextSwitchMode.NEWREL,
                         ContextSwitchMode.SUBSTMT}:

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -161,7 +161,7 @@ class CompilerContextLevel(compiler.ContextLevel):
         ]
     ]
 
-    #: The ir statement and CTE of any enclosing iterator-like
+    #: The CTE and some metadata of any enclosing iterator-like
     #: construct (which includes iterators, insert/update, and INSERT
     #: ELSE select clauses) currently being compiled.
     enclosing_cte_iterator: Optional[pgast.IteratorCTE]

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -768,6 +768,9 @@ def process_update_body(
     update_stmt = update_cte.query
     assert isinstance(update_stmt, pgast.UpdateStmt)
 
+    if ctx.enclosing_cte_iterator:
+        pathctx.put_path_bond(update_stmt, ctx.enclosing_cte_iterator.path_id)
+
     external_updates = []
 
     with ctx.newscope() as subctx:

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -309,18 +309,23 @@ def wrap_dml_cte(
     return dml_rvar
 
 
-def merge_iterator_scope(iterator: Optional[pgast.IteratorCTE],
-                         select: pgast.SelectStmt,
-                         *, ctx: context.CompilerContextLevel) -> None:
+def merge_iterator_scope(
+    iterator: Optional[pgast.IteratorCTE],
+    select: pgast.SelectStmt,
+    *,
+    ctx: context.CompilerContextLevel
+) -> None:
     while iterator:
         ctx.path_scope[iterator.path_id] = select
         iterator = iterator.parent
 
 
-def merge_iterator(iterator: Optional[pgast.IteratorCTE],
-                   select: pgast.SelectStmt,
-                   *,
-                   ctx: context.CompilerContextLevel) -> None:
+def merge_iterator(
+    iterator: Optional[pgast.IteratorCTE],
+    select: pgast.SelectStmt,
+    *,
+    ctx: context.CompilerContextLevel
+) -> None:
     merge_iterator_scope(iterator, select, ctx=ctx)
 
     while iterator:

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -320,16 +320,13 @@ def merge_iterator_scope(iterator: Optional[pgast.IteratorCTE],
 def merge_iterator(iterator: Optional[pgast.IteratorCTE],
                    select: pgast.SelectStmt,
                    *,
-                   unmask: bool = False,
-                   put_path_bond: bool = True,
                    ctx: context.CompilerContextLevel) -> None:
     merge_iterator_scope(iterator, select, ctx=ctx)
 
     while iterator:
         iterator_rvar = relctx.rvar_for_rel(iterator.cte, ctx=ctx)
 
-        if put_path_bond:
-            pathctx.put_path_bond(select, iterator.path_id)
+        pathctx.put_path_bond(select, iterator.path_id)
         relctx.include_rvar(
             select, iterator_rvar,
             path_id=iterator.path_id,
@@ -474,7 +471,7 @@ def compile_iterator_ctes(
             ictx.path_scope[iterator_set.path_id] = ictx.rel
 
             # Correlate with enclosing iterators
-            merge_iterator(last_iterator, ictx.rel, unmask=True, ctx=ictx)
+            merge_iterator(last_iterator, ictx.rel, ctx=ictx)
             if last_iterator is not None:
                 ictx.volatility_ref = pathctx.get_path_identity_var(
                     ictx.rel,

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -57,18 +57,15 @@ def compile_SelectStmt(
             # then explicitly join them back into the query.
             iterator = dml.compile_iterator_ctes(iterators, ctx=ctx)
             if iterator is not None:
-                # XXX: put_path_bond?
-                pathctx.put_path_bond(ctx.rel, iterator.set.path_id)
+                pathctx.put_path_bond(ctx.rel, iterator.path_id)
 
                 iterator_rvar = relctx.rvar_for_rel(iterator.cte, ctx=ctx)
                 relctx.include_rvar(ctx.rel, iterator_rvar,
-                                    path_id=iterator.set.path_id,
+                                    path_id=iterator.path_id,
                                     ctx=ctx)
 
                 ctx.path_scope = ctx.path_scope.new_child()
-                ctx.path_scope[iterator.set.path_id] = ctx.rel
-                for id in iterator.all_ids:
-                    ctx.path_scope[id] = ctx.rel
+                dml.merge_iterator_scope(iterator, ctx.rel, ctx=ctx)
 
             ctx.enclosing_cte_iterator = iterator
 

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -51,6 +51,8 @@ def compile_SelectStmt(
 
         if not isinstance(stmt.result.expr, irast.MutatingStmt):
             iterators = irutils.get_iterator_sets(stmt)
+            # if iterators:
+            #     assert not irutils.contains_dml(stmt)
             for iterator_set in iterators:
                 # Process FOR clause.
                 iterator_rvar = clauses.compile_iterator_expr(

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -32,7 +32,6 @@ from . import context
 from . import dispatch
 from . import dml
 from . import pathctx
-from . import relctx
 
 
 @dispatch.compile.register(irast.SelectStmt)
@@ -56,16 +55,8 @@ def compile_SelectStmt(
             # statements, we need to hoist the iterators into CTEs and
             # then explicitly join them back into the query.
             iterator = dml.compile_iterator_ctes(iterators, ctx=ctx)
-            if iterator is not None:
-                pathctx.put_path_bond(ctx.rel, iterator.path_id)
-
-                iterator_rvar = relctx.rvar_for_rel(iterator.cte, ctx=ctx)
-                relctx.include_rvar(ctx.rel, iterator_rvar,
-                                    path_id=iterator.path_id,
-                                    ctx=ctx)
-
-                ctx.path_scope = ctx.path_scope.new_child()
-                dml.merge_iterator_scope(iterator, ctx.rel, ctx=ctx)
+            ctx.path_scope = ctx.path_scope.new_child()
+            dml.merge_iterator(iterator, ctx.rel, ctx=ctx)
 
             ctx.enclosing_cte_iterator = iterator
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -58,6 +58,8 @@ warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
 
+[mypy-edb.pgsql.ast]
+ignore_errors = False
 
 [mypy-edb.pgsql.compiler.*]
 ignore_errors = False

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1123,6 +1123,42 @@ class TestInsert(tb.QueryTestCase):
             ["ac", "ad", "bc", "bd"]
         )
 
+    async def test_edgeql_insert_for_15(self):
+        await self.con.execute(r"""
+            WITH MODULE test
+            FOR noob in {"Phil Emarg", "Madeline Hatch"}
+            UNION (
+                INSERT Person {name := noob ++ "!",
+                               notes := (INSERT Note {name := noob})});
+        """)
+
+        await self.assert_query_result(
+            "SELECT test::Person { name, notes: {name} }",
+            [{"name": "Phil Emarg!", "notes": [{"name": "Phil Emarg"}]},
+             {"name": "Madeline Hatch!", "notes": [{"name": "Madeline Hatch"}]}],
+        )
+
+    async def test_edgeql_insert_for_16(self):
+        await self.con.execute(r"""
+            WITH MODULE test
+            FOR noob in {"Phil Emarg", "Madeline Hatch"}
+            UNION (
+                INSERT Person {name := noob,
+                               notes := (
+                    FOR suffix in {"?", "!"} UNION (
+                        INSERT Note {name := noob ++ suffix}))});
+        """)
+
+        await self.assert_query_result(
+            "SELECT test::Person { name, notes: {name} }",
+            [
+                {"name": "Phil Emarg",
+                 "notes": [{"name": "Phil Emarg?"}, {"name": "Phil Emarg!"}]},
+                {"name": "Madeline Hatch",
+                 "notes": [{"name": "Madeline Hatch?"}, {"name": "Madeline Hatch!"}]},
+            ],
+        )
+
     async def test_edgeql_insert_default_01(self):
         await self.con.execute(r'''
             # create 10 DefaultTest3 objects, each object is defined

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -940,6 +940,61 @@ class TestInsert(tb.QueryTestCase):
             }]
         )
 
+    async def test_edgeql_insert_for_06(self):
+        res = await self.con.query(r'''
+            WITH MODULE test
+            FOR a in {"a", "b"} UNION (
+                FOR b in {"c", "d"} UNION (
+                    INSERT Note {name := b}));
+        ''')
+        self.assertEqual(len(res), 4)
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT Note.name
+                ORDER BY Note.name;
+            ''',
+            ["c", "c", "d", "d"]
+        )
+
+    async def test_edgeql_insert_for_07(self):
+        res = await self.con.query(r'''
+            WITH MODULE test
+            FOR a in {"a", "b"} UNION (
+                FOR b in {a++"c", a++"d"} UNION (
+                    INSERT Note {name := b}));
+        ''')
+        self.assertEqual(len(res), 4)
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT Note.name
+                ORDER BY Note.name;
+            ''',
+            ["ac", "ad", "bc", "bd"]
+        )
+
+    async def test_edgeql_insert_for_08(self):
+        res = await self.con.query(r'''
+            WITH MODULE test
+            FOR a in {"a", "b"} UNION (
+                FOR b in {"a", "b"} UNION (
+                    FOR c in {a++b++"a", a++b++"b"} UNION (
+                        INSERT Note {name := c})));
+        ''')
+        self.assertEqual(len(res), 8)
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT Note.name
+                ORDER BY Note.name;
+            ''',
+            ["aaa", "aab", "aba", "abb", "baa", "bab", "bba", "bbb"]
+        )
+
     async def test_edgeql_insert_default_01(self):
         await self.con.execute(r'''
             # create 10 DefaultTest3 objects, each object is defined

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1134,8 +1134,10 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             "SELECT test::Person { name, notes: {name} }",
-            [{"name": "Phil Emarg!", "notes": [{"name": "Phil Emarg"}]},
-             {"name": "Madeline Hatch!", "notes": [{"name": "Madeline Hatch"}]}],
+            [{"name": "Phil Emarg!",
+              "notes": [{"name": "Phil Emarg"}]},
+             {"name": "Madeline Hatch!",
+              "notes": [{"name": "Madeline Hatch"}]}],
         )
 
     async def test_edgeql_insert_for_16(self):
@@ -1153,9 +1155,11 @@ class TestInsert(tb.QueryTestCase):
             "SELECT test::Person { name, notes: {name} }",
             [
                 {"name": "Phil Emarg",
-                 "notes": [{"name": "Phil Emarg?"}, {"name": "Phil Emarg!"}]},
+                 "notes": [{"name": "Phil Emarg?"},
+                           {"name": "Phil Emarg!"}]},
                 {"name": "Madeline Hatch",
-                 "notes": [{"name": "Madeline Hatch?"}, {"name": "Madeline Hatch!"}]},
+                 "notes": [{"name": "Madeline Hatch?"},
+                           {"name": "Madeline Hatch!"}]},
             ],
         )
 
@@ -1176,9 +1180,11 @@ class TestInsert(tb.QueryTestCase):
             "SELECT test::Person { name, notes: {name} }",
             [
                 {"name": "Phil Emarg",
-                 "notes": [{"name": "Phil Emarg?"}, {"name": "Phil Emarg!"}]},
+                 "notes": [{"name": "Phil Emarg?"},
+                           {"name": "Phil Emarg!"}]},
                 {"name": "Madeline Hatch",
-                 "notes": [{"name": "Madeline Hatch?"}, {"name": "Madeline Hatch!"}]},
+                 "notes": [{"name": "Madeline Hatch?"},
+                           {"name": "Madeline Hatch!"}]},
             ],
         )
 

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2535,7 +2535,7 @@ class TestInsert(tb.QueryTestCase):
             ]
         )
 
-    async def test_edgeql_insert_dependent_08(self):
+    async def test_edgeql_insert_dependent_10(self):
         await self.con.execute(r"""INSERT test::Note { name := "foo" };""")
 
         query = r"""

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -1566,6 +1566,49 @@ class TestUpdate(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_update_for_02(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test
+                FOR x IN {
+                        'update-test1',
+                        'update-test2',
+                    }
+                UNION (
+                    UPDATE UpdateTest
+                    FILTER UpdateTest.name = x
+                    SET {
+                        comment := x ++ "!"
+                    }
+                );
+            """,
+            [{}, {}],  # since updates are in FOR they return objects
+        )
+
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test
+                SELECT UpdateTest {
+                    name,
+                    comment
+                } ORDER BY UpdateTest.name;
+            """,
+            [
+                {
+                    'name': 'update-test1',
+                    'comment': 'update-test1!'
+                },
+                {
+                    'name': 'update-test2',
+                    'comment': 'update-test2!'
+                },
+                {
+                    'name': 'update-test3',
+                    'comment': 'third'
+                },
+            ]
+        )
+
     async def test_edgeql_update_empty_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
We now always compile FOR iterators when they are seen at SELECT
statements, rather than looking back up the tree to find them when we
encounter them at DML statements. At the compilation site, we check
whether there is DML in the body and hoist the iterator to a CTE if
so.

This fixes some issues involving nested iterators and mixed SELECT/DML
inside iterators and allows us to loosen the restrictions on
correlation of iterator variables.

It should make fixing #1699 (volatile keys with UNLESS CONFLICT ELSE)
practical. Hopefully it also clears the way for additional refactors.

Closes #1724. Closes #1674. Closes #1686.