### PR TITLE
Use "edgedb0" for system purposes and stop treating "edgedb" as special

### DIFF
--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -316,7 +316,7 @@ cdef class DatabaseIndex:
         return self._instance_data[key]
 
     async def reload_config(self):
-        conn = await self._server.new_pgcon(defines.EDGEDB_SUPERUSER_DB)
+        conn = await self._server.new_pgcon(defines.EDGEDB_TEMPLATE_DB)
 
         query = await self.get_sys_query(conn, 'config')
         try:

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_08_25_00_00
+EDGEDB_CATALOG_VERSION = 2020_08_31_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -299,7 +299,7 @@ def run_server(args: ServerConfig):
                     cluster.set_connection_params(
                         pgconnparams.ConnectionParameters(
                             user=defines.EDGEDB_SUPERUSER,
-                            database=defines.EDGEDB_SUPERUSER_DB,
+                            database=defines.EDGEDB_TEMPLATE_DB,
                         ),
                     )
 

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -60,6 +60,7 @@ from edb.server import config
 
 from edb.server import buildmeta
 from edb.server import compiler
+from edb.server import defines as edbdef
 from edb.server.compiler import errormech
 from edb.server.pgcon cimport pgcon
 from edb.server.pgcon import errors as pgerror
@@ -263,6 +264,15 @@ cdef class EdgeConnection:
 
         logger.debug('received connection request by %s to database %s',
                      user, database)
+
+        if database == edbdef.EDGEDB_TEMPLATE_DB:
+            # Prevent connections to the system template database,
+            # which only purpose is to serve as a template for new
+            # databases.
+            raise errors.AccessError(
+                f'database {edbdef.EDGEDB_TEMPLATE_DB!r} does not '
+                f'accept connections'
+            )
 
         dbv = self.port.new_view(
             dbname=database, user=user,

--- a/edb/tools/wipe.py
+++ b/edb/tools/wipe.py
@@ -110,10 +110,10 @@ async def do_wipe(
 ) -> None:
 
     try:
-        pgconn = await cluster.connect(database=edbdef.EDGEDB_SUPERUSER_DB)
+        pgconn = await cluster.connect(database=edbdef.EDGEDB_TEMPLATE_DB)
     except asyncpg.InvalidCatalogNameError:
         click.secho(
-            f'Instance does not have the {edbdef.EDGEDB_SUPERUSER_DB!r} '
+            f'Instance does not have the {edbdef.EDGEDB_TEMPLATE_DB!r} '
             f'database. Is it already clean?'
         )
         return


### PR DESCRIPTION
The `edgedb` database is a database that we create by default, but it
should not be special: it can be dropped, and, accordingly, the server
should not rely on it being present.  Instead, use the `edgedb0`
template database for system purposes.  To do this, hoist the connection
block from PostgreSQL level to EdgeDB level.

Fixes: #1729