### PR TITLE
Don't inject defaults into INSERT result shapes

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -381,6 +381,7 @@ class ContextLevel(compiler.ContextLevel):
     shape_type_cache: Dict[
         Tuple[
             s_objtypes.ObjectType,
+            bool, bool, bool,
             Tuple[qlast.ShapeElement, ...],
         ],
         s_objtypes.ObjectType,

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -70,7 +70,7 @@ def process_view(
     ctx: context.ContextLevel,
 ) -> s_objtypes.ObjectType:
 
-    cache_key = (stype, tuple(elements))
+    cache_key = (stype, is_insert, is_update, is_delete, tuple(elements))
     view_scls = ctx.shape_type_cache.get(cache_key)
     if view_scls is not None:
         return view_scls

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1059,11 +1059,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             """)
 
-    @test.xfail('''
-        Issue #1721
-
-        Two TestDefaultInsert03 objects are created instead of one.
-    ''')
     async def test_edgeql_ddl_default_03(self):
         # Test INSERT as default link expression
         await self.con.execute(r"""

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1336,6 +1336,15 @@ class TestInsert(tb.QueryTestCase):
             {1, 2, 3}
         )
 
+    async def test_edgeql_insert_default_06(self):
+        res = await self.con.query(r'''
+            INSERT test::DefaultTest1;
+        ''')
+        assert len(res) == 1
+        obj = res[0]
+        # The result should not include the default param
+        assert not hasattr(obj, 'num')
+
     async def test_edgeql_insert_as_expr_01(self):
         await self.con.execute(r'''
             # insert several objects, then annotate one of the inserted batch


### PR DESCRIPTION
Currently we inject default values into the result shapes of INSERTs
due to incorrect caching. Broaden the shape_type_cache to include the
is_* flags, since those produce noticable behavior changes.

Fixes #1721.