### PR TITLE
Add tracking of DML inside function bodies.

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -244,6 +244,9 @@ def compile_ast_to_ir(
         debug.header('EdgeDB IR')
         debug.dump(ir_expr, schema=getattr(ir_expr, 'schema', None))
 
+    if isinstance(ir_expr, irast.Statement):
+        ir_expr.dml_exprs = ctx.env.dml_exprs
+
     return ir_expr
 
 
@@ -293,6 +296,7 @@ def compile_ast_fragment_to_ir(
         expr=ir_set,
         schema=ctx.env.schema,
         stype=result_type,
+        dml_exprs=ctx.env.dml_exprs,
     )
 
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -228,6 +228,11 @@ class Environment:
     ptr_ref_cache: PointerRefCache
     type_ref_cache: Dict[irtyputils.TypeRefCacheKey, irast.TypeRef]
 
+    dml_exprs: List[qlast.Base]
+    """A list of DML expressions (statements and DML-containing
+    functions) that appear in a function body.
+    """
+
     def __init__(
         self,
         *,
@@ -256,6 +261,7 @@ class Environment:
         self.created_schema_objects = set()
         self.ptr_ref_cache = PointerRefCache()
         self.type_ref_cache = {}
+        self.dml_exprs = []
 
     @overload
     def get_track_schema_object(  # NoQA: F811

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -333,6 +333,9 @@ def compile_InsertQuery(
             context=expr.context,
         )
 
+    # Record this node in the list of potential DML expressions.
+    ctx.env.dml_exprs.append(expr)
+
     with ctx.subquery() as ictx:
         stmt = irast.InsertStmt()
         init_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
@@ -416,6 +419,9 @@ def compile_UpdateQuery(
             context=expr.context,
         )
 
+    # Record this node in the list of potential DML expressions.
+    ctx.env.dml_exprs.append(expr)
+
     with ctx.subquery() as ictx:
         stmt = irast.UpdateStmt()
         init_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
@@ -483,6 +489,9 @@ def compile_DeleteQuery(
             'DELETE statements cannot be used inside conditional expressions',
             context=expr.context,
         )
+
+    # Record this node in the list of potential DML expressions.
+    ctx.env.dml_exprs.append(expr)
 
     with ctx.subquery() as ictx:
         stmt = irast.DeleteStmt()

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -449,6 +449,7 @@ class Statement(Command):
                                          compiler.ContextLevel,
                                          PathId,
                                          typing.Optional[WeakNamespace]]]
+    dml_exprs: typing.List[qlast.Base]
 
 
 class TypeIntrospection(ImmutableExpr):


### PR DESCRIPTION
Track the presence of DML statemnts and function calls that appear
inside function bodies.

Issue #1661