### PR TITLE
Try harder when reconstructing delta trees after depsorting

### DIFF
--- a/edb/common/struct.py
+++ b/edb/common/struct.py
@@ -328,16 +328,22 @@ class Struct(metaclass=StructMeta):
         return iter(self.__class__._fields)
 
     def __str__(self) -> str:
-        fields = ', '.join(('%s=%s' % (name, value))
-                           for name, value in self.formatfields('str'))
-        return '<{}{}>'.format(
-            self.__class__.__name__, ' ' + fields if fields else '')
+        fields = ', '.join(
+            f'{name}={value}'
+            for name, value in self.formatfields('str')
+        )
+        if fields:
+            fields = f' {fields}'
+        return f'<{self.__class__.__name__}{fields} at {id(self):#x}>'
 
     def __repr__(self) -> str:
-        fields = ', '.join(('%s=%s' % (name, value))
-                           for name, value in self.formatfields('repr'))
-        return '<{}{}>'.format(
-            self.__class__.__name__, ' ' + fields if fields else '')
+        fields = ', '.join(
+            f'{name}={value}'
+            for name, value in self.formatfields('repr')
+        )
+        if fields:
+            fields = f' {fields}'
+        return f'<{self.__class__.__name__}{fields} at {id(self):#x}>'
 
     def _init_fields(
         self,

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2009,14 +2009,14 @@ class DeleteObjectType(ObjectTypeMetaCommand,
 
         orig_schema = schema
         schema = ObjectTypeMetaCommand.apply(self, schema, context)
+        schema = s_objtypes.DeleteObjectType.apply(self, schema, context)
 
-        if has_table(objtype, schema):
+        if has_table(objtype, orig_schema):
+            self.attach_alter_table(context)
             self.pgops.add(dbops.DropTable(name=old_table_name, priority=3))
             self.update_base_inhviews(orig_schema, context, objtype)
 
         self.schedule_inhview_deletion(orig_schema, context, objtype)
-
-        schema = s_objtypes.DeleteObjectType.apply(self, schema, context)
 
         return schema
 
@@ -2759,6 +2759,8 @@ class DeleteLink(LinkMetaCommand, adapts=s_links.DeleteLink):
             if link.get_is_owned(orig_schema):
                 self.schedule_endpoint_delete_action_update(
                     link, orig_schema, schema, context)
+
+            self.attach_alter_table(context)
 
         self.pgops.add(
             dbops.DropTable(

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -743,15 +743,6 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
             raise RuntimeError(f'context class not defined for {cls}')
         return ctxcls
 
-    def __str__(self) -> str:
-        return struct.MixedStruct.__str__(self)
-
-    def __repr__(self) -> str:
-        flds = struct.MixedStruct.__repr__(self)
-        return '<{}.{}{}>'.format(self.__class__.__module__,
-                                  self.__class__.__name__,
-                                  (' ' + flds) if flds else '')
-
 
 # Similarly to _dummy_object, we use _dummy_command for places where
 # the typing requires an object, but we don't have it just yet.
@@ -2049,11 +2040,6 @@ class CreateObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
             schema = self._create_finalize(schema, context)
         return schema
 
-    def __repr__(self) -> str:
-        return '<%s.%s "%s">' % (self.__class__.__module__,
-                                 self.__class__.__name__,
-                                 self.classname)
-
 
 class AlterObjectFragment(ObjectCommand[so.Object_T]):
 
@@ -2121,11 +2107,6 @@ class RenameObject(AlterObjectFragment[so.Object_T]):
     astnode = qlast.Rename
 
     new_name = struct.Field(str)
-
-    def __repr__(self) -> str:
-        return '<%s.%s "%s" to "%s">' % (self.__class__.__module__,
-                                         self.__class__.__name__,
-                                         self.classname, self.new_name)
 
     def _rename_begin(
         self,

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -2459,6 +2459,21 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }]
         )
 
+    async def test_edgeql_migration_43(self):
+        await self.con.execute("""
+            SET MODULE test;
+        """)
+        await self.migrate(r"""
+            abstract link Ordered {
+                property index -> int32;
+            }
+            type User;
+            abstract type Permissions {
+                multi link owners extending Ordered -> User;
+            };
+        """)
+        await self.migrate(r"")
+
     async def test_edgeql_migration_function_01(self):
         await self.con.execute("""
             SET MODULE test;


### PR DESCRIPTION
When performing topological sorting on delta trees we break them into 
linear command branches first, sort the branches, and the reassemble the 
branches back into trees that hopefully resemble trees produced when 
processing an equivalent set of DDL commands.  The reassembly process is 
currently far from perfect an sometimes produces trees that break delta 
executor expectations.  This improves the reassembly process in two ways:

1) implicit commands now get reattached to inheritance parents, like
   they would be in a tree produced by inheritance propagation in a DDL
   command;

2) trivial DELETE and ALTER commands now opportunistically get merged
   into an earlier corresponding ALTER command (which gets turned into
   a DELETE if merging a DELETE command).