### PR TITLE
Fix issue with coalescing inside UPDATE

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -161,9 +161,9 @@ def get_set_rvar(
         is_empty_set = isinstance(ir_set, irast.EmptySet)
 
         path_scope = relctx.get_scope(ir_set, ctx=subctx)
-        scope = path_scope or subctx.scope_tree
+        new_scope = path_scope or subctx.scope_tree
         is_optional = (
-            scope.is_optional(path_id) or
+            new_scope.is_optional(path_id) or
             path_id in subctx.force_optional
         )
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -160,8 +160,10 @@ def get_set_rvar(
 
         is_empty_set = isinstance(ir_set, irast.EmptySet)
 
+        path_scope = relctx.get_scope(ir_set, ctx=subctx)
+        scope = path_scope or subctx.scope_tree
         is_optional = (
-            subctx.scope_tree.is_optional(path_id) or
+            scope.is_optional(path_id) or
             path_id in subctx.force_optional
         )
 
@@ -172,7 +174,6 @@ def get_set_rvar(
                 ir_set=ir_set, stmt=stmt, ctx=subctx)
             subctx.pending_query = subctx.rel = stmt
 
-        path_scope = relctx.get_scope(ir_set, ctx=subctx)
         if path_scope:
             if path_scope.is_visible(path_id):
                 subctx.path_scope[path_id] = scope_stmt

--- a/tests/test_edgeql_tree.py
+++ b/tests/test_edgeql_tree.py
@@ -716,12 +716,6 @@ class TestTree(tb.QueryTestCase):
             ],
         )
 
-    @test.xfail('''
-        This test fails with the following error:
-
-        edgedb.errors.MissingRequiredError:
-        missing value for required property test::Tree.val
-    ''')
     async def test_edgeql_tree_update_03(self):
         # Update all the tree nodes to base their val on the parent
         # val.
@@ -756,14 +750,6 @@ class TestTree(tb.QueryTestCase):
             ]
         )
 
-    @test.xfail('''
-        This test fails with the following error:
-
-        edgedb.errors.QueryError: possibly more than one element
-        returned by an expression where only singletons are allowed
-
-        Seems to be related to #1098.
-    ''')
     async def test_edgeql_tree_update_04(self):
         # Update all the tree nodes to base their val on the parent
         # val.


### PR DESCRIPTION
The check for optionality in get_set_rvar was not being done in the
scope of the path, so we could miss optionality in some cases, such as
two xfailing tree tests.