### PR TITLE
Fix the test case retry loop

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -114,9 +114,11 @@ class TestCaseMeta(type(unittest.TestCase)):
                     if try_no == 3:
                         raise
                     else:
-                        self.loop.run_until_complete(self.con.execute(
-                            'ROLLBACK;'
-                        ))
+                        if getattr(self, 'ISOLATED_METHODS'):
+                            self.loop.run_until_complete(self.xact.rollback())
+                            self.xact = self.con.transaction()
+                            self.loop.run_until_complete(self.xact.start())
+
                         try_no += 1
                 else:
                     break

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -111,8 +111,11 @@ class TestCaseMeta(type(unittest.TestCase)):
                         __meth__(self, *args, **kwargs))
                 except (edgedb.TransactionSerializationError,
                         edgedb.TransactionDeadlockError):
-                    # Only do a retry loop when we have a transaction
-                    if try_no == 3 or not getattr(self, 'ISOLATED_METHODS'):
+                    if (
+                        try_no == 3
+                        # Only do a retry loop when we have a transaction
+                        or not getattr(self, 'ISOLATED_METHODS', False)
+                    ):
                         raise
                     else:
                         self.loop.run_until_complete(self.xact.rollback())


### PR DESCRIPTION
It was failing due to not starting a new transaction.  I tested by
putting some diagnostics in and running it until I observed that the
retry happened sucessfully.