### PR TITLE
Fix SDL dependency inference for functions.

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -42,6 +42,7 @@ from edb.common import topological
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import codegen as qlcodegen
+from edb.edgeql import parser as qlparser
 from edb.edgeql import tracer as qltracer
 
 from edb.schema import name as s_name
@@ -480,6 +481,11 @@ def trace_Function(node: qlast.CreateFunction, *, ctx: DepTraceContext):
 
     if node.nativecode is not None:
         deps.append((node.nativecode, params))
+    elif (node.code is not None
+            and node.code.language is qlast.Language.EdgeQL
+            and node.code.code):
+        # Need to parse the actual code string and use that as the dependency.
+        deps.append((qlparser.parse(node.code.code), params))
 
     # XXX: hard_dep_expr is used because it ultimately calls the
     # _get_hard_deps helper that extracts the proper dependency list

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1840,6 +1840,26 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_schema_get_migration_34(self):
+        # Make sure that awkward order of function definitions doesn't
+        # affect the migraiton.
+        #
+        # Issue #1649.
+        schema = r'''
+        function b() -> int64 {
+            using EdgeQL $$
+                SELECT a()
+            $$
+        }
+        function a() -> int64 {
+            using EdgeQL $$
+                SELECT 1
+            $$
+        }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_schema_get_migration_multi_module_01(self):
         schema = r'''
             # The two declared types declared are from different


### PR DESCRIPTION
SDL with functions with bodies given as strings will now be converted to
correctly ordered DDL same as functions where bodies are EdgeQL
expressions.

Fixes #1649