### PR TITLE
Allow trailing commas in collection types.

### DIFF
--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1383,6 +1383,12 @@ class CollectionTypeName(Nonterm):
             subtypes=kids[2].val,
         )
 
+    def reduce_NodeName_LANGBRACKET_SubtypeList_COMMA_RANGBRACKET(self, *kids):
+        self.val = qlast.TypeName(
+            maintype=kids[0].val,
+            subtypes=kids[2].val,
+        )
+
 
 class TypeName(Nonterm):
     def reduce_SimpleTypeName(self, *kids):

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1971,6 +1971,28 @@ aa';
         SELECT <std::tuple<obj: Foo, count: int, name: str>>$1;
         """
 
+    def test_edgeql_syntax_cast_08(self):
+        """
+        SELECT <array<int64,>>$1;
+        SELECT <std::array<std::str,>>$1;
+
+% OK %
+
+        SELECT <array<int64>>$1;
+        SELECT <std::array<std::str>>$1;
+        """
+
+    def test_edgeql_syntax_cast_09(self):
+        """
+        SELECT <tuple<Foo, int, str,>>$1;
+        SELECT <std::tuple<obj: Foo, count: int, name: str,>>$1;
+
+% OK %
+
+        SELECT <tuple<Foo, int, str>>$1;
+        SELECT <std::tuple<obj: Foo, count: int, name: str>>$1;
+        """
+
     def test_edgeql_syntax_with_01(self):
         """
         WITH


### PR DESCRIPTION
Collection type specification should allow trailing commas.
E.g. `tuple<str, str,>`.