### PR TITLE
Improve database initialization

### DIFF
--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -483,7 +483,7 @@ _server_options = [
         '--bootstrap-command', metavar="QUERIES",
         help='run the commands when initializing the database. '
              'Queries are executed by default user within default '
-             'database. May be used with or without `--bootstrap`.'),
+             'database. May be used with or without `--bootstrap-only`.'),
     click.option(
         '--bootstrap-script', type=PathPath(), metavar="PATH",
         help='run the script when initializing the database. '

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -488,7 +488,7 @@ _server_options = [
         '--bootstrap-script', type=PathPath(), metavar="PATH",
         help='run the script when initializing the database. '
              'Script run by default user within default database. '
-             'May be used with or without `--bootstrap`.'),
+             'May be used with or without `--bootstrap-only`.'),
     click.option(
         '--devmode/--no-devmode',
         help='enable or disable the development mode',


### PR DESCRIPTION
1. Added `--bootstrap-script` and `--bootstrap-command` arguments to run some
   commands just after bootstrap
2. Renamed `--bootstrap` to `--bootstrap-only`
3. Automatic user and database (either --default-database or unix user name)
   are not created at the server restart any more (only at bootstrap)

A little bit related to edgedb/edgedb-docker#3 but not exactly that