### PR TITLE
workflows: Make sure docker images are built in the correct job

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -169,13 +169,12 @@ jobs:
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
+    <% if tgt.name == 'debian-buster' %>
     - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
         path: dockerfile
-    <% if tgt.name == 'debian-stretch' %>
-
     - name: Publish Docker Image
       uses: elgohr/Publish-Docker-Github-Action@2.6
       with:

--- a/.github/workflows.src/release.tpl.yml
+++ b/.github/workflows.src/release.tpl.yml
@@ -176,13 +176,12 @@ jobs:
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
+    <% if tgt.name == 'debian-buster' %>
     - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
         path: dockerfile
-    <% if tgt.name == 'debian-stretch' %>
-
     - name: Publish Docker Image
       uses: elgohr/Publish-Docker-Github-Action@2.6
       with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -385,22 +385,6 @@ jobs:
         PKG_PLATFORM_VERSION: "stretch"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v2
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
-    
-
-    - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@2.6
-      with:
-        name: edgedb/edgedb:nightly
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        snapshot: true
-        workdir: dockerfile
-        buildargs: version=${{ steps.describe.outputs.version-slot }},subdist=.nightly
     
 
   publish-debian-buster:
@@ -436,11 +420,21 @@ jobs:
         PKG_PLATFORM_VERSION: "buster"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
+    
     - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
         path: dockerfile
+    - name: Publish Docker Image
+      uses: elgohr/Publish-Docker-Github-Action@2.6
+      with:
+        name: edgedb/edgedb:nightly
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        snapshot: true
+        workdir: dockerfile
+        buildargs: version=${{ steps.describe.outputs.version-slot }},subdist=.nightly
     
 
   publish-ubuntu-xenial:
@@ -476,11 +470,6 @@ jobs:
         PKG_PLATFORM_VERSION: "xenial"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v2
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
     
 
   publish-ubuntu-bionic:
@@ -516,11 +505,6 @@ jobs:
         PKG_PLATFORM_VERSION: "bionic"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v2
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
     
 
   publish-ubuntu-focal:
@@ -556,11 +540,6 @@ jobs:
         PKG_PLATFORM_VERSION: "focal"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v2
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
     
 
   publish-centos-7:
@@ -596,11 +575,6 @@ jobs:
         PKG_PLATFORM_VERSION: "7"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v2
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
     
 
   publish-centos-8:
@@ -636,11 +610,6 @@ jobs:
         PKG_PLATFORM_VERSION: "8"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v2
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
     
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -434,22 +434,6 @@ jobs:
         PKG_PLATFORM_VERSION: "stretch"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v2
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
-    
-
-    - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@2.6
-      with:
-        name: edgedb/edgedb:${{ steps.describe.outputs.version-slot }}
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        snapshot: true
-        workdir: dockerfile
-        buildargs: version=${{ steps.describe.outputs.version-slot }}
     
 
   publish-debian-buster:
@@ -483,11 +467,21 @@ jobs:
         PKG_PLATFORM_VERSION: "buster"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
+    
     - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-docker
         ref: master
         path: dockerfile
+    - name: Publish Docker Image
+      uses: elgohr/Publish-Docker-Github-Action@2.6
+      with:
+        name: edgedb/edgedb:${{ steps.describe.outputs.version-slot }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        snapshot: true
+        workdir: dockerfile
+        buildargs: version=${{ steps.describe.outputs.version-slot }}
     
 
   publish-ubuntu-xenial:
@@ -521,11 +515,6 @@ jobs:
         PKG_PLATFORM_VERSION: "xenial"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v2
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
     
 
   publish-ubuntu-bionic:
@@ -559,11 +548,6 @@ jobs:
         PKG_PLATFORM_VERSION: "bionic"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v2
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
     
 
   publish-ubuntu-focal:
@@ -597,11 +581,6 @@ jobs:
         PKG_PLATFORM_VERSION: "focal"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v2
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
     
 
   publish-centos-7:
@@ -635,11 +614,6 @@ jobs:
         PKG_PLATFORM_VERSION: "7"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v2
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
     
 
   publish-centos-8:
@@ -673,11 +647,6 @@ jobs:
         PKG_PLATFORM_VERSION: "8"
         PKG_VERSION_SLOT: "${{ steps.describe.outputs.version-slot }}"
 
-    - uses: actions/checkout@v2
-      with:
-        repository: edgedb/edgedb-docker
-        ref: master
-        path: dockerfile
     
 
 


### PR DESCRIPTION
The docker images use Buster packages, but are built in the job that
builds Stretch packages, which would lead to failures if Buster hadn't
been built yet.