### PR TITLE
Disallow DELETE and UPDATE in many cases without FILTER

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -420,6 +420,47 @@ def compile_InsertQuery(
     return result
 
 
+def allow_update_or_delete(
+        subject: irast.Set,
+        *,
+        ctx: context.ContextLevel) -> bool:
+    # Allow deleting (...).foo if we would allow deleting (...)
+    if subject.rptr and allow_update_or_delete(subject.rptr.source, ctx=ctx):
+        return True
+
+    # This is a bit of a hack, but allow deleting paths that are in
+    # the factoring_allowlist. This lets us delete FOR iterators and
+    # the INSERT set in INSERT ... ELSE.
+    if (ctx.path_scope.parent
+            and subject.path_id in ctx.path_scope.parent.factoring_allowlist):
+        return True
+
+    sexpr = subject.expr
+
+    if not sexpr:
+        return False
+
+    # Allow non SELECT and filtered things
+    if not isinstance(sexpr, irast.SelectStmt) or sexpr.where:
+        return True
+
+    return allow_update_or_delete(sexpr.result, ctx=ctx)
+
+
+def enforce_constrained_dml(
+        expr: qlast.Expr,
+        subject: irast.Set,
+        where: Optional[qlast.Expr],
+        *,
+        ctx: context.ContextLevel) -> None:
+    if not where and not allow_update_or_delete(subject, ctx=ctx):
+        typ = "DELETE" if isinstance(expr, qlast.DeleteQuery) else "UPDATE"
+        raise errors.QueryError(
+            f'{typ} statement requires a FILTER clause',
+            context=expr.context
+        )
+
+
 @dispatch.compile.register(qlast.UpdateQuery)
 def compile_UpdateQuery(
         expr: qlast.UpdateQuery, *, ctx: context.ContextLevel) -> irast.Set:
@@ -439,6 +480,8 @@ def compile_UpdateQuery(
 
         subject = dispatch.compile(expr.subject, ctx=ictx)
         assert isinstance(subject, irast.Set)
+
+        enforce_constrained_dml(expr, subject, where=expr.where, ctx=ictx)
 
         subj_type = inference.infer_type(subject, ictx.env)
         if not isinstance(subj_type, s_objtypes.ObjectType):
@@ -508,6 +551,7 @@ def compile_DeleteQuery(
         stmt = irast.DeleteStmt(context=expr.context)
         # Expand the DELETE from sugar into full DELETE (SELECT ...)
         # form, if there's any additional clauses.
+        where = expr.where
         if any([expr.where, expr.orderby, expr.offset, expr.limit]):
             if expr.offset or expr.limit:
                 subjql = qlast.SelectQuery(
@@ -547,6 +591,8 @@ def compile_DeleteQuery(
             scopectx.implicit_limit = 0
             subject = setgen.scoped_set(
                 dispatch.compile(expr.subject, ctx=scopectx), ctx=scopectx)
+
+        enforce_constrained_dml(expr, subject, where=where, ctx=ictx)
 
         subj_type = inference.infer_type(subject, ictx.env)
         if not isinstance(subj_type, s_objtypes.ObjectType):

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -659,12 +659,16 @@ class GraphQLTranslator:
             if delete_mode:
                 # this should be a DELETE operation, so we'll rearrange the
                 # components of the SelectQuery
+
+                # edgeql doesn't allow unconditional DELETE
+                where = filterable.where or qlast.BooleanConstant(value="true")
+
                 filterable.aliases = [
                     qlast.AliasedExpr(
                         alias=alias,
                         expr=qlast.DeleteQuery(
                             subject=filterable.result.expr,
-                            where=filterable.where,
+                            where=where,
                         )
                     )
                 ]
@@ -675,12 +679,16 @@ class GraphQLTranslator:
                 update_shape = self._visit_update_arguments(node.arguments)
                 # this should be an UPDATE operation, so we'll rearrange the
                 # components of the SelectQuery and add data operations
+
+                # edgeql doesn't allow unconditional UPDATE
+                where = filterable.where or qlast.BooleanConstant(value="true")
+
                 filterable.aliases = [
                     qlast.AliasedExpr(
                         alias=alias,
                         expr=qlast.UpdateQuery(
                             subject=filterable.result.expr,
-                            where=filterable.where,
+                            where=where,
                             shape=update_shape,
                         )
                     )

--- a/tests/schemas/dump01_setup.edgeql
+++ b/tests/schemas/dump01_setup.edgeql
@@ -190,7 +190,7 @@ SET {
 
 INSERT X {name := 'x0'};
 INSERT Y {name := 'y0', x := (SELECT X LIMIT 1)};
-UPDATE X SET {y := (SELECT Y LIMIT 1)};
+UPDATE X FILTER true SET {y := (SELECT Y LIMIT 1)};
 
 INSERT Z {
     ck := (SELECT C FILTER .val = 'F00'),
@@ -212,6 +212,7 @@ INSERT DefB {other := (SELECT test::TestB LIMIT 1)};
 INSERT test::TestC {c := 'TestC'};
 INSERT DefC {other := (SELECT test::TestC LIMIT 1)};
 UPDATE test::TestC
+FILTER true
 SET {clink := (SELECT DefC LIMIT 1)};
 
 # on delete

--- a/tests/test_dump01.py
+++ b/tests/test_dump01.py
@@ -1687,6 +1687,7 @@ class DumpTestCaseMixin:
                 await self.con.execute(
                     r'''
                     UPDATE ROPropsA
+                    FILTER true
                     SET {
                         rop0 := 99,
                     };
@@ -1700,6 +1701,7 @@ class DumpTestCaseMixin:
                 await self.con.execute(
                     r'''
                     UPDATE ROPropsA
+                    FILTER true
                     SET {
                         rop1 := 99,
                     };
@@ -1752,6 +1754,7 @@ class DumpTestCaseMixin:
                 await self.con.execute(
                     r'''
                     UPDATE ROLinksA
+                    FILTER true
                     SET {
                         rol0 := <C>{},
                     };
@@ -1765,6 +1768,7 @@ class DumpTestCaseMixin:
                 await self.con.execute(
                     r'''
                     UPDATE ROLinksA
+                    FILTER true
                     SET {
                         rol1 := <C>{},
                     };
@@ -1778,6 +1782,7 @@ class DumpTestCaseMixin:
                 await self.con.execute(
                     r'''
                     UPDATE ROLinksA
+                    FILTER true
                     SET {
                         rol2 := <C>{},
                     };
@@ -1829,6 +1834,7 @@ class DumpTestCaseMixin:
                 await self.con.execute(
                     r'''
                     UPDATE ROLinksB
+                    FILTER true
                     SET {
                         rol0: {@rolp00 := 1},
                     };
@@ -1842,6 +1848,7 @@ class DumpTestCaseMixin:
                 await self.con.execute(
                     r'''
                     UPDATE ROLinksB
+                    FILTER true
                     SET {
                         rol0: {@rolp01 := 1},
                     };
@@ -1855,6 +1862,7 @@ class DumpTestCaseMixin:
                 await self.con.execute(
                     r'''
                     UPDATE ROLinksB
+                    FILTER true
                     SET {
                         rol1: {@rolp10 := 1},
                     };
@@ -1868,6 +1876,7 @@ class DumpTestCaseMixin:
                 await self.con.execute(
                     r'''
                     UPDATE ROLinksB
+                    FILTER true
                     SET {
                         rol1: {@rolp11 := 1},
                     };

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -2180,6 +2180,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         await self.con.execute("""
             UPDATE
                 Base
+            FILTER true
             SET {
                 name := 'base_01'
             };
@@ -2503,6 +2504,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # Fix the data.
         await self.con.execute(r"""
             UPDATE Base
+            FILTER true
             SET {
                 foo := 'base_08',
             };
@@ -2559,6 +2561,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # Fix the data.
         await self.con.execute(r"""
             UPDATE Base
+            FILTER true
             SET {
                 foo := 'base_09',
             };
@@ -2941,6 +2944,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.con.execute(r"""
             UPDATE Base
+            FILTER true
             SET {
                 bar := 21
             };
@@ -3027,6 +3031,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.con.execute(r"""
             UPDATE NewBase
+            FILTER true
             SET {
                 bar := 22
             };
@@ -3794,6 +3799,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             INSERT Child2;
 
             UPDATE Base
+            FILTER true
             SET {
                 foo := (SELECT Child2 LIMIT 1)
             };
@@ -3870,6 +3876,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.con.execute(r"""
             UPDATE Base
+            FILTER true
             SET {
                 foo := 'base_foo_34'
             };
@@ -3958,6 +3965,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 name := 'child_35'
             };
             UPDATE Base
+            FILTER true
             SET {
                 foo := (
                     SELECT Child FILTER .name = 'child_35'
@@ -5189,6 +5197,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         await self.con.execute(r"""
             UPDATE
                 Base
+            FILTER true
             SET {
                 foo: {
                     @bar := 'lp01'
@@ -5220,6 +5229,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             INSERT Base {foo := (INSERT Child)};
             UPDATE Base
+            FILTER true
             SET {
                 foo: {@bar := 'lp02'},
             };
@@ -5260,6 +5270,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             INSERT Base {foo := (INSERT Child)};
             UPDATE Base
+            FILTER true
             SET {
                 foo: {@bar := 3},
             };
@@ -5306,6 +5317,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             INSERT Base {foo := (INSERT Child)};
             UPDATE Base
+            FILTER true
             SET {
                 foo: {@bar := 'lp04'},
             };
@@ -5346,6 +5358,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             INSERT Base {foo := (INSERT Child)};
             UPDATE Base
+            FILTER true
             SET {
                 foo: {@bar := 'lp05'},
             };
@@ -5386,6 +5399,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             INSERT Base {child := (INSERT Child)};
             UPDATE Base
+            FILTER true
             SET {
                 child: {
                     @foo := 'lp06',
@@ -5407,6 +5421,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # update the existing data with a new link prop 'bar'
         await self.con.execute(r"""
             UPDATE Base
+            FILTER true
             SET {
                 child: {
                     @bar := 111,
@@ -5456,6 +5471,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             INSERT Derived {child := (INSERT Child)};
             UPDATE Derived
+            FILTER true
             SET {
                 child: {
                     @foo := 'lp07',
@@ -5510,6 +5526,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self.con.execute(r"""
             UPDATE Derived
+            FILTER true
             SET {
                 child: {
                     @foo := 'lp08',
@@ -5583,6 +5600,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             INSERT Derived {child := (INSERT Child)};
             UPDATE Derived
+            FILTER true
             SET {
                 child: {
                     @foo := 'lp09',
@@ -5654,6 +5672,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             INSERT Derived {child := (INSERT Child)};
             UPDATE Derived
+            FILTER true
             SET {
                 child: {
                     @foo := 'lp10',
@@ -5719,6 +5738,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             INSERT Owner {item := (INSERT Thing)};
             UPDATE Owner
+            FILTER true
             SET {
                 item: {
                     @foo := 'owner_lp11',
@@ -5727,6 +5747,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             INSERT Renter {item := (INSERT Thing)};
             UPDATE Renter
+            FILTER true
             SET {
                 item: {
                     @foo := 'renter_lp11',
@@ -5819,6 +5840,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             INSERT Owner {item := (INSERT Thing)};
             UPDATE Owner
+            FILTER true
             SET {
                 item: {
                     @foo := 'owner_lp11',
@@ -5827,6 +5849,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             INSERT Renter {item := (INSERT Thing)};
             UPDATE Renter
+            FILTER true
             SET {
                 item: {
                     @bar := 'renter_lp11',
@@ -6654,6 +6677,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.con.execute(r"""
             UPDATE Base
+            FILTER true
             SET {
                 foo := [1.2, 4.5]
             };
@@ -6682,6 +6706,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.con.execute(r"""
             UPDATE Base
+            FILTER true
             SET {
                 foo := ('hello', 42)
             };
@@ -6711,6 +6736,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.con.execute(r"""
             UPDATE Base
+            FILTER true
             SET {
                 foo := ('test', 42, [1.2, 4.5])
             };
@@ -6739,6 +6765,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.con.execute(r"""
             UPDATE Base
+            FILTER true
             SET {
                 foo := (a := 'hello', b := 42)
             };
@@ -6823,6 +6850,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.con.execute(r"""
             UPDATE Base
+            FILTER true
             SET {
                 foo := ('new', 7, 1)
             };

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5889,7 +5889,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 t := T
             };
             ALTER TYPE B ALTER LINK t CREATE ANNOTATION title := 'overloaded';
-            UPDATE B SET { t := T };
+            UPDATE B FILTER true SET { t := T };
         """)
 
         await self.assert_query_result(

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -52,7 +52,7 @@ class TestDelete(tb.QueryTestCase):
     async def test_edgeql_delete_simple_01(self):
         # ensure a clean slate, not part of functionality testing
         await self.con.execute(r"""
-            DELETE test::DeleteTest;
+            DELETE test::DeleteTest FILTER TRUE;
         """)
 
         await self.con.execute(r"""
@@ -69,7 +69,7 @@ class TestDelete(tb.QueryTestCase):
         )
 
         await self.con.execute(r"""
-            DELETE test::DeleteTest;
+            DELETE test::DeleteTest FILTER true;
         """)
 
         await self.assert_query_result(
@@ -205,7 +205,7 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH D := (DELETE test::DeleteTest)
+                WITH D := (DELETE test::DeleteTest FILTER true)
                 SELECT count(D);
             """,
             [3],
@@ -236,7 +236,7 @@ class TestDelete(tb.QueryTestCase):
             r"""
                 WITH
                     MODULE test,
-                    D := (DELETE DeleteTest)
+                    D := (DELETE DeleteTest FILTER true)
                 SELECT DeleteTest2 {
                     name,
                     foo := 'bar'
@@ -251,7 +251,7 @@ class TestDelete(tb.QueryTestCase):
         deleted = await self.con.query(
             r"""
                 WITH MODULE test
-                DELETE DeleteTest2;
+                DELETE DeleteTest2 FILTER true;
             """,
         )
 
@@ -280,7 +280,7 @@ class TestDelete(tb.QueryTestCase):
                     MODULE test,
                     # make sure that aliased deletion works as an expression
                     #
-                    Q := (DELETE DeleteTest)
+                    Q := (DELETE DeleteTest FILTER true)
                 SELECT DeleteTest2 {
                     name,
                     count := count(Q),
@@ -295,7 +295,7 @@ class TestDelete(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH MODULE test
-                SELECT (DELETE DeleteTest2) {name};
+                SELECT (DELETE DeleteTest2 FILTER true) {name};
             """,
             [{
                 'name': 'dt2.1',
@@ -323,7 +323,7 @@ class TestDelete(tb.QueryTestCase):
             r"""
                 WITH
                     MODULE test,
-                    D := (DELETE DeleteTest)
+                    D := (DELETE DeleteTest FILTER true)
                 # the returning clause is actually trying to simulate
                 # returning "stats" of deleted objects
                 #
@@ -341,7 +341,7 @@ class TestDelete(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH MODULE test
-                SELECT (DELETE DeleteTest2) {name};
+                SELECT (DELETE DeleteTest2 FILTER true) {name};
             """,
             [{
                 'name': 'dt2.1',

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -45,7 +45,7 @@ class TestDelete(tb.QueryTestCase):
                 r'cannot delete non-ObjectType object'):
 
             await self.con.execute('''\
-                DELETE 42;
+                DELETE 42 FILTER true;
             ''')
         pass
 
@@ -95,8 +95,8 @@ class TestDelete(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH MODULE test
-                DELETE (SELECT DeleteTest
-                        FILTER DeleteTest.name = 'bad name');
+                DELETE DeleteTest
+                FILTER DeleteTest.name = 'bad name';
             """,
             [],
         )
@@ -112,8 +112,8 @@ class TestDelete(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH MODULE test
-                SELECT (DELETE (SELECT DeleteTest
-                        FILTER DeleteTest.name = 'delete-test1'));
+                SELECT (DELETE DeleteTest
+                        FILTER DeleteTest.name = 'delete-test1');
             """,
             [{'id': id1}],
         )
@@ -129,8 +129,8 @@ class TestDelete(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH MODULE test
-                SELECT (DELETE (SELECT DeleteTest
-                        FILTER DeleteTest.name = 'delete-test2'));
+                SELECT (DELETE DeleteTest
+                        FILTER DeleteTest.name = 'delete-test2');
             """,
             [{'id': id2}],
         )
@@ -409,7 +409,7 @@ class TestDelete(tb.QueryTestCase):
                     UNION
                     (SELECT DeleteTest2 FILTER .name ILIKE 'delete union%')
                 )
-            DELETE ToDelete;
+            DELETE ToDelete FILTER true;
         """)
 
         await self.assert_query_result(
@@ -508,15 +508,3 @@ class TestDelete(tb.QueryTestCase):
                 WITH X := test::DeleteTest
                 DELETE X
             ''')
-
-    async def test_edgeql_delete_all_03(self):
-        # We want to allow it for FOR ... UNION
-        await self.con.execute(r'''
-            FOR X IN {test::DeleteTest}
-            UNION (DELETE X)
-        ''')
-
-        await self.assert_query_result(
-            r'''SELECT test::DeleteTest''',
-            [],
-        )

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -491,3 +491,32 @@ class TestDelete(tb.QueryTestCase):
                         (DELETE DeleteTest)
                     );
             ''')
+
+    async def test_edgeql_delete_all_01(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                'DELETE statement requires a FILTER clause'):
+            await self.con.execute(r'''
+                DELETE test::DeleteTest
+            ''')
+
+    async def test_edgeql_delete_all_02(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                'DELETE statement requires a FILTER clause'):
+            await self.con.execute(r'''
+                WITH X := test::DeleteTest
+                DELETE X
+            ''')
+
+    async def test_edgeql_delete_all_03(self):
+        # We want to allow it for FOR ... UNION
+        await self.con.execute(r'''
+            FOR X IN {test::DeleteTest}
+            UNION (DELETE X)
+        ''')
+
+        await self.assert_query_result(
+            r'''SELECT test::DeleteTest''',
+            [],
+        )

--- a/tests/test_edgeql_enums.py
+++ b/tests/test_edgeql_enums.py
@@ -123,6 +123,7 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
             r'''
                 WITH MODULE test
                 UPDATE Foo
+                FILTER true
                 SET {
                     color := 'GREEN'
                 };
@@ -172,6 +173,7 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
             r'''
                 WITH MODULE test
                 UPDATE Bar
+                FILTER true
                 SET {
                     color := 'GREEN'
                 };

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2271,6 +2271,7 @@ class TestExpressions(tb.QueryTestCase):
             await self.con.execute(r"""
                 WITH MODULE test
                 UPDATE Issue.related_to
+                FILTER true
                 SET {
                     related_to := Issue
                 };

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2174,7 +2174,7 @@ class TestInsert(tb.QueryTestCase):
             WITH MODULE test
             SELECT (
                 INSERT Person {name := "Emmanuel Villip"} UNLESS CONFLICT
-                ON .name ELSE (UPDATE Person SET { tag := "redo" })
+                ON .name ELSE (UPDATE Person FILTER true SET { tag := "redo" })
             ) {name, tag};
         '''
 
@@ -2213,7 +2213,8 @@ class TestInsert(tb.QueryTestCase):
             SELECT (
                 FOR noob in {"Emmanuel Villip", "Madeline Hatch"} UNION (
                     INSERT Person {name := noob} UNLESS CONFLICT
-                    ON .name ELSE (UPDATE Person SET { tag := "redo" })
+                    ON .name ELSE (
+                        UPDATE Person FILTER true SET { tag := "redo" })
                 )
             ) {name, tag} ORDER BY .name;
         '''
@@ -2254,7 +2255,7 @@ class TestInsert(tb.QueryTestCase):
             WITH MODULE test
             SELECT (
                 INSERT Person UNLESS CONFLICT
-                ON .name ELSE (UPDATE Person SET { tag := "redo" })
+                ON .name ELSE (UPDATE Person FILTER true SET { tag := "redo" })
             ) {name};
         '''
 

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -1328,9 +1328,9 @@ class TestIntrospection(tb.QueryTestCase):
         )
 
         await self.con.execute(r"""
-            DELETE test::Priority;
-            DELETE test::Status;
-            DELETE test::User;
+            DELETE test::Priority FILTER true;
+            DELETE test::Status FILTER true;
+            DELETE test::User FILTER true;
         """)
 
     async def test_edgeql_introspection_database_01(self):

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -851,11 +851,11 @@ name[IS std::str]"
 
     @tb.must_fail(errors.QueryError,
                   "reference to 'User.name' changes the interpretation",
-                  line=3, col=40)
+                  line=3, col=52)
     def test_edgeql_ir_scope_tree_bad_04(self):
         """
         WITH MODULE test
-        UPDATE User.deck SET { name := User.name }
+        UPDATE User.deck FILTER true SET { name := User.name }
         """
 
     @tb.must_fail(errors.QueryError,

--- a/tests/test_edgeql_ir_volatility_inference.py
+++ b/tests/test_edgeql_ir_volatility_inference.py
@@ -129,6 +129,7 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
             MODULE test
         UPDATE
             Card
+        FILTER true
         SET {
                 name := 'foo',
         }
@@ -142,6 +143,7 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
             MODULE test
         DELETE
             Card
+        FILTER true
 % OK %
         VOLATILE
         """

--- a/tests/test_edgeql_tree.py
+++ b/tests/test_edgeql_tree.py
@@ -32,7 +32,7 @@ class TestTree(tb.QueryTestCase):
 
     async def test_edgeql_tree_delete_01(self):
         await self.con.execute(r"""
-            DELETE test::Tree;
+            DELETE test::Tree FILTER true;
         """)
         await self.assert_query_result(
             r"""
@@ -589,6 +589,7 @@ class TestTree(tb.QueryTestCase):
             r"""
                 WITH MODULE test
                 UPDATE Tree
+                FILTER true
                 SET {
                     val := array_join(
                         [.val, 'c'] ++ array_agg((
@@ -656,6 +657,7 @@ class TestTree(tb.QueryTestCase):
             r"""
                 WITH MODULE test
                 UPDATE Eert
+                FILTER true
                 SET {
                     val := array_join(
                         [.val, 'c'] ++ array_agg((
@@ -723,6 +725,7 @@ class TestTree(tb.QueryTestCase):
             r"""
                 WITH MODULE test
                 UPDATE Tree
+                FILTER true
                 SET {
                     val := .val ++ '_p' ++ (('_' ++ .parent.val) ?? '')
                 };
@@ -757,6 +760,7 @@ class TestTree(tb.QueryTestCase):
             r"""
                 WITH MODULE test
                 UPDATE Eert
+                FILTER true
                 SET {
                     val := .val ++ '_p' ++ (('_' ++ .parent.val) ?? '')
                 };
@@ -802,6 +806,7 @@ class TestTree(tb.QueryTestCase):
                     # update its first child node ('000')
                     TC := (
                         UPDATE (SELECT T00.children
+                        FILTER true
                         ORDER BY .val
                         LIMIT 1)
                         SET {parent := T00.parent}

--- a/tests/test_edgeql_tree.py
+++ b/tests/test_edgeql_tree.py
@@ -806,12 +806,13 @@ class TestTree(tb.QueryTestCase):
                     # update its first child node ('000')
                     TC := (
                         UPDATE (SELECT T00.children
-                        FILTER true
                         ORDER BY .val
                         LIMIT 1)
+                        FILTER true
                         SET {parent := T00.parent}
                     ),
                 UPDATE T00
+                FILTER true
                 SET {parent := TC};
             """
         )
@@ -976,6 +977,7 @@ class TestTree(tb.QueryTestCase):
                         SET {parent := .parent.parent}
                     )
                 UPDATE TP
+                FILTER true
                 SET {parent := T000};
             """
         )
@@ -1043,6 +1045,7 @@ class TestTree(tb.QueryTestCase):
                     # update the parent of '000'
                     TP := (
                         UPDATE (SELECT T000.parent)
+                        FILTER true
                         SET {
                             children := (
                                 SELECT _ := .children
@@ -1053,6 +1056,7 @@ class TestTree(tb.QueryTestCase):
                     # update the grand-parent of '000'
                     TPP := (
                         UPDATE (SELECT TP.parent)
+                        FILTER true
                         SET {
                             children := (
                                 SELECT _ := {.children, T000}
@@ -1062,6 +1066,7 @@ class TestTree(tb.QueryTestCase):
                     )
                 # update node '000'
                 UPDATE (SELECT _ := TPP.children FILTER _ = T000)
+                FILTER true
                 SET {
                     children := {.children, TP}
                 };

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -2570,3 +2570,32 @@ class TestUpdate(tb.QueryTestCase):
                 },
             ]
         )
+
+    async def test_edgeql_update_all_01(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                'UPDATE statement requires a FILTER clause'):
+            await self.con.execute(r'''
+                UPDATE test::UpdateTest
+                SET { comment := '' }
+            ''')
+
+    async def test_edgeql_update_all_02(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                'UPDATE statement requires a FILTER clause'):
+            await self.con.execute(r'''
+                WITH X := test::UpdateTest
+                UPDATE X SET { comment := '' }
+            ''')
+
+    async def test_edgeql_update_all_03(self):
+        await self.con.execute(r'''
+            FOR X IN {test::UpdateTest}
+            UNION (UPDATE X SET { comment := '' })
+        ''')
+
+        await self.assert_query_result(
+            r'''SELECT DISTINCT test::UpdateTest.comment''',
+            [''],
+        )

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -172,6 +172,7 @@ class TestUpdate(tb.QueryTestCase):
             r"""
                 WITH MODULE test
                 UPDATE UpdateTest
+                FILTER true
                 SET {
                     comment := UpdateTest.comment ++ "!",
                     status := (SELECT Status FILTER Status.name = 'Closed')
@@ -251,6 +252,7 @@ class TestUpdate(tb.QueryTestCase):
                 WITH MODULE test
                 SELECT (
                     UPDATE UpdateTest
+                    FILTER true
                     SET {
                         comment := UpdateTest.comment ++ "!",
                         status := (SELECT Status FILTER Status.name = 'Closed')
@@ -321,6 +323,7 @@ class TestUpdate(tb.QueryTestCase):
                     MODULE test,
                     Q := (
                         UPDATE UpdateTest
+                        FILTER true
                         SET {
                             comment := UpdateTest.comment ++ "!",
                             status := (SELECT
@@ -1615,6 +1618,7 @@ class TestUpdate(tb.QueryTestCase):
                 # just clear all the comments
                 WITH MODULE test
                 UPDATE UpdateTest
+                FILTER true
                 SET {
                     comment := {}
                 };
@@ -1638,6 +1642,7 @@ class TestUpdate(tb.QueryTestCase):
                 # just clear all the comments
                 WITH MODULE test
                 UPDATE UpdateTest
+                FILTER true
                 SET {
                     comment := <int64>{}
                 };
@@ -1651,6 +1656,7 @@ class TestUpdate(tb.QueryTestCase):
                 # just clear all the comments
                 WITH MODULE test
                 UPDATE UpdateTest
+                FILTER true
                 SET {
                     name := {}
                 };
@@ -1662,6 +1668,7 @@ class TestUpdate(tb.QueryTestCase):
                 # just clear all the statuses
                 WITH MODULE test
                 UPDATE UpdateTest
+                FILTER true
                 SET {
                     status := {}
                 };
@@ -1686,6 +1693,7 @@ class TestUpdate(tb.QueryTestCase):
                 # just clear all the statuses
                 WITH MODULE test
                 UPDATE UpdateTest
+                FILTER true
                 SET {
                     status := <Object>{}
                 };
@@ -1699,6 +1707,7 @@ class TestUpdate(tb.QueryTestCase):
                 SET MODULE test;
 
                 UPDATE UpdateTest
+                FILTER true
                 SET {
                     status := Status
                 };
@@ -1877,7 +1886,7 @@ class TestUpdate(tb.QueryTestCase):
                 SELECT
                     (SELECT UpdateTest)
                     ??
-                    (UPDATE UpdateTest SET { name := 'no way' });
+                    (UPDATE UpdateTest FILTER true SET { name := 'no way' });
             ''')
 
     async def test_edgeql_update_in_conditional_bad_02(self):
@@ -1892,7 +1901,8 @@ class TestUpdate(tb.QueryTestCase):
                     ELSE (
                         (SELECT UpdateTest)
                         UNION
-                        (UPDATE UpdateTest SET { name := 'no way' })
+                        (UPDATE UpdateTest FILTER true
+                         SET { name := 'no way' })
                     );
             ''')
 
@@ -1904,7 +1914,7 @@ class TestUpdate(tb.QueryTestCase):
                 WITH MODULE test
                 SELECT (
                     Status,
-                    (UPDATE UpdateTest SET {
+                    (UPDATE UpdateTest FILTER true SET {
                         status := Status
                     })
                 );
@@ -1917,7 +1927,7 @@ class TestUpdate(tb.QueryTestCase):
             await self.con.execute(r'''
                 WITH MODULE test
                 SELECT (
-                    (UPDATE UpdateTest SET {
+                    (UPDATE UpdateTest FILTER true SET {
                         status := Status
                     }),
                     Status,
@@ -1932,7 +1942,7 @@ class TestUpdate(tb.QueryTestCase):
                 WITH MODULE test
                 SELECT (
                     UpdateTest,
-                    (UPDATE UpdateTest SET {name := 'update bad'}),
+                    (UPDATE UpdateTest FILTER true SET {name := 'update bad'}),
                 )
             ''')
 

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -456,10 +456,8 @@ class TestUpdate(tb.QueryTestCase):
 
         finally:
             await self.con.execute(r"""
-                DELETE (
-                    SELECT test::UpdateTest
-                    FILTER .name LIKE '%ret5._'
-                );
+                DELETE test::UpdateTest
+                FILTER .name LIKE '%ret5._';
             """)
 
     async def test_edgeql_update_generic_01(self):
@@ -2588,14 +2586,3 @@ class TestUpdate(tb.QueryTestCase):
                 WITH X := test::UpdateTest
                 UPDATE X SET { comment := '' }
             ''')
-
-    async def test_edgeql_update_all_03(self):
-        await self.con.execute(r'''
-            FOR X IN {test::UpdateTest}
-            UNION (UPDATE X SET { comment := '' })
-        ''')
-
-        await self.assert_query_result(
-            r'''SELECT DISTINCT test::UpdateTest.comment''',
-            [''],
-        )

--- a/tests/test_link_target_delete.py
+++ b/tests/test_link_target_delete.py
@@ -218,7 +218,7 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
                 };
 
                 # no source, so the deletion should not be a problem
-                DELETE Target1;
+                DELETE Target1 FILTER true;
             """)
 
             success = True
@@ -244,8 +244,8 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
                     )
                 };
 
-                DELETE Source1;
-                DELETE Target1;
+                DELETE Source1 FILTER true;
+                DELETE Target1 FILTER true;
             """)
 
             success = True
@@ -274,8 +274,8 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
                     )
                 };
 
-                DELETE Source1;
-                DELETE Target1;
+                DELETE Source1 FILTER true;
+                DELETE Target1 FILTER true;
             """)
             success = True
 
@@ -362,7 +362,7 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
                     )
                 };
 
-                DELETE Named;
+                DELETE Named FILTER true;
             """)
 
             success = True

--- a/tests/test_link_target_delete.py
+++ b/tests/test_link_target_delete.py
@@ -132,7 +132,7 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
                     edgedb.ConstraintViolationError,
                     'deletion of test::Target1.* is prohibited by link'):
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                    DELETE test::Target1 FILTER .name = 'Target1.1';
                 """)
 
     async def test_link_on_target_delete_restrict_02(self):
@@ -155,8 +155,8 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
                     edgedb.ConstraintViolationError,
                     'deletion of test::Target1.* is prohibited by link'):
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1Child
-                            FILTER .name = 'Target1Child.1');
+                    DELETE test::Target1Child
+                    FILTER .name = 'Target1Child.1';
                 """)
 
     async def test_link_on_target_delete_restrict_03(self):
@@ -179,7 +179,7 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
                     edgedb.ConstraintViolationError,
                     'deletion of test::Target1 .* is prohibited by link'):
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                    DELETE test::Target1 FILTER .name = 'Target1.1';
                 """)
 
     async def test_link_on_target_delete_restrict_04(self):
@@ -202,8 +202,8 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
                     edgedb.ConstraintViolationError,
                     'deletion of test::Target1.* is prohibited by link'):
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1Child
-                            FILTER .name = 'Target1Child.1');
+                    DELETE test::Target1Child
+                    FILTER .name = 'Target1Child.1';
                 """)
 
     async def test_link_on_target_delete_restrict_05(self):
@@ -304,8 +304,8 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
                 """)
 
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1
-                            FILTER .name = 'Target1.1');
+                    DELETE test::Target1
+                    FILTER .name = 'Target1.1';
                 """)
 
                 exception_is_deferred = True
@@ -335,8 +335,8 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
                 """)
 
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1
-                            FILTER .name = 'Target1.1');
+                    DELETE test::Target1
+                    FILTER .name = 'Target1.1';
                 """)
 
                 exception_is_deferred = True
@@ -388,8 +388,8 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
                     };
 
                     # delete the target with deferred trigger
-                    DELETE (SELECT Target1
-                            FILTER .name = 'Target4.1');
+                    DELETE Target1
+                    FILTER .name = 'Target4.1';
 
                     # assign a new target to the `tgt1_deferred_restrict`
                     INSERT Target1 {
@@ -418,10 +418,10 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
         finally:
             # cleanup
             await self.con.execute("""
-                DELETE (SELECT test::Source1
-                        FILTER .name = 'Source4.1');
-                DELETE (SELECT test::Target1
-                        FILTER .name = 'Target4.2');
+                DELETE test::Source1
+                FILTER .name = 'Source4.1';
+                DELETE test::Target1
+                FILTER .name = 'Target4.2';
             """)
 
     async def test_link_on_target_delete_allow_01(self):
@@ -456,7 +456,7 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE test::Target1 FILTER .name = 'Target1.1';
             """)
 
             await self.assert_query_result(
@@ -508,7 +508,7 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE test::Target1 FILTER .name = 'Target1.1';
             """)
 
             await self.assert_query_result(
@@ -573,7 +573,7 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE test::Target1 FILTER .name = 'Target1.1';
             """)
 
             await self.assert_query_result(
@@ -664,7 +664,7 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE test::Target1 FILTER .name = 'Target1.1';
             """)
 
             await self.assert_query_result(
@@ -771,7 +771,7 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE test::Target1 FILTER .name = 'Target1.1';
             """)
 
             await self.assert_query_result(
@@ -841,7 +841,7 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE test::Target1 FILTER .name = 'Target1.1';
             """)
 
             await self.assert_query_result(
@@ -905,10 +905,8 @@ class TestLinkTargetDeleteMigrations(stb.DDLTestCase):
                     )
                 };
 
-                DELETE (
-                    SELECT test::AbstractObjectType
-                    FILTER .foo.name = 'Target1_migration_01'
-                );
+                DELETE test::AbstractObjectType
+                FILTER .foo.name = 'Target1_migration_01';
             ''')
 
     async def test_link_on_target_delete_migration_02(self):
@@ -942,5 +940,5 @@ class TestLinkTargetDeleteMigrations(stb.DDLTestCase):
                     edgedb.ConstraintViolationError,
                     'deletion of test::Target1 .* is prohibited by link'):
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1 FILTER .name = 'Target1.m02');
+                    DELETE test::Target1 FILTER .name = 'Target1.m02';
                 """)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1394,7 +1394,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                 required property bar -> str {
                     # if bar is not specified, grab it from Bar and
                     # delete the object
-                    default := (DELETE Bar LIMIT 1).data
+                    default := (DELETE Bar FILTER true LIMIT 1).data
                 }
             };
         '''

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1712,8 +1712,8 @@ class TestServerProto(tb.QueryTestCase):
 
                     SET ALIAS f3 AS MODULE std;
 
-                    DELETE (SELECT test::Tmp_tx_13
-                            FILTER test::Tmp_tx_13.tmp_tx_13_1 = 1);
+                    DELETE test::Tmp_tx_13
+                    FILTER test::Tmp_tx_13.tmp_tx_13_1 = 1;
 
                     SET ALIAS f4 AS MODULE std;
                 ''')

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1476,7 +1476,7 @@ class TestServerProto(tb.QueryTestCase):
             [1])
 
         await self.con.execute('''
-            DELETE (SELECT test::Tmp);
+            DELETE (SELECT test::Tmp) FILTER true;
         ''')
 
         self.assertTrue(await self.is_testmode_on())
@@ -2054,7 +2054,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                     edgedb.Set(['aaa']))
 
             await con2.execute(f'''
-                DELETE (SELECT test::{typename});
+                DELETE (SELECT test::{typename}) FILTER true;
 
                 ALTER TYPE test::{typename} {{
                     DROP PROPERTY prop1;
@@ -2103,7 +2103,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                     edgedb.Set(['aaa']))
 
             await con2.query(f'''
-                DELETE (SELECT test::{typename});
+                DELETE (SELECT test::{typename}) FILTER true;
             ''')
 
             await con2.query(f'''
@@ -2156,7 +2156,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                     edgedb.Set([['a', 'aa']]))
 
             await con2.execute(f'''
-                DELETE (SELECT test::{typename});
+                DELETE (SELECT test::{typename}) FILTER true;
 
                 ALTER TYPE test::{typename} {{
                     DROP PROPERTY prop1;
@@ -2203,7 +2203,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                     edgedb.Set(['aaa']))
 
             await con2.execute(f'''
-                DELETE (SELECT test::{typename});
+                DELETE (SELECT test::{typename}) FILTER true;
 
                 ALTER TYPE test::{typename} {{
                     DROP PROPERTY prop1;
@@ -2258,7 +2258,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                     edgedb.Set(['aaa']))
 
             await con2.execute(f'''
-                DELETE (SELECT test::{typename});
+                DELETE (SELECT test::{typename}) FILTER true;
 
                 ALTER TYPE test::{typename} {{
                     DROP PROPERTY prop1;
@@ -2317,7 +2317,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                     foo)
 
             await con2.execute(f'''
-                DELETE (SELECT test::{typename});
+                DELETE (SELECT test::{typename}) FILTER true;
 
                 ALTER TYPE test::{typename} {{
                     DROP LINK link1;
@@ -2380,7 +2380,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                     edgedb.Set(['aaa']))
 
             await con2.execute(f'''
-                DELETE (SELECT test::{typename});
+                DELETE (SELECT test::{typename}) FILTER true;
 
                 ALTER ABSTRACT LINK test::link1 {{
                     DROP PROPERTY prop1;
@@ -2464,7 +2464,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                     edgedb.Set(['aaa']))
 
             await self.con.execute(f'''
-                DELETE (SELECT test::{typename});
+                DELETE (SELECT test::{typename}) FILTER true;
 
                 ALTER TYPE test::{typename} {{
                     DROP PROPERTY prop1;

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -209,6 +209,7 @@ class TestSession(tb.QueryTestCase):
 
             await self.con.execute(r"""
                 UPDATE Flag
+                FILTER true
                 SET {
                     value := NOT sys::sleep(0)
                 };


### PR DESCRIPTION
This patch errs on the side of disallowing, since it is pretty easy to
workaround.

We allow DML when the source is filtered, comes from a query that is
not a set reference, when it is a FOR iterator, and when it is the set
being inserted in the ELSE clause of INSERT ... ELSE.
(FOR is allowed because the meaning seems to clearly imply applying to
everything ...and because it made the implementation easy.)

Most of the test cases for things we allow are existing ones.

I can follow up with a documentation update if there is agreement on
this one.

Closes #1742.