### PR TITLE
Disallow correlation with iterator set if body contains DML

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -175,8 +175,9 @@ def compile_ForQuery(
             # Do this by sticking the iterator subtree onto a branch
             # with a factoring fence.
             if qlutils.contains_dml(qlstmt.result):
-                node = node.attach_branch().attach_branch()
-                node.parent.factoring_fence = True
+                node = node.attach_branch()
+                node.factoring_fence = True
+                node = node.attach_branch()
 
             node.attach_subtree(view_scope_info.path_scope,
                                 context=iterator.context)

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -121,3 +121,17 @@ def inline_anchors(
 
     inliner = AnchorInliner(anchors)
     inliner.visit(ql_expr)
+
+
+def contains_dml(ql_expr: qlast.Base) -> bool:
+    """Check whether a expression contains any DML in a subtree."""
+    # If this ends up being a perf problem, we can use a visitor
+    # directly and cache.
+    dml_types = (qlast.InsertQuery, qlast.UpdateQuery, qlast.DeleteQuery)
+    if isinstance(ql_expr, dml_types):
+        return True
+
+    res = ast.find_children(ql_expr, lambda x: isinstance(x, dml_types),
+                            terminate_early=True)
+
+    return bool(res)

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1188,6 +1188,42 @@ class TestInsert(tb.QueryTestCase):
             ],
         )
 
+    async def test_edgeql_insert_for_bad_01(self):
+        with self.assertRaisesRegex(
+            edgedb.errors.QueryError,
+            "cannot reference correlated set",
+        ):
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT (Person,
+                        (FOR x in {Person} UNION (
+                             INSERT Note {name := x.name})));
+            """)
+
+    async def test_edgeql_insert_for_bad_02(self):
+        with self.assertRaisesRegex(
+            edgedb.errors.QueryError,
+            "cannot reference correlated set",
+        ):
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT (Person,
+                        (FOR x in {Person} UNION (
+                             SELECT (INSERT Note {name := x.name}))));
+            """)
+
+    async def test_edgeql_insert_for_bad_03(self):
+        with self.assertRaisesRegex(
+            edgedb.errors.QueryError,
+            "cannot reference correlated set",
+        ):
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT ((FOR x in {Person} UNION (
+                             INSERT Note {name := x.name})),
+                        Person);
+            """)
+
     async def test_edgeql_insert_default_01(self):
         await self.con.execute(r'''
             # create 10 DefaultTest3 objects, each object is defined

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1224,6 +1224,21 @@ class TestInsert(tb.QueryTestCase):
                         Person);
             """)
 
+    async def test_edgeql_insert_for_bad_04(self):
+        with self.assertRaisesRegex(
+            edgedb.errors.QueryError,
+            "cannot reference correlated set",
+        ):
+            await self.con.execute("""
+                WITH MODULE test
+                SELECT (Person,
+                        (FOR x in {Person} UNION (
+                             SELECT (
+                                 20,
+                                 (FOR y in {"hello", "world"} UNION (
+                                  INSERT Note {name := y ++ x.name}))))));
+            """)
+
     async def test_edgeql_insert_default_01(self):
         await self.con.execute(r'''
             # create 10 DefaultTest3 objects, each object is defined


### PR DESCRIPTION
Currently we generate invalid SQL, since we would need to lift the
correlated set into CTEs, which we don't want to deal with.

Fixes #1739.

(Stacked on top of https://github.com/edgedb/edgedb/pull/1776, can't merge yet)