### PR TITLE
Restore find_path_output as an optimization

### DIFF
--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1003,16 +1003,19 @@ def get_path_output_or_null(
 
     path_id = map_path_id(path_id, rel.view_path_id_map)
 
-    ref = maybe_get_path_output(rel, path_id, disable_output_fusion=disable_output_fusion,
-                                aspect=aspect, env=env)
+    ref = maybe_get_path_output(
+        rel, path_id,
+        disable_output_fusion=disable_output_fusion,
+        aspect=aspect, env=env)
     if ref is not None:
         return ref, False
 
     alt_aspect = get_less_specific_aspect(path_id, aspect)
     if alt_aspect is not None:
-        ref = maybe_get_path_output(rel, path_id,
-                                    disable_output_fusion=disable_output_fusion,
-                                    aspect=alt_aspect, env=env)
+        ref = maybe_get_path_output(
+            rel, path_id,
+            disable_output_fusion=disable_output_fusion,
+            aspect=alt_aspect, env=env)
         if ref is not None:
             _put_path_output_var(rel, path_id, aspect, ref, env=env)
             return ref, False


### PR DESCRIPTION
This will fix an issue where fetch something twice for expr and
serialized, or similar, including sometimes doing two function calls!

A fix I made in #1762 made find_path_output no longer necessary for
correctness, so I removed it, but it will still important as an
optimization.

Restore the optimization bit of that code, and add a comment so I
don't forget and delete it again ;P.