### PR TITLE
Use pointer object ID instead of name for table column names

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -484,6 +484,9 @@ class ContextLevel(compiler.ContextLevel):
     defining_view: Optional[s_types.Type]
     """Whether a view is currently being defined (as opposed to be compiled)"""
 
+    compiling_update_shape: bool
+    """Whether an UPDATE shape is currently being compiled."""
+
     in_conditional: Optional[parsing.ParserContext]
     """Whether currently in a conditional branch."""
 
@@ -557,6 +560,7 @@ class ContextLevel(compiler.ContextLevel):
             self.special_computables_in_mutation_shape = frozenset()
             self.empty_result_type_hint = None
             self.defining_view = None
+            self.compiling_update_shape = False
             self.in_conditional = None
             self.in_temp_scope = False
             self.tentative_work = []
@@ -605,6 +609,7 @@ class ContextLevel(compiler.ContextLevel):
                 prevlevel.special_computables_in_mutation_shape
             self.empty_result_type_hint = prevlevel.empty_result_type_hint
             self.defining_view = prevlevel.defining_view
+            self.compiling_update_shape = prevlevel.compiling_update_shape
             self.in_conditional = prevlevel.in_conditional
             self.in_temp_scope = prevlevel.in_temp_scope
             self.tentative_work = prevlevel.tentative_work

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -137,7 +137,6 @@ def extend_path_id(
     path_id: irast.PathId,
     *,
     ptrcls: s_pointers.PointerLike,
-    include_descendants_in_ptrref: bool = False,
     direction: s_pointers.PointerDirection = (
         s_pointers.PointerDirection.Outbound),
     ns: AbstractSet[str] = frozenset(),
@@ -153,7 +152,6 @@ def extend_path_id(
         direction=direction,
         cache=ctx.env.ptr_ref_cache,
         typeref_cache=ctx.env.type_ref_cache,
-        include_descendants=include_descendants_in_ptrref,
     )
     stmtctx.ensure_ptrref_cardinality(ptrcls, ptrref, ctx=ctx)
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1137,7 +1137,12 @@ def compile_query_subject(
 
     if compile_views:
         rptr = view_rptr.rptr if view_rptr is not None else None
-        viewgen.compile_view_shapes(expr, rptr=rptr, ctx=ctx)
+        if is_update:
+            with ctx.new() as subctx:
+                subctx.compiling_update_shape = True
+                viewgen.compile_view_shapes(expr, rptr=rptr, ctx=subctx)
+        else:
+            viewgen.compile_view_shapes(expr, rptr=rptr, ctx=ctx)
 
     if (shape is not None or view_scls is not None) and len(expr.path_id) == 1:
         ctx.class_view_overrides[expr.path_id.target.id] = expr_stype

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1197,7 +1197,6 @@ def _compile_view_shapes_in_set(
                 ptr,
                 unnest_fence=True,
                 same_computable_scope=True,
-                hoist_iterators=True,
                 ctx=ctx,
             )
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -201,8 +201,19 @@ class BasePointerRef(ImmutableBase):
             return self.out_source
 
     @property
+    def dir_source(self) -> TypeRef:
+        if self.direction is s_pointers.PointerDirection.Outbound:
+            return self.out_source
+        else:
+            return self.out_target
+
+    @property
     def required(self) -> bool:
         return self.out_cardinality.to_schema_value()[0]
+
+    @property
+    def is_inbound(self) -> bool:
+        return self.direction is self.direction.Inbound
 
 
 class PointerRef(BasePointerRef):

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -35,6 +35,7 @@ from edb.schema import modules as s_mod
 from edb.schema import name as s_name
 from edb.schema import objtypes as s_objtypes
 from edb.schema import operators as s_opers
+from edb.schema import pointers as s_pointers
 from edb.schema import scalars as s_scalars
 from edb.schema import types as s_types
 
@@ -371,9 +372,13 @@ def get_backend_name(schema, obj, catenate=True, *, aspect=None):
 
 def get_object_from_backend_name(schema, metaclass, name, *, aspect=None):
 
-    if metaclass is s_objtypes.ObjectType:
+    if issubclass(metaclass, s_objtypes.ObjectType):
         table_name = name[1]
         obj_id = uuidgen.UUID(table_name)
+        return schema.get_by_id(obj_id)
+
+    elif issubclass(metaclass, s_pointers.Pointer):
+        obj_id = uuidgen.UUID(name)
         return schema.get_by_id(obj_id)
 
     else:

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -126,9 +126,9 @@ class CompilerContextLevel(compiler.ContextLevel):
     #: optionality scaffolding.
     force_optional: Set[irast.PathId]
 
-    #: ir.TypeRef used to narrow the joined relation representing
-    #: the mapping key.
-    join_target_type_filter: Dict[irast.Set, irast.TypeRef]
+    #: Specifies that references to a specific Set must be narrowed
+    #: by only selecting instances of type specified by the mapping value.
+    intersection_narrowing: Dict[irast.Set, irast.Set]
 
     #: Which SQL query holds the SQL scope for the given PathId
     path_scope: ChainMap[irast.PathId, pgast.SelectStmt]
@@ -198,7 +198,7 @@ class CompilerContextLevel(compiler.ContextLevel):
 
             self.disable_semi_join = set()
             self.force_optional = set()
-            self.join_target_type_filter = {}
+            self.intersection_narrowing = {}
 
             self.path_scope = collections.ChainMap()
             self.scope_tree = scope_tree
@@ -227,7 +227,7 @@ class CompilerContextLevel(compiler.ContextLevel):
 
             self.disable_semi_join = prevlevel.disable_semi_join.copy()
             self.force_optional = prevlevel.force_optional.copy()
-            self.join_target_type_filter = prevlevel.join_target_type_filter
+            self.intersection_narrowing = prevlevel.intersection_narrowing
 
             self.path_scope = prevlevel.path_scope
             self.scope_tree = prevlevel.scope_tree

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -21,8 +21,9 @@
 
 
 from __future__ import annotations
-
 from typing import *
+
+import uuid
 
 from edb import errors
 
@@ -321,58 +322,65 @@ def new_empty_rvar(
     return rvar
 
 
-def new_root_rvar(
-        ir_set: irast.Set, *,
-        typeref: Optional[irast.TypeRef]=None,
-        as_intersection_el: bool=False,
-        ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
+def new_primitive_rvar(
+    ir_set: irast.Set,
+    *,
+    path_id: irast.PathId,
+    ctx: context.CompilerContextLevel,
+) -> pgast.PathRangeVar:
     if not ir_set.path_id.is_objtype_path():
         raise ValueError('cannot create root rvar for non-object path')
-    if typeref is None:
-        typeref = ir_set.typeref
 
-    if typeref.intersection:
-        wrapper = pgast.SelectStmt()
-        component_rvars = []
-        for component in typeref.intersection:
-            component_rvar = new_root_rvar(
-                ir_set,
-                typeref=component,
-                as_intersection_el=True,
-                ctx=ctx,
-            )
-            component_rvars.append(component_rvar)
-            include_rvar(wrapper, component_rvar, ir_set.path_id, ctx=ctx)
-
-        int_rvar = pgast.IntersectionRangeVar(component_rvars=component_rvars)
-        for aspect in ('source', 'value'):
-            pathctx.put_path_rvar(
-                wrapper, ir_set.path_id, int_rvar, aspect=aspect, env=ctx.env
-            )
-
-        result_rvar = rvar_for_rel(wrapper, ctx=ctx)
-        pathctx.put_rvar_path_bond(result_rvar, ir_set.path_id)
-
-        return result_rvar
-
+    typeref = ir_set.typeref
     dml_source = irutils.get_nearest_dml_stmt(ir_set)
     set_rvar = range_for_typeref(
-        typeref, ir_set.path_id, dml_source=dml_source, ctx=ctx)
-    pathctx.put_rvar_path_bond(set_rvar, ir_set.path_id)
+        typeref, path_id, dml_source=dml_source, ctx=ctx)
+    pathctx.put_rvar_path_bond(set_rvar, path_id)
 
-    if ir_set.rptr and ir_set.rptr.is_inbound:
-        ptrref = ir_set.rptr.ptrref
+    if ir_set.rptr is not None:
+        ptr_ref_map: Dict[uuid.UUID, irast.BasePointerRef] = {}
+        p: irast.BasePointerRef
+
+        rptrref = ir_set.rptr.ptrref
+        if isinstance(rptrref, irast.TypeIntersectionPointerRef):
+            if rptrref.rptr_specialization:
+                for p in rptrref.rptr_specialization:
+                    ptr_ref_map[p.dir_target.id] = p
+
+            src_set = ir_set.rptr.source
+            if src_set.rptr is not None:
+                src_rptrref = src_set.rptr.ptrref
+                if src_rptrref.union_components:
+                    for p in src_rptrref.union_components:
+                        ptr_ref_map[p.dir_target.id] = p
+                else:
+                    ptr_ref_map[src_rptrref.dir_target.id] = src_rptrref
+                rptrref = src_rptrref
+            else:
+                ptr_ref_map[rptrref.dir_target.id] = rptrref
+        else:
+            if rptrref.union_components:
+                for p in rptrref.union_components:
+                    ptr_ref_map[p.dir_target.id] = p
+            else:
+                ptr_ref_map[rptrref.dir_target.id] = rptrref
+
+        if (
+            set_rvar.typeref is not None
+            and (narrow_rptrref := ptr_ref_map.get(set_rvar.typeref.id))
+        ):
+            rptrref = narrow_rptrref
+
         ptr_info = pg_types.get_ptrref_storage_info(
-            ptrref, resolve_type=False, link_bias=False)
+            rptrref, resolve_type=False, link_bias=False)
 
-        if (ptr_info.table_type == 'ObjectType'
-                and (not as_intersection_el or typeref == ptrref.dir_target)):
+        if ptr_info.table_type == 'ObjectType' and rptrref.is_inbound:
             # Inline link
-            prefix_path_id = ir_set.path_id.src_path()
+            prefix_path_id = path_id.src_path()
             assert prefix_path_id is not None, 'expected a path'
             rref = pgast.ColumnRef(
                 name=[ptr_info.column_name],
-                nullable=not ptrref.required)
+                nullable=not rptrref.required)
             pathctx.put_rvar_path_bond(set_rvar, prefix_path_id)
             pathctx.put_rvar_path_output(
                 set_rvar, prefix_path_id,
@@ -380,18 +388,75 @@ def new_root_rvar(
 
             if astutils.is_set_op_query(set_rvar.query):
                 assert isinstance(set_rvar.query, pgast.SelectStmt)
+
+                def _pull_col(comp_qry: pgast.Query) -> None:
+                    rvar = pathctx.get_path_rvar(
+                        comp_qry, path_id, aspect='source', env=ctx.env)
+                    typeref = rvar.typeref
+                    assert typeref is not None
+                    comp_ptrref = ptr_ref_map[typeref.id]
+                    comp_pi = pg_types.get_ptrref_storage_info(
+                        comp_ptrref, resolve_type=False, link_bias=False)
+
+                    comp_qry.target_list.append(
+                        pgast.ResTarget(
+                            val=pgast.ColumnRef(name=[comp_pi.column_name]),
+                            name=ptr_info.column_name,
+                        )
+                    )
+
                 astutils.for_each_query_in_set(
                     set_rvar.query,
-                    lambda qry:
-                        qry.target_list.append(
+                    _pull_col,
+                )
+            elif isinstance(set_rvar, pgast.RangeSubselect):
+                rvar_path_var = pathctx.maybe_get_path_rvar(
+                    set_rvar.query,
+                    path_id=path_id,
+                    aspect='identity',
+                    env=ctx.env,
+                )
+
+                if isinstance(rvar_path_var, pgast.IntersectionRangeVar):
+                    for comp_rvar in rvar_path_var.component_rvars:
+                        if comp_rvar.typeref is None:
+                            continue
+                        comp_ptrref = ptr_ref_map.get(comp_rvar.typeref.id)
+                        if comp_ptrref is None:
+                            continue
+                        comp_pi = pg_types.get_ptrref_storage_info(
+                            comp_ptrref, resolve_type=False)
+
+                        set_rvar.query.target_list.append(
                             pgast.ResTarget(
-                                val=rref,
+                                val=pgast.ColumnRef(
+                                    name=[
+                                        comp_rvar.alias.aliasname,
+                                        comp_pi.column_name,
+                                    ]
+                                ),
                                 name=ptr_info.column_name,
                             )
                         )
-                )
 
     return set_rvar
+
+
+def new_root_rvar(
+    ir_set: irast.Set,
+    *,
+    path_id: Optional[irast.PathId] = None,
+    ctx: context.CompilerContextLevel,
+) -> pgast.PathRangeVar:
+
+    if path_id is None:
+        path_id = ir_set.path_id
+
+    narrowing = ctx.intersection_narrowing.get(ir_set)
+    if narrowing is not None:
+        return new_primitive_rvar(narrowing, path_id=path_id, ctx=ctx)
+    else:
+        return new_primitive_rvar(ir_set, path_id=path_id, ctx=ctx)
 
 
 def new_pointer_rvar(
@@ -509,8 +574,7 @@ def semi_join(
     rptr = ir_set.rptr
 
     # Target set range.
-    typeref = ctx.join_target_type_filter.get(ir_set, ir_set.typeref)
-    set_rvar = new_root_rvar(ir_set, typeref=typeref, ctx=ctx)
+    set_rvar = new_root_rvar(ir_set, ctx=ctx)
 
     ptrref = rptr.ptrref
     ptr_info = pg_types.get_ptrref_storage_info(
@@ -858,6 +922,30 @@ def range_for_typeref(
             set_ops.append(('union', qry))
 
         rvar = range_from_queryset(set_ops, typeref.name_hint, ctx=ctx)
+
+    elif typeref.intersection:
+        wrapper = pgast.SelectStmt()
+        component_rvars = []
+        for component in typeref.intersection:
+            component_rvar = range_for_typeref(
+                component,
+                path_id=path_id,
+                for_mutation=for_mutation,
+                dml_source=dml_source,
+                ctx=ctx,
+            )
+            pathctx.put_rvar_path_bond(component_rvar, path_id)
+            component_rvars.append(component_rvar)
+            include_rvar(wrapper, component_rvar, path_id, ctx=ctx)
+
+        int_rvar = pgast.IntersectionRangeVar(component_rvars=component_rvars)
+        for aspect in ('source', 'value'):
+            pathctx.put_path_rvar(
+                wrapper, path_id, int_rvar, aspect=aspect, env=ctx.env
+            )
+
+        pathctx.put_path_bond(wrapper, path_id)
+        rvar = rvar_for_rel(wrapper, ctx=ctx)
 
     else:
         rvar = range_for_material_objtype(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -765,9 +765,9 @@ def process_set_as_path(
             # we have an opportunity to opmimize the target join by
             # directly replacing the target type.
             with ctx.new() as subctx:
-                subctx.join_target_type_filter = (
-                    subctx.join_target_type_filter.copy())
-                subctx.join_target_type_filter[ir_source] = ir_set.typeref
+                subctx.intersection_narrowing = (
+                    subctx.intersection_narrowing.copy())
+                subctx.intersection_narrowing[ir_source] = ir_set
                 source_rvar = get_set_rvar(ir_source, ctx=subctx)
 
             stmt.view_path_id_map[ir_set.path_id] = ir_source.path_id
@@ -794,11 +794,12 @@ def process_set_as_path(
             else:
                 target_typeref = ptrref.out_target
 
-            poly_rvar = relctx.new_root_rvar(
-                ir_set,
-                typeref=target_typeref,
+            poly_rvar = relctx.range_for_typeref(
+                target_typeref,
+                path_id=ir_set.path_id,
                 ctx=ctx,
             )
+
             prefix_path_id = ir_set.path_id.src_path()
             assert prefix_path_id is not None, 'expected a path'
             pathctx.put_rvar_path_bond(poly_rvar, prefix_path_id)
@@ -958,9 +959,7 @@ def process_set_as_path(
 
         # Target set range.
         if irtyputils.is_object(ir_set.typeref):
-            typeref = ctx.join_target_type_filter.get(ir_set, ir_set.typeref)
-            target_rvar = relctx.new_root_rvar(
-                ir_set, typeref=typeref, ctx=ctx)
+            target_rvar = relctx.new_root_rvar(ir_set, ctx=ctx)
 
             main_rvar = SetRVar(
                 target_rvar,

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -100,6 +100,7 @@ class SchemaConstraintTableConstraint(ConstraintCommon, dbops.TableConstraint):
         origin_table_name,
         constraint,
         exprdata,
+        origin_exprdata,
         scope,
         type,
         schema,
@@ -108,6 +109,7 @@ class SchemaConstraintTableConstraint(ConstraintCommon, dbops.TableConstraint):
         dbops.TableConstraint.__init__(self, table_name, None)
         self._origin_table_name = origin_table_name
         self._exprdata = exprdata
+        self._origin_exprdata = origin_exprdata
         self._scope = scope
         self._type = type
 
@@ -185,8 +187,9 @@ class SchemaConstraintTableConstraint(ConstraintCommon, dbops.TableConstraint):
         errmsg = 'duplicate key value violates unique ' \
                  'constraint {constr}'.format(constr=constr_name)
 
-        for expr in self._exprdata:
+        for expr, origin_expr in zip(self._exprdata, self._origin_exprdata):
             exprdata = expr['exprdata']
+            origin_exprdata = origin_expr['exprdata']
 
             text = '''
                 PERFORM
@@ -205,7 +208,7 @@ class SchemaConstraintTableConstraint(ConstraintCommon, dbops.TableConstraint):
                           DETAIL = 'Key ({plain_expr}) already exists.';
                 END IF;
             '''.format(
-                plain_expr=exprdata['plain'],
+                plain_expr=origin_exprdata['plain'],
                 new_expr=exprdata['new'],
                 table=common.qname(*self.get_origin_table_name()),
                 constr=raw_constr_name,

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -358,7 +358,7 @@ def get_pointer_storage_info(
     if pointer.get_computable(schema):
         material_ptrcls = None
     else:
-        material_ptrcls = pointer.material_type(schema)
+        schema, material_ptrcls = pointer.material_type(schema)
     if material_ptrcls is not None:
         pointer = material_ptrcls
     return _PointerStorageInfo(

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -239,7 +239,11 @@ class _PointerStorageInfo:
     def _source_table_info(cls, schema, pointer):
         table = common.get_backend_name(
             schema, pointer.get_source(schema), catenate=False)
-        col_name = pointer.get_shortname(schema).name
+        ptr_name = pointer.get_shortname(schema).name
+        if ptr_name.startswith('__') or ptr_name == 'id':
+            col_name = ptr_name
+        else:
+            col_name = str(pointer.id)
         table_type = 'ObjectType'
 
         return table, table_type, col_name
@@ -308,7 +312,10 @@ class _PointerStorageInfo:
             table = common.get_backend_name(
                 schema, source, catenate=False)
             table_type = 'link'
-            col_name = pointer.get_shortname(schema).name
+            if pointer.get_shortname(schema).name == 'source':
+                col_name = 'source'
+            else:
+                col_name = str(pointer.id)
         else:
             if isinstance(source, s_scalars.ScalarType):
                 # This is a pseudo-link on an scalar (__type__)
@@ -412,7 +419,10 @@ def get_ptrref_storage_info(
     elif is_lprop:
         table = common.get_pointer_backend_name(source.id, source.module_id)
         table_type = 'link'
-        col_name = ptrref.shortname.name
+        if ptrref.shortname.name == 'source':
+            col_name = 'source'
+        else:
+            col_name = str(ptrref.id)
     else:
         if irtyputils.is_scalar(source):
             # This is a pseudo-link on an scalar (__type__)
@@ -423,7 +433,11 @@ def get_ptrref_storage_info(
         elif _storable_in_source(ptrref) and not link_bias:
             table = common.get_objtype_backend_name(
                 source.id, source.module_id)
-            col_name = ptrref.shortname.name
+            ptrname = ptrref.shortname.name
+            if ptrname.startswith('__') or ptrname == 'id':
+                col_name = ptrname
+            else:
+                col_name = str(ptrref.id)
             table_type = 'ObjectType'
 
         elif _storable_in_pointer(ptrref):

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -263,6 +263,7 @@ def get_or_create_union_type(
     type_id, name = s_types.get_union_type_id(
         schema,
         components,
+        opaque=opaque,
         module=module,
     )
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -338,12 +338,16 @@ class Pointer(referencing.ReferencedInheritingObject,
     def is_scalar(self) -> bool:
         return False
 
-    def material_type(self, schema: s_schema.Schema) -> Pointer:
+    def material_type(
+        self,
+        schema: s_schema.Schema,
+    ) -> Tuple[s_schema.Schema, Pointer]:
         non_derived_parent = self.get_nearest_non_derived_parent(schema)
-        if non_derived_parent.generic(schema):
-            return self
+        source = non_derived_parent.get_source(schema)
+        if source is None:
+            return schema, self
         else:
-            return non_derived_parent
+            return schema, non_derived_parent
 
     def get_near_endpoint(
         self,
@@ -776,8 +780,11 @@ class PseudoPointer(s_abc.Pointer):
     def scalar(self) -> bool:
         raise NotImplementedError
 
-    def material_type(self, schema: s_schema.Schema) -> PseudoPointer:
-        return self
+    def material_type(
+        self,
+        schema: s_schema.Schema,
+    ) -> Tuple[s_schema.Schema, PseudoPointer]:
+        return schema, self
 
     def is_pure_computable(self, schema: s_schema.Schema) -> bool:
         return False

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -967,6 +967,9 @@ class CreateReferencedInheritingObject(
 
                     self.set_attribute_value('bases', bases)
 
+                if referrer.get_is_derived(schema):
+                    self.set_attribute_value('is_derived', True)
+
         schema = super()._create_begin(schema, context)
 
         if referrer_ctx is not None and not context.canonical:

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1830,15 +1830,18 @@ def generate_array_type_id(
 
 def get_union_type_id(
     schema: s_schema.Schema,
-    components: typing.Iterable[Union[Type, TypeShell]], *,
-    module: typing.Optional[str]=None,
+    components: typing.Iterable[Union[Type, TypeShell]],
+    *,
+    opaque: bool = False,
+    module: typing.Optional[str] = None,
 ) -> typing.Tuple[uuid.UUID, s_name.Name]:
 
     component_ids = sorted(str(t.get_id(schema)) for t in components)
-    name = s_name.Name(
-        name=f"({' | '.join(component_ids)})",
-        module=module or '__derived__',
-    )
+    if opaque:
+        name = f"(opaque: {' | '.join(component_ids)})"
+    else:
+        name = f"({' | '.join(component_ids)})"
+    name = s_name.Name(name=name, module=module or '__derived__')
 
     return generate_type_id(name), name
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -674,7 +674,7 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
 
 async def _execute_ddl(conn, sql_text):
     try:
-        if debug.flags.delta_execute:
+        if debug.flags.bootstrap:
             debug.header('Delta Script')
             debug.dump_code(sql_text, lexer='sql')
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_09_21_00_00
+EDGEDB_CATALOG_VERSION = 2020_09_23_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/schemas/updates.esdl
+++ b/tests/schemas/updates.esdl
@@ -67,6 +67,8 @@ type UpdateTest {
 
 type UpdateTestSubType extending UpdateTest;
 
+type UpdateTestSubSubType extending UpdateTestSubType;
+
 type CollectionTest {
     required property name -> str;
     property some_tuple -> tuple<str, int64>;

--- a/tests/test_edgeql_advtypes.py
+++ b/tests/test_edgeql_advtypes.py
@@ -291,3 +291,14 @@ class TestEdgeQLAdvancedTypes(tb.QueryTestCase):
                 }],
             }]
         )
+
+    async def test_edgeql_advtypes_union_opaque_narrowing_nop(self):
+        await self.con.execute("""
+            INSERT A { name := 'aaa' };
+            INSERT S { name := 'sss', s := 'sss', l_a := A };
+        """)
+
+        await self.assert_query_result(
+            'SELECT A.<l_a[IS R].name',
+            ['sss'],
+        )

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -1772,11 +1772,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        edgedb.errors.InternalServerError: column Base~2.foo does not exist
-
-        The migration succeeds, but the propertry 'foo' can't be selected.
-    ''')
     async def test_edgeql_migration_34(self):
         # this is the reverse of test_edgeql_migration_11
         await self.con.execute("""

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -36,9 +36,14 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'cards.esdl')
 
-    UUID_RE = re.compile(
-        r'[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}'
-        r'-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}'
+    UNION_NAME_RE = re.compile(
+        r'''
+            (?:opaque:\s)?
+            ([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}
+                           -[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})
+            (\s \| \s \1)*
+        ''',
+        re.X,
     )
 
     def run_test(self, *, source, spec, expected):
@@ -55,7 +60,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
         scope_tree = next(iter(root.children))
 
-        path_scope = self.UUID_RE.sub(
+        path_scope = self.UNION_NAME_RE.sub(
             '@SID@',
             textwrap.indent(scope_tree.pformat(), '    '),
         )


### PR DESCRIPTION
Currently, we use the name of a link or property as the name of a 
corresponding column in the PostgreSQL table.  When we switched to the use
of object IDs for table names, column names were left as is, because there
was still reliance on table inheritance.  Now that table inheritance was
replaced with direct use of `UNION`, the requirement of matching column
names no longer exists and we can switch to rename-resistant column mapping
instead.