### PR TITLE
Fix result type serialization crash

### DIFF
--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -233,9 +233,9 @@ class TypeSerializer:
                 links.append(not ptr.is_property(self.schema))
 
             t_rptr = t.get_rptr(self.schema)
-            if t_rptr is not None:
+            if t_rptr is not None and (rptr_ptrs := view_shapes.get(t_rptr)):
                 # There are link properties in the mix
-                for ptr in view_shapes[t_rptr]:
+                for ptr in rptr_ptrs:
                     if ptr.singular(self.schema):
                         subtype_id = self._describe_type(
                             ptr.get_target(self.schema), view_shapes,

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1716,6 +1716,19 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 ''',
             )
 
+    async def test_edgeql_select_nested_redefined_link(self):
+        await self.assert_query_result(
+            '''
+                WITH MODULE test
+                SELECT (SELECT (SELECT Issue { watchers: {name} }).watchers);
+            ''',
+            [
+                {'name': 'Elvis'},
+                {'name': 'Yury'},
+            ],
+            sort=lambda x: x['name'],
+        )
+
     async def test_edgeql_select_tvariant_01(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
If a pointer is defined in a sufficiently deeply nested query,
`view_shapes` wouldn't get populated for it, which is really a separate
issue, but the crux here is that `TypeSerializer` should not rely on
object being present in the `view_shapes` map at all.

Fixes: #1812.