### PR TITLE
Handle CloseComplete Postgres response in _parse_execute_to_buf

### DIFF
--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -368,11 +368,12 @@ cdef class PGProto:
                     if store_stmt:
                         self.prep_stmts[stmt_name] = dbver
 
-                elif mtype in {b'C', b'n', b'2', b'I'}:
+                elif mtype in {b'C', b'n', b'2', b'I', b'3'}:
                     # CommandComplete
                     # NoData
                     # BindComplete
                     # EmptyQueryResponse
+                    # CloseComplete
                     self.buffer.discard_message()
 
                 elif mtype == b'Z':


### PR DESCRIPTION
The `_parse_execute_to_buf`, which is used for JSON-based queries is
currently forgetting to handle the `CloseComplete` (3) response message
from Postgres despite engaging in prepared statement cleanup like its
cousin `_parse_execute` (which handles `CloseComplete` correctly).  This
leads to crashes when the prepared statement cache buffer overflows, and
is most prominent on HTTP ports, however it's also possible to trigger
this via a normal connection, because prepared statements also get
invalidated on schema version changes, as @vpetrovykh uncovered recently
in #1780.

Fixes: #1334
Fixes: #1314
Fixes: #1770