### PR TITLE
Run --bootstrap-script in the context of a full server instance

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -22,6 +22,7 @@ from typing import *
 
 import json
 import logging
+import pathlib
 
 from edb import errors
 


### PR DESCRIPTION
Currently `--bootstrap-script` uses the bootstrap facilities to compile
and execute the script, which aren't set up to handle the entirety of
possible EdgeQL statement, most importantly, `CONFIGURE SYSTEM` requires
extra handling.  This reimplements `--bootstrap-script` and
`--bootstrap-command` handling as a special `run_script` mode, which
starts a port, runs an EdgeQL script and then, if `--bootstrap-only` is
specified, immediately shuts down the port and the entire server with
it.

Use this new functionality to configure authentication appropriately in
tests to remove the remaining uses of deprecated admin connection mode.