### PR TITLE
Add std::throw() and 'never' pseudo-type.

### DIFF
--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -110,6 +110,8 @@
 0x_05_03_00_01   TransactionSerializationError
 0x_05_03_00_02   TransactionDeadlockError
 
+0x_05_04_00_00   RuntimeUserError
+
 
 ####
 

--- a/edb/edgeql-parser/src/keywords.rs
+++ b/edb/edgeql-parser/src/keywords.rs
@@ -163,6 +163,7 @@ pub const CURRENT_RESERVED_KEYWORDS: &[&str] = &[
     "like",
     "limit",
     "module",
+    "never",
     "not",
     "offset",
     "optional",

--- a/edb/edgeql-parser/src/tokenizer.rs
+++ b/edb/edgeql-parser/src/tokenizer.rs
@@ -885,6 +885,7 @@ pub fn is_keyword(s: &str) -> bool {
         | "lock"
         | "match"
         | "move"
+        | "never"
         | "notify"
         | "prepare"
         | "partition"

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -228,6 +228,10 @@ class AnyTuple(PseudoObjectRef):
     pass
 
 
+class Never(PseudoObjectRef):
+    pass
+
+
 class Anchor(Expr):
     __abstract_node__ = True
     name: str

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -672,6 +672,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
     def visit_AnyTuple(self, node: qlast.AnyTuple) -> None:
         self.write('anytuple')
 
+    def visit_Never(self, node: qlast.AnyType) -> None:
+        self.write('never')
+
     def visit_TypeCast(self, node: qlast.TypeCast) -> None:
         self.write('<')
         self.visit(node.type)

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -282,6 +282,14 @@ def __infer_anytupleref(
 
 
 @_infer_type.register
+def __infer_neverref(
+    ir: irast.NeverRef,
+    env: context.Environment,
+) -> s_types.Type:
+    return s_pseudo.PseudoType.get(env.schema, 'never')
+
+
+@_infer_type.register
 def __infer_typeref(
     ir: irast.TypeRef,
     env: context.Environment,

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -150,6 +150,10 @@ def try_bind_call_args(
     ) -> int:
         nonlocal resolved_poly_base_type
 
+        if arg_type.is_never(schema):
+            # "never" is assignable to every type.
+            return 0
+
         if in_polymorphic_func:
             # Compiling a body of a polymorphic function.
 

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -64,6 +64,8 @@ def get_schema_object(
         return s_pseudo.PseudoType.get(ctx.env.schema, 'anytype')
     elif isinstance(name, qlast.AnyTuple):
         return s_pseudo.PseudoType.get(ctx.env.schema, 'anytuple')
+    elif isinstance(name, qlast.Never):
+        return s_pseudo.PseudoType.get(ctx.env.schema, 'never')
     elif isinstance(name, qlast.BaseObjectRef):
         raise AssertionError(f"Unhandled BaseObjectRef subclass: {name!r}")
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1358,6 +1358,9 @@ class SimpleTypeName(Nonterm):
     def reduce_NodeName(self, *kids):
         self.val = qlast.TypeName(maintype=kids[0].val)
 
+    def reduce_NEVER(self, *kids):
+        self.val = qlast.TypeName(maintype=qlast.Never())
+
     def reduce_ANYTYPE(self, *kids):
         self.val = qlast.TypeName(maintype=qlast.AnyType())
 

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -72,6 +72,7 @@ __all__ = base.__all__ + (
     'TransactionError',
     'TransactionSerializationError',
     'TransactionDeadlockError',
+    'RuntimeUserError',
     'ConfigurationError',
     'AccessError',
     'AuthenticationError',
@@ -322,6 +323,10 @@ class TransactionSerializationError(TransactionError):
 
 class TransactionDeadlockError(TransactionError):
     _code = 0x_05_03_00_02
+
+
+class RuntimeUserError(ExecutionError):
+    _code = 0x_05_04_00_00
 
 
 class ConfigurationError(EdgeDBError):

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -165,6 +165,10 @@ class AnyTupleRef(TypeRef):
     pass
 
 
+class NeverRef(TypeRef):
+    pass
+
+
 class BasePointerRef(ImmutableBase):
     __abstract_node__ = True
 

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -175,6 +175,11 @@ def type_to_typeref(
             id=t.id,
             name_hint=typename or t.get_name(schema),
         )
+    elif t.is_never(schema):
+        result = irast.NeverRef(
+            id=t.id,
+            name_hint=typename or t.get_name(schema),
+        )
     elif not isinstance(t, s_types.Collection):
         assert isinstance(t, s_types.InheritingType)
         union_of = t.get_union_of(schema)

--- a/edb/lib/std/10-scalars.edgeql
+++ b/edb/lib/std/10-scalars.edgeql
@@ -21,6 +21,8 @@ CREATE PSEUDO TYPE `anytype`;
 
 CREATE PSEUDO TYPE `anytuple`;
 
+CREATE PSEUDO TYPE `never`;
+
 CREATE ABSTRACT SCALAR TYPE std::anyscalar;
 
 CREATE SCALAR TYPE std::bool EXTENDING std::anyscalar;

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -388,6 +388,27 @@ std::find(haystack: array<anytype>, needle: anytype,
     $$;
 };
 
+# std::throw
+# ----------
+
+CREATE FUNCTION
+std::throw(message: std::str) -> never
+{
+    CREATE ANNOTATION std::description :=
+        'Throws a RuntimeUserError with the passed message.';
+
+    # See comment in metaschama.py/RaiseExceptionFunction
+    SET volatility := 'STABLE';
+
+    USING SQL $$
+    SELECT edgedb._raise_edgedb_exception(
+        "message",
+        x'05040000'::int8, -- RuntimeUserError
+        NULL::int4
+    )
+    LIMIT 1
+    $$;
+};
 
 # Generic comparison operators
 # ----------------------------

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -226,6 +226,25 @@ def compile_TypeCast(
             )
         )
 
+    elif expr.sql_expr and isinstance(expr.from_type, irast.NeverRef):
+        pg_type = pg_types.pg_type_from_ir_typeref(expr.to_type)
+
+        res = pgast.TypeCast(
+            arg=pgast.CaseExpr(
+                args=[
+                    pgast.CaseWhen(
+                        expr=pgast.NullTest(
+                            arg=pg_expr,
+                            negated=False
+                        ),
+                        result=pgast.NullConstant()
+                    )
+                ],
+                defresult=pgast.NullConstant()
+            ),
+            type_name=pgast.TypeName(name=pg_type)
+        )
+
     elif expr.sql_function or expr.sql_expr:
         # Cast implemented as a function.
 

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -171,6 +171,9 @@ def pg_type_from_object(
     elif obj.is_type() and obj.is_any(schema):
         return ('anyelement',)
 
+    elif obj.is_type() and obj.is_never(schema):
+        return ('void',)
+
     else:
         raise ValueError(f'could not determine PG type for {obj!r}')
 

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -60,7 +60,7 @@ class PseudoType(so.InheritingObject, s_types.Type):
         return True
 
     def is_polymorphic(self, schema: s_schema.Schema) -> bool:
-        return True
+        return self.get_name(schema) != 'never'
 
     def material_type(
         self,
@@ -77,20 +77,25 @@ class PseudoType(so.InheritingObject, s_types.Type):
     def is_anytuple(self, schema: s_schema.Schema) -> bool:
         return self.get_name(schema) == 'anytuple'
 
+    def is_never(self, schema: s_schema.Schema) -> bool:
+        return self.get_name(schema) == 'never'
+
     def implicitly_castable_to(
         self,
         other: s_types.Type,
         schema: s_schema.Schema
     ) -> bool:
-        return self == other
+        return True if self.get_name(schema) == 'never' else self == other
 
     def find_common_implicitly_castable_type(
         self,
         other: s_types.Type,
         schema: s_schema.Schema,
-    ) -> Tuple[s_schema.Schema, Optional[PseudoType]]:
+    ) -> Tuple[s_schema.Schema, Optional[s_types.Type]]:
         if self == other:
             return schema, self
+        elif self.is_never(schema):
+            return schema, other
         else:
             return schema, None
 
@@ -99,7 +104,7 @@ class PseudoType(so.InheritingObject, s_types.Type):
         other: s_types.Type,
         schema: s_schema.Schema
     ) -> int:
-        if self == other:
+        if self == other or self.is_never(schema):
             return 0
         else:
             return s_types.MAX_TYPE_DISTANCE

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -226,6 +226,9 @@ class Type(
     def is_enum(self, schema: s_schema.Schema) -> bool:
         return False
 
+    def is_never(self, schema: s_schema.Schema) -> bool:
+        return False
+
     def test_polymorphic(self, schema: s_schema.Schema, poly: Type) -> bool:
         """Check if this type can be matched by a polymorphic type.
 
@@ -318,7 +321,7 @@ class Type(
         self: TypeT,
         other: Type,
         schema: s_schema.Schema,
-    ) -> typing.Tuple[s_schema.Schema, Optional[TypeT]]:
+    ) -> typing.Tuple[s_schema.Schema, Optional[Type]]:
         return schema, None
 
     def explicitly_castable_to(

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -223,6 +223,10 @@ def ast_to_type_shell(
         from . import pseudo as s_pseudo
         return s_pseudo.PseudoTypeShell(name='anytuple')
 
+    elif isinstance(node.maintype, qlast.Never):
+        from . import pseudo as s_pseudo
+        return s_pseudo.PseudoTypeShell(name='never')
+
     assert isinstance(node.maintype, qlast.ObjectRef)
 
     return ast_objref_to_type_shell(

--- a/edb/tools/gen_errors.py
+++ b/edb/tools/gen_errors.py
@@ -336,6 +336,8 @@ def main(*, base_class, message_base_class,
         f'\n\n\n'
         f'# flake8: noqa'
         f'\n\n\n'
+        f'from __future__ import annotations'
+        f'\n\n'
         f'{code}'
         f'\n'
     )


### PR DESCRIPTION
@elprans This is draft, but I'd appreciate you reviewing it now so that I know if I'm on the right path.

The PR adds a new `never` pseudo-type and a `std::throw()` function.

### TODO

- [x] Add `never`
- [x] Add `std::throw`
- [ ] Add basic `std::throw` tests
- [ ] Add tests that `never` is castable to object types and collections
- [ ] Add tests that `never` can't be a valid parameter type, a valid property target type, etc
- [ ] Add `never` to `api/types.txt` -- type of `SELECT std::throw()` should be `never`
- [ ] Add tests that `std::throw()` can appear virtually in every kind of expression


### Motivation

**Runtime assertions:**

```
WITH
    MODULE schema
SELECT Type {
    id,
    name,
    kind := 'object' IF Type IS ObjectType ELSE
            'scalar' IF Type IS ScalarType ELSE
            'array' IF Type IS Array ELSE
            'tuple' IF Type IS Tuple ELSE
            std::throw('unknown type kind'),
    [IS ScalarType].enum_values,
    [IS ObjectType].union_of,
    # ...
}
```

The above would fail if we add new kind of type in future EdgeDB versions. That allows, for example, to use discriminated union types in Python or TypeScript, making `enum_values` to be only available when `kind = 'scalar'`. We could, of course, return `'unknown'` instead of using `std::throw` and handle that in the client code, but that's way less elegant.

**Combating empty sets:**

```
SELECT (
    (SELECT schema::Type {id, name} FILTER .name = <str>$name).id ?? 
    throw('could not resolve type: ' ++ <str>$name)
)
```

The query would return an ID of a type by name and throw an explicit user friendly exception if no type is found.