### PR TITLE
Correlate volatile functions with enclosing FORs and in clauses

### DIFF
--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -120,6 +120,9 @@ def setup_iterator_volatility(
     path_id = iterator.path_id
     ref: Optional[pgast.BaseExpr] = None
 
+    # We use a callback scheme here to avoid inserting volatility ref
+    # columns unless there is actually a volatile operation that
+    # requires it.
     def get_ref() -> pgast.BaseExpr:
         nonlocal ref
         if ref is None:

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -77,6 +77,58 @@ def fini_stmt(
                 )
 
 
+def get_volatility_ref(
+        path_id: irast.PathId, *,
+        ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
+    """Produce an appropriate volatility_ref from a path_id."""
+
+    ref: Optional[pgast.BaseExpr] = relctx.maybe_get_path_var(
+        ctx.rel, path_id, aspect='identity', ctx=ctx)
+    if not ref:
+        rvar = relctx.maybe_get_path_rvar(
+            ctx.rel, path_id, aspect='value', ctx=ctx)
+        if rvar and isinstance(rvar.query, pgast.ReturningQuery):
+            # If we are selecting from a nontrivial subquery, manually
+            # add a volatility ref based on row_number. We do it
+            # manually because the row number isn't /really/ the
+            # identity of the set.
+            name = ctx.env.aliases.get('key')
+            rvar.query.target_list.append(
+                pgast.ResTarget(
+                    name=name,
+                    val=pgast.FuncCall(name=('row_number',), args=[],
+                                       over=pgast.WindowDef())
+                )
+            )
+            ref = pgast.ColumnRef(name=[rvar.alias.aliasname, name])
+        else:
+            ref = relctx.get_path_var(
+                ctx.rel, path_id, aspect='value', ctx=ctx)
+
+    return ref
+
+
+def setup_iterator_volatility(
+        iterator: Optional[Union[irast.Set, pgast.IteratorCTE]], *,
+        is_cte: bool=False,
+        ctx: context.CompilerContextLevel) -> None:
+    if iterator is None:
+        return
+
+    old = () if is_cte else ctx.volatility_ref
+
+    path_id = iterator.path_id
+    ref: Optional[pgast.BaseExpr] = None
+
+    def get_ref() -> pgast.BaseExpr:
+        nonlocal ref
+        if ref is None:
+            ref = get_volatility_ref(path_id, ctx=ctx)
+        return ref
+
+    ctx.volatility_ref = old + (get_ref,)
+
+
 def compile_iterator_expr(
         query: pgast.SelectStmt, iterator_expr: irast.Set, *,
         ctx: context.CompilerContextLevel) \
@@ -87,6 +139,8 @@ def compile_iterator_expr(
     with ctx.new() as subctx:
         subctx.rel = query
 
+        already_existed = bool(relctx.maybe_get_path_rvar(
+            query, iterator_expr.path_id, aspect='value', ctx=ctx))
         dispatch.visit(iterator_expr, ctx=subctx)
         iterator_rvar = relctx.get_path_rvar(
             query, iterator_expr.path_id, aspect='value', ctx=ctx)
@@ -96,8 +150,12 @@ def compile_iterator_expr(
         # for path identity of the iterator expression.  This is
         # necessary to maintain correct correlation for the state
         # of iteration in DML statements.
-        relctx.ensure_bond_for_expr(
-            iterator_expr.expr.result, iterator_query, type='uuid', ctx=subctx)
+        # The already_existed check is to avoid adding in bogus volatility refs
+        # when we reprocess an iterator that was hoisted.
+        if not already_existed:
+            relctx.ensure_bond_for_expr(
+                iterator_expr.expr.result, iterator_query, type='uuid',
+                ctx=subctx)
 
     return iterator_rvar
 

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -112,7 +112,9 @@ class CompilerContextLevel(compiler.ContextLevel):
     expr_exposed: Optional[bool]
 
     #: Expression to use to force SQL expression volatility in this context
-    volatility_ref: Optional[Union[pgast.BaseExpr, NoVolatilitySentinel]]
+    #: (Delayed with a lambda to avoid inserting it when not used.)
+    volatility_ref: Tuple[Union[Callable[[], pgast.BaseExpr],
+                                NoVolatilitySentinel], ...]
 
     group_by_rels: Dict[
         Tuple[irast.PathId, irast.PathId],
@@ -193,7 +195,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.pending_query = None
 
             self.expr_exposed = None
-            self.volatility_ref = None
+            self.volatility_ref = ()
             self.group_by_rels = {}
 
             self.disable_semi_join = set()

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -734,7 +734,9 @@ def compile_insert_shape_element(
             # computable volatility, and, furthermore,
             # we do not have a valid identity reference
             # anyway.
-            insvalctx.volatility_ref = (context.NO_VOLATILITY,)
+            insvalctx.volatility_ref = ()
+
+        insvalctx.current_insert_path_id = ir_stmt.subject.path_id
 
         dispatch.visit(shape_el, ctx=insvalctx)
 

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -890,10 +890,12 @@ def _get_path_output(
                 # first for tuple serialized var disambiguation.
                 element = _get_path_output(
                     rel, el_path_id, aspect=aspect,
+                    disable_output_fusion=disable_output_fusion,
                     allow_nullable=False, env=env)
             except LookupError:
                 element = get_path_output(
                     rel, el_path_id, aspect=aspect,
+                    disable_output_fusion=disable_output_fusion,
                     allow_nullable=False, env=env)
 
             elements.append(pgast.TupleElementBase(

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -639,8 +639,6 @@ def apply_volatility_ref(
         stmt: pgast.SelectStmt, *,
         ctx: context.CompilerContextLevel) -> None:
     for ref in ctx.volatility_ref:
-        if isinstance(ref, context.NoVolatilitySentinel):
-            continue
         # Apply the volatility reference.
         # See the comment in process_set_as_subquery().
         stmt.where_clause = astutils.extend_binop(

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -655,18 +655,19 @@ def ensure_transient_identity_for_set(
                                   id_expr, force=True, env=ctx.env)
     pathctx.put_path_bond(stmt, ir_set.path_id)
 
-    if (ctx.volatility_ref is not None and
-            ctx.volatility_ref is not context.NO_VOLATILITY and
-            isinstance(stmt, pgast.SelectStmt)):
-        # Apply the volatility reference.
-        # See the comment in process_set_as_subquery().
-        stmt.where_clause = astutils.extend_binop(
-            stmt.where_clause,
-            pgast.NullTest(
-                arg=ctx.volatility_ref,
-                negated=True,
+    if isinstance(stmt, pgast.SelectStmt):
+        for ref in ctx.volatility_ref:
+            if isinstance(ref, context.NoVolatilitySentinel):
+                continue
+            # Apply the volatility reference.
+            # See the comment in process_set_as_subquery().
+            stmt.where_clause = astutils.extend_binop(
+                stmt.where_clause,
+                pgast.NullTest(
+                    arg=ref(),
+                    negated=True,
+                )
             )
-        )
 
 
 def get_scope(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1957,18 +1957,7 @@ def _compile_func_epilogue(
     assert isinstance(expr, irast.FunctionCall)
 
     if expr.volatility is qltypes.Volatility.Volatile:
-        for ref in ctx.volatility_ref:
-            if isinstance(ref, context.NoVolatilitySentinel):
-                continue
-            # Apply the volatility reference.
-            # See the comment in process_set_as_subquery().
-            func_rel.where_clause = astutils.extend_binop(
-                func_rel.where_clause,
-                pgast.NullTest(
-                    arg=ref(),
-                    negated=True,
-                )
-            )
+        relctx.apply_volatility_ref(func_rel, ctx=ctx)
 
     pathctx.put_path_var_if_not_exists(
         func_rel, ir_set.path_id, set_expr, aspect='value', env=ctx.env)

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1037,12 +1037,19 @@ def process_set_as_subquery(
             ctx.rel.view_path_id_map[outer_id] = inner_id
 
         if ir_source is not None:
-            if is_scalar_path and not newctx.volatility_ref:
+            if (
+                is_scalar_path
+                and ir_source.path_id != ctx.current_insert_path_id
+            ):
                 # This is a computable pointer.  In order to ensure that
                 # the volatile functions in the pointer expression are called
                 # the necessary number of times, we must inject a
                 # "volatility reference" into function expressions.
                 # The volatility_ref is the identity of the pointer source.
+
+                # If the source is an insert that we are in the middle
+                # of doing, we don't have a volatility ref to add, so
+                # skip it based on the current_insert_path_id check.
                 path_id = ir_source.path_id
                 newctx.volatility_ref += (
                     lambda: relctx.maybe_get_path_var(

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2542,6 +2542,11 @@ class TestExpressions(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
+            r'''SELECT {(1, 2), (3, 4.5)} FILTER true;''',
+            [[1, 2], [3, 4.5]],
+        )
+
+        await self.assert_query_result(
             r'''SELECT {(3, 4.5), (1, 2.0)};''',
             [[3, 4.5], [1, 2]],
         )

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -22,6 +22,7 @@ import os.path
 import edgedb
 
 from edb.testbase import server as tb
+from edb.tools import test
 
 
 class TestEdgeQLVolatility(tb.QueryTestCase):
@@ -159,3 +160,246 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             {'x': 1},
             {'x': 1},
         ])
+
+    async def test_edgeql_volatility_for_01(self):
+        await self.assert_query_result(
+            r'''
+                SELECT count(DISTINCT (FOR x in {1,2} UNION (
+                    uuid_generate_v1mc())));
+            ''',
+            [2],
+        )
+
+    async def test_edgeql_volatility_for_02(self):
+        await self.assert_query_result(
+            r'''
+                WITH X := (FOR x in {1,2} UNION (uuid_generate_v1mc(), x))
+                SELECT count(DISTINCT X.0);
+            ''',
+            [2],
+        )
+
+    async def test_edgeql_volatility_for_03(self):
+        await self.assert_query_result(
+            r'''
+                WITH X := (FOR y in {1, 2} UNION (
+                               FOR x in {1,2} UNION (uuid_generate_v1mc(), x)))
+                SELECT count(DISTINCT X.0);
+            ''',
+            [4],
+        )
+
+    async def test_edgeql_volatility_for_04(self):
+        await self.assert_query_result(
+            r'''
+                WITH X := (FOR y in {1, 2} UNION (
+                               (0,
+                                (FOR x in {1,2} UNION (
+                                     uuid_generate_v1mc(), x)))))
+                SELECT count(DISTINCT X.1.0);
+            ''',
+            [4],
+        )
+
+    async def test_edgeql_volatility_for_05(self):
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test,
+                     X := (FOR y in {1, 2} UNION (
+                               (uuid_generate_v1mc(),
+                                (INSERT Obj { n := y }))))
+                SELECT count(DISTINCT X.0);
+            ''',
+            [2],
+        )
+
+    async def test_edgeql_volatility_for_06(self):
+        await self.assert_query_result(
+            r'''
+                SELECT count(DISTINCT (FOR x in {1,1} UNION (
+                    uuid_generate_v1mc())));
+            ''',
+            [2],
+        )
+
+    async def test_edgeql_volatility_for_07(self):
+        await self.assert_query_result(
+            r'''
+                SELECT count(DISTINCT (FOR x in {(),()} UNION (
+                    uuid_generate_v1mc())));
+            ''',
+            [2],
+        )
+
+    async def test_edgeql_volatility_for_08(self):
+        await self.assert_query_result(
+            r'''
+                SELECT count(DISTINCT (FOR x in {({1,2}, 0).1} UNION (
+                    uuid_generate_v1mc())));
+            ''',
+            [2],
+        )
+
+    async def test_edgeql_volatility_for_09(self):
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT count(
+                    DISTINCT (FOR x in {(Obj { x := random() }).x} UNION (
+                        uuid_generate_v1mc())));
+            ''',
+            [3],
+        )
+
+    async def test_edgeql_volatility_select_clause_01(self):
+        # Spurious failure probability: 1/100!
+
+        # We need a nested SELECT because of bug #1816
+        # loses the ORDER BY otherwise
+        await self.assert_query_result(
+            r'''
+                WITH X := enumerate((SELECT _gen_series(0,99)
+                                     ORDER BY random()))
+                SELECT all(X.0 = X.1);
+            ''',
+            [False],
+        )
+
+    async def test_edgeql_volatility_select_clause_02(self):
+        # Spurious failure probability: 1/2^99
+        await self.assert_query_result(
+            r'''
+                SELECT count((SELECT _gen_series(0,99) FILTER random() > 0.5))
+                       NOT IN {0, 100};
+            ''',
+            [True],
+        )
+
+    @test.xfail('triggers issue #1818')
+    async def test_edgeql_volatility_select_clause_03(self):
+        # Spurious failure probability: 1/2^100 I think
+
+        # We want to test that the two SELECTs do separate FILTERs
+        # This is written in an awful way because of a bug with WITH.
+        await self.assert_query_result(
+            r'''
+                FOR X in {
+                    array_agg(
+                       (FOR x in {0, 1} UNION (SELECT _gen_series(0,100)
+                        FILTER random() > 0.5)))}
+                UNION (
+                SELECT count(array_unpack(X))
+                         != 2*count(DISTINCT array_unpack(X)));
+            ''',
+            [True],
+        )
+
+    async def test_edgeql_volatility_select_clause_04(self):
+        # Spurious failure probability: 1/2^100 I think
+
+        # This is just the test above but manually...
+
+        result = await self.con.query(
+            r'''
+                FOR x in {0, 1} UNION (
+                    SELECT _gen_series(0,100) FILTER random() > 0.5
+                )
+            ''',
+        )
+
+        self.assertNotEqual(
+            2 * len(set(result)), len(result),
+            'SELECT in FOR loop not doing independent filters'
+        )
+
+    async def test_edgeql_volatility_select_clause_05(self):
+        # Spurious failure probability: 1/2^99
+        await self.assert_query_result(
+            r'''
+                WITH X := (FOR x in {_gen_series(0,99)} UNION (()))
+                SELECT count((SELECT X FILTER random() > 0.5))
+                       NOT IN {0, 100};
+            ''',
+            [True],
+        )
+
+    async def test_edgeql_volatility_select_clause_06(self):
+        # Spurious failure probability: 1/2^99
+        await self.assert_query_result(
+            r'''
+                WITH X := (_gen_series(0,99), 0).1
+                SELECT count((SELECT X FILTER random() > 0.5))
+                       NOT IN {0, 100};
+            ''',
+            [True],
+        )
+
+    @test.xfail('volatiles inside WITH get reevaluated')
+    async def test_edgeql_volatility_with_01(self):
+        # We want *one* SELECT to be done for with WITH
+        await self.assert_query_result(
+            r'''
+                WITH X := random() SELECT sum(X) = sum(X);
+            ''',
+            [True],
+        )
+
+    async def test_edgeql_volatility_update_clause_01(self):
+        # Spurious failure probability: 1/2^99
+        await self.con.execute(r'''
+            WITH MODULE test
+            FOR x in {_gen_series(4,100)} UNION (
+            INSERT Obj { n := x })
+        ''')
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT count(Obj)
+            ''',
+            [100],
+        )
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test,
+                     X := (UPDATE Obj FILTER random() > 0.5
+                           SET { n := -1 })
+                SELECT count(X) != 0 AND count(X) != 100
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test,
+                     X := (SELECT Obj FILTER .n < 0)
+                SELECT count(X) != 0 AND count(X) != 100
+            ''',
+            [True],
+        )
+
+    async def test_edgeql_volatility_delete_clause_01(self):
+        # Spurious failure probability: 1/2^99
+        await self.con.execute(r'''
+            WITH MODULE test
+            FOR x in {_gen_series(4,100)} UNION (
+            INSERT Obj { n := x })
+        ''')
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test,
+                     X := (DELETE Obj FILTER random() > 0.5)
+                SELECT count(X) != 0 AND count(X) != 100
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT count(Obj) != 0 AND count(Obj) != 100
+            ''',
+            [True],
+        )


### PR DESCRIPTION
This means that things like `ORDER BY random()` and
`FILTER random() < 0.5` will work.

Part of #1784.