### PR TITLE
Convert data migration tests to also test DESCRIBE MIGRATION.

### DIFF
--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -167,6 +167,7 @@ class SchemaObjectClass(s_enum.StrEnum):
     MIGRATION = 'MIGRATION'
     MODULE = 'MODULE'
     OPERATOR = 'OPERATOR'
+    PARAMETER = 'PARAMETER'
     PROPERTY = 'PROPERTY'
     ROLE = 'ROLE'
     SCALAR_TYPE = 'SCALAR TYPE'

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -59,6 +59,7 @@ class Annotation(so.QualifiedObject,
 
 class AnnotationValue(
     referencing.ReferencedInheritingObject,
+    qlkind=qltypes.SchemaObjectClass.ANNOTATION,
     reflection=so.ReflectionMethod.AS_LINK,
     reflection_link='annotation',
 ):
@@ -198,6 +199,18 @@ class AnnotationValueCommand(
     context_class=AnnotationValueCommandContext,
     referrer_context_class=AnnotationSubjectCommandContext,
 ):
+
+    def _deparse_name(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        name: str,
+    ) -> qlast.ObjectRef:
+        ref = super()._deparse_name(schema, context, name)
+        # Clear `itemclass`
+        ref.itemclass = None
+
+        return ref
 
     def add_annotation(self,
                        schema: s_schema.Schema,

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -29,6 +29,7 @@ from edb.server import defines
 
 from . import delta as sd
 from . import expr as s_expr
+from . import functions as s_func
 from . import migrations as s_migr
 from . import modules as s_mod
 from . import objects as so
@@ -233,7 +234,8 @@ def delta_schemas(
         schemacls
         for schemacls in so.ObjectMeta.get_schema_metaclasses()
         if (
-            not issubclass(schemacls, (so.GlobalObject, s_mod.Module))
+            not issubclass(schemacls, (so.GlobalObject, s_mod.Module,
+                                       s_func.Parameter))
             and schemacls.get_ql_class() is not None
             and (
                 include_migrations

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -319,7 +319,11 @@ class ParameterDesc(ParameterLike):
         return cmd
 
 
-class Parameter(so.ObjectFragment, ParameterLike):
+class Parameter(
+    so.ObjectFragment,
+    ParameterLike,
+    qlkind=ft.SchemaObjectClass.PARAMETER,
+):
 
     num = so.SchemaField(
         int, compcoef=0.4)
@@ -428,6 +432,17 @@ class ParameterCommand(
     context_class=ParameterCommandContext,
     referrer_context_class=CallableCommandContext
 ):
+
+    def get_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        *,
+        parent_node: Optional[qlast.DDLOperation] = None,
+    ) -> Optional[qlast.DDLOperation]:
+        # ParameterCommand cannot have its own AST because it is a
+        # side-effect of a FunctionCommand.
+        return None
 
     def canonicalize_attributes(
         self,

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1264,7 +1264,11 @@ class CollectionExprAlias(so.QualifiedObject, Collection):
         return 'view'
 
 
-class ArrayExprAlias(CollectionExprAlias, Array):
+class ArrayExprAlias(
+    CollectionExprAlias,
+    Array,
+    qlkind=qltypes.SchemaObjectClass.ALIAS,
+):
     pass
 
 
@@ -1795,7 +1799,11 @@ class TupleTypeShell(CollectionTypeShell):
         return cmd
 
 
-class TupleExprAlias(CollectionExprAlias, Tuple):
+class TupleExprAlias(
+    CollectionExprAlias,
+    Tuple,
+    qlkind=qltypes.SchemaObjectClass.ALIAS,
+):
     pass
 
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -89,7 +89,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             self.add_fail_notes(serialization='json')
             raise
 
-    async def migrate(self, migration, *, module: str = 'test', ff=False):
+    async def migrate(self, migration, *, module: str = 'test', ff=True):
         async with self.con.transaction():
             mig = f"""
                 START MIGRATION TO {{
@@ -152,6 +152,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             ]
         )
 
+    @test.xfail('''
+        The "complete" flag is not set even though the DDL from
+        "proposed" list is used.
+
+        This happens on the first migration.
+    ''')
     async def test_edgeql_migration_link_inheritance(self):
         schema_f = os.path.join(os.path.dirname(__file__), 'schemas',
                                 'links_1.esdl')
@@ -1750,11 +1756,11 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         })
 
     @test.xfail('''
-        edgedb.errors.InternalServerError: <class
-        'edb.schema.annos.AnnotationValue'> has no edgeql class string
-        assigned
+        edgedb.errors.SchemaError: cannot get 'name' value: item
+        'bc6c9f68-049d-11eb-a183-c1f86eaf323b' is not present in the
+        schema <Schema gen:3708 at 0x7efef93f1430>
 
-        First DESCRIBE fails.
+        The error occurs on committing the second migration.
     ''')
     async def test_edgeql_migration_describe_annotation_02(self):
         # Migration that creates an annotation.
@@ -1770,8 +1776,14 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             };
         ''')
 
+        await self.con.execute('''
+            CREATE TYPE test::AnnoType2;
+        ''')
+
         await self.assert_describe_migration({
-            'confirmed': [],
+            'confirmed': [
+                'CREATE TYPE test::AnnoType2;'
+            ],
             'complete': False,
             'proposed': {
                 'statements': [{
@@ -1801,7 +1813,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text': (
                         'ALTER TYPE test::AnnoType2 {\n'
-                        '    DROP ANNOTATION test::my_anno2;\\n'
+                        '    DROP ANNOTATION test::my_anno2;\n'
                         '};'
                     )
                 }],
@@ -1878,9 +1890,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         )
 
     @test.xfail('''
-        edgedb.errors.InternalServerError: <class
-        'edb.schema.functions.Parameter'> has no edgeql class string
-        assigned
+        edgedb.errors.InternalServerError: missing AlterObject
+        implementation for Parameter
     ''')
     async def test_edgeql_migration_describe_constraint_01(self):
         # Migration that renames a constraint.
@@ -1915,11 +1926,14 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         })
 
     @test.xfail('''
-        edgedb.errors.InternalServerError: <class
-        'edb.schema.functions.Parameter'> has no edgeql class string
-        assigned
+        edgedb.errors.SchemaError: Parameter
+        'test::__subject__@test|my_one_of' is already present in the
+        schema <Schema gen:3726 at 0x7ff99249ffd0>
 
-        First DESCRIBE fails.
+        Exception: Error while processing
+        'CREATE ABSTRACT CONSTRAINT test::my_one_of(one_of: array<anytype>) {
+            USING (std::contains(one_of, __subject__));
+        };'
     ''')
     async def test_edgeql_migration_describe_constraint_02(self):
         # Migration that creates a constraint.
@@ -1937,14 +1951,25 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             };
         ''')
 
+        await self.con.execute('''
+            CREATE SCALAR TYPE test::my_str EXTENDING std::str;
+        ''')
+
         await self.assert_describe_migration({
-            'confirmed': [],
+            'confirmed': [
+                'CREATE SCALAR TYPE test::my_str EXTENDING std::str;'
+            ],
             'complete': False,
             'proposed': {
-                # FIXME: actually test the 'statement' instead of simply
-                # 'operation_id'
+                'statements': [{
+                    'text': (
+                        'CREATE ABSTRACT CONSTRAINT test::my_one_of('
+                        'one_of: array<anytype>) {\n'
+                        '    USING (std::contains(one_of, __subject__));\n'
+                        '};'
+                    ),
+                }],
                 'confidence': 1.0,
-                'operation_id': 'CREATE ABSTRACT CONSTRAINT test::my_oneof',
             },
         })
         # Auto-complete migration
@@ -1982,10 +2007,14 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             'confirmed': [],
             'complete': False,
             'proposed': {
-                # FIXME: actually test the 'statement' instead of simply
-                # 'operation_id'
+                'statements': [{
+                    'text': (
+                        "ALTER SCALAR TYPE test::my_str {\n"
+                        "    DROP CONSTRAINT test::my_one_of(['my', 'str']);\n"
+                        "};"
+                    ),
+                }],
                 'confidence': 1.0,
-                'operation_id': 'ALTER TYPE test::my_str',
             },
         })
         # Auto-complete migration
@@ -2024,10 +2053,16 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             'confirmed': [],
             'complete': False,
             'proposed': {
-                # FIXME: actually test the 'statement' instead of simply
-                # 'operation_id'
+                'statements': [{
+                    'text': (
+                        'CREATE ABSTRACT CONSTRAINT '
+                        'test::my_one_of(one_of: array<anytype>) {\n'
+                        '    USING (std::contains(one_of, __subject__));\n'
+                        '};'
+                    ),
+                }],
                 'confidence': 1.0,
-                'operation_id': 'CREATE ABSTRACT CONSTRAINT test::my_one_of',
+                'operation_id': 'CREATE CONSTRAINT test::my_one_of',
             },
         })
         # Auto-complete migration
@@ -2078,7 +2113,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
     async def test_edgeql_migration_eq_01(self):
         await self.migrate("""
             type Base;
-        """, ff=True)
+        """)
         await self.con.execute("""
             SET MODULE test;
 
@@ -2094,13 +2129,13 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 type Base {
                     required property name -> str;
                 }
-            """, ff=True)
+            """)
         # Migration without making the property required.
         await self.migrate("""
             type Base {
                 property name -> str;
             }
-        """, ff=True)
+        """)
 
         await self.assert_query_result(
             r"""
@@ -2141,7 +2176,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Derived extending Base {
                 overloaded required property name -> str;
             }
-        """, ff=True)
+        """)
         await self.con.execute("""
             INSERT Derived {
                 name := 'derived_01'
@@ -2164,7 +2199,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Derived extending Base {
                 overloaded required property foo -> str;
             }
-        """, ff=True)
+        """)
         await self.con.execute("""
             SET MODULE test;
 
@@ -2185,7 +2220,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Derived extending Base {
                 overloaded required property foo2 -> str;
             }
-        """, ff=True)
+        """)
 
         # the data still persists
         await self.assert_query_result(
@@ -2213,7 +2248,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Derived extending Base {
                 overloaded required property foo -> str;
             }
-        """, ff=True)
+        """)
         await self.con.execute("""
             SET MODULE test;
 
@@ -2233,7 +2268,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 # completely different property
                 property foo2 -> str;
             }
-        """, ff=True)
+        """)
 
         await self.assert_query_result(
             r"""
@@ -2262,7 +2297,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Further extending Derived {
                 overloaded required property foo -> str;
             }
-        """, ff=True)
+        """)
         await self.con.execute("""
             SET MODULE test;
 
@@ -2287,7 +2322,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 # completely different property
                 property foo2 -> str;
             };
-        """, ff=True)
+        """)
 
         await self.assert_query_result(
             r"""
@@ -2317,7 +2352,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Derived extending Base {
                 overloaded required property foo -> int64;
             }
-        """, ff=True)
+        """)
         await self.con.execute("""
             SET MODULE test;
 
@@ -2349,7 +2384,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Derived extending Base {
                 overloaded required property foo -> str;
             }
-        """, ff=True)
+        """)
 
         await self.assert_query_result(
             r"""
@@ -2371,7 +2406,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Base {
                 link bar -> Child;
             }
-        """, ff=True)
+        """)
         await self.con.execute("""
             SET MODULE test;
         """)
@@ -2394,7 +2429,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                     constraint exclusive;
                 }
             }
-        """, ff=True)
+        """)
 
         await self.assert_query_result(
             r"""
@@ -2412,7 +2447,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Base {
                 property foo -> str;
             }
-        """, ff=True)
+        """)
         await self.con.execute(r"""
             SET MODULE test;
 
@@ -2466,7 +2501,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Base {
                 property foo -> constraint_length;
             }
-        """, ff=True)
+        """)
         await self.con.execute(r"""
             SET MODULE test;
 
@@ -2651,6 +2686,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        The "complete" flag is not set even though the DDL from
+        "proposed" list is used.
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_14(self):
         await self.migrate(r"""
             type Base;
@@ -2698,7 +2739,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Derived extending Base {
                 link bar -> Child;
             }
-        """)
+        """, ff=False)
         await self.con.execute("""
             SET MODULE test;
         """)
@@ -2721,7 +2762,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }
 
             type Derived extending Base;
-        """)
+        """, ff=False)
 
         await self.assert_query_result(
             r"""
@@ -2745,7 +2786,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 # also make the link 'required'
                 overloaded required link bar -> Child;
             }
-        """)
+        """, ff=False)
 
         await self.assert_query_result(
             r"""
@@ -2758,6 +2799,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        The "complete" flag is not set even though the DDL from
+        "proposed" list is used.
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_18(self):
         await self.migrate(r"""
             type Base {
@@ -2797,6 +2844,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        The "complete" flag is not set even though the DDL from
+        "proposed" list is used.
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_19(self):
         await self.migrate(r"""
             type Base {
@@ -2829,6 +2882,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        The "complete" flag is not set even though the DDL from
+        "proposed" list is used.
+
+        This happens on the third migration.
+    ''')
     async def test_edgeql_migration_eq_21(self):
         await self.migrate(r"""
             type Base {
@@ -2891,6 +2950,11 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        edgedb.errors.InvalidReferenceError: property 'foo' does not exist
+
+        This error happens in the last migration.
+    ''')
     async def test_edgeql_migration_eq_22(self):
         await self.migrate(r"""
             type Base {
@@ -2976,6 +3040,18 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        edgedb.errors.SchemaError: ObjectType 'test::Base' is already
+        present in the schema <Schema gen:3757 at 0x7fc3319fa820>
+
+        Exception: Error while processing
+        'CREATE ALIAS test::Base := (
+            SELECT
+                test::Child {
+                    bar := test::Child
+                }
+        );'
+    ''')
     async def test_edgeql_migration_eq_23(self):
         await self.migrate(r"""
             type Child {
@@ -3036,6 +3112,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        The "complete" flag is not set even though the DDL from
+        "proposed" list is used.
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_24(self):
         await self.migrate(r"""
             type Child;
@@ -3077,6 +3159,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        The "complete" flag is not set even though the DDL from
+        "proposed" list is used.
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_25(self):
         await self.migrate(r"""
             type Child;
@@ -3147,7 +3235,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Parent {
                 link bar -> Child;
             }
-        """)
+        """, ff=False)
         await self.con.execute(r"""
             SET MODULE test;
 
@@ -3165,7 +3253,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             # derive a type
             type DerivedParent extending Parent;
-        """)
+        """, ff=False)
 
         await self.assert_query_result(
             r"""
@@ -3193,7 +3281,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type DerivedParent extending Parent {
                 overloaded link bar -> DerivedChild;
             }
-        """)
+        """, ff=False)
 
         await self.con.execute(r"""
             INSERT DerivedParent {
@@ -3216,6 +3304,18 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        edgedb.errors.InvalidReferenceError: property 'name' does not exist
+
+        Exception: Error while processing
+        'ALTER TYPE test::Bar {
+            DROP EXTENDING test::Named;
+            ALTER PROPERTY name {
+                DROP OWNED;
+                SET TYPE std::str;
+            };
+        };'
+    ''')
     async def test_edgeql_migration_eq_27(self):
         await self.migrate(r"""
             abstract type Named {
@@ -3334,7 +3434,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Bar {
                 property title -> str;
             };
-        """)
+        """, ff=False)
         await self.con.execute(r"""
             SET MODULE test;
 
@@ -3355,7 +3455,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 # rename 'title' to 'name'
                 property name -> str;
             };
-        """)
+        """, ff=False)
 
         await self.assert_query_result(
             r"""
@@ -3383,7 +3483,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
             type Foo extending Named;
             type Bar extending Named;
-        """)
+        """, ff=False)
 
         await self.assert_query_result(
             r"""
@@ -3402,6 +3502,16 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             ],
         )
 
+    @test.xfail('''
+        edgedb.errors.EdgeQLSyntaxError: Unexpected '{'
+
+        Exception: Error while processing
+        'ALTER TYPE test::Text {
+            DROP PROPERTY body {
+                DROP CONSTRAINT std::max_len_value(10000);
+            };
+        };'
+    ''')
     async def test_edgeql_migration_eq_31(self):
         # Issue 727.
         #
@@ -3595,6 +3705,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             ],
         )
 
+    @test.xfail('''
+        The "complete" flag is not set even though the DDL from
+        "proposed" list is used.
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_33(self):
         await self.migrate(r"""
             type Child;
@@ -3747,6 +3863,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        The "complete" flag is not set even though the DDL from
+        "proposed" list is used.
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_35(self):
         await self.migrate(r"""
             type Child {
@@ -3835,6 +3957,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }]
         )
 
+    @test.xfail('''
+        The "complete" flag is not set even though the DDL from
+        "proposed" list is used.
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_36(self):
         await self.migrate(r"""
             type Child {
@@ -4349,8 +4477,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             abstract type Permissions {
                 multi link owners extending Ordered -> User;
             };
-        """, ff=True)
-        await self.migrate(r"", ff=True)
+        """)
+        await self.migrate(r"")
 
     async def test_edgeql_migration_eq_function_01(self):
         await self.migrate(r"""
@@ -4578,6 +4706,11 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             {4, 2},
         )
 
+    @test.xfail('''
+        edgedb.errors.SchemaError: cannot drop function
+        'test::hello07(a: std::int64)' because other objects in the
+        schema depend on it
+    ''')
     async def test_edgeql_migration_eq_function_07(self):
         await self.migrate(r"""
             function hello07(a: int64) -> str
@@ -4619,6 +4752,11 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             {2},
         )
 
+    @test.xfail('''
+        edgedb.errors.SchemaError: cannot drop function
+        'test::hello08(a: std::int64)' because other objects in the
+        schema depend on it
+    ''')
     async def test_edgeql_migration_eq_function_08(self):
         await self.migrate(r"""
             function hello08(a: int64) -> str
@@ -4654,6 +4792,11 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             {2},
         )
 
+    @test.xfail('''
+        edgedb.errors.SchemaError: cannot drop function
+        'test::hello09(a: std::int64)' because other objects in the
+        schema depend on it
+    ''')
     async def test_edgeql_migration_eq_function_09(self):
         await self.migrate(r"""
             function hello09(a: int64) -> str
@@ -5170,6 +5313,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [{'foo': [{'@bar': 'lp04'}]}],
         )
 
+    @test.xfail('''
+        The "complete" flag is not set even though the DDL from
+        "proposed" list is used.
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_linkprops_05(self):
         await self.migrate(r"""
             type Child;
@@ -5283,7 +5432,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                     property foo -> str
                 }
             };
-        """)
+        """, ff=False)
         await self.con.execute(r"""
             SET MODULE test;
 
@@ -5307,7 +5456,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             };
 
             type Derived extending Base;
-        """)
+        """, ff=False)
 
         await self.assert_query_result(
             r"""
@@ -5335,7 +5484,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             };
 
             type Derived extending Base;
-        """)
+        """, ff=False)
         await self.con.execute(r"""
             SET MODULE test;
 
@@ -5363,7 +5512,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                     property foo -> str
                 }
             };
-        """)
+        """, ff=False)
 
         await self.assert_query_result(
             r"""
@@ -5404,7 +5553,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                     property foo -> str
                 }
             };
-        """)
+        """, ff=False)
         await self.con.execute(r"""
             SET MODULE test;
 
@@ -5430,7 +5579,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             };
 
             type Derived extending Base;
-        """)
+        """, ff=False)
 
         await self.assert_query_result(
             r"""
@@ -5468,7 +5617,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             };
 
             type Derived extending Base;
-        """)
+        """, ff=False)
         await self.con.execute(r"""
             SET MODULE test;
 
@@ -5494,7 +5643,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                     property foo -> str
                 }
             };
-        """)
+        """, ff=False)
 
         await self.assert_query_result(
             r"""
@@ -5527,7 +5676,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                     property foo -> str;
                 }
             };
-        """)
+        """, ff=False)
         await self.con.execute(r"""
             SET MODULE test;
 
@@ -5560,7 +5709,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type Owner extending Base;
 
             type Renter extending Base;
-        """)
+        """, ff=False)
 
         await self.assert_query_result(
             r"""
@@ -5592,6 +5741,25 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        edgedb.errors.SchemaError: cannot drop inherited property
+        'bar' of link 'item' of object type 'test::Owner'
+
+        DETAILS: property 'bar' of link 'item' of object type
+        'test::Owner' is inherited from:
+        - link 'item' of object type 'test::Base'
+
+        Exception: Error while processing
+        'ALTER TYPE test::Owner {
+            EXTENDING test::Base LAST;
+            ALTER LINK item {
+                DROP OWNED;
+                ALTER PROPERTY foo {
+                    DROP OWNED;
+                };
+            };
+        };'
+    ''')
     async def test_edgeql_migration_eq_linkprops_12(self):
         # merging a link with different properties
         await self.migrate(r"""
@@ -5822,6 +5990,13 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        edgedb.errors.SchemaError: cannot get 'name' value: item
+        '4e2fe443-04a6-11eb-a38f-a315784c86dc' is not present in the
+        schema <Schema gen:3747 at 0x7fd78b613790>
+
+        This happens on the final migration.
+    ''')
     async def test_edgeql_migration_eq_annotation_02(self):
         await self.migrate(r"""
             type Base;
@@ -5923,6 +6098,13 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        edgedb.errors.SchemaError: cannot get 'name' value: item
+        '54615193-04a6-11eb-a05a-af5ecac7408d' is not present in the
+        schema <Schema gen:3751 at 0x7fd78bbe74c0>
+
+        This happens on the final migration.
+    ''')
     async def test_edgeql_migration_eq_annotation_03(self):
         await self.migrate(r"""
             type Base;
@@ -6027,6 +6209,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        The "complete" flag is not set even though the DDL from
+        "proposed" list is used.
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_annotation_04(self):
         # Test migration of annotation value ano nothing else.
         await self.migrate(r"""
@@ -6375,6 +6563,13 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+    @test.xfail('''
+        AssertionError: data shape differs: 'SELECT .name' != '.name'
+        PATH: [0]["indexes"][0]["expr"]
+
+        This may be using obsolete `orig_expr`, so perhaps the test is
+        no longer correct.
+    ''')
     async def test_edgeql_migration_eq_index_05(self):
         await self.migrate(r"""
             type Base {
@@ -6525,6 +6720,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [{'a': 'hello', 'b': 42}],
         )
 
+    @test.xfail('''
+        The "complete" flag is not set even though the DDL from
+        "proposed" list is used.
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_collections_06(self):
         await self.migrate(r"""
             type Base {
@@ -6679,6 +6880,15 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [{'a': 'test', 'b': 9}],
         )
 
+    @test.xfail('''
+        edgedb.errors.SchemaError: cannot drop scalar type
+        'test::CollAlias' because other objects in the schema depend
+        on it
+
+        Exception: Error while processing 'DROP SCALAR TYPE test::CollAlias;'
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_collections_13(self):
         await self.migrate(r"""
             type Base {
@@ -6727,6 +6937,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [[13.5]],
         )
 
+    @test.xfail('''
+        edgedb.errors.InvalidReferenceError: object type or alias
+        'default::Base' does not exist
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_collections_14(self):
         await self.migrate(r"""
             type Base {
@@ -6776,6 +6992,16 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [['coll_14', 14.5]],
         )
 
+    @test.xfail('''
+        edgedb.errors.SchemaError: cannot drop scalar type
+        'test::CollAlias' because other objects in the schema depend
+        on it
+
+        Exception: Error while processing
+        'DROP SCALAR TYPE test::CollAlias;'
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_collections_15(self):
         await self.migrate(r"""
             type Base {
@@ -6832,6 +7058,16 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [['coll_15', 15, [15.5]]],
         )
 
+    @test.xfail('''
+        edgedb.errors.SchemaError: cannot drop scalar type
+        'test::CollAlias' because other objects in the schema depend
+        on it
+
+        Exception: Error while processing
+        'DROP SCALAR TYPE test::CollAlias;'
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_collections_16(self):
         await self.migrate(r"""
             type Base {
@@ -6885,6 +7121,15 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [{'a': 'coll_16', 'b': 16.5}],
         )
 
+    @test.xfail('''
+        edgedb.errors.InvalidReferenceError: schema item
+        'test::CollAlias' does not exist
+
+        Exception: Error while processing
+        'ALTER ALIAS test::CollAlias USING ([test::Base.foo]);'
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_collections_17(self):
         await self.migrate(r"""
             type Base {
@@ -6936,6 +7181,19 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [[17.5]],
         )
 
+    @test.xfail('''
+        edgedb.errors.InvalidReferenceError: schema item
+        'test::CollAlias' does not exist
+
+        Exception: Error while processing
+        'ALTER ALIAS test::CollAlias USING ((
+            test::Base.name,
+            test::Base.number,
+            test::Base.foo
+        ));'
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_collections_18(self):
         await self.migrate(r"""
             type Base {
@@ -6994,6 +7252,18 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [['coll_18', 18, 18.5]],
         )
 
+    @test.xfail('''
+        edgedb.errors.InvalidReferenceError: schema item
+        'test::CollAlias' does not exist
+
+        Exception: Error while processing
+        'ALTER ALIAS test::CollAlias USING ((
+            test::Base.name,
+            test::Base.foo
+        ));'
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_collections_20(self):
         await self.migrate(r"""
             type Base {
@@ -7052,6 +7322,18 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [['test20', 123.5]],
         )
 
+    @test.xfail('''
+        edgedb.errors.InvalidReferenceError: schema item
+        'test::CollAlias' does not exist
+
+        Exception: Error while processing
+        'ALTER ALIAS test::CollAlias USING ((
+            a := test::Base.name,
+            b := test::Base.foo
+        ));'
+
+        This happens on the second migration.
+    ''')
     async def test_edgeql_migration_eq_collections_21(self):
         await self.migrate(r"""
             type Base {


### PR DESCRIPTION
Most of the data migration tests now also apply the migration
in a step-by-step fashion based on the DESCRIBE MIGRATION output.

Issue #1772