### PR TITLE
Fix handling of computables with bare backlinks

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1072,9 +1072,11 @@ def computable_ptr_set(
     )
 
     result_stype = ptrcls.get_target(ctx.env.schema)
+    base_object = ctx.env.schema.get('std::BaseObject', type=s_types.Type)
     with newctx() as subctx:
         subctx.disable_shadowing.add(ptrcls)
-        subctx.view_scls = result_stype
+        if result_stype != base_object:
+            subctx.view_scls = result_stype
         subctx.view_rptr = context.ViewRPtr(
             source_scls, ptrcls=ptrcls, rptr=rptr)  # type: ignore
         subctx.anchors[qlast.Source().name] = source_set

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -185,16 +185,16 @@ class Cast(
         qlast.Language, default=None, compcoef=0.4, coerce=True)
 
     from_function = so.SchemaField(
-        str, default=None, compcoef=0.4, introspectable=False)
+        str, default=None, compcoef=0.4)
 
     from_expr = so.SchemaField(
-        bool, default=False, compcoef=0.4, introspectable=False)
+        bool, default=False, compcoef=0.4)
 
     from_cast = so.SchemaField(
-        bool, default=False, compcoef=0.4, introspectable=False)
+        bool, default=False, compcoef=0.4)
 
     code = so.SchemaField(
-        str, default=None, compcoef=0.4, introspectable=False)
+        str, default=None, compcoef=0.4)
 
 
 class CastCommandContext(sd.ObjectCommandContext[Cast],

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -965,19 +965,19 @@ class Function(CallableObject, VolatilitySubject, s_abc.Function,
         qlast.Language, default=None, compcoef=0.4, coerce=True)
 
     from_function = so.SchemaField(
-        str, default=None, compcoef=0.4, introspectable=False)
+        str, default=None, compcoef=0.4)
 
     from_expr = so.SchemaField(
-        bool, default=False, compcoef=0.4, introspectable=False)
+        bool, default=False, compcoef=0.4)
 
     force_return_cast = so.SchemaField(
-        bool, default=False, compcoef=0.9, introspectable=False)
+        bool, default=False, compcoef=0.9)
 
     sql_func_has_out_params = so.SchemaField(
-        bool, default=False, compcoef=0.9, introspectable=False)
+        bool, default=False, compcoef=0.9)
 
     error_on_null_result = so.SchemaField(
-        str, default=None, compcoef=0.9, introspectable=False)
+        str, default=None, compcoef=0.9)
 
     initial_value = so.SchemaField(
         expr.Expression, default=None, compcoef=0.4, coerce=True)
@@ -986,7 +986,7 @@ class Function(CallableObject, VolatilitySubject, s_abc.Function,
         bool, default=False, compcoef=0.4, coerce=True, allow_ddl_set=True)
 
     has_dml = so.SchemaField(
-        bool, default=False, allow_ddl_set=True, introspectable=False)
+        bool, default=False, allow_ddl_set=True)
 
     def has_inlined_defaults(self, schema: s_schema.Schema) -> bool:
         # This can be relaxed to just `language is EdgeQL` when we

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -281,6 +281,8 @@ def get_or_create_union_type(
                 id=type_id,
                 union_of=so.ObjectSet.create(schema, components),
                 is_opaque_union=opaque,
+                is_abstract=True,
+                is_final=True,
             ),
         )
 
@@ -322,6 +324,8 @@ def get_or_create_intersection_type(
             attrs=dict(
                 id=type_id,
                 intersection_of=so.ObjectSet.create(schema, components),
+                is_abstract=True,
+                is_final=True,
             ),
         )
 

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -70,7 +70,7 @@ class ObjectType(
     is_opaque_union = so.SchemaField(
         bool,
         default=False,
-        introspectable=False)
+    )
 
     @classmethod
     def get_schema_class_displayname(cls) -> str:

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -47,19 +47,19 @@ class Operator(s_func.CallableObject, s_func.VolatilitySubject,
 
     from_operator = so.SchemaField(
         checked.CheckedList[str], coerce=True,
-        default=None, compcoef=0.4, introspectable=False)
+        default=None, compcoef=0.4)
 
     from_function = so.SchemaField(
-        str, default=None, compcoef=0.4, introspectable=False)
+        str, default=None, compcoef=0.4)
 
     from_expr = so.SchemaField(
-        bool, default=False, compcoef=0.4, introspectable=False)
+        bool, default=False, compcoef=0.4)
 
     force_return_cast = so.SchemaField(
-        bool, default=False, compcoef=0.9, introspectable=False)
+        bool, default=False, compcoef=0.9)
 
     code = so.SchemaField(
-        str, default=None, compcoef=0.4, introspectable=False)
+        str, default=None, compcoef=0.4)
 
     # If this is a derivative operator, *derivative_of* would
     # contain the name of the origin operator.
@@ -75,7 +75,7 @@ class Operator(s_func.CallableObject, s_func.VolatilitySubject,
         sn.Name, coerce=True, default=None, compcoef=0.99)
 
     recursive = so.SchemaField(
-        bool, default=False, compcoef=0.4, introspectable=False)
+        bool, default=False, compcoef=0.4)
 
     def get_display_signature(self, schema: s_schema.Schema) -> str:
         params = [

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -271,7 +271,6 @@ class ReferencedInheritingObject(
         bool,
         default=False,
         compcoef=None,
-        introspectable=False,
         inheritable=False,
         ephemeral=True,
     )

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -105,7 +105,7 @@ class Type(
     # The OID by which the backend refers to the type.
     backend_id = so.SchemaField(
         int,
-        default=None, inheritable=False, introspectable=False)
+        default=None, inheritable=False)
 
     def is_blocking_ref(
         self, schema: s_schema.Schema, reference: so.Object

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4241,7 +4241,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 volatility := 'IMMUTABLE';
                 annotation std::description := 'Return the array made from all
                     of the input set elements.';
-                using sql;
+                using sql function 'array_agg';
             };
             """,
 
@@ -5263,7 +5263,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             #     volatility := 'IMMUTABLE';
             #     annotation std::description := 'Generalized boolean `AND`
                       applied to the set of *values*.';
-            #     using sql
+            #     using sql function 'bool_and'
             # ;};
             """,
 


### PR DESCRIPTION
The bare backlink computable (e.g. `.<link`) should resolve into
`std::BaseObject`, while still being handled as an appropriate opaque union
internally.

Fixes: #1830