### PR TITLE
Eliminate deferred cardinality checking

### DIFF
--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -35,7 +35,6 @@ from . import inference
 from . import polyres
 from . import schemactx
 from . import setgen
-from . import stmtctx
 
 
 def compile_where_clause(
@@ -53,9 +52,6 @@ def compile_where_clause(
         ir_set = setgen.scoped_set(ir_expr, typehint=bool_t, ctx=subctx)
 
     ir_stmt.where = ir_set
-    stmtctx.get_expr_cardinality_later(
-        target=ir_stmt, field='where_card', irexpr=ir_set,
-        ctx=ctx)
 
 
 def compile_orderby_clause(
@@ -74,7 +70,6 @@ def compile_orderby_clause(
                 ir_sortexpr = setgen.scoped_set(
                     ir_sortexpr, force_reassign=True, ctx=exprctx)
                 ir_sortexpr.context = sortexpr.context
-                stmtctx.enforce_singleton(ir_sortexpr, ctx=exprctx)
 
                 # Check that the sortexpr type is actually orderable
                 # with either '>' or '<' based on the DESC or ASC sort
@@ -135,6 +130,5 @@ def compile_limit_offset_clause(
             ir_set = setgen.scoped_set(
                 ir_expr, force_reassign=True, typehint=int_t, ctx=subctx)
             ir_set.context = expr.context
-            stmtctx.enforce_singleton(ir_set, ctx=subctx)
 
     return ir_set

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -49,7 +49,6 @@ from . import pathctx
 from . import polyres
 from . import schemactx
 from . import setgen
-from . import stmtctx
 from . import typegen
 
 if TYPE_CHECKING:
@@ -777,11 +776,7 @@ def finalize_args(
             arg = casts.compile_cast(
                 arg, paramtype, srcctx=None, ctx=ctx)
 
-        call_arg = irast.CallArg(expr=arg, cardinality=None)
-        stmtctx.get_expr_cardinality_later(
-            target=call_arg, field='cardinality', irexpr=arg, ctx=ctx)
-
-        args.append(call_arg)
+        args.append(irast.CallArg(expr=arg, cardinality=None))
 
         # If we have any logged paths left over and our enclosing
         # context is logging paths, propagate them up.

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -322,15 +322,6 @@ def _find_visible(
         else:
             path_id = ir.path_id
 
-        # This is a nasty hack, I think. If a path is an unfenced
-        # descendant, don't find a visible node above us. This fixes
-        # issues like in test_edgeql_scope_filter_01 where we mean to
-        # refer to our ought-to-be-namespaced child but instead find
-        # something else.
-        if ((nobe := scope_tree.find_descendant(path_id))
-                and nobe.fence == scope_tree.fence):
-            return None
-
         return parent_fence.find_visible(path_id)
     else:
         return None

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -129,7 +129,7 @@ def _infer_type(
     ir: irast.Base,
     env: context.Environment,
 ) -> s_types.Type:
-    raise ValueError(f'infer_cardinality: cannot handle {ir!r}')
+    raise ValueError(f'infer_type: cannot handle {ir!r}')
 
 
 @_infer_type.register(type(None))

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -34,7 +34,6 @@ from edb.schema import pointers as s_pointers
 from edb.schema import types as s_types
 
 from . import context
-from . import stmtctx
 
 
 def get_path_id(stype: s_types.Type, *,
@@ -153,7 +152,6 @@ def extend_path_id(
         cache=ctx.env.ptr_ref_cache,
         typeref_cache=ctx.env.type_ref_cache,
     )
-    stmtctx.ensure_ptrref_cardinality(ptrcls, ptrref, ctx=ctx)
 
     return path_id.extend(ptrref=ptrref, direction=direction,
                           ns=ns, schema=ctx.env.schema)

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -43,7 +43,6 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
 from . import context
-from . import stmtctx
 
 
 def get_schema_object(
@@ -208,10 +207,8 @@ def derive_view(
                 if computable_data is not None:
                     ctx.source_map[ptr] = computable_data
 
-                if src_ptr in ctx.pending_cardinality:
-                    ctx.pointer_derivation_map[src_ptr].append(ptr)
-                    stmtctx.pend_pointer_cardinality_inference(
-                        ptrcls=ptr, ctx=ctx)
+                if src_ptr in ctx.env.pointer_specified_info:
+                    ctx.env.pointer_derivation_map[src_ptr].append(ptr)
 
     else:
         raise TypeError("unsupported type in derive_view")

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -150,9 +150,6 @@ def compile_ForQuery(
             iterator_ctx.stmt.hoisted_iterators.append(iterator_stmt)
 
         view_scope_info = sctx.path_scope_map[iterator_view]
-        for cb in view_scope_info.tentative_work:
-            stmtctx.at_stmt_fini(cb, ctx=ctx)
-        view_scope_info.tentative_work[:] = []
 
         pathctx.register_set_in_scope(
             iterator_stmt,

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -105,20 +105,22 @@ def fini_expression(
     *,
     ctx: context.ContextLevel,
 ) -> irast.Command:
+
+    cardinality = qltypes.Cardinality.AT_MOST_ONE
+    if ctx.path_scope is not None:
+        # Simple expressions have no scope.
+        cardinality = inference.infer_cardinality(
+            ir, scope_tree=ctx.path_scope, env=ctx.env)
+
+    # Strip weak namespaces
     for ir_set in ctx.env.set_types:
         if ir_set.path_id.namespace:
             ir_set.path_id = ir_set.path_id.strip_weak_namespaces()
 
     if ctx.path_scope is not None:
-        # Simple expressions have no scope.
         for node in ctx.path_scope.path_descendants:
             if node.path_id.namespace:
                 node.path_id = node.path_id.strip_weak_namespaces()
-
-        cardinality = inference.infer_cardinality(
-            ir, scope_tree=ctx.path_scope, env=ctx.env)
-    else:
-        cardinality = qltypes.Cardinality.AT_MOST_ONE
 
     if isinstance(ir, irast.Command):
         if isinstance(ir, irast.ConfigCommand):

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -707,7 +707,6 @@ class Stmt(Expr):
 
     name: str
     result: Set
-    cardinality: qltypes.Cardinality
     parent_stmt: typing.Optional[Stmt]
     iterator_stmt: typing.Optional[Set]
     hoisted_iterators: typing.List[Set]

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -429,7 +429,7 @@ class ScopeTreeNode:
         *node* is expected to be a balanced scope tree and may be modified
         by this function.
 
-        If *node* is not a path node (path_id is None), it is discared,
+        If *node* is not a path node (path_id is None), it is discarded,
         and it's descendants are attached directly.  The tree balance is
         maintained.
         """
@@ -603,7 +603,7 @@ class ScopeTreeNode:
 
         for node in self.descendants:
             if (node.path_id is not None
-                    and _paths_equal_to_shortest_ns(node.path_id, path_id)):
+                    and _paths_equal(node.path_id, path_id, set())):
                 matching.add(node)
 
         for node in matching:
@@ -936,24 +936,3 @@ def _paths_equal(path_id_1: pathid.PathId, path_id_2: pathid.PathId,
         path_id_2 = path_id_2.strip_namespace(namespaces)
 
     return path_id_1 == path_id_2
-
-
-def _paths_equal_to_shortest_ns(path_id_1: pathid.PathId,
-                                path_id_2: pathid.PathId) -> bool:
-    ns1: AbstractSet[str] = path_id_1.namespace or set()
-    ns2: AbstractSet[str] = path_id_2.namespace or set()
-
-    if not ns1 and not ns2:
-        return path_id_1 == path_id_2
-    else:
-        extra_in_1 = ns1 - ns2
-        extra_in_2 = ns2 - ns1
-
-        if extra_in_1 and extra_in_2:
-            # neither namespace is a proper subset of another
-            return False
-        else:
-            path_id_1 = path_id_1.replace_namespace(set())
-            path_id_2 = path_id_2.replace_namespace(set())
-
-            return path_id_1 == path_id_2


### PR DESCRIPTION
Make the cardinality checker do a full top-down cardinality inference
of all parts of the tree, performing cardinality checks and filling in
cardinality fields in the AST.

This allows us to ditch all of the at_stmt_fini machinery and
once_pointer_cardinality_is_inferred machinery.

It fixes some incorrect inference of function/operator argument
cardinalities that had been causing me trouble when trying to do
checks for volatility cardinality restrictions; these were cauesd by
not being able to find the proper scope in the callback.