### PR TITLE
Prohibit taking implicit cross products with volatile operations

### DIFF
--- a/edb/edgeql/compiler/inference/__init__.py
+++ b/edb/edgeql/compiler/inference/__init__.py
@@ -24,9 +24,9 @@ __all__ = (
     'infer_cardinality',
     'infer_type',
     'infer_volatility',
-    'CardCtx',
+    'make_ctx',
 )
 
-from .cardinality import infer_cardinality, CardCtx  # NOQA
+from .cardinality import infer_cardinality, make_ctx  # NOQA
 from .types import amend_empty_set_type, infer_type  # NOQA
 from .volatility import infer_volatility  # NOQA

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -117,7 +117,9 @@ def __infer_set(
     ir: irast.Set,
     env: context.Environment,
 ) -> qltypes.Volatility:
-    if ir.rptr is not None:
+    if ir.is_binding:
+        return STABLE
+    elif ir.rptr is not None:
         return infer_volatility(ir.rptr.source, env)
     elif ir.expr is not None:
         return infer_volatility(ir.expr, env)
@@ -216,6 +218,8 @@ def __infer_select_stmt(
 
     if ir.limit is not None:
         components.append(ir.limit)
+
+    components.extend(ir.bindings)
 
     return _common_volatility(components, env)
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -136,6 +136,7 @@ def new_set_from_set(
         stype: Optional[s_types.Type]=None,
         rptr: Optional[irast.Pointer]=None,
         context: Optional[parsing.ParserContext]=None,
+        is_binding: Optional[bool]=None,
         ctx: context.ContextLevel) -> irast.Set:
     """Create a new ir.Set from another ir.Set.
 
@@ -154,6 +155,8 @@ def new_set_from_set(
         rptr = ir_set.rptr
     if context is None:
         context = ir_set.context
+    if is_binding is None:
+        is_binding = ir_set.is_binding
     return new_set(
         path_id=path_id,
         path_scope_id=ir_set.path_scope_id,
@@ -161,6 +164,7 @@ def new_set_from_set(
         expr=ir_set.expr,
         rptr=rptr,
         context=context,
+        is_binding=is_binding,
         ircls=type(ir_set),
         ctx=ctx,
     )
@@ -272,6 +276,7 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
                         preserve_scope_ns=(
                             view_scope_info.pinned_path_id_ns is not None
                         ),
+                        is_binding=True,
                         ctx=ctx,
                     )
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -118,9 +118,7 @@ def fini_expression(
         cardinality = inference.infer_cardinality(
             ir,
             scope_tree=ctx.path_scope,
-            ctx=inference.CardCtx(
-                env=ctx.env, inferred_cardinality={}, singletons=()
-            )
+            ctx=inference.make_ctx(env=ctx.env),
         )
 
     # Strip weak namespaces

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -419,6 +419,7 @@ class Set(Base):
     anchor: typing.Optional[str]
     show_as_anchor: typing.Optional[str]
     shape: typing.List[typing.Tuple[Set, qlast.ShapeOp]]
+    is_binding: bool
 
     def __repr__(self) -> str:
         return f'<ir.Set \'{self.path_id}\' at 0x{id(self):x}>'
@@ -714,6 +715,7 @@ class Stmt(Expr):
     parent_stmt: typing.Optional[Stmt]
     iterator_stmt: typing.Optional[Set]
     hoisted_iterators: typing.List[Set]
+    bindings: typing.List[Set]
 
 
 class FilteredStmt(Stmt):

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -157,6 +157,7 @@ cfg::get_config_json(
 CREATE FUNCTION
 cfg::_quote(text: std::str) -> std::str
 {
+    SET volatility := 'STABLE';
     SET internal := true;
     USING SQL $$
         SELECT replace(quote_literal(text), '''''', '\\''')

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3158,9 +3158,13 @@ def _describe_config(
         " ?? false"
     )
     query = (
-        f"WITH\n  conf := cfg::get_config_json(sources := [{ql(source)}]),\n"
-        + (f"  testmode := {testmode_check}\n" if testmode else "")
+        f"FOR conf IN {{cfg::get_config_json(sources := [{ql(source)}])}} "
+        + "UNION (\n"
+        + (f"FOR testmode IN {{{testmode_check}}} UNION (\n"
+           if testmode else "")
         + "SELECT\n  " + ' ++ '.join(items)
+        + (")" if testmode else "")
+        + ")"
     )
     return query
 

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -671,22 +671,24 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         } FILTER .name = 'Alice'
 
 % OK %
+    "FENCE": {
+        "(test::User)",
         "FENCE": {
-            "(test::User)",
+            "(__derived__::__derived__|letter@w~1)",
+            "(test::User).>select_deck[IS test::Card]",
             "FENCE": {
-                "(__derived__::__derived__|letter@w~1)",
-                "(test::User).>select_deck[IS test::Card]",
                 "FENCE": {
                     "(test::User).>deck[IS test::Card]",
                     "FENCE": {
                         "(test::User).>deck[IS test::Card].>name[IS std::str]"
                     }
                 }
-            },
-            "FENCE": {
-                "(test::User).>name[IS std::str]"
             }
+        },
+        "FENCE": {
+            "(test::User).>name[IS std::str]"
         }
+    }
         """
 
     def test_edgeql_ir_scope_tree_26(self):
@@ -706,25 +708,27 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         } FILTER .name = 'Alice'
 
 % OK %
+    "FENCE": {
+        "(test::User)",
         "FENCE": {
-            "(test::User)",
+            "(__derived__::__derived__|letter@w~1)",
+            "(test::User).>select_deck[IS test::Card]",
             "FENCE": {
                 "(__derived__::__derived__|foo@w~2)": {
                     "FENCE": {
                         "(test::User).>deck[IS test::Card]",
                         "FENCE": {
-                            "(test::User).>deck[IS test::Card]\
-.>name[IS std::str]"
+                            "(test::User).>deck[IS test::Card].>\
+name[IS std::str]"
                         }
                     }
-                },
-                "(__derived__::__derived__|letter@w~1)",
-                "(test::User).>select_deck[IS test::Card]"
-            },
-            "FENCE": {
-                "(test::User).>name[IS std::str]"
+                }
             }
+        },
+        "FENCE": {
+            "(test::User).>name[IS std::str]"
         }
+    }
         """
 
     def test_edgeql_ir_scope_tree_27(self):

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -251,6 +251,19 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             [3],
         )
 
+    async def test_edgeql_volatility_for_10(self):
+        # We would eventually like to compute this correctly instead
+        async with self._run_and_rollback():
+            with self.assertRaisesRegex(
+                    edgedb.QueryError,
+                    "volatile aliased expressions may not be used "
+                    "inside FOR bodies"):
+                await self.con.execute(
+                    r'''
+                    WITH x := random() FOR y in {1,2,3} UNION (x);
+                    ''',
+                )
+
     async def test_edgeql_volatility_select_clause_01a(self):
         # Spurious failure probability: 1/100!
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -417,6 +417,7 @@ _123456789_123456789_123456789 -> str
         schema = self.run_ddl(schema, '''
             CREATE FUNCTION
             test::my_contains(arr: array<anytype>, val: anytype) -> bool {
+                SET volatility := 'STABLE';
                 USING (
                     SELECT contains(arr, val)
                 );


### PR DESCRIPTION
I wanted error spans on these messages, which meant threading around
a few more contexts in the compiler.

I needed to make the bodies of FOR scoped in order to have the
iterator variable recognized as having single cardinality inside the
body when the body is just an expression and not an explicit subquery.

Fixes #1784.