### PR TITLE
Basic query rewrite implementation

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -356,6 +356,9 @@ class ContextLevel(compiler.ContextLevel):
     view_sets: Dict[s_types.Type, irast.Set]
     """A dictionary of IR expressions for views declared in the query."""
 
+    type_rewrites: Dict[s_types.Type, irast.Set]
+    """Access policy rewrites for schema-level types."""
+
     aliased_views: ChainMap[str, Optional[s_types.Type]]
     """A dictionary of views aliased in a statement body."""
 
@@ -488,6 +491,7 @@ class ContextLevel(compiler.ContextLevel):
             self.source_map = {}
             self.view_nodes = {}
             self.view_sets = {}
+            self.type_rewrites = {}
             self.aliased_views = collections.ChainMap()
             self.must_use_views = {}
             self.expr_view_cache = {}
@@ -501,7 +505,7 @@ class ContextLevel(compiler.ContextLevel):
             self.pending_stmt_full_path_id_namespace = frozenset()
             self.banned_paths = set()
             self.view_map = collections.ChainMap()
-            self.path_scope = irast.new_scope_tree()
+            self.path_scope = env.path_scope
             self.path_scope_map = {}
             self.iterator_ctx = None
             self.iterator_path_ids = frozenset()
@@ -535,6 +539,7 @@ class ContextLevel(compiler.ContextLevel):
             self.source_map = prevlevel.source_map
             self.view_nodes = prevlevel.view_nodes
             self.view_sets = prevlevel.view_sets
+            self.type_rewrites = prevlevel.type_rewrites
             self.must_use_views = prevlevel.must_use_views
             self.expr_view_cache = prevlevel.expr_view_cache
             self.shape_type_cache = prevlevel.shape_type_cache

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -42,8 +42,8 @@ class GlobalCompilerOptions:
     #: Allow writing to protected pointers in INSERT.
     allow_writing_protected_pointers: bool = False
 
-    #: Whether to apply various introspection query rewrites.
-    introspection_schema_rewrites: bool = True
+    #: Whether to apply various query rewrites, including access policy.
+    apply_query_rewrites: bool = True
 
     #: Enables constant folding optimization (enabled by default).
     constant_folding: bool = True

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -223,6 +223,7 @@ def fini_expression(
             t for t in ctx.env.created_schema_objects
             if isinstance(t, s_types.Collection) and t != expr_type
         ),
+        type_rewrites={s.typeref.id: s for s in ctx.type_rewrites.values()},
     )
     return result
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -255,7 +255,7 @@ def _process_view(
 
     elif (
         stype.get_name(ctx.env.schema).module == 'schema'
-        and ctx.env.options.introspection_schema_rewrites
+        and ctx.env.options.apply_query_rewrites
     ):
         explicit_ptrs = {
             ptrcls.get_shortname(ctx.env.schema).name

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -464,6 +464,7 @@ class Statement(Command):
                                          PathId,
                                          typing.Optional[WeakNamespace]]]
     dml_exprs: typing.List[qlast.Base]
+    type_rewrites: typing.Dict[uuid.UUID, Set]
 
 
 class TypeIntrospection(ImmutableExpr):

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -144,6 +144,7 @@ cfg::get_config_json() -> std::json
 CREATE FUNCTION
 cfg::_quote(text: std::str) -> std::str
 {
+    SET internal := true;
     USING SQL $$
         SELECT replace(quote_literal(text), '''''', '\\''')
     $$
@@ -158,6 +159,7 @@ cfg::_name_value(
     default: OPTIONAL std::int16
 ) -> std::str
 {
+    SET internal := true;
     USING (
         SELECT '' IF EXISTS default AND default = value
             ELSE prefix ++ name ++ ' := ' ++ <str>value ?? '{}' ++ suffix
@@ -173,6 +175,7 @@ cfg::_name_value(
     default: OPTIONAL std::int32
 ) -> std::str
 {
+    SET internal := true;
     USING (
         SELECT '' IF EXISTS default AND default = value
             ELSE prefix ++ name ++ ' := ' ++ <str>value ?? '{}' ++ suffix
@@ -188,6 +191,7 @@ cfg::_name_value(
     default: OPTIONAL std::int64
 ) -> std::str
 {
+    SET internal := true;
     USING (
         SELECT '' IF EXISTS default AND default = value
             ELSE prefix ++ name ++ ' := ' ++ <str>value ?? '{}' ++ suffix
@@ -203,6 +207,7 @@ cfg::_name_value(
     default: OPTIONAL std::bool
 ) -> std::str
 {
+    SET internal := true;
     USING (
         SELECT '' IF EXISTS default AND default = value
             ELSE prefix ++ name ++ ' := ' ++ <str>value ?? '{}' ++ suffix
@@ -218,6 +223,7 @@ cfg::_name_value(
     default: OPTIONAL std::str
 ) -> std::str
 {
+    SET internal := true;
     USING (
         SELECT '' IF EXISTS default AND default = value
             ELSE prefix ++
@@ -234,6 +240,7 @@ cfg::_name_value_array(
     value: array<std::str>
 ) -> std::str
 {
+    SET internal := true;
     USING SQL $$
         SELECT
             CASE WHEN array_length(value, 1) > 0 THEN
@@ -250,6 +257,7 @@ cfg::_describe_system_config_as_ddl() -> str
 {
     # The results won't change within a single statement.
     SET volatility := 'STABLE';
+    SET internal := true;
     USING SQL FUNCTION 'edgedb._describe_system_config_as_ddl';
 };
 
@@ -258,6 +266,7 @@ cfg::_config_insert_all_ports() -> str
 {
     # The results won't change within a single statement.
     SET volatility := 'STABLE';
+    SET internal := true;
     USING SQL FUNCTION 'edgedb._config_insert_all_ports';
 };
 
@@ -266,5 +275,6 @@ cfg::_config_insert_all_auth() -> str
 {
     # The results won't change within a single statement.
     SET volatility := 'STABLE';
+    SET internal := true;
     USING SQL FUNCTION 'edgedb._config_insert_all_auth';
 };

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -44,7 +44,7 @@ CREATE SCALAR TYPE schema::TypeModifier
 # Base type for all schema entities.
 CREATE ABSTRACT TYPE schema::Object EXTENDING std::BaseObject {
     CREATE REQUIRED PROPERTY name -> std::str;
-    CREATE REQUIRED PROPERTY is_internal -> std::bool {
+    CREATE REQUIRED PROPERTY internal -> std::bool {
         SET default := false;
     };
     CREATE REQUIRED PROPERTY builtin -> std::bool {

--- a/edb/lib/std/50-constraints.edgeql
+++ b/edb/lib/std/50-constraints.edgeql
@@ -25,6 +25,7 @@ std::_is_exclusive(s: SET OF anytype) -> std::bool
 {
     SET volatility := 'IMMUTABLE';
     SET initial_value := True;
+    SET internal := true;
     USING SQL EXPRESSION;
 };
 

--- a/edb/lib/stdgraphql.edgeql
+++ b/edb/lib/stdgraphql.edgeql
@@ -34,6 +34,7 @@ ALTER TYPE stdgraphql::Mutation {
 
 CREATE FUNCTION stdgraphql::short_name(name: str) -> str {
     SET volatility := 'IMMUTABLE';
+    SET internal := true;
     USING (
         SELECT (
             name[5:] IF name LIKE 'std::%' ELSE

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -142,6 +142,7 @@ sys::__version_internal() -> tuple<major: std::int64,
 {
     # This function reads from a table.
     SET volatility := 'STABLE';
+    SET internal := true;
     USING SQL $$
     SELECT
         (v ->> 'major')::int8,
@@ -222,5 +223,6 @@ sys::_describe_roles_as_ddl() -> str
 {
     # The results won't change within a single statement.
     SET volatility := 'STABLE';
+    SET internal := true;
     USING SQL FUNCTION 'edgedb._describe_roles_as_ddl';
 };

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -174,6 +174,8 @@ class CommonTableExpr(Base):
     query: Query
     # True if this CTE is recursive
     recursive: bool
+    # If specified, determines if CTE is [NOT] MATERIALIZED
+    materialized: typing.Optional[bool]
 
     def __repr__(self):
         return (

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -92,6 +92,11 @@ class SQLSourceGenerator(codegen.SourceGenerator):
                 self.write('RECURSIVE ')
             self.write(common.quote_ident(cte.name))
             self.write(' AS ')
+            if cte.materialized is not None:
+                if cte.materialized:
+                    self.write('MATERIALIZED ')
+                else:
+                    self.write('NOT MATERIALIZED ')
             self.indentation += 1
             self.new_lines = 1
             self.write('(')

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -52,10 +52,12 @@ def compile_ir_to_sql_tree(
     try:
         # Transform to sql tree
         query_params = []
+        type_rewrites = {}
 
         if isinstance(ir_expr, irast.Statement):
             scope_tree = ir_expr.scope_tree
             query_params = list(ir_expr.params)
+            type_rewrites = ir_expr.type_rewrites
             ir_expr = ir_expr.expr
         elif isinstance(ir_expr, irast.ConfigCommand):
             scope_tree = ir_expr.scope_tree
@@ -67,6 +69,7 @@ def compile_ir_to_sql_tree(
             expected_cardinality_one=expected_cardinality_one,
             use_named_params=use_named_params,
             query_params=query_params,
+            type_rewrites=type_rewrites,
             ignore_object_shapes=ignore_shapes,
             explicit_top_cast=explicit_top_cast,
             singleton_mode=singleton_mode)

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -46,6 +46,9 @@ def fini_stmt(
         parent_ctx: context.CompilerContextLevel) -> None:
 
     if stmt is ctx.toplevel_stmt:
+        # Type rewrites go first.
+        stmt.ctes[:0] = list(ctx.type_ctes.values())
+
         stmt.argnames = argmap = ctx.argmap
 
         if not ctx.env.use_named_params:

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -27,6 +27,7 @@ from edb.edgeql import qltypes
 from edb.pgsql import ast as pgast
 
 from . import astutils
+from . import clauses
 from . import context
 from . import dispatch
 from . import pathctx
@@ -235,6 +236,7 @@ def compile_ConfigInsert(
         subctx.expr_exposed = True
         rewritten = _rewrite_config_insert(stmt.expr, ctx=subctx)
         dispatch.compile(rewritten, ctx=subctx)
+        clauses.fini_stmt(ctx.rel, ctx=subctx, parent_ctx=ctx)
 
     return pathctx.get_path_serialized_output(
         ctx.rel, stmt.expr.path_id, env=ctx.env)

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -2449,6 +2449,8 @@ def _generate_database_views(schema):
             (SELECT id FROM edgedb."_SchemaObjectType"
                  WHERE name = 'sys::Database')
                 AS {qi(ptr_col_name(schema, Database, '__type__'))},
+            (datname = {ql(defines.EDGEDB_TEMPLATE_DB)})
+                AS {qi(ptr_col_name(schema, Database, 'internal'))},
             datname AS {qi(ptr_col_name(schema, Database, 'name'))},
             datname AS {qi(ptr_col_name(schema, Database, 'name__internal'))},
             ((d.description)->>'builtin')::bool
@@ -2575,6 +2577,8 @@ def _generate_role_views(schema, *, superuser_role):
                 AS {qi(ptr_col_name(schema, Role, 'inherited_fields'))},
             ((d.description)->>'builtin')::bool
                 AS {qi(ptr_col_name(schema, Role, 'builtin'))},
+            False
+                AS {qi(ptr_col_name(schema, Role, 'internal'))},
             (d.description)->>'password_hash'
                 AS {qi(ptr_col_name(schema, Role, 'password'))}
         FROM

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -227,7 +227,7 @@ class ConstraintMech:
 
     @classmethod
     def schema_constraint_to_backend_constraint(
-            cls, subject, constraint, schema):
+            cls, subject, constraint, schema, context):
         assert constraint.get_subject(schema) is not None
 
         constraint_origin = cls._get_constraint_origin(schema, constraint)
@@ -247,6 +247,7 @@ class ConstraintMech:
             options=qlcompiler.CompilerOptions(
                 anchors={qlast.Subject().name: subject},
                 path_prefix_anchor=path_prefix_anchor,
+                apply_query_rewrites=not context.stdmode,
             ),
         )
 
@@ -276,6 +277,7 @@ class ConstraintMech:
                 schema,
                 options=qlcompiler.CompilerOptions(
                     anchors={qlast.Subject().name: origin_subject},
+                    apply_query_rewrites=not context.stdmode,
                 ),
             )
 

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -301,6 +301,7 @@ class CreateAnnotationValue(
             'is_final',
             not anno.get_inheritable(schema),
         )
+        self.set_attribute_value('internal', True)
         return schema
 
     def _apply_field_ast(self,

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -417,6 +417,7 @@ class ConstraintCommand(
                         path_prefix_anchor=path_prefix_anchor,
                         allow_generic_type_output=True,
                         schema_object_context=self.get_schema_metaclass(),
+                        apply_query_rewrites=not context.stdmode,
                     ),
                 )
 
@@ -443,6 +444,7 @@ class ConstraintCommand(
                     func_params=params,
                     allow_generic_type_output=True,
                     schema_object_context=self.get_schema_metaclass(),
+                    apply_query_rewrites=not context.stdmode,
                 ),
             )
         else:
@@ -726,7 +728,8 @@ class CreateConstraint(
             shortname = sn.shortname_from_fullname(fullname)
             self._populate_concrete_constraint_attrs(
                 schema,
-                subject,
+                context,
+                subject_obj=subject,
                 name=shortname,
                 sourcectx=self.source_context,
                 **props)
@@ -738,6 +741,7 @@ class CreateConstraint(
     def _populate_concrete_constraint_attrs(
         self,
         schema: s_schema.Schema,
+        context: sd.CommandContext,
         subject_obj: Optional[so.Object],
         *,
         name: str,
@@ -842,6 +846,7 @@ class CreateConstraint(
             options=qlcompiler.CompilerOptions(
                 anchors={qlast.Subject().name: subject},
                 path_prefix_anchor=path_prefix_anchor,
+                apply_query_rewrites=not context.stdmode,
             ),
         )
 
@@ -866,6 +871,7 @@ class CreateConstraint(
                     anchors={qlast.Subject().name: subject},
                     path_prefix_anchor=path_prefix_anchor,
                     singletons=frozenset({subject_obj}),
+                    apply_query_rewrites=not context.stdmode,
                 ),
             )
             assert isinstance(final_subjectexpr.irast, ir_ast.Statement)

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -431,6 +431,7 @@ def apply_ddl_script_ex(
     schema: s_schema.Schema,
     modaliases: Optional[Mapping[Optional[str], str]] = None,
     stdmode: bool = False,
+    internal_schema_mode: bool = False,
     testmode: bool = False,
 ) -> Tuple[s_schema.Schema, sd.DeltaRoot]:
 
@@ -445,6 +446,7 @@ def apply_ddl_script_ex(
             schema=schema,
             modaliases=modaliases,
             stdmode=stdmode,
+            internal_schema_mode=internal_schema_mode,
             testmode=testmode,
         )
 
@@ -483,6 +485,7 @@ def _delta_from_ddl(
     schema: s_schema.Schema,
     modaliases: Mapping[Optional[str], str],
     stdmode: bool=False,
+    internal_schema_mode: bool=False,
     testmode: bool=False,
     schema_object_ids: Optional[
         Mapping[Tuple[str, Optional[str]], uuid.UUID]
@@ -494,6 +497,7 @@ def _delta_from_ddl(
         modaliases=modaliases,
         schema=schema,
         stdmode=stdmode,
+        internal_schema_mode=internal_schema_mode,
         testmode=testmode,
         schema_object_ids=schema_object_ids,
         compat_ver=compat_ver,

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -839,6 +839,7 @@ class CommandContext:
         declarative: bool = False,
         stdmode: bool = False,
         testmode: bool = False,
+        internal_schema_mode: bool = False,
         disable_dep_verification: bool = False,
         descriptive_mode: bool = False,
         schema_object_ids: Optional[
@@ -855,6 +856,7 @@ class CommandContext:
         self._modaliases = modaliases if modaliases is not None else {}
         self._localnames = localnames
         self.stdmode = stdmode
+        self.internal_schema_mode = internal_schema_mode
         self.testmode = testmode
         self.descriptive_mode = descriptive_mode
         self.disable_dep_verification = disable_dep_verification
@@ -2002,6 +2004,7 @@ class CreateObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
     ) -> s_schema.Schema:
         schema = super().canonicalize_attributes(schema, context)
         self.set_attribute_value('builtin', context.stdmode)
+        self.set_attribute_value('internal', context.internal_schema_mode)
         return schema
 
     def _get_ast(

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1364,6 +1364,7 @@ class ObjectCommand(
                                 anchors={qlast.Source().name: source},
                                 path_prefix_anchor=qlast.Source().name,
                                 singletons=frozenset([source]),
+                                apply_query_rewrites=not context.stdmode,
                             ),
                         )
 
@@ -2004,7 +2005,10 @@ class CreateObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
     ) -> s_schema.Schema:
         schema = super().canonicalize_attributes(schema, context)
         self.set_attribute_value('builtin', context.stdmode)
-        self.set_attribute_value('internal', context.internal_schema_mode)
+        if not self.has_attribute_value('builtin'):
+            self.set_attribute_value('builtin', context.stdmode)
+        if not self.has_attribute_value('internal'):
+            self.set_attribute_value('internal', context.internal_schema_mode)
         return schema
 
     def _get_ast(

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1072,6 +1072,7 @@ class FunctionCommand(
                 options=qlcompiler.CompilerOptions(
                     allow_generic_type_output=True,
                     schema_object_context=self.get_schema_metaclass(),
+                    apply_query_rewrites=not context.stdmode,
                 ),
             )
         elif field.name == 'nativecode':
@@ -1134,6 +1135,7 @@ class FunctionCommand(
                 # the body of a session_only function can contain calls to
                 # other session_only functions
                 session_mode=session_only,
+                apply_query_rewrites=not context.stdmode,
             ),
         )
 

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -356,6 +356,7 @@ class CreateIndex(
                     anchors={qlast.Subject().name: subject},
                     path_prefix_anchor=path_prefix_anchor,
                     singletons=frozenset(singletons),
+                    apply_query_rewrites=not context.stdmode,
                 ),
             )
 

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -162,6 +162,7 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
         cmd = cls(classname=name)
         cmd.set_attribute_value('script', ddl_text)
         cmd.set_attribute_value('builtin', False)
+        cmd.set_attribute_value('internal', False)
         if parent is not None:
             cmd.set_attribute_value('parents', [parent])
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -391,6 +391,8 @@ class SchemaField(Field[Type_T]):
     default: Any
     #: Whether the field participates in object hash.
     hashable: bool
+    #: Whether it's possible to set the field in DDL.
+    allow_ddl_set: bool
 
     def __init__(
         self,
@@ -740,6 +742,12 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
         inheritable=False,
         simpledelta=False,
         allow_ddl_set=True,
+    )
+
+    internal = SchemaField(
+        bool,
+        default=False,
+        inheritable=True,
     )
 
     # Schema source context for this object

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -746,7 +746,6 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
 
     internal = SchemaField(
         bool,
-        default=False,
         inheritable=True,
     )
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -888,6 +888,7 @@ class PointerCommandOrFragment(
                 path_prefix_anchor=qlast.Source().name,
                 singletons=frozenset([source]),
                 in_ddl_context_name=f'computable {ptr_name!r}',
+                apply_query_rewrites=not context.stdmode,
             ),
         )
 
@@ -1267,6 +1268,7 @@ class PointerCommand(
                     anchors=anchors,
                     path_prefix_anchor=path_prefix_anchor,
                     singletons=frozenset(singletons),
+                    apply_query_rewrites=not context.stdmode,
                 ),
             )
         else:

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -96,6 +96,7 @@ def _run_ddl(
         ddl_text,
         schema=schema,
         stdmode=True,
+        internal_schema_mode=True,
     )
 
     delta.update(cmd.get_subcommands())

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -47,7 +47,7 @@ def write_meta(
     schema: s_schema.Schema,
     context: sd.CommandContext,
     blocks: List[Tuple[str, Dict[str, Any]]],
-    is_internal_reflection: bool,
+    internal_schema_mode: bool,
     stdmode: bool,
 ) -> None:
     """Generate EdgeQL statements populating schema metadata.
@@ -65,7 +65,7 @@ def write_meta(
         blocks:
             A list where a sequence of (edgeql, args) tuples will
             be appended to.
-        is_internal_reflection:
+        internal_schema_mode:
             If True, *cmd* represents internal `schema` modifications.
         stdmode:
             If True, *cmd* represents a standard library bootstrap DDL.
@@ -80,7 +80,7 @@ def _descend(
     schema: s_schema.Schema,
     context: sd.CommandContext,
     blocks: List[Tuple[str, Dict[str, Any]]],
-    is_internal_reflection: bool,
+    internal_schema_mode: bool,
     stdmode: bool,
     prerequisites: bool = False,
 ) -> None:
@@ -115,7 +115,7 @@ def _descend(
                     schema=schema,
                     context=context,
                     blocks=blocks,
-                    is_internal_reflection=is_internal_reflection,
+                    internal_schema_mode=internal_schema_mode,
                     stdmode=stdmode,
                 )
     else:
@@ -128,7 +128,7 @@ def _descend(
                 schema=schema,
                 context=context,
                 blocks=blocks,
-                is_internal_reflection=is_internal_reflection,
+                internal_schema_mode=internal_schema_mode,
                 stdmode=stdmode,
             )
 
@@ -141,7 +141,7 @@ def write_meta_delta_root(
     schema: s_schema.Schema,
     context: sd.CommandContext,
     blocks: List[Tuple[str, Dict[str, Any]]],
-    is_internal_reflection: bool,
+    internal_schema_mode: bool,
     stdmode: bool,
 ) -> None:
     _descend(
@@ -150,7 +150,7 @@ def write_meta_delta_root(
         schema=schema,
         context=context,
         blocks=blocks,
-        is_internal_reflection=is_internal_reflection,
+        internal_schema_mode=internal_schema_mode,
         stdmode=stdmode,
     )
 
@@ -163,7 +163,7 @@ def _build_object_mutation_shape(
         Dict[str, Tuple[s_types.Type, sr_struct.FieldType]]
     ] = None,
     lprops_only: bool = False,
-    is_internal_reflection: bool,
+    internal_schema_mode: bool,
     stdmode: bool,
     var_prefix: str = '',
     schema: s_schema.Schema,
@@ -400,10 +400,6 @@ def _build_object_mutation_shape(
         variables[var_n] = json.dumps(target_value)
 
     if isinstance(cmd, sd.CreateObject):
-        assignments.append(f'is_internal := <bool>$__{var_prefix}is_internal')
-        variables[f'__{var_prefix}is_internal'] = (
-            json.dumps(is_internal_reflection))
-
         if (
             issubclass(mcls, s_scalars.ScalarType)
             and not cmd.get_attribute_value('is_abstract')
@@ -514,7 +510,7 @@ def write_meta_create_object(
     schema: s_schema.Schema,
     context: sd.CommandContext,
     blocks: List[Tuple[str, Dict[str, Any]]],
-    is_internal_reflection: bool,
+    internal_schema_mode: bool,
     stdmode: bool,
 ) -> None:
     _descend(
@@ -524,7 +520,7 @@ def write_meta_create_object(
         context=context,
         blocks=blocks,
         prerequisites=True,
-        is_internal_reflection=is_internal_reflection,
+        internal_schema_mode=internal_schema_mode,
         stdmode=stdmode,
     )
 
@@ -539,7 +535,7 @@ def write_meta_create_object(
             shape, variables = _build_object_mutation_shape(
                 cmd,
                 classlayout=classlayout,
-                is_internal_reflection=is_internal_reflection,
+                internal_schema_mode=internal_schema_mode,
                 stdmode=stdmode,
                 schema=schema,
                 context=context,
@@ -568,7 +564,7 @@ def write_meta_create_object(
                 classlayout=classlayout,
                 lprop_fields=lprops,
                 lprops_only=reflect_as_link,
-                is_internal_reflection=is_internal_reflection,
+                internal_schema_mode=internal_schema_mode,
                 stdmode=stdmode,
                 schema=schema,
                 context=context,
@@ -599,7 +595,7 @@ def write_meta_create_object(
                 shadow_shape, shadow_variables = _build_object_mutation_shape(
                     cmd,
                     classlayout=classlayout,
-                    is_internal_reflection=is_internal_reflection,
+                    internal_schema_mode=internal_schema_mode,
                     lprop_fields=shadow_link_layout.properties,
                     stdmode=stdmode,
                     var_prefix='shadow_',
@@ -653,7 +649,7 @@ def write_meta_create_object(
         schema=schema,
         context=context,
         blocks=blocks,
-        is_internal_reflection=is_internal_reflection,
+        internal_schema_mode=internal_schema_mode,
         stdmode=stdmode,
     )
 
@@ -666,7 +662,7 @@ def write_meta_alter_object(
     schema: s_schema.Schema,
     context: sd.CommandContext,
     blocks: List[Tuple[str, Dict[str, Any]]],
-    is_internal_reflection: bool,
+    internal_schema_mode: bool,
     stdmode: bool,
 ) -> None:
     _descend(
@@ -676,7 +672,7 @@ def write_meta_alter_object(
         context=context,
         blocks=blocks,
         prerequisites=True,
-        is_internal_reflection=is_internal_reflection,
+        internal_schema_mode=internal_schema_mode,
         stdmode=stdmode,
     )
 
@@ -685,7 +681,7 @@ def write_meta_alter_object(
         shape, variables = _build_object_mutation_shape(
             cmd,
             classlayout=classlayout,
-            is_internal_reflection=False,
+            internal_schema_mode=False,
             stdmode=stdmode,
             schema=schema,
             context=context,
@@ -711,7 +707,7 @@ def write_meta_alter_object(
                     schema=schema,
                     blocks=blocks,
                     context=context,
-                    is_internal_reflection=is_internal_reflection,
+                    internal_schema_mode=internal_schema_mode,
                     stdmode=stdmode,
                 )
 
@@ -721,7 +717,7 @@ def write_meta_alter_object(
         schema=schema,
         context=context,
         blocks=blocks,
-        is_internal_reflection=is_internal_reflection,
+        internal_schema_mode=internal_schema_mode,
         stdmode=stdmode,
     )
 
@@ -733,7 +729,7 @@ def _update_lprops(
     schema: s_schema.Schema,
     blocks: List[Tuple[str, Dict[str, Any]]],
     context: sd.CommandContext,
-    is_internal_reflection: bool,
+    internal_schema_mode: bool,
     stdmode: bool,
 ) -> None:
     mcls = cmd.get_schema_metaclass()
@@ -775,7 +771,7 @@ def _update_lprops(
         classlayout=classlayout,
         lprop_fields=lprops,
         lprops_only=True,
-        is_internal_reflection=is_internal_reflection,
+        internal_schema_mode=internal_schema_mode,
         stdmode=stdmode,
         schema=schema,
         context=context,
@@ -830,7 +826,7 @@ def write_meta_delete_object(
     schema: s_schema.Schema,
     context: sd.CommandContext,
     blocks: List[Tuple[str, Dict[str, Any]]],
-    is_internal_reflection: bool,
+    internal_schema_mode: bool,
     stdmode: bool,
 ) -> None:
     _descend(
@@ -840,7 +836,7 @@ def write_meta_delete_object(
         context=context,
         blocks=blocks,
         prerequisites=True,
-        is_internal_reflection=is_internal_reflection,
+        internal_schema_mode=internal_schema_mode,
         stdmode=stdmode,
     )
 
@@ -850,7 +846,7 @@ def write_meta_delete_object(
         schema=schema,
         context=context,
         blocks=blocks,
-        is_internal_reflection=is_internal_reflection,
+        internal_schema_mode=internal_schema_mode,
         stdmode=stdmode,
     )
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -319,6 +319,7 @@ def compile_bootstrap_script(
         expected_cardinality_one=expected_cardinality_one,
         json_parameters=True,
         output_format=output_format,
+        bootstrap_mode=True,
     )
 
     return edbcompiler.compile_edgeql_script(compiler, ctx, eql)
@@ -583,7 +584,7 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
             stdlib.reflschema,
             '''
             UPDATE schema::ScalarType
-            FILTER .builtin AND NOT .is_abstract
+            FILTER .builtin AND NOT (.is_abstract ?? False)
             SET {
                 backend_id := sys::_get_pg_type_for_scalar_type(.id)
             }
@@ -621,7 +622,7 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
         SELECT schema::ScalarType {
             id,
             backend_id,
-        } FILTER .builtin AND NOT .is_abstract;
+        } FILTER .builtin AND NOT (.is_abstract ?? False);
         ''',
         expected_cardinality_one=False,
         single_statement=True,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -517,6 +517,7 @@ class Compiler(BaseCompiler):
                 schema_reflection_mode=True,
                 output_format=enums.IoFormat.JSON,
                 expected_cardinality_one=False,
+                bootstrap_mode=ctx.bootstrap_mode,
             )
 
             return self._compile_ql_script(newctx, eql)
@@ -602,7 +603,10 @@ class Compiler(BaseCompiler):
                 implicit_limit=ctx.implicit_limit,
                 session_mode=session_mode,
                 allow_writing_protected_pointers=ctx.schema_reflection_mode,
-                introspection_schema_rewrites=not ctx.schema_reflection_mode,
+                apply_query_rewrites=(
+                    not ctx.bootstrap_mode
+                    and not ctx.schema_reflection_mode
+                ),
             ),
         )
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_09_30_00_00
+EDGEDB_CATALOG_VERSION = 2020_10_02_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2694,17 +2694,14 @@ class TestExpressions(tb.QueryTestCase):
                     A := (
                         SELECT ObjectType
                         FILTER ObjectType.name ILIKE 'schema::a%'
-                               AND NOT .internal
                     ),
                     D := (
                         SELECT ObjectType
                         FILTER ObjectType.name ILIKE 'schema::d%'
-                               AND NOT .internal
                     ),
                     O := (
                         SELECT ObjectType
                         FILTER ObjectType.name ILIKE 'schema::o%'
-                               AND NOT .internal
                     )
                 SELECT _ := {A, D, O}.name
                 ORDER BY _;

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2694,17 +2694,17 @@ class TestExpressions(tb.QueryTestCase):
                     A := (
                         SELECT ObjectType
                         FILTER ObjectType.name ILIKE 'schema::a%'
-                               AND NOT .is_internal
+                               AND NOT .internal
                     ),
                     D := (
                         SELECT ObjectType
                         FILTER ObjectType.name ILIKE 'schema::d%'
-                               AND NOT .is_internal
+                               AND NOT .internal
                     ),
                     O := (
                         SELECT ObjectType
                         FILTER ObjectType.name ILIKE 'schema::o%'
-                               AND NOT .is_internal
+                               AND NOT .internal
                     )
                 SELECT _ := {A, D, O}.name
                 ORDER BY _;

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -1228,12 +1228,10 @@ class TestIntrospection(tb.QueryTestCase):
                         name,
                         required,
                     }
-                    FILTER NOT .internal
                     ORDER BY .name
                 }
                 FILTER
                     .name IN {'schema::CallableObject', 'schema::Parameter'}
-                    AND NOT .internal
                 ORDER BY .name;
             ''',
             [

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -1228,12 +1228,12 @@ class TestIntrospection(tb.QueryTestCase):
                         name,
                         required,
                     }
-                    FILTEr NOT .is_internal
+                    FILTER NOT .internal
                     ORDER BY .name
                 }
                 FILTER
                     .name IN {'schema::CallableObject', 'schema::Parameter'}
-                    AND NOT .is_internal
+                    AND NOT .internal
                 ORDER BY .name;
             ''',
             [

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -280,9 +280,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(__derived__::expr~51)",
+            "(__derived__::expr~67)",
             "FENCE": {
-                "(__derived__::expr~51).>foo[IS std::str]"
+                "(__derived__::expr~67).>foo[IS std::str]"
             },
             "FENCE": {
                 "(schema::Type)"

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -48,7 +48,13 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     def run_test(self, *, source, spec, expected):
         qltree = qlparser.parse(source)
-        ir = compiler.compile_ast_to_ir(qltree, self.schema)
+        ir = compiler.compile_ast_to_ir(
+            qltree,
+            self.schema,
+            options=compiler.CompilerOptions(
+                apply_query_rewrites=False,
+            )
+        )
 
         root = ir.scope_tree
         if len(root.children) != 1:
@@ -280,9 +286,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(__derived__::expr~67)",
+            "(__derived__::expr~3)",
             "FENCE": {
-                "(__derived__::expr~67).>foo[IS std::str]"
+                "(__derived__::expr~3).>foo[IS std::str]"
             },
             "FENCE": {
                 "(schema::Type)"


### PR DESCRIPTION
This adds the necessary compiler groundwork to implement conditional 
injection of filters into type sets based on schema policy.  This commit
also uses the new framework to filter out schema objects marked as
`internal` from the introspection schema.