### PR TITLE
Don't import setuptools-scm directly

### DIFF
--- a/edb/tools/gen_test_dumps.py
+++ b/edb/tools/gen_test_dumps.py
@@ -28,7 +28,6 @@ import tempfile
 import unittest
 
 import click
-import setuptools_scm
 
 from edb.server import buildmeta
 from edb.server import cluster as edgedb_cluster
@@ -108,9 +107,7 @@ def die(msg):
     help="number of parallel processes to use",
 )
 def gen_test_dumps(*, jobs, tests_dir):
-    version = setuptools_scm.get_version(
-        version_scheme=buildmeta.scm_version_scheme
-    )
+    version = buildmeta.get_version()
     if not jobs:
         jobs = os.cpu_count()
 


### PR DESCRIPTION
`setuptools` is not bundled with the packaged binaries so `setuptools-scm` would fail. Instead, properly use `buildmeta.get_version()`.