### PR TITLE
Fixup expressions when schema objects are renamed

### DIFF
--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -142,7 +142,7 @@ def compile_ConfigInsert(
 
     level = 'SYSTEM' if expr.system else 'SESSION'
     subject = ctx.env.get_track_schema_object(
-        f'cfg::{expr.name.name}', default=None)
+        f'cfg::{expr.name.name}', expr.name, default=None)
     if subject is None:
         raise errors.ConfigurationError(
             f'{expr.name.name!r} is not a valid configuration item',

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -195,6 +195,11 @@ class Environment:
     schema_refs: Set[s_obj.Object]
     """A set of all schema objects referenced by an expression."""
 
+    schema_ref_exprs: Optional[Dict[s_obj.Object, Set[qlast.Base]]]
+    """Map from all schema objects referenced to the ast referants.
+
+    This is used for rewriting expressions in the schema after a rename. """
+
     created_schema_objects: Set[s_obj.Object]
     """A set of all schema objects derived by this compilation."""
 
@@ -231,6 +236,7 @@ class Environment:
         self.view_shapes_metadata = collections.defaultdict(
             irast.ViewShapeMetadata)
         self.schema_refs = set()
+        self.schema_ref_exprs = {} if options.track_schema_ref_exprs else None
         self.created_schema_objects = set()
         self.ptr_ref_cache = PointerRefCache()
         self.type_ref_cache = {}
@@ -238,10 +244,17 @@ class Environment:
         self.pointer_derivation_map = collections.defaultdict(list)
         self.pointer_specified_info = {}
 
+    def add_schema_ref(
+            self, sobj: s_obj.Object, expr: Optional[qlast.Base]) -> None:
+        self.schema_refs.add(sobj)
+        if self.schema_ref_exprs is not None and expr:
+            self.schema_ref_exprs.setdefault(sobj, set()).add(expr)
+
     @overload
     def get_track_schema_object(  # NoQA: F811
         self,
         name: str,
+        expr: Optional[qlast.Base],
         *,
         modaliases: Optional[Mapping[Optional[str], str]] = None,
         type: Optional[Type[s_obj.Object]] = None,
@@ -255,6 +268,7 @@ class Environment:
     def get_track_schema_object(  # NoQA: F811
         self,
         name: str,
+        expr: Optional[qlast.Base],
         *,
         modaliases: Optional[Mapping[Optional[str], str]] = None,
         type: Optional[Type[s_obj.Object]] = None,
@@ -267,6 +281,7 @@ class Environment:
     def get_track_schema_object(  # NoQA: F811
         self,
         name: str,
+        expr: Optional[qlast.Base],
         *,
         modaliases: Optional[Mapping[Optional[str], str]] = None,
         type: Optional[Type[s_obj.Object]] = None,
@@ -278,7 +293,7 @@ class Environment:
                                condition=condition, label=label,
                                default=default)
         if sobj is not None and sobj is not default:
-            self.schema_refs.add(sobj)
+            self.add_schema_ref(sobj, expr)
 
             if (
                 isinstance(sobj, s_types.Type)
@@ -292,13 +307,15 @@ class Environment:
                     scls_type=s_aliases.Alias,
                     field_name='type',
                 )
-                self.schema_refs.update(alias_objs)
+                for obj in alias_objs:
+                    self.add_schema_ref(obj, expr)  # is this right?
 
         return sobj
 
     def get_track_schema_type(
         self,
         name: str,
+        expr: Optional[qlast.Base]=None,
         *,
         modaliases: Optional[Mapping[Optional[str], str]] = None,
         default: Union[None, s_obj.Object, s_obj.NoDefaultT] = s_obj.NoDefault,
@@ -307,7 +324,7 @@ class Environment:
     ) -> s_types.Type:
 
         stype = self.get_track_schema_object(
-            name, modaliases=modaliases, default=default, label=label,
+            name, expr, modaliases=modaliases, default=default, label=label,
             condition=condition, type=s_types.Type,
         )
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -308,7 +308,7 @@ class Environment:
                     field_name='type',
                 )
                 for obj in alias_objs:
-                    self.add_schema_ref(obj, expr)  # is this right?
+                    self.add_schema_ref(obj, expr)
 
         return sobj
 

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -598,7 +598,7 @@ def compile_type_check_op(
 
     if ltype.is_object_type():
         left = setgen.ptr_step_set(
-            left, source=ltype, ptr_name='__type__',
+            left, expr=None, source=ltype, ptr_name='__type__',
             source_context=expr.context, ctx=ctx)
         pathctx.register_set_in_scope(left, ctx=ctx)
         result = None

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -174,7 +174,7 @@ def compile_FunctionCall(
         # We cannot add strong references to functions from
         # abstract constraints, since we cannot know which
         # form of the function is actually used.
-        env.schema_refs.add(func)
+        env.add_schema_ref(func, expr)
 
     func_initial_value: Optional[irast.Set]
 
@@ -473,7 +473,7 @@ def compile_operator(
 
     oper = matched_call.func
     assert isinstance(oper, s_oper.Operator)
-    env.schema_refs.add(oper)
+    env.add_schema_ref(oper, expr=qlexpr)
     oper_name = oper.get_shortname(env.schema)
 
     matched_params = oper.get_params(env.schema)

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -57,6 +57,9 @@ class GlobalCompilerOptions:
     #: Use material types for pointer targets in schema views.
     schema_view_mode: bool = False
 
+    #: Whether to track which subexpressions reference each schema object.
+    track_schema_ref_exprs: bool = False
+
     #: If the expression is being processed in the context of a certain
     #: schema object, i.e. a constraint expression, or a pointer default,
     #: this contains the type of the schema object.

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -45,6 +45,7 @@ from edb.edgeql import qltypes
 from . import context
 
 
+# XXX: COME BACK TO THIS
 def get_schema_object(
         name: Union[str, qlast.BaseObjectRef],
         module: Optional[str]=None, *,
@@ -53,6 +54,8 @@ def get_schema_object(
         label: Optional[str]=None,
         ctx: context.ContextLevel,
         srcctx: Optional[parsing.ParserContext] = None) -> s_obj.Object:
+
+    expr = name if isinstance(name, qlast.BaseObjectRef) else None
 
     if isinstance(name, qlast.ObjectRef):
         if srcctx is None:
@@ -76,7 +79,7 @@ def get_schema_object(
 
     try:
         stype = ctx.env.get_track_schema_object(
-            name=name, modaliases=ctx.modaliases,
+            name=name, expr=expr, modaliases=ctx.modaliases,
             type=item_type, condition=condition,
             label=label,
         )
@@ -327,7 +330,7 @@ def get_union_type(
             or union.get_name(ctx.env.schema).module != '__derived__'
         )
     ):
-        ctx.env.schema_refs.add(union)
+        ctx.env.add_schema_ref(union, expr=None)
 
     return union
 
@@ -350,7 +353,7 @@ def get_intersection_type(
             or intersection.get_name(ctx.env.schema).module != '__derived__'
         )
     ):
-        ctx.env.schema_refs.add(intersection)
+        ctx.env.add_schema_ref(intersection, expr=None)
 
     return intersection
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -224,6 +224,7 @@ def fini_expression(
         schema=ctx.env.schema,
         schema_refs=frozenset(
             ctx.env.schema_refs - ctx.env.created_schema_objects),
+        schema_ref_exprs=ctx.env.schema_ref_exprs,
         new_coll_types=frozenset(
             t for t in ctx.env.created_schema_objects
             if isinstance(t, s_types.Collection) and t != expr_type

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -423,7 +423,8 @@ def _normalize_view_ptr_expr(
     ptrcls: Optional[s_pointers.Pointer]
 
     if compexpr is None:
-        ptrcls = setgen.resolve_ptr(ptrsource, ptrname, ctx=ctx)
+        ptrcls = setgen.resolve_ptr(
+            ptrsource, ptrname, track_ref=lexpr, ctx=ctx)
         if is_polymorphic:
             ptrcls = schemactx.derive_ptr(
                 ptrcls, view_scls,
@@ -568,7 +569,8 @@ def _normalize_view_ptr_expr(
         if (is_mutation
                 and ptrname not in ctx.special_computables_in_mutation_shape):
             # If this is a mutation, the pointer must exist.
-            ptrcls = setgen.resolve_ptr(ptrsource, ptrname, ctx=ctx)
+            ptrcls = setgen.resolve_ptr(
+                ptrsource, ptrname, track_ref=lexpr, ctx=ctx)
 
             base_ptrcls = ptrcls.get_bases(
                 ctx.env.schema).first(ctx.env.schema)
@@ -758,9 +760,9 @@ def _normalize_view_ptr_expr(
             src_scls = view_scls
 
         if ptr_target.is_object_type():
-            base = ctx.env.get_track_schema_object('std::link')
+            base = ctx.env.get_track_schema_object('std::link', expr=None)
         else:
-            base = ctx.env.get_track_schema_object('std::property')
+            base = ctx.env.get_track_schema_object('std::property', expr=None)
 
         if base_ptrcls is not None:
             derive_from = base_ptrcls
@@ -944,10 +946,11 @@ def derive_ptrcls(
             transparent = False
 
             if target_scls.is_object_type():
-                base = ctx.env.get_track_schema_object('std::link')
+                base = ctx.env.get_track_schema_object('std::link', expr=None)
                 view_rptr.base_ptrcls = cast(s_links.Link, base)
             else:
-                base = ctx.env.get_track_schema_object('std::property')
+                base = ctx.env.get_track_schema_object(
+                    'std::property', expr=None)
                 view_rptr.base_ptrcls = cast(s_props.Property, base)
 
         derived_name = schemactx.derive_view_name(
@@ -1116,7 +1119,7 @@ def _get_shape_configuration(
         assert isinstance(stype, s_objtypes.ObjectType)
 
         try:
-            ptr = setgen.resolve_ptr(stype, '__tid__', ctx=ctx)
+            ptr = setgen.resolve_ptr(stype, '__tid__', track_ref=None, ctx=ctx)
         except errors.InvalidReferenceError:
             ql = qlast.ShapeElement(
                 expr=qlast.Path(

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -456,6 +456,8 @@ class Statement(Command):
     view_shapes_metadata: typing.Dict[so.Object, ViewShapeMetadata]
     schema: s_schema.Schema
     schema_refs: typing.FrozenSet[so.Object]
+    schema_ref_exprs: typing.Optional[
+        typing.Dict[so.Object, typing.Set[qlast.Base]]]
     new_coll_types: typing.FrozenSet[s_types.Collection]
     scope_tree: ScopeTreeNode
     source_map: typing.Dict[s_pointers.Pointer,

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1096,6 +1096,8 @@ class AlterConstraint(
         orig_schema = delta_root_ctx.original_schema
         schema = super().apply(schema, context)
         constraint = self.scls
+        if self.metadata_only:
+            return schema
         if (
             not self.constraint_is_effective(schema, constraint)
             and not self.constraint_is_effective(orig_schema, constraint)

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -613,6 +613,9 @@ class AlterFunction(
     ) -> s_schema.Schema:
         schema = super().apply(schema, context)
 
+        if self.metadata_only:
+            return schema
+
         if (
             self.get_attribute_value('volatility') is not None or
             self.get_attribute_value('nativecode') is not None
@@ -2866,6 +2869,9 @@ class AlterProperty(
         schema = s_props.AlterProperty.apply(self, schema, context)
         prop = self.scls
         schema = PropertyMetaCommand.apply(self, schema, context)
+
+        if self.metadata_only:
+            return schema
 
         with context(
                 s_props.PropertyCommandContext(schema, self, prop)) as ctx:

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -386,7 +386,7 @@ class ConstraintCommand(
         track_schema_ref_exprs: bool=False,
     ) -> s_expr.Expression:
 
-        base = None
+        base: Optional[so.Object] = None
         if isinstance(self, AlterConstraint):
             base = self.scls.get_subject(schema)
         else:

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -383,6 +383,7 @@ class ConstraintCommand(
         context: sd.CommandContext,
         field: so.Field[Any],
         value: s_expr.Expression,
+        track_schema_ref_exprs: bool=False,
     ) -> s_expr.Expression:
 
         referrer_ctx = self.get_referrer_context(context)
@@ -418,6 +419,7 @@ class ConstraintCommand(
                         allow_generic_type_output=True,
                         schema_object_context=self.get_schema_metaclass(),
                         apply_query_rewrites=not context.stdmode,
+                        track_schema_ref_exprs=track_schema_ref_exprs,
                     ),
                 )
 
@@ -445,10 +447,12 @@ class ConstraintCommand(
                     allow_generic_type_output=True,
                     schema_object_context=self.get_schema_metaclass(),
                     apply_query_rewrites=not context.stdmode,
+                    track_schema_ref_exprs=track_schema_ref_exprs,
                 ),
             )
         else:
-            return super().compile_expr_field(schema, context, field, value)
+            return super().compile_expr_field(
+                schema, context, field, value, track_schema_ref_exprs)
 
     @classmethod
     def get_inherited_ref_name(

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1267,6 +1267,10 @@ class ObjectCommand(
                     delta_create, cmd_create = ref.init_delta_branch(
                         schema, cmdtype=AlterObject)
                     cmd_create.scls = ref
+                    # Mark it metadata_only so that if it actually gets
+                    # applied, only the metadata is changed but not
+                    # the real underlying schema.
+                    cmd_create.metadata_only = True
 
                     # Compute a dummy value
                     dummy = None
@@ -2356,6 +2360,9 @@ class AlterObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
 
     #: If True, apply the command only if the object exists.
     if_exists = struct.Field(bool, default=False)
+
+    #: If True, only apply changes to properties, not "real" schema changes
+    metadata_only = struct.Field(bool, default=False)
 
     @classmethod
     def _cmd_tree_from_ast(

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1400,10 +1400,18 @@ class ObjectCommand(
                 )
                 cmd.add(rename)
 
-            if not context.canonical and really_apply and delta:
-                self.add(delta)
-
             schema = delta.apply(schema, context)
+
+            if not context.canonical and really_apply and delta:
+                # We need to force the attributes to be resolved so
+                # that expressions get compiled *now* under a schema
+                # where they are correct, and not later, when more
+                # renames may have broken them.
+                assert isinstance(cmd, ObjectCommand)
+                for key, value in cmd.get_resolved_attributes(
+                        schema, context).items():
+                    cmd.set_attribute_value(key, value)
+                self.add(delta)
 
         return schema
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1299,6 +1299,10 @@ class ObjectCommand(
 
                     # Copy own fields into the create command.
                     value = ref.get_explicit_field_value(schema, fn, None)
+                    if isinstance(value, s_expr.Expression):
+                        # Strip the "compiled" out of the expression
+                        value = s_expr.Expression(
+                            text=value.text, origtext=value.origtext)
                     cmd_drop.set_attribute_value(
                         fn, ref.get_dummy_body(schema))
                     cmd_create.set_attribute_value(fn, value)

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -344,15 +344,15 @@ def imprint_expr_context(
 
 
 def get_expr_referrers(schema: s_schema.Schema,
-                       obj: so.Object) -> Dict[so.Object, str]:
+                       obj: so.Object) -> List[Tuple[so.Object, str]]:
     """Return schema referrers with refs in expressions."""
 
     refs = schema.get_referrers_ex(obj)
-    result = {}
+    result = []
 
     for (mcls, fn), referrers in refs.items():
         field = mcls.get_field(fn)
         if issubclass(field.type, (Expression, ExpressionList)):
-            result.update({ref: fn for ref in referrers})
+            result.extend([(ref, fn) for ref in referrers])
 
     return result

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -344,15 +344,16 @@ def imprint_expr_context(
 
 
 def get_expr_referrers(schema: s_schema.Schema,
-                       obj: so.Object) -> List[Tuple[so.Object, str]]:
+                       obj: so.Object) -> Dict[so.Object, List[str]]:
     """Return schema referrers with refs in expressions."""
 
     refs = schema.get_referrers_ex(obj)
-    result = []
+    result: Dict[so.Object, List[str]] = {}
 
     for (mcls, fn), referrers in refs.items():
         field = mcls.get_field(fn)
         if issubclass(field.type, (Expression, ExpressionList)):
-            result.extend([(ref, fn) for ref in referrers])
+            for ref in referrers:
+                result.setdefault(ref, []).append(fn)
 
     return result

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -135,6 +135,10 @@ class Expression(struct.MixedStruct, s_abc.ObjectContainer, s_abc.Expression):
         )
 
     @classmethod
+    def not_compiled(cls: Type[Expression], expr: Expression) -> Expression:
+        return Expression(text=expr.text, origtext=expr.origtext)
+
+    @classmethod
     def compiled(
         cls: Type[Expression],
         expr: Expression,

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1079,6 +1079,7 @@ class FunctionCommand(
         context: sd.CommandContext,
         field: so.Field[Any],
         value: expr.Expression,
+        track_schema_ref_exprs: bool=False,
     ) -> expr.Expression:
         if field.name == 'initial_value':
             return type(value).compiled(
@@ -1088,12 +1089,15 @@ class FunctionCommand(
                     allow_generic_type_output=True,
                     schema_object_context=self.get_schema_metaclass(),
                     apply_query_rewrites=not context.stdmode,
+                    track_schema_ref_exprs=track_schema_ref_exprs,
                 ),
             )
         elif field.name == 'nativecode':
-            return self.compile_function(schema, context, value)
+            return self.compile_function(
+                schema, context, value, track_schema_ref_exprs)
         else:
-            return super().compile_expr_field(schema, context, field, value)
+            return super().compile_expr_field(
+                schema, context, field, value, track_schema_ref_exprs)
 
     def _get_attribute_value(
         self,
@@ -1123,6 +1127,7 @@ class FunctionCommand(
         schema: s_schema.Schema,
         context: sd.CommandContext,
         body: expr.Expression,
+        track_schema_ref_exprs: bool=False,
     ) -> expr.Expression:
         from edb.ir import ast as irast
 
@@ -1151,6 +1156,7 @@ class FunctionCommand(
                 # other session_only functions
                 session_mode=session_only,
                 apply_query_rewrites=not context.stdmode,
+                track_schema_ref_exprs=track_schema_ref_exprs,
             ),
         )
 

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -265,59 +265,6 @@ class IndexCommand(
         else:
             return None
 
-
-class CreateIndex(
-    IndexCommand,
-    referencing.CreateReferencedInheritingObject[Index],
-):
-    astnode = qlast.CreateIndex
-    referenced_astnode = qlast.CreateIndex
-
-    @classmethod
-    def _cmd_tree_from_ast(
-        cls,
-        schema: s_schema.Schema,
-        astnode: qlast.DDLOperation,
-        context: sd.CommandContext,
-    ) -> sd.Command:
-        cmd = super()._cmd_tree_from_ast(schema, astnode, context)
-        assert isinstance(astnode, qlast.CreateIndex)
-        orig_text = cls.get_orig_expr_text(schema, astnode, 'expr')
-        cmd.set_attribute_value(
-            'expr',
-            s_expr.Expression.from_ast(
-                astnode.expr,
-                schema,
-                context.modaliases,
-                orig_text=orig_text,
-            ),
-        )
-
-        return cmd
-
-    @classmethod
-    def as_inherited_ref_ast(
-        cls,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-        name: str,
-        parent: referencing.ReferencedObject,
-    ) -> qlast.ObjectDDL:
-        assert isinstance(parent, Index)
-        nref = cls.get_inherited_ref_name(schema, context, parent, name)
-        astnode_cls = cls.referenced_astnode
-
-        expr = parent.get_expr(schema)
-        if expr is not None:
-            expr_ql = edgeql.parse_fragment(expr.origtext)
-        else:
-            expr_ql = None
-
-        return astnode_cls(
-            name=nref,
-            expr=expr_ql,
-        )
-
     def compile_expr_field(
         self,
         schema: s_schema.Schema,
@@ -373,6 +320,59 @@ class CreateIndex(
         else:
             return super().compile_expr_field(
                 schema, context, field, value, track_schema_ref_exprs)
+
+
+class CreateIndex(
+    IndexCommand,
+    referencing.CreateReferencedInheritingObject[Index],
+):
+    astnode = qlast.CreateIndex
+    referenced_astnode = qlast.CreateIndex
+
+    @classmethod
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.Command:
+        cmd = super()._cmd_tree_from_ast(schema, astnode, context)
+        assert isinstance(astnode, qlast.CreateIndex)
+        orig_text = cls.get_orig_expr_text(schema, astnode, 'expr')
+        cmd.set_attribute_value(
+            'expr',
+            s_expr.Expression.from_ast(
+                astnode.expr,
+                schema,
+                context.modaliases,
+                orig_text=orig_text,
+            ),
+        )
+
+        return cmd
+
+    @classmethod
+    def as_inherited_ref_ast(
+        cls,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        name: str,
+        parent: referencing.ReferencedObject,
+    ) -> qlast.ObjectDDL:
+        assert isinstance(parent, Index)
+        nref = cls.get_inherited_ref_name(schema, context, parent, name)
+        astnode_cls = cls.referenced_astnode
+
+        expr = parent.get_expr(schema)
+        if expr is not None:
+            expr_ql = edgeql.parse_fragment(expr.origtext)
+        else:
+            expr_ql = None
+
+        return astnode_cls(
+            name=nref,
+            expr=expr_ql,
+        )
 
 
 class RenameIndex(

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -324,6 +324,7 @@ class CreateIndex(
         context: sd.CommandContext,
         field: so.Field[Any],
         value: s_expr.Expression,
+        track_schema_ref_exprs: bool=False,
     ) -> s_expr.Expression:
         from . import objtypes as s_objtypes
 
@@ -357,6 +358,7 @@ class CreateIndex(
                     path_prefix_anchor=path_prefix_anchor,
                     singletons=frozenset(singletons),
                     apply_query_rewrites=not context.stdmode,
+                    track_schema_ref_exprs=track_schema_ref_exprs,
                 ),
             )
 
@@ -369,7 +371,8 @@ class CreateIndex(
 
             return expr
         else:
-            return super().compile_expr_field(schema, context, field, value)
+            return super().compile_expr_field(
+                schema, context, field, value, track_schema_ref_exprs)
 
 
 class RenameIndex(

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1235,6 +1235,7 @@ class PointerCommand(
         context: sd.CommandContext,
         field: so.Field[Any],
         value: s_expr.Expression,
+        track_schema_ref_exprs: bool=False,
     ) -> s_expr.Expression:
         from . import sources as s_sources
 
@@ -1269,10 +1270,12 @@ class PointerCommand(
                     path_prefix_anchor=path_prefix_anchor,
                     singletons=frozenset(singletons),
                     apply_query_rewrites=not context.stdmode,
+                    track_schema_ref_exprs=track_schema_ref_exprs,
                 ),
             )
         else:
-            return super().compile_expr_field(schema, context, field, value)
+            return super().compile_expr_field(
+                schema, context, field, value, track_schema_ref_exprs)
 
     def _apply_field_ast(
         self,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1324,7 +1324,7 @@ class SetPointerType(
         # alter to the type that is compatible (i.e. does not change)
         # with all expressions it is used in.
         vn = scls.get_verbosename(schema, with_parent=True)
-        schema, finalize_ast = self._propagate_if_expr_refs(
+        schema = self._propagate_if_expr_refs(
             schema, context, action=f'alter the type of {vn}')
 
         if not context.canonical:

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6619,8 +6619,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         """)
 
         await self.con.execute("""
-            WITH MODULE test
-            ALTER TYPE Note {
+            ALTER TYPE test::Note {
                 ALTER PROPERTY note {
                     RENAME TO remark;
                 }
@@ -6667,7 +6666,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         self.assertEqual(res.count("note"), 0)
         self.assertEqual(res.count("remark"), 2)
 
-    @test.xfail('''constraints aren't supported yet''')
     async def test_edgeql_ddl_rename_ref_03(self):
         await self.con.execute("""
             WITH MODULE test

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6666,3 +6666,54 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         self.assertEqual(res.count("note"), 0)
         self.assertEqual(res.count("remark"), 2)
+
+    @test.xfail('''constraints aren't supported yet''')
+    async def test_edgeql_ddl_rename_ref_03(self):
+        await self.con.execute("""
+            WITH MODULE test
+            CREATE TYPE Note {
+                CREATE PROPERTY note -> str;
+                CREATE CONSTRAINT exclusive ON (__subject__.note);
+            };
+        """)
+
+        await self.con.execute("""
+            WITH MODULE test
+            ALTER TYPE Note {
+                ALTER PROPERTY note {
+                    RENAME TO remark;
+                }
+            }
+        """)
+
+        res = await self.con.query_one("""
+            DESCRIBE MODULE test
+        """)
+
+        self.assertEqual(res.count("note"), 0)
+        self.assertEqual(res.count("remark"), 2)
+
+    async def test_edgeql_ddl_rename_ref_04(self):
+        await self.con.execute("""
+            WITH MODULE test
+            CREATE TYPE Note {
+                CREATE PROPERTY note -> str;
+                CREATE INDEX ON (.note);
+            };
+        """)
+
+        await self.con.execute("""
+            WITH MODULE test
+            ALTER TYPE Note {
+                ALTER PROPERTY note {
+                    RENAME TO remark;
+                }
+            }
+        """)
+
+        res = await self.con.query_one("""
+            DESCRIBE MODULE test
+        """)
+
+        self.assertEqual(res.count("note"), 0)
+        self.assertEqual(res.count("remark"), 2)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6666,6 +6666,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         self.assertEqual(res.count("note"), 0)
         self.assertEqual(res.count("remark"), 2)
 
+        await self.con.execute("""
+            ALTER TYPE test::Object2
+            DROP PROPERTY x;
+        """)
+
     async def test_edgeql_ddl_rename_ref_03(self):
         await self.con.execute("""
             WITH MODULE test
@@ -6691,6 +6696,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         self.assertEqual(res.count("note"), 0)
         self.assertEqual(res.count("remark"), 2)
 
+        await self.con.execute("""
+            ALTER TYPE test::Note
+            DROP CONSTRAINT exclusive ON (__subject__.remark);
+        """)
+
     async def test_edgeql_ddl_rename_ref_04(self):
         await self.con.execute("""
             WITH MODULE test
@@ -6715,6 +6725,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         self.assertEqual(res.count("note"), 0)
         self.assertEqual(res.count("remark"), 2)
+
+        await self.con.execute("""
+            ALTER TYPE test::Note
+            DROP INDEX ON (.note);
+        """)
 
     @test.xfail('''
         Fails doing the delete with function does not exist, due to

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6604,7 +6604,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ['test::Post', 'test::Video']
         )
 
-    async def test_edgeql_ddl_rename_w_func_ref_01(self):
+    async def test_edgeql_ddl_rename_ref_01(self):
         await self.con.execute("""
             WITH MODULE test
             CREATE TYPE Note {
@@ -6613,37 +6613,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             WITH MODULE test
             CREATE FUNCTION hello(x: Note) ->  str {
-                USING (SELECT ('hello ' ++ x.note))
-            }
-        """)
-
-        await self.con.execute("""
-            WITH MODULE test
-            ALTER TYPE Note {
-                ALTER PROPERTY note {
-                    RENAME TO remark;
-                }
-            }
-            """)
-
-        res = await self.con.query_one("""
-            DESCRIBE MODULE test
-        """)
-
-        self.assertNotIn(res, "note")
-        self.assertEqual(res.count("remark"), 2)
-
-    # honestly this should just merge with the first test
-    async def test_edgeql_ddl_rename_w_func_ref_02(self):
-        await self.con.execute("""
-            WITH MODULE test
-            CREATE TYPE Note {
-                CREATE PROPERTY note -> str;
-            };
-
-            WITH MODULE test
-            CREATE FUNCTION hello(x: Note) ->  str {
-                USING (SELECT ('note ' ++ x.note))
+                USING (SELECT ('note ' ++ x.note ++
+                               (SELECT Note.note LIMIT 1)))
             }
         """)
 
@@ -6661,4 +6632,37 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         """)
 
         self.assertEqual(res.count("note"), 1)
+        self.assertEqual(res.count("remark"), 3)
+
+    async def test_edgeql_ddl_rename_ref_02(self):
+        await self.con.execute("""
+            WITH MODULE test
+            CREATE TYPE Note {
+                CREATE PROPERTY note -> str;
+            };
+
+            WITH MODULE test
+            CREATE TYPE Object2 {
+                CREATE REQUIRED PROPERTY x -> str {
+                    SET default := (
+                        SELECT Note.note LIMIT 1
+                    )
+                }
+            };
+        """)
+
+        await self.con.execute("""
+            WITH MODULE test
+            ALTER TYPE Note {
+                ALTER PROPERTY note {
+                    RENAME TO remark;
+                }
+            }
+        """)
+
+        res = await self.con.query_one("""
+            DESCRIBE MODULE test
+        """)
+
+        self.assertEqual(res.count("note"), 0)
         self.assertEqual(res.count("remark"), 2)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4067,6 +4067,29 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         """])
 
+    @test.xfail("""
+        The diff generates:
+          ALTER PROPERTY, CREATE CONSTRAINT, DELETE CONSTRAINT
+        which fails, because the alter renames the constraint and so
+        collides with the CREATE. We should instead always put the DELETE
+        first or (more ideally) realize that the ALTER is sufficient.
+    """)
+    def test_schema_migrations_equivalence_constraints_01(self):
+        # Irritatingly, if we start with it named note and rename to
+        # remark, it works! Probably the ordering ends up comparing
+        # the names at some point to provide a kind of ersatz determinism.
+        self._assert_migration_equivalence([r"""
+            type Note {
+                required property remark -> str;
+                constraint exclusive on (__subject__.remark);
+            };
+        """, r"""
+            type Note {
+                required property note -> str;
+                constraint exclusive on (__subject__.note);
+            };
+        """])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
We do this by adding infrastructure to track where in the AST
references to schema objects appear, and then using that to rewrite
expressions when we need to do a rename.

There are still some gaps in this, but I wanted to get something up
for review as a start:
 * Renaming types used in function arguments makes it impossible to
   delete the functions (since the argument types are encoded in
   the underlying name and I haven't implemented renaming there yet).
 * Migrations that rename a property used in an object constraint
   don't always work, since the DDL-based recompilation can interfere
   with how the migration wants to do it.
 * Lots of cases don't have tests written yet.

This is much of the way on #1841.