### PR TITLE
Fixed bootstrapping with reserved keywords in role name, deprecate --default-database and -user

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1093,26 +1093,27 @@ async def _bootstrap(
         cluster=cluster,
         objid=superuser_db.id,
     )
+    if args['default_database_user']:
+        await _ensure_edgedb_role(
+            cluster,
+            pgconn,
+            args['default_database_user'],
+            membership=membership,
+            is_superuser=True,
+        )
 
-    await _ensure_edgedb_role(
-        cluster,
-        pgconn,
-        args['default_database_user'],
-        membership=membership,
-        is_superuser=True,
-    )
+        await _execute(
+            pgconn,
+            f"SET ROLE {qi(args['default_database_user'])};",
+        )
 
-    await _execute(
-        pgconn,
-        f"SET ROLE {qi(args['default_database_user'])};",
-    )
-
-    await _ensure_edgedb_database(
-        pgconn,
-        args['default_database'],
-        args['default_database_user'],
-        cluster=cluster,
-    )
+    if args['default_database']:
+        await _ensure_edgedb_database(
+            pgconn,
+            args['default_database'],
+            args['default_database_user'] or edbdef.EDGEDB_SUPERUSER,
+            cluster=cluster,
+        )
 
 
 async def ensure_bootstrapped(

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -59,6 +59,7 @@ from edb.pgsql import common as pg_common
 from edb.pgsql import dbops
 from edb.pgsql import delta as delta_cmds
 from edb.pgsql import metaschema
+from edb.pgsql.common import quote_ident as qi
 
 from edgedb import scram
 
@@ -1038,7 +1039,7 @@ async def _bootstrap(
 
     await _execute(
         pgconn,
-        f'SET ROLE {edbdef.EDGEDB_SUPERUSER};',
+        f'SET ROLE {qi(edbdef.EDGEDB_SUPERUSER)};',
     )
     cluster.set_default_session_authorization(edbdef.EDGEDB_SUPERUSER)
 
@@ -1103,7 +1104,7 @@ async def _bootstrap(
 
     await _execute(
         pgconn,
-        f"SET ROLE {args['default_database_user']};",
+        f"SET ROLE {qi(args['default_database_user'])};",
     )
 
     await _ensure_edgedb_database(

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -256,6 +256,8 @@ class Cluster:
         conn_args = self.get_connect_args().copy()
         conn_args['host'] = str(self._runstate_dir)
         conn_args['admin'] = True
+        conn_args['user'] = 'edgedb'
+        conn_args['database'] = 'edgedb'
         conn = self.connect(**conn_args)
 
         try:

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -256,8 +256,8 @@ class Cluster:
         conn_args = self.get_connect_args().copy()
         conn_args['host'] = str(self._runstate_dir)
         conn_args['admin'] = True
-        conn_args['user'] = 'edgedb'
-        conn_args['database'] = 'edgedb'
+        conn_args['user'] = edgedb_defines.EDGEDB_SUPERUSER
+        conn_args['database'] = edgedb_defines.EDGEDB_SUPERUSER_DB
         conn = self.connect(**conn_args)
 
         try:

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -200,8 +200,8 @@ def _run_server(cluster, args: ServerConfig,
     if bootstrap_script_text is not None:
         bootstrap_script = server.StartupScript(
             text=bootstrap_script_text,
-            database=args.default_database,
-            user=args.default_database_user,
+            database=edgedb_defines.EDGEDB_SUPERUSER,
+            user=edgedb_defines.EDGEDB_SUPERUSER_DB,
         )
     else:
         bootstrap_script = None

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -23,7 +23,6 @@ from typing import *
 import asyncio
 import contextlib
 import errno
-import getpass
 import logging
 import os
 import os.path
@@ -417,8 +416,8 @@ class ServerConfig(typing.NamedTuple):
     bootstrap_only: bool
     bootstrap_command: str
     bootstrap_script: pathlib.Path
-    default_database: str
-    default_database_user: str
+    default_database: Optional[str]
+    default_database_user: Optional[str]
     devmode: bool
     testmode: bool
     bind_address: str
@@ -494,16 +493,16 @@ _server_options = [
         type=str, metavar='DEST', default='stderr'),
     click.option(
         '--bootstrap', is_flag=True, hidden=True,
-        help='bootstrap the database cluster and exit'),
+        help='[DEPRECATED] bootstrap the database cluster and exit'),
     click.option(
         '--bootstrap-only', is_flag=True,
         help='bootstrap the database cluster and exit'),
     click.option(
-        '--default-database', type=str, default=getpass.getuser(),
-        help='the name of the default database to create'),
+        '--default-database', type=str, hidden=True,
+        help='[DEPRECATED] the name of the default database to create'),
     click.option(
-        '--default-database-user', type=str, default=getpass.getuser(),
-        help='the name of the default database owner'),
+        '--default-database-user', type=str, hidden=True,
+        help='[DEPRECATED] the name of the default database owner'),
     click.option(
         '--bootstrap-command', metavar="QUERIES",
         help='run the commands when initializing the database. '
@@ -589,6 +588,36 @@ def server_main(*, insecure=False, bootstrap, **kwargs):
             DeprecationWarning,
         )
         kwargs['bootstrap_only'] = True
+
+    if kwargs['default_database_user']:
+        if kwargs['default_database_user'] == 'edgedb':
+            warnings.warn(
+                "Option `--default-database-user` is deprecated."
+                " Role `edgedb` is always created and"
+                " no role named after unix user is created any more.",
+                DeprecationWarning,
+            )
+        else:
+            warnings.warn(
+                "Option `--default-database-user` is deprecated."
+                " Please create the role explicitly.",
+                DeprecationWarning,
+            )
+
+    if kwargs['default_database']:
+        if kwargs['default_database'] == 'edgedb':
+            warnings.warn(
+                "Option `--default-database` is deprecated."
+                " Database `edgedb` is always created and"
+                " no database named after unix user is created any more.",
+                DeprecationWarning,
+            )
+        else:
+            warnings.warn(
+                "Option `--default-database` is deprecated."
+                " Please create the database explicitly.",
+                DeprecationWarning,
+            )
 
     if kwargs['temp_dir']:
         if kwargs['data_dir']:

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -202,10 +202,13 @@ def _run_server(cluster, args: ServerConfig,
     if bootstrap_script_text is not None:
         bootstrap_script = server.StartupScript(
             text=bootstrap_script_text,
-            database=args.default_database or edgedb_defines.EDGEDB_SUPERUSER,
+            database=(
+                args.default_database or
+                edgedb_defines.EDGEDB_SUPERUSER_DB
+            ),
             user=(
                 args.default_database_user or
-                edgedb_defines.EDGEDB_SUPERUSER_DB
+                edgedb_defines.EDGEDB_SUPERUSER
             ),
         )
     else:

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -202,8 +202,11 @@ def _run_server(cluster, args: ServerConfig,
     if bootstrap_script_text is not None:
         bootstrap_script = server.StartupScript(
             text=bootstrap_script_text,
-            database=edgedb_defines.EDGEDB_SUPERUSER,
-            user=edgedb_defines.EDGEDB_SUPERUSER_DB,
+            database=args.default_database or edgedb_defines.EDGEDB_SUPERUSER,
+            user=(
+                args.default_database_user or
+                edgedb_defines.EDGEDB_SUPERUSER_DB
+            ),
         )
     else:
         bootstrap_script = None

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -44,6 +44,8 @@ import setproctitle
 from edb.common import devmode
 from edb.common import exceptions
 
+from edb.server import defines as edgedb_defines
+
 from . import buildmeta
 from . import cluster as edgedb_cluster
 from . import daemon

--- a/edb/tools/wipe.py
+++ b/edb/tools/wipe.py
@@ -124,7 +124,7 @@ async def do_wipe(
         await pgconn.close()
 
     stmts = [
-        f'SET ROLE {edbdef.EDGEDB_SUPERUSER}',
+        f'SET ROLE {qi(edbdef.EDGEDB_SUPERUSER)}',
     ]
 
     pgconn = await cluster.connect()

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -44,6 +44,8 @@ class TestServerOps(tb.TestCase):
         async def read_runtime_info(stdout: asyncio.StreamReader):
             while True:
                 line = await stdout.readline()
+                if not line:
+                    raise RuntimeError("EdgeDB server terminated")
                 if line.startswith(b'EDGEDB_SERVER_DATA:'):
                     break
 

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -86,10 +86,12 @@ class TestServerOps(tb.TestCase):
 
             self.assertTrue(os.path.exists(runstate_dir))
 
-            con1 = await edgedb.async_connect(host=runstate_dir, port=port)
+            con1 = await edgedb.async_connect(
+                user='edgedb', host=runstate_dir, port=port)
             self.assertEqual(await con1.query_one('SELECT 1'), 1)
 
-            con2 = await edgedb.async_connect(host=runstate_dir, port=port)
+            con2 = await edgedb.async_connect(
+                user='edgedb', host=runstate_dir, port=port)
             self.assertEqual(await con2.query_one('SELECT 1'), 1)
 
             await con1.aclose()
@@ -102,7 +104,8 @@ class TestServerOps(tb.TestCase):
                 # the cluster was started with an "--auto-shutdown"
                 # option, we expect this connection to be rejected
                 # and the cluster to be shutdown soon.
-                await edgedb.async_connect(host=runstate_dir, port=port)
+                await edgedb.async_connect(
+                    user='edgedb', host=runstate_dir, port=port)
 
             i = 600 * 5  # Give it up to 5 minutes to cleanup.
             while i > 0:


### PR DESCRIPTION
Discussed in #1879 