### PR TITLE
Add support for chained schemas

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -783,7 +783,7 @@ def type_intersection_set(
     arg_type = get_set_type(source_set, ctx=ctx)
 
     result = schemactx.apply_intersection(arg_type, stype, ctx=ctx)
-    if result.stype is arg_type:
+    if result.stype == arg_type:
         return source_set
 
     poly_set = new_set(stype=result.stype, ctx=ctx)

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -334,7 +334,7 @@ def _process_view(
             ctx.env.view_shapes[source].append((ptrcls, shape_op))
 
     if (view_rptr is not None and view_rptr.ptrcls is not None and
-            view_scls is not stype):
+            view_scls != stype):
         ctx.env.schema = view_scls.set_field_value(
             ctx.env.schema, 'rptr', view_rptr.ptrcls)
 

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -205,7 +205,7 @@ def type_to_typeref(
         schema, material_type = t.material_type(schema)
 
         material_typeref: Optional[irast.TypeRef]
-        if material_type is not t:
+        if material_type != t:
             material_typeref = type_to_typeref(
                 schema,
                 material_type,
@@ -218,7 +218,7 @@ def type_to_typeref(
         if (isinstance(material_type, s_scalars.ScalarType)
                 and not material_type.get_is_abstract(schema)):
             base_type = material_type.get_topmost_concrete_base(schema)
-            if base_type is material_type:
+            if base_type == material_type:
                 base_typeref = None
             else:
                 assert isinstance(base_type, s_types.Type)
@@ -282,7 +282,7 @@ def type_to_typeref(
     elif isinstance(t, s_types.Tuple) and t.is_named(schema):
         schema, material_type = t.material_type(schema)
 
-        if material_type is not t:
+        if material_type != t:
             material_typeref = type_to_typeref(
                 schema, material_type, cache=cache
             )
@@ -304,7 +304,7 @@ def type_to_typeref(
     else:
         schema, material_type = t.material_type(schema)
 
-        if material_type is not t:
+        if material_type != t:
             material_typeref = type_to_typeref(
                 schema, material_type, cache=cache
             )
@@ -517,7 +517,7 @@ def ptrref_from_ptrcls(  # NoQA: F811
 
     schema, material_ptrcls = ptrcls.material_type(schema)
     material_ptr: Optional[irast.BasePointerRef]
-    if material_ptrcls is not None and material_ptrcls is not ptrcls:
+    if material_ptrcls is not None and material_ptrcls != ptrcls:
         material_ptr = ptrref_from_ptrcls(
             ptrcls=material_ptrcls,
             direction=direction,

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -243,7 +243,8 @@ class CastCommand(sd.QualifiedObjectCommand[Cast],
             schema=schema,
         )
 
-        return get_cast_fullname(schema, 'std', from_type, to_type)
+        module = 'std' if context.stdmode else '__derived__'
+        return get_cast_fullname(schema, module, from_type, to_type)
 
     def canonicalize_attributes(
         self,

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -143,7 +143,7 @@ def delta_schemas(
 
     if schema_a is None:
         if include_std_diff:
-            schema_a = s_schema.Schema()
+            schema_a = s_schema.FlatSchema()
         else:
             schema_a = schema_b
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -953,7 +953,7 @@ class CommandContext:
             True if *obj* is being deleted in this context.
         """
         return any(isinstance(ctx.op, DeleteObject)
-                   and ctx.op.scls is obj for ctx in self.stack)
+                   and ctx.op.scls == obj for ctx in self.stack)
 
     def push(self, token: CommandContextToken[Command]) -> None:
         self.stack.append(token)

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -276,13 +276,12 @@ class CommandMeta(
             mapping[astnode] = cast(Type["Command"], cls)
 
 
-_void = object()
-
-
 # We use _DummyObject for contexts where an instance of an object is
 # required by type signatures, and the actual reference will be quickly
 # replaced by a real object.
-_dummy_object = so.Object(_private_init=True)
+_dummy_object = so.Object(
+    _private_id=uuid.UUID('C0FFEE00-C0DE-0000-0000-000000000000'),
+)
 
 
 Command_T = TypeVar("Command_T", bound="Command")

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -61,18 +61,18 @@ def delta_objects(
 
     delta = DeltaRoot()
 
-    oldkeys = {o.id: o.hash_criteria(old_schema) for o in old}
-    newkeys = {o.id: o.hash_criteria(new_schema) for o in new}
+    oldkeys = {o: o.hash_criteria(old_schema) for o in old}
+    newkeys = {o: o.hash_criteria(new_schema) for o in new}
 
     unchanged = set(oldkeys.values()) & set(newkeys.values())
 
     old = ordered.OrderedSet[so.Object_T](
-        o for o in old
-        if oldkeys[o.id] not in unchanged
+        o for o, checksum in oldkeys.items()
+        if checksum not in unchanged
     )
     new = ordered.OrderedSet[so.Object_T](
-        o for o in new
-        if newkeys[o.id] not in unchanged
+        o for o, checksum in newkeys.items()
+        if checksum not in unchanged
     )
 
     oldnames = {o.get_name(old_schema) for o in old}

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -396,6 +396,8 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
         old_bases: List[so.InheritingObjectT],
         new_bases: List[so.InheritingObjectT],
     ) -> Tuple[s_schema.Schema, AlterInheritingObject[so.InheritingObjectT]]:
+        from . import referencing as s_referencing
+
         old_base_names = [b.get_name(schema) for b in old_bases]
         new_base_names = [b.get_name(schema) for b in new_bases]
 
@@ -412,8 +414,8 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
             schema, new_bases)
         schema = scls.set_field_value(schema, 'bases', new_bases_coll)
         ancestors = so.compute_ancestors(schema, scls)
-        ancestors_coll = so.ObjectList[so.InheritingObjectT].create(
-            schema, ancestors)
+        ancestors_coll = so.ObjectList[
+            s_referencing.ReferencedInheritingObject].create(schema, ancestors)
 
         if rebase is not None:
             rebase_cmd = rebase(

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -199,7 +199,7 @@ class LinkCommand(lproperties.PropertySourceCommand,
         schema: s_schema.Schema,
         astnode: qlast.CreateConcretePointer,
         context: sd.CommandContext,
-        target_ref: Union[so.Object, so.ObjectShell],
+        target_ref: Union[so.Object, so.ObjectShell, pointers.ComputableRef],
     ) -> None:
         assert astnode.target is not None
         slt = SetLinkType(classname=self.classname, type=target_ref)

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -208,7 +208,7 @@ class PropertyCommand(pointers.PointerCommand,
         schema: s_schema.Schema,
         astnode: qlast.CreateConcretePointer,
         context: sd.CommandContext,
-        target_ref: Union[so.Object, so.ObjectShell],
+        target_ref: Union[so.Object, so.ObjectShell, pointers.ComputableRef],
     ) -> None:
         assert astnode.target is not None
         spt = SetPropertyType(classname=self.classname, type=target_ref)

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -2718,8 +2718,10 @@ def _serialize_to_markup(o: Object, *, ctx: markup.Context) -> markup.Markup:
 
 
 def _merge_lineage(
-    schema: s_schema.Schema, obj: Object, lineage: Iterable[Any]
-) -> List[Any]:
+    schema: s_schema.Schema,
+    obj: InheritingObjectT,
+    lineage: Iterable[List[InheritingObjectT]],
+) -> List[InheritingObjectT]:
     result: List[Any] = []
 
     while True:
@@ -2729,8 +2731,7 @@ def _merge_lineage(
 
         for line in nonempty:
             candidate = line[0]
-            tails = [m for m in nonempty
-                     if id(candidate) in {id(c) for c in m[1:]}]
+            tails = [m for m in nonempty if candidate in m[1:]]
             if not tails:
                 break
         else:
@@ -2742,15 +2743,16 @@ def _merge_lineage(
         result.append(candidate)
 
         for line in nonempty:
-            if line[0] is candidate:
+            if line[0] == candidate:
                 del line[0]
 
     return result
 
 
 def compute_lineage(
-    schema: s_schema.Schema, obj: InheritingObject
-) -> List[Any]:
+    schema: s_schema.Schema,
+    obj: InheritingObjectT,
+) -> List[InheritingObjectT]:
     bases = tuple(obj.get_bases(schema).objects(schema))
     lineage = [[obj]]
 
@@ -2761,8 +2763,9 @@ def compute_lineage(
 
 
 def compute_ancestors(
-    schema: s_schema.Schema, obj: InheritingObject
-) -> List[Any]:
+    schema: s_schema.Schema,
+    obj: InheritingObjectT,
+) -> List[InheritingObjectT]:
     return compute_lineage(schema, obj)[1:]
 
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -881,7 +881,7 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
 
         id = cls._prepare_id(id, data)
         scls = cls._create_from_id(id)
-        schema = schema._add(id, scls, obj_data)
+        schema = schema.add(id, scls, obj_data)
 
         return schema, scls
 
@@ -930,7 +930,7 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
         *,
         allow_default: bool = True,
     ) -> Any:
-        val = schema._get_obj_field(self.id, field_name)
+        val = schema.get_obj_field(self.id, field_name)
         if val is not None:
             return val
 
@@ -975,7 +975,7 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
         field = type(self).get_field(field_name)
 
         if field.is_schema_field:
-            val = schema._get_obj_field(self.id, field_name)
+            val = schema.get_obj_field(self.id, field_name)
             if val is not None:
                 return val
             elif default is not NoDefault:
@@ -1004,10 +1004,10 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
         assert field.is_schema_field
 
         if value is None:
-            return schema._unset_obj_field(self.id, name)
+            return schema.unset_obj_field(self.id, name)
         else:
             value = field.coerce_value(schema, value)
-            return schema._set_obj_field(self.__dict__['id'], name, value)
+            return schema.set_obj_field(self.__dict__['id'], name, value)
 
     def update(
         self, schema: s_schema.Schema, updates: Dict[str, Any]
@@ -1024,7 +1024,7 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
                 new_val = field.coerce_value(schema, new_val)
                 updates[field_name] = new_val
 
-        return schema._update_obj(self.__dict__['id'], updates)
+        return schema.update_obj(self.__dict__['id'], updates)
 
     def is_type(self) -> bool:
         return False
@@ -1037,7 +1037,7 @@ class Object(s_abc.Object, s_abc.ObjectContainer, metaclass=ObjectMeta):
         sig: List[Union[Type[Object_T], Tuple[str, Any]]] = [cls]
         for f in cls._hashable_fields:
             fn = f.name
-            val = schema._get_obj_field(self.id, fn)
+            val = schema.get_obj_field(self.id, fn)
             if val is None:
                 continue
             sig.append((fn, val))

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -131,7 +131,7 @@ class ObjectType(
                 return ' & '.join(
                     dn for dn in comp_dns if dn != 'std::BaseObject'
                 )
-            elif mtype is self:
+            elif mtype == self:
                 return super().get_displayname(schema)
             else:
                 return mtype.get_displayname(schema)

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -206,7 +206,7 @@ class CreateOperator(
                 context=self.source_context)
 
         for oper in schema.get_operators(shortname, ()):
-            if oper is self.scls:
+            if oper == self.scls:
                 continue
 
             oper_return_typemod = oper.get_return_typemod(schema)

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -631,7 +631,7 @@ class Pointer(referencing.ReferencedInheritingObject,
 
         assert isinstance(schema_objtype, so.QualifiedObject)
         src_name = schema_objtype.get_name(schema)
-        mcls = so.ObjectMeta.get_schema_metaclass(src_name.name)
+        mcls = so.ObjectMeta.maybe_get_schema_class(src_name.name)
         if mcls is None:
             # This schema class is not (publicly) reflected.
             return None
@@ -808,14 +808,13 @@ class PseudoPointer(s_abc.Pointer):
 PointerLike = Union[Pointer, PseudoPointer]
 
 
-class ComputableRef(so.Object):
+class ComputableRef:
     """A shell for a computed target type."""
 
-    expr: qlast.Expr
+    expr: qlast.Base
 
     def __init__(self, expr: qlast.Base) -> None:
-        super().__init__(_private_init=True)
-        self.__dict__['expr'] = expr
+        self.expr = expr
 
 
 class PointerCommandContext(sd.ObjectCommandContext[Pointer],
@@ -1014,7 +1013,7 @@ class PointerCommand(
         schema: s_schema.Schema,
         astnode: qlast.CreateConcretePointer,
         context: sd.CommandContext,
-        target_ref: Union[so.Object, so.ObjectShell],
+        target_ref: Union[so.Object, so.ObjectShell, ComputableRef],
     ) -> None:
         return None
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -386,7 +386,7 @@ class Pointer(referencing.ReferencedInheritingObject,
         *,
         allow_contravariant: bool = False,
     ) -> Tuple[s_schema.Schema, Optional[s_types.Type]]:
-        if t1 is t2:
+        if t1 == t2:
             return schema, t1
 
         # When two pointers are merged, check target compatibility

--- a/edb/schema/reflection/reader.py
+++ b/edb/schema/reflection/reader.py
@@ -39,10 +39,11 @@ from . import structure as sr_struct
 
 
 def parse_into(
-    schema: s_schema.Schema,
+    base_schema: s_schema.Schema,
+    schema: s_schema.FlatSchema,
     data: Sequence[str],
     schema_class_layout: Dict[Type[s_obj.Object], sr_struct.SchemaTypeLayout],
-) -> s_schema.Schema:
+) -> s_schema.FlatSchema:
     """Parse JSON-encoded schema objects and populate the schema with them.
 
     Args:
@@ -125,7 +126,7 @@ def parse_into(
                     if newobj is not None:
                         val = newobj[0]
                     else:
-                        val = schema.get_by_id(refid)
+                        val = base_schema.get_by_id(refid)
                     objdata[fn] = val
                     refs_to[val.id][mcls, fn][objid] = None
 

--- a/edb/schema/reflection/reader.py
+++ b/edb/schema/reflection/reader.py
@@ -81,7 +81,7 @@ def parse_into(
     for entry_json in data:
         entry = json.loads(entry_json)
         _, _, clsname = entry['_tname'].rpartition('::')
-        mcls = s_obj.ObjectMeta.get_schema_metaclass(clsname)
+        mcls = s_obj.ObjectMeta.maybe_get_schema_class(clsname)
         if mcls is None:
             raise ValueError(
                 f'unexpected type in schema reflection: {clsname}')
@@ -135,8 +135,8 @@ def parse_into(
                     if issubclass(ftype, s_obj.ObjectDict):
                         refids = ftype._container(
                             uuidgen.UUID(e['value']) for e in v)
-                        val = ftype(refids, _private_init=True)
-                        val._keys = tuple(e['name'] for e in v)
+                        refkeys = tuple(e['name'] for e in v)
+                        val = ftype(refids, refkeys, _private_init=True)
                     else:
                         refids = ftype._container(
                             uuidgen.UUID(e['id']) for e in v)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -111,7 +111,7 @@ class Type(
     def is_blocking_ref(
         self, schema: s_schema.Schema, reference: so.Object
     ) -> bool:
-        return reference is not self.get_rptr(schema)
+        return reference != self.get_rptr(schema)
 
     def derive_subtype(
         self: TypeT,
@@ -436,7 +436,7 @@ class InheritingType(so.DerivableInheritingObject, Type):
 
         if ancestor is None:
             return -1
-        elif ancestor is self:
+        elif ancestor == self:
             return 0
         else:
             ancestors = list(self.get_ancestors(schema).objects(schema))
@@ -1139,7 +1139,7 @@ class Array(
 
         st = self.get_element_type(schema)
         schema, stm = st.material_type(schema)
-        if stm is not st:
+        if stm != st:
             return self.__class__.from_subtypes(
                 schema,
                 [stm],
@@ -1662,7 +1662,7 @@ class Tuple(
 
         for st_name, st in self.iter_subtypes(schema):
             schema, stm = st.material_type(schema)
-            if stm is not st:
+            if stm != st:
                 new_material_type = True
             subtypes[st_name] = stm
 

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -941,7 +941,7 @@ def get_config_type_shape(
 
             elem_path: List[qlast.Base] = []
 
-            if t is not stype:
+            if t != stype:
                 elem_path.append(
                     qlast.TypeIntersection(
                         type=qlast.TypeName(

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -342,7 +342,7 @@ class StdlibBits(NamedTuple):
 
 
 async def _make_stdlib(testmode: bool, global_ids) -> StdlibBits:
-    schema = s_schema.Schema()
+    schema: s_schema.Schema = s_schema.FlatSchema()
     schema, _ = s_mod.Module.create_in_schema(schema, name='__derived__')
 
     current_block = dbops.PLTopBlock()

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_10_16_00_00
+EDGEDB_CATALOG_VERSION = 2020_10_20_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -237,7 +237,7 @@ def _load_std_schema():
                 std_dirs_hash, 'transient-stdschema.pickle')
 
         if schema is None:
-            schema = s_schema.Schema()
+            schema = s_schema.FlatSchema()
             for modname in s_schema.STD_LIB + ('stdgraphql',):
                 schema = s_std.load_std_module(schema, modname)
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2802,7 +2802,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.InvalidOperatorDefinitionError,
                 r'cannot create the non-recursive '
-                r'`std::=\(l: array<std::int64>, '
+                r'`test::=\(l: array<std::int64>, '
                 r'r: array<std::int64>\)` operator: '
                 r'overloading a recursive operator '
                 r'`array<anytype> = array<anytype>` with a non-recursive one '
@@ -2811,7 +2811,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             # non-recursive version
             await self.con.execute('''
                 CREATE INFIX OPERATOR
-                std::`=` (l: array<int64>, r: array<int64>) -> std::bool {
+                test::`=` (l: array<anytype>, r: array<anytype>) -> std::bool {
+                    SET recursive := true;
+                    USING SQL EXPRESSION;
+                };
+
+                CREATE INFIX OPERATOR
+                test::`=` (l: array<int64>, r: array<int64>) -> std::bool {
                     USING SQL EXPRESSION;
                 };
             ''')


### PR DESCRIPTION
The new `ChainedSchema` implementation added here takes two regular
schemas and chains them together a-la `ChainMap`.  This is necessary to
separate the read-only `std` portion of schema from user-defined schema
in order to save on serialization cost of transmitting the schema over
RPC.