### PR TITLE
Finish supporting renames of objects used in expressions

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1723,6 +1723,7 @@ class RenameIndex(IndexCommand, RenameObject, adapts=s_indexes.RenameIndex):
 
         return schema
 
+
 class AlterIndexOwned(
     IndexCommand,
     AlterObject,

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1719,34 +1719,9 @@ class RenameIndex(IndexCommand, RenameObject, adapts=s_indexes.RenameIndex):
         context: sd.CommandContext,
     ) -> s_schema.Schema:
         schema = s_indexes.RenameIndex.apply(self, schema, context)
-        index = self.scls
         schema = RenameObject.apply(self, schema, context)
 
-        subject = context.get(s_links.LinkCommandContext)
-        if not subject:
-            subject = context.get(s_objtypes.ObjectTypeCommandContext)
-        orig_table_name = common.get_backend_name(
-            subject.original_schema, index, catenate=False)
-
-        index_ctx = context.get(s_indexes.IndexCommandContext)
-
-        orig_schema = index_ctx.original_schema
-        module = schema.get_global(
-            s_mod.Module, index.get_name(orig_schema).module)
-        orig_idx_name = common.get_index_backend_name(
-            index.id, module.id, catenate=False)
-
-        new_index_name = orig_idx_name
-
-        orig_pg_idx = dbops.Index(
-            name=orig_idx_name[1], table_name=orig_table_name, inherit=True,
-            metadata={'schemaname': index.get_name(schema)})
-
-        rename = dbops.RenameIndex(orig_pg_idx, new_name=new_index_name[1])
-        self.pgops.add(rename)
-
         return schema
-
 
 class AlterIndexOwned(
     IndexCommand,

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1309,14 +1309,15 @@ class ObjectCommand(
                     schema = delta_drop.apply(schema, context)
                     continue
 
-                if fn == 'expr':
-                    fdesc = 'expression'
-                else:
-                    fdesc = f"{fn.replace('_', ' ')} expression"
+                for fn in fns:
+                    if fn == 'expr':
+                        fdesc = 'expression'
+                    else:
+                        fdesc = f"{fn.replace('_', ' ')} expression"
 
-                vn = ref.get_verbosename(schema, with_parent=True)
+                    vn = ref.get_verbosename(schema, with_parent=True)
 
-                ref_desc.append(f'{fdesc} of {vn}')
+                    ref_desc.append(f'{fdesc} of {vn}')
 
             if ref_desc:
                 expr_s = (

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1304,12 +1304,12 @@ class ObjectCommand(
                     # compile_expr_field calls in the fixer can find
                     # the subject.
                     obj_cmd = next(iter(delta_create.ops))
+                    assert isinstance(obj_cmd, ObjectCommand)
                     obj = obj_cmd.get_object(schema, context)
 
                     for fn in fns:
                         # Do the switcheraroos
                         value = ref.get_explicit_field_value(schema, fn, None)
-                        ovalue = value
                         assert isinstance(value, s_expr.Expression)
                         # Strip the "compiled" out of the expression
                         value = s_expr.Expression.not_compiled(value)

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -84,18 +84,16 @@ class AliasCommand(
         assert isinstance(name, sn.Name)
         return name
 
-
     def compile_expr_field(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
         field: so.Field[Any],
-        value: expr.Expression,
+        value: s_expr.Expression,
         track_schema_ref_exprs: bool=False,
-    ) -> expr.Expression:
+    ) -> s_expr.Expression:
         assert field.name == 'expr'
         classname = sn.shortname_from_fullname(self.classname)
-        # XXX: dedup with below?
         return type(value).compiled(
             value,
             schema=schema,

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -84,6 +84,31 @@ class AliasCommand(
         assert isinstance(name, sn.Name)
         return name
 
+
+    def compile_expr_field(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        field: so.Field[Any],
+        value: expr.Expression,
+        track_schema_ref_exprs: bool=False,
+    ) -> expr.Expression:
+        assert field.name == 'expr'
+        classname = sn.shortname_from_fullname(self.classname)
+        # XXX: dedup with below?
+        return type(value).compiled(
+            value,
+            schema=schema,
+            options=qlcompiler.CompilerOptions(
+                derived_target_module=classname.module,
+                result_view_name=classname,
+                modaliases=context.modaliases,
+                schema_view_mode=True,
+                in_ddl_context_name='alias definition',
+                track_schema_ref_exprs=track_schema_ref_exprs,
+            ),
+        )
+
     def _compile_alias_expr(
         self,
         expr: qlast.Base,
@@ -319,7 +344,7 @@ class AlterAlias(
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> s_schema.Schema:
-        if not context.canonical:
+        if not context.canonical and not self.metadata_only:
             expr = self.get_attribute_value('expr')
             if expr:
                 alias_name = sn.shortname_from_fullname(self.classname)

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -284,8 +284,7 @@ class IndexCommand(
             )
             assert parent_ctx is not None
             assert isinstance(parent_ctx.op, sd.ObjectCommand)
-            subject_name = parent_ctx.op.classname
-            subject = schema.get(subject_name, default=None)
+            subject = parent_ctx.op.get_object(schema, context)
 
             if isinstance(subject, s_abc.Pointer):
                 singletons = []

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -309,6 +309,8 @@ class IndexCommand(
             )
 
             # Check that the inferred cardinality is no more than 1
+            from edb.ir import ast as ir_ast
+            assert isinstance(expr.irast, ir_ast.Statement)
             if expr.irast.cardinality.is_multi():
                 raise errors.ResultCardinalityMismatchError(
                     f'possibly more than one element returned by '

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -279,6 +279,10 @@ class CreateProperty(
 
     referenced_astnode = qlast.CreateConcreteProperty
 
+    # def __init__(self, *args, **kwargs):
+    #     # print("CREATE PROPERTY", self, args, kwargs)
+    #     super().__init__(*args, **kwargs)
+
     @classmethod
     def _cmd_tree_from_ast(
         cls,

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -279,10 +279,6 @@ class CreateProperty(
 
     referenced_astnode = qlast.CreateConcreteProperty
 
-    # def __init__(self, *args, **kwargs):
-    #     # print("CREATE PROPERTY", self, args, kwargs)
-    #     super().__init__(*args, **kwargs)
-
     @classmethod
     def _cmd_tree_from_ast(
         cls,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1256,8 +1256,7 @@ class PointerCommand(
                 )
                 assert parent_ctx is not None
                 assert isinstance(parent_ctx.op, sd.ObjectCommand)
-                source_name = parent_ctx.op.classname
-                source = schema.get(source_name, default=None)
+                source = parent_ctx.op.get_object(schema, context)
                 anchors[qlast.Source().name] = source
                 if not isinstance(source, Pointer):
                     assert source is not None

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1967,9 +1967,9 @@ class TypeCommand(sd.ObjectCommand[TypeT]):
         schema: s_schema.Schema,
         context: sd.CommandContext,
         field: so.Field[Any],
-        value: expr.Expression,
+        value: s_expr.Expression,
         track_schema_ref_exprs: bool=False,
-    ) -> expr.Expression:
+    ) -> s_expr.Expression:
         assert field.name == 'expr'
         return type(value).compiled(
             value,

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -32,6 +32,7 @@ from edb.common import uuidgen
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
+from edb.edgeql import compiler as qlcompiler
 
 from . import abc as s_abc
 from . import delta as sd
@@ -83,7 +84,7 @@ class Type(
         default=None, coerce=True, compcoef=0.909)
 
     # For a type representing an expression alias, this would contain the
-    # expressoin type.  Non-alias types have None here.
+    # expression type.  Non-alias types have None here.
     expr_type = so.SchemaField(
         ExprType,
         default=None, compcoef=0.909)
@@ -1960,6 +1961,25 @@ class TypeCommand(sd.ObjectCommand[TypeT]):
             return None
         else:
             return super().get_ast(schema, context, parent_node=parent_node)
+
+    def compile_expr_field(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        field: so.Field[Any],
+        value: expr.Expression,
+        track_schema_ref_exprs: bool=False,
+    ) -> expr.Expression:
+        assert field.name == 'expr'
+        return type(value).compiled(
+            value,
+            schema=schema,
+            options=qlcompiler.CompilerOptions(
+                modaliases=context.modaliases,
+                in_ddl_context_name='type definition',
+                track_schema_ref_exprs=track_schema_ref_exprs,
+            ),
+        )
 
     def _create_begin(
         self, schema: s_schema.Schema, context: sd.CommandContext

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -6294,15 +6294,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        Fails on the last migration that attempts to rename the
-        property being indexed.
-
-        edgedb.errors.InternalServerError: cannot determine backend
-        name for <edb.schema.indexes.Index
-        UUID('38a6b615-0224-11eb-b246-672ac1280943') at
-        0x7ff2a317d3d0>
-    ''')
     async def test_edgeql_migration_eq_index_01(self):
         await self.con.execute("""
             SET MODULE test;

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6841,3 +6841,30 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         self.assertEqual(res.count("Note"), 0)
         self.assertEqual(res.count("Remark"), 3)
+
+    async def test_edgeql_ddl_rename_ref_08(self):
+        await self.con.execute("""
+            WITH MODULE test
+            CREATE TYPE Note {
+                CREATE PROPERTY note -> str;
+            };
+
+            WITH MODULE test
+            CREATE ALIAS Alias := Note;
+        """)
+
+        await self.con.execute("""
+            WITH MODULE test
+            ALTER TYPE Note {
+                RENAME TO Remark;
+            }
+            """)
+
+        res = await self.con.query_one("""
+            DESCRIBE MODULE test
+        """)
+
+        self.assertEqual(res.count("Note"), 0)
+        self.assertEqual(res.count("Remark"), 2)
+
+    # how about: function that returns the type?

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6846,6 +6846,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             };
         """, prop_refs=2, type_refs=2)
 
+    async def test_edgeql_ddl_rename_ref_computable_01(self):
+        await self._simple_rename_ref_tests(
+            """
+            ALTER TYPE Note {
+                CREATE PROPERTY x := .note ++ "!";
+            };
+            """,
+            """ALTER TYPE Note DROP PROPERTY x;""",
+            type_refs=0,
+        )
+
     async def test_edgeql_ddl_rename_ref_type_alias_01(self):
         await self._simple_rename_ref_tests(
             """CREATE ALIAS Alias := Note;""",
@@ -6865,5 +6876,4 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             """DROP ALIAS Alias;""",
         )
 
-    # need computable property
     # how about: function that returns the type?

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6773,6 +6773,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             DROP FUNCTION foo(x: Remark, y: Handle);
         """)
 
+    async def test_edgeql_ddl_rename_ref_function_03(self):
+        await self._simple_rename_ref_tests(
+            """
+            CREATE FUNCTION foo(x: str) -> Note {
+                USING (SELECT Note FILTER .note = x LIMIT 1)
+            }
+            """,
+            """DROP FUNCTION foo(x: str);""",
+            type_refs=2,
+        )
+
     async def test_edgeql_ddl_rename_ref_default_01(self):
         await self._simple_rename_ref_tests(
             """
@@ -6888,5 +6899,3 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             """CREATE ALIAS Alias := Note { command := .note ++ "!" };""",
             """DROP ALIAS Alias;""",
         )
-
-    # how about: function that returns the type?

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6857,6 +6857,19 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             type_refs=0,
         )
 
+    async def test_edgeql_ddl_rename_ref_computable_02(self):
+        await self._simple_rename_ref_tests(
+            """
+            CREATE TYPE Foo {
+                CREATE PROPERTY foo -> str;
+                CREATE MULTI LINK x := (
+                    SELECT Note FILTER Note.note = Foo.foo);
+            };
+            """,
+            """ALTER TYPE Foo DROP LINK x;""",
+            type_refs=2,
+        )
+
     async def test_edgeql_ddl_rename_ref_type_alias_01(self):
         await self._simple_rename_ref_tests(
             """CREATE ALIAS Alias := Note;""",

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6842,6 +6842,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         self.assertEqual(res.count("Note"), 0)
         self.assertEqual(res.count("Remark"), 3)
 
+    # _07 should be a computable property
+
     async def test_edgeql_ddl_rename_ref_08(self):
         await self.con.execute("""
             WITH MODULE test
@@ -6866,5 +6868,113 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         self.assertEqual(res.count("Note"), 0)
         self.assertEqual(res.count("Remark"), 2)
+
+    async def test_edgeql_ddl_rename_ref_09(self):
+        await self.con.execute("""
+            WITH MODULE test
+            CREATE TYPE Note {
+                CREATE PROPERTY note -> str;
+            };
+
+            WITH MODULE test
+            CREATE ALIAS Alias := (SELECT Note.note);
+        """)
+
+        await self.con.execute("""
+            WITH MODULE test
+            ALTER TYPE Note {
+                ALTER PROPERTY note {
+                    RENAME TO remark;
+                }
+            }
+            """)
+
+        res = await self.con.query_one("""
+            DESCRIBE MODULE test
+        """)
+
+        self.assertEqual(res.count("note"), 0)
+        self.assertEqual(res.count("remark"), 2)
+
+    async def test_edgeql_ddl_rename_ref_10(self):
+        await self.con.execute("""
+            WITH MODULE test
+            CREATE TYPE Note {
+                CREATE PROPERTY note -> str;
+            };
+
+            WITH MODULE test
+            CREATE ALIAS Alias := (SELECT Note.note);
+        """)
+
+        await self.con.execute("""
+            WITH MODULE test
+            ALTER TYPE Note {
+                RENAME TO Remark;
+            }
+            """)
+
+        res = await self.con.query_one("""
+            DESCRIBE MODULE test
+        """)
+
+        self.assertEqual(res.count("Note"), 0)
+        self.assertEqual(res.count("Remark"), 2)
+
+    async def test_edgeql_ddl_rename_ref_11(self):
+        await self.con.execute("""
+            WITH MODULE test
+            CREATE TYPE Note {
+                CREATE PROPERTY note -> str;
+            };
+
+            WITH MODULE test
+            CREATE ALIAS Alias := (SELECT Note.note);
+        """)
+
+        await self.con.execute("""
+            WITH MODULE test
+            ALTER TYPE Note {
+                RENAME TO Remark;
+                ALTER PROPERTY note {
+                    RENAME TO remark;
+                }
+            }
+            """)
+
+        res = await self.con.query_one("""
+            DESCRIBE MODULE test
+        """)
+
+        self.assertEqual(res.count("note"), 0)
+        self.assertEqual(res.count("remark"), 2)
+        self.assertEqual(res.count("Note"), 0)
+        self.assertEqual(res.count("Remark"), 2)
+
+    async def test_edgeql_ddl_rename_ref_12(self):
+        await self.con.execute("""
+            WITH MODULE test
+            CREATE TYPE Note {
+                CREATE PROPERTY note -> str;
+            };
+
+            WITH MODULE test
+            CREATE ALIAS Alias := Note { command := .note ++ "!" };
+        """)
+
+        await self.con.execute("""
+            WITH MODULE test
+            ALTER TYPE Note {
+                RENAME TO Remark;
+            }
+            """)
+
+        res = await self.con.query_one("""
+            DESCRIBE MODULE test
+        """)
+
+        self.assertEqual(res.count("Note"), 0)
+        self.assertEqual(res.count("Remark"), 2)
+
 
     # how about: function that returns the type?

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6638,10 +6638,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         type_refs=1,
         prop_refs=1,
     ):
-        """Driver for doing simple rename tests for objects with expr references.
+        """Driver for simple rename tests for objects with expr references.
 
-        Supports renaming a type, a property, or both. By default, each is expected
-        to be named once in the referencing object.
+        Supports renaming a type, a property, or both. By default,
+        each is expected to be named once in the referencing object.
+
         """
         await self.con.execute(f"""
             WITH MODULE test

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4131,6 +4131,36 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         """])
 
+    def test_schema_migrations_equivalence_rename_refs_05(self):
+        self._assert_migration_equivalence([r"""
+            type Note {
+                required property note -> str;
+                property foo := .note ++ "!";
+            };
+        """, r"""
+            type Remark {
+                required property remark -> str;
+                property foo := .remark ++ "!";
+            };
+        """])
+
+    def test_schema_migrations_equivalence_rename_refs_06(self):
+        self._assert_migration_equivalence([r"""
+            type Note {
+                required property note -> str;
+            };
+            alias Alias1 := Note;
+            alias Alias2 := (SELECT Note.note);
+            alias Alias3 := Note { command := .note ++ "!" };
+        """, r"""
+            type Remark {
+                required property remark -> str;
+            };
+            alias Alias1 := Remark;
+            alias Alias2 := (SELECT Remark.remark);
+            alias Alias3 := Remark { command := .remark ++ "!" };
+        """])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
- Generalize the scheme for testing these things
- Rename indexes when the expression changes
- Support aliases
- Fix some issues with computables

I think we've caught everything now.

Fixes #1841.