### PR TITLE
Change how inheriting cardinality is determined.

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1589,7 +1589,16 @@ class ObjectCommand(
                     new_value = field.get_default()
 
                 if (
-                    (fop.source != 'inheritance' or context.descriptive_mode)
+                    # For all properties other than cardinality, if they
+                    # are inherited and have the default value, skip them.
+                    # Cardinality is special and should be explicitly
+                    # included, though.
+                    fop.property == 'cardinality'
+                    or
+                    (
+                        fop.source != 'inheritance'
+                        or context.descriptive_mode
+                    )
                     and fop.old_value != new_value
                 ):
                     self._apply_field_ast(schema, context, node, fop)

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -156,10 +156,13 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
             else:
                 ours = None
 
-            inherited = result is not None and ours is None
+            inherited = self.is_field_inherited(
+                schema, field_name, bases, result, ours)
+
             inherited_fields_update[field_name] = inherited
 
-            if (result is not None or ours is not None) and result != ours:
+            if (result is not None or ours is not None) and (
+                    result != ours or inherited):
                 schema = self.inherit_field(
                     schema,
                     context,
@@ -172,6 +175,16 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
             schema, context, inherited_fields_update)
 
         return schema
+
+    def is_field_inherited(
+        self,
+        schema: s_schema.Schema,
+        field_name: str,
+        bases: Tuple[so.Object, ...],
+        merged_value: Any,
+        explicit_value: Any
+    ) -> bool:
+        return merged_value is not None and explicit_value is None
 
     def inherit_field(
         self,

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -548,6 +548,13 @@ class AlterLink(
                     value=op.new_value,
                 ),
             )
+        elif op.property == 'cardinality':
+            node.commands.append(
+                qlast.SetSpecialField(
+                    name='cardinality',
+                    value=op.new_value,
+                ),
+            )
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -419,6 +419,13 @@ class AlterProperty(
                     value=op.new_value,
                 ),
             )
+        elif op.property == 'cardinality':
+            node.commands.append(
+                qlast.SetSpecialField(
+                    name='cardinality',
+                    value=op.new_value,
+                ),
+            )
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -2706,12 +2706,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_14(self):
         await self.migrate(r"""
             type Base;

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -3132,12 +3132,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_24(self):
         await self.migrate(r"""
             type Child;
@@ -3179,12 +3173,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_25(self):
         await self.migrate(r"""
             type Child;
@@ -3983,12 +3971,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }]
         )
 
-    @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_36(self):
         await self.migrate(r"""
             type Child {
@@ -5340,12 +5322,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [{'foo': [{'@bar': 'lp04'}]}],
         )
 
-    @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_linkprops_05(self):
         await self.migrate(r"""
             type Child;

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4262,7 +4262,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             """
             type test::Child extending test::Parent, test::Parent2 {
                 annotation test::anno := 'annotated';
-                overloaded link foo extending test::f -> test::Foo {
+                overloaded single link foo extending test::f -> test::Foo {
                     annotation test::anno := 'annotated link';
                     constraint std::exclusive {
                         annotation test::anno := 'annotated constraint';


### PR DESCRIPTION
Cardinality cannot be changed once it is set, this affects the
logic of checking whether it is inherited or not, since it may
be inherited and yet also explicitly specified.

Issue #1772