### PR TITLE
Fix source version resolution when cwd is somewhere else

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@
 
 
 import binascii
+import functools
 import os
 import os.path
 import pathlib
@@ -539,7 +540,11 @@ else:
 
 def custom_scm_version():
     from edb.server import buildmeta
-    return {'version_scheme': buildmeta.scm_version_scheme}
+    return {
+        'version_scheme': (
+            functools.partial(buildmeta.scm_version_scheme, ROOT_PATH)
+        ),
+    }
 
 
 setuptools.setup(


### PR DESCRIPTION
Our `scm_version_scheme` implementation currently only works if the
current working directory is within the correct repo, which it might not
always be.