### PR TITLE
Stricter typing for schema.get

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -289,9 +289,10 @@ class Environment:
         label: Optional[str] = None,
         condition: Optional[Callable[[s_obj.Object], bool]] = None,
     ) -> Optional[s_obj.Object]:
-        sobj = self.schema.get(name, module_aliases=modaliases, type=type,
-                               condition=condition, label=label,
-                               default=default)
+        sobj = self.schema.get(
+            name, module_aliases=modaliases, type=type,
+            condition=condition, label=label,
+            default=default)
         if sobj is not None and sobj is not default:
             self.add_schema_ref(sobj, expr)
 

--- a/edb/edgeql/compiler/normalization.py
+++ b/edb/edgeql/compiler/normalization.py
@@ -387,7 +387,9 @@ def compile_Path(
                     module_aliases=modaliases,
                 )
                 if obj is not None:
-                    step.module = obj.get_name(schema).module
+                    name = obj.get_name(schema)
+                    assert isinstance(name, sn.Name)
+                    step.module = name.module
                 elif None in modaliases:
                     # Even if the name was not resolved in the
                     # schema it may be the name of the object
@@ -461,7 +463,9 @@ def compile_TypeName(
             )
 
             if maintype is not None:
-                node.maintype.module = maintype.get_name(schema).module
+                name = maintype.get_name(schema)
+                assert isinstance(name, sn.Name)
+                node.maintype.module = name.module
             elif None in modaliases:
                 # Even if the name was not resolved in the schema it
                 # may be the name of the object being defined, as such

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -442,10 +442,11 @@ def derive_dummy_ptr(
     *,
     ctx: context.ContextLevel,
 ) -> s_pointers.Pointer:
-    stdobj = cast(s_objtypes.ObjectType, ctx.env.schema.get('std::BaseObject'))
+    stdobj = ctx.env.schema.get('std::BaseObject', type=s_objtypes.ObjectType)
     derived_obj_name = stdobj.get_derived_name(
         ctx.env.schema, stdobj, module='__derived__')
-    derived_obj = ctx.env.schema.get(derived_obj_name, None)
+    derived_obj = ctx.env.schema.get(
+        derived_obj_name, None, type=s_obj.QualifiedObject)
     if derived_obj is None:
         ctx.env.schema, derived_obj = stdobj.derive_subtype(
             ctx.env.schema, name=derived_obj_name)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -266,7 +266,7 @@ def compile_insert_unless_conflict(
             context=constraint_spec.context,
         )
 
-    exclusive_constr: s_constr.Constraint = schema.get('std::exclusive')
+    exclusive_constr = schema.get('std::exclusive', type=s_constr.Constraint)
     ex_cnstrs = [c for c in ptr.get_constraints(schema).objects(schema)
                  if c.issubclass(schema, exclusive_constr)]
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -43,6 +43,7 @@ from edb.schema import objtypes as s_objtypes
 from edb.schema import pointers as s_pointers
 from edb.schema import pseudo as s_pseudo
 from edb.schema import types as s_types
+from edb.schema import constraints as s_constr
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import utils as qlutils
@@ -59,9 +60,6 @@ from . import viewgen
 from . import schemactx
 from . import stmtctx
 from . import typegen
-
-if TYPE_CHECKING:
-    from edb.schema import constraints as s_constr
 
 
 @dispatch.compile.register(qlast.SelectQuery)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -168,7 +168,8 @@ def fini_expression(
                     # in schema views.
                     ctx.env.schema = vptr.set_target(
                         ctx.env.schema,
-                        ctx.env.schema.get('std::BaseObject'),
+                        ctx.env.schema.get(
+                            'std::BaseObject', type=s_types.Type),
                     )
 
                 if not hasattr(vptr, 'get_pointers'):

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -208,7 +208,9 @@ def _process_view(
                         assert ptrcls_target is not None
                         if ptrcls_target.issubclass(
                                 ctx.env.schema,
-                                ctx.env.schema.get('std::sequence')):
+                                ctx.env.schema.get(
+                                    'std::sequence',
+                                    type=s_objects.SubclassableObject)):
                             continue
 
                         what = 'property'

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -208,7 +208,8 @@ def int_const_to_python(
 
     stype = schema.get_by_id(ir.typeref.id)
     assert isinstance(stype, s_types.Type)
-    if stype.issubclass(schema, schema.get('std::bigint')):
+    bigint = schema.get('std::bigint', type=s_obj.SubclassableObject)
+    if stype.issubclass(schema, bigint):
         return decimal.Decimal(ir.value)
     else:
         return int(ir.value)
@@ -221,7 +222,8 @@ def float_const_to_python(
 
     stype = schema.get_by_id(ir.typeref.id)
     assert isinstance(stype, s_types.Type)
-    if stype.issubclass(schema, schema.get('std::decimal')):
+    bigint = schema.get('std::bigint', type=s_obj.SubclassableObject)
+    if stype.issubclass(schema, bigint):
         return decimal.Decimal(ir.value)
     else:
         return float(ir.value)
@@ -282,7 +284,7 @@ def scalar_type_to_python_type(
     }
 
     for basetype_name, python_type in typemap.items():
-        basetype: s_obj.InheritingObject = schema.get(basetype_name)
+        basetype = schema.get(basetype_name, type=s_obj.InheritingObject)
         if stype.issubclass(schema, basetype):
             return python_type
 
@@ -340,7 +342,7 @@ def object_type_to_python_type(
                 default = frozenset((default,))
 
         constraints = p.get_constraints(schema).objects(schema)
-        exclusive: s_constr.Constraint = schema.get('std::exclusive')
+        exclusive = schema.get('std::exclusive', type=s_constr.Constraint)
         unique = (
             not ptype.is_object_type()
             and any(c.issubclass(schema, exclusive) for c in constraints)

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -44,11 +44,9 @@ from edb.schema import objtypes as s_objtypes
 from edb.schema import types as s_types
 from edb.schema import scalars as s_scalars
 from edb.schema import schema as s_schema
+from edb.schema import constraints as s_constr
 
 from edb.server import config
-
-if TYPE_CHECKING:
-    from edb.schema import constraints as s_constr
 
 
 class StaticEvaluationError(errors.QueryError):

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -860,7 +860,7 @@ class CreateConstraint(
             ),
         )
 
-        bool_t: s_scalars.ScalarType = schema.get('std::bool')
+        bool_t = schema.get('std::bool', type=s_scalars.ScalarType)
         assert isinstance(final_expr.irast, ir_ast.Statement)
 
         expr_type = final_expr.irast.stype

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -374,10 +374,10 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
                 assert isinstance(obj,
                                   s_referencing.ReferencedInheritingObject)
                 existing_bases = obj.get_implicit_bases(schema)
-                schema, cmd = self._rebase_ref(
+                schema, cmd2 = self._rebase_ref(
                     schema, context, obj, existing_bases, bases)
-                group.add(cmd)
-                schema = cmd.apply(schema, context)
+                group.add(cmd2)
+                schema = cmd2.apply(schema, context)
 
         for fqname, delete_cmd_cls in deleted_refs.items():
             delete_cmd = delete_cmd_cls(classname=fqname)
@@ -393,8 +393,8 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
         schema: s_schema.Schema,
         context: sd.CommandContext,
         scls: s_referencing.ReferencedInheritingObject,
-        old_bases: List[so.InheritingObjectT],
-        new_bases: List[so.InheritingObjectT],
+        old_bases: Sequence[so.InheritingObject],
+        new_bases: Sequence[so.InheritingObject],
     ) -> Tuple[s_schema.Schema, AlterInheritingObject[so.InheritingObjectT]]:
         from . import referencing as s_referencing
 
@@ -410,8 +410,7 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
         alter_cmd = scls.init_delta_command(schema, sd.AlterObject)
         assert isinstance(alter_cmd, AlterInheritingObject)
 
-        new_bases_coll = so.ObjectList[so.InheritingObjectT].create(
-            schema, new_bases)
+        new_bases_coll = so.ObjectList.create(schema, new_bases)
         schema = scls.set_field_value(schema, 'bases', new_bases_coll)
         ancestors = so.compute_ancestors(schema, scls)
         ancestors_coll = so.ObjectList[

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -95,9 +95,11 @@ class Property(pointers.Pointer, s_abc.Property,
         if (not self.generic(our_schema) and
                 not other.generic(their_schema) and
                 self.issubclass(
-                    our_schema, our_schema.get('std::source')) and
+                    our_schema,
+                    our_schema.get('std::source', type=Property)) and
                 other.issubclass(
-                    their_schema, their_schema.get('std::source'))):
+                    their_schema,
+                    their_schema.get('std::source', type=Property))):
             # Make std::source link property ignore differences in its target.
             # This is consistent with skipping the comparison on Pointer.source
             # in general.

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -82,7 +82,8 @@ class ObjectType(
     ) -> Optional[s_expr.ExpressionList]:
         if (
             self.get_name(schema).module == 'schema'
-            and self.issubclass(schema, schema.get('schema::Object'))
+            and self.issubclass(schema,
+                                schema.get('schema::Object', type=ObjectType))
         ):
             return s_expr.ExpressionList([
                 s_expr.Expression.from_ast(

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -207,7 +207,7 @@ class ReferencedObject(so.DerivableObject):
             parent_cmd.add(cmd)
             schema = delta.apply(schema, context)
 
-        derived: ReferencedT = schema.get(derived_name)
+        derived = cast(ReferencedT, schema.get(derived_name))
 
         return schema, derived
 

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -339,7 +339,8 @@ def generate_structure(
                 delta=delta,
             )
 
-            schema_objtype = schema.get(rschema_name)
+            schema_objtype = schema.get(
+                rschema_name, type=s_objtypes.ObjectType)
         else:
             ex_bases = schema_objtype.get_bases(schema).names(schema)
             _, added_bases = s_inh.delta_bases(ex_bases, bases)

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -250,7 +250,33 @@ class Schema(abc.ABC):
         default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Optional[Type[so.Object_T]] = None,
+        condition: Optional[Callable[[so.Object], bool]] = None,
+        label: Optional[str] = None,
+        sourcectx: Optional[parsing.ParserContext] = None,
+    ) -> so.Object:
+        ...
+
+    @overload
+    def get(  # NoQA: F811
+        self,
+        name: str,
+        default: None,
+        *,
+        module_aliases: Optional[Mapping[Optional[str], str]] = None,
+        condition: Optional[Callable[[so.Object], bool]] = None,
+        label: Optional[str] = None,
+        sourcectx: Optional[parsing.ParserContext] = None,
+    ) -> Optional[so.Object]:
+        ...
+
+    @overload
+    def get(  # NoQA: F811
+        self,
+        name: str,
+        default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
+        *,
+        module_aliases: Optional[Mapping[Optional[str], str]] = None,
+        type: Type[so.Object_T],
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
         sourcectx: Optional[parsing.ParserContext] = None,
@@ -261,28 +287,42 @@ class Schema(abc.ABC):
     def get(  # NoQA: F811
         self,
         name: str,
-        default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
+        default: None,
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Optional[Type[so.Object_T]] = None,
+        type: Type[so.Object_T],
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
         sourcectx: Optional[parsing.ParserContext] = None,
     ) -> Optional[so.Object_T]:
         ...
 
-    @abc.abstractmethod
+    @overload
     def get(  # NoQA: F811
         self,
         name: str,
-        default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
+        default: Union[so.Object, so.NoDefaultT, None] = so.NoDefault,
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
         type: Optional[Type[so.Object_T]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
         sourcectx: Optional[parsing.ParserContext] = None,
-    ) -> Optional[so.Object_T]:
+    ) -> Optional[so.Object]:
+        ...
+
+    @abc.abstractmethod
+    def get(  # NoQA: F811
+        self,
+        name: str,
+        default: Union[so.Object, so.NoDefaultT, None] = so.NoDefault,
+        *,
+        module_aliases: Optional[Mapping[Optional[str], str]] = None,
+        type: Optional[Type[so.Object_T]] = None,
+        condition: Optional[Callable[[so.Object], bool]] = None,
+        label: Optional[str] = None,
+        sourcectx: Optional[parsing.ParserContext] = None,
+    ) -> Optional[so.Object]:
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -1086,7 +1126,33 @@ class FlatSchema(Schema):
         default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Optional[Type[so.Object_T]] = None,
+        condition: Optional[Callable[[so.Object], bool]] = None,
+        label: Optional[str] = None,
+        sourcectx: Optional[parsing.ParserContext] = None,
+    ) -> so.Object:
+        ...
+
+    @overload
+    def get(  # NoQA: F811
+        self,
+        name: str,
+        default: None,
+        *,
+        module_aliases: Optional[Mapping[Optional[str], str]] = None,
+        condition: Optional[Callable[[so.Object], bool]] = None,
+        label: Optional[str] = None,
+        sourcectx: Optional[parsing.ParserContext] = None,
+    ) -> Optional[so.Object]:
+        ...
+
+    @overload
+    def get(  # NoQA: F811
+        self,
+        name: str,
+        default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
+        *,
+        module_aliases: Optional[Mapping[Optional[str], str]] = None,
+        type: Type[so.Object_T],
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
         sourcectx: Optional[parsing.ParserContext] = None,
@@ -1097,27 +1163,41 @@ class FlatSchema(Schema):
     def get(  # NoQA: F811
         self,
         name: str,
-        default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
+        default: None,
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Optional[Type[so.Object_T]] = None,
+        type: Type[so.Object_T],
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
         sourcectx: Optional[parsing.ParserContext] = None,
     ) -> Optional[so.Object_T]:
         ...
 
+    @overload
     def get(  # NoQA: F811
         self,
         name: str,
-        default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
+        default: Union[so.Object, so.NoDefaultT, None] = so.NoDefault,
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
         type: Optional[Type[so.Object_T]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
         sourcectx: Optional[parsing.ParserContext] = None,
-    ) -> Optional[so.Object_T]:
+    ) -> Optional[so.Object]:
+        ...
+
+    def get(  # NoQA: F811
+        self,
+        name: str,
+        default: Union[so.Object, so.NoDefaultT, None] = so.NoDefault,
+        *,
+        module_aliases: Optional[Mapping[Optional[str], str]] = None,
+        type: Optional[Type[so.Object_T]] = None,
+        condition: Optional[Callable[[so.Object], bool]] = None,
+        label: Optional[str] = None,
+        sourcectx: Optional[parsing.ParserContext] = None,
+    ) -> Optional[so.Object]:
         def getter(schema: FlatSchema, name: str) -> Optional[so.Object]:
             obj = schema._get_by_name(name, type=type)
             if obj is not None and condition is not None:
@@ -1542,7 +1622,33 @@ class ChainedSchema(Schema):
         default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Optional[Type[so.Object_T]] = None,
+        condition: Optional[Callable[[so.Object], bool]] = None,
+        label: Optional[str] = None,
+        sourcectx: Optional[parsing.ParserContext] = None,
+    ) -> so.Object:
+        ...
+
+    @overload
+    def get(  # NoQA: F811
+        self,
+        name: str,
+        default: None,
+        *,
+        module_aliases: Optional[Mapping[Optional[str], str]] = None,
+        condition: Optional[Callable[[so.Object], bool]] = None,
+        label: Optional[str] = None,
+        sourcectx: Optional[parsing.ParserContext] = None,
+    ) -> Optional[so.Object]:
+        ...
+
+    @overload
+    def get(  # NoQA: F811
+        self,
+        name: str,
+        default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
+        *,
+        module_aliases: Optional[Mapping[Optional[str], str]] = None,
+        type: Type[so.Object_T],
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
         sourcectx: Optional[parsing.ParserContext] = None,
@@ -1553,27 +1659,41 @@ class ChainedSchema(Schema):
     def get(  # NoQA: F811
         self,
         name: str,
-        default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
+        default: None,
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Optional[Type[so.Object_T]] = None,
+        type: Type[so.Object_T],
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
         sourcectx: Optional[parsing.ParserContext] = None,
     ) -> Optional[so.Object_T]:
         ...
 
+    @overload
     def get(  # NoQA: F811
         self,
         name: str,
-        default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
+        default: Union[so.Object, so.NoDefaultT, None] = so.NoDefault,
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
         type: Optional[Type[so.Object_T]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
         sourcectx: Optional[parsing.ParserContext] = None,
-    ) -> Optional[so.Object_T]:
+    ) -> Optional[so.Object]:
+        ...
+
+    def get(  # NoQA: F811
+        self,
+        name: str,
+        default: Union[so.Object, so.NoDefaultT, None] = so.NoDefault,
+        *,
+        module_aliases: Optional[Mapping[Optional[str], str]] = None,
+        type: Optional[Type[so.Object]] = None,
+        condition: Optional[Callable[[so.Object], bool]] = None,
+        label: Optional[str] = None,
+        sourcectx: Optional[parsing.ParserContext] = None,
+    ) -> Optional[so.Object]:
         obj = self._top_schema.get(
             name,
             module_aliases=module_aliases,

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -311,7 +311,6 @@ class Schema(abc.ABC):
     ) -> Optional[so.Object]:
         ...
 
-    @abc.abstractmethod
     def get(  # NoQA: F811
         self,
         name: str,
@@ -322,6 +321,28 @@ class Schema(abc.ABC):
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
         sourcectx: Optional[parsing.ParserContext] = None,
+    ) -> Optional[so.Object]:
+        return self.get_generic(
+            name,
+            default,
+            module_aliases=module_aliases,
+            type=type,
+            condition=condition,
+            label=label,
+            sourcectx=sourcectx,
+        )
+
+    @abc.abstractmethod
+    def get_generic(  # NoQA: F811
+        self,
+        name: str,
+        default: Union[so.Object, so.NoDefaultT, None],
+        *,
+        module_aliases: Optional[Mapping[Optional[str], str]],
+        type: Optional[Type[so.Object_T]],
+        condition: Optional[Callable[[so.Object], bool]],
+        label: Optional[str],
+        sourcectx: Optional[parsing.ParserContext],
     ) -> Optional[so.Object]:
         raise NotImplementedError
 
@@ -1119,84 +1140,16 @@ class FlatSchema(Schema):
             raise errors.InvalidReferenceError(
                 f'{desc} {name!r} does not exist')
 
-    @overload
-    def get(  # NoQA: F811
+    def get_generic(
         self,
         name: str,
-        default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
+        default: Union[so.Object, so.NoDefaultT, None],
         *,
-        module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        condition: Optional[Callable[[so.Object], bool]] = None,
-        label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
-    ) -> so.Object:
-        ...
-
-    @overload
-    def get(  # NoQA: F811
-        self,
-        name: str,
-        default: None,
-        *,
-        module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        condition: Optional[Callable[[so.Object], bool]] = None,
-        label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
-    ) -> Optional[so.Object]:
-        ...
-
-    @overload
-    def get(  # NoQA: F811
-        self,
-        name: str,
-        default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
-        *,
-        module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Type[so.Object_T],
-        condition: Optional[Callable[[so.Object], bool]] = None,
-        label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
-    ) -> so.Object_T:
-        ...
-
-    @overload
-    def get(  # NoQA: F811
-        self,
-        name: str,
-        default: None,
-        *,
-        module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Type[so.Object_T],
-        condition: Optional[Callable[[so.Object], bool]] = None,
-        label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
-    ) -> Optional[so.Object_T]:
-        ...
-
-    @overload
-    def get(  # NoQA: F811
-        self,
-        name: str,
-        default: Union[so.Object, so.NoDefaultT, None] = so.NoDefault,
-        *,
-        module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Optional[Type[so.Object_T]] = None,
-        condition: Optional[Callable[[so.Object], bool]] = None,
-        label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
-    ) -> Optional[so.Object]:
-        ...
-
-    def get(  # NoQA: F811
-        self,
-        name: str,
-        default: Union[so.Object, so.NoDefaultT, None] = so.NoDefault,
-        *,
-        module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Optional[Type[so.Object_T]] = None,
-        condition: Optional[Callable[[so.Object], bool]] = None,
-        label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        module_aliases: Optional[Mapping[Optional[str], str]],
+        type: Optional[Type[so.Object_T]],
+        condition: Optional[Callable[[so.Object], bool]],
+        label: Optional[str],
+        sourcectx: Optional[parsing.ParserContext],
     ) -> Optional[so.Object]:
         def getter(schema: FlatSchema, name: str) -> Optional[so.Object]:
             obj = schema._get_by_name(name, type=type)
@@ -1615,84 +1568,16 @@ class ChainedSchema(Schema):
         except errors.InvalidReferenceError:
             return self._base_schema.get_global(objtype, name, default=default)
 
-    @overload
-    def get(  # NoQA: F811
+    def get_generic(  # NoQA: F811
         self,
         name: str,
-        default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
+        default: Union[so.Object, so.NoDefaultT, None],
         *,
-        module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        condition: Optional[Callable[[so.Object], bool]] = None,
-        label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
-    ) -> so.Object:
-        ...
-
-    @overload
-    def get(  # NoQA: F811
-        self,
-        name: str,
-        default: None,
-        *,
-        module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        condition: Optional[Callable[[so.Object], bool]] = None,
-        label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
-    ) -> Optional[so.Object]:
-        ...
-
-    @overload
-    def get(  # NoQA: F811
-        self,
-        name: str,
-        default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
-        *,
-        module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Type[so.Object_T],
-        condition: Optional[Callable[[so.Object], bool]] = None,
-        label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
-    ) -> so.Object_T:
-        ...
-
-    @overload
-    def get(  # NoQA: F811
-        self,
-        name: str,
-        default: None,
-        *,
-        module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Type[so.Object_T],
-        condition: Optional[Callable[[so.Object], bool]] = None,
-        label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
-    ) -> Optional[so.Object_T]:
-        ...
-
-    @overload
-    def get(  # NoQA: F811
-        self,
-        name: str,
-        default: Union[so.Object, so.NoDefaultT, None] = so.NoDefault,
-        *,
-        module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Optional[Type[so.Object_T]] = None,
-        condition: Optional[Callable[[so.Object], bool]] = None,
-        label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
-    ) -> Optional[so.Object]:
-        ...
-
-    def get(  # NoQA: F811
-        self,
-        name: str,
-        default: Union[so.Object, so.NoDefaultT, None] = so.NoDefault,
-        *,
-        module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        type: Optional[Type[so.Object]] = None,
-        condition: Optional[Callable[[so.Object], bool]] = None,
-        label: Optional[str] = None,
-        sourcectx: Optional[parsing.ParserContext] = None,
+        module_aliases: Optional[Mapping[Optional[str], str]],
+        type: Optional[Type[so.Object_T]],
+        condition: Optional[Callable[[so.Object], bool]],
+        label: Optional[str],
+        sourcectx: Optional[parsing.ParserContext],
     ) -> Optional[so.Object]:
         obj = self._top_schema.get(
             name,

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -60,6 +60,7 @@ def ast_objref_to_object_shell(
     else:
         if obj is not None:
             actual_name = obj.get_name(schema)
+            assert isinstance(actual_name, sn.Name)
             module = actual_name.module
         else:
             aliased_module = modaliases.get(module)
@@ -97,6 +98,7 @@ def ast_objref_to_type_shell(
     obj = schema.get(lname, module_aliases=modaliases, default=None)
     if obj is not None:
         actual_name = obj.get_name(schema)
+        assert isinstance(actual_name, sn.Name)
         module = actual_name.module
     else:
         aliased_module = modaliases.get(module)


### PR DESCRIPTION
Get rid of the basically unconstrainted output type variable in the
type of schema.get(). Explicitly return so.Object when no `type`
argument is passed.

My motivation for this is that I had run into a few cases where the
output type was being inferred as `None` and so code wasn't getting
typechecked. And when I spot-checked some other call sites, the first
two I picked had the same problem. When I fixed the typing, though,
this didn't catch /that/ many places that had been missing
type-checking. I had to fix a handful of errors, and running with
--warn-unreachable now reports 144 errors instead of 150.

So maybe this isn't worth landing? It does give better type checking,
just not as impactfully as I had expected.