### PR TITLE
Fix some more between module type move things

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2294,7 +2294,7 @@ class RenameObject(AlterObjectFragment[so.Object_T]):
         assert compiled.irast.schema_ref_exprs is not None
 
         # Now that the compilation is done, try to do the fixup.
-        new_shortname = sn.shortname_from_fullname(self.new_name).name
+        new_shortname = sn.shortname_from_fullname(self.new_name)
         old_shortname = sn.shortname_from_fullname(self.classname).name
         for ref in compiled.irast.schema_ref_exprs.get(self.scls, []):
             if isinstance(ref, qlast.Ptr):
@@ -2302,7 +2302,9 @@ class RenameObject(AlterObjectFragment[so.Object_T]):
             assert isinstance(ref, qlast.ObjectRef), (
                 f"only support object refs but got {ref}")
             assert ref.name == old_shortname, (ref.name, old_shortname)
-            ref.name = new_shortname
+            ref.name = new_shortname.name
+            if new_shortname.module != "__":
+                ref.module = new_shortname.module
 
         # say as_fragment=True as a hack to avoid renormalizing it
         out = s_expr.Expression.from_ast(


### PR DESCRIPTION
Fix modifying expressions and add more testing.

Since types are the only qualified objects that we are claiming
working rename support for in #1772, I'm going to declare victory and
say fixes #1890 and handle issues in other constructs as I write
tests/fix renaming in those.