### PR TITLE
Prohibit functions from sharing shortname with types.

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2118,6 +2118,16 @@ class CreateObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
 
         props = self.get_resolved_attributes(schema, context)
         metaclass = self.get_schema_metaclass()
+
+        # Check if functions by this name exist
+        fn = props.get('name')
+        if fn is not None:
+            funcs = schema.get_functions(fn, tuple())
+            if funcs:
+                raise errors.SchemaError(
+                    f'{funcs[0].get_verbosename(schema)} is already present '
+                    f'in the schema {schema!r}')
+
         schema, self.scls = metaclass.create_in_schema(schema, **props)
 
         if not props.get('id'):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2622,6 +2622,26 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 DROP FUNCTION test::constant_decimal();
             """)
 
+    async def test_edgeql_ddl_function_28(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                r"'test::foo' is already present in the schema"):
+
+            await self.con.execute('''\
+                CREATE TYPE test::foo;
+                CREATE FUNCTION test::foo() -> str USING ('a');
+            ''')
+
+    async def test_edgeql_ddl_function_29(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                r"'test::foo\(\)' is already present in the schema"):
+
+            await self.con.execute('''\
+                CREATE FUNCTION test::foo() -> str USING ('a');
+                CREATE TYPE test::foo;
+            ''')
+
     async def test_edgeql_ddl_module_01(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaError,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5460,8 +5460,6 @@ class TestDescribe(tb.BaseSchemaLoadTest):
     def test_schema_describe_poly_01(self):
         self._assert_describe(
             """
-            scalar type all extending str;
-
             type Object {
                 property real -> bool;
             }
@@ -5479,8 +5477,6 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             function test::all() -> std::bool using (SELECT
                 true
             );
-            scalar type test::all extending std::str;
-
             # The following builtins are masked by the above:
 
             # function std::all(vals: SET OF std::bool) ->  std::bool {


### PR DESCRIPTION
Functions can no longer share their name with other schema objects. The
reasoning is that we may want to implement traits as some kind of
specialized functions and name clashes with types would cause problems.

Fixes #1465