### PR TITLE
Parallelize dump tests

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -30,10 +30,12 @@ import inspect
 import json
 import math
 import os
+import pathlib
 import pprint
 import re
 import subprocess
 import sys
+import tempfile
 import unittest
 import uuid
 
@@ -887,6 +889,101 @@ class NonIsolatedDDLTestCase(DDLTestCase):
 class QueryTestCase(BaseQueryTestCase):
 
     BASE_TEST_CLASS = True
+
+
+class DumpCompatTestCaseMeta(TestCaseMeta):
+
+    def __new__(
+        mcls,
+        name,
+        bases,
+        ns,
+        *,
+        dump_subdir=None,
+        check_method=None,
+    ):
+        if not name.startswith('Test'):
+            return super().__new__(mcls, name, bases, ns)
+
+        if dump_subdir is None:
+            raise TypeError(
+                f'{name}: missing required "dump_subdir" class argument')
+
+        if check_method is None:
+            raise TypeError(
+                f'{name}: missing required "check_method" class argument')
+
+        mod = sys.modules[ns['__module__']]
+        dumps_dir = pathlib.Path(mod.__file__).parent / 'dumps' / dump_subdir
+
+        async def check_dump_restore_compat(self, *, dumpfn: pathlib.Path):
+
+            dbname = f"{type(self).__name__}_{dumpfn.stem}"
+            await self.con.execute(f'CREATE DATABASE `{dbname}`')
+            try:
+                self.run_cli('-d', dbname, 'restore', str(dumpfn))
+                con2 = await self.connect(database=dbname)
+            except Exception:
+                await self.con.execute(f'DROP DATABASE `{dbname}`')
+                raise
+
+            oldcon = self.__class__.con
+            self.__class__.con = con2
+            try:
+                await check_method(self)
+            finally:
+                self.__class__.con = oldcon
+                await con2.aclose()
+                await self.con.execute(f'DROP DATABASE `{dbname}`')
+
+        for entry in dumps_dir.iterdir():
+            if not entry.is_file() or not entry.name.endswith(".dump"):
+                continue
+
+            mcls.add_method(
+                f'test_{dump_subdir}_restore_compatibility_{entry.stem}',
+                ns,
+                functools.partial(check_dump_restore_compat, dumpfn=entry),
+            )
+
+        return super().__new__(mcls, name, bases, ns)
+
+
+class DumpCompatTestCase(
+    ConnectedTestCase,
+    CLITestCaseMixin,
+    metaclass=DumpCompatTestCaseMeta,
+):
+    BASE_TEST_CLASS = True
+
+
+class StableDumpTestCase(QueryTestCase, CLITestCaseMixin):
+
+    BASE_TEST_CLASS = True
+    ISOLATED_METHODS = False
+    STABLE_DUMP = True
+
+    async def check_dump_restore(self, check_method):
+        dbname = self.get_database_name()
+        with tempfile.NamedTemporaryFile() as f:
+            self.run_cli('-d', dbname, 'dump', f.name)
+
+            await self.con.execute(f'CREATE DATABASE {dbname}_restored')
+            try:
+                self.run_cli('-d', f'{dbname}_restored', 'restore', f.name)
+                con2 = await self.connect(database=f'{dbname}_restored')
+            except Exception:
+                await self.con.execute(f'DROP DATABASE {dbname}_restored')
+                raise
+
+        oldcon = self.con
+        self.__class__.con = con2
+        try:
+            await check_method(self)
+        finally:
+            self.__class__.con = oldcon
+            await con2.aclose()
+            await self.con.execute(f'DROP DATABASE {dbname}_restored')
 
 
 def get_test_cases_setup(

--- a/tests/test_dump01.py
+++ b/tests/test_dump01.py
@@ -18,78 +18,13 @@
 
 
 import os.path
-import tempfile
 
 import edgedb
 
 from edb.testbase import server as tb
 
 
-class TestDump01(tb.QueryTestCase, tb.CLITestCaseMixin):
-
-    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
-                          'dump01_test.esdl')
-    SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
-                                  'dump01_default.esdl')
-
-    SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
-                         'dump01_setup.edgeql')
-
-    ISOLATED_METHODS = False
-    SERIALIZED = True
-    STABLE_DUMP = True
-
-    async def test_dump01_dump_restore(self):
-        assert type(self).__name__.startswith('Test')
-        # The name of the database created for this test case by
-        # the test runner:
-        dbname = type(self).__name__[4:].lower()
-
-        with tempfile.NamedTemporaryFile() as f:
-            self.run_cli('-d', dbname, 'dump', f.name)
-
-            await self.con.execute(f'CREATE DATABASE {dbname}_restored')
-            try:
-                self.run_cli('-d', f'{dbname}_restored', 'restore', f.name)
-                con2 = await self.connect(database=f'{dbname}_restored')
-            except Exception:
-                await self.con.execute(f'DROP DATABASE {dbname}_restored')
-                raise
-
-        oldcon = self.con
-        self.__class__.con = con2
-        try:
-            await self.ensure_schema_data_integrity()
-        finally:
-            self.__class__.con = oldcon
-            await con2.aclose()
-            await self.con.execute(f'DROP DATABASE {dbname}_restored')
-
-    async def test_dump01_restore_compatibility(self):
-        current_dir = os.path.dirname(__file__)
-        dumps_dir = os.path.join(current_dir, 'dumps', 'dump01')
-        for entry in os.scandir(dumps_dir):
-            if not entry.is_file() or not entry.name.endswith(".dump"):
-                continue
-
-            dbname = type(self).__name__ + "_" + entry.name[:-len(".dump")]
-            dumpfn = os.path.join(dumps_dir, entry.name)
-            await self.con.execute(f'CREATE DATABASE `{dbname}`')
-            try:
-                self.run_cli('-d', dbname, 'restore', dumpfn)
-                con2 = await self.connect(database=dbname)
-            except Exception:
-                await self.con.execute(f'DROP DATABASE `{dbname}`')
-                raise
-
-            oldcon = self.con
-            self.__class__.con = con2
-            try:
-                await self.ensure_schema_data_integrity()
-            finally:
-                self.__class__.con = oldcon
-                await con2.aclose()
-                await self.con.execute(f'DROP DATABASE `{dbname}`')
+class DumpTestCaseMixin:
 
     async def ensure_schema_data_integrity(self):
         tx = self.con.transaction()
@@ -1937,3 +1872,27 @@ class TestDump01(tb.QueryTestCase, tb.CLITestCaseMixin):
                         rol1: {@rolp11 := 1},
                     };
                     ''')
+
+
+class TestDump01(tb.StableDumpTestCase, DumpTestCaseMixin):
+
+    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
+                          'dump01_test.esdl')
+    SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
+                                  'dump01_default.esdl')
+
+    SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
+                         'dump01_setup.edgeql')
+
+    async def test_dump01_dump_restore(self):
+        await self.check_dump_restore(
+            DumpTestCaseMixin.ensure_schema_data_integrity)
+
+
+class TestDump01Compat(
+    tb.DumpCompatTestCase,
+    DumpTestCaseMixin,
+    dump_subdir='dump01',
+    check_method=DumpTestCaseMixin.ensure_schema_data_integrity,
+):
+    pass


### PR DESCRIPTION
The current implementation of dump compatibiliy tests checks them
sequentially one by one.  Since each check is very slow, this test is,
by far, the slowest in the test suite.  Fix this by generating a test
method for each dump file, which makes it possible to run them in
parallel.