### PR TITLE
Fix renaming and deleting abstract constraints

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -1112,7 +1112,38 @@ class CreateConstraint(
 class RenameConstraint(
     ConstraintCommand, s_func.RenameCallableObject[Constraint]
 ):
-    pass
+    def _canonicalize(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        scls: so.Object,
+    ) -> List[sd.Command]:
+        assert isinstance(scls, Constraint)
+        commands = list(super()._canonicalize(schema, context, scls))
+
+        # Don't do anything for concrete constraints
+        if not scls.get_is_abstract(schema):
+            return commands
+
+        # Concrete constraints are children of abstract constraints
+        # and have names derived from the abstract constraints. We
+        # unfortunately need to go update their names.
+        children = scls.children(schema)
+        for ref in children:
+            if ref.get_is_abstract(schema):
+                continue
+
+            ref_name = ref.get_name(schema)
+            quals = list(sn.quals_from_fullname(ref_name))
+            new_ref_name = sn.Name(
+                name=sn.get_specialized_name(self.new_name, *quals),
+                module=sn.Name(ref_name).module,
+            )
+            commands.append(
+                self._canonicalize_ref_rename(
+                    ref, ref_name, new_ref_name, schema, context, scls))
+
+        return commands
 
 
 class AlterConstraintOwned(

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -1109,7 +1109,9 @@ class CreateConstraint(
             return super()._classbases_from_ast(schema, astnode, context)
 
 
-class RenameConstraint(ConstraintCommand, sd.RenameObject[Constraint]):
+class RenameConstraint(
+    ConstraintCommand, s_func.RenameCallableObject[Constraint]
+):
     pass
 
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -553,8 +553,10 @@ class ConstraintCommand(
             modaliases.update(
                 cls._modaliases_from_ast(schema, astnode, context))
             # Get the original constraint.
+            name = (sn.Name(objref.name, module=objref.module)
+                    if objref.module else objref.name)
             constr = schema.get(
-                objref.name,
+                name,
                 module_aliases=modaliases,
                 type=Constraint,
             )

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1094,10 +1094,11 @@ class TestConstraintsDDL(tb.DDLTestCase):
             RENAME TO test::mymax6;
         """)
 
-        with self.assertRaises(edgedb.ConstraintViolationError):
-            await self.con.execute(r"""
-                INSERT test::ConstraintTest10 { foo := 4 }
-            """)
+        async with self._run_and_rollback():
+            with self.assertRaises(edgedb.ConstraintViolationError):
+                await self.con.execute(r"""
+                    INSERT test::ConstraintTest10 { foo := 4 }
+                """)
 
         await self.con.execute(r"""
             CREATE MODULE foo IF NOT EXISTS;

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -1891,8 +1891,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         )
 
     @test.xfail('''
-        edgedb.errors.InternalServerError: missing AlterObject
-        implementation for Parameter
+        We drop and create a new constraint but would prefer to
+        rename it directly.
     ''')
     async def test_edgeql_migration_describe_constraint_01(self):
         # Migration that renames a constraint.

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -1926,16 +1926,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             },
         })
 
-    @test.xfail('''
-        edgedb.errors.SchemaError: Parameter
-        'test::__subject__@test|my_one_of' is already present in the
-        schema <Schema gen:3726 at 0x7ff99249ffd0>
-
-        Exception: Error while processing
-        'CREATE ABSTRACT CONSTRAINT test::my_one_of(one_of: array<anytype>) {
-            USING (std::contains(one_of, __subject__));
-        };'
-    ''')
     async def test_edgeql_migration_describe_constraint_02(self):
         # Migration that creates a constraint.
         await self.con.execute('''

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4270,6 +4270,29 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
+    def test_schema_migrations_equivalence_rename_abs_constraint_01(self):
+        # This drops and recreates the constraint; we'd prefer if that
+        # didn't happen
+        self._assert_migration_equivalence([r"""
+            abstract constraint greater_or_equal(val: int64) {
+                using (SELECT __subject__ >= val);
+            };
+            type Note {
+                required property note -> int64 {
+                    constraint greater_or_equal(10);
+                }
+            };
+        """, r"""
+            abstract constraint not_less(val: int64) {
+                using (SELECT __subject__ >= val);
+            };
+            type Note {
+                required property note -> int64 {
+                    constraint not_less(10);
+                }
+            };
+        """])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4271,8 +4271,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         """])
 
     def test_schema_migrations_equivalence_rename_abs_constraint_01(self):
-        # This drops and recreates the constraint; we'd prefer if that
-        # didn't happen
         self._assert_migration_equivalence([r"""
             abstract constraint greater_or_equal(val: int64) {
                 using (SELECT __subject__ >= val);


### PR DESCRIPTION
The parameter renaming logic is shared with functions (for now only
used when renaming due to a type change).

Work on #1772.