### PR TITLE
Stop storing instances of schema objects in the schema container

### DIFF
--- a/edb/common/parametric.py
+++ b/edb/common/parametric.py
@@ -278,6 +278,10 @@ class ParametricType:
         cls.types = tuple(types)
         cls._forward_refs = {}
 
+    @classmethod
+    def is_anon_parametrized(cls) -> bool:
+        return cls.__name__.endswith(']')
+
     def __reduce__(self) -> Tuple[Any, ...]:
         raise NotImplementedError(
             'must implement explicit __reduce__ for ParametricType subclass'

--- a/edb/schema/abc.py
+++ b/edb/schema/abc.py
@@ -18,25 +18,33 @@
 
 
 from __future__ import annotations
-
 import typing
-
-
-if typing.TYPE_CHECKING:
-    ObjectContainer_T = typing.TypeVar(
-        'ObjectContainer_T', bound='ObjectContainer'
-    )
 
 
 class Schema:
     pass
 
 
+class Reducible:
+    """An interface implemented by all non-builtin objects stored in schema."""
+
+    def schema_reduce(self) -> typing.Any:
+        """Return a primitive representation of the object.
+
+        The return value must consist of primitive Python objects.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def schema_restore(
+        cls,
+        data: typing.Any,
+    ) -> Reducible:
+        """Restore object from data returned by *schema_reduce*."""
+        raise NotImplementedError
+
+
 class Object:
-    pass
-
-
-class ObjectContainer:
     pass
 
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1309,6 +1309,8 @@ class ObjectCommand(
                     for fn in fns:
                         # Do the switcheraroos
                         value = ref.get_explicit_field_value(schema, fn, None)
+                        if value is None:
+                            continue
                         assert isinstance(value, s_expr.Expression)
                         # Strip the "compiled" out of the expression
                         value = s_expr.Expression.not_compiled(value)

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_10_20_00_00
+EDGEDB_CATALOG_VERSION = 2020_10_30_00_01
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs


### PR DESCRIPTION
Currently, the `Schema` object stores schema object dicts but _also_ the
Python object instances of the corresponding schema objects and schema
object collections.  This is detrimental for schema serialization as it
adds overhead when unpickling or introspecting the schema.  Fix this by
constructing the necessary objects on the fly instead.  The extra
runtime overhead is mitigated by a reasonably sized LRU cache.

This also includes some schema field getter optimizations that balance
the runtime performance hit from the above so the effect of this patch
on compilation performance is neutral.