### PR TITLE
Fix non-devmode bootstrap

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -782,7 +782,7 @@ async def _configure(
 
         for setting, value in settings.items():
             scripts.append(f'''
-                CONFIGURE SYSTEM SET {setting} := {value};
+                CONFIGURE SYSTEM SET {setting} := {value.value};
             ''')
     else:
         settings = {}


### PR DESCRIPTION
The config rework in c1d346c9b38 broke non-devmode bootstrap due to an
oversight.  Fix this.