### PR TITLE
Testing and some fixes for DDL/migration of abstract links

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2646,6 +2646,10 @@ class DeleteLink(LinkMetaCommand, adapts=s_links.DeleteLink):
             self.attach_alter_table(context)
 
         self.pgops.add(
+            self.drop_inhview(orig_schema, context, link, drop_ancestors=True)
+        )
+
+        self.pgops.add(
             dbops.DropTable(
                 name=old_table_name,
                 priority=1,

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1011,6 +1011,12 @@ class AlterAnnotationValue(
     pass
 
 
+class RenameAnnotationValue(
+        AnnotationValueCommand, RenameObject,
+        adapts=s_anno.RenameAnnotationValue):
+    pass
+
+
 class RebaseAnnotationValue(
     AnnotationValueCommand,
     RebaseObject,

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -394,6 +394,13 @@ class RebaseAnnotationValue(
     pass
 
 
+class RenameAnnotationValue(
+    AnnotationValueCommand,
+    referencing.RenameReferencedInheritingObject[AnnotationValue],
+):
+    pass
+
+
 class DeleteAnnotationValue(
     AnnotationValueCommand,
     referencing.DeleteReferencedInheritingObject[AnnotationValue],

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -216,7 +216,11 @@ class LinkCommand(lproperties.PropertySourceCommand,
     ) -> None:
         if issubclass(refdict.ref_cls, pointers.Pointer):
             for op in self.get_subcommands(metaclass=refdict.ref_cls):
-                if isinstance(op, pointers.PointerCommand):
+                if (
+                    isinstance(op, pointers.PointerCommand)
+                    and op.classname != self.classname
+
+                ):
                     pname = sn.shortname_from_fullname(op.classname)
                     if pname.name not in {'source', 'target'}:
                         self._append_subcmd_ast(schema, node, op, context)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4543,6 +4543,64 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             DROP ABSTRACT LINK foo::new_abs_link2;
         """)
 
+    async def test_edgeql_ddl_rename_abs_ptr_02(self):
+        await self.con.execute("""
+            CREATE ABSTRACT PROPERTY test::abs_prop {
+                CREATE ANNOTATION title := "lol";
+            };
+
+            CREATE TYPE test::RenameObj {
+                CREATE PROPERTY prop EXTENDING test::abs_prop -> str;
+            };
+        """)
+
+        await self.con.execute("""
+            ALTER ABSTRACT PROPERTY test::abs_prop
+            RENAME TO test::new_abs_prop;
+        """)
+
+        # Check we can create a new type that uses it
+        await self.con.execute("""
+            CREATE TYPE test::RenameObj2 {
+                CREATE PROPERTY prop EXTENDING test::new_abs_prop -> str;
+            };
+        """)
+
+        # Check we can create a new prop with the same name
+        await self.con.execute("""
+            CREATE ABSTRACT PROPERTY test::abs_prop {
+                CREATE ANNOTATION title := "lol";
+            };
+        """)
+
+        await self.con.execute("""
+            CREATE MODULE foo;
+
+            ALTER ABSTRACT PROPERTY test::new_abs_prop
+            RENAME TO foo::new_abs_prop2;
+        """)
+
+        await self.con.execute("""
+            ALTER TYPE test::RenameObj DROP PROPERTY prop;
+            ALTER TYPE test::RenameObj2 DROP PROPERTY prop;
+            DROP ABSTRACT PROPERTY foo::new_abs_prop2;
+        """)
+
+    async def test_edgeql_ddl_rename_annotated_01(self):
+        await self.con.execute("""
+            CREATE TYPE test::RenameObj {
+                CREATE PROPERTY prop -> str {
+                   CREATE ANNOTATION title := "lol";
+                }
+            };
+        """)
+
+        await self.con.execute("""
+            ALTER TYPE test::RenameObj {
+                ALTER PROPERTY prop RENAME TO prop2;
+            };
+        """)
+
     async def test_edgeql_ddl_delete_abs_link_01(self):
         # test deleting a trivial abstract link
         await self.con.execute("""

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4485,6 +4485,74 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ALTER TYPE test::Foo RENAME TO test::FooRenamed;
         """)
 
+    async def test_edgeql_ddl_rename_abs_ptr_01(self):
+        await self.con.execute("""
+            CREATE ABSTRACT LINK test::abs_link {
+                CREATE PROPERTY prop -> std::int64;
+            };
+
+            CREATE TYPE test::LinkedObj;
+            CREATE TYPE test::RenameObj {
+                CREATE MULTI LINK link EXTENDING test::abs_link
+                    -> test::LinkedObj;
+            };
+
+            INSERT test::LinkedObj;
+            INSERT test::RenameObj {
+                link := test::LinkedObj {@prop := 123}
+            };
+        """)
+
+        await self.con.execute("""
+            ALTER ABSTRACT LINK test::abs_link
+            RENAME TO test::new_abs_link;
+        """)
+
+        await self.assert_query_result(
+            r'''
+                SELECT test::RenameObj.link@prop;
+            ''',
+            [123]
+        )
+
+        # Check we can create a new type that uses it
+        await self.con.execute("""
+            CREATE TYPE test::RenameObj2 {
+                CREATE MULTI LINK link EXTENDING test::new_abs_link
+                    -> test::LinkedObj;
+            };
+        """)
+
+        # Check we can create a new link with the same name
+        await self.con.execute("""
+            CREATE ABSTRACT LINK test::abs_link {
+                CREATE PROPERTY prop -> std::int64;
+            };
+        """)
+
+        await self.con.execute("""
+            CREATE MODULE foo;
+
+            ALTER ABSTRACT LINK test::new_abs_link
+            RENAME TO foo::new_abs_link2;
+        """)
+
+        await self.con.execute("""
+            ALTER TYPE test::RenameObj DROP LINK link;
+            ALTER TYPE test::RenameObj2 DROP LINK link;
+            DROP ABSTRACT LINK foo::new_abs_link2;
+        """)
+
+    async def test_edgeql_ddl_delete_abs_link_01(self):
+        # test deleting a trivial abstract link
+        await self.con.execute("""
+            CREATE ABSTRACT LINK test::abs_link;
+        """)
+
+        await self.con.execute("""
+            DROP ABSTRACT LINK test::abs_link;
+        """)
+
     @test.xfail('''
         Fails with the below on "CREATE ALIAS Alias2":
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4291,6 +4291,29 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         """])
 
+    def test_schema_migrations_equivalence_rename_abs_ptr_01(self):
+        self._assert_migration_equivalence([r"""
+            abstract link abs_link {
+                property prop -> int64;
+            };
+
+            type LinkedObj;
+            type RenameObj {
+                multi link link EXTENDING abs_link
+                    -> LinkedObj;
+            };
+        """, r"""
+            abstract link new_abs_link {
+                property prop -> int64;
+            };
+
+            type LinkedObj;
+            type RenameObj {
+                multi link link EXTENDING new_abs_link
+                    -> LinkedObj;
+            };
+        """])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4314,6 +4314,25 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         """])
 
+    def test_schema_migrations_equivalence_rename_abs_ptr_02(self):
+        self._assert_migration_equivalence([r"""
+            abstract property abs_prop {
+                annotation title := "lol";
+            };
+
+            type RenameObj {
+                property prop EXTENDING abs_prop -> str;
+            };
+        """, r"""
+            abstract property new_abs_prop {
+                annotation title := "lol";
+            };
+
+            type RenameObj {
+                property prop EXTENDING new_abs_prop -> str;
+            };
+        """])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
Renames basically worked already except that the generated migration
script would include two RENAMEs.

Also fixed a bug deleting trivial abstract links.

Work on #1772.