### PR TITLE
Add a `DROP EXPRESSION` sub-command to DDL grammar.

### DIFF
--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -981,10 +981,13 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_SetSpecialField(self, node: qlast.SetSpecialField) -> None:
         if node.name == 'expr':
-            self._write_keywords('USING')
-            self.write(' (')
-            self.visit(node.value)
-            self.write(')')
+            if node.value is None:
+                self._write_keywords('DROP', 'EXPRESSION')
+            else:
+                self._write_keywords('USING')
+                self.write(' (')
+                self.visit(node.value)
+                self.write(')')
         else:
             keywords = self._process_SetSpecialField(node)
             self.write(*keywords, delimiter=' ')

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -290,6 +290,14 @@ class UsingStmt(Nonterm):
         )
 
 
+class DropUsingStmt(Nonterm):
+    def reduce_DROP_EXPRESSION(self, *kids):
+        self.val = qlast.SetSpecialField(
+            name='expr',
+            value=None
+        )
+
+
 class SetFieldStmt(Nonterm):
     # field := <expr>
     def reduce_SET_Identifier_ASSIGN_Expr(self, *kids):
@@ -339,6 +347,7 @@ commands_block(
 commands_block(
     'Alter',
     UsingStmt,
+    DropUsingStmt,
     RenameStmt,
     SetFieldStmt,
     CreateAnnotationValueStmt,
@@ -1078,6 +1087,7 @@ class AlterPropertyOwned(Nonterm):
 commands_block(
     'AlterConcreteProperty',
     UsingStmt,
+    DropUsingStmt,
     RenameStmt,
     SetFieldStmt,
     AlterPropertyOwned,
@@ -1297,6 +1307,7 @@ class AlterLinkOwned(Nonterm):
 commands_block(
     'AlterConcreteLink',
     UsingStmt,
+    DropUsingStmt,
     RenameStmt,
     SetFieldStmt,
     AlterLinkOwned,

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3812,6 +3812,37 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_type_12(self):
+        """
+        CREATE TYPE Foo {
+            CREATE PROPERTY bar := 'something';
+        };
+
+% OK %
+
+        CREATE TYPE Foo {
+            CREATE PROPERTY bar := ('something');
+        };
+        """
+
+    def test_edgeql_syntax_ddl_type_13(self):
+        """
+        ALTER TYPE Foo {
+            ALTER PROPERTY bar {
+                DROP EXPRESSION;
+            };
+        };
+        """
+
+    def test_edgeql_syntax_ddl_type_14(self):
+        """
+        ALTER TYPE Foo {
+            ALTER LINK bar {
+                DROP EXPRESSION;
+            };
+        };
+        """
+
     def test_edgeql_syntax_set_command_01(self):
         """
         SET MODULE default;


### PR DESCRIPTION
We need a command to express the change from a computable to
non-computable links and properties.

Issue #1772