### PR TITLE
Add a test for dropping a type with a link with a property

### DIFF
--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5540,6 +5540,24 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             []
         )
 
+    async def test_edgeql_ddl_drop_03(self):
+        await self.con.execute("""
+            CREATE TYPE test::Foo {
+                CREATE REQUIRED SINGLE PROPERTY name -> std::str;
+            };
+        """)
+        await self.con.execute("""
+            CREATE TYPE test::Bar {
+                CREATE OPTIONAL SINGLE LINK lol -> test::Foo {
+                    CREATE PROPERTY note -> str;
+                };
+            };
+        """)
+
+        await self.con.execute("""
+            DROP TYPE test::Bar;
+        """)
+
     async def test_edgeql_ddl_drop_refuse_01(self):
         # Check that the schema refuses to drop objects with live references
         await self.con.execute("""


### PR DESCRIPTION
This used to be broken, but in a flaky way, so I didn't add an xfailed
test for it. I fixed it by accident in #1918 when I added a
`drop_inhview` call to `DeleteLink.apply`.