### PR TITLE
Use tuples instead of maps to hold object data in schema

### DIFF
--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_10_30_00_01
+EDGEDB_CATALOG_VERSION = 2020_10_30_00_02
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs


### PR DESCRIPTION
Currently, we use instances of `immutables.Map` to hold schema object
"dicts" in the schema container.  This is somewhat wasteful, because we
store map keys repeatedly for every object, but the type layout is known
and static.  This can be fixed by storing object data as tuples instead,
which poses a different tradeoff: most fields in objects are `None`, but
that is still more efficient than duplicating sparse map keys.  More
importantly, however, unpickling `immutables.Map` is significantly
slower than unpickling raw tuples.  For example on the `dump01` test
schema I get the following figures:

Tuples:

- pickle size: 353,560 bytes
- unpickle time: 7,643,447 nanoseconds

immutables.Map:

- pickle size: 384,861 bytes
- unpickle time: 97,480,621 nanoseconds