### PR TITLE
Use a table instead of functions for system data

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -2159,7 +2159,11 @@ class SysConfigFunction(dbops.Function):
             (s.value->>'typemod') AS typemod,
             (s.value->>'backend_setting') AS backend_setting
         FROM
-            jsonb_each(edgedbinstdata.__syscache_configspec()) AS s
+            jsonb_each(
+                (SELECT json
+                 FROM edgedbinstdata.instdata
+                 WHERE key = 'configspec')
+            ) AS s
     ),
 
     config_defaults AS (

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -201,8 +201,10 @@ def new_compiler_context(
 
 
 async def load_cached_schema(backend_conn, key) -> s_schema.Schema:
-    data = await backend_conn.fetchval(
-        f'SELECT edgedbinstdata.__syscache_{key}();')
+    data = await backend_conn.fetchval(f'''\
+        SELECT bin FROM edgedbinstdata.instdata
+        WHERE key = {pg_common.quote_literal(key)};
+    ''')
     try:
         return pickle.loads(data)
     except Exception as e:
@@ -215,14 +217,17 @@ async def load_std_schema(backend_conn) -> s_schema.Schema:
 
 
 async def load_schema_intro_query(backend_conn) -> str:
-    return json.loads(await backend_conn.fetchval(
-        'SELECT edgedbinstdata.__syscache_introquery();'))
+    return await backend_conn.fetchval(f'''\
+        SELECT text FROM edgedbinstdata.instdata
+        WHERE key = 'introquery';
+    ''')
 
 
 async def load_schema_class_layout(backend_conn) -> s_schema.Schema:
-    data = await backend_conn.fetchval(
-        'SELECT edgedbinstdata.__syscache_classlayout();',
-    )
+    data = await backend_conn.fetchval(f'''\
+        SELECT bin FROM edgedbinstdata.instdata
+        WHERE key = 'classlayout';
+    ''')
     try:
         return pickle.loads(data)
     except Exception as e:

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -315,10 +315,10 @@ cdef class DatabaseIndex:
 
     async def get_sys_query(self, conn, key: str) -> bytes:
         if self._sys_queries is None:
-            result = await conn.simple_query(
-                b'SELECT edgedbinstdata.__syscache_sysqueries()',
-                ignore_data=False,
-            )
+            result = await conn.simple_query(b'''\
+                SELECT json FROM edgedbinstdata.instdata
+                WHERE key = 'sysqueries';
+            ''', ignore_data=False)
             queries = json.loads(result[0][0].decode('utf-8'))
             self._sys_queries = {k: q.encode() for k, q in queries.items()}
 
@@ -326,10 +326,10 @@ cdef class DatabaseIndex:
 
     async def get_instance_data(self, conn, key: str) -> object:
         if self._instance_data is None:
-            result = await conn.simple_query(
-                b'SELECT edgedbinstdata.__syscache_instancedata()',
-                ignore_data=False,
-            )
+            result = await conn.simple_query(b'''\
+                SELECT json FROM edgedbinstdata.instdata
+                WHERE key = 'instancedata';
+            ''', ignore_data=False)
             self._instance_data = json.loads(result[0][0].decode('utf-8'))
 
         return self._instance_data[key]

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_10_30_00_02
+EDGEDB_CATALOG_VERSION = 2020_10_30_00_03
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs


### PR DESCRIPTION
It turns out that calling an immutable constant-returning function is a
lot slower than selecting from a table if the size of the returned
datum is considerable, an order of magnitude slower, in fact.  So,
switch system data storage to use a regular table, this shaves off a few
milliseconds from the cold compiler startup time.