### PR TITLE
Implement `DROP EXPRESSION`

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2854,6 +2854,7 @@ class AlterSpecialObjectProperty(Command):
         field = parent_cls.get_field(propname)
 
         new_value: Any = astnode.value
+        old_value: Any = None
 
         if field.type is s_expr.Expression:
             if parent_cls.has_field(f'orig_{field.name}'):
@@ -2861,17 +2862,20 @@ class AlterSpecialObjectProperty(Command):
                     schema, parent_op.qlast, field.name)
             else:
                 orig_text = None
-            new_value = s_expr.Expression.from_ast(
-                astnode.value,
-                schema,
-                context.modaliases,
-                context.localnames,
-                orig_text=orig_text,
-            )
+
+            if astnode.value is not None:
+                new_value = s_expr.Expression.from_ast(
+                    astnode.value,
+                    schema,
+                    context.modaliases,
+                    context.localnames,
+                    orig_text=orig_text,
+                )
 
         return AlterObjectProperty(
             property=astnode.name,
             new_value=new_value,
+            old_value=old_value,
             source_context=astnode.context,
         )
 

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -376,6 +376,7 @@ class AlterPropertyOwned(
 
 class AlterProperty(
     PropertyCommand,
+    pointers.PointerAlterFragment,
     referencing.AlterReferencedInheritingObject[Property],
 ):
     astnode = [qlast.AlterConcreteProperty,
@@ -428,6 +429,14 @@ class AlterProperty(
                     value=op.new_value,
                 ),
             )
+        elif op.property == 'computable':
+            if not op.new_value:
+                node.commands.append(
+                    qlast.SetSpecialField(
+                        name='expr',
+                        value=None,
+                    ),
+                )
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -2961,12 +2961,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_18(self):
         await self.migrate(r"""
             type Base {
@@ -3006,12 +3000,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_19(self):
         await self.migrate(r"""
             type Base {
@@ -3044,12 +3032,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
-
-        This happens on the third migration.
-    ''')
     async def test_edgeql_migration_eq_21(self):
         await self.migrate(r"""
             type Base {
@@ -4019,12 +4001,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_35(self):
         await self.migrate(r"""
             type Child {


### PR DESCRIPTION
Implement `DROP EXPRESSION` command to make property or link no longer
computable.

Issue #1772