### PR TITLE
Use original token stream when generating migration names

### DIFF
--- a/edb/common/context.py
+++ b/edb/common/context.py
@@ -201,6 +201,16 @@ def _get_context(items, *, reverse=False):
     return None
 
 
+def empty_context():
+    """Return a dummy context that points to an empty string."""
+    return ParserContext(
+        name='<empty>',
+        buffer='',
+        start=SourcePoint(0, 0, 0),
+        end=SourcePoint(0, 0, 0),
+    )
+
+
 def get_context(*kids):
     start_ctx = _get_context(kids)
     end_ctx = _get_context(kids, reverse=True)

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -697,8 +697,14 @@ class Migration:
     __abstract_node__ = True
 
 
+class MigrationBody(DDL):
+
+    commands: typing.List[DDLOperation]
+
+
 class CreateMigration(CreateObject, Migration):
 
+    body: MigrationBody
     parent: typing.Optional[ObjectRef] = None
     message: typing.Optional[str] = None
     # XXX: due to unresolved issues in DDL IR decompilation

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1036,8 +1036,8 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             if node.parent is not None:
                 self.write(' ONTO ')
                 self.write(ident_to_str(node.parent.name))
-        if node.commands:
-            self._ddl_visit_body(node.commands)
+        if node.body.commands:
+            self._ddl_visit_body(node.body.commands)
 
     def visit_StartMigration(self, node: qlast.StartMigration) -> None:
         self.write('START MIGRATION TO {')

--- a/edb/edgeql/hasher.py
+++ b/edb/edgeql/hasher.py
@@ -1,0 +1,22 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+from typing import *
+
+from edb._edgeql_rust import Hasher  # noqa

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -29,7 +29,7 @@ from edb.common import debug
 from edb.edgeql import ast as qlast
 from edb.edgeql import codegen as qlcodegen
 from edb.edgeql import qltypes
-from edb._edgeql_rust import Hasher
+from edb.edgeql import hasher as qlhasher
 
 from . import abc as s_abc
 from . import delta as sd
@@ -129,16 +129,22 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
         else:
             parent_name = 'initial'
 
-        hasher = Hasher.start_migration(parent_name)
-        if astnode.commands:
+        hasher = qlhasher.Hasher.start_migration(parent_name)
+        if astnode.body.context is not None:
+            # This is an explicitly specified CREATE MIGRATION
+            src_start = astnode.body.context.start.pointer
+            src_end = astnode.body.context.end.pointer
+            ddl_text = astnode.context.buffer[src_start:src_end]
+        elif astnode.body.commands:
+            # An implicit CREATE MIGRATION produced by START MIGRATION
             ddl_text = ';\n'.join(
                 qlcodegen.generate_source(stmt)
-                for stmt in astnode.commands
+                for stmt in astnode.body.commands
             ) + ';'
-            hasher.add_source(ddl_text)
         else:
             ddl_text = ''
 
+        hasher.add_source(ddl_text)
         name = hasher.make_migration_id()
 
         if specified_name is not None and name != specified_name:
@@ -174,6 +180,12 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
         assert isinstance(astnode, qlast.CreateMigration)
 
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
+
+        if astnode.body.commands:
+            for subastnode in astnode.body.commands:
+                subcmd = sd.compile_ddl(schema, subastnode, context=context)
+                if subcmd is not None:
+                    cmd.add(subcmd)
 
         if (
             astnode.auto_diff is not None

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1062,8 +1062,8 @@ class Compiler(BaseCompiler):
                 last_migration_ref = None
 
             create_migration = qlast.CreateMigration(
+                body=qlast.MigrationBody(commands=mstate.current_ddl),
                 parent=last_migration_ref,
-                commands=mstate.current_ddl,
                 auto_diff=mstate.auto_diff,
             )
 

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -373,7 +373,7 @@ class BaseSchemaTest(BaseDocTest):
                     last_migration_ref = None
 
                 create_migration = qlast.CreateMigration(
-                    commands=migration_script,
+                    body=qlast.MigrationBody(commands=migration_script),
                     auto_diff=migration_plan,
                     parent=last_migration_ref,
                 )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5759,3 +5759,109 @@ class TestCreateMigration(tb.BaseSchemaTest):
                     }};
                 '''
             )
+
+    def test_schema_create_migration_hashing_01(self):
+        schema = self.schema
+        schema = self.run_ddl(schema, 'CREATE MODULE default;')
+        m1 = 'm1tjyzfl33vvzwjd5izo5nyp4zdsekyvxpdm7zhtt5ufmqjzczopdq'
+        schema = self.run_ddl(
+            schema,
+            f'''
+                CREATE MIGRATION {m1} ONTO initial;
+            '''
+        )
+
+    def test_schema_create_migration_hashing_02(self):
+        # this should yield the same hash as hashing_01
+        schema = self.schema
+        schema = self.run_ddl(schema, 'CREATE MODULE default;')
+        m1 = 'm1tjyzfl33vvzwjd5izo5nyp4zdsekyvxpdm7zhtt5ufmqjzczopdq'
+        schema = self.run_ddl(
+            schema,
+            f'''
+                CREATE MIGRATION {m1} ONTO initial {{
+                }};
+            '''
+        )
+
+    def test_schema_create_migration_hashing_03(self):
+        # this is different from the above because
+        # of the semicolon arrangement.
+        schema = self.schema
+        schema = self.run_ddl(schema, 'CREATE MODULE default;')
+        m1 = 'm1sdg27s7lffr7knqhlzq5oegfqr74esj5k3busddccorbj5vv2afa'
+        schema = self.run_ddl(
+            schema,
+            f'''
+                CREATE MIGRATION {m1} ONTO initial {{
+                    ;
+                }};
+            '''
+        )
+
+    def test_schema_create_migration_hashing_04(self):
+        # this is different from the above because
+        # of the semicolon arrangement.
+        schema = self.schema
+        schema = self.run_ddl(schema, 'CREATE MODULE default;')
+        m1 = 'm1cbiul6yeoa52xehujfb4l4uh34ty2vrsu5mvxk7h63q6ov57lqtq'
+        schema = self.run_ddl(
+            schema,
+            f'''
+                CREATE MIGRATION {m1} ONTO initial {{
+                    ;;
+                }};
+            '''
+        )
+
+    def test_schema_create_migration_hashing_05(self):
+        schema = self.schema
+        schema = self.run_ddl(schema, 'CREATE MODULE default;')
+        m1 = 'm1vrzjotjgjxhdratq7jz5vdxmhvg2yun2xobiddag4aqr3y4gavgq'
+        schema = self.run_ddl(
+            schema,
+            f'''
+                CREATE MIGRATION {m1} ONTO initial {{
+                    CREATE TYPE Foo;
+                }};
+            '''
+        )
+
+    def test_schema_create_migration_hashing_06(self):
+        schema = self.schema
+        schema = self.run_ddl(schema, 'CREATE MODULE default;')
+        m1 = 'm1oppdh5pqk2mi45e6s7zw3zbmwqgcmbwyew2vwa7pkqs7evmx3eca'
+        schema = self.run_ddl(
+            schema,
+            f'''
+                CREATE MIGRATION {m1} ONTO initial {{
+                    CREATE TYPE Foo;;
+                }};
+            '''
+        )
+
+    def test_schema_create_migration_hashing_07(self):
+        schema = self.schema
+        schema = self.run_ddl(schema, 'CREATE MODULE default;')
+        m1 = 'm1qunrujj5tnobsit2cpok4tpbdpagvfr5kqqvwqva3b2lurt7kzia'
+        schema = self.run_ddl(
+            schema,
+            f'''
+                CREATE MIGRATION {m1} ONTO initial {{
+                    CREATE TYPE Foo {{}}
+                }};
+            '''
+        )
+
+    def test_schema_create_migration_hashing_08(self):
+        schema = self.schema
+        schema = self.run_ddl(schema, 'CREATE MODULE default;')
+        m1 = 'm1usqifmekhxos6pmrjuqdl7qdewxhz32uqfh3loaywiyafdswqdaa'
+        schema = self.run_ddl(
+            schema,
+            f'''
+                CREATE MIGRATION {m1} ONTO initial {{
+                    CREATE TYPE Foo {{}};
+                }};
+            '''
+        )


### PR DESCRIPTION
Currently, the migration name is derived from a list of tokens obtained
by deparsing DDL AST.  This is problematic, because the migration source
might not be "canonical" from the standpoint of EdgeQL codegen and so
either the client tools will have a very hard time "normalizing" the
migration source.  Avoid this by always using the original token stream,
if available.