### PR TITLE
Use an inferred volatility for functions

### DIFF
--- a/tests/schemas/dump01_default.esdl
+++ b/tests/schemas/dump01_default.esdl
@@ -32,7 +32,7 @@ function user_func_1(x: array<int64>, y: str) -> str {
     using (
         SELECT array_join(<array<str>>x, y)
     );
-    volatility := 'IMMUTABLE';
+    volatility := 'STABLE';
 };
 
 function user_func_2(x: OPTIONAL int64, y: str = 'x') -> SET OF str {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3369,6 +3369,54 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                 )
         """])
 
+    def test_schema_migrations_equivalence_function_18(self):
+        self._assert_migration_equivalence([r"""
+            function a() -> float64 {
+                using (
+                    SELECT random()
+                )
+            }
+        """, r"""
+            function a() -> float64 {
+                volatility := "volatile";
+                using (
+                    SELECT random()
+                )
+            }
+        """])
+
+    def test_schema_migrations_equivalence_function_19(self):
+        self._assert_migration_equivalence([r"""
+            function a() -> float64 {
+                volatility := "volatile";
+                using (
+                    SELECT random()
+                )
+            }
+        """, r"""
+            function a() -> float64 {
+                using (
+                    SELECT random()
+                )
+            }
+        """])
+
+    def test_schema_migrations_equivalence_function_20(self):
+        self._assert_migration_equivalence([r"""
+            function a() -> float64 {
+                volatility := "volatile";
+                using (
+                    SELECT 1.0
+                )
+            }
+        """, r"""
+            function a() -> float64 {
+                using (
+                    SELECT 1.0
+                )
+            }
+        """])
+
     def test_schema_migrations_equivalence_linkprops_03(self):
         self._assert_migration_equivalence([r"""
             type Child;


### PR DESCRIPTION
We do this by adding a new inferred_volatility field to
VolatilitySubject and falling back to that (via a new pseudo-field
"effective volatility") when volatility isn't specified.

I did it that way instead of just populating volatility with the
inferred value because that caused us to include 'SET volatility :=
...' in our DESCRIBE output when volatility was inferred.

We then expose `inferred_volatility` and `effective_volatility` via
introspection. The change in the behavior/meaning of the volatility
field here is something of a compatibility break.

Not sure if there is a better way to structure this all that would
preserve the meaning of the `volatility` field for introspection?

Fixes #1888.