### PR TITLE
Update messages.py

### DIFF
--- a/edb/testbase/protocol/messages.py
+++ b/edb/testbase/protocol/messages.py
@@ -569,7 +569,6 @@ class Data(ServerMessage):
 
     mtype = MessageType('D')
     message_length = MessageLength
-    reserved = UInt32()
 
     data = ArrayOf(
         UInt16,


### PR DESCRIPTION
The [documentation](https://www.edgedb.com/docs/internals/protocol/messages#data) currently says that there is a reserved field after the message length for data messages. However the server does not send this field. This change removes the reserved field from the documentation to match real behavior.