### PR TITLE
Make migration constraint renames actually generate renames

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -137,7 +137,7 @@ class Constraint(referencing.ReferencedInheritingObject,
     @classmethod
     def _maybe_fix_name(
         cls,
-        name: sn.Name,
+        name: sn.QualName,
         *,
         schema: s_schema.Schema,
         context: so.ComparisonContext,
@@ -149,9 +149,9 @@ class Constraint(referencing.ReferencedInheritingObject,
             base_name = context.get_obj_name(schema, base)
 
             quals = list(sn.quals_from_fullname(name))
-            name = sn.Name(
+            name = sn.QualName(
                 name=sn.get_specialized_name(base_name, *quals),
-                module=sn.Name(name).module,
+                module=name.module,
             )
 
         return name
@@ -170,8 +170,8 @@ class Constraint(referencing.ReferencedInheritingObject,
         # When comparing names, patch up the names to take into
         # account renames of the base abstract constraints.
         if field.name == 'name':
-            assert isinstance(our_value, sn.Name)
-            assert isinstance(their_value, sn.Name)
+            assert isinstance(our_value, sn.QualName)
+            assert isinstance(their_value, sn.QualName)
             our_value = cls._maybe_fix_name(  # type: ignore
                 our_value, schema=our_schema, context=context)
             their_value = cls._maybe_fix_name(  # type: ignore

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -232,6 +232,14 @@ def delta_schemas(
 
     objects = sd.DeltaRoot(canonical=True)
 
+    # FIXME: We (mostly accidentally) rely on the ordering of
+    # schemaclasses, which is totally implicit from our import
+    # structures but also deterministic.
+    # This is because in some cases involving renames, we need to
+    # process the rename before we process consumers of it.
+    # In particular, I think ObjectType needs to be processed pretty late.
+    #
+    # This should be explicit and not implicit.
     schemaclasses = [
         schemacls
         for schemacls in so.ObjectMeta.get_schema_metaclasses()

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -116,6 +116,17 @@ def delta_objects(
     seen_x = set()
     seen_y = set()
     comparison_map: Dict[so.Object_T, Tuple[float, so.Object_T]] = {}
+
+    # If there are any renames that are already decided on, honor those first
+    for y in old:
+        rename = context.renames.get((type(y), y.get_name(old_schema)))
+        if rename:
+            x = cast(so.Object_T, new_schema.get(rename.new_name))
+            comparison_map[x] = (0.99, y)
+            seen_x.add(x)
+            seen_y.add(y)
+
+    # Find the top similarity pairs
     for x, y, similarity in full_matrix:
         if x not in seen_x and y not in seen_y:
             comparison_map[x] = (similarity, y)

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -412,6 +412,36 @@ class Parameter(
     def as_str(self, schema: s_schema.Schema) -> str:
         return param_as_str(schema, self)
 
+    @classmethod
+    def compare_field_value(
+        cls,
+        field: so.Field[Type[so.T]],
+        our_value: so.T,
+        their_value: so.T,
+        *,
+        our_schema: s_schema.Schema,
+        their_schema: s_schema.Schema,
+        context: so.ComparisonContext,
+    ) -> float:
+        # Only compare the actual param name, not the full name.
+        if field.name == 'name':
+            assert isinstance(our_value, sn.Name)
+            assert isinstance(their_value, sn.Name)
+            if (
+                cls.paramname_from_fullname(our_value) ==
+                cls.paramname_from_fullname(their_value)
+            ):
+                return 1.0
+
+        return super().compare_field_value(
+            field,
+            our_value,
+            their_value,
+            our_schema=our_schema,
+            their_schema=their_schema,
+            context=context,
+        )
+
     def get_ast(self, schema: s_schema.Schema) -> qlast.FuncParam:
         default = self.get_default(schema)
         type = utils.typeref_to_ast(schema, self.get_type(schema))
@@ -615,6 +645,34 @@ class FuncParameterList(so.ObjectList[Parameter], ParameterLikeList):
         for param in self.objects(schema):
             result.append(param.get_ast(schema))
         return result
+
+    @classmethod
+    def compare_values(
+        cls,
+        ours_o: so.ObjectCollection[Parameter],
+        theirs_o: so.ObjectCollection[Parameter],
+        *,
+        our_schema: s_schema.Schema,
+        their_schema: s_schema.Schema,
+        context: so.ComparisonContext,
+        compcoef: float,
+    ) -> float:
+        ours = list(ours_o.objects(our_schema))
+        theirs = list(theirs_o.objects(their_schema))
+
+        # Because parameter lists can't currently be ALTERed, any
+        # changes are catastrophic, so return compcoef on any mismatch
+        # at all.
+        if len(ours) != len(theirs):
+            return compcoef
+        for param1, param2 in zip(ours, theirs):
+            coef = param1.compare(
+                param2, our_schema=our_schema,
+                their_schema=their_schema, context=context)
+            if coef != 1.0:
+                return compcoef
+
+        return 1.0
 
 
 class VolatilitySubject(so.Object):

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -981,6 +981,9 @@ class AlterCallableObject(
             super()._get_ast(schema, context, parent_node=parent_node)
         )
 
+        if not node:
+            return None
+
         scls = self.get_object(schema, context)
         node.params = scls.get_params(schema).get_ast(schema)
 

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -697,7 +697,8 @@ def _trace_op(
 
                     if not isinstance(op, sd.CreateObject):
                         assert old_schema is not None
-                        old_obj = get_object(old_schema, op)
+                        name = renames_r.get(op.classname, op.classname)
+                        old_obj = get_object(old_schema, op, name)
                         assert isinstance(
                             old_obj,
                             referencing.ReferencedInheritingObject,

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -49,7 +49,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 await tx.rollback()
 
             res = json.loads(res)
-            print("FUCK", res)
             self._assert_data_shape(res, exp_result_json, message=msg)
         except Exception:
             self.add_fail_notes(serialization='json')


### PR DESCRIPTION
Previously we would drop the constraint and create a new one,
which is bad because it requires checking the constraint for
the whole table.

Fixing this required:
 * Making parameter comparisions compare based on just the
   real param name, not the fully encoding one that includes
   the constraint/function name.
 * Having concrete constraint comparisons take into account
   in-flight renames of base constraints when comparing names.

(Should we try to move to a world where all these sorts of derived
objects don't have global derived names? They cause a lot of
grief. But probably the change would also.)

Work on #1772