### PR TITLE
Consistent handling of small constants like '1e-999'

### DIFF
--- a/edb/edgeql-rust/src/float.rs
+++ b/edb/edgeql-rust/src/float.rs
@@ -1,0 +1,19 @@
+use std::borrow::Cow;
+
+
+pub fn convert(text: &str) -> Result<f64, Cow<'static, str>> {
+    let value = text.replace("_", "").parse()
+        .map_err(|e| format!("can't parse std::float64: {}", e))?;
+    if value == f64::INFINITY || value == -f64::INFINITY {
+        return Err("number is out of range for std::float64".into());
+    }
+    if value == 0.0 {
+        let mend = text.find(|c| c == 'e' || c == 'E')
+            .unwrap_or(text.len());
+        let mantissa = &text[..mend];
+        if mantissa.chars().any(|c| c != '0' && c != '.') {
+            return Err("number is out of range for std::float64".into());
+        }
+    }
+    Ok(value)
+}

--- a/edb/edgeql-rust/src/lib.rs
+++ b/edb/edgeql-rust/src/lib.rs
@@ -3,6 +3,7 @@
 use cpython::PyString;
 
 mod errors;
+mod float;
 mod keywords;
 mod tokenizer;
 pub mod normalize;

--- a/edb/edgeql-rust/src/normalize.rs
+++ b/edb/edgeql-rust/src/normalize.rs
@@ -6,6 +6,7 @@ use edgeql_parser::helpers::unquote_string;
 use num_bigint::{BigInt, ToBigInt};
 use bigdecimal::BigDecimal;
 use crate::tokenizer::{CowToken};
+use crate::float;
 
 
 #[derive(Debug, PartialEq)]
@@ -146,15 +147,8 @@ pub fn normalize<'x>(text: &'x str)
                 push_var(&mut rewritten_tokens, "__std__::float64",
                     next_var(variables.len()),
                     tok.start, tok.end);
-                let value = tok.value.replace("_", "").parse()
-                    .map_err(|e| Error::Tokenizer(
-                        format!("can't parse std::float64: {}", e),
-                        tok.start))?;
-                if value == f64::INFINITY || value == -f64::INFINITY {
-                    return Err(Error::Tokenizer(
-                        format!("number is out of range for std::float64"),
-                        tok.start));
-                }
+                let value = float::convert(&tok.value)
+                    .map_err(|msg| Error::Tokenizer(msg.into(), tok.start))?;
                 variables.push(Variable {
                     value: Value::Float(value),
                 });

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -110,6 +110,31 @@ class TestEdgeQLParser(EdgeQLSyntaxTest):
     def test_edgeql_syntax_float_number_too_large(self):
         """SELECT 2+1e999;"""
 
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=1, col=8)
+    def test_edgeql_syntax_float_number_too_small_01(self):
+        """SELECT 0.01e-322;"""
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=1, col=8)
+    def test_edgeql_syntax_float_number_too_small_02(self):
+        """SELECT 1e-324;"""
+
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=1, col=8)
+    def test_edgeql_syntax_float_number_too_small_03(self):
+        (
+            "SELECT 0."
+            "0000000000_0000000000_0000000000_0000000000"
+            "0000000000_0000000000_0000000000_0000000000"
+            "0000000000_0000000000_0000000000_0000000000"
+            "0000000000_0000000000_0000000000_0000000000"
+            "0000000000_0000000000_0000000000_0000000000"
+            "0000000000_0000000000_0000000000_0000000000"
+            "0000000000_0000000000_0000000000_0000000000"
+            "0000000000_0000000000_0000000000_0000000000"
+            "0000000000_0000000000_0000000000_0000000000"
+            "0000000000_0000000000_0000000000_0000000000"
+            "1;"
+        )
+
     def test_edgeql_syntax_constants_01(self):
         """
         SELECT 0;
@@ -157,6 +182,7 @@ class TestEdgeQLParser(EdgeQLSyntaxTest):
         SELECT 3.543_2e-20;
         SELECT 354.32e-20;
         SELECT 2_354.32e-20;
+        SELECT 0e-999;
 
 % OK %
 
@@ -169,6 +195,7 @@ class TestEdgeQLParser(EdgeQLSyntaxTest):
         SELECT 3.543_2e-20;
         SELECT 354.32e-20;
         SELECT 2_354.32e-20;
+        SELECT 0e-999;
         """
 
     def test_edgeql_syntax_constants_05(self):


### PR DESCRIPTION
Fixes #1402