### PR TITLE
Remove RENAME as an option when altering a concrete constraint

### DIFF
--- a/docs/edgeql/ddl/constraints.rst
+++ b/docs/edgeql/ddl/constraints.rst
@@ -373,7 +373,6 @@ Alter the definition of a concrete constraint on the specified schema item.
 
       SET DELEGATED
       DROP DELEGATED
-      RENAME TO <newname>
       SET errmessage := <error-message>
       CREATE ANNOTATION <annotation-name> := <value>
       ALTER ANNOTATION <annotation-name>

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -635,7 +635,6 @@ class AlterConstraintOwned(Nonterm):
 
 commands_block(
     'AlterConcreteConstraint',
-    RenameStmt,
     SetFieldStmt,
     SetDelegatedStmt,
     AlterConstraintOwned,

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3242,6 +3242,19 @@ aa';
         };
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Unexpected 'RENAME'", line=5, col=21)
+    def test_edgeql_syntax_ddl_constraint_11(self):
+        """
+        ALTER TYPE Foo {
+            ALTER LINK bar {
+                ALTER CONSTRAINT my_constraint ON (foo) {
+                    RENAME TO myconstraint;
+                };
+            };
+        };
+        """
+
     def test_edgeql_syntax_ddl_function_01(self):
         """
         CREATE FUNCTION std::strlen(string: std::str) -> std::int64


### PR DESCRIPTION
It doesn't make sense, and #1949, which fixes constraint renames in
migrations, doesn't need it.

Work on #1772.