### PR TITLE
Add missing attrs in handle_signature methods to fix docs search

### DIFF
--- a/edb/tools/docs/eql.py
+++ b/edb/tools/docs/eql.py
@@ -685,6 +685,10 @@ class EQLFunctionDirective(BaseEQLDirective):
         if debug.flags.disable_docs_edgeql_validation:
             signode['eql-fullname'] = fullname = sig.split('(')[0]
             signode['eql-signature'] = sig
+            mod, name = fullname.split('::')
+            signode['eql-module'] = mod
+            signode['eql-name'] = name
+
             return fullname
 
         from edb.edgeql.parser import parser as edgeql_parser
@@ -758,6 +762,10 @@ class EQLConstraintDirective(BaseEQLDirective):
         if debug.flags.disable_docs_edgeql_validation:
             signode['eql-fullname'] = fullname = re.split(r'\(| ', sig)[0]
             signode['eql-signature'] = sig
+            mod, name = fullname.split('::')
+            signode['eql-module'] = mod
+            signode['eql-name'] = name
+
             return fullname
 
         from edb.edgeql.parser import parser as edgeql_parser


### PR DESCRIPTION
Previous refactor (https://github.com/edgedb/edgedb/pull/1905) to edb.tools.docs didn't add the `eql-module` and `eql-name` attrs to the signature node, causing functions and constraints to not be indexed correctly in the docs search build step.