### PR TITLE
Change the lower bound of type annotations tag to 0x80

### DIFF
--- a/docs/internals/protocol/typedesc.rst
+++ b/docs/internals/protocol/typedesc.rst
@@ -306,7 +306,7 @@ Drivers must ignore unknown type annotations.
     struct TypeAnnotationDescriptor {
         // Indicates that this is an
         // Type Annotation descriptor.
-        uint8        type = 0x7f..0xfe;
+        uint8        type = 0x80..0xfe;
 
         // ID of the descriptor the
         // annotation is for.

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -463,7 +463,7 @@ class TypeSerializer:
             return ArrayDesc(
                 tid=tid, dim_len=dim_len, subtype=codecs_list[pos])
 
-        elif (t >= 0x7f and t <= 0xff):
+        elif (t >= 0x80 and t <= 0xff):
             # Ignore all type annotations.
             desc.read_len32_prefixed_bytes()
 

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -466,6 +466,7 @@ class TypeSerializer:
         elif (t >= 0x80 and t <= 0xff):
             # Ignore all type annotations.
             desc.read_len32_prefixed_bytes()
+            return None
 
         else:
             raise NotImplementedError(
@@ -480,7 +481,9 @@ class TypeSerializer:
             desc = cls._parse(wrapped, codecs_list)
             if desc is not None:
                 codecs_list.append(desc)
-        return desc
+        if not codecs_list:
+            raise errors.InternalServerError('could not parse type descriptor')
+        return codecs_list[-1]
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
This way it's easy to test if a tag is an annotation or not
with a simple bitwise check: 0x80 & tag == 0x80.