### PR TITLE
Reparse query on syntax error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
+dependencies = [
+ "crypto-mac",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +134,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +216,7 @@ name = "edgeql-rust"
 version = "0.1.0"
 dependencies = [
  "bigdecimal",
+ "blake2",
  "bytes",
  "combine 4.3.2",
  "cpython",
@@ -480,6 +502,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"

--- a/edb/edgeql-rust/Cargo.toml
+++ b/edb/edgeql-rust/Cargo.toml
@@ -11,6 +11,7 @@ combine = "4.0.0-beta.1"
 bytes = "0.5.3"
 num-bigint = "0.3.0"
 bigdecimal = "0.2.0"
+blake2 = "0.9.1"
 
 [dependencies.edgedb-protocol]
 git = "https://github.com/edgedb/edgedb-rust"

--- a/edb/edgeql-rust/src/normalize.rs
+++ b/edb/edgeql-rust/src/normalize.rs
@@ -5,6 +5,7 @@ use edgeql_parser::position::Pos;
 use edgeql_parser::helpers::unquote_string;
 use num_bigint::{BigInt, ToBigInt};
 use bigdecimal::BigDecimal;
+use blake2::{Blake2b, Digest};
 use crate::tokenizer::{CowToken};
 use crate::float;
 
@@ -23,9 +24,9 @@ pub struct Variable {
     pub value: Value,
 }
 
-#[derive(Debug)]
 pub struct Entry<'a> {
-    pub key: String,
+    pub processed_source: String,
+    pub hash: [u8; 64],
     pub tokens: Vec<CowToken<'a>>,
     pub variables: Vec<Variable>,
     pub end_pos: Pos,
@@ -76,6 +77,12 @@ fn scan_vars<'x, 'y: 'x, I>(tokens: I) -> Option<(bool, usize)>
     }
 }
 
+fn hash(text: &str) -> [u8; 64] {
+    let mut result = [0u8; 64];
+    result.copy_from_slice(Blake2b::digest(text.as_bytes()).as_slice());
+    return result;
+}
+
 pub fn normalize<'x>(text: &'x str)
     -> Result<Entry<'x>, Error>
 {
@@ -100,8 +107,10 @@ pub fn normalize<'x>(text: &'x str)
         Some(pair) => pair,
         None => {
             // don't extract from invalid query, let python code do its work
+            let processed_source = serialize_tokens(&tokens);
             return Ok(Entry {
-                key: serialize_tokens(&tokens),
+                hash: hash(&processed_source),
+                processed_source,
                 tokens,
                 variables: Vec::new(),
                 end_pos,
@@ -202,8 +211,10 @@ pub fn normalize<'x>(text: &'x str)
             if (matches!(&(&tok.value[..].to_uppercase())[..],
                 "CONFIGURE"|"CREATE"|"ALTER"|"DROP"|"START"))
             => {
+                let processed_source = serialize_tokens(&tokens);
                 return Ok(Entry {
-                    key: serialize_tokens(&tokens),
+                    hash: hash(&processed_source),
+                    processed_source,
                     tokens,
                     variables: Vec::new(),
                     end_pos,
@@ -214,10 +225,12 @@ pub fn normalize<'x>(text: &'x str)
             _ => rewritten_tokens.push(tok.clone()),
         }
     }
+    let processed_source = serialize_tokens(&rewritten_tokens[..]);
     return Ok(Entry {
+        hash: hash(&processed_source),
+        processed_source,
         named_args,
         first_arg: if variables.is_empty() { None } else { Some(var_idx) },
-        key: serialize_tokens(&rewritten_tokens[..]),
         tokens: rewritten_tokens,
         variables,
         end_pos,

--- a/edb/edgeql-rust/src/pynormalize.rs
+++ b/edb/edgeql-rust/src/pynormalize.rs
@@ -16,14 +16,15 @@ use crate::tokenizer::convert_tokens;
 
 
 py_class!(pub class Entry |py| {
-    data _key: PyString;
+    data _key: PyBytes;
+    data _processed_source: String;
     data _tokens: PyList;
     data _extra_blob: PyBytes;
     data _extra_named: bool;
     data _first_extra: Option<usize>;
     data _extra_count: usize;
     data _variables: Vec<Variable>;
-    def key(&self) -> PyResult<PyString> {
+    def key(&self) -> PyResult<PyBytes> {
         Ok(self._key(py).clone_ref(py))
     }
     def variables(&self) -> PyResult<PyDict> {
@@ -137,7 +138,8 @@ pub fn normalize(py: Python<'_>, text: &PyString)
                 .map_err(|e| PyErr::new::<AssertionError, _>(py, e))?;
 
             Ok(Entry::create_instance(py,
-                /* key: */ entry.key.to_py_object(py),
+                /* key: */ PyBytes::new(py, &entry.hash[..]),
+                /* processed_source: */ entry.processed_source,
                 /* tokens: */ convert_tokens(py, entry.tokens, entry.end_pos)?,
                 /* extra_blob: */ PyBytes::new(py, &blob),
                 /* extra_named: */ entry.named_args,

--- a/edb/edgeql/tokenizer.py
+++ b/edb/edgeql/tokenizer.py
@@ -61,8 +61,8 @@ class Source:
 
 class NormalizedSource(Source):
 
-    def __init__(self, normalized: Entry) -> None:
-        self._text = normalized.key()
+    def __init__(self, normalized: Entry, text: str) -> None:
+        self._text = text
         self._tokens = normalized.tokens()
         self._variables = normalized.variables()
         self._first_extra = normalized.first_extra()
@@ -89,7 +89,13 @@ class NormalizedSource(Source):
 
     @classmethod
     def from_string(cls, text: str) -> NormalizedSource:
-        return cls(normalize(text))
+        return cls(normalize(text), text)
+
+    @classmethod
+    def from_string_with_cache_key(cls, text: str) -> (NormalizedSource, str):
+        """Returns a tuple of Source and canonical cache key for the query"""
+        normalized = normalize(text)
+        return cls(normalized, text), normalized.key()
 
 
 def tokenize(eql: str) -> List[Token]:

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1415,6 +1415,32 @@ class Compiler(BaseCompiler):
         ctx: CompileContext,
         source: edgeql.Source,
     ) -> List[dbstate.QueryUnit]:
+        try:
+            return self._try_compile(ctx=ctx, source=source)
+        except errors.EdgeQLSyntaxError as original_err:
+            if isinstance(source, edgeql.NormalizedSource):
+                # try non-normalized source
+                try:
+                    original = edgeql.Source.from_string(source.text())
+                    ctx = dataclasses.replace(ctx, source=original)
+                    self._try_compile(ctx=ctx, source=original)
+                except errors.EdgeQLSyntaxError as denormalized_err:
+                    raise denormalized_err
+                except Exception:
+                    raise AssertionError(
+                        "Normalized and non-normalized query errors differ")
+                else:
+                    raise AssertionError(
+                        "Normalized query is broken while original is valid")
+            else:
+                raise original_err
+
+    def _try_compile(
+        self,
+        *,
+        ctx: CompileContext,
+        source: edgeql.Source,
+    ) -> List[dbstate.QueryUnit]:
 
         # When True it means that we're compiling for "connection.query()".
         # That means that the returned QueryUnit has to have the in/out codec

--- a/edb/server/mng_port/edgecon.pxd
+++ b/edb/server/mng_port/edgecon.pxd
@@ -53,6 +53,7 @@ cdef enum EdgeConnectionStatus:
 @cython.final
 cdef class QueryRequestInfo:
     cdef public object source  # edgeql.Source
+    cdef public str cache_key
     cdef public object io_format
     cdef public bint expect_one
     cdef public int implicit_limit

--- a/edb/server/mng_port/edgecon.pxd
+++ b/edb/server/mng_port/edgecon.pxd
@@ -53,7 +53,6 @@ cdef enum EdgeConnectionStatus:
 @cython.final
 cdef class QueryRequestInfo:
     cdef public object source  # edgeql.Source
-    cdef public str cache_key
     cdef public object io_format
     cdef public bint expect_one
     cdef public int implicit_limit

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -108,6 +108,7 @@ cdef class QueryRequestInfo:
     def __cinit__(
         self,
         source: edgeql.Source,
+        cache_key: str,
         io_format: object,
         expect_one: bint,
         implicit_limit: int,
@@ -115,6 +116,7 @@ cdef class QueryRequestInfo:
         inline_typenames: bint,
     ):
         self.source = source
+        self.cache_key = cache_key
         self.io_format = io_format
         self.expect_one = expect_one
         self.implicit_limit = implicit_limit
@@ -122,7 +124,7 @@ cdef class QueryRequestInfo:
         self.inline_typenames = inline_typenames
 
         self.cached_hash = hash((
-            self.source.text(),
+            self.cache_key,
             self.io_format,
             self.expect_one,
             self.implicit_limit,
@@ -135,7 +137,7 @@ cdef class QueryRequestInfo:
 
     def __eq__(self, other: QueryRequestInfo) -> bool:
         return (
-            self.source.text() == other.source.text() and
+            self.cache_key == other.cache_key and
             self.io_format == other.io_format and
             self.expect_one == other.expect_one and
             self.implicit_limit == other.implicit_limit and
@@ -902,11 +904,12 @@ cdef class EdgeConnection:
 
         return query_unit
 
-    def _tokenize(self, eql: bytes) -> edgeql.Source:
+    def _tokenize(self, eql: bytes) -> (edgeql.Source, str):
+        text = eql.decode('utf-8')
         if debug.flags.edgeql_disable_normalization:
-            return edgeql.Source.from_string(eql.decode('utf-8'))
+            return edgeql.Source.from_string(text), text
         else:
-            return edgeql.NormalizedSource.from_string(eql.decode('utf-8'))
+            return edgeql.NormalizedSource.from_string_with_cache_key(text)
 
     async def _parse(
         self,
@@ -1047,10 +1050,11 @@ cdef class EdgeConnection:
             raise errors.BinaryProtocolError('empty query')
 
         with self.timer.timed("Query normalization"):
-            source = self._tokenize(eql)
+            source, cache_key = self._tokenize(eql)
 
         query_req = QueryRequestInfo(
             source,
+            cache_key,
             io_format,
             expect_one,
             implicit_limit,

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4620,3 +4620,12 @@ aa \
             await self.con.execute("""
                 SELECT 1[1];
             """)
+
+    async def test_edgeql_expr_error_after_extraction_01(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                "Unexpected \"'1'\""):
+
+            await self.con.query("""
+                SELECT '''1''';
+            """)


### PR DESCRIPTION
Here are couple of things to watch out:
1. First commit starts sending original query text to compiler instead of cache key (which is a compressed and perhaps normalized query)
2. I'm not sure if it's save to reuse `CommandContext` as it is done in the PR

Fixes #1496

