### PR TITLE
Fix some non-delegated constraint issues

### DIFF
--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -189,6 +189,15 @@ def get_scalar_backend_name(id, module_id, catenate=True, *, aspect=None):
     return convert_name(name, aspect, catenate)
 
 
+def get_aspect_suffix(aspect):
+    if aspect == 'table':
+        return ''
+    elif aspect == 'inhview':
+        return 't'
+    else:
+        return aspect
+
+
 def get_objtype_backend_name(id, module_id, *, catenate=True, aspect=None):
     if aspect is None:
         aspect = 'table'
@@ -199,13 +208,7 @@ def get_objtype_backend_name(id, module_id, *, catenate=True, aspect=None):
 
     name = s_name.Name(module=str(module_id), name=str(id))
 
-    if aspect == 'table':
-        suffix = ''
-    elif aspect == 'inhview':
-        suffix = 't'
-    else:
-        suffix = aspect
-
+    suffix = get_aspect_suffix(aspect)
     return convert_name(name, suffix=suffix, catenate=catenate)
 
 
@@ -219,13 +222,7 @@ def get_pointer_backend_name(id, module_id, *, catenate=False, aspect=None):
 
     name = s_name.Name(module=str(module_id), name=str(id))
 
-    if aspect == 'table':
-        suffix = ''
-    elif aspect == 'inhview':
-        suffix = 't'
-    else:
-        suffix = aspect
-
+    suffix = get_aspect_suffix(aspect)
     return convert_name(name, suffix=suffix, catenate=catenate)
 
 

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -272,11 +272,16 @@ class ConstraintMech:
         }
 
         if constraint_origin != constraint:
+            origin_path_prefix_anchor = (
+                qlast.Subject().name
+                if isinstance(origin_subject, s_types.Type) else None
+            )
             origin_ir = qlcompiler.compile_ast_to_ir(
                 constraint_origin.get_finalexpr(schema).qlast,
                 schema,
                 options=qlcompiler.CompilerOptions(
                     anchors={qlast.Subject().name: origin_subject},
+                    path_prefix_anchor=origin_path_prefix_anchor,
                     apply_query_rewrites=not context.stdmode,
                 ),
             )

--- a/tests/schemas/tree.esdl
+++ b/tests/schemas/tree.esdl
@@ -35,8 +35,8 @@ type Eert {
         constraint exclusive;
     }
 
-    link parent := .<children[IS Eert];
-    multi link children -> Eert {
-        constraint exclusive;
-    }
+    # We need the limit 1 because children isn't exclusive and we can't
+    # have it be exclusive if we want to do an atomic swap...
+    link parent := (SELECT .<children[IS Eert] LIMIT 1);
+    multi link children -> Eert;
 }

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -183,6 +183,21 @@ class TestConstraintsSchema(tb.QueryTestCase):
                 """)
 
         async with self._run_and_rollback():
+            with self.assertRaisesRegex(
+                    edgedb.ConstraintViolationError,
+                    'name violates exclusivity constraint'):
+
+                await self.con.execute("""
+                    INSERT test::UniqueNameInherited {
+                        name := 'exclusive_name_across'
+                    };
+
+                    INSERT test::UniqueName {
+                        name := 'exclusive_name_across'
+                    };
+                """)
+
+        async with self._run_and_rollback():
             await self.con.execute("""
                 INSERT test::UniqueName {
                     name := 'exclusive_name_ok'

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5196,6 +5196,27 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     };
                 """)
 
+    async def test_edgeql_ddl_constraint_08(self):
+        # Test non-delegated object constraints on abstract types
+        await self.con.execute(r"""
+            CREATE TYPE test::Base {
+                CREATE PROPERTY x -> str {
+                    CREATE CONSTRAINT exclusive;
+                }
+            };
+            CREATE TYPE test::Foo EXTENDING test::Base;
+            CREATE TYPE test::Bar EXTENDING test::Base;
+
+            INSERT test::Foo { x := "a" };
+        """)
+
+        with self.assertRaisesRegex(
+                edgedb.ConstraintViolationError,
+                r'violates exclusivity constraint'):
+            await self.con.execute(r"""
+                INSERT test::Foo { x := "a" };
+            """)
+
     async def test_edgeql_ddl_constraint_alter_01(self):
         await self.con.execute(r"""
             CREATE TYPE test::ConTest01 {

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2688,3 +2688,36 @@ class TestInsert(tb.QueryTestCase):
             ''',
             [2]
         )
+
+    async def test_edgeql_insert_and_update_01(self):
+        # INSERTing something that would violate a constraint while
+        # fixing the violation is still supposed to be an error.
+        await self.con.execute('''
+            INSERT test::Person { name := 'foo' };
+        ''')
+
+        with self.assertRaisesRegex(edgedb.ConstraintViolationError,
+                                    "violates exclusivity constraint"):
+            await self.con.execute('''
+                SELECT (
+                    (UPDATE test::Person FILTER .name = 'foo'
+                        SET { name := 'foo' }),
+                    (INSERT test::Person { name := 'foo' })
+                )
+            ''')
+
+    async def test_edgeql_insert_and_delete_01(self):
+        # INSERTing something that would violate a constraint while
+        # fixing the violation is still supposed to be an error.
+        await self.con.execute('''
+            INSERT test::Person { name := 'foo' };
+        ''')
+
+        with self.assertRaisesRegex(edgedb.ConstraintViolationError,
+                                    "violates exclusivity constraint"):
+            await self.con.execute('''
+                SELECT (
+                    (DELETE test::Person FILTER .name = 'foo'),
+                    (INSERT test::Person { name := 'foo' })
+                )
+            ''')


### PR DESCRIPTION
* Don't fail when extending a type with a non-delegated object
   constraint that uses an implicit path prefix. Fixes #1938.
 * Fix non-delegated exclusive constraints not working properly in many
   cases.
 * As an (apparently correct) side effect of this, INSERTing something
   that would violate an exclusive constraint at the same time as
   DELETE/UPDATEing the conflicting object now fails.
 * Include correct TABLE and SCHEMA entries when raising unique_violation.
   (Instead of individuals characters from the name string :P)