### PR TITLE
Support renaming functions

### DIFF
--- a/docs/edgeql/ddl/functions.rst
+++ b/docs/edgeql/ddl/functions.rst
@@ -51,6 +51,7 @@ CREATE FUNCTION
 
       SET session_only := {true | false} ;
       SET volatility := {'VOLATILE' | 'IMMUTABLE' | 'STABLE'} ;
+      RENAME TO <newname> ;
       CREATE ANNOTATION <annotation-name> := <value> ;
       USING ( <expr> ) ;
       USING <language> <functionbody> ;

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -220,7 +220,7 @@ def compile_FunctionCall(
         func_module_id=env.schema.get_global(
             s_mod.Module, func_name.module).id,
         func_shortname=func_name,
-        func_id=func.get_func_id(env.schema),
+        backend_name=func.get_backend_name(env.schema),
         func_polymorphic=is_polymorphic,
         func_sql_function=func.get_from_function(env.schema),
         force_return_cast=func.get_force_return_cast(env.schema),

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -220,6 +220,7 @@ def compile_FunctionCall(
         func_module_id=env.schema.get_global(
             s_mod.Module, func_name.module).id,
         func_shortname=func_name,
+        func_id=func.get_func_id(env.schema),
         func_polymorphic=is_polymorphic,
         func_sql_function=func.get_from_function(env.schema),
         force_return_cast=func.get_force_return_cast(env.schema),

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1639,6 +1639,7 @@ commands_block(
     'AlterFunction',
     commondl.FromFunction,
     SetFieldStmt,
+    RenameStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -650,8 +650,8 @@ class FunctionCall(Call):
     # The underlying SQL function has OUT parameters.
     sql_func_has_out_params: bool = False
 
-    # func_id for the underlying function
-    func_id: typing.Optional[str] = None
+    # backend_name for the underlying function
+    backend_name: typing.Optional[str] = None
 
     # Error to raise if the underlying SQL function returns NULL.
     error_on_null_result: typing.Optional[str] = None

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -650,6 +650,9 @@ class FunctionCall(Call):
     # The underlying SQL function has OUT parameters.
     sql_func_has_out_params: bool = False
 
+    # func_id for the underlying function
+    func_id: typing.Optional[str] = None
+
     # Error to raise if the underlying SQL function returns NULL.
     error_on_null_result: typing.Optional[str] = None
 

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -282,8 +282,10 @@ def get_cast_backend_name(name, module_id, catenate=False, *, aspect=None):
             f'unexpected aspect for cast backend name: {aspect!r}')
 
 
-def get_function_backend_name(name, module_id, catenate=False):
-    fullname = s_name.QualName(module=str(module_id), name=name.name)
+def get_function_backend_name(name, module_id, func_id, catenate=False):
+    real_name = func_id or name.name
+
+    fullname = s_name.QualName(module=str(module_id), name=real_name)
     schema, func_name = convert_name(fullname, catenate=False)
     if catenate:
         return qname(schema, func_name)
@@ -347,8 +349,9 @@ def get_backend_name(schema, obj, catenate=True, *, aspect=None):
     elif isinstance(obj, s_func.Function):
         name = obj.get_shortname(schema)
         module = schema.get_global(s_mod.Module, name.module)
+        func_id = obj.get_func_id(schema)
         return get_function_backend_name(
-            name, module.id, catenate)
+            name, module.id, func_id, catenate)
 
     elif isinstance(obj, s_mod.Module):
         return get_module_backend_name(str(obj.id))

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -282,8 +282,8 @@ def get_cast_backend_name(name, module_id, catenate=False, *, aspect=None):
             f'unexpected aspect for cast backend name: {aspect!r}')
 
 
-def get_function_backend_name(name, module_id, func_id, catenate=False):
-    real_name = func_id or name.name
+def get_function_backend_name(name, module_id, backend_name, catenate=False):
+    real_name = backend_name or name.name
 
     fullname = s_name.QualName(module=str(module_id), name=real_name)
     schema, func_name = convert_name(fullname, catenate=False)
@@ -349,9 +349,9 @@ def get_backend_name(schema, obj, catenate=True, *, aspect=None):
     elif isinstance(obj, s_func.Function):
         name = obj.get_shortname(schema)
         module = schema.get_global(s_mod.Module, name.module)
-        func_id = obj.get_func_id(schema)
+        backend_name = obj.get_backend_name(schema)
         return get_function_backend_name(
-            name, module.id, func_id, catenate)
+            name, module.id, backend_name, catenate)
 
     elif isinstance(obj, s_mod.Module):
         return get_module_backend_name(str(obj.id))

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -558,13 +558,7 @@ def compile_FunctionCall(
 
         args.append(pgast.VariadicArgument(expr=var))
 
-    if expr.func_sql_function:
-        # The name might contain a "." if it's one of our
-        # metaschema helpers.
-        name = tuple(expr.func_sql_function.split('.', 1))
-    else:
-        name = common.get_function_backend_name(expr.func_shortname,
-                                                expr.func_module_id)
+    name = relgen.get_func_call_backend_name(expr, ctx=ctx)
 
     result: pgast.BaseExpr = pgast.FuncCall(name=name, args=args)
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2043,7 +2043,7 @@ def get_func_call_backend_name(
         func_name = tuple(expr.func_sql_function.split('.', 1))
     else:
         func_name = common.get_function_backend_name(
-            expr.func_shortname, expr.func_module_id, expr.func_id)
+            expr.func_shortname, expr.func_module_id, expr.backend_name)
     return func_name
 
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2034,6 +2034,19 @@ def _compile_func_args(
     return args
 
 
+def get_func_call_backend_name(
+        expr: irast.FunctionCall, *,
+        ctx: context.CompilerContextLevel) -> Tuple[str, ...]:
+    if expr.func_sql_function:
+        # The name might contain a "." if it's one of our
+        # metaschema helpers.
+        func_name = tuple(expr.func_sql_function.split('.', 1))
+    else:
+        func_name = common.get_function_backend_name(
+            expr.func_shortname, expr.func_module_id, expr.func_id)
+    return func_name
+
+
 def process_set_as_func_enumerate(
         ir_set: irast.Set, stmt: pgast.SelectStmt, *,
         ctx: context.CompilerContextLevel) -> SetRVars:
@@ -2047,14 +2060,7 @@ def process_set_as_func_enumerate(
     with ctx.subrel() as newctx:
         newctx.expr_exposed = False
         args = _compile_func_args(inner_func_set, ctx=newctx)
-
-        if inner_func.func_sql_function:
-            # The name might contain a "." if it's one of our
-            # metaschema helpers.
-            func_name = tuple(inner_func.func_sql_function.split('.', 1))
-        else:
-            func_name = common.get_function_backend_name(
-                inner_func.func_shortname, inner_func.func_module_id)
+        func_name = get_func_call_backend_name(inner_func, ctx=newctx)
 
         set_expr = _process_set_func_with_ordinality(
             ir_set=inner_func_set,
@@ -2078,14 +2084,7 @@ def process_set_as_func_expr(
     with ctx.subrel() as newctx:
         newctx.expr_exposed = False
         args = _compile_func_args(ir_set, ctx=newctx)
-
-        if expr.func_sql_function:
-            # The name might contain a "." if it's one of our
-            # metaschema helpers.
-            name = tuple(expr.func_sql_function.split('.', 1))
-        else:
-            name = common.get_function_backend_name(
-                expr.func_shortname, expr.func_module_id)
+        name = get_func_call_backend_name(expr, ctx=newctx)
 
         if expr.typemod is qltypes.TypeModifier.SetOfType:
             set_expr = _process_set_func(
@@ -2245,13 +2244,7 @@ def process_set_as_agg_expr(
 
                 args.append(arg_ref)
 
-        if expr.func_sql_function:
-            # The name might contain a "." if it's one of our
-            # metaschema helpers.
-            name = tuple(expr.func_sql_function.split('.', 1))
-        else:
-            name = common.get_function_backend_name(expr.func_shortname,
-                                                    expr.func_module_id)
+        name = get_func_call_backend_name(expr, ctx=newctx)
 
         set_expr = pgast.FuncCall(
             name=name, args=args, agg_order=agg_sort, agg_filter=agg_filter,

--- a/edb/pgsql/dbops/functions.py
+++ b/edb/pgsql/dbops/functions.py
@@ -168,25 +168,30 @@ class CreateOrReplaceFunction(ddl.DDLOperation, FunctionOperation):
 
 class RenameFunction(base.CommandGroup):
     def __init__(
-            self, name, args, new_name, *, conditions=None,
+            self, name, args, new_name, *,
+            has_variadic=False,
+            conditions=None,
             neg_conditions=None, priority=0):
         super().__init__(
             conditions=conditions, neg_conditions=neg_conditions,
             priority=priority)
 
         if name[0] != new_name[0]:
-            cmd = AlterFunctionSetSchema(name, args, new_name[0])
+            cmd = AlterFunctionSetSchema(
+                name, args, has_variadic, new_name[0])
             self.add_command(cmd)
             name = (new_name[0], name[1])
 
         if name[1] != new_name[1]:
-            cmd = AlterFunctionRenameTo(name, args, new_name[1])
+            cmd = AlterFunctionRenameTo(
+                name, args, has_variadic, new_name[1])
             self.add_command(cmd)
 
 
-class AlterFunctionSetSchema(ddl.DDLOperation):
+class AlterFunctionSetSchema(ddl.DDLOperation, FunctionOperation):
     def __init__(
-            self, name, args, new_schema, *, conditions=None,
+            self, name, args, has_variadic, new_schema, *,
+            conditions=None,
             neg_conditions=None, priority=0):
         super().__init__(
             conditions=conditions, neg_conditions=neg_conditions,
@@ -194,16 +199,19 @@ class AlterFunctionSetSchema(ddl.DDLOperation):
         self.name = name
         self.args = args
         self.new_schema = new_schema
+        self.has_variadic = has_variadic
 
     def code(self, block: base.PLBlock) -> str:
-        args = ', '.join(qi(a) for a in self.args)
+        args = self.format_args(self.args, self.has_variadic,
+                                include_defaults=False)
         return (f'ALTER FUNCTION {qn(*self.name)}({args}) '
                 f'SET SCHEMA {qi(self.new_schema)}')
 
 
-class AlterFunctionRenameTo(ddl.DDLOperation):
+class AlterFunctionRenameTo(ddl.DDLOperation, FunctionOperation):
     def __init__(
-            self, name, args, new_name, *, conditions=None,
+            self, name, args, has_variadic, new_name, *,
+            conditions=None,
             neg_conditions=None, priority=0):
         super().__init__(
             conditions=conditions, neg_conditions=neg_conditions,
@@ -211,9 +219,11 @@ class AlterFunctionRenameTo(ddl.DDLOperation):
         self.name = name
         self.args = args
         self.new_name = new_name
+        self.has_variadic = has_variadic
 
     def code(self, block: base.PLBlock) -> str:
-        args = ', '.join(qi(a) for a in self.args)
+        args = self.format_args(self.args, self.has_variadic,
+                                include_defaults=False)
         return (f'ALTER FUNCTION {qn(*self.name)}({args}) '
                 f'RENAME TO {qi(self.new_name)}')
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1709,7 +1709,8 @@ class RenameFunction(RenameCallableObject[Function], FunctionCommand):
         if target:
             raise errors.SchemaError(
                 f"can not rename function to '{new_name!s}' because "
-                f"a function with the same name already exists, and renaming into an overload is not supported",
+                f"a function with the same name already exists, and "
+                f"renaming into an overload is not supported",
                 context=self.source_context)
 
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1101,9 +1101,9 @@ class DeleteCallableObject(
 class Function(CallableObject, VolatilitySubject, s_abc.Function,
                qlkind=ft.SchemaObjectClass.FUNCTION):
 
-    # A func_id that is shared between all overloads of the same
+    # A backend_name that is shared between all overloads of the same
     # function, to make them independent from the actual name.
-    func_id = so.SchemaField(
+    backend_name = so.SchemaField(
         uuid.UUID,
         default=None,
     )
@@ -1553,11 +1553,11 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
         shortname = sn.shortname_from_fullname(fullname)
         if others := schema.get_functions(
                 sn.QualName(fullname.module, shortname.name), ()):
-            func_id = others[0].get_func_id(schema)
+            backend_name = others[0].get_backend_name(schema)
         else:
-            func_id = uuidgen.uuid1mc()
+            backend_name = uuidgen.uuid1mc()
 
-        cmd.set_attribute_value('func_id', func_id)
+        cmd.set_attribute_value('backend_name', backend_name)
 
         assert isinstance(astnode, qlast.CreateFunction)
         if astnode.code is not None:

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1709,7 +1709,7 @@ class RenameFunction(RenameCallableObject[Function], FunctionCommand):
         if target:
             raise errors.SchemaError(
                 f"can not rename function to '{new_name!s}' because "
-                f"it already exists",
+                f"a function with the same name already exists, and renaming into an overload is not supported",
                 context=self.source_context)
 
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -859,7 +859,8 @@ class Compiler(BaseCompiler):
                 debug.header('Populate Migration Diff')
                 debug.dump(diff, schema=schema)
 
-            new_ddl = s_ddl.ddlast_from_delta(mstate.target_schema, diff)
+            new_ddl = s_ddl.ddlast_from_delta(
+                schema, mstate.target_schema, diff)
             all_ddl = mstate.current_ddl + new_ddl
             if not mstate.current_ddl:
                 mstate = mstate._replace(current_ddl=all_ddl, auto_diff=diff)
@@ -931,6 +932,7 @@ class Compiler(BaseCompiler):
                 )
 
                 proposed_ddl = s_ddl.statements_from_delta(
+                    schema,
                     mstate.target_schema,
                     guided_diff,
                 )

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -27,7 +27,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_11_11_00_00
+EDGEDB_CATALOG_VERSION = 2020_11_16_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -351,6 +351,7 @@ class BaseSchemaTest(BaseDocTest):
 
                 migration_script.extend(
                     s_ddl.ddlast_from_delta(
+                        migration_schema,
                         migration_target,
                         migration_diff,
                     ),

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2682,7 +2682,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
                 r"can not rename function to 'test::foo' because "
-                r"it already exists"):
+                r"a function with the same name already exists"):
             await self.con.execute("""
                 ALTER FUNCTION test::bar(s: int64)
                 RENAME TO test::foo;


### PR DESCRIPTION
We do this by adding a func_id field that is used to determine the
backend name and that is shared between all functions sharing a name.