### PR TITLE
Make sure an alter can be generated for low-similarity pairs

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -268,11 +268,22 @@ class Constraint(referencing.ReferencedInheritingObject,
         self_schema: s_schema.Schema,
         other_schema: s_schema.Schema,
         context: so.ComparisonContext,
-    ) -> sd.Command:
+    ) -> sd.ObjectCommand[Constraint]:
         return super().as_alter_delta(
             other,
             self_schema=self_schema,
             other_schema=other_schema,
+            context=context,
+        )
+
+    def as_delete_delta(
+        self,
+        *,
+        schema: s_schema.Schema,
+        context: so.ComparisonContext,
+    ) -> sd.ObjectCommand[Constraint]:
+        return super().as_delete_delta(
+            schema=schema,
             context=context,
         )
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -288,7 +288,7 @@ class ParameterDesc(ParameterLike):
         func_fqname: sn.QualName,
         *,
         context: sd.CommandContext,
-    ) -> sd.Command:
+    ) -> sd.CreateObject[Parameter]:
         CreateParameter = sd.ObjectCommandMeta.get_command_class_or_die(
             sd.CreateObject, Parameter)
 
@@ -309,7 +309,7 @@ class ParameterDesc(ParameterLike):
         func_fqname: sn.QualName,
         *,
         context: sd.CommandContext,
-    ) -> sd.Command:
+    ) -> sd.ObjectCommand[Parameter]:
         DeleteParameter = sd.ObjectCommandMeta.get_command_class_or_die(
             sd.DeleteObject, Parameter)
 
@@ -733,7 +733,7 @@ class CallableObject(
         self: CallableObjectT,
         schema: s_schema.Schema,
         context: so.ComparisonContext,
-    ) -> sd.Command:
+    ) -> sd.ObjectCommand[CallableObjectT]:
         delta = super().as_create_delta(schema, context)
 
         new_params = self.get_params(schema).objects(schema)
@@ -752,7 +752,7 @@ class CallableObject(
         self_schema: s_schema.Schema,
         other_schema: s_schema.Schema,
         context: so.ComparisonContext,
-    ) -> sd.Command:
+    ) -> sd.ObjectCommand[CallableObjectT]:
         delta = super().as_alter_delta(
             other,
             self_schema=self_schema,
@@ -790,7 +790,7 @@ class CallableObject(
         *,
         schema: s_schema.Schema,
         context: so.ComparisonContext,
-    ) -> sd.Command:
+    ) -> sd.ObjectCommand[CallableObjectT]:
         delta = super().as_delete_delta(schema=schema, context=context)
         old_params = self.get_params(schema).objects(schema)
         for p in old_params:

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1405,7 +1405,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         self: Object_T,
         schema: s_schema.Schema,
         context: ComparisonContext,
-    ) -> sd.Command:
+    ) -> sd.ObjectCommand[Object_T]:
         from . import delta as sd
 
         cls = type(self)
@@ -1458,7 +1458,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         self_schema: s_schema.Schema,
         other_schema: s_schema.Schema,
         context: ComparisonContext,
-    ) -> sd.Command:
+    ) -> sd.ObjectCommand[Object_T]:
         from . import delta as sd
 
         cls = type(self)
@@ -1561,7 +1561,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         *,
         schema: s_schema.Schema,
         context: ComparisonContext,
-    ) -> sd.Command:
+    ) -> sd.ObjectCommand[Object_T]:
         from . import delta as sd
 
         cls = type(self)
@@ -2726,7 +2726,7 @@ class InheritingObject(SubclassableObject):
         self_schema: s_schema.Schema,
         other_schema: s_schema.Schema,
         context: ComparisonContext,
-    ) -> sd.Command:
+    ) -> sd.ObjectCommand[InheritingObjectT]:
         from . import delta as sd
         from . import inheriting as s_inh
 

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -301,7 +301,7 @@ class ReferencedInheritingObject(
         *,
         schema: s_schema.Schema,
         context: so.ComparisonContext,
-    ) -> sd.Command:
+    ) -> sd.ObjectCommand[ReferencedInheritingObjectT]:
         del_op = super().as_delete_delta(schema=schema, context=context)
 
         if (
@@ -318,13 +318,9 @@ class ReferencedInheritingObject(
             alter_op.add(owned_op)
             del_op.set_attribute_value('is_owned', None, orig_value=False)
 
-            group = sd.CommandGroup()
-            group.add(alter_op)
-            group.add(del_op)
+            del_op.add(alter_op)
 
-            return group
-        else:
-            return del_op
+        return del_op
 
     def record_field_alter_delta(
         self: ReferencedInheritingObjectT,

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -7672,3 +7672,73 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 };
                 POPULATE MIGRATION;
             """)
+
+    async def test_edgeql_migration_force_alter(self):
+        await self.con.execute('''
+            START MIGRATION TO {
+                module test {
+                    type Obj1 {
+                        property foo -> str;
+                        property bar -> str;
+                    }
+
+                    type Obj2 {
+                        property o -> int64;
+                        link o1 -> Obj1;
+                    }
+                };
+            };
+        ''')
+        await self.fast_forward_describe_migration()
+
+        await self.con.execute('''
+            START MIGRATION TO {
+                module test {
+                    type Obj1 {
+                        property foo -> str;
+                        property bar -> str;
+                    }
+
+                    type NewObj2 {
+                        property name -> str;
+                        annotation title := 'Obj2';
+                    }
+                };
+            };
+        ''')
+
+        await self.assert_describe_migration({
+            'confirmed': [],
+            'complete': False,
+            'proposed': {
+                'statements': [{
+                    'text':
+                        'CREATE TYPE test::NewObj2 {\n'
+                        '    CREATE OPTIONAL SINGLE PROPERTY name'
+                        ' -> std::str;\n'
+                        "    CREATE ANNOTATION std::title := 'Obj2';\n"
+                        '};'
+                }],
+            },
+        })
+
+        await self.con.execute('''
+            ALTER CURRENT MIGRATION REJECT PROPOSED;
+        ''')
+
+        await self.assert_describe_migration({
+            'confirmed': [],
+            'complete': False,
+            'proposed': {
+                'statements': [{
+                    'text':
+                        'ALTER TYPE test::Obj2 {\n'
+                        '    RENAME TO test::NewObj2;\n'
+                        '    DROP LINK o1;\n'
+                        '    DROP PROPERTY o;\n'
+                        '    CREATE OPTIONAL SINGLE PROPERTY name -> std::str;'
+                        "\n    CREATE ANNOTATION std::title := 'Obj2';\n"
+                        '};'
+                }],
+            },
+        })


### PR DESCRIPTION
For low similarity scores (< 0.6) we generate a `DROP` followed by a
`CREATE`, treating the pair as disinct objects.  However, the intent might
still be to actually alter (and possibly rename) the existing type and
hence we must handle the rejection of `DROP`/`CREATE` appropriately.