### PR TITLE
Fix creation of collection types during AlterObjectFragments

### DIFF
--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2204,8 +2204,14 @@ def materialize_type_in_attribute(
             schema = cc_cmd.apply(schema, context)
 
     if isinstance(type_ref, CollectionTypeShell):
+        # If the current command is a fragment, we want the collection
+        # creation to live in the parent operation, in order for the
+        # logic to skip it if the object already exists to work.
+        op = (cmd.get_parent_op(context)
+              if isinstance(cmd, sd.AlterObjectFragment) else cmd)
+
         make_coll = type_ref.as_create_delta(schema)
-        cmd.add_prerequisite(make_coll)
+        op.add_prerequisite(make_coll)
         schema = make_coll.apply(schema, context)
 
     if isinstance(type_ref, TypeShell):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1509,6 +1509,21 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ALTER TYPE Base1 CREATE LINK foo -> A;
         ''')
 
+    async def test_edgeql_ddl_prop_target_alter_array_01(self):
+        await self.con.execute(r"""
+            CREATE TYPE test::Foo {
+                CREATE PROPERTY foo -> array<int32>;
+            };
+
+            ALTER TYPE test::Foo {
+                ALTER PROPERTY foo SET TYPE array<float32>;
+            };
+
+            ALTER TYPE test::Foo {
+                ALTER PROPERTY foo SET TYPE array<int32>;
+            };
+        """)
+
     async def test_edgeql_ddl_link_property_01(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidPropertyDefinitionError,


### PR DESCRIPTION
The collection creation to go into the parent operation in order for
the if_exists logic in CreateObject to work properly.