### PR TITLE
Fix deletion of collection types when they are orphaned

### DIFF
--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -235,7 +235,7 @@ def fini_expression(
             ctx.env.schema_refs - ctx.env.created_schema_objects),
         schema_ref_exprs=ctx.env.schema_ref_exprs,
         new_coll_types=frozenset(
-            t for t in ctx.env.created_schema_objects
+            t for t in (ctx.env.schema_refs | ctx.env.created_schema_objects)
             if isinstance(t, s_types.Collection) and t != expr_type
         ),
         type_rewrites={s.typeref.id: s for s in ctx.type_rewrites.values()},

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2151,13 +2151,15 @@ class PointerMetaCommand(MetaCommand, sd.ObjectCommand,
 
         type_change_ok = False
 
-        if (old_target.get_name(schema) != new_target.get_name(schema) or
+        if (old_target.get_name(orig_schema) != new_target.get_name(schema) or
                 old_ptr_stor_info.table_type != new_ptr_stor_info.table_type):
 
             for op in self.get_subcommands(type=s_scalars.ScalarTypeCommand):
                 for rename in op(s_scalars.RenameScalarType):
-                    if (old_target.get_name(schema) == rename.classname and
-                            new_target.get_name(schema) == rename.new_name):
+                    if (
+                        old_target.get_name(orig_schema) == rename.classname
+                        and new_target.get_name(schema) == rename.new_name
+                    ):
                         # Our target alter is a mere rename
                         type_change_ok = True
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2715,6 +2715,11 @@ class DeleteObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
     #: in the schema.
     if_unused = struct.Field(bool, default=False)
 
+    #: Potential references to this object that we know are being
+    #: deleted, which we use to resolve if_unused.
+    expiring_refs = struct.Field(AbstractSet[so.Object],
+                                 default=frozenset())
+
     def _delete_begin(
         self,
         schema: s_schema.Schema,
@@ -2833,7 +2838,7 @@ class DeleteObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
             if (
                 not self.canonical
                 and self.if_unused
-                and schema.get_referrers(scls)
+                and (schema.get_referrers(scls) - self.expiring_refs)
             ):
                 parent_ctx = context.parent()
                 if parent_ctx is not None:

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -326,7 +326,9 @@ class ParameterDesc(ParameterLike):
         if isinstance(self.type, s_types.CollectionTypeShell):
             colltype = self.type.resolve(schema)
             assert isinstance(colltype, s_types.Collection)
-            cmd.add(colltype.as_colltype_delete_delta(schema))
+            obj = schema.get(param_name)
+            cmd.add(
+                colltype.as_colltype_delete_delta(schema, expiring_refs={obj}))
 
         return cmd
 
@@ -1093,7 +1095,8 @@ class DeleteCallableObject(
 
         return_type = obj.get_return_type(schema)
         if isinstance(return_type, s_types.Collection):
-            cmd.add(return_type.as_colltype_delete_delta(schema))
+            cmd.add(return_type.as_colltype_delete_delta(
+                schema, expiring_refs={obj}))
 
         return cmd
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1437,6 +1437,13 @@ class SetPointerType(
             schema, context, action=f'alter the type of {vn}')
 
         if not context.canonical:
+            if (
+                orig_target is not None
+                and isinstance(orig_target, s_types.Collection)
+            ):
+                self.add(orig_target.as_colltype_delete_delta(
+                    schema, expiring_refs={scls}))
+
             implicit_bases = scls.get_implicit_bases(schema)
             non_altered_bases = []
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3794,6 +3794,18 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
+    def test_schema_migrations_equivalence_collections_05b(self):
+        self._assert_migration_equivalence([r"""
+            type Base {
+                property foo -> array<float32>;
+            }
+        """, r"""
+            type Base {
+                # convert property type to array
+                property foo -> float32;
+            }
+        """])
+
     def test_schema_migrations_equivalence_collections_06(self):
         self._assert_migration_equivalence([r"""
             type Base {


### PR DESCRIPTION
This fixes a bunch of test_schema tests with DDL migrations turned on.