### PR TITLE
Fix a cluster of bugs related to rebasing and constraints

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1154,8 +1154,7 @@ class AlterConstraint(
         ConstraintCommand, AlterObject,
         adapts=s_constr.AlterConstraint):
     def apply(self, schema, context):
-        delta_root_ctx = context.top()
-        orig_schema = delta_root_ctx.original_schema
+        orig_schema = schema
         schema = super().apply(schema, context)
         constraint = self.scls
         if self.metadata_only:
@@ -1610,6 +1609,11 @@ class CompositeObjectMetaCommand(ObjectMetaCommand):
         update_ancestors: Optional[bool]=None,
         update_descendants: Optional[bool]=None,
     ):
+        self.pgops.add(
+            self.drop_inhview(
+                schema, context, obj, drop_ancestors=update_ancestors)
+        )
+
         root = context.get(sd.DeltaRootContext).op
         updates = root.update_inhviews.view_updates
         update = updates.get(obj)

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -271,6 +271,20 @@ class LinkCommand(lproperties.PropertySourceCommand,
                 node.is_required = True
         return node
 
+    def _reinherit_classref_dict(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        refdict: so.RefDict,
+    ) -> s_schema.Schema:
+        if self.scls.get_computable(schema) and refdict.attr != 'pointers':
+            # If the link is a computable, the inheritance would only
+            # happen in the case of aliasing, and in that case we only
+            # need to inherit the link properties and nothing else.
+            return schema
+
+        return super()._reinherit_classref_dict(schema, context, refdict)
+
 
 class CreateLink(
     LinkCommand,

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -853,11 +853,12 @@ class ReferencedInheritingObjectCommand(
 
         return schema
 
-    def _drop_owned_refs(
+    def _set_owned_refs(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
         refdict: so.RefDict,
+        new_is_owned: bool,
     ) -> s_schema.Schema:
 
         scls = self.scls
@@ -865,14 +866,14 @@ class ReferencedInheritingObjectCommand(
 
         for ref in refs.objects(schema):
             inherited = ref.get_implicit_bases(schema)
-            if inherited and ref.get_is_owned(schema):
-                drop_owned = ref.init_delta_command(schema, AlterOwned)
-                drop_owned.set_attribute_value('is_owned', False)
+            if inherited and ref.get_is_owned(schema) != new_is_owned:
+                set_owned = ref.init_delta_command(schema, AlterOwned)
+                set_owned.set_attribute_value('is_owned', new_is_owned)
                 alter = ref.init_delta_command(schema, sd.AlterObject)
-                alter.add(drop_owned)
+                alter.add(set_owned)
                 schema = alter.apply(schema, context)
                 self.add(alter)
-            else:
+            elif not new_is_owned:
                 drop_ref = ref.init_delta_command(schema, sd.DeleteObject)
                 self.add(drop_ref)
 
@@ -964,10 +965,13 @@ class CreateReferencedInheritingObject(
                 if implicit_bases:
                     bases = self.get_attribute_value('bases')
                     if bases:
+                        res_bases = cast(
+                            List[ReferencedInheritingObjectT],
+                            self.resolve_obj_collection(bases, schema))
                         bases = so.ObjectList.create(
                             schema,
                             implicit_bases + [
-                                b for b in bases.objects(schema)
+                                b for b in res_bases
                                 if b not in implicit_bases
                             ],
                         )
@@ -1436,7 +1440,14 @@ class AlterOwned(
             )
 
             for refdict in type(scls).get_refdicts():
-                schema = self._drop_owned_refs(schema, context, refdict)
+                schema = self._set_owned_refs(schema, context, refdict, owned)
+        elif (
+            orig_owned != owned
+            and owned
+            and not context.canonical
+        ):
+            for refdict in type(scls).get_refdicts():
+                schema = self._set_owned_refs(schema, context, refdict, owned)
 
         return schema
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1043,6 +1043,152 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             };
         """)
 
+    async def test_edgeql_ddl_drop_extending_01(self):
+        await self.con.execute("""
+            SET MODULE test;
+
+            CREATE TYPE Parent {
+                CREATE PROPERTY name -> str {
+                    CREATE CONSTRAINT exclusive;
+                };
+            };
+            CREATE TYPE Child EXTENDING Parent;
+        """)
+
+        await self.con.execute("""
+            ALTER TYPE Child DROP EXTENDING Parent;
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "object type 'test::Child' has no link or property 'name'",
+        ):
+            await self.con.execute("""
+                SELECT Child.name
+            """)
+
+        # Should be able to drop parent
+        await self.con.execute("""
+            DROP TYPE Parent;
+        """)
+
+    async def test_edgeql_ddl_drop_extending_02(self):
+        await self.con.execute("""
+            SET MODULE test;
+
+            CREATE TYPE Parent {
+                CREATE PROPERTY name -> str {
+                    CREATE CONSTRAINT exclusive;
+                };
+            };
+            CREATE TYPE Child EXTENDING Parent {
+                ALTER PROPERTY name {
+                    SET OWNED;
+                };
+            };
+        """)
+
+        await self.con.execute("""
+            ALTER TYPE Child DROP EXTENDING Parent;
+        """)
+
+        # The constraint shouldn't be linked anymore
+        await self.con.execute("""
+            INSERT Child { name := "foo" };
+            INSERT Parent { name := "foo" };
+        """)
+        await self.con.execute("""
+            INSERT Parent { name := "bar" };
+            INSERT Child { name := "bar" };
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            'name violates exclusivity constraint',
+        ):
+            await self.con.execute("""
+                INSERT Parent { name := "bar" };
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            'name violates exclusivity constraint',
+        ):
+            await self.con.execute("""
+                INSERT Child { name := "bar" };
+            """)
+
+        # Should be able to drop parent
+        await self.con.execute("""
+            DROP TYPE Parent;
+        """)
+
+    async def test_edgeql_ddl_drop_extending_03(self):
+        await self.con.execute("""
+            SET MODULE test;
+
+            CREATE TYPE Parent {
+                CREATE PROPERTY name -> str {
+                    CREATE CONSTRAINT exclusive;
+                };
+            };
+            CREATE TYPE Child EXTENDING Parent {
+                ALTER PROPERTY name {
+                    SET OWNED;
+                };
+            };
+            CREATE TYPE Grandchild EXTENDING Child;
+        """)
+
+        await self.con.execute("""
+            ALTER TYPE Child DROP EXTENDING Parent;
+        """)
+
+        # Should be able to drop parent
+        await self.con.execute("""
+            DROP TYPE Parent;
+        """)
+
+    async def test_edgeql_ddl_drop_extending_04(self):
+        await self.con.execute("""
+            SET MODULE test;
+
+            CREATE TYPE Parent {
+                CREATE PROPERTY name -> str {
+                    CREATE CONSTRAINT exclusive;
+                };
+            };
+            CREATE TYPE Child EXTENDING Parent {
+                ALTER PROPERTY name {
+                    SET OWNED;
+                };
+            };
+            CREATE TYPE Grandchild EXTENDING Child {
+                ALTER PROPERTY name {
+                    SET OWNED;
+                };
+            };
+        """)
+
+        await self.con.execute("""
+            ALTER TYPE Grandchild DROP EXTENDING Child;
+        """)
+
+        # Should be able to drop parent
+        await self.con.execute("""
+            DROP TYPE Child;
+            DROP TYPE Parent;
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            'name violates exclusivity constraint',
+        ):
+            await self.con.execute("""
+                INSERT Grandchild { name := "bar" };
+                INSERT Grandchild { name := "bar" };
+            """)
+
     async def test_edgeql_ddl_default_01(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,


### PR DESCRIPTION
* SET OWNED needs to proceed recursively (or else things like
   constraints and link properties will be lost when a parent is
   dropped)
 * When parents are dropped, we need to go through the object and
   find parent objects for refs and rebase those
 * We need to drop a view while rebasing
 * AlterConstraint's pgsql delta can't use the original_schema since
   the constraint might not have existed in the original schema