### PR TITLE
Multiplicity inference and enforcement

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -171,6 +171,11 @@ class Environment:
         qltypes.Volatility]
     """A dictionary of expressions and their inferred volatility."""
 
+    inferred_multiplicity: Dict[
+        irast.Base,
+        qltypes.Multiplicity]
+    """A dictionary of expressions and their inferred multiplicity."""
+
     view_shapes: Dict[
         Union[s_types.Type, s_pointers.PointerLike],
         List[Tuple[s_pointers.Pointer, qlast.ShapeOp]]
@@ -232,6 +237,7 @@ class Environment:
         self.type_origins = {}
         self.inferred_types = {}
         self.inferred_volatility = {}
+        self.inferred_multiplicity = {}
         self.view_shapes = collections.defaultdict(list)
         self.view_shapes_metadata = collections.defaultdict(
             irast.ViewShapeMetadata)

--- a/edb/edgeql/compiler/inference/__init__.py
+++ b/edb/edgeql/compiler/inference/__init__.py
@@ -24,9 +24,13 @@ __all__ = (
     'infer_cardinality',
     'infer_type',
     'infer_volatility',
+    'infer_multiplicity',
+    'InfCtx',
     'make_ctx',
 )
 
-from .cardinality import infer_cardinality, make_ctx  # NOQA
+from .cardinality import infer_cardinality  # NOQA
+from .context import InfCtx, make_ctx  # NOQA
+from .multiplicity import infer_multiplicity  # NOQA
 from .types import amend_empty_set_type, infer_type  # NOQA
 from .volatility import infer_volatility  # NOQA

--- a/edb/edgeql/compiler/inference/context.py
+++ b/edb/edgeql/compiler/inference/context.py
@@ -1,0 +1,52 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+from typing import *
+
+from edb.ir import ast as irast
+from edb.edgeql import qltypes
+
+from .. import context
+
+
+class InfCtx(NamedTuple):
+    env: context.Environment
+    inferred_cardinality: Dict[
+        Tuple[irast.Base, irast.ScopeTreeNode],
+        qltypes.Cardinality]
+    inferred_multiplicity: Dict[
+        Tuple[irast.Base, irast.ScopeTreeNode],
+        qltypes.Multiplicity]
+    singletons: Collection[irast.PathId]
+    bindings: Dict[irast.PathId, irast.ScopeTreeNode]
+    volatile_uses: Dict[irast.PathId, irast.ScopeTreeNode]
+    in_for_body: bool
+
+
+def make_ctx(env: context.Environment) -> InfCtx:
+    return InfCtx(
+        env=env,
+        inferred_cardinality={},
+        inferred_multiplicity={},
+        singletons={},
+        bindings={},
+        volatile_uses={},
+        in_for_body=False,
+    )

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -1,0 +1,690 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+"""EdgeQL multiplicity inference.
+
+A top-down multiplicity inferer that traverses the full AST populating
+multiplicity fields and performing multiplicity checks.
+"""
+
+
+from __future__ import annotations
+from typing import *
+
+import functools
+
+from edb import errors
+
+from edb.edgeql import qltypes
+
+from edb.schema import pointers as s_pointers
+
+from edb.ir import ast as irast
+from edb.ir import typeutils as irtyputils
+
+from . import cardinality
+from . import context as inference_context
+
+
+ZERO = qltypes.Multiplicity.ZERO
+ONE = qltypes.Multiplicity.ONE
+MANY = qltypes.Multiplicity.MANY
+
+
+def _max_multiplicity(
+    args: Iterable[qltypes.Multiplicity]
+) -> qltypes.Multiplicity:
+    # Coincidentally, the lexical order of multiplicity is opposite of
+    # order of multiplicity values.
+    arg_list = list(args)
+    if not arg_list:
+        return ZERO
+    else:
+        return min(arg_list)
+
+
+def _common_multiplicity(
+    args: Iterable[irast.Base],
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    return _max_multiplicity(
+        infer_multiplicity(a, scope_tree=scope_tree, ctx=ctx) for a in args)
+
+
+@functools.singledispatch
+def _infer_multiplicity(
+    ir: irast.Expr,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    # return MANY
+    raise ValueError(f'infer_multiplicity: cannot handle {ir!r}')
+
+
+@_infer_multiplicity.register
+def __infer_none(
+    ir: None,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    # Here for debugging purposes.
+    raise ValueError('invalid infer_multiplicity(None, schema) call')
+
+
+@_infer_multiplicity.register
+def __infer_statement(
+    ir: irast.Statement,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    return infer_multiplicity(
+        ir.expr, scope_tree=scope_tree, ctx=ctx)
+
+
+@_infer_multiplicity.register
+def __infer_empty_set(
+    ir: irast.EmptySet,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    return ZERO
+
+
+@_infer_multiplicity.register
+def __infer_type_introspection(
+    ir: irast.TypeIntrospection,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    # TODO: The result is always ONE, but we still want to actually
+    # introspect the expression. Unfortunately, currently the
+    # expression is not available at this stage.
+    #
+    # E.g. consider:
+    #   WITH X := Foo {bar := {Bar, Bar}}
+    #   SELECT INTROSPECT TYPEOF X.bar;
+    return ONE
+
+
+def _infer_shape(
+    ir: irast.Set,
+    *,
+    is_mutation: bool=False,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> None:
+    for shape_set, _ in ir.shape:
+        new_scope = cardinality._get_set_scope(shape_set, scope_tree)
+        if shape_set.expr and shape_set.rptr:
+            expr_mult = infer_multiplicity(
+                shape_set.expr, scope_tree=new_scope, ctx=ctx)
+
+            ptrref = shape_set.rptr.ptrref
+            if expr_mult is MANY and irtyputils.is_object(ptrref.out_target):
+                raise errors.QueryError(
+                    f'possibly not a strict set returned by an '
+                    f'expression for a computable '
+                    f'{ptrref.shortname.name}.',
+                    hint=(
+                        f'Use DISTINCT for the entire computable expression '
+                        f'to resolve this.'
+                    ),
+                    context=shape_set.context
+                )
+
+        _infer_shape(
+            shape_set, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx)
+
+
+def _infer_set(
+    ir: irast.Set,
+    *,
+    is_mutation: bool=False,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    result = _infer_set_inner(
+        ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx)
+    ctx.inferred_multiplicity[ir, scope_tree] = result
+    # The shape doesn't affect multiplicity, but requires validation.
+    _infer_shape(ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx)
+
+    return result
+
+
+def _infer_set_inner(
+    ir: irast.Set,
+    *,
+    is_mutation: bool=False,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    rptr = ir.rptr
+    new_scope = cardinality._get_set_scope(ir, scope_tree)
+
+    if rptr is not None:
+        # Validate the source
+        infer_multiplicity(rptr.source, scope_tree=new_scope, ctx=ctx)
+
+    if ir.expr:
+        expr_mult = infer_multiplicity(ir.expr, scope_tree=new_scope, ctx=ctx)
+
+    if rptr is not None:
+        rptrref = rptr.ptrref
+
+        if isinstance(rptr.ptrref, irast.TupleIndirectionPointerRef):
+            # All bets are off for tuple elements.
+            return MANY
+        elif not irtyputils.is_object(ir.typeref):
+            # This is not an expression and is some kind of scalar, so
+            # multiplicity cannot be guaranteed to be ONE (most scalar
+            # expressions don't have an implicit requirement to be sets)
+            # unless we also have an exclusive constraint.
+
+            if rptr is not None:
+                schema = ctx.env.schema
+                # We should only have some kind of path terminating in a
+                # property here.
+                assert isinstance(rptrref, irast.PointerRef)
+                _ptr = schema.get_by_id(rptrref.id)
+                assert isinstance(_ptr, s_pointers.Pointer)
+                ptr = _ptr.get_nearest_non_derived_parent(ctx.env.schema)
+                if ptr.is_exclusive(schema):
+                    # Got an exclusive constraint
+                    return ONE
+
+            return MANY
+
+        else:
+            # This is some kind of a link at the end of a path.
+            # Therefore the target is a proper set.
+            return ONE
+
+    elif ir.expr is not None:
+        return expr_mult
+
+    else:
+        # Evidently this is not a pointer, expression, or a scalar.
+        # This is an object type and therefore a proper set.
+        return ONE
+
+
+@_infer_multiplicity.register
+def __infer_func_call(
+    ir: irast.FunctionCall,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    # If the function returns a set (for any reason), all bets are off
+    # and the maximum multiplicity cannot be inferred.
+    card = cardinality.infer_cardinality(
+        ir, scope_tree=scope_tree, ctx=ctx)
+
+    # We still want to validate the multiplicity of the arguments, though.
+    for arg in ir.args:
+        infer_multiplicity(arg.expr, scope_tree=scope_tree, ctx=ctx)
+
+    if card is not None and card.is_single():
+        return ONE
+    elif str(ir.func_shortname) == 'std::enumerate':
+        # Technically the output of enumerate is always of
+        # multiplicity ONE because it's a set of tuples with first
+        # elements being guaranteed to be distinct.
+        return ONE
+    else:
+        return MANY
+
+
+@_infer_multiplicity.register
+def __infer_oper_call(
+    ir: irast.OperatorCall,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    mult = []
+    cards = []
+    for arg in ir.args:
+        cards.append(
+            cardinality.infer_cardinality(
+                arg.expr, scope_tree=scope_tree, ctx=ctx))
+        mult.append(
+            infer_multiplicity(
+                arg.expr, scope_tree=scope_tree, ctx=ctx))
+
+    op_name = str(ir.func_shortname)
+
+    if op_name == 'std::UNION':
+        # UNION will produce multiplicity MANY unless most or all of
+        # the elements multiplicity is ZERO (from an empty set).
+        result = ZERO
+        for m in mult:
+            if m is ONE and result is ZERO:
+                result = m
+            elif m is ONE and result is not ZERO:
+                return MANY
+            elif m is MANY:
+                return MANY
+        return result
+
+    elif op_name == 'std::DISTINCT':
+        if mult[0] is ZERO:
+            return ZERO
+        else:
+            return ONE
+    elif op_name == 'std::IF':
+        # If the cardinality of the condition is more than ONE, then
+        # the multiplicity cannot be inferred.
+        if cards[1].is_single():
+            # Now it's just a matter of the multiplicity of the
+            # possible results.
+            return _max_multiplicity((mult[0], mult[2]))
+        else:
+            return MANY
+
+    else:
+        # The rest of the operators (other than UNION, DISTINCT, or
+        # IF..ELSE). We can ignore the SET OF args because the results
+        # are actually proportional to the element-wise args in our
+        # operators.
+        result = _max_multiplicity(mult)
+        if result is MANY:
+            return result
+
+        # Even when arguments are of multiplicity ONE, we cannot
+        # exclude the possibility of the result being of multiplicity
+        # MANY. We need to check that at most one argument has
+        # cardinality more than ONE.
+
+        if len([card for card in cards if card.is_multi()]) > 1:
+            return MANY
+        else:
+            return result
+
+
+@_infer_multiplicity.register
+def __infer_const(
+    ir: irast.BaseConstant,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    return ONE
+
+
+@_infer_multiplicity.register
+def __infer_param(
+    ir: irast.Parameter,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    return ONE
+
+
+@_infer_multiplicity.register
+def __infer_const_set(
+    ir: irast.ConstantSet,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    if len(ir.elements) == len({el.value for el in ir.elements}):
+        return ONE
+    else:
+        return MANY
+
+
+@_infer_multiplicity.register
+def __infer_typecheckop(
+    ir: irast.TypeCheckOp,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    # Unless this is a singleton, the multiplicity cannot be assumed to be ONE.
+    card = cardinality.infer_cardinality(
+        ir, scope_tree=scope_tree, ctx=ctx)
+    if card is not None and card.is_single():
+        return ONE
+    else:
+        return MANY
+
+
+@_infer_multiplicity.register
+def __infer_typecast(
+    ir: irast.TypeCast,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    return infer_multiplicity(
+        ir.expr, scope_tree=scope_tree, ctx=ctx,
+    )
+
+
+def _infer_stmt_multiplicity(
+    ir: irast.FilteredStmt,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    result = infer_multiplicity(
+        ir.subject if isinstance(ir, irast.MutatingStmt) else ir.result,
+        scope_tree=scope_tree,
+        ctx=ctx,
+    )
+
+    # WITH block bindings need to be validated, they don't have to
+    # have multiplicity ONE, but their sub-expressions must be valid.
+    #
+    # Inferring how the FILTER clause affects multiplicity is in
+    # general impossible, but we still want to ensure that the FILTER
+    # expression has valid multiplicity.
+    for part in ir.bindings + [ir.where]:
+        if part:
+            infer_multiplicity(part, scope_tree=scope_tree, ctx=ctx)
+
+    return result
+
+
+def _infer_for_multiplicity(
+    ir: irast.SelectStmt,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+
+    assert ir.iterator_stmt is not None
+    itexpr = ir.iterator_stmt.expr
+
+    if isinstance(ir.result.expr, irast.SelectStmt):
+        union = ir.result.expr
+        if (isinstance(union.where, irast.Set) and
+                isinstance(union.where.expr, irast.OperatorCall) and
+                str(union.where.expr.func_shortname) == 'std::='):
+
+            op = union.where.expr
+            left, right = (a.expr for a in op.args)
+
+            # The iterator set may be wrapped in an `enumerate`, this
+            # requires different handling.
+            has_enumerate = (
+                isinstance(itexpr, irast.SelectStmt) and
+                isinstance(itfn := itexpr.result.expr, irast.FunctionCall) and
+                str(itfn.func_shortname) == 'std::enumerate'
+            )
+
+            # First make sure that the cardinality of the FILTER
+            # expression is is no more than 1. Then make sure both
+            # operands are paths.
+            if union.where_card.is_single():
+                it = None
+                if left.rptr is not None:
+                    it = right
+                elif right.rptr is not None:
+                    it = left
+
+                if has_enumerate:
+                    assert isinstance(itfn, irast.FunctionCall)
+                    enumerate_mult = infer_multiplicity(
+                        itfn.args[0].expr, scope_tree=scope_tree, ctx=ctx,
+                    )
+                    if (enumerate_mult is ONE and
+                            isinstance(
+                                it.rptr, irast.TupleIndirectionPointer) and
+                            # Tuple comes from the iterator set
+                            it.rptr.source.expr is itexpr and
+                            # the indirection is accessing element 1
+                            str(it.rptr.ptrref.name) == '__tuple__::1'):
+                        return ONE
+                elif (it.is_binding and it.expr is itexpr):
+                    return ONE
+
+    elif isinstance(ir.result.expr, irast.InsertStmt):
+        # A union of inserts always has multiplicity ONE
+        return ONE
+
+    return MANY
+
+
+@_infer_multiplicity.register
+def __infer_select_stmt(
+    ir: irast.SelectStmt,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    result = _infer_stmt_multiplicity(ir, scope_tree=scope_tree, ctx=ctx)
+    itmult = None
+
+    if ir.iterator_stmt:
+        # If this is a FOR, then there's a common pattern which can be
+        # detected and the multiplicity of it is ONE. Otherwise it
+        # cannot be reliably inferred.
+        #
+        # The pattern is: FOR x IN {<set of multiplicity ONE>} UNION
+        # (SELECT ... FILTER .prop = x) As long as the FILTER has just
+        # a single .prop = x expression, this is going to be a bunch
+        # of disjoint unions and the final multiplicity will be ONE.
+        itmult = infer_multiplicity(
+            ir.iterator_stmt, scope_tree=scope_tree, ctx=ctx,
+        )
+
+        ctx = ctx._replace(in_for_body=True)
+
+    # OFFSET, LIMIT and ORDER BY have already been validated to be
+    # singletons, but their sub-expressions (if any) still need to be
+    # validated.
+    for part in [ir.limit, ir.offset] + [sort.expr for sort in ir.orderby]:
+        if part:
+            new_scope = cardinality._get_set_scope(part, scope_tree)
+            infer_multiplicity(part, scope_tree=new_scope, ctx=ctx)
+
+    if itmult is not None:
+        if itmult is ONE:
+            return _infer_for_multiplicity(
+                ir, scope_tree=scope_tree, ctx=ctx)
+
+        return MANY
+    else:
+        return result
+
+
+@_infer_multiplicity.register
+def __infer_insert_stmt(
+    ir: irast.InsertStmt,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    # INSERT will always return a proper set, but we still want to
+    # process the sub-expressions.
+    infer_multiplicity(
+        ir.subject, is_mutation=True, scope_tree=scope_tree, ctx=ctx
+    )
+    new_scope = cardinality._get_set_scope(ir.result, scope_tree)
+    infer_multiplicity(
+        ir.result, is_mutation=True, scope_tree=new_scope, ctx=ctx
+    )
+
+    if ir.on_conflict and ir.on_conflict.else_ir:
+        for part in [ir.on_conflict.else_ir.select,
+                     ir.on_conflict.else_ir.body]:
+            infer_multiplicity(part, scope_tree=scope_tree, ctx=ctx)
+
+    return ONE
+
+
+@_infer_multiplicity.register
+def __infer_update_stmt(
+    ir: irast.UpdateStmt,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    # Presumably UPDATE will always return a proper set, even if it's
+    # fed something with higher multiplicity, but we still want to
+    # process the expression being updated.
+    infer_multiplicity(
+        ir.result, is_mutation=True, scope_tree=scope_tree, ctx=ctx,
+    )
+    result = _infer_stmt_multiplicity(ir, scope_tree=scope_tree, ctx=ctx)
+    if result is ZERO:
+        return ZERO
+    else:
+        return ONE
+
+
+@_infer_multiplicity.register
+def __infer_delete_stmt(
+    ir: irast.DeleteStmt,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    # Presumably DELETE will always return a proper set, even if it's
+    # fed something with higher multiplicity, but we still want to
+    # process the expression being deleted.
+    infer_multiplicity(
+        ir.result, is_mutation=True, scope_tree=scope_tree, ctx=ctx,
+    )
+    result = _infer_stmt_multiplicity(ir, scope_tree=scope_tree, ctx=ctx)
+    if result is ZERO:
+        return ZERO
+    else:
+        return ONE
+
+
+@_infer_multiplicity.register
+def __infer_group_stmt(
+    ir: irast.GroupStmt,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    raise NotImplementedError
+
+
+@_infer_multiplicity.register
+def __infer_slice(
+    ir: irast.SliceIndirection,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    # Slice indirection multiplicity is guaranteed to be ONE as long
+    # as the cardinality of this expression is at most one, otherwise
+    # the results of index indirection can contain values with
+    # multiplicity > 1.
+    card = cardinality.infer_cardinality(
+        ir, scope_tree=scope_tree, ctx=ctx)
+    if card is not None and card.is_single():
+        return ONE
+    else:
+        return MANY
+
+
+@_infer_multiplicity.register
+def __infer_index(
+    ir: irast.IndexIndirection,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    # Index indirection multiplicity is guaranteed to be ONE as long
+    # as the cardinality of this expression is at most one, otherwise
+    # the results of index indirection can contain values with
+    # multiplicity > 1.
+    card = cardinality.infer_cardinality(
+        ir, scope_tree=scope_tree, ctx=ctx)
+    if card is not None and card.is_single():
+        return ONE
+    else:
+        return MANY
+
+
+@_infer_multiplicity.register
+def __infer_array(
+    ir: irast.Array,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    return _common_multiplicity(ir.elements, scope_tree=scope_tree, ctx=ctx)
+
+
+@_infer_multiplicity.register
+def __infer_tuple(
+    ir: irast.Tuple,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+    return _common_multiplicity(
+        [el.val for el in ir.elements], scope_tree=scope_tree, ctx=ctx
+    )
+
+
+def infer_multiplicity(
+    ir: irast.Base,
+    *,
+    is_mutation: bool=False,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inference_context.InfCtx,
+) -> qltypes.Multiplicity:
+
+    result = ctx.inferred_multiplicity.get((ir, scope_tree))
+    if result is not None:
+        return result
+
+    # We can use cardinality as a helper in determining multiplicity,
+    # since singletons have multiplicity one.
+    card = cardinality.infer_cardinality(
+        ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx)
+
+    if isinstance(ir, irast.Set):
+        result = _infer_set(
+            ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx,
+        )
+    else:
+        result = _infer_multiplicity(ir, scope_tree=scope_tree, ctx=ctx)
+
+    if card is not None and card.is_single():
+        # We've validated multiplicity, so now we can just override it
+        # safely.
+        result = ONE
+
+    if result not in {ZERO, ONE, MANY}:
+        raise errors.QueryError(
+            'could not determine the multiplicity of '
+            'set produced by expression',
+            context=ir.context)
+
+    ctx.inferred_multiplicity[ir, scope_tree] = result
+
+    return result

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -75,6 +75,10 @@ class GlobalCompilerOptions:
     #: to contain DML in the top-level shape computables.
     allow_top_level_shape_dml: bool = False
 
+    #: This is meant to be a temporary flag, needed while we iron out
+    #: multiplicity issues.
+    validate_multiplicity: bool = False
+
 
 @dataclass
 class CompilerOptions(GlobalCompilerOptions):

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -166,6 +166,12 @@ class Volatility(s_enum.StrEnum):
         return cls(name.title())
 
 
+class Multiplicity(s_enum.StrEnum):
+    ZERO = 'ZERO'  # This is valid for empty sets
+    ONE = 'ONE'
+    MANY = 'MANY'
+
+
 class DescribeLanguage(s_enum.StrEnum):
     DDL = 'DDL'
     SDL = 'SDL'

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -456,6 +456,7 @@ class Statement(Command):
     params: typing.List[Param]
     cardinality: qltypes.Cardinality
     volatility: qltypes.Volatility
+    multiplicity: typing.Optional[qltypes.Multiplicity]
     stype: s_types.Type
     view_shapes: typing.Dict[so.Object, typing.List[s_pointers.Pointer]]
     view_shapes_metadata: typing.Dict[so.Object, ViewShapeMetadata]
@@ -632,7 +633,7 @@ class Call(ImmutableExpr):
     # of tuple element path ids relative to the call set.
     tuple_path_ids: typing.List[PathId]
 
-    # Volatility of the funciton or operator.
+    # Volatility of the function or operator.
     volatility: qltypes.Volatility
 
 

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -1,0 +1,645 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os.path
+import textwrap
+
+from edb import errors
+from edb.testbase import lang as tb
+
+from edb.edgeql import compiler
+from edb.edgeql import qltypes
+from edb.edgeql import parser as qlparser
+from edb.tools import test
+
+
+class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
+    """Unit tests for multiplicity inference."""
+
+    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
+                          'cards_ir_inference.esdl')
+
+    def run_test(self, *, source, spec, expected):
+        qltree = qlparser.parse(source)
+        ir = compiler.compile_ast_to_ir(
+            qltree,
+            self.schema,
+            options=compiler.CompilerOptions(
+                validate_multiplicity=True
+            )
+        )
+
+        # The expected multiplicity is given for the whole query.
+        exp = textwrap.dedent(expected).strip(' \n')
+        expected_multiplicity = qltypes.Multiplicity(exp)
+        self.assertEqual(ir.multiplicity, expected_multiplicity,
+                         'unexpected multiplicity:\n' + source)
+
+    def test_edgeql_ir_mult_inference_00(self):
+        """
+        WITH MODULE test
+        SELECT Card
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_01(self):
+        """
+        WITH MODULE test
+        SELECT Card.id
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_02(self):
+        """
+        WITH MODULE test
+        SELECT User.name
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_03(self):
+        # Unconstrained property
+        """
+        WITH MODULE test
+        SELECT User.deck_cost
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_04(self):
+        """
+        WITH MODULE test
+        SELECT Card FILTER Card.name = 'Djinn'
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_05(self):
+        """
+        WITH MODULE test
+        SELECT Card LIMIT 1
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_06(self):
+        """
+        SELECT 1
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_07(self):
+        """
+        SELECT {1, 2}
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_08(self):
+        """
+        SELECT {1, 1}
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_09(self):
+        """
+        WITH MODULE test
+        SELECT User.deck
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_10(self):
+        """
+        WITH MODULE test
+        SELECT Card.cost
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_11(self):
+        """
+        WITH MODULE test
+        SELECT Card.owners
+% OK %
+        ONE
+        """
+
+    @test.xfail('''
+        Ideally this should be inferred as ONE because Card and User
+        sets are non-intersecting (one is not a subset of the
+        other).
+
+        Currently, this is not taken into account.
+    ''')
+    def test_edgeql_ir_mult_inference_12(self):
+        """
+        WITH MODULE test
+        SELECT {Card, User}
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_13(self):
+        """
+        SELECT 1 + 2
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_14(self):
+        """
+        SELECT 1 + {2, 3}
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_15(self):
+        """
+        SELECT {1, 2} + {2, 3}
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_16(self):
+        """
+        WITH MODULE test
+        SELECT 'pre_' ++ Card.name
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_17(self):
+        """
+        WITH MODULE test
+        SELECT User.name ++ Card.name
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_18(self):
+        """
+        SELECT (1, {'a', 'b'})
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_19(self):
+        """
+        WITH MODULE test
+        SELECT (1, Card.name)
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_20(self):
+        """
+        SELECT [1, {1, 2}]
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_21(self):
+        """
+        WITH MODULE test
+        SELECT ['card', Card.name]
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_22(self):
+        """
+        WITH MODULE test
+        SELECT User.name ++ Card.name
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_23(self):
+        """
+        SELECT to_str(1)
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_24(self):
+        """
+        WITH
+            MODULE test,
+            C := (SELECT Card FILTER .name = 'Imp')
+        SELECT str_split(<str>C.id, '')
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_25(self):
+        # Any time a function returns a set for any reason the
+        # multiplicity cannot be reliably inferred.
+        #
+        # We don't know what a set-returning function really does.
+        #
+        # We also don't know that an element-wise function doesn't end
+        # up with collisions.
+        """
+        WITH MODULE test
+        SELECT str_split(<str>Card.id, '')
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_26(self):
+        # Any time a function returns a set for any reason the
+        # multiplicity cannot be reliably inferred.
+        #
+        # We don't know what a set-returning function really does.
+        #
+        # We also don't know that an element-wise function doesn't end
+        # up with collisions.
+        """
+        WITH MODULE test
+        SELECT array_unpack(str_split(<str>Card.id, ''))
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_27(self):
+        """
+        WITH MODULE test
+        SELECT count(Card)
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_28(self):
+        """
+        WITH MODULE test
+        SELECT 1 IN {1, 2, 3}
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_29(self):
+        """
+        WITH MODULE test
+        SELECT 1 IN {1, 1, 3}
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_30(self):
+        """
+        WITH MODULE test
+        SELECT {1, 2} IN {1, 2, 3}
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_31(self):
+        """
+        WITH MODULE test
+        SELECT Card.name IN {'Imp', 'Dragon'}
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_32(self):
+        """
+        SELECT <str>{1, 2, 3}
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_33(self):
+        """
+        SELECT <str>{1, 1, 3}
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_34(self):
+        """
+        WITH MODULE test
+        SELECT <str>Card.id
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_35(self):
+        """
+        WITH MODULE test
+        SELECT <json>User.name
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_36(self):
+        """
+        WITH MODULE test
+        SELECT <str>Card.cost
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_37(self):
+        """
+        WITH MODULE test
+        SELECT User.deck[IS SpecialCard]
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_38(self):
+        """
+        WITH MODULE test
+        SELECT Award.<awards[IS User]
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_39(self):
+        """
+        WITH MODULE test
+        SELECT (1, Card.name).0
+% OK %
+        MANY
+        """
+
+    @test.xfail('''
+        Ideally this should be inferred as ONE because that tuple
+        element is Card.name and that's unique.
+    ''')
+    def test_edgeql_ir_mult_inference_40(self):
+        """
+        WITH MODULE test
+        SELECT (1, Card.name).1
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_41(self):
+        """
+        WITH MODULE test
+        SELECT ['card', Card.name][0]
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_42(self):
+        # It's probably impractical to even try to infer that we're
+        # only fetching a unique array element here.
+        """
+        WITH MODULE test
+        SELECT ['card', Card.name][1]
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_43(self):
+        """
+        WITH MODULE test
+        SELECT DISTINCT Card.element
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_44(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            friends_of_friends := .friends.friends,
+            others := (
+                SELECT WaterOrEarthCard.owners
+            )
+        }
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_45(self):
+        """
+        WITH MODULE test
+        SELECT Award {
+            owner := .<awards[IS User]
+        }
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_46(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            card_names := .deck.name,
+            card_elements := DISTINCT .deck.element,
+            deck: {
+                el := User.deck.element[:2]
+            }
+        }
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_47(self):
+        """
+        SELECT 1 IS str
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_48(self):
+        """
+        WITH MODULE test
+        SELECT Award IS Named
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_49(self):
+        """
+        WITH
+            MODULE test,
+            A := (
+                SELECT Award FILTER .name = 'Wow'
+            )
+        SELECT A IS Named
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_50(self):
+        """
+        WITH MODULE test
+        SELECT Award.name IS str
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_51(self):
+        """
+        WITH MODULE test
+        SELECT INTROSPECT TYPEOF User.deck
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_52(self):
+        """
+        WITH MODULE test
+        SELECT (INTROSPECT TYPEOF User.deck).name
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_53(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            card_elements := .deck.element
+        }
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_54(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            foo := {1, 1, 2}
+        }
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_55(self):
+        """
+        WITH MODULE test
+        FOR x IN {'fire', 'water'}
+        UNION (
+            SELECT Card
+            FILTER .element = x
+        )
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_56(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            wishlist := (
+                FOR x IN {'fire', 'water'}
+                UNION (
+                    SELECT Card
+                    FILTER .element = x
+                )
+            )
+        }
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_57(self):
+        """
+        SELECT enumerate({2, 2})
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_58(self):
+        """
+        WITH MODULE test
+        SELECT enumerate(Card)
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_59(self):
+        """
+        WITH MODULE test
+        FOR x IN {enumerate({'fire', 'water'})}
+        UNION (
+            SELECT Card
+            FILTER .element = x.1
+        )
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_60(self):
+        """
+        WITH MODULE test
+        FOR x IN {
+            enumerate(
+                DISTINCT array_unpack(['fire', 'water']))
+        }
+        UNION (
+            SELECT Card
+            FILTER .element = x.1
+        )
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_61(self):
+        """
+        WITH MODULE test
+        FOR x IN {
+            enumerate(
+                array_unpack(['A', 'B']))
+        }
+        UNION (
+            INSERT Card {
+                name := x.1,
+                element := 'test',
+                cost := 0,
+            }
+        )
+% OK %
+        ONE
+        """
+
+    @tb.must_fail(errors.QueryError,
+                  r"possibly not a strict set.+computable bad_link",
+                  line=4, col=13)
+    def test_edgeql_ir_mult_inference_error_01(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            bad_link := {Card, Card},
+            name,
+        }
+        """
+
+    @tb.must_fail(errors.QueryError,
+                  r"possibly not a strict set.+computable bad_link",
+                  line=6, col=13)
+    def test_edgeql_ir_mult_inference_error_02(self):
+        """
+        WITH
+            MODULE test,
+            A := {Card, Card}
+        SELECT User {
+            bad_link := A,
+            name,
+        }
+        """


### PR DESCRIPTION
Implement some basic multiplicity inference.
    
The inference is currently hidden behind a `validate_multiplicity`
compiler option due to current limitations of using `DISTINCT` to "fix"
multiplicity inference issues. These issues arise in EdgeQL generated
for schema objects and more broadly for specifying multi links with link
properties using `FOR`.
    
Currently, only the multiplicity tests are actually running with the flag enabled.
    
Issue #117
