### PR TITLE
Fix migrations modifying collection aliases

### DIFF
--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -760,9 +760,13 @@ def generate_structure(
         str_objname = str(objname)
         if (
             not shape_els
+            # The CollectionExprAlias family needs to be excluded
+            # because TupleExprAlias and ArrayExprAlias inherit from
+            # concrete classes and so are picked up from those.
             or str_objname in {
+                'schema::CollectionExprAlias',
                 'schema::TupleExprAlias',
-                'schema::ArrayExprAlias'
+                'schema::ArrayExprAlias',
             }
         ):
             continue

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1279,6 +1279,8 @@ class ArrayExprAlias(
     Array,
     qlkind=qltypes.SchemaObjectClass.ALIAS,
 ):
+    # N.B: Don't add any SchemaFields to this class, they won't be
+    # reflected properly (since this inherits from the concrete Array).
     pass
 
 
@@ -1818,6 +1820,8 @@ class TupleExprAlias(
     Tuple,
     qlkind=qltypes.SchemaObjectClass.ALIAS,
 ):
+    # N.B: Don't add any SchemaFields to this class, they won't be
+    # reflected properly (since this inherits from the concrete Array).
     pass
 
 
@@ -2105,7 +2109,14 @@ class CreateCollectionExprAlias(
     CollectionExprAliasCommand[CollectionExprAliasT],
     sd.CreateObject[CollectionExprAliasT],
 ):
-    pass
+    def canonicalize_attributes(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = super().canonicalize_attributes(schema, context)
+        self.set_attribute_value('internal', True)
+        return schema
 
 
 class DeleteCollectionExprAlias(

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1821,7 +1821,7 @@ class TupleExprAlias(
     qlkind=qltypes.SchemaObjectClass.ALIAS,
 ):
     # N.B: Don't add any SchemaFields to this class, they won't be
-    # reflected properly (since this inherits from the concrete Array).
+    # reflected properly (since this inherits from the concrete Tuple).
     pass
 
 
@@ -2109,14 +2109,7 @@ class CreateCollectionExprAlias(
     CollectionExprAliasCommand[CollectionExprAliasT],
     sd.CreateObject[CollectionExprAliasT],
 ):
-    def canonicalize_attributes(
-        self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-    ) -> s_schema.Schema:
-        schema = super().canonicalize_attributes(schema, context)
-        self.set_attribute_value('internal', True)
-        return schema
+    pass
 
 
 class DeleteCollectionExprAlias(

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -7794,3 +7794,27 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'confidence': 1.0,
             },
         })
+
+
+class TestEdgeQLDataMigrationNonisolated(tb.DDLTestCase):
+    TRANSACTION_ISOLATION = False
+
+    async def test_edgeql_migration_eq_collections_25(self):
+        await self.con.execute(r"""
+            START MIGRATION TO {
+                module test {
+                    alias Foo := [20];
+                }
+            };
+            POPULATE MIGRATION;
+            COMMIT MIGRATION;
+        """)
+
+        await self.con.execute(r"""
+            START MIGRATION TO {
+                module test {
+                }
+            };
+            POPULATE MIGRATION;
+            COMMIT MIGRATION;
+        """)


### PR DESCRIPTION
Some Array fields in ArrayExprAlias weren't being serialized because
the introspection query was looking at its parent
CollectionExprAlias. Similar for tuples. Skip that.

The obvious tests for this didn't catch it because if the alias was
created during the same transaction, the reflection didn't come into
play.

Also, hide the CollectionExprAliases from reflection.