### PR TITLE
Fix some DDL/migration bugs relating to aliases

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2860,6 +2860,7 @@ class DeleteObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
             if refs:
                 for ref in refs:
                     if (not context.is_deleting(ref)
+                            and ref not in self.expiring_refs
                             and ref.is_blocking_ref(orig_schema, self.scls)):
                         ref_strs.append(
                             ref.get_verbosename(orig_schema, with_parent=True))

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1441,7 +1441,9 @@ class SetPointerType(
                 orig_target is not None
                 and isinstance(orig_target, s_types.Collection)
             ):
-                self.add(orig_target.as_colltype_delete_delta(
+                parent_ctx = context.parent()
+                assert parent_ctx
+                parent_ctx.op.add(orig_target.as_colltype_delete_delta(
                     schema, expiring_refs={scls}))
 
             implicit_bases = scls.get_implicit_bases(schema)

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -528,3 +528,17 @@ class DeleteScalarType(
     inheriting.DeleteInheritingObject[ScalarType],
 ):
     astnode = qlast.DropScalarType
+
+    def _get_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        *,
+        parent_node: Optional[qlast.DDLOperation] = None,
+    ) -> Optional[qlast.DDLOperation]:
+        if self.get_orig_attribute_value('expr_type'):
+            # This is an alias type, appropriate DDL would be generated
+            # from the corresponding DeleteAlias node.
+            return None
+        else:
+            return super()._get_ast(schema, context, parent_node=parent_node)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1165,7 +1165,8 @@ class Array(
             cmd = DeleteArray(classname=self.get_name(schema), if_unused=True,
                               expiring_refs=expiring_refs)
         else:
-            cmd = DeleteArrayExprAlias(classname=view_name)
+            cmd = DeleteArrayExprAlias(classname=view_name,
+                                       expiring_refs=expiring_refs)
 
         el = self.get_element_type(schema)
         if isinstance(el, Collection):
@@ -1700,6 +1701,7 @@ class Tuple(
         else:
             cmd = DeleteTupleExprAlias(
                 classname=view_name,
+                expiring_refs=expiring_refs,
             )
 
         for el in self.get_subtypes(schema):

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -6865,12 +6865,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [{'a': 'hello', 'b': 42}],
         )
 
-    @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_collections_06(self):
         await self.migrate(r"""
             type Base {
@@ -6903,10 +6897,11 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         )
 
     @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
+        ISE: column <blah> cannot be cast automatically to type
+           <blah>
 
-        This happens on the second migration.
+        I think we ought to generate a DROP/CREATE and also reject the ALTER
+        with a real error message.
     ''')
     async def test_edgeql_migration_eq_collections_07(self):
         await self.con.execute("""
@@ -6950,10 +6945,9 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         )
 
     @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
+        ISE: cannot be cast automatically
 
-        This happens on the second migration.
+        The test case thinks this ought to work, at least.
     ''')
     async def test_edgeql_migration_eq_collections_08(self):
         await self.migrate(r"""
@@ -6987,10 +6981,9 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         )
 
     @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
+        ISE: cannot be cast automatically
 
-        This happens on the second migration.
+        The test case thinks this ought to work, at least.
     ''')
     async def test_edgeql_migration_eq_collections_09(self):
         await self.migrate(r"""
@@ -7022,15 +7015,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [{'a': 'test', 'b': 9}],
         )
 
-    @test.xfail('''
-        edgedb.errors.SchemaError: cannot drop scalar type
-        'test::CollAlias' because other objects in the schema depend
-        on it
-
-        Exception: Error while processing 'DROP SCALAR TYPE test::CollAlias;'
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_collections_13(self):
         await self.migrate(r"""
             type Base {
@@ -7079,18 +7063,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [[13.5]],
         )
 
-    @test.xfail('''
-        edgedb.errors.SchemaError: cannot drop scalar type
-        'test::CollAlias' because other objects in the schema depend
-        on it
-
-        DETAILS: alias 'test::CollAlias' depends on test::CollAlias
-
-        Exception: Error while processing
-        'DROP SCALAR TYPE test::CollAlias;'
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_collections_14(self):
         await self.migrate(r"""
             type Base {
@@ -7104,6 +7076,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
 
         await self.con.execute(r"""
+            SET MODULE test;
+
             INSERT Base {
                 name := 'coll_14',
                 foo := 14.5,
@@ -7140,16 +7114,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [['coll_14', 14.5]],
         )
 
-    @test.xfail('''
-        edgedb.errors.SchemaError: cannot drop scalar type
-        'test::CollAlias' because other objects in the schema depend
-        on it
-
-        Exception: Error while processing
-        'DROP SCALAR TYPE test::CollAlias;'
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_collections_15(self):
         await self.migrate(r"""
             type Base {
@@ -7206,16 +7170,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [['coll_15', 15, [15.5]]],
         )
 
-    @test.xfail('''
-        edgedb.errors.SchemaError: cannot drop scalar type
-        'test::CollAlias' because other objects in the schema depend
-        on it
-
-        Exception: Error while processing
-        'DROP SCALAR TYPE test::CollAlias;'
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_collections_16(self):
         await self.migrate(r"""
             type Base {
@@ -7269,15 +7223,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [{'a': 'coll_16', 'b': 16.5}],
         )
 
-    @test.xfail('''
-        edgedb.errors.InvalidReferenceError: schema item
-        'test::CollAlias' does not exist
-
-        Exception: Error while processing
-        'ALTER ALIAS test::CollAlias USING ([test::Base.foo]);'
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_collections_17(self):
         await self.migrate(r"""
             type Base {
@@ -7329,19 +7274,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [[17.5]],
         )
 
-    @test.xfail('''
-        edgedb.errors.InvalidReferenceError: schema item
-        'test::CollAlias' does not exist
-
-        Exception: Error while processing
-        'ALTER ALIAS test::CollAlias USING ((
-            test::Base.name,
-            test::Base.number,
-            test::Base.foo
-        ));'
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_collections_18(self):
         await self.migrate(r"""
             type Base {
@@ -7400,18 +7332,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [['coll_18', 18, 18.5]],
         )
 
-    @test.xfail('''
-        edgedb.errors.InvalidReferenceError: schema item
-        'test::CollAlias' does not exist
-
-        Exception: Error while processing
-        'ALTER ALIAS test::CollAlias USING ((
-            test::Base.name,
-            test::Base.foo
-        ));'
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_collections_20(self):
         await self.migrate(r"""
             type Base {
@@ -7470,18 +7390,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [['test20', 123.5]],
         )
 
-    @test.xfail('''
-        edgedb.errors.InvalidReferenceError: schema item
-        'test::CollAlias' does not exist
-
-        Exception: Error while processing
-        'ALTER ALIAS test::CollAlias USING ((
-            a := test::Base.name,
-            b := test::Base.foo
-        ));'
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_collections_21(self):
         await self.migrate(r"""
             type Base {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4034,7 +4034,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                 property bar -> int32;
             };
 
-            # aliases with array<flaot32>
+            # aliases with array<float32>
             alias BaseAlias := Base { data := [Base.foo] };
             alias CollAlias := [Base.foo];
         """])


### PR DESCRIPTION
* Don't generate a 'DROP SCALAR TYPE' when an alias is ALTERed away
   from a scalar.
 * Fix several different things that could go wrong when ALTERing aliases,
   especially with regard to generating DeleteObjects for the old underlying
   type.

All of the test_schema_migrations_equivalence_collections_ tests now pass

Work on #1987.