### PR TITLE
Add a DROP command for fields

### DIFF
--- a/docs/edgeql/ddl/constraints.rst
+++ b/docs/edgeql/ddl/constraints.rst
@@ -135,6 +135,7 @@ Alter the definition of an
       RENAME TO <newname>
       USING <constr-expression>
       SET errmessage := <error-message>
+      DROP errmessage
       CREATE ANNOTATION <annotation-name> := <value>
       ALTER ANNOTATION <annotation-name> := <value>
       DROP ANNOTATION <annotation-name>
@@ -174,6 +175,11 @@ CONSTRAINT`` block:
 :eql:synopsis:`DROP ANNOTATION <annotation-name>;`
     Remove constraint :eql:synopsis:`<annotation-name>`.
     See :eql:stmt:`DROP ANNOTATION <DROP ANNOTATION>` for details.
+
+:eql:synopsis:`DROP errmessage;`
+    Remove the error message from this abstract constraint.
+    The error message specified in the base abstract constraint
+    will be used instead.
 
 All the subcommands allowed in a ``CREATE ABSTRACT CONSTRAINT`` block
 are also valid subcommands for an ``ALTER ABSTRACT CONSTRAINT`` block.
@@ -374,6 +380,7 @@ Alter the definition of a concrete constraint on the specified schema item.
       SET DELEGATED
       DROP DELEGATED
       SET errmessage := <error-message>
+      DROP errmessage
       CREATE ANNOTATION <annotation-name> := <value>
       ALTER ANNOTATION <annotation-name>
       DROP ANNOTATION <annotation-name>
@@ -426,6 +433,10 @@ The following subcommands are allowed in the ``ALTER CONSTRAINT`` block:
 
 :eql:synopsis:`DROP ANNOTATION <annotation-name>;`
     Remove an *annotation*. See :eql:stmt:`DROP ANNOTATION` for details.
+
+:eql:synopsis:`DROP errmessage;`
+    Remove the error message from this constraint. The error message
+    specified in the abstract constraint will be used instead.
 
 All the subcommands allowed in the ``CREATE CONSTRAINT`` block are also
 valid subcommands for ``ALTER CONSTRAINT`` block.

--- a/docs/edgeql/ddl/functions.rst
+++ b/docs/edgeql/ddl/functions.rst
@@ -242,6 +242,7 @@ Change the definition of a function.
 
       SET session_only := {true | false} ;
       SET volatility := {'VOLATILE' | 'IMMUTABLE' | 'STABLE'} ;
+      DROP volatility
       CREATE ANNOTATION <annotation-name> := <value> ;
       ALTER ANNOTATION <annotation-name> := <value> ;
       DROP ANNOTATION <annotation-name> ;

--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -216,6 +216,7 @@ Change the definition of a :ref:`link <ref_datamodel_links>`.
     # where <subcommand> is one of
 
       SET default := <expression>
+      DROP default
       SET readonly := {true | false}
       RENAME TO <newname>
       EXTENDING ...
@@ -329,6 +330,9 @@ The following subcommands are allowed in the ``ALTER LINK`` block:
 :eql:synopsis:`DROP INDEX ON <index-expr>`
     Remove an :ref:`index <ref_datamodel_indexes>` defined on *index-expr*
     from this link.  See :eql:stmt:`DROP INDEX` for details.
+
+:eql:synopsis:`DROP default`
+    Remove the default value from this link.
 
 All the subcommands allowed in the ``CREATE LINK`` block are also
 valid subcommands for ``ALTER LINK`` block.

--- a/docs/edgeql/ddl/props.rst
+++ b/docs/edgeql/ddl/props.rst
@@ -188,6 +188,7 @@ Change the definition of a :ref:`property <ref_datamodel_props>`.
     # where <subcommand> is one of
 
       SET default := <expression>
+      DROP default
       SET readonly := {true | false}
       RENAME TO <newname>
       EXTENDING ...
@@ -296,6 +297,9 @@ The following subcommands are allowed in the ``ALTER LINK`` block:
 :eql:synopsis:`DROP CONSTRAINT <constraint-name>;`
     Remove a constraint from this property.  See
     :eql:stmt:`DROP CONSTRAINT` for details.
+
+:eql:synopsis:`DROP default`
+    Remove the default value from this property.
 
 All the subcommands allowed in the ``CREATE PROPERTY`` block are also
 valid subcommands for ``ALTER PROPERTY`` block.

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -648,7 +648,7 @@ class OnTargetDelete(DDLOperation):
 class BaseSetField(DDLOperation):
     __abstract_node__ = True
     name: str
-    value: Expr
+    value: typing.Optional[Expr]
 
 
 class SetField(BaseSetField):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1108,10 +1108,13 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self._visit_DropObject(node, 'ALIAS')
 
     def visit_SetField(self, node: qlast.SetField) -> None:
-        if not self.sdlmode:
-            self.write('SET ')
-        self.write(f'{node.name} := ')
-        self.visit(node.value)
+        if node.value:
+            if not self.sdlmode:
+                self.write('SET ')
+            self.write(f'{node.name} := ')
+            self.visit(node.value)
+        elif not self.sdlmode:
+            self.write(f'DROP {node.name}')
 
     def visit_CreateAnnotation(self, node: qlast.CreateAnnotation) -> None:
         after_name = lambda: self._ddl_visit_bases(node)

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -175,6 +175,7 @@ class TraceContextBase:
 
             for cmd in decl.commands:
                 if isinstance(cmd, qlast.SetField) and cmd.name == "expr":
+                    assert cmd.value, "sdl SetField should always have value"
                     exprs.append(cmd.value)
 
             extra_name = '|'.join(qlcodegen.generate_source(e) for e in exprs)
@@ -576,6 +577,7 @@ def trace_SetField(
 ) -> None:
     deps = set()
 
+    assert node.value, "sdl SetField should always have value"
     for dep in qltracer.trace_refs(
         node.value,
         schema=ctx.schema,
@@ -608,6 +610,7 @@ def trace_ConcreteConstraint(
 
     for cmd in node.commands:
         if isinstance(cmd, qlast.SetField) and cmd.name == "expr":
+            assert cmd.value, "sdl SetField should always have value"
             exprs.append(ExprDependency(expr=cmd.value))
 
     loop_control: Optional[s_name.QualName]
@@ -681,6 +684,7 @@ def trace_Alias(
     for cmd in node.commands:
         # SetField or SetSpecialField are equivalent here
         if isinstance(cmd, qlast.BaseSetField) and cmd.name == "expr":
+            assert cmd.value, "sdl SetField should always have value"
             hard_dep_exprs.append(ExprDependency(expr=cmd.value))
             break
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -308,6 +308,21 @@ class SetFieldStmt(Nonterm):
         )
 
 
+class DropFieldStmt(Nonterm):
+    # DROP field
+    def reduce_DROP_IDENT(self, *kids):
+        self.val = qlast.SetField(
+            name=kids[1].val,
+            value=None,
+        )
+
+    def reduce_DROP_DEFAULT(self, *kids):
+        self.val = qlast.SetField(
+            name=kids[1].val,
+            value=None,
+        )
+
+
 class CreateAnnotationValueStmt(Nonterm):
     def reduce_CREATE_ANNOTATION_NodeName_ASSIGN_Expr(self, *kids):
         self.val = qlast.CreateAnnotationValue(
@@ -351,6 +366,7 @@ commands_block(
     DropUsingStmt,
     RenameStmt,
     SetFieldStmt,
+    DropFieldStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -521,6 +537,7 @@ commands_block(
     'AlterRole',
     RenameStmt,
     SetFieldStmt,
+    DropFieldStmt,
     AlterRoleExtending,
     opt=False
 )
@@ -636,6 +653,7 @@ class AlterConstraintOwned(Nonterm):
 commands_block(
     'AlterConcreteConstraint',
     SetFieldStmt,
+    DropFieldStmt,
     SetDelegatedStmt,
     AlterConstraintOwned,
     CreateAnnotationValueStmt,
@@ -751,6 +769,7 @@ commands_block(
     'AlterScalarType',
     RenameStmt,
     SetFieldStmt,
+    DropFieldStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -855,6 +874,7 @@ class AlterIndexOwned(Nonterm):
 commands_block(
     'AlterIndex',
     SetFieldStmt,
+    DropFieldStmt,
     AlterIndexOwned,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
@@ -938,6 +958,7 @@ commands_block(
     'AlterProperty',
     RenameStmt,
     SetFieldStmt,
+    DropFieldStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -1090,6 +1111,7 @@ commands_block(
     DropUsingStmt,
     RenameStmt,
     SetFieldStmt,
+    DropFieldStmt,
     AlterPropertyOwned,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
@@ -1167,6 +1189,7 @@ commands_block(
     'AlterLink',
     RenameStmt,
     SetFieldStmt,
+    DropFieldStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -1310,6 +1333,7 @@ commands_block(
     DropUsingStmt,
     RenameStmt,
     SetFieldStmt,
+    DropFieldStmt,
     AlterLinkOwned,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
@@ -1412,6 +1436,7 @@ commands_block(
     'AlterObjectType',
     RenameStmt,
     SetFieldStmt,
+    DropFieldStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -1518,6 +1543,7 @@ commands_block(
     UsingStmt,
     RenameStmt,
     SetFieldStmt,
+    DropFieldStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -1639,6 +1665,7 @@ commands_block(
     'AlterFunction',
     commondl.FromFunction,
     SetFieldStmt,
+    DropFieldStmt,
     RenameStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
@@ -1866,6 +1893,7 @@ class CreateOperatorStmt(Nonterm):
 commands_block(
     'AlterOperator',
     SetFieldStmt,
+    DropFieldStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -2091,6 +2119,7 @@ class CreateCastStmt(Nonterm):
 commands_block(
     'AlterCast',
     SetFieldStmt,
+    DropFieldStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -2318,6 +2347,7 @@ class CommitMigrationStmt(Nonterm):
 commands_block(
     'AlterMigration',
     SetFieldStmt,
+    DropFieldStmt,
     opt=False,
 )
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3048,6 +3048,10 @@ class AlterObjectProperty(Command):
         new_value_empty = \
             (value is None or
                 (isinstance(value, collections.abc.Container) and not value))
+        old_value_empty = \
+            (self.old_value is None or
+                (isinstance(self.old_value, collections.abc.Container)
+                 and not self.old_value))
 
         parent_ctx = context.current()
         parent_op = parent_ctx.op
@@ -3094,7 +3098,10 @@ class AlterObjectProperty(Command):
                 return None
 
         if new_value_empty:
-            value = None
+            if old_value_empty:
+                return None
+            else:
+                value = None
         elif issubclass(field.type, s_expr.Expression):
             return self._get_expr_field_ast(
                 schema,

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3006,7 +3006,7 @@ class AlterObjectProperty(Command):
                 schema,
                 context.modaliases,
                 orig_text=orig_text,
-            )
+            ) if astnode.value else None
         else:
             if isinstance(astnode.value, qlast.Tuple):
                 new_value = tuple(
@@ -3030,7 +3030,7 @@ class AlterObjectProperty(Command):
 
             else:
                 new_value = qlcompiler.evaluate_ast_to_python_val(
-                    astnode.value, schema=schema)
+                    astnode.value, schema=schema) if astnode.value else None
 
         return cls(property=propname, new_value=new_value,
                    source_context=astnode.context)
@@ -3094,9 +3094,8 @@ class AlterObjectProperty(Command):
                 return None
 
         if new_value_empty:
-            return None
-
-        if issubclass(field.type, s_expr.Expression):
+            value = None
+        elif issubclass(field.type, s_expr.Expression):
             return self._get_expr_field_ast(
                 schema,
                 context,

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -839,8 +839,6 @@ class AlterInheritingObject(
         if not context.canonical:
             props = self.enumerate_attributes()
             if props:
-                if context.enable_recursion:
-                    self._propagate_field_alter(schema, context, scls, props)
                 bases = scls.get_bases(schema).objects(schema)
                 schema = self.inherit_fields(
                     schema,
@@ -848,6 +846,8 @@ class AlterInheritingObject(
                     bases,
                     fields=props,
                 )
+                if context.enable_recursion:
+                    self._propagate_field_alter(schema, context, scls, props)
 
         return schema
 

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -539,7 +539,7 @@ class AlterLink(
                     slt.set_attribute_value(
                         'target',
                         target_ref,
-                        source_context=expr_cmd.value.context,
+                        source_context=expr.context,
                     )
                     cmd.add(slt)
                     cmd.discard_attribute('expr')

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2927,6 +2927,14 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_role_07(self):
+        """
+        ALTER ROLE username {
+            DROP password;
+            EXTENDING generic, morestuff;
+        };
+        """
+
     def test_edgeql_syntax_ddl_delta_02(self):
         """
         START MIGRATION TO {type test::Foo;};
@@ -3261,6 +3269,7 @@ aa';
             ALTER LINK bar {
                 ALTER CONSTRAINT my_constraint ON (foo) {
                     CREATE ANNOTATION title := 'special';
+                    DROP errmessage;
                 };
             };
             ALTER LINK baz {
@@ -3280,6 +3289,12 @@ aa';
                 };
             };
         };
+        """
+
+    def test_edgeql_syntax_ddl_constraint_12(self):
+        """
+        ALTER ABSTRACT CONSTRAINT my_constraint
+        DROP errmessage;
         """
 
     def test_edgeql_syntax_ddl_function_01(self):
@@ -3725,6 +3740,17 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_property_06(self):
+        """
+        ALTER ABSTRACT PROPERTY prop {
+            DROP default;
+        };
+
+% OK %
+
+        ALTER ABSTRACT PROPERTY prop DROP default;
+        """
+
     def test_edgeql_syntax_ddl_module_01(self):
         """
         CREATE MODULE foo;
@@ -3912,6 +3938,7 @@ aa';
         ALTER TYPE Foo {
             ALTER PROPERTY bar {
                 DROP EXPRESSION;
+                DROP default;
             };
         };
         """
@@ -3921,6 +3948,7 @@ aa';
         ALTER TYPE Foo {
             ALTER LINK bar {
                 DROP EXPRESSION;
+                DROP default;
             };
         };
         """


### PR DESCRIPTION
This lets us do things like `DROP default` and `DROP errmessage`.

Work on #1987: fixes test_schema_migrations_equivalence_20
when using DDL migrations.