### PR TITLE
Refactor remote Postgres support to be more generic and robust

### DIFF
--- a/edb/pgsql/dbops/roles.py
+++ b/edb/pgsql/dbops/roles.py
@@ -40,6 +40,7 @@ class Role(base.DBObject):
         password: Union[None, str, base.NotSpecifiedT] = base.NotSpecified,
         is_superuser: Union[bool, base.NotSpecifiedT] = base.NotSpecified,
         membership: Optional[Iterable[str]] = None,
+        members: Optional[Iterable[str]] = None,
         metadata: Optional[Mapping[str, Any]] = None,
     ) -> None:
         super().__init__(metadata=metadata)
@@ -50,6 +51,7 @@ class Role(base.DBObject):
         self.allow_createrole = allow_createrole
         self.password = password
         self.membership = membership
+        self.members = members
 
     def get_type(self):
         return 'ROLE'
@@ -110,7 +112,12 @@ class CreateRole(ddl.CreateObject, RoleCommand):
             membership = f'IN ROLE {roles}'
         else:
             membership = ''
-        return f'CREATE {self._render()} {membership}'
+        if self.object.members:
+            roles = ', '.join(qi(str(m)) for m in self.object.members)
+            members = f'ROLE {roles}'
+        else:
+            members = ''
+        return f'CREATE {self._render()} {membership} {members}'
 
 
 class AlterRole(ddl.AlterObject, RoleCommand):

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -907,7 +907,7 @@ class CommandContext:
         schema_object_ids: Optional[
             Mapping[Tuple[sn.Name, Optional[str]], uuid.UUID]
         ] = None,
-        backend_superuser_role: Optional[str] = None,
+        backend_runtime_params: Optional[Any] = None,
         compat_ver: Optional[verutils.Version] = None,
     ) -> None:
         self.stack: List[CommandContextToken[Command]] = []
@@ -926,7 +926,7 @@ class CommandContext:
         self.renamed_objs: Set[so.Object] = set()
         self.altered_targets: Set[so.Object] = set()
         self.schema_object_ids = schema_object_ids
-        self.backend_superuser_role = backend_superuser_role
+        self.backend_runtime_params = backend_runtime_params
         self.affected_finalization: \
             Dict[Command, List[Tuple[DeltaRoot, Command, bool]]] = dict()
         self.compat_ver = compat_ver

--- a/edb/server/baseport.py
+++ b/edb/server/baseport.py
@@ -61,8 +61,8 @@ class Port:
     def get_compiler_worker_args(self):
         return {
             'connect_args': self._pg_addr,
-            'backend_instance_params': (
-                self.get_server().get_backend_instance_params()
+            'backend_runtime_params': (
+                self.get_server().get_backend_runtime_params()
             ),
         }
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -55,6 +55,7 @@ from edb.server import buildmeta
 from edb.server import config
 from edb.server import compiler as edbcompiler
 from edb.server import defines as edbdef
+from edb.server import pgcluster
 
 from edb.pgsql import common as pg_common
 from edb.pgsql import dbops
@@ -67,7 +68,6 @@ from edgedb import scram
 if TYPE_CHECKING:
     import uuid
 
-    from . import pgcluster
     from asyncpg import connection as asyncpg_con
 
 
@@ -111,40 +111,83 @@ async def _execute_edgeql_ddl(
     return schema
 
 
+async def _ensure_edgedb_supergroup(
+    cluster,
+    conn,
+    username,
+    *,
+    member_of=(),
+    members=(),
+) -> None:
+    member_of = set(member_of)
+    instance_params = cluster.get_runtime_params().instance_params
+    superuser_role = instance_params.base_superuser
+    if superuser_role:
+        # If the cluster is exposing an explicit superuser role,
+        # become a member of that instead of creating a superuser
+        # role directly.
+        member_of.add(superuser_role)
+
+    role = dbops.Role(
+        name=username,
+        is_superuser=bool(
+            instance_params.capabilities
+            & pgcluster.BackendCapabilities.SUPERUSER_ACCESS
+        ),
+        allow_login=False,
+        allow_createdb=True,
+        allow_createrole=True,
+        membership=member_of,
+        members=members,
+    )
+
+    create_role = dbops.CreateRole(
+        role,
+        neg_conditions=[dbops.RoleExists(username)],
+    )
+
+    block = dbops.PLTopBlock()
+    create_role.generate(block)
+
+    await _execute_block(conn, block)
+
+
 async def _ensure_edgedb_role(
     cluster,
     conn,
     username,
     *,
-    membership=(),
     is_superuser=False,
     builtin=False,
     objid=None,
 ) -> None:
-    membership = set(membership)
+    member_of = set()
     if is_superuser:
-        superuser_role = cluster.get_superuser_role()
-        if superuser_role:
-            # If the cluster is exposing an explicit superuser role,
-            # become a member of that instead of creating a superuser
-            # role directly.
-            membership.add(superuser_role)
-            superuser_flag = False
-        else:
-            superuser_flag = True
-    else:
-        superuser_flag = False
+        member_of.add(edbdef.EDGEDB_SUPERGROUP)
 
     if objid is None:
         objid = uuidgen.uuid1mc()
 
+    members = set()
+    login_role = cluster.get_connection_params().user
+    if login_role != edbdef.EDGEDB_SUPERUSER:
+        members.add(login_role)
+
+    instance_params = cluster.get_runtime_params().instance_params
     role = dbops.Role(
         name=username,
-        is_superuser=superuser_flag,
+        is_superuser=(
+            is_superuser
+            and bool(
+                instance_params.capabilities
+                & pgcluster.BackendCapabilities.SUPERUSER_ACCESS
+            )
+        ),
         allow_login=True,
         allow_createdb=True,
         allow_createrole=True,
-        membership=membership,
+        membership=member_of,
+        members=members,
         metadata=dict(
             id=str(objid),
             builtin=builtin,
@@ -185,6 +228,11 @@ async def _ensure_edgedb_template_database(cluster, conn):
     result = await _get_db_info(conn, edbdef.EDGEDB_TEMPLATE_DB)
 
     if not result:
+        instance_params = cluster.get_runtime_params().instance_params
+        capabilities = instance_params.capabilities
+        have_c_utf8 = (
+            capabilities & pgcluster.BackendCapabilities.C_UTF8_LOCALE)
+
         logger.info('Creating template database...')
         block = dbops.SQLBlock()
         dbid = uuidgen.uuid1mc()
@@ -194,8 +242,7 @@ async def _ensure_edgedb_template_database(cluster, conn):
             is_template=True,
             template='template0',
             lc_collate='C',
-            lc_ctype=('C.UTF-8' if cluster.supports_c_utf8_locale()
-                      else 'en_US.UTF-8'),
+            lc_ctype='C.UTF-8' if have_c_utf8 else 'en_US.UTF-8',
             encoding='UTF8',
             metadata=dict(
                 id=str(dbid),
@@ -293,16 +340,6 @@ async def _store_static_json_cache(cluster, key: str, data: str) -> None:
         await _execute(dbconn, text)
     finally:
         await dbconn.close()
-
-
-async def _ensure_extensions(conn):
-    logger.info('Creating the necessary PostgreSQL extensions...')
-    await metaschema.create_pg_extensions(conn)
-
-
-async def _ensure_meta_schema(conn):
-    logger.info('Bootstrapping meta schema...')
-    await metaschema.bootstrap(conn)
 
 
 def _process_delta(delta, schema):
@@ -546,7 +583,7 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
         cache_dir = None
 
     stdlib_cache = 'backend-stdlib.pickle'
-    tpldbdump_cache = 'backend-tpldbdump.sql'
+    tpldbdump_cache = f'backend-tpldbdump.sql'
     src_hash = buildmeta.hash_dirs(CACHE_SRC_DIRS)
     stdlib = buildmeta.read_data_cache(
         src_hash, stdlib_cache, source_dir=cache_dir)
@@ -559,10 +596,13 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
     else:
         cache_hit = True
 
-    await _ensure_extensions(conn)
+    logger.info('Creating the necessary PostgreSQL extensions...')
+    await metaschema.create_pg_extensions(conn)
 
     if tpldbdump is None:
-        await _ensure_meta_schema(conn)
+        logger.info('Populating internal SQL structures...')
+        await metaschema.bootstrap(conn)
+        logger.info('Building the standard library...')
         await _execute_ddl(conn, stdlib.sqltext)
 
         if in_dev_mode or specified_cache_dir:
@@ -590,6 +630,7 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
                 target_dir=cache_dir,
             )
     else:
+        logger.info('Initializing the standard library...')
         await metaschema._execute_sql_script(conn, tpldbdump.decode('utf-8'))
 
         # When we restore a database from a dump, OIDs for non-system
@@ -954,6 +995,13 @@ async def _populate_misc_instance_data(cluster, conn):
         json.dumps(json_instance_data),
     )
 
+    instance_params = cluster.get_runtime_params().instance_params
+    await _store_static_json_cache(
+        cluster,
+        'backend_instance_params',
+        json.dumps(instance_params._asdict()),
+    )
+
     return json_instance_data
 
 
@@ -1078,16 +1126,16 @@ async def _bootstrap(
     pgconn: asyncpg_con.Connection,
     args: Dict[str, Any],
 ) -> None:
-    membership = set()
-    session_user = cluster.get_connection_params().user
-    if session_user != edbdef.EDGEDB_SUPERUSER:
-        membership.add(session_user)
+    await _ensure_edgedb_supergroup(
+        cluster,
+        pgconn,
+        edbdef.EDGEDB_SUPERGROUP,
+    )
 
     superuser_uid = await _ensure_edgedb_role(
         cluster,
         pgconn,
         edbdef.EDGEDB_SUPERUSER,
-        membership=membership,
         is_superuser=True,
         builtin=True,
     )
@@ -1103,11 +1151,6 @@ async def _bootstrap(
 
     conn = await cluster.connect(database=edbdef.EDGEDB_TEMPLATE_DB)
     conn.add_log_listener(_pg_log_listener)
-
-    await _execute(
-        conn,
-        f'ALTER SCHEMA public OWNER TO {edbdef.EDGEDB_SUPERUSER}',
-    )
 
     try:
         conn.add_log_listener(_pg_log_listener)
@@ -1153,7 +1196,6 @@ async def _bootstrap(
             cluster,
             pgconn,
             args['default_database_user'],
-            membership=membership,
             is_superuser=True,
         )
 

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -23,7 +23,6 @@ from .compiler import Compiler, BaseCompiler, CompilerDatabaseState
 from .compiler import compile_edgeql_script
 from .compiler import load_std_schema
 from .compiler import new_compiler, new_compiler_context
-from .compiler import BackendInstanceParams
 from .dbstate import QueryUnit
 from .enums import Capability, CompileStatementMode, ResultCardinality
 from .enums import IoFormat
@@ -31,7 +30,6 @@ from .enums import IoFormat
 
 __all__ = (
     'Compiler', 'BaseCompiler', 'CompilerDatabaseState',
-    'BackendInstanceParams',
     'QueryUnit',
     'Capability', 'CompileStatementMode', 'ResultCardinality', 'IoFormat',
     'compile_edgeql_script',

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 EDGEDB_PORT = 5656
+EDGEDB_SUPERGROUP = 'edgedb_supergroup'
 EDGEDB_SUPERUSER = 'edgedb'
 EDGEDB_TEMPLATE_DB = 'edgedb0'
 EDGEDB_SUPERUSER_DB = 'edgedb'
@@ -27,7 +28,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_11_17_00_00
+EDGEDB_CATALOG_VERSION = 2020_12_01_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -30,7 +30,6 @@ from edb.common import taskgroup
 from edb.edgeql import parser as ql_parser
 
 from edb.server import config
-from edb.server import compiler as edbcompiler
 from edb.server import defines
 from edb.server import http
 from edb.server import http_edgeql_port
@@ -370,7 +369,5 @@ class Server:
     async def get_instance_data(self, conn, key):
         return await self._dbindex.get_instance_data(conn, key)
 
-    def get_backend_instance_params(self) -> edbcompiler.BackendInstanceParams:
-        return edbcompiler.BackendInstanceParams(
-            explicit_superuser_role=self._cluster.get_superuser_role(),
-        )
+    def get_backend_runtime_params(self) -> Any:
+        return self._cluster.get_runtime_params()

--- a/edb/tools/wipe.py
+++ b/edb/tools/wipe.py
@@ -170,6 +170,7 @@ async def _get_dbs_and_roles(pgconn) -> Tuple[List[str], List[str]]:
         schema,
         expected_cardinality_one=False,
         single_statement=True,
+        output_format=edbcompiler.IoFormat.JSON,
     )
 
     schema, get_databases_sql = edbcompiler.compile_edgeql_script(


### PR DESCRIPTION
The current support for managed Postgres instances via `--postgres-dsn`
is limited to RDS and is rather clunky.  In order to support more
managed hosts and with less specific code, implement a notion of
"backend parameters", which include things like the cluster superuser
role and a capability bitmask that informs EdgeDB of the availability
(or lack of) certain features.

With this, EdgeDB can be bootstrapped on a DO instance and I plan to
test more providers soon.

Issue: #2006