### PR TITLE
Fix cardinality inference on operators

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -748,7 +748,10 @@ def __infer_oper_call(
 
             return card
         else:
-            return AT_MOST_ONE
+            if ir.typemod is qltypes.TypeModifier.OptionalType:
+                return AT_MOST_ONE
+            else:
+                return ONE
 
 
 @_infer_cardinality.register

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -481,3 +481,13 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         as_card: AT_MOST_ONE
         """
+
+    def test_edgeql_ir_card_inference_47(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            foo := EXISTS(.friends)
+        }
+% OK %
+        foo: ONE
+        """

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5561,7 +5561,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 CREATE OPTIONAL MULTI LINK intersection_of
                     -> schema::ObjectType;
                 CREATE OPTIONAL MULTI LINK union_of -> schema::ObjectType;
-                CREATE OPTIONAL SINGLE PROPERTY is_compound_type := (
+                CREATE REQUIRED SINGLE PROPERTY is_compound_type := (
                     (EXISTS (.union_of) OR EXISTS (.intersection_of))
                 );
                 CREATE OPTIONAL MULTI LINK links := (
@@ -5589,7 +5589,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     .pointers[IS schema::Property]
                 );
                 optional multi link union_of -> schema::ObjectType;
-                optional single property is_compound_type := (
+                required single property is_compound_type := (
                     (EXISTS (.union_of) OR EXISTS (.intersection_of))
                 );
             };


### PR DESCRIPTION
The operator cardinality inference currently doesn't take into account
the optionality of the return type, which results in incorrect lower
cardinality bound for most operators.  Function inference handles this
correctly.

Fixes: #2001