### PR TITLE
Resolve backward links properly when link target is a union

### DIFF
--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -171,6 +171,12 @@ class ObjectType(
                 )
             )
 
+        unions = schema.get_referrers(
+            self, scls_type=ObjectType, field_name='union_of')
+
+        for union in unions:
+            ptrs.update(union.getrptrs(schema, name, sources=sources))
+
         return ptrs
 
     def implicitly_castable_to(

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -6072,3 +6072,31 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                     todo: { name: {bogus} }
                 }
             """)
+
+    async def test_edgeql_select_revlink_on_union(self):
+        await self.assert_query_result(
+            """
+                WITH MODULE test
+                SELECT
+                    File {
+                        referrers := (
+                            SELECT .<references[IS Issue] {
+                                name,
+                                number,
+                            } ORDER BY .number
+                        )
+                    }
+                FILTER
+                    .name = 'screenshot.png'
+            """,
+            [
+                {
+                    'referrers': [
+                        {
+                            'name': 'Improve EdgeDB repl output rendering.',
+                            'number': '2'
+                        }
+                    ]
+                }
+            ],
+        )


### PR DESCRIPTION
A path `Foo.<flink[IS Bar]` should resolve if `Bar` links to `Foo`
indirectly via a union type, like this:

    type Bar {
        link flink -> Foo | Spam;
    }

While at it, fix type annotations for `Schema.get_referrers()`

Fixes: #2000