### PR TITLE
Rework how rebasing is handled in DDL and migrations

### DIFF
--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -207,25 +207,23 @@ class LinkCommand(lproperties.PropertySourceCommand,
             'target', target_ref, source_context=astnode.target.context)
         self.add(slt)
 
-    def _apply_refs_fields_ast(
+    def _append_subcmd_ast(
         self,
         schema: s_schema.Schema,
-        context: sd.CommandContext,
         node: qlast.DDLOperation,
-        refdict: so.RefDict,
+        subcmd: sd.Command,
+        context: sd.CommandContext,
     ) -> None:
-        if issubclass(refdict.ref_cls, pointers.Pointer):
-            for op in self.get_subcommands(metaclass=refdict.ref_cls):
-                if (
-                    isinstance(op, pointers.PointerCommand)
-                    and op.classname != self.classname
+        if (
+            isinstance(subcmd, pointers.PointerCommand)
+            and subcmd.classname != self.classname
 
-                ):
-                    pname = sn.shortname_from_fullname(op.classname)
-                    if pname.name not in {'source', 'target'}:
-                        self._append_subcmd_ast(schema, node, op, context)
-        else:
-            super()._apply_refs_fields_ast(schema, context, node, refdict)
+        ):
+            pname = sn.shortname_from_fullname(subcmd.classname)
+            if pname.name in {'source', 'target'}:
+                return
+
+        super()._append_subcmd_ast(schema, node, subcmd, context)
 
     def _validate_pointer_def(
         self,

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -853,7 +853,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
 
     internal = SchemaField(
         bool,
-        inheritable=True,
+        inheritable=False,
     )
 
     # Schema source context for this object

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -3519,12 +3519,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             # drop everything
         """)
 
-    @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
-
-        This happens on the third migration.
-    ''')
     async def test_edgeql_migration_eq_30(self):
         await self.migrate(r"""
             type Foo {
@@ -7575,9 +7569,9 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text':
                         'CREATE TYPE test::NewObj2 {\n'
+                        "    CREATE ANNOTATION std::title := 'Obj2';\n"
                         '    CREATE OPTIONAL SINGLE PROPERTY name'
                         ' -> std::str;\n'
-                        "    CREATE ANNOTATION std::title := 'Obj2';\n"
                         '};'
                 }],
             },
@@ -7594,11 +7588,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text':
                         'ALTER TYPE test::Obj2 {\n'
-                        '    RENAME TO test::NewObj2;\n'
                         '    DROP LINK o1;\n'
                         '    DROP PROPERTY o;\n'
+                        '    RENAME TO test::NewObj2;\n'
+                        "    CREATE ANNOTATION std::title := 'Obj2';\n"
                         '    CREATE OPTIONAL SINGLE PROPERTY name -> std::str;'
-                        "\n    CREATE ANNOTATION std::title := 'Obj2';\n"
+                        '\n'
                         '};'
                 }],
             },

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4504,6 +4504,88 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         """])
 
+    def test_schema_migrations_drop_parent_01(self):
+        self._assert_migration_equivalence([r"""
+            type Parent {
+                property name -> str {
+                    constraint exclusive;
+                }
+            }
+            type Child extending Parent {
+                overloaded property name -> str;
+            };
+        """, r"""
+            type Parent {
+                property name -> str {
+                    constraint exclusive;
+                }
+            }
+            type Child {
+                property name -> str;
+            };
+        """])
+
+    def test_schema_migrations_drop_parent_02(self):
+        self._assert_migration_equivalence([r"""
+            type Parent {
+                property name -> str {
+                    constraint exclusive;
+                }
+            }
+            type Child extending Parent;
+        """, r"""
+            type Parent {
+                property name -> str {
+                    constraint exclusive;
+                }
+            }
+            type Child {
+                property name -> str;
+            }
+        """])
+
+    def test_schema_migrations_drop_parent_03(self):
+        self._assert_migration_equivalence([r"""
+            type Parent {
+                property name -> str {
+                    delegated constraint exclusive;
+                }
+            }
+            type Child extending Parent;
+        """, r"""
+            type Parent {
+                property name -> str {
+                    delegated constraint exclusive;
+                }
+            }
+            type Child {
+                property name -> str {
+                    constraint exclusive;
+                }
+            }
+        """])
+
+    def test_schema_migrations_drop_parent_04(self):
+        self._assert_migration_equivalence([r"""
+            type Parent {
+                link foo -> Object {
+                    property x -> str;
+                }
+            }
+            type Child extending Parent;
+        """, r"""
+            type Parent {
+                link foo -> Object {
+                    property x -> str;
+                }
+            }
+            type Child {
+                link foo -> Object {
+                    property x -> str;
+                }
+            }
+        """])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
Currently, rebases are performed as the last operation in an ALTER,
since they are generated after everything else. (Though prior to

This changes rebases so that they can be executed at any point in a
sequence of commands inside an ALTER, which allows us to do things
like "SET OWNED on a field before dropping a base" or "add a base and
then DROP OWNED on a property declared in it", depending on how we
structure the command.

We implement this by recording the base information in AlterInherit as
we go, and then merging sequences of AlterInherit commands into Rebase
commands after the fact. All that logic moves into inheriting, which
lets us drop a nested cyclic import.

I added a group of schema tests that touch various things related to
the issue at play here, though only one of them actually failed before
this patch.

Progress on #1987: Fixes:
 * test_schema_migrations_drop_parent_03 (... which it also adds)
 * test_schema_migrations_equivalence_30

And test_constraints_exclusive_migration is getting closer...