### PR TITLE
Assume inline_typeids for protocol <= 0.8

### DIFF
--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -1014,7 +1014,7 @@ cdef class EdgeConnection:
             bytes eql
             dict headers
             uint64_t implicit_limit = 0
-            bint inline_typeids = False
+            bint inline_typeids = self.protocol_version <= (0, 8)
             bint inline_typenames = False
             bytes stmt_name = b''
 


### PR DESCRIPTION
Was broken in d7b08f7b281144a20f9ca0c559a457037fa38b6e
In particular, JavaScript tests are broken because of this.