### PR TITLE
Fix injection of implicit limit in some cases

### DIFF
--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -58,6 +58,15 @@ def ensure_qlstmt(expr: qlast.Expr) -> qlast.Statement:
     return expr
 
 
+def ensure_ql_select(expr: qlast.Expr) -> qlast.SelectQuery:
+    if not isinstance(expr, qlast.SelectQuery):
+        expr = qlast.SelectQuery(
+            result=expr,
+            implicit=True,
+        )
+    return expr
+
+
 def is_ql_empty_set(expr: qlast.Expr) -> bool:
     return isinstance(expr, qlast.Set) and len(expr.elements) == 0
 

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -601,6 +601,9 @@ def _cast_array(
                 ],
             )
 
+            if el_type.contains_json(subctx.env.schema):
+                subctx.inhibit_implicit_limit = True
+
             array_ir = dispatch.compile(elements, ctx=subctx)
             assert isinstance(array_ir, irast.Set)
 

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -399,7 +399,8 @@ def compile_UnaryOp(
 @dispatch.compile.register(qlast.TypeCast)
 def compile_TypeCast(
         expr: qlast.TypeCast, *, ctx: context.ContextLevel) -> irast.Set:
-    target_typeref = typegen.ql_typeexpr_to_ir_typeref(expr.type, ctx=ctx)
+    target_stype = typegen.ql_typeexpr_to_type(expr.type, ctx=ctx)
+    target_typeref = typegen.type_to_typeref(target_stype, env=ctx.env)
     ir_expr: irast.Base
 
     if (isinstance(expr.expr, qlast.Array) and not expr.expr.elements and
@@ -510,17 +511,14 @@ def compile_TypeCast(
 
     else:
         with ctx.new() as subctx:
-            # We use "exposed" mode in case this is a type of a cast
-            # that wants view shapes, e.g. a std::json cast.  We do
-            # this wholesale to support tuple and array casts without
-            # having to analyze the target type (which is cumbersome
-            # in QL AST).
-            subctx.expr_exposed = True
+            if target_stype.contains_json(subctx.env.schema):
+                # JSON wants type shapes and acts as an output sink.
+                subctx.expr_exposed = True
+                subctx.inhibit_implicit_limit = True
             ir_expr = dispatch.compile(expr.expr, ctx=subctx)
 
-    new_stype = typegen.ql_typeexpr_to_type(expr.type, ctx=ctx)
     return casts.compile_cast(
-        ir_expr, new_stype, cardinality_mod=expr.cardinality_mod,
+        ir_expr, target_stype, cardinality_mod=expr.cardinality_mod,
         ctx=ctx, srcctx=expr.expr.context)
 
 

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -71,6 +71,12 @@ class ScalarType(
     def is_polymorphic(self, schema: s_schema.Schema) -> bool:
         return self.get_is_abstract(schema)
 
+    def contains_json(self, schema: s_schema.Schema) -> bool:
+        return self.issubclass(
+            schema,
+            schema.get(s_name.QualName('std', 'json'), type=ScalarType),
+        )
+
     def can_accept_constraints(self, schema: s_schema.Schema) -> bool:
         return not self.is_enum(schema)
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -214,6 +214,9 @@ class Type(
     def contains_any(self, schema: s_schema.Schema) -> bool:
         return self.is_any(schema)
 
+    def contains_json(self, schema: s_schema.Schema) -> bool:
+        return False
+
     def is_scalar(self) -> bool:
         return False
 
@@ -675,6 +678,10 @@ class Collection(Type, s_abc.Collection):
 
     def contains_any(self, schema: s_schema.Schema) -> bool:
         return any(st.contains_any(schema) for st in self.get_subtypes(schema))
+
+    def contains_json(self, schema: s_schema.Schema) -> bool:
+        return any(
+            st.contains_json(schema) for st in self.get_subtypes(schema))
 
     def contains_object(self, schema: s_schema.Schema) -> bool:
         return any(

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -622,15 +622,14 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(__derived__::__derived__|x@w~1)": {
+                "(__derived__::__derived__|x@w~2)": {
                     "FENCE": {
                         "(test::User).>deck[IS test::Card]"
                     }
                 },
                 "(test::User).>deck[IS test::Card]",
                 "FENCE": {
-                    "(__derived__::__derived__|x@w~1)\
-.>name[IS std::str]"
+                    "(__derived__::__derived__|x@w~2).>name[IS std::str]"
                 }
             }
         }


### PR DESCRIPTION
Currently, implicit limit is injected into `SET OF` arguments of all
generic functions (with the original intent to cover `array_agg`-like
functions).  Unfortunately, this breaks `std::max` and the like, and
while we could add an extra condition to check for the array return
type, it seems like the best thing to do is to hardcode for `array_agg`
for now.  A better implementation might be to slice all output arrays,
but that seems like more effort than its worth.

Additionally, stop implicit injection if inside a `json` cast.  JSON
strings, unlike structured output, have no indication of truncation, and
so the result would appear wrong.  A future improvement might add JSON
string truncation and some magic tokens to indicate truncation.

`std::max` bug reported by @ambv.