### PR TITLE
Avoid needlessly altering cardinality in some cases

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1650,15 +1650,17 @@ class ObjectCommand(
                     new_value = field.get_default()
 
                 if (
-                    # For all properties other than cardinality, if they
-                    # are inherited and have the default value, skip them.
-                    # Cardinality is special and should be explicitly
-                    # included, though.
-                    fop.property == 'cardinality'
-                    or
                     (
-                        fop.source != 'inheritance'
-                        or context.descriptive_mode
+                        # For all properties other than cardinality, if they
+                        # are inherited and have the default value, skip them.
+                        # Cardinality is special and should be explicitly
+                        # included, though.
+                        fop.property == 'cardinality'
+                        or
+                        (
+                            fop.source != 'inheritance'
+                            or context.descriptive_mode
+                        )
                     )
                     and fop.old_value != new_value
                 ):

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -3130,11 +3130,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        edgedb.errors.InvalidReferenceError: property 'foo' does not exist
-
-        This error happens in the last migration.
-    ''')
     async def test_edgeql_migration_eq_22(self):
         await self.migrate(r"""
             type Base {


### PR DESCRIPTION
The logic for determining whether to output a property alter had (I
believe) a precedence bug, which resulted in outputting `SET SINGLE`
and `SET MULTI` in some migrations where they didn't change.
Clean that up.