### PR TITLE
Fix ordering of rebases in another case

### DIFF
--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -555,7 +555,7 @@ def _trace_op(
                         anc_item.deps.add(('alterowned', str(op.classname)))
 
                         if is_set_owned:
-                            # SET OWNED needs to come before ancestor rebases too
+                            # SET OWNED must come before ancestor rebases too
                             anc_item = get_deps(('rebase', str(ancestor_name)))
                             anc_item.deps.add(
                                 ('alterowned', str(op.classname)))

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -516,7 +516,8 @@ def _trace_op(
             else:
                 # Otherwise, things must be deleted _after_ their referrers
                 # have been deleted or altered.
-                deps.add(('delete', str(ref.get_name(old_schema))))
+                deps.add(('delete', ref_name_str))
+                deps.add(('rebase', ref_name_str))
 
         if isinstance(obj, referencing.ReferencedObject):
             referrer = obj.get_referrer(old_schema)
@@ -530,10 +531,11 @@ def _trace_op(
                 # object to come *after*, because otherwise obj could
                 # get dropped before the SET OWNED takes effect.
                 # For DROP OWNED and DROP we want it after the rebase.
-                if (
+                is_set_owned = (
                     isinstance(op, referencing.AlterOwned)
                     and op.get_attribute_value('is_owned')
-                ):
+                )
+                if is_set_owned:
                     ref_item = get_deps(('rebase', str(referrer_name)))
                     ref_item.deps.add(('alterowned', str(op.classname)))
                 else:
@@ -551,6 +553,12 @@ def _trace_op(
                         implicit_ancestors.append(ancestor_name)
                         anc_item = get_deps(('delete', str(ancestor_name)))
                         anc_item.deps.add(('alterowned', str(op.classname)))
+
+                        if is_set_owned:
+                            # SET OWNED needs to come before ancestor rebases too
+                            anc_item = get_deps(('rebase', str(ancestor_name)))
+                            anc_item.deps.add(
+                                ('alterowned', str(op.classname)))
 
         graph_key = str(op.classname)
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -5724,20 +5724,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        edgedb.errors.SchemaError: cannot drop abstract link
-        'test::base_child' because other objects in the schema depend
-        on it
-
-        DETAILS: link 'child' of object type 'test::Derived' depends
-        on test::base_child; link 'child' of object type 'test::Base'
-        depends on test::base_child
-
-        Exception: Error while processing
-        'DROP ABSTRACT LINK test::base_child {
-            DROP PROPERTY foo;
-        };'
-    ''')
     async def test_edgeql_migration_eq_linkprops_10(self):
         # reverse of the test_edgeql_migration_eq_linkprops_09 refactoring
         await self.migrate(r"""
@@ -5782,7 +5768,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.assert_query_result(
             r"""
-                SELECT Base {
+                SELECT Derived {
                     child: {
                         @foo,
                     }


### PR DESCRIPTION
A delete needs to come after the references have been rebased away,
and SET OWNED needs to come before *ancestor* rebases.

Progress on #1987. Fixes test_schema_migrations_equivalence_linkprops_10