### PR TITLE
Fix dropping an overloaded pointer in both a parent and child class

### DIFF
--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -776,18 +776,8 @@ def _extract_op(stack: Sequence[sd.Command]) -> List[sd.Command]:
         parent_op = alter_delta
         new_stack.append(parent_op)
 
-    op = stack[-1]
-    # We don't want duplicate nested Alters on the same object (which
-    # can happen when an operation is transformed from a different
-    # type), so prune it away as necessary.
-    if (
-        isinstance(op, sd.AlterObject) and
-        isinstance(parent_op, sd.AlterObject) and
-        op.classname == parent_op.classname
-    ):
-        new_stack.pop()
-    stack[-2].discard(op)
-    new_stack[-1].add(op)
-    new_stack.append(op)
+    stack[-2].discard(stack[-1])
+    parent_op.add(stack[-1])
+    new_stack.append(stack[-1])
 
     return new_stack

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -318,13 +318,11 @@ class ReferencedInheritingObject(
                 for ancestor in self.get_implicit_ancestors(schema)
             )
         ):
-            alter_op = self.init_delta_command(schema, sd.AlterObject)
             owned_op = self.init_delta_command(schema, AlterOwned)
             owned_op.set_attribute_value('is_owned', False, orig_value=True)
-            alter_op.add(owned_op)
             del_op.set_attribute_value('is_owned', None, orig_value=False)
 
-            del_op.add(alter_op)
+            del_op.add(owned_op)
 
         return del_op
 


### PR DESCRIPTION
This ran into a fiddly issue where the DROP OWNED was nested inside of
redundant AlterPropertys as an artifact of how opbranches are
constructed.

Progress on #1987: Fixes:
 * test_schema_migrations_equivalence_03
 * test_schema_migrations_equivalence_04