### PR TITLE
Fix dropping inherited properties with constraints

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1708,22 +1708,29 @@ class ObjectCommand(
 
                     setattr(node, ast_attr, attr_val)
 
-            # No subcommands for delete are permitted
-            if not isinstance(self, DeleteObject):
-                # Keep subcommands from refdicts and alter fragments (like
-                # rename, rebase) in order when producing DDL asts
-                refdicts = tuple(x.ref_cls for x in mcls.get_refdicts())
-                for op in self.get_subcommands():
-                    if (
-                        isinstance(op, AlterObjectFragment)
-                        or (isinstance(op, ObjectCommand) and
-                            issubclass(op.get_schema_metaclass(), refdicts))
-                    ):
-                        self._append_subcmd_ast(schema, node, op, context)
+            # Keep subcommands from refdicts and alter fragments (like
+            # rename, rebase) in order when producing DDL asts
+            refdicts = tuple(x.ref_cls for x in mcls.get_refdicts())
+            for op in self.get_subcommands():
+                if (
+                    isinstance(op, AlterObjectFragment)
+                    or (isinstance(op, ObjectCommand) and
+                        issubclass(op.get_schema_metaclass(), refdicts))
+                ):
+                    self._append_subcmd_ast(schema, node, op, context)
 
         else:
             for op in self.get_subcommands(type=AlterObjectFragment):
                 self._append_subcmd_ast(schema, node, op, context)
+
+        if isinstance(node, qlast.DropObject):
+            # Deletes in the AST shouldn't have subcommands, so we
+            # drop them.  To try to make sure we aren't papering
+            # over bugs by dropping things we dont expect, make
+            # sure every subcommand was also a delete.
+            assert all(
+                isinstance(sub, qlast.DropObject) for sub in node.commands)
+            node.commands = []
 
     def _apply_field_ast(
         self,

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1708,16 +1708,18 @@ class ObjectCommand(
 
                     setattr(node, ast_attr, attr_val)
 
-            # Keep subcommands from refdicts and alter fragments (like
-            # rename, rebase) in order when producing DDL asts
-            refdicts = tuple(x.ref_cls for x in mcls.get_refdicts())
-            for op in self.get_subcommands():
-                if (
-                    isinstance(op, AlterObjectFragment)
-                    or (isinstance(op, ObjectCommand)
-                        and issubclass(op.get_schema_metaclass(), refdicts))
-                ):
-                    self._append_subcmd_ast(schema, node, op, context)
+            # No subcommands for delete are permitted
+            if not isinstance(self, DeleteObject):
+                # Keep subcommands from refdicts and alter fragments (like
+                # rename, rebase) in order when producing DDL asts
+                refdicts = tuple(x.ref_cls for x in mcls.get_refdicts())
+                for op in self.get_subcommands():
+                    if (
+                        isinstance(op, AlterObjectFragment)
+                        or (isinstance(op, ObjectCommand) and
+                            issubclass(op.get_schema_metaclass(), refdicts))
+                    ):
+                        self._append_subcmd_ast(schema, node, op, context)
 
         else:
             for op in self.get_subcommands(type=AlterObjectFragment):

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -28,7 +28,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_12_01_00_00
+EDGEDB_CATALOG_VERSION = 2020_12_04_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -3647,16 +3647,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             ],
         )
 
-    @test.xfail('''
-        edgedb.errors.EdgeQLSyntaxError: Unexpected '{'
-
-        Exception: Error while processing
-        'ALTER TYPE test::Text {
-            DROP PROPERTY body {
-                DROP CONSTRAINT std::max_len_value(10000);
-            };
-        };'
-    ''')
     async def test_edgeql_migration_eq_31(self):
         # Issue 727.
         #

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6095,6 +6095,62 @@ type test::Foo {
                 INSERT test::Foo { x := "a" };
             """)
 
+    async def test_edgeql_ddl_constraint_09(self):
+        await self.con.execute(r"""
+            SET MODULE test;
+
+            CREATE ABSTRACT TYPE Text {
+                CREATE REQUIRED SINGLE PROPERTY body -> str {
+                    CREATE CONSTRAINT max_len_value(10000);
+                };
+            };
+            CREATE TYPE Comment EXTENDING Text;
+        """)
+
+        await self.con.execute("""
+            ALTER TYPE Text
+                ALTER PROPERTY body
+                    DROP CONSTRAINT max_len_value(10000);
+        """)
+
+    async def test_edgeql_ddl_constraint_10(self):
+        await self.con.execute(r"""
+            SET MODULE test;
+
+            CREATE ABSTRACT TYPE Text {
+                CREATE REQUIRED SINGLE PROPERTY body -> str {
+                    CREATE CONSTRAINT max_len_value(10000);
+                };
+            };
+            CREATE TYPE Comment EXTENDING Text;
+        """)
+
+        await self.con.execute("""
+            ALTER TYPE Text
+                DROP PROPERTY body;
+        """)
+
+    async def test_edgeql_ddl_constraint_11(self):
+        await self.con.execute(r"""
+            SET MODULE test;
+
+            CREATE ABSTRACT TYPE Text {
+                CREATE REQUIRED SINGLE PROPERTY body -> str {
+                    CREATE CONSTRAINT max_value(10000)
+                        ON (len(__subject__));
+                };
+            };
+            CREATE TYPE Comment EXTENDING Text;
+            CREATE TYPE Troll EXTENDING Comment;
+        """)
+
+        await self.con.execute("""
+            ALTER TYPE Text
+                ALTER PROPERTY body
+                    DROP CONSTRAINT max_value(10000)
+                        ON (len(__subject__));
+        """)
+
     async def test_edgeql_ddl_constraint_alter_01(self):
         await self.con.execute(r"""
             CREATE TYPE test::ConTest01 {


### PR DESCRIPTION
The main bug is that inherited constraints would end up using the
subjectexpr of the abstract constraint in computing their name quals,
if the concrete parent had no subjectexpr. This resulted in it having
an incorrect name, causing it to be missed in places.

Additionally, the DDL text we generated contained subcommands nested
in a DropProperty. Prevent that, since it isn't valid in the concrete
syntax.

I think that changing how constraint names are computed means I had to
bump the version?

Progress on #1987. Fixes test_schema_migrations_equivalence_31.