### PR TITLE
Fix two issues with migrations of annotations

### DIFF
--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -407,6 +407,18 @@ class AlterAnnotationValue(
 
         return cmd
 
+    def _get_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        *,
+        parent_node: Optional[qlast.DDLOperation] = None,
+    ) -> Optional[qlast.DDLOperation]:
+        # Skip AlterObject's _get_ast, because we *don't* want to
+        # filter out things without subcommands!
+        return sd.ObjectCommand._get_ast(
+            self, schema, context, parent_node=parent_node)
+
     def _apply_field_ast(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -414,6 +414,8 @@ class AlterAnnotationValue(
         *,
         parent_node: Optional[qlast.DDLOperation] = None,
     ) -> Optional[qlast.DDLOperation]:
+        if not self.has_attribute_value('value'):
+            return None
         # Skip AlterObject's _get_ast, because we *don't* want to
         # filter out things without subcommands!
         return sd.ObjectCommand._get_ast(

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -874,7 +874,7 @@ def write_meta_delete_object(
             parent_variables = {}
 
             parent_variables[f'__{target_link}'] = (
-                json.dumps(str(target.get_name(schema)))
+                json.dumps(str(target.id))
             )
 
             parent_update_query = f'''
@@ -883,7 +883,7 @@ def write_meta_delete_object(
                 SET {{
                     {refdict.attr} -= (
                         SELECT DETACHED (schema::{target_field.type.__name__})
-                        FILTER .name__internal = <str>$__{target_link}
+                        FILTER .id = <uuid>$__{target_link}
                     )
                 }}
             '''

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -1724,13 +1724,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             },
         })
 
-    @test.xfail('''
-        edgedb.errors.SchemaError: cannot get 'name' value: item
-        'bc6c9f68-049d-11eb-a183-c1f86eaf323b' is not present in the
-        schema <Schema gen:3708 at 0x7efef93f1430>
-
-        The error occurs on committing the second migration.
-    ''')
     async def test_edgeql_migration_describe_annotation_02(self):
         # Migration that creates an annotation.
         await self.con.execute('''
@@ -1849,7 +1842,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [{
                 'name': 'test::AnnoType2',
                 'annotations': [{
-                    'name': 'my_anno2',
+                    'name': 'test::my_anno2',
                     '@value': 'retest_my_anno2',
                 }]
             }],
@@ -6076,13 +6069,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        edgedb.errors.SchemaError: cannot get 'name' value: item
-        '4e2fe443-04a6-11eb-a38f-a315784c86dc' is not present in the
-        schema <Schema gen:3747 at 0x7fd78b613790>
-
-        This happens on the final migration.
-    ''')
     async def test_edgeql_migration_eq_annotation_02(self):
         await self.migrate(r"""
             type Base;
@@ -6184,13 +6170,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        edgedb.errors.SchemaError: cannot get 'name' value: item
-        '54615193-04a6-11eb-a05a-af5ecac7408d' is not present in the
-        schema <Schema gen:3751 at 0x7fd78bbe74c0>
-
-        This happens on the final migration.
-    ''')
     async def test_edgeql_migration_eq_annotation_03(self):
         await self.migrate(r"""
             type Base;
@@ -6295,14 +6274,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail('''
-        The "complete" flag is not set even though the DDL from
-        "proposed" list is used.
-
-        This happens on the second migration.
-    ''')
     async def test_edgeql_migration_eq_annotation_04(self):
-        # Test migration of annotation value ano nothing else.
+        # Test migration of annotation value and nothing else.
         await self.migrate(r"""
             abstract annotation description;
 


### PR DESCRIPTION
1. Actually generate DDL for altering concrete annotations
2. Avoid a crash in write_meta when both a concrete annotation and its
   abstract annotation are dropped by filtering on id instead of name.