### PR TITLE
Improvements of new protocol headers

### DIFF
--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -97,8 +97,8 @@ cdef object logger = logging.getLogger('edb.server')
 cdef object log_metrics = logging.getLogger('edb.server.metrics')
 
 DEF QUERY_HEADER_IMPLICIT_LIMIT = 0xFF01
-DEF QUERY_HEADER_INLINE_TYPENAMES = 0xFF02
-DEF QUERY_HEADER_INLINE_TYPEIDS = 0xFF03
+DEF QUERY_HEADER_IMPLICIT_TYPENAMES = 0xFF02
+DEF QUERY_HEADER_IMPLICIT_TYPEIDS = 0xFF03
 DEF QUERY_HEADER_ALLOW_CAPABILITIES = 0xFF04
 
 DEF SERVER_HEADER_CAPABILITIES = 0x1001
@@ -1092,12 +1092,12 @@ cdef class EdgeConnection:
             for k, v in headers.items():
                 if k == QUERY_HEADER_IMPLICIT_LIMIT:
                     implicit_limit = self._parse_implicit_limit(v)
-                elif k == QUERY_HEADER_INLINE_TYPEIDS:
-                    self.version_check("INLINE_TYPEIDS header", (0, 9))
-                    inline_typeids = parse_boolean(v, "INLINE_TYPEIDS")
-                elif k == QUERY_HEADER_INLINE_TYPENAMES:
-                    self.version_check("INLINE_TYPENAMES header", (0, 9))
-                    inline_typenames = parse_boolean(v, "INLINE_TYPENAMES")
+                elif k == QUERY_HEADER_IMPLICIT_TYPEIDS:
+                    self.version_check("IMPLICIT_TYPEIDS header", (0, 9))
+                    inline_typeids = parse_boolean(v, "IMPLICIT_TYPEIDS")
+                elif k == QUERY_HEADER_IMPLICIT_TYPENAMES:
+                    self.version_check("IMPLICIT_TYPENAMES header", (0, 9))
+                    inline_typenames = parse_boolean(v, "IMPLICIT_TYPENAMES")
                 elif k == QUERY_HEADER_ALLOW_CAPABILITIES:
                     self.version_check("ALLOW_CAPABILITIES header", (0, 9))
                     allow_capabilities = parse_capabilities_header(v)

--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -96,10 +96,10 @@ cdef tuple DUMP_VER_MAX = (0, 9)
 cdef object logger = logging.getLogger('edb.server')
 cdef object log_metrics = logging.getLogger('edb.server.metrics')
 
-DEF QUERY_OPT_IMPLICIT_LIMIT = 0xFF01
-DEF QUERY_OPT_INLINE_TYPENAMES = 0xFF02
-DEF QUERY_OPT_INLINE_TYPEIDS = 0xFF03
-DEF QUERY_OPT_ALLOW_CAPABILITIES = 0xFF04
+DEF QUERY_HEADER_IMPLICIT_LIMIT = 0xFF01
+DEF QUERY_HEADER_INLINE_TYPENAMES = 0xFF02
+DEF QUERY_HEADER_INLINE_TYPEIDS = 0xFF03
+DEF QUERY_HEADER_ALLOW_CAPABILITIES = 0xFF04
 
 DEF SERVER_HEADER_CAPABILITIES = 0x1001
 
@@ -840,7 +840,7 @@ cdef class EdgeConnection:
         headers = self.parse_headers()
         if headers:
             for k, v in headers.items():
-                if k == QUERY_OPT_ALLOW_CAPABILITIES:
+                if k == QUERY_HEADER_ALLOW_CAPABILITIES:
                     allow_capabilities = parse_capabilities_header(v)
                 else:
                     raise errors.BinaryProtocolError(
@@ -1069,13 +1069,13 @@ cdef class EdgeConnection:
         headers = self.parse_headers()
         if headers:
             for k, v in headers.items():
-                if k == QUERY_OPT_IMPLICIT_LIMIT:
+                if k == QUERY_HEADER_IMPLICIT_LIMIT:
                     implicit_limit = self._parse_implicit_limit(v)
-                elif k == QUERY_OPT_INLINE_TYPEIDS:
+                elif k == QUERY_HEADER_INLINE_TYPEIDS:
                     inline_typeids = v.lower() == b'true'
-                elif k == QUERY_OPT_INLINE_TYPENAMES:
+                elif k == QUERY_HEADER_INLINE_TYPENAMES:
                     inline_typenames = v.lower() == b'true'
-                elif k == QUERY_OPT_ALLOW_CAPABILITIES:
+                elif k == QUERY_HEADER_ALLOW_CAPABILITIES:
                     allow_capabilities = parse_capabilities_header(v)
                 else:
                     raise errors.BinaryProtocolError(
@@ -1420,7 +1420,7 @@ cdef class EdgeConnection:
         headers = self.parse_headers()
         if headers:
             for k, v in headers.items():
-                if k == QUERY_OPT_ALLOW_CAPABILITIES:
+                if k == QUERY_HEADER_ALLOW_CAPABILITIES:
                     allow_capabilities = parse_capabilities_header(v)
                 else:
                     raise errors.BinaryProtocolError(


### PR DESCRIPTION
* QUERY_OPT -> QUERY_HEADER
* IMPLICIT_TYPEIDS -> INLINE_TYPEIDS, IMPLICIT_TYPENAMES -> INLINE_TYPENAMES
* proper protocol version checks for new headers
* boolean headers now restricted to non-case-sensitive `true` and `false` rather than `true` and anything else

This also contains minimum changes for #2004. I've neither converted header to binary, nor turned this to a bitmask because that would require release-python-bindings-again dance for no sufficient profit.