### PR TITLE
Add a set_trace method to edb.common.debug that succesfully sets a breakpoint

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import builtins
 import contextlib
 import os
+import sys
 import time
 import warnings
 
@@ -156,6 +157,21 @@ def dump(*args, **kwargs):
 def dump_code(*args, **kwargs):
     from . import markup as _markup
     _markup.dump_code(*args, **kwargs)
+
+
+def set_trace(**kwargs):
+    """Debugger hook that works inside worker processes.
+
+    Set PYTHONBREAKPOINT=edb.common.debug.set_trace, and this will be triggered
+    by `breakpoint()`.
+
+    Unfortunately readline doesn't work when not using stdin itself,
+    so try running the server wrapped with `rlwrap.`
+    """
+    from pdb import Pdb
+    new_stdin = open("/dev/tty", "r")
+    Pdb(stdin=new_stdin, stdout=sys.stdout).set_trace(
+        sys._getframe().f_back, **kwargs)
 
 
 def print(*args):


### PR DESCRIPTION
The obvious thing doesn't work because our worker processes have stdin
closed, so work around that by just opening up `/dev/tty`.