### PR TITLE
Untangle the handling of cardinality in the schema

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -262,7 +262,8 @@ def compile_insert_unless_conflict(
         )
 
     ptr = ptr.get_nearest_non_derived_parent(schema)
-    if ptr.get_cardinality(schema) != qltypes.SchemaCardinality.One:
+    ptr_card = ptr.get_cardinality(schema)
+    if not ptr_card.is_single():
         raise errors.QueryError(
             'UNLESS CONFLICT property must be a SINGLE property',
             context=constraint_spec.context,
@@ -1128,6 +1129,11 @@ def compile_query_subject(
         and view_rptr.ptrcls_name is not None
         and expr_rptr is not None
         and expr_rptr.direction is s_pointers.PointerDirection.Outbound
+        and expr_rptr.source.rptr is None
+        and (
+            view_rptr.source.get_bases(ctx.env.schema).first(ctx.env.schema).id
+            == expr_rptr.source.typeref.id
+        )
         and (
             view_rptr.ptrcls_is_linkprop
             == (expr_rptr.ptrref.source_ptr is not None)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -478,4 +478,62 @@ def declare_view_from_schema(
         ctx.view_nodes[vc.get_name(ctx.env.schema)] = vc
         ctx.view_sets[vc] = subctx.view_sets[vc]
 
+        # XXX: The current cardinality inference machine does not look
+        # into unreferenced expression parts, which includes computables
+        # that may be declared on an alias that another alias is referencing,
+        # leaving Unknown cardinalities in place.  To fix this, copy
+        # cardinalities for computed pointers from the alias object in the
+        # schema.
+        view_type = setgen.get_set_type(view_set, ctx=subctx)
+        if isinstance(view_type, s_objtypes.ObjectType):
+            assert isinstance(viewcls, s_objtypes.ObjectType)
+            _fixup_cardinalities(
+                view_type,
+                viewcls,
+                ctx=ctx,
+            )
+
     return vc
+
+
+def _fixup_cardinalities(
+    subj_source: s_sources.Source,
+    tpl_source: s_sources.Source,
+    *,
+    ctx: context.ContextLevel,
+) -> None:
+    """Copy pointer cardinalities from *tpl_source* to *subj_source*."""
+
+    subj_ptrs = subj_source.get_pointers(ctx.env.schema).items(ctx.env.schema)
+    tpl_ptrs = dict(
+        tpl_source.get_pointers(ctx.env.schema).items(ctx.env.schema))
+
+    for pn, ptrcls in subj_ptrs:
+        card = ptrcls.get_cardinality(ctx.env.schema)
+        tpl_ptrcls = tpl_ptrs.get(pn)
+        if tpl_ptrcls is None:
+            raise AssertionError(
+                f'expected to find {pn!r} in template source object'
+            )
+
+        if not card.is_known():
+            tpl_card = tpl_ptrcls.get_cardinality(ctx.env.schema)
+            if not tpl_card.is_known():
+                raise AssertionError(
+                    f'{pn!r} cardinality in template source is unknown'
+                )
+
+            ctx.env.schema = ptrcls.set_field_value(
+                ctx.env.schema,
+                'cardinality',
+                tpl_card,
+            )
+
+        subj_target = ptrcls.get_target(ctx.env.schema)
+        if (
+            isinstance(subj_target, s_sources.Source)
+            and subj_target.is_view(ctx.env.schema)
+        ):
+            tpl_target = tpl_ptrcls.get_target(ctx.env.schema)
+            assert isinstance(tpl_target, s_sources.Source)
+            _fixup_cardinalities(subj_target, tpl_target, ctx=ctx)

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -81,12 +81,29 @@ class SchemaCardinality(s_enum.StrEnum):
     '''This enum is used to store cardinality in the schema.'''
     One = 'One'
     Many = 'Many'
+    Unknown = 'Unknown'
+
+    def is_multi(self) -> bool:
+        if self is SchemaCardinality.One:
+            return False
+        elif self is SchemaCardinality.Many:
+            return True
+        else:
+            raise ValueError('cardinality is unknown')
+
+    def is_single(self) -> bool:
+        return not self.is_multi()
+
+    def is_known(self) -> bool:
+        return self is not SchemaCardinality.Unknown
 
     def as_ptr_qual(self) -> str:
         if self is SchemaCardinality.One:
             return 'single'
-        else:
+        elif self is SchemaCardinality.Many:
             return 'multi'
+        else:
+            raise ValueError('cardinality is unknown')
 
     def to_edgeql(self) -> str:
         return self.as_ptr_qual().upper()

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -327,7 +327,8 @@ def object_type_to_python_type(
         else:
             pytype = scalar_type_to_python_type(ptype, schema)
 
-        is_multi = p.get_cardinality(schema) is qltypes.SchemaCardinality.Many
+        ptr_card = p.get_cardinality(schema)
+        is_multi = ptr_card.is_multi()
         if is_multi:
             pytype = FrozenSet[pytype]  # type: ignore
 

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -709,7 +709,7 @@ def cardinality_from_ptrcls(
 
     out_card = ptrcls.get_cardinality(schema)
     required = ptrcls.get_required(schema)
-    if out_card is None:
+    if out_card is None or not out_card.is_known():
         # The cardinality is not yet known.
         out_cardinality = None
         dir_cardinality = None

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -162,7 +162,16 @@ class AnnotationCommandContext(sd.ObjectCommandContext[Annotation]):
 class AnnotationCommand(sd.QualifiedObjectCommand[Annotation],
                         schema_metaclass=Annotation,
                         context_class=AnnotationCommandContext):
-    pass
+
+    def get_ast_attr_for_field(
+        self,
+        field: str,
+        astnode: Type[qlast.DDLOperation],
+    ) -> Optional[str]:
+        if field in {'is_abstract', 'inheritable'}:
+            return field
+        else:
+            return super().get_ast_attr_for_field(field, astnode)
 
 
 class CreateAnnotation(AnnotationCommand, sd.CreateObject[Annotation]):
@@ -184,16 +193,6 @@ class CreateAnnotation(AnnotationCommand, sd.CreateObject[Annotation]):
 
         assert isinstance(cmd, CreateAnnotation)
         return cmd
-
-    def _apply_field_ast(self,
-                         schema: s_schema.Schema,
-                         context: sd.CommandContext,
-                         node: qlast.DDLOperation,
-                         op: sd.AlterObjectProperty) -> None:
-        if op.property == 'inheritable':
-            node.inheritable = op.new_value
-        else:
-            super()._apply_field_ast(schema, context, node, op)
 
 
 class RenameAnnotation(AnnotationCommand, sd.RenameObject[Annotation]):

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -64,6 +64,7 @@ def delta_schemas(
     include_derived_types: bool=True,
     include_migrations: bool=False,
     linearize_delta: bool=True,
+    descriptive_mode: bool=False,
     generate_prompts: bool=False,
     guidance: Optional[so.DeltaGuidance]=None,
 ) -> sd.DeltaRoot:
@@ -121,6 +122,9 @@ def delta_schemas(
             Whether the resulting diff should be properly ordered
             using the dependencies between objects.
 
+        descriptive_mode:
+            DESCRIBE AS TEXT mode.
+
         generate_prompts:
             Whether to generate prompts that can be used in
             DESCRIBE MIGRATION.
@@ -139,6 +143,7 @@ def delta_schemas(
     schema_b_filters = list(schema_b_filters)
     context = so.ComparisonContext(
         generate_prompts=generate_prompts,
+        descriptive_mode=descriptive_mode,
         guidance=guidance,
     )
 
@@ -779,6 +784,7 @@ def descriptive_text_from_schema(
         include_std_diff=include_std_ddl,
         include_derived_types=False,
         linearize_delta=False,
+        descriptive_mode=True,
     )
     return descriptive_text_from_delta(
         None, schema, diff, limit_ref_classes=included_ref_classes)

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1215,11 +1215,15 @@ class FunctionCommand(
 
         return cls.get_schema_metaclass().get_fqname(schema, name, params)
 
-    def get_ast_attr_for_field(self, field: str) -> Optional[str]:
+    def get_ast_attr_for_field(
+        self,
+        field: str,
+        astnode: Type[qlast.DDLOperation],
+    ) -> Optional[str]:
         if field == 'nativecode':
             return 'nativecode'
         else:
-            return None
+            return super().get_ast_attr_for_field(field, astnode)
 
     def compile_expr_field(
         self,

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -259,11 +259,15 @@ class IndexCommand(
         )
         return cmd
 
-    def get_ast_attr_for_field(self, field: str) -> Optional[str]:
+    def get_ast_attr_for_field(
+        self,
+        field: str,
+        astnode: Type[qlast.DDLOperation],
+    ) -> Optional[str]:
         if field == 'expr':
             return 'expr'
         else:
-            return None
+            return super().get_ast_attr_for_field(field, astnode)
 
     def compile_expr_field(
         self,

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -514,26 +514,18 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
 
         return base_refs
 
-    def _apply_field_ast(
+    def get_ast_attr_for_field(
         self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-        node: qlast.DDLOperation,
-        op: sd.AlterObjectProperty,
-    ) -> None:
+        field: str,
+        astnode: Type[qlast.DDLOperation],
+    ) -> Optional[str]:
         if (
-            op.property in {'is_abstract', 'is_final'}
-            and not isinstance(self, sd.DeleteObject)
+            field in {'is_abstract', 'is_final'}
+            and issubclass(astnode, qlast.CreateObject)
         ):
-            node.commands.append(
-                qlast.SetField(
-                    name=op.property,
-                    value=qlast.BooleanConstant.from_python(op.new_value),
-                    special_syntax=True,
-                )
-            )
+            return field
         else:
-            super()._apply_field_ast(schema, context, node, op)
+            return super().get_ast_attr_for_field(field, astnode)
 
 
 BaseDelta_T = Tuple[
@@ -782,10 +774,6 @@ class CreateInheritingObject(
                             ],
                         )
                     )
-        elif op.property == 'is_abstract':
-            node.is_abstract = op.new_value
-        elif op.property == 'is_final':
-            node.is_final = op.new_value
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -163,6 +163,34 @@ class DeltaGuidance(NamedTuple):
     ] = frozenset()
 
 
+class DescribeVisibilityFlags(enum.IntFlag):
+
+    #: Show the field if it is set explicitly, i.e. not inherited or computed.
+    SHOW_IF_EXPLICIT = 1 << 0
+    #: Show the field if it is inherited or computed.
+    SHOW_IF_DERIVED = 1 << 1
+    #: Show if the field value matches the default.
+    SHOW_IF_DEFAULT = 1 << 2
+
+
+class DescribeVisibilityPolicy(enum.IntEnum):
+
+    SHOW_IF_EXPLICIT = (
+        DescribeVisibilityFlags.SHOW_IF_EXPLICIT
+    )
+
+    SHOW_IF_EXPLICIT_OR_DERIVED = (
+        DescribeVisibilityFlags.SHOW_IF_EXPLICIT
+        | DescribeVisibilityFlags.SHOW_IF_DERIVED
+        | DescribeVisibilityFlags.SHOW_IF_DEFAULT
+    )
+
+    SHOW_IF_EXPLICIT_OR_DERIVED_NOT_DEFAULT = (
+        DescribeVisibilityFlags.SHOW_IF_EXPLICIT
+        | DescribeVisibilityFlags.SHOW_IF_DERIVED
+    )
+
+
 class ComparisonContext:
 
     renames: Dict[Tuple[Type[Object], sn.Name], sd.RenameObject[Object]]
@@ -173,9 +201,11 @@ class ComparisonContext:
         self,
         *,
         generate_prompts: bool = False,
+        descriptive_mode: bool = False,
         guidance: Optional[DeltaGuidance] = None,
     ) -> None:
         self.generate_prompts = generate_prompts
+        self.descriptive_mode = descriptive_mode
         self.guidance = guidance
         self.renames = {}
         self.deletions = {}
@@ -244,6 +274,9 @@ class Field(struct.ProtoField, Generic[T]):
     #: Whether this field is set using special DDL syntax or a generic
     #: SET command.
     special_ddl_syntax: bool
+    #: Determines when this field is shown in
+    #: DESCRIBE AS TEXT [VERBOSE].
+    describe_visibility: DescribeVisibilityPolicy
     #: Used for fields holding references to objects.  If True,
     #: the reference is considered "weak", i.e. not essential for
     #: object definition.  The schema and delta linearization
@@ -273,6 +306,8 @@ class Field(struct.ProtoField, Generic[T]):
         ephemeral: bool = False,
         weak_ref: bool = False,
         allow_ddl_set: bool = False,
+        describe_visibility: DescribeVisibilityPolicy = (
+            DescribeVisibilityPolicy.SHOW_IF_EXPLICIT),
         ddl_identity: bool = False,
         aux_cmd_data: bool = False,
         special_ddl_syntax: bool = False,
@@ -293,6 +328,7 @@ class Field(struct.ProtoField, Generic[T]):
         self.ddl_identity = ddl_identity
         self.aux_cmd_data = aux_cmd_data
         self.special_ddl_syntax = special_ddl_syntax
+        self.describe_visibility = describe_visibility
 
         self.compcoef = compcoef
         self.inheritable = inheritable
@@ -898,6 +934,16 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         ephemeral=True,
         default=None)
 
+    # Fields that have been computed by the system as opposed to
+    # set explicitly or inherited.
+    computed_fields = SchemaField(
+        checked.FrozenCheckedSet[str],
+        default=DEFAULT_CONSTRUCTOR,
+        coerce=True,
+        inheritable=False,
+        compcoef=0.999,
+    )
+
     _fields: Dict[str, SchemaField[Any]]
 
     def schema_reduce(self) -> Tuple[str, uuid.UUID]:
@@ -1244,7 +1290,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
             our_value = ours.get_field_value(our_schema, fname)
             their_value = theirs.get_field_value(their_schema, fname)
 
-        return cls.compare_field_value(
+        similarity = cls.compare_field_value(
             field,
             our_value,
             their_value,
@@ -1252,6 +1298,17 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
             their_schema=their_schema,
             context=context,
         )
+
+        # Check to see if this field's computed status has changed.
+        our_cfs = ours.get_computed_fields(our_schema)
+        their_cfs = theirs.get_computed_fields(their_schema)
+
+        fname = field.name
+        if (fname in our_cfs) != (fname in their_cfs):
+            # The change in computed status decreases the similarity.
+            similarity *= 0.95
+
+        return similarity
 
     @classmethod
     def compare_values(
@@ -1441,6 +1498,20 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         fields = {fn: f for fn, f in ff if f.simpledelta and not f.ephemeral}
         for fn, f in fields.items():
             value = self.get_explicit_field_value(schema, fn, None)
+
+            if (
+                value is None
+                and context.descriptive_mode
+                and (
+                    f.describe_visibility
+                    & DescribeVisibilityFlags.SHOW_IF_DERIVED
+                )
+            ):
+                value = self.get_field_value(schema, fn)
+                value_from_default = True
+            else:
+                value_from_default = False
+
             if f.aux_cmd_data:
                 delta.set_object_aux_data(fn, value)
             if value is not None:
@@ -1449,7 +1520,14 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
                     v = value.as_shell(schema)
                 else:
                     v = value
-                self.record_field_create_delta(schema, delta, context, fn, v)
+                self.record_field_create_delta(
+                    schema,
+                    delta,
+                    context=context,
+                    fname=fn,
+                    value=v,
+                    from_default=value_from_default,
+                )
 
         for refdict in cls.get_refdicts():
             refcoll: ObjectCollection[Object] = (
@@ -1636,16 +1714,35 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         orig_value: Any,
         orig_schema: Optional[s_schema.Schema],
         orig_object: Optional[Object_T],
+        from_default: bool = False,
     ) -> None:
-        delta.set_attribute_value(fname, value, orig_value=orig_value)
+        computed_fields = self.get_computed_fields(schema)
+        is_computed = fname in computed_fields
+        if orig_schema is not None and orig_object is not None:
+            orig_computed_fields = (
+                orig_object.get_computed_fields(orig_schema))
+            orig_is_computed = fname in orig_computed_fields
+        else:
+            orig_is_computed = is_computed
+
+        delta.set_attribute_value(
+            fname,
+            value,
+            orig_value=orig_value,
+            computed=is_computed,
+            orig_computed=orig_is_computed,
+            from_default=from_default,
+        )
 
     def record_field_create_delta(
         self: Object_T,
         schema: s_schema.Schema,
         delta: sd.ObjectCommand[Object_T],
         context: ComparisonContext,
+        *,
         fname: str,
         value: Any,
+        from_default: bool,
     ) -> None:
         self.record_simple_field_delta(
             schema,
@@ -1656,6 +1753,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
             orig_value=None,
             orig_schema=None,
             orig_object=None,
+            from_default=from_default,
         )
 
     def record_field_alter_delta(
@@ -2626,7 +2724,7 @@ class InheritingObject(SubclassableObject):
         compcoef=0.999,
     )
 
-    # Attributes that have been set locally as opposed to inherited.
+    # Fields that have been inherited as opposed to set explicitly.
     inherited_fields = SchemaField(
         checked.FrozenCheckedSet[str],
         default=DEFAULT_CONSTRUCTOR,
@@ -2822,6 +2920,7 @@ class InheritingObject(SubclassableObject):
         orig_value: Any,
         orig_schema: Optional[s_schema.Schema],
         orig_object: Optional[InheritingObjectT],
+        from_default: bool = False,
     ) -> None:
         inherited_fields = self.get_inherited_fields(schema)
         is_inherited = fname in inherited_fields
@@ -2832,12 +2931,24 @@ class InheritingObject(SubclassableObject):
         else:
             orig_is_inherited = is_inherited
 
+        computed_fields = self.get_computed_fields(schema)
+        is_computed = fname in computed_fields
+        if orig_schema is not None and orig_object is not None:
+            orig_computed_fields = (
+                orig_object.get_computed_fields(orig_schema))
+            orig_is_computed = fname in orig_computed_fields
+        else:
+            orig_is_computed = is_computed
+
         delta.set_attribute_value(
             fname,
             value=value,
             orig_value=orig_value,
             inherited=is_inherited,
             orig_inherited=orig_is_inherited,
+            computed=is_computed,
+            orig_computed=orig_is_computed,
+            from_default=from_default,
         )
 
     def get_field_create_delta(

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -241,6 +241,9 @@ class Field(struct.ProtoField, Generic[T]):
     #: Whether the value of this field should be included in the
     #: aux_object_data for delta commands of objects containing the field.
     aux_cmd_data: bool
+    #: Whether this field is set using special DDL syntax or a generic
+    #: SET command.
+    special_ddl_syntax: bool
     #: Used for fields holding references to objects.  If True,
     #: the reference is considered "weak", i.e. not essential for
     #: object definition.  The schema and delta linearization
@@ -272,6 +275,7 @@ class Field(struct.ProtoField, Generic[T]):
         allow_ddl_set: bool = False,
         ddl_identity: bool = False,
         aux_cmd_data: bool = False,
+        special_ddl_syntax: bool = False,
         reflection_method: ReflectionMethod = ReflectionMethod.REGULAR,
         reflection_proxy: Optional[Tuple[str, str]] = None,
         **kwargs: Any,
@@ -288,6 +292,7 @@ class Field(struct.ProtoField, Generic[T]):
         self.allow_ddl_set = allow_ddl_set
         self.ddl_identity = ddl_identity
         self.aux_cmd_data = aux_cmd_data
+        self.special_ddl_syntax = special_ddl_syntax
 
         self.compcoef = compcoef
         self.inheritable = inheritable
@@ -2566,11 +2571,17 @@ class SubclassableObject(Object):
     is_abstract = SchemaField(
         bool,
         default=False,
-        inheritable=False, compcoef=0.909)
+        inheritable=False,
+        special_ddl_syntax=True,
+        compcoef=0.909,
+    )
 
     is_final = SchemaField(
         bool,
-        default=False, compcoef=0.909)
+        default=False,
+        special_ddl_syntax=True,
+        compcoef=0.909,
+    )
 
     def _issubclass(
         self, schema: s_schema.Schema, parent: SubclassableObject

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -246,8 +246,11 @@ class Pointer(referencing.ReferencedInheritingObject,
 
     required = so.SchemaField(
         bool,
-        default=False, compcoef=0.909,
-        merge_fn=merge_required)
+        default=False,
+        compcoef=0.909,
+        special_ddl_syntax=True,
+        merge_fn=merge_required,
+    )
 
     readonly = so.SchemaField(
         bool,
@@ -287,8 +290,12 @@ class Pointer(referencing.ReferencedInheritingObject,
 
     cardinality = so.SchemaField(
         qltypes.SchemaCardinality,
-        default=None, compcoef=0.833, coerce=True,
-        merge_fn=merge_cardinality)
+        default=None,
+        compcoef=0.833,
+        coerce=True,
+        special_ddl_syntax=True,
+        merge_fn=merge_cardinality,
+    )
 
     union_of = so.SchemaField(
         so.ObjectSet['Pointer'],

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -141,18 +141,18 @@ class CreateRole(RoleCommand, inheriting.CreateInheritingObject[Role]):
         cls._process_role_body(cmd, schema, astnode, context)
         return cmd
 
-    def _apply_field_ast(
+    def get_ast_attr_for_field(
         self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-        node: qlast.DDLOperation,
-        op: sd.AlterObjectProperty,
-    ) -> None:
-        if op.property == 'is_superuser':
-            node.superuser = op.new_value
-            return
-
-        super()._apply_field_ast(schema, context, node, op)
+        field: str,
+        astnode: Type[qlast.DDLOperation],
+    ) -> Optional[str]:
+        if (
+            field == 'is_superuser'
+            and issubclass(astnode, qlast.CreateRole)
+        ):
+            return 'superuser'
+        else:
+            return super().get_ast_attr_for_field(field, astnode)
 
 
 class RebaseRole(RoleCommand, inheriting.RebaseInheritingObject[Role]):

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -464,6 +464,9 @@ class Compiler(BaseCompiler):
         # be able to resolve them just using the new schema.)
         if not context:
             context = s_delta.CommandContext()
+        else:
+            context.renames.clear()
+            context.early_renames.clear()
 
         s_refl.write_meta(
             delta,

--- a/edb/server/config/spec.py
+++ b/edb/server/config/spec.py
@@ -25,7 +25,6 @@ import json
 from typing import *
 
 from edb.edgeql import compiler as qlcompiler
-from edb.edgeql import qltypes
 from edb.ir import staeval
 
 from . import types
@@ -137,8 +136,8 @@ def load_spec_from_schema(schema):
             for a, v in p.get_annotations(schema).items(schema)
         }
 
-        set_of = p.get_cardinality(schema) is qltypes.SchemaCardinality.Many
-
+        ptr_card = p.get_cardinality(schema)
+        set_of = ptr_card.is_multi()
         deflt = p.get_default(schema)
         if deflt is not None:
             deflt = qlcompiler.evaluate_to_python_val(

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -28,7 +28,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_12_04_00_00
+EDGEDB_CATALOG_VERSION = 2020_12_11_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -2873,7 +2873,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
-    @test.xfail
     async def test_edgeql_migration_eq_14b(self):
         # Same as above, except POPULATE and inspect the query
         await self.migrate(r"""
@@ -2903,6 +2902,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             """, """
                 ALTER TYPE test::Derived {
                     ALTER PROPERTY foo {
+                        RESET CARDINALITY;
                         SET REQUIRED;
                     };
                 };

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -454,7 +454,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text': (
                         'CREATE TYPE test::Type1 {\n'
-                        '    CREATE OPTIONAL SINGLE PROPERTY field1'
+                        '    CREATE PROPERTY field1'
                         ' -> std::str;\n'
                         '};'
                     )
@@ -466,7 +466,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.con.execute('''
             CREATE TYPE test::Type1 {
-                CREATE OPTIONAL SINGLE PROPERTY field1 -> std::str;
+                CREATE PROPERTY field1 -> std::str;
             };
         ''')
 
@@ -474,7 +474,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             'parent': 'm1a2l6lbzimqokzygdzbkyjrhbmjh3iljg7i2m6r2ias2z2de4x4cq',
             'confirmed': [
                 'CREATE TYPE test::Type1 {\n'
-                '    CREATE OPTIONAL SINGLE PROPERTY field1 -> std::str;\n'
+                '    CREATE PROPERTY field1 -> std::str;\n'
                 '};'
             ],
             'complete': True,
@@ -872,14 +872,13 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1a2l6lbzimqokzygdzbkyjrhbmjh3iljg7i2m6r2ias2z2de4x4cq',
             'confirmed': [],
             'complete': False,
             'proposed': {
                 'statements': [{
                     'text': (
                         'CREATE TYPE test::Type01 {\n'
-                        '    CREATE OPTIONAL SINGLE PROPERTY field1'
+                        '    CREATE PROPERTY field1'
                         ' -> std::str;\n'
                         '};'
                     )
@@ -908,7 +907,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1qbv2f3km5xs5teyya5yog6areb33lnsqvs5prmyumtehnmpdfy3q',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -949,14 +947,13 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1a2l6lbzimqokzygdzbkyjrhbmjh3iljg7i2m6r2ias2z2de4x4cq',
             'confirmed': [],
             'complete': False,
             'proposed': {
                 'statements': [{
                     'text': (
                         'CREATE TYPE test::Type02 {\n'
-                        '    CREATE OPTIONAL SINGLE PROPERTY field02'
+                        '    CREATE PROPERTY field02'
                         ' -> std::str;\n'
                         '};'
                     )
@@ -984,7 +981,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1plg55ylmquxeeurgqtp7uuaupb463z4htxw3rregmzx42zs5lxea',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1025,14 +1021,13 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1dsogsjmchh4kivd633z6jjivjlve4hmqofr2obt3rq5koakemc5a',
             'confirmed': [],
             'complete': False,
             'proposed': {
                 'statements': [{
                     'text': (
                         'ALTER TYPE test::Type02 {\n'
-                        '    CREATE OPTIONAL SINGLE PROPERTY field02'
+                        '    CREATE PROPERTY field02'
                         ' -> std::str;\n'
                         '};'
                     )
@@ -1073,14 +1068,13 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1a2l6lbzimqokzygdzbkyjrhbmjh3iljg7i2m6r2ias2z2de4x4cq',
             'confirmed': ['CREATE TYPE test::Foo;'],
             'complete': False,
             'proposed': {
                 'statements': [{
                     'text': (
                         'CREATE TYPE test::Type01 {\n'
-                        '    CREATE OPTIONAL SINGLE LINK foo1'
+                        '    CREATE LINK foo1'
                         ' -> test::Foo;\n'
                         '};'
                     )
@@ -1115,7 +1109,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1wmfeopwqccjy35fuf73j6g6sgrqnmes53gjpizw5tyehwiij6yhq',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1162,14 +1155,13 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1a2l6lbzimqokzygdzbkyjrhbmjh3iljg7i2m6r2ias2z2de4x4cq',
             'confirmed': ['CREATE TYPE test::Foo;'],
             'complete': False,
             'proposed': {
                 'statements': [{
                     'text': (
                         'CREATE TYPE test::Type02 {\n'
-                        '    CREATE OPTIONAL SINGLE LINK foo02'
+                        '    CREATE LINK foo02'
                         ' -> test::Foo;\n'
                         '};'
                     )
@@ -1203,7 +1195,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1tul34c3bsnuzypwqo4cgpryguamjffvqme3c66id7nxasbsjyhda',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1252,14 +1243,13 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1zo2zt4im2gkkavxn6hzs432k5fvkdz42tswbphejihqe2yul47la',
             'confirmed': [],
             'complete': False,
             'proposed': {
                 'statements': [{
                     'text': (
                         'ALTER TYPE test::Type02 {\n'
-                        '    CREATE OPTIONAL SINGLE LINK foo02'
+                        '    CREATE LINK foo02'
                         ' -> test::Foo;\n'
                         '};'
                     )
@@ -1296,7 +1286,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1a2l6lbzimqokzygdzbkyjrhbmjh3iljg7i2m6r2ias2z2de4x4cq',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1321,7 +1310,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1okv4ltfh3dphmqfmmx5bjusyzsnvc7sgjtb6vdo26mjf6rtmdqxq',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1349,7 +1337,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm17h46d7r6h5rbxxsr2dlpowpklqze4iqhadkr6tlwedwguex5dbba',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1378,7 +1365,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1a2l6lbzimqokzygdzbkyjrhbmjh3iljg7i2m6r2ias2z2de4x4cq',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1408,7 +1394,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1svrt2rvolv2f3fgtpgj2qikec4o4v6a5le5u6jfpyrzfhybr2ipa',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1443,7 +1428,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1a2l6lbzimqokzygdzbkyjrhbmjh3iljg7i2m6r2ias2z2de4x4cq',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1473,7 +1457,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1azidpr7ai7z2u4rcfx2awxdxy5ouenhvmb2otxew4penhxnruvuq',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1508,7 +1491,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm13agjryb2lawnugaty4gkqzjvxvrbod3olf3abupck7x2777yntta',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1540,7 +1522,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1a2l6lbzimqokzygdzbkyjrhbmjh3iljg7i2m6r2ias2z2de4x4cq',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1570,7 +1551,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1e7h52ims4j4ijfbdfrvm453vgldwsok6f7oiosyhvcmjvrjgefqq',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1605,7 +1585,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1a2l6lbzimqokzygdzbkyjrhbmjh3iljg7i2m6r2ias2z2de4x4cq',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1635,7 +1614,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm16yh2sfnw2of6eikwc3u4odjeie2cvz54qe3e4jk7o3tvc3q5xzjq',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -1670,7 +1648,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ''')
 
         await self.assert_describe_migration({
-            'parent': 'm1pbb5jssdc652jn74enr3cnvynydww476glgodzyufbru6hcqsmsq',
             'confirmed': [],
             'complete': False,
             'proposed': {
@@ -2897,12 +2874,11 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         await self.assert_describe_migration({
             'confirmed': ["""
                 ALTER TYPE test::Base {
-                    CREATE OPTIONAL SINGLE PROPERTY foo -> std::str;
+                    CREATE PROPERTY foo -> std::str;
                 };
             """, """
                 ALTER TYPE test::Derived {
                     ALTER PROPERTY foo {
-                        RESET CARDINALITY;
                         SET REQUIRED;
                     };
                 };
@@ -7522,7 +7498,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                     'text':
                         'CREATE TYPE test::NewObj2 {\n'
                         "    CREATE ANNOTATION std::title := 'Obj2';\n"
-                        '    CREATE OPTIONAL SINGLE PROPERTY name'
+                        '    CREATE PROPERTY name'
                         ' -> std::str;\n'
                         '};'
                 }],
@@ -7544,7 +7520,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         '    DROP PROPERTY o;\n'
                         '    RENAME TO test::NewObj2;\n'
                         "    CREATE ANNOTATION std::title := 'Obj2';\n"
-                        '    CREATE OPTIONAL SINGLE PROPERTY name -> std::str;'
+                        '    CREATE PROPERTY name -> std::str;'
                         '\n'
                         '};'
                 }],
@@ -7599,9 +7575,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text':
                         'CREATE TYPE test::NewObj1 {\n'
-                        '    CREATE OPTIONAL SINGLE PROPERTY bar -> std::str;'
-                        '\n    CREATE OPTIONAL SINGLE PROPERTY foo '
-                        '-> std::str;'
+                        '    CREATE PROPERTY bar -> std::str;'
+                        '\n    CREATE PROPERTY foo -> std::str;'
                         '\n};'
                 }],
                 'confidence': 1.0,

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -491,3 +491,29 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         foo: ONE
         """
+
+    def test_edgeql_ir_card_inference_48(self):
+        """
+        WITH
+            MODULE test
+        SELECT Card {
+            o_name := .owners.name,
+        }
+% OK %
+        o_name: MANY
+        """
+
+    def test_edgeql_ir_card_inference_49(self):
+        """
+        WITH MODULE test
+        SELECT User {
+            name,
+            fire_deck := (
+                SELECT User.deck {name, element}
+                FILTER .element = 'Fire'
+                ORDER BY .name
+            ).name
+        }
+% OK %
+        fire_deck: MANY
+        """

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -2332,9 +2332,14 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     {
                         "name": "of_group",
                         "type": {
-                            "kind": "OBJECT",
-                            "name": "_edb__SettingAliasAugmented__of_group",
-                            "ofType": None,
+                            "kind": "NON_NULL",
+                            "name": None,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name":
+                                    "_edb__SettingAliasAugmented__of_group",
+                                "__typename": "__Type"
+                            },
                             "__typename": "__Type"
                         },
                         "__typename": "__Field",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -229,26 +229,13 @@ _123456789_123456789_123456789 -> str
     @tb.must_fail(errors.SchemaDefinitionError,
                   "possibly more than one element returned by an expression "
                   "for the computable 'ham' declared as 'single'",
-                  line=5, col=29)
+                  line=5, col=36)
     def test_schema_computable_cardinality_inference_03(self):
         """
             type Spam {
                 required property title -> str;
                 multi link spams -> Spam;
-                link ham := .spams;
-            }
-        """
-
-    @tb.must_fail(errors.SchemaDefinitionError,
-                  "possibly more than one element returned by an expression "
-                  "for the computable 'hams' declared as 'single'",
-                  line=5, col=34)
-    def test_schema_computable_cardinality_inference_04(self):
-        """
-            type Spam {
-                required property title -> str;
-                multi link spams -> Spam;
-                property hams := .spams.title;
+                single link ham := .spams;
             }
         """
 
@@ -256,7 +243,7 @@ _123456789_123456789_123456789 -> str
                   "possibly more than one element returned by an expression "
                   "for the computable 'hams' declared as 'single'",
                   line=5, col=41)
-    def test_schema_computable_cardinality_inference_05(self):
+    def test_schema_computable_cardinality_inference_04(self):
         """
             type Spam {
                 required property title -> str;
@@ -269,7 +256,7 @@ _123456789_123456789_123456789 -> str
                   "possibly an empty set returned by an expression for "
                   "the computable 'hams' declared as 'required'",
                   line=5, col=43)
-    def test_schema_computable_cardinality_inference_06(self):
+    def test_schema_computable_cardinality_inference_05(self):
         """
             type Spam {
                 required property title -> str;
@@ -1255,7 +1242,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             if list(diff.get_subcommands()):
                 self.fail(
                     f'unexpected difference in schema produced by\n'
-                    f'alternative migration paths on step {i}:\n'
+                    f'alternative migration paths on step {i + 1}:\n'
                     f'{markup.dumps(diff)}\n'
                 )
 
@@ -4700,7 +4687,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             """
             type test::Child extending test::Parent, test::Parent2 {
                 annotation test::anno := 'annotated';
-                overloaded single link foo extending test::f -> test::Foo {
+                overloaded link foo extending test::f -> test::Foo {
                     annotation test::anno := 'annotated link';
                     constraint std::exclusive {
                         annotation test::anno := 'annotated constraint';
@@ -4812,12 +4799,12 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             [
                 """
                 type test::Spam {
-                    optional single link foobar -> (test::Foo | test::Bar);
+                    link foobar -> (test::Foo | test::Bar);
                 };
                 """,
                 """
                 type test::Spam {
-                    optional single link foobar -> (test::Bar | test::Foo);
+                    link foobar -> (test::Bar | test::Foo);
                 };
                 """,
             ]
@@ -4990,7 +4977,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::User extending test::HasImage {
-                optional single property name -> std::str;
+                property name -> std::str;
             };
             ''',
 
@@ -5029,7 +5016,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             '''
             abstract type test::HasImage {
                 index on (__subject__.image);
-                required single property image -> std::str;
+                required property image -> std::str;
             };
             ''',
 
@@ -5037,7 +5024,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             CREATE ABSTRACT TYPE test::HasImage {
-                CREATE REQUIRED SINGLE PROPERTY image -> std::str;
+                CREATE REQUIRED PROPERTY image -> std::str;
                 CREATE INDEX ON (__subject__.image);
             };
             '''
@@ -5099,8 +5086,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::UniqueName {
-                optional single link translated_label
-                extending test::translated_label
+                link translated_label extending test::translated_label
                         -> test::Label {
                     constraint std::exclusive on (__subject__@prop1);
                     constraint std::exclusive on (
@@ -5210,7 +5196,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE OPTIONAL SINGLE PROPERTY bar -> std::str {
+                CREATE PROPERTY bar -> std::str {
                     SET readonly := false;
                 };
             };
@@ -5219,7 +5205,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Foo {
-                optional single property bar -> std::str {
+                property bar -> std::str {
                     readonly := false;
                 };
             };
@@ -5357,7 +5343,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::Bar0 {
-                optional single link insert_foo -> test::Foo {
+                link insert_foo -> test::Foo {
                     default := (INSERT
                         test::Foo
                         {
@@ -5370,7 +5356,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::Bar1 {
-                optional multi link update_foo -> test::Foo {
+                multi link update_foo -> test::Foo {
                     default := (UPDATE
                         test::Foo
                     FILTER
@@ -5385,7 +5371,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::Bar2 {
-                optional multi link for_foo -> test::Foo {
+                multi link for_foo -> test::Foo {
                     default := (FOR x IN {2, 3}
                     UNION
                         (SELECT
@@ -5400,7 +5386,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::Bar3 {
-                optional single property delete_foo -> std::int64 {
+                property delete_foo -> std::int64 {
                     default := (SELECT
                         ((DELETE
                             test::Foo
@@ -5429,7 +5415,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE OPTIONAL SINGLE PROPERTY name -> std::str;
+                CREATE PROPERTY name -> std::str;
             };
             CREATE ALIAS test::Bar := (
                 SELECT test::Foo {
@@ -5457,7 +5443,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE OPTIONAL SINGLE PROPERTY name -> std::str;
+                CREATE PROPERTY name -> std::str;
             };
             CREATE ALIAS test::Bar {
                 USING (
@@ -5523,7 +5509,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE OPTIONAL SINGLE PROPERTY name -> std::str;
+                CREATE PROPERTY name -> std::str;
             };
             CREATE ALIAS test::Bar := (
                 SELECT test::Foo {
@@ -5555,17 +5541,17 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE OPTIONAL SINGLE LINK annotated_link {
+                CREATE LINK annotated_link {
                     USING (SELECT test::Foo LIMIT 1);
                     CREATE ANNOTATION std::title := 'complink';
                 };
-                CREATE OPTIONAL SINGLE LINK complink :=
+                CREATE LINK complink :=
                     (SELECT test::Foo LIMIT 1);
-                CREATE OPTIONAL SINGLE PROPERTY annotated_compprop {
+                CREATE PROPERTY annotated_compprop {
                     USING ('foo');
                     CREATE ANNOTATION std::title := 'compprop';
                 };
-                CREATE REQUIRED SINGLE PROPERTY compprop := ('foo');
+                CREATE PROPERTY compprop := ('foo');
             };
             """
         )
@@ -5591,18 +5577,18 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE OPTIONAL SINGLE LINK annotated_link {
+                CREATE LINK annotated_link {
                     USING (SELECT test::Foo LIMIT 1);
                     CREATE ANNOTATION std::title := 'complink';
                 };
-                CREATE OPTIONAL SINGLE LINK complink := (
+                CREATE LINK complink := (
                     SELECT test::Foo LIMIT 1
                 );
-                CREATE OPTIONAL SINGLE PROPERTY annotated_compprop {
+                CREATE PROPERTY annotated_compprop {
                     USING ('foo');
                     CREATE ANNOTATION std::title := 'compprop';
                 };
-                CREATE REQUIRED SINGLE PROPERTY compprop := ('foo');
+                CREATE PROPERTY compprop := ('foo');
             };
             """
         )
@@ -5654,16 +5640,15 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                       schema::Type,
                       schema::Source
             {
-                CREATE OPTIONAL MULTI LINK intersection_of
-                    -> schema::ObjectType;
-                CREATE OPTIONAL MULTI LINK union_of -> schema::ObjectType;
-                CREATE REQUIRED SINGLE PROPERTY is_compound_type := (
+                CREATE MULTI LINK intersection_of -> schema::ObjectType;
+                CREATE MULTI LINK union_of -> schema::ObjectType;
+                CREATE PROPERTY is_compound_type := (
                     (EXISTS (.union_of) OR EXISTS (.intersection_of))
                 );
-                CREATE OPTIONAL MULTI LINK links := (
+                CREATE MULTI LINK links := (
                     .pointers[IS schema::Link]
                 );
-                CREATE OPTIONAL MULTI LINK properties := (
+                CREATE MULTI LINK properties := (
                     .pointers[IS schema::Property]
                 );
             };
@@ -5679,13 +5664,13 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     schema::Type,
                     schema::Source
             {
-                optional multi link intersection_of -> schema::ObjectType;
-                optional multi link links := (.pointers[IS schema::Link]);
-                optional multi link properties := (
+                multi link intersection_of -> schema::ObjectType;
+                multi link links := (.pointers[IS schema::Link]);
+                multi link properties := (
                     .pointers[IS schema::Property]
                 );
-                optional multi link union_of -> schema::ObjectType;
-                required single property is_compound_type := (
+                multi link union_of -> schema::ObjectType;
+                property is_compound_type := (
                     (EXISTS (.union_of) OR EXISTS (.intersection_of))
                 );
             };
@@ -5721,7 +5706,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Foo {
-                CREATE OPTIONAL SINGLE LINK bar -> std::Object {
+                CREATE LINK bar -> std::Object {
                     ON TARGET DELETE ALLOW;
                 };
             };
@@ -5731,7 +5716,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Foo {
-                optional single link bar -> std::Object {
+                link bar -> std::Object {
                     on target delete  allow;
                 };
             };
@@ -5842,13 +5827,12 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             CREATE TYPE test::Tree {
-                CREATE OPTIONAL SINGLE LINK parent -> test::Tree;
-                CREATE OPTIONAL MULTI LINK children :=
-                    (.<parent[IS test::Tree]);
-                CREATE REQUIRED SINGLE PROPERTY val -> std::str {
+                CREATE LINK parent -> test::Tree;
+                CREATE MULTI LINK children := (.<parent[IS test::Tree]);
+                CREATE REQUIRED PROPERTY val -> std::str {
                     CREATE CONSTRAINT std::exclusive;
                 };
-                CREATE REQUIRED MULTI LINK test_comp := (
+                CREATE MULTI LINK test_comp := (
                     SELECT
                         test::Tree
                     FILTER


### PR DESCRIPTION
There is currently a fair amount of brittle special-casing around the 
handling of `cardinality` and `required` in pointers, specifically around
the handling of inherited and computed status, and how those and other
fields are emitted in `DESCRIBE`.

Now, there's nothing fundamentally special in `cardinality` or
`required` that prevents them to be handled in a generic fashion, except 
that we need to keep track of whether the values were inferred or specified
explicitly.  For this we introduce the `computed_fields` array that is
substantially similar to the existing `inherited_fields` attribute, but
tracks the "computed" status instead.

This change has a visible effect: `DESCRIBE AS DDL|SDL` now does _not_ 
output the cardinality attributes if they weren't specified explicitly in
the original schema, meaning that `link foo -> Bar` would be described as
`link foo -> Bar`, and an explicit `single link foo -> Bar` would be
described as such.  This will result in a need to make a simple migration
for databases restored from previous versions of EdgeDB for applications
that use SDL schemas (in order to correctly reflect the
"inherited" and "computed" status of fields that was discarded previously).

This patch also moves some hardcoded `DESCRIBE` bits into generic `Field` 
attributes.