### PR TITLE
Remove duplication of metainformation in delta command class decls

### DIFF
--- a/edb/common/markup/__init__.py
+++ b/edb/common/markup/__init__.py
@@ -32,8 +32,8 @@ from .elements.base import Markup  # noqa
 
 class MarkupCapableMeta(type):
 
-    def __new__(mcls, name, bases, dct):
-        cls = super().__new__(mcls, name, bases, dct)
+    def __new__(mcls, name, bases, dct, **kwargs):
+        cls = super().__new__(mcls, name, bases, dct, **kwargs)
         if 'as_markup' in dct:
             serializer.serializer.register(cls)(cls.as_markup)
         return cls

--- a/edb/common/struct.py
+++ b/edb/common/struct.py
@@ -113,6 +113,7 @@ class StructMeta(type):
         clsdict: Dict[str, Any],
         *,
         use_slots: bool = True,
+        **kwargs: Any,
     ) -> StructMeta_T:
         fields = {}
         myfields = {}
@@ -143,7 +144,8 @@ class StructMeta(type):
 
         cls = cast(
             StructMeta_T,
-            super().__new__(mcls, name, bases, clsdict),
+            super().__new__(
+                mcls, name, bases, clsdict, **kwargs),  # type: ignore
         )
 
         if use_slots:
@@ -472,8 +474,16 @@ class MixedStructMeta(StructMeta):
         clsdict: Dict[str, Any],
         *,
         use_slots: bool = False,
+        **kwargs: Any,
     ) -> MixedStructMeta:
-        return super().__new__(mcls, name, bases, clsdict, use_slots=use_slots)
+        return super().__new__(
+            mcls,
+            name,
+            bases,
+            clsdict,
+            use_slots=use_slots,
+            **kwargs,
+        )
 
 
 class MixedStruct(Struct, metaclass=MixedStructMeta):

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -189,6 +189,7 @@ class SchemaObjectClass(s_enum.StrEnum):
     OPERATOR = 'OPERATOR'
     PARAMETER = 'PARAMETER'
     PROPERTY = 'PROPERTY'
+    PSEUDO_TYPE = 'PSEUDO TYPE'
     ROLE = 'ROLE'
     SCALAR_TYPE = 'SCALAR TYPE'
     TUPLE_TYPE = 'TUPLE TYPE'

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -52,7 +52,6 @@ from edb.schema import name as sn
 from edb.schema import operators as s_opers
 from edb.schema import pointers as s_pointers
 from edb.schema import pseudo as s_pseudo
-from edb.schema import referencing as s_referencing
 from edb.schema import roles as s_roles
 from edb.schema import sources as s_sources
 from edb.schema import types as s_types
@@ -113,15 +112,6 @@ def has_table(obj, schema):
 
 class CommandMeta(sd.CommandMeta):
     pass
-
-
-class ObjectCommandMeta(sd.ObjectCommandMeta, CommandMeta):
-    _transparent_adapter_subclass = True
-
-
-class ReferencedObjectCommandMeta(
-        s_referencing.ReferencedObjectCommandMeta, ObjectCommandMeta):
-    _transparent_adapter_subclass = True
 
 
 class MetaCommand(sd.Command, metaclass=CommandMeta):
@@ -185,7 +175,7 @@ class Record:
 
 
 class ObjectMetaCommand(MetaCommand, sd.ObjectCommand,
-                        metaclass=ObjectCommandMeta):
+                        metaclass=CommandMeta):
     op_priority = 0
 
 
@@ -443,7 +433,7 @@ class DeleteArrayExprAlias(
 
 
 class ParameterCommand(sd.ObjectCommand,
-                       metaclass=ReferencedObjectCommandMeta):
+                       metaclass=CommandMeta):
     pass
 
 
@@ -1017,7 +1007,7 @@ class DeleteAnnotation(
 
 
 class AnnotationValueCommand(sd.ObjectCommand,
-                             metaclass=ReferencedObjectCommandMeta):
+                             metaclass=CommandMeta):
     op_priority = 4
 
 
@@ -1054,7 +1044,7 @@ class DeleteAnnotationValue(
 
 
 class ConstraintCommand(sd.ObjectCommand,
-                        metaclass=ReferencedObjectCommandMeta):
+                        metaclass=CommandMeta):
     op_priority = 3
 
     def constraint_is_effective(self, schema, constraint):
@@ -1694,7 +1684,7 @@ class CompositeObjectMetaCommand(ObjectMetaCommand):
         return cmd
 
 
-class IndexCommand(sd.ObjectCommand, metaclass=ReferencedObjectCommandMeta):
+class IndexCommand(sd.ObjectCommand, metaclass=CommandMeta):
     pass
 
 
@@ -1830,7 +1820,7 @@ class RebaseIndex(
 class CreateUnionType(
     MetaCommand,
     adapts=s_types.CreateUnionType,
-    metaclass=ObjectCommandMeta,
+    metaclass=CommandMeta,
 ):
 
     def apply(self, schema, context):
@@ -2014,7 +2004,7 @@ class CancelPointerCardinalityUpdate(MetaCommand):
 
 
 class PointerMetaCommand(MetaCommand, sd.ObjectCommand,
-                         metaclass=ReferencedObjectCommandMeta):
+                         metaclass=CommandMeta):
     def get_host(self, schema, context):
         if context:
             link = context.get(s_links.LinkCommandContext)

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -160,7 +160,6 @@ class AnnotationCommandContext(sd.ObjectCommandContext[Annotation]):
 
 
 class AnnotationCommand(sd.QualifiedObjectCommand[Annotation],
-                        schema_metaclass=Annotation,
                         context_class=AnnotationCommandContext):
 
     def get_ast_attr_for_field(
@@ -238,7 +237,7 @@ class AnnotationSubjectCommandContext:
     pass
 
 
-class AnnotationSubjectCommand(sd.ObjectCommand[so.Object]):
+class AnnotationSubjectCommand(sd.ObjectCommand[so.Object_T]):
     pass
 
 
@@ -248,7 +247,6 @@ class AnnotationValueCommandContext(sd.ObjectCommandContext[AnnotationValue]):
 
 class AnnotationValueCommand(
     referencing.ReferencedInheritingObjectCommand[AnnotationValue],
-    schema_metaclass=AnnotationValue,
     context_class=AnnotationValueCommandContext,
     referrer_context_class=AnnotationSubjectCommandContext,
 ):

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -203,7 +203,6 @@ class CastCommandContext(sd.ObjectCommandContext[Cast],
 
 
 class CastCommand(sd.QualifiedObjectCommand[Cast],
-                  schema_metaclass=Cast,
                   context_class=CastCommandContext):
 
     @classmethod

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -366,7 +366,6 @@ class ConstraintCommandContext(sd.ObjectCommandContext[Constraint],
 class ConstraintCommand(
     referencing.ReferencedInheritingObjectCommand[Constraint],
     s_func.CallableCommand[Constraint],
-    schema_metaclass=Constraint,
     context_class=ConstraintCommandContext,
     referrer_context_class=ConsistencySubjectCommandContext,
 ):
@@ -1216,7 +1215,6 @@ class RenameConstraint(
 
 class AlterConstraintOwned(
     referencing.AlterOwned[Constraint],
-    schema_metaclass=Constraint,
     referrer_context_class=ConsistencySubjectCommandContext,
 ):
     astnode = qlast.AlterConstraintOwned

--- a/edb/schema/database.py
+++ b/edb/schema/database.py
@@ -43,8 +43,10 @@ class DatabaseCommandContext(sd.ObjectCommandContext[Database]):
     pass
 
 
-class DatabaseCommand(sd.GlobalObjectCommand, schema_metaclass=Database,
-                      context_class=DatabaseCommandContext):
+class DatabaseCommand(
+    sd.GlobalObjectCommand[Database],
+    context_class=DatabaseCommandContext,
+):
 
     def _create_begin(
         self,

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -36,6 +36,7 @@ from . import name as sn
 from . import objects as so
 from . import objtypes as s_objtypes
 from . import ordering as s_ordering
+from . import pseudo as s_pseudo
 from . import schema as s_schema
 
 
@@ -235,13 +236,19 @@ def delta_schemas(
 
                 result.add(create)
 
+    excluded_classes = (
+        so.GlobalObject,
+        s_mod.Module,
+        s_func.Parameter,
+        s_pseudo.PseudoType,
+    )
+
     schemaclasses = [
         schemacls
         for schemacls in so.ObjectMeta.get_schema_metaclasses()
         if (
-            not issubclass(schemacls, (so.GlobalObject, s_mod.Module,
-                                       s_func.Parameter))
-            and schemacls.get_ql_class() is not None
+            not issubclass(schemacls, excluded_classes)
+            and not schemacls.is_abstract()
             and (
                 include_migrations
                 or not issubclass(schemacls, s_migr.Migration)

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -26,6 +26,8 @@ import contextlib
 import itertools
 import uuid
 
+import typing_inspect
+
 from edb import errors
 
 from edb.common import adapter
@@ -1197,79 +1199,37 @@ class DeltaRoot(CommandGroup, context_class=DeltaRootContext):
         return schema
 
 
-class ObjectCommandMeta(CommandMeta):
-    _transparent_adapter_subclass: ClassVar[bool] = True
-    _schema_metaclasses: ClassVar[
-        Dict[Tuple[str, Type[so.Object]], Type[ObjectCommand[so.Object]]]
-    ] = {}
+_command_registry: Dict[
+    Tuple[str, Type[so.Object]],
+    Type[ObjectCommand[so.Object]]
+] = {}
 
-    def __new__(
-        mcls,
-        name: str,
-        bases: Tuple[type, ...],
-        dct: Dict[str, Any],
-        *,
-        schema_metaclass: Optional[Type[so.Object]] = None,
-        **kwargs: Any,
-    ) -> ObjectCommandMeta:
-        cls = cast(
-            Type["ObjectCommand[so.Object]"],
-            super().__new__(mcls, name, bases, dct, **kwargs),
-        )
-        if cls.has_adaptee():
-            # This is a command adapter rather than the actual
-            # command, so skip the registrations.
-            return cls
 
-        if (schema_metaclass is not None or
-                not hasattr(cls, '_schema_metaclass')):
-            cls._schema_metaclass = schema_metaclass
+def get_object_command_class(
+    cmdtype: Type[Command_T],
+    schema_metaclass: Type[so.Object],
+) -> Optional[Type[Command_T]]:
+    assert issubclass(cmdtype, ObjectCommand)
+    return _command_registry.get(  # type: ignore
+        (cmdtype._delta_action, schema_metaclass),
+    )
 
-        delta_action = getattr(cls, '_delta_action', None)
-        if cls._schema_metaclass is not None and delta_action is not None:
-            key = delta_action, cls._schema_metaclass
-            cmdcls = mcls._schema_metaclasses.get(key)
-            if cmdcls is not None:
-                raise TypeError(
-                    f'Action {cls._delta_action!r} for '
-                    f'{cls._schema_metaclass} is already claimed by {cmdcls}'
-                )
-            mcls._schema_metaclasses[key] = cls
 
-        return cls
-
-    @classmethod
-    def get_command_class(
-        mcls,
-        cmdtype: Type[Command_T],
-        schema_metaclass: Type[so.Object],
-    ) -> Optional[Type[Command_T]]:
-        assert issubclass(cmdtype, ObjectCommand)
-        return mcls._schema_metaclasses.get(  # type: ignore
-            (cmdtype._delta_action, schema_metaclass),
-        )
-
-    @classmethod
-    def get_command_class_or_die(
-        mcls,
-        cmdtype: Type[Command_T],
-        schema_metaclass: Type[so.Object],
-    ) -> Type[Command_T]:
-        cmdcls = mcls.get_command_class(cmdtype, schema_metaclass)
-        if cmdcls is None:
-            raise TypeError(f'missing {cmdtype.__name__} implementation '
-                            f'for {schema_metaclass.__name__}')
-        return cmdcls
+def get_object_command_class_or_die(
+    cmdtype: Type[Command_T],
+    schema_metaclass: Type[so.Object],
+) -> Type[Command_T]:
+    cmdcls = get_object_command_class(cmdtype, schema_metaclass)
+    if cmdcls is None:
+        raise TypeError(f'missing {cmdtype.__name__} implementation '
+                        f'for {schema_metaclass.__name__}')
+    return cmdcls
 
 
 ObjectCommand_T = TypeVar("ObjectCommand_T", bound='ObjectCommand[so.Object]')
 
 
-class ObjectCommand(
-    Command,
-    Generic[so.Object_T],
-    metaclass=ObjectCommandMeta,
-):
+class ObjectCommand(Command, Generic[so.Object_T]):
     """Base class for all Object-related commands."""
 
     #: Full name of the object this command operates on.
@@ -1293,9 +1253,60 @@ class ObjectCommand(
 
     scls: so.Object_T
     _delta_action: ClassVar[str]
-    _schema_metaclass: ClassVar[Optional[Type[so.Object_T]]]
+    _schema_metaclass: ClassVar[Optional[Type[so.Object_T]]] = None
     astnode: ClassVar[Union[Type[qlast.DDLOperation],
                             List[Type[qlast.DDLOperation]]]]
+
+    def __init_subclass__(cls, *args: Any, **kwargs: Any) -> None:
+        # Check if the command subclass has been parametrized with
+        # a concrete schema object class, and if so, record the
+        # argument to be made available via get_schema_metaclass().
+        super().__init_subclass__(*args, **kwargs)  # type: ignore
+        generic_bases = typing_inspect.get_generic_bases(cls)
+        mcls: Optional[Type[so.Object]] = None
+        for gb in generic_bases:
+            base_origin = typing_inspect.get_origin(gb)
+            # Find the <ObjectCommand>[Type] base, where ObjectCommand
+            # is any ObjectCommand subclass.
+            if (
+                base_origin is not None
+                and issubclass(base_origin, ObjectCommand)
+            ):
+                args = typing_inspect.get_args(gb)
+                if len(args) != 1:
+                    raise AssertionError(
+                        'expected only one argument to ObjectCommand generic')
+                arg_0 = args[0]
+                if not typing_inspect.is_typevar(arg_0):
+                    assert issubclass(arg_0, so.Object)
+                    if not arg_0.is_abstract():
+                        mcls = arg_0
+                        break
+
+        if mcls is not None:
+            existing = getattr(cls, '_schema_metaclass', None)
+            if existing is not None and existing is not mcls:
+                raise TypeError(
+                    f'cannot redefine schema class of {cls.__name__} to '
+                    f'{mcls.__name__}: a superclass has already defined it as '
+                    f'{existing.__name__}'
+                )
+            cls._schema_metaclass = mcls
+
+        # If this is a command adapter rather than the actual
+        # command, skip the command class registration.
+        if not cls.has_adaptee():
+            delta_action = getattr(cls, '_delta_action', None)
+            schema_metaclass = getattr(cls, '_schema_metaclass', None)
+            if schema_metaclass is not None and delta_action is not None:
+                key = delta_action, schema_metaclass
+                cmdcls = _command_registry.get(key)
+                if cmdcls is not None:
+                    raise TypeError(
+                        f'Action {cls._delta_action!r} for '
+                        f'{schema_metaclass} is already claimed by {cmdcls}'
+                    )
+                _command_registry[key] = cls  # type: ignore
 
     @classmethod
     def _classname_from_ast(
@@ -1844,7 +1855,7 @@ class ObjectCommand(
         cmdtype: Type[ObjectCommand_T],
     ) -> Type[ObjectCommand_T]:
         mcls = cls.get_schema_metaclass()
-        return ObjectCommandMeta.get_command_class_or_die(cmdtype, mcls)
+        return get_object_command_class_or_die(cmdtype, mcls)
 
     def _validate_legal_command(
         self,
@@ -2191,7 +2202,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
         )
 
 
-class GlobalObjectCommand(ObjectCommand[so.GlobalObject]):
+class GlobalObjectCommand(ObjectCommand[so.GlobalObject_T]):
     pass
 
 
@@ -2228,7 +2239,7 @@ class CreateObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
                 classname = cls._classname_from_ast(schema, astnode, context)
             mcls = cls.get_schema_metaclass()
             if schema.get(classname, default=None) is not None:
-                return ObjectCommandMeta.get_command_class_or_die(
+                return get_object_command_class_or_die(
                     AlterObject, mcls)
 
         return cls
@@ -2677,7 +2688,7 @@ class RenameObject(AlterObjectFragment[so.Object_T]):
         parent_op = parent_ctx.op
         assert isinstance(parent_op, ObjectCommand)
         parent_class = parent_op.get_schema_metaclass()
-        rename_class = ObjectCommandMeta.get_command_class_or_die(
+        rename_class = get_object_command_class_or_die(
             RenameObject, parent_class)
         return rename_class._rename_cmd_from_ast(schema, astnode, context)
 
@@ -2694,7 +2705,7 @@ class RenameObject(AlterObjectFragment[so.Object_T]):
         parent_op = parent_ctx.op
         assert isinstance(parent_op, ObjectCommand)
         parent_class = parent_op.get_schema_metaclass()
-        rename_class = ObjectCommandMeta.get_command_class_or_die(
+        rename_class = get_object_command_class_or_die(
             RenameObject, parent_class)
 
         new_name = cls._classname_from_ast(schema, astnode, context)
@@ -3343,7 +3354,7 @@ def get_object_delta_command(
 
     cmdcls = cast(
         Type[ObjectCommand_T],
-        ObjectCommandMeta.get_command_class_or_die(cmdtype, objtype),
+        get_object_command_class_or_die(cmdtype, objtype),
     )
 
     return cmdcls(

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -67,7 +67,6 @@ class AliasCommandContext(
 class AliasCommand(
     sd.QualifiedObjectCommand[Alias],
     context_class=AliasCommandContext,
-    schema_metaclass=Alias,
 ):
 
     @classmethod

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -289,7 +289,7 @@ class ParameterDesc(ParameterLike):
         *,
         context: sd.CommandContext,
     ) -> sd.CreateObject[Parameter]:
-        CreateParameter = sd.ObjectCommandMeta.get_command_class_or_die(
+        CreateParameter = sd.get_object_command_class_or_die(
             sd.CreateObject, Parameter)
 
         param_name = self.get_fqname(schema, func_fqname)
@@ -310,7 +310,7 @@ class ParameterDesc(ParameterLike):
         *,
         context: sd.CommandContext,
     ) -> sd.ObjectCommand[Parameter]:
-        DeleteParameter = sd.ObjectCommandMeta.get_command_class_or_die(
+        DeleteParameter = sd.get_object_command_class_or_die(
             sd.DeleteObject, Parameter)
 
         param_name = sn.QualName(
@@ -482,7 +482,6 @@ class ParameterCommandContext(sd.ObjectCommandContext[Parameter]):
 # a referencing.ReferencedObject breaks the code
 class ParameterCommand(
     referencing.StronglyReferencedObjectCommand[Parameter],  # type: ignore
-    schema_metaclass=Parameter,
     context_class=ParameterCommandContext,
     referrer_context_class=CallableCommandContext
 ):
@@ -1193,7 +1192,6 @@ class FunctionCommandContext(CallableCommandContext):
 
 class FunctionCommand(
     CallableCommand[Function],
-    schema_metaclass=Function,
     context_class=FunctionCommandContext,
 ):
 

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -90,6 +90,9 @@ class Index(
         return shortname.name
 
 
+IndexableSubject_T = TypeVar('IndexableSubject_T', bound='IndexableSubject')
+
+
 class IndexableSubject(so.InheritingObject):
     indexes_refs = so.RefDict(
         attr='indexes',
@@ -112,7 +115,9 @@ class IndexSourceCommandContext:
     pass
 
 
-class IndexSourceCommand(inheriting.InheritingObjectCommand[Index]):
+class IndexSourceCommand(
+    inheriting.InheritingObjectCommand[IndexableSubject_T],
+):
     pass
 
 
@@ -123,7 +128,6 @@ class IndexCommandContext(sd.ObjectCommandContext[Index],
 
 class IndexCommand(
     referencing.ReferencedInheritingObjectCommand[Index],
-    schema_metaclass=Index,
     context_class=IndexCommandContext,
     referrer_context_class=IndexSourceCommandContext,
 ):

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -230,7 +230,7 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
                     continue
 
                 mcls = type(v)
-                create_cmd = sd.ObjectCommandMeta.get_command_class_or_die(
+                create_cmd = sd.get_object_command_class_or_die(
                     sd.CreateObject, mcls)
                 assert issubclass(
                     create_cmd,
@@ -288,7 +288,7 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
         for k, v in local_refs.items(schema):
             if not v.get_is_owned(schema):
                 mcls = type(v)
-                create_cmd = sd.ObjectCommandMeta.get_command_class_or_die(
+                create_cmd = sd.get_object_command_class_or_die(
                     sd.CreateObject, mcls)
                 assert issubclass(
                     create_cmd,
@@ -302,7 +302,7 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
                     schema, astnode, context)
 
                 if fqname not in present_refs:
-                    delete_cmd = sd.ObjectCommandMeta.get_command_class_or_die(
+                    delete_cmd = sd.get_object_command_class_or_die(
                         sd.DeleteObject, mcls)
                     dropped_refs[fqname] = delete_cmd
 
@@ -411,7 +411,7 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
         removed, added = delta_bases(
             old_base_names, new_base_names)
 
-        rebase = sd.ObjectCommandMeta.get_command_class(
+        rebase = sd.get_object_command_class(
             RebaseInheritingObject, type(scls))
 
         alter_cmd = scls.init_delta_command(schema, sd.AlterObject)
@@ -849,7 +849,7 @@ class AlterInheritingObject(
             # combine what we've seen and turn it into a rebase.
 
             parent_class = cmd.get_schema_metaclass()
-            rebase_class = sd.ObjectCommandMeta.get_command_class_or_die(
+            rebase_class = sd.get_object_command_class_or_die(
                 RebaseInheritingObject, parent_class)
 
             cmd.replace(
@@ -874,7 +874,7 @@ class AlterInheritingObject(
                     [b.get_name(schema) for b in bases],
                 )
 
-                rebase = sd.ObjectCommandMeta.get_command_class_or_die(
+                rebase = sd.get_object_command_class_or_die(
                     RebaseInheritingObject, cmd.get_schema_metaclass())
 
                 rebase_cmd = rebase(
@@ -988,7 +988,7 @@ class RebaseInheritingObject(
             schema = self._recompute_inheritance(schema, context)
 
             if context.enable_recursion:
-                alter_cmd = sd.ObjectCommandMeta.get_command_class_or_die(
+                alter_cmd = sd.get_object_command_class_or_die(
                     sd.AlterObject, type(scls))
                 assert issubclass(alter_cmd, AlterInheritingObject)
 

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -178,21 +178,23 @@ class LinkSourceCommandContext(sources.SourceCommandContext):
     pass
 
 
-class LinkSourceCommand(inheriting.InheritingObjectCommand[Link]):
+class LinkSourceCommand(inheriting.InheritingObjectCommand[sources.Source_T]):
     pass
 
 
-class LinkCommandContext(pointers.PointerCommandContext,
+class LinkCommandContext(pointers.PointerCommandContext[Link],
                          constraints.ConsistencySubjectCommandContext,
                          lproperties.PropertySourceContext,
                          indexes.IndexSourceCommandContext):
     pass
 
 
-class LinkCommand(lproperties.PropertySourceCommand,
-                  pointers.PointerCommand,
-                  schema_metaclass=Link, context_class=LinkCommandContext,
-                  referrer_context_class=LinkSourceCommandContext):
+class LinkCommand(
+    lproperties.PropertySourceCommand[Link],
+    pointers.PointerCommand[Link],
+    context_class=LinkCommandContext,
+    referrer_context_class=LinkSourceCommandContext,
+):
 
     def _set_pointer_type(
         self,
@@ -476,9 +478,10 @@ class RebaseLink(
         return schema
 
 
-class SetLinkType(pointers.SetPointerType,
-                  schema_metaclass=Link,
-                  referrer_context_class=LinkSourceCommandContext):
+class SetLinkType(
+    pointers.SetPointerType[Link],
+    referrer_context_class=LinkSourceCommandContext,
+):
 
     astnode = qlast.SetLinkType
 
@@ -510,7 +513,6 @@ class SetLinkType(pointers.SetPointerType,
 
 class AlterLinkOwned(
     referencing.AlterOwned[Link],
-    schema_metaclass=Link,
     referrer_context_class=LinkSourceCommandContext,
 ):
     astnode = qlast.AlterLinkOwned
@@ -546,7 +548,7 @@ class SetTargetDeletePolicy(sd.Command):
 
 class AlterLink(
     LinkCommand,
-    pointers.PointerAlterFragment,
+    pointers.PointerAlterFragment[Link],
     referencing.AlterReferencedInheritingObject[Link],
 ):
     astnode = [qlast.AlterConcreteLink, qlast.AlterLink]

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -191,19 +191,22 @@ class PropertySourceContext(sources.SourceCommandContext):
     pass
 
 
-class PropertySourceCommand(inheriting.InheritingObjectCommand[Property]):
+class PropertySourceCommand(
+    inheriting.InheritingObjectCommand[sources.Source_T],
+):
     pass
 
 
-class PropertyCommandContext(pointers.PointerCommandContext,
+class PropertyCommandContext(pointers.PointerCommandContext[Property],
                              constraints.ConsistencySubjectCommandContext):
     pass
 
 
-class PropertyCommand(pointers.PointerCommand,
-                      schema_metaclass=Property,
-                      context_class=PropertyCommandContext,
-                      referrer_context_class=PropertySourceContext):
+class PropertyCommand(
+    pointers.PointerCommand[Property],
+    context_class=PropertyCommandContext,
+    referrer_context_class=PropertySourceContext,
+):
 
     def _set_pointer_type(
         self,
@@ -365,16 +368,15 @@ class RebaseProperty(
     pass
 
 
-class SetPropertyType(pointers.SetPointerType,
-                      schema_metaclass=Property,
-                      referrer_context_class=PropertySourceContext):
-
+class SetPropertyType(
+    pointers.SetPointerType[Property],
+    referrer_context_class=PropertySourceContext,
+):
     astnode = qlast.SetPropertyType
 
 
 class AlterPropertyOwned(
     referencing.AlterOwned[Property],
-    schema_metaclass=Property,
     referrer_context_class=PropertySourceContext,
 ):
     astnode = qlast.AlterPropertyOwned
@@ -382,7 +384,7 @@ class AlterPropertyOwned(
 
 class AlterProperty(
     PropertyCommand,
-    pointers.PointerAlterFragment,
+    pointers.PointerAlterFragment[Property],
     referencing.AlterReferencedInheritingObject[Property],
 ):
     astnode = [qlast.AlterConcreteProperty,

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -67,9 +67,10 @@ class MigrationCommandContext(sd.ObjectCommandContext[Migration]):
     pass
 
 
-class MigrationCommand(sd.ObjectCommand[Migration],
-                       schema_metaclass=Migration,
-                       context_class=MigrationCommandContext):
+class MigrationCommand(
+    sd.ObjectCommand[Migration],
+    context_class=MigrationCommandContext,
+):
     pass
 
 

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -40,8 +40,10 @@ class ModuleCommandContext(sd.ObjectCommandContext[Module]):
     pass
 
 
-class ModuleCommand(sd.ObjectCommand[Module], schema_metaclass=Module,
-                    context_class=ModuleCommandContext):
+class ModuleCommand(
+    sd.ObjectCommand[Module],
+    context_class=ModuleCommandContext,
+):
 
     def _validate_legal_command(
         self,

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -879,6 +879,11 @@ class ObjectMeta(type):
     def get_reflection_link(cls) -> Optional[str]:
         return cls._reflection_link
 
+    def is_abstract(cls) -> bool:
+        """Return True if this type does NOT represent a concrete schema class.
+        """
+        return cls.get_ql_class() is None
+
 
 class FieldValueNotFoundError(Exception):
     pass
@@ -1864,6 +1869,9 @@ class ObjectFragment(QualifiedObject):
 
 class GlobalObject(Object):
     pass
+
+
+GlobalObject_T = TypeVar('GlobalObject_T', bound='GlobalObject')
 
 
 class DerivableObject(QualifiedObject):
@@ -2876,7 +2884,7 @@ class InheritingObject(SubclassableObject):
             context=context,
         )
 
-        rebase = sd.ObjectCommandMeta.get_command_class(
+        rebase = sd.get_object_command_class(
             s_inh.RebaseInheritingObject, type(self))
 
         old_base_names = tuple(

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -391,11 +391,13 @@ class ObjectTypeCommandContext(sd.ObjectCommandContext[ObjectType],
     pass
 
 
-class ObjectTypeCommand(s_types.InheritingTypeCommand[ObjectType],
-                        constraints.ConsistencySubjectCommand[ObjectType],
-                        sources.SourceCommand, links.LinkSourceCommand,
-                        schema_metaclass=ObjectType,
-                        context_class=ObjectTypeCommandContext):
+class ObjectTypeCommand(
+    s_types.InheritingTypeCommand[ObjectType],
+    constraints.ConsistencySubjectCommand[ObjectType],
+    sources.SourceCommand[ObjectType],
+    links.LinkSourceCommand[ObjectType],
+    context_class=ObjectTypeCommandContext,
+):
     pass
 
 

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -110,7 +110,6 @@ class OperatorCommandContext(s_func.CallableCommandContext):
 
 class OperatorCommand(
     s_func.CallableCommand[Operator],
-    schema_metaclass=Operator,
     context_class=OperatorCommandContext,
 ):
 

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -219,7 +219,7 @@ def reconstruct_tree(
         ):
             return False
 
-        alter_cmd_cls = sd.ObjectCommandMeta.get_command_class(
+        alter_cmd_cls = sd.get_object_command_class(
             sd.AlterObject, op.get_schema_metaclass())
 
         if alter_cmd_cls is None:

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -872,13 +872,13 @@ class ComputableRef:
         self.expr = expr
 
 
-class PointerCommandContext(sd.ObjectCommandContext[Pointer],
+class PointerCommandContext(sd.ObjectCommandContext[Pointer_T],
                             s_anno.AnnotationSubjectCommandContext):
     pass
 
 
 class PointerCommandOrFragment(
-    referencing.ReferencedObjectCommandBase[Pointer]
+    referencing.ReferencedObjectCommandBase[Pointer_T]
 ):
 
     def canonicalize_attributes(
@@ -1076,7 +1076,7 @@ class PointerCommandOrFragment(
 
 
 class PointerAlterFragment(
-    referencing.ReferencedObjectCommandBase[Pointer]
+    referencing.ReferencedObjectCommandBase[Pointer_T]
 ):
     @classmethod
     def _cmd_tree_from_ast(
@@ -1142,10 +1142,10 @@ class PointerAlterFragment(
 
 
 class PointerCommand(
-    referencing.ReferencedInheritingObjectCommand[Pointer],
-    constraints.ConsistencySubjectCommand[Pointer],
-    s_anno.AnnotationSubjectCommand,
-    PointerCommandOrFragment,
+    referencing.ReferencedInheritingObjectCommand[Pointer_T],
+    constraints.ConsistencySubjectCommand[Pointer_T],
+    s_anno.AnnotationSubjectCommand[Pointer_T],
+    PointerCommandOrFragment[Pointer_T],
 ):
 
     def _set_pointer_type(
@@ -1410,9 +1410,9 @@ class PointerCommand(
 
 
 class SetPointerType(
-        referencing.ReferencedInheritingObjectCommand[Pointer],
-        inheriting.AlterInheritingObjectFragment[Pointer],
-        PointerCommandOrFragment):
+        referencing.ReferencedInheritingObjectCommand[Pointer_T],
+        inheriting.AlterInheritingObjectFragment[Pointer_T],
+        PointerCommandOrFragment[Pointer_T]):
 
     def _alter_begin(
         self,
@@ -1500,7 +1500,7 @@ class SetPointerType(
         schema: s_schema.Schema,
         astnode: qlast.DDLOperation,
         context: sd.CommandContext,
-    ) -> sd.ObjectCommand[Pointer]:
+    ) -> sd.ObjectCommand[Pointer_T]:
         this_op = context.current().op
         assert isinstance(this_op, sd.ObjectCommand)
         return cls(classname=this_op.classname)

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -22,6 +22,7 @@ from typing import *
 
 from edb import errors
 from edb.edgeql import ast as qlast
+from edb.edgeql import qltypes
 
 from . import delta as sd
 from . import name as sn
@@ -36,7 +37,11 @@ if TYPE_CHECKING:
 PseudoType_T = TypeVar("PseudoType_T", bound="PseudoType")
 
 
-class PseudoType(so.InheritingObject, s_types.Type):
+class PseudoType(
+    so.InheritingObject,
+    s_types.Type,
+    qlkind=qltypes.SchemaObjectClass.PSEUDO_TYPE,
+):
 
     @classmethod
     def get(
@@ -161,7 +166,6 @@ class PseudoTypeCommandContext(sd.ObjectCommandContext[PseudoType]):
 
 class PseudoTypeCommand(
     s_types.TypeCommand[PseudoType],
-    schema_metaclass=PseudoType,
     context_class=PseudoTypeCommandContext,
 ):
     pass

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -64,11 +64,12 @@ class RoleCommandContext(
     pass
 
 
-class RoleCommand(sd.GlobalObjectCommand,
-                  inheriting.InheritingObjectCommand[Role],
-                  s_anno.AnnotationSubjectCommand,
-                  schema_metaclass=Role,
-                  context_class=RoleCommandContext):
+class RoleCommand(
+    sd.GlobalObjectCommand[Role],
+    inheriting.InheritingObjectCommand[Role],
+    s_anno.AnnotationSubjectCommand[Role],
+    context_class=RoleCommandContext,
+):
 
     @classmethod
     def _process_role_body(

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -223,8 +223,7 @@ class ScalarTypeCommandContext(sd.ObjectCommandContext[ScalarType],
 class ScalarTypeCommand(
     s_types.InheritingTypeCommand[ScalarType],
     constraints.ConsistencySubjectCommand[ScalarType],
-    s_anno.AnnotationSubjectCommand,
-    schema_metaclass=ScalarType,
+    s_anno.AnnotationSubjectCommand[ScalarType],
     context_class=ScalarTypeCommandContext,
 ):
     def validate_scalar_ancestors(

--- a/edb/schema/sources.py
+++ b/edb/schema/sources.py
@@ -30,12 +30,15 @@ if TYPE_CHECKING:
     from . import schema as s_schema
 
 
+Source_T = TypeVar('Source_T', bound='Source')
+
+
 class SourceCommandContext(indexes.IndexSourceCommandContext):
     # context mixin
     pass
 
 
-class SourceCommand(indexes.IndexSourceCommand):
+class SourceCommand(indexes.IndexSourceCommand[Source_T]):
     pass
 
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2128,12 +2128,11 @@ class DeleteCollectionExprAlias(
     pass
 
 
-class CreateTuple(CreateCollectionType[Tuple], schema_metaclass=Tuple):
+class CreateTuple(CreateCollectionType[Tuple]):
     pass
 
 
-class CreateTupleExprAlias(CreateCollectionExprAlias[TupleExprAlias],
-                           schema_metaclass=TupleExprAlias):
+class CreateTupleExprAlias(CreateCollectionExprAlias[TupleExprAlias]):
     def _get_ast_node(
         self, schema: s_schema.Schema, context: sd.CommandContext
     ) -> typing.Type[qlast.CreateAlias]:
@@ -2142,24 +2141,25 @@ class CreateTupleExprAlias(CreateCollectionExprAlias[TupleExprAlias],
         return qlast.CreateAlias
 
 
-class RenameTupleExprAlias(CollectionExprAliasCommand[TupleExprAlias],
-                           sd.RenameObject[TupleExprAlias],
-                           schema_metaclass=TupleExprAlias):
+class RenameTupleExprAlias(
+    CollectionExprAliasCommand[TupleExprAlias],
+    sd.RenameObject[TupleExprAlias],
+):
     pass
 
 
-class AlterTupleExprAlias(CollectionExprAliasCommand[TupleExprAlias],
-                          sd.AlterObject[TupleExprAlias],
-                          schema_metaclass=TupleExprAlias):
+class AlterTupleExprAlias(
+    CollectionExprAliasCommand[TupleExprAlias],
+    sd.AlterObject[TupleExprAlias],
+):
     pass
 
 
-class CreateArray(CreateCollectionType[Array], schema_metaclass=Array):
+class CreateArray(CreateCollectionType[Array]):
     pass
 
 
-class CreateArrayExprAlias(CreateCollectionExprAlias[TupleExprAlias],
-                           schema_metaclass=ArrayExprAlias):
+class CreateArrayExprAlias(CreateCollectionExprAlias[ArrayExprAlias]):
     def _get_ast_node(
         self, schema: s_schema.Schema, context: sd.CommandContext
     ) -> typing.Type[qlast.CreateAlias]:
@@ -2168,33 +2168,33 @@ class CreateArrayExprAlias(CreateCollectionExprAlias[TupleExprAlias],
         return qlast.CreateAlias
 
 
-class RenameArrayExprAlias(CollectionExprAliasCommand[ArrayExprAlias],
-                           sd.RenameObject[ArrayExprAlias],
-                           schema_metaclass=ArrayExprAlias):
+class RenameArrayExprAlias(
+    CollectionExprAliasCommand[ArrayExprAlias],
+    sd.RenameObject[ArrayExprAlias],
+):
     pass
 
 
-class AlterArrayExprAlias(CollectionExprAliasCommand[ArrayExprAlias],
-                          sd.AlterObject[ArrayExprAlias],
-                          schema_metaclass=ArrayExprAlias):
+class AlterArrayExprAlias(
+    CollectionExprAliasCommand[ArrayExprAlias],
+    sd.AlterObject[ArrayExprAlias],
+):
     pass
 
 
-class DeleteTuple(DeleteCollectionType[Tuple], schema_metaclass=Tuple):
+class DeleteTuple(DeleteCollectionType[Tuple]):
     pass
 
 
-class DeleteTupleExprAlias(DeleteCollectionExprAlias[TupleExprAlias],
-                           schema_metaclass=TupleExprAlias):
+class DeleteTupleExprAlias(DeleteCollectionExprAlias[TupleExprAlias]):
     pass
 
 
-class DeleteArray(DeleteCollectionType[Array], schema_metaclass=Array):
+class DeleteArray(DeleteCollectionType[Array]):
     pass
 
 
-class DeleteArrayExprAlias(DeleteCollectionExprAlias[ArrayExprAlias],
-                           schema_metaclass=ArrayExprAlias):
+class DeleteArrayExprAlias(DeleteCollectionExprAlias[ArrayExprAlias]):
     pass
 
 


### PR DESCRIPTION
Delta command implementations are currently associated with their
subject schema classes via the `schema_metaclass` class argument, which
is used by `ObjectCommandMeta` to populate the registry.  The class
argument is now fully redundant, because `ObjectCommand` is a `Generic`
and we can extract the schema class from its arguments instead.

This change has a benefit of increased validation of declarations,
making sure there aren't inconsistent annotations, and, more
importantly, makes it easier to use `__init_subclass__` for registries,
which, in turn, removes the need for a few metaclasses.