### PR TITLE
Fix DROP PROPERTY for MULTI properties

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2986,15 +2986,20 @@ class DeleteProperty(
                 link_bias=prop.is_link_property(orig_schema),
             )
 
-            col = dbops.AlterTableDropColumn(
-                dbops.Column(name=ptr_stor_info.column_name,
-                             type=ptr_stor_info.column_type))
+            if ptr_stor_info.table_type == 'ObjectType':
+                col = dbops.AlterTableDropColumn(
+                    dbops.Column(name=ptr_stor_info.column_name,
+                                 type=ptr_stor_info.column_type))
 
-            alter_table.add_operation(col)
+                alter_table.add_operation(col)
 
         if has_table(prop, orig_schema):
+            self.pgops.add(
+                self.drop_inhview(
+                    orig_schema, context, prop, drop_ancestors=True)
+            )
             old_table_name = common.get_backend_name(
-                schema, prop, catenate=False)
+                orig_schema, prop, catenate=False)
             self.pgops.add(dbops.DropTable(name=old_table_name, priority=1))
             self.update_base_inhviews(orig_schema, context, prop)
             self.schedule_inhview_deletion(orig_schema, context, prop)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -8316,6 +8316,24 @@ type test::Foo {
             """DROP ALIAS Alias;""",
         )
 
+    async def test_edgeql_ddl_drop_multi_prop_01(self):
+        await self.con.execute(r"""
+            SET MODULE test;
+
+            CREATE TYPE Test {
+                CREATE MULTI PROPERTY x -> str;
+                CREATE MULTI PROPERTY y := {1, 2, 3};
+            };
+        """)
+
+        await self.con.execute(r"""
+            ALTER TYPE Test DROP PROPERTY x;
+        """)
+
+        await self.con.execute(r"""
+            ALTER TYPE Test DROP PROPERTY y;
+        """)
+
     async def test_edgeql_ddl_collection_cleanup_01(self):
         count_query = "SELECT count(schema::Array);"
         orig_count = await self.con.query_one(count_query)


### PR DESCRIPTION
Currently it triggers ISEs for both computed and non-computed.