### PR TITLE
Formalize and simplify handling of special schema object fields

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -624,26 +624,6 @@ class AlterDropInherit(DDLOperation, BasesMixin):
     pass
 
 
-class AlterOwned(DDLOperation):
-    owned: bool
-
-
-class AlterPropertyOwned(AlterOwned):
-    pass
-
-
-class AlterLinkOwned(AlterOwned):
-    pass
-
-
-class AlterConstraintOwned(AlterOwned):
-    pass
-
-
-class AlterIndexOwned(AlterOwned):
-    pass
-
-
 class OnTargetDelete(DDLOperation):
     cascade: qltypes.LinkTargetDeleteAction
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1154,6 +1154,13 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 value = self._eval_enum_expr(
                     node.value, qltypes.SchemaCardinality)
                 keywords.extend(('SET', value.to_edgeql()))
+        elif fname == 'is_owned':
+            if node.value is None:
+                keywords.extend(('DROP', 'OWNED'))
+            elif self._eval_bool_expr(node.value):
+                keywords.extend(('SET', 'OWNED'))
+            else:
+                keywords.extend(('DROP', 'OWNED'))
         else:
             raise EdgeQLSourceGeneratorError(
                 'unknown special field: {!r}'.format(fname))
@@ -1518,21 +1525,6 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
     def visit_SetLinkType(self, node: qlast.SetLinkType) -> None:
         self.write('SET TYPE ')
         self.visit(node.type)
-
-    def visit_AlterPropertyOwned(self, node: qlast.AlterPropertyOwned) -> None:
-        self.write('SET OWNED' if node.owned else 'DROP OWNED')
-
-    def visit_AlterLinkOwned(self, node: qlast.AlterLinkOwned) -> None:
-        self.write('SET OWNED' if node.owned else 'DROP OWNED')
-
-    def visit_AlterConstraintOwned(
-        self,
-        node: qlast.AlterConstraintOwned,
-    ) -> None:
-        self.write('SET OWNED' if node.owned else 'DROP OWNED')
-
-    def visit_AlterIndexOwned(self, node: qlast.AlterIndexOwned) -> None:
-        self.write('SET OWNED' if node.owned else 'DROP OWNED')
 
     def visit_OnTargetDelete(self, node: qlast.OnTargetDelete) -> None:
         self._write_keywords('ON TARGET DELETE ', node.cascade.to_edgeql())

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -471,6 +471,23 @@ class AlterExtending(Nonterm):
         self.val = kids[0].val
 
 
+class AlterOwnedStmt(Nonterm):
+
+    def reduce_DROP_OWNED(self, *kids):
+        self.val = qlast.SetField(
+            name='is_owned',
+            value=qlast.BooleanConstant(value='false'),
+            special_syntax=True,
+        )
+
+    def reduce_SET_OWNED(self, *kids):
+        self.val = qlast.SetField(
+            name='is_owned',
+            value=qlast.BooleanConstant(value='true'),
+            special_syntax=True,
+        )
+
+
 commands_block(
     'CreateDatabase',
     SetFieldStmt,
@@ -704,21 +721,12 @@ class SetDelegatedStmt(Nonterm):
         )
 
 
-class AlterConstraintOwned(Nonterm):
-
-    def reduce_DROP_OWNED(self, *kids):
-        self.val = qlast.AlterConstraintOwned(owned=False)
-
-    def reduce_SET_OWNED(self, *kids):
-        self.val = qlast.AlterConstraintOwned(owned=True)
-
-
 commands_block(
     'AlterConcreteConstraint',
     SetFieldStmt,
     ResetFieldStmt,
     SetDelegatedStmt,
-    AlterConstraintOwned,
+    AlterOwnedStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -926,20 +934,11 @@ class DropAnnotationStmt(Nonterm):
         )
 
 
-class AlterIndexOwned(Nonterm):
-
-    def reduce_DROP_OWNED(self, *kids):
-        self.val = qlast.AlterIndexOwned(owned=False)
-
-    def reduce_SET_OWNED(self, *kids):
-        self.val = qlast.AlterIndexOwned(owned=True)
-
-
 commands_block(
     'AlterIndex',
     SetFieldStmt,
     ResetFieldStmt,
-    AlterIndexOwned,
+    AlterOwnedStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -1175,22 +1174,13 @@ class SetRequiredStmt(Nonterm):
         )
 
 
-class AlterPropertyOwned(Nonterm):
-
-    def reduce_DROP_OWNED(self, *kids):
-        self.val = qlast.AlterPropertyOwned(owned=False)
-
-    def reduce_SET_OWNED(self, *kids):
-        self.val = qlast.AlterPropertyOwned(owned=True)
-
-
 commands_block(
     'AlterConcreteProperty',
     UsingStmt,
     RenameStmt,
     SetFieldStmt,
     ResetFieldStmt,
-    AlterPropertyOwned,
+    AlterOwnedStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
@@ -1397,22 +1387,13 @@ class CreateConcreteLinkStmt(Nonterm):
         )
 
 
-class AlterLinkOwned(Nonterm):
-
-    def reduce_DROP_OWNED(self, *kids):
-        self.val = qlast.AlterLinkOwned(owned=False)
-
-    def reduce_SET_OWNED(self, *kids):
-        self.val = qlast.AlterLinkOwned(owned=True)
-
-
 commands_block(
     'AlterConcreteLink',
     UsingStmt,
     RenameStmt,
     SetFieldStmt,
     ResetFieldStmt,
-    AlterLinkOwned,
+    AlterOwnedStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -90,9 +90,6 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
 
         self.set_hint_and_details(hint, details)
 
-        if details:
-            msg = f'{msg}\n\nDETAILS: {details}'
-
         super().__init__(msg)
 
     @classmethod

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2541,6 +2541,19 @@ class SetLinkType(LinkMetaCommand, adapts=s_links.SetLinkType):
         return LinkMetaCommand.apply(self, schema, context)
 
 
+class AlterLinkUpperCardinality(
+    LinkMetaCommand,
+    adapts=s_links.AlterLinkUpperCardinality,
+):
+    def apply(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = s_links.AlterLinkUpperCardinality.apply(self, schema, context)
+        return LinkMetaCommand.apply(self, schema, context)
+
+
 class AlterLinkOwned(
     LinkMetaCommand,
     AlterObject,
@@ -2873,6 +2886,20 @@ class SetPropertyType(
         context: sd.CommandContext,
     ) -> s_schema.Schema:
         schema = s_props.SetPropertyType.apply(self, schema, context)
+        return PropertyMetaCommand.apply(self, schema, context)
+
+
+class AlterPropertyUpperCardinality(
+    PropertyMetaCommand,
+    adapts=s_props.AlterPropertyUpperCardinality,
+):
+    def apply(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = s_props.AlterPropertyUpperCardinality.apply(
+            self, schema, context)
         return PropertyMetaCommand.apply(self, schema, context)
 
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -1215,9 +1215,10 @@ class RenameConstraint(
 
 class AlterConstraintOwned(
     referencing.AlterOwned[Constraint],
+    field='is_owned',
     referrer_context_class=ConsistencySubjectCommandContext,
 ):
-    astnode = qlast.AlterConstraintOwned
+    pass
 
 
 class AlterConstraint(

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -435,12 +435,15 @@ class ConstraintCommand(
 
         return args
 
-    def get_verbosename(self) -> str:
+    def get_verbosename(self, parent: Optional[str] = None) -> str:
         mcls = self.get_schema_metaclass()
         vname = mcls.get_verbosename_static(self.classname)
         if self.get_attribute_value('is_abstract'):
             vname = f'abstract {vname}'
-        return vname
+        if parent is not None:
+            return f'{vname} of {parent}'
+        else:
+            return vname
 
     def compile_expr_field(
         self,

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1772,11 +1772,9 @@ class AlterFunction(AlterCallableObject[Function], FunctionCommand):
         schema = super()._alter_begin(schema, context)
         scls = self.scls
 
-        # If volatilitiy changed, propagate that to referring exprs
+        # If volatility changed, propagate that to referring exprs
         if not self.has_attribute_value("volatility"):
             return schema
-
-        context.altered_targets.add(scls)
 
         vn = scls.get_verbosename(schema, with_parent=True)
         schema = self._propagate_if_expr_refs(

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -398,8 +398,12 @@ class RenameIndex(
         )
 
 
-class AlterIndexOwned(IndexCommand, referencing.AlterOwned[Index]):
-    astnode = qlast.AlterIndexOwned
+class AlterIndexOwned(
+    IndexCommand,
+    referencing.AlterOwned[Index],
+    field='is_owned',
+):
+    pass
 
 
 class AlterIndex(

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -143,12 +143,8 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
                     schema=schema,
                 )
             except errors.SchemaDefinitionError as e:
-                field_op = self.get_attribute_set_cmd(field_name)
-                if (
-                    field_op is not None
-                    and field_op.source_context is not None
-                ):
-                    e.set_source_context(field_op.source_context)
+                if (srcctx := self.get_attribute_source_context(field_name)):
+                    e.set_source_context(srcctx)
                 raise
 
             if not ignore_local_field:

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -511,6 +511,14 @@ class SetLinkType(
         return schema
 
 
+class AlterLinkUpperCardinality(
+    pointers.AlterPointerUpperCardinality[Link],
+    referrer_context_class=LinkSourceCommandContext,
+    field='cardinality',
+):
+    pass
+
+
 class AlterLinkOwned(
     referencing.AlterOwned[Link],
     referrer_context_class=LinkSourceCommandContext,

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -514,8 +514,9 @@ class SetLinkType(
 class AlterLinkOwned(
     referencing.AlterOwned[Link],
     referrer_context_class=LinkSourceCommandContext,
+    field='is_owned',
 ):
-    astnode = qlast.AlterLinkOwned
+    pass
 
 
 class SetTargetDeletePolicy(sd.Command):

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -378,6 +378,14 @@ class SetPropertyType(
     astnode = qlast.SetPropertyType
 
 
+class AlterPropertyUpperCardinality(
+    pointers.AlterPointerUpperCardinality[Property],
+    referrer_context_class=PropertySourceContext,
+    field='cardinality',
+):
+    pass
+
+
 class AlterPropertyOwned(
     referencing.AlterOwned[Property],
     referrer_context_class=PropertySourceContext,

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -381,8 +381,9 @@ class SetPropertyType(
 class AlterPropertyOwned(
     referencing.AlterOwned[Property],
     referrer_context_class=PropertySourceContext,
+    field='is_owned',
 ):
-    astnode = qlast.AlterPropertyOwned
+    pass
 
 
 class AlterProperty(

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -988,10 +988,18 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         return str(cls.get_shortname_static(name))
 
     @classmethod
-    def get_verbosename_static(cls, name: sn.Name) -> str:
+    def get_verbosename_static(
+        cls,
+        name: sn.Name,
+        *,
+        parent: Optional[str] = None,
+    ) -> str:
         clsname = cls.get_schema_class_displayname()
         dname = cls.get_displayname_static(name)
-        return f"{clsname} '{dname}'"
+        if parent is not None:
+            return f"{clsname} '{dname}' of {parent}"
+        else:
+            return f"{clsname} '{dname}'"
 
     def get_shortname(self, schema: s_schema.Schema) -> sn.Name:
         return type(self).get_shortname_static(self.get_name(schema))

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -319,11 +319,12 @@ class CreateScalarType(
                         f' the only supertype specified',
                         context=astnode.bases[0].context,
                     )
-                deflt = create_cmd.get_attribute_set_cmd('default')
-                if deflt is not None:
+                if create_cmd.has_attribute_value('default'):
                     raise errors.UnsupportedFeatureError(
                         f'enumerated types do not support defaults',
-                        context=deflt.source_context,
+                        context=(
+                            create_cmd.get_attribute_source_context('default')
+                        ),
                     )
 
                 shell = bases[0]

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -308,6 +308,8 @@ class BaseSchemaTest(BaseDocTest):
         script = cls.get_schema_script()
         if script is not None:
             cls.schema = cls.run_ddl(_load_std_schema(), script)
+        else:
+            cls.schema = _load_std_schema()
 
     @classmethod
     def run_ddl(cls, schema, ddl, default_module=defines.DEFAULT_MODULE_ALIAS):


### PR DESCRIPTION
Schema object fields are not created equal.  Some, like `cardinality` or `is_owned`, require specialized treatment.  The current DDL AST binding system works at the AST node class level, and so to support existing custom field handlers we have a set of duplicate AST nodes and parser productions for each concrete schema object (e.g. for `SET OWNED` we have `AlterLinkOwned`, `AlterPropertyOwned`, `AlterIndexOwned`, etc).

Migration improvements in the pipeline require a lot more specialization like this, and it's clear that the current system has too much pointless boilerplate.  To alleviate this, add a mechanism to bind `AlterObjectFragment` implementations to specific fields.  Convert `SET/DROP OWNED` to it, and implement a custom handler for `SET SINGLE/MULTI` as a demonstration of the concept.