### PR TITLE
Add the computed_fields property to schema::

### DIFF
--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -50,6 +50,7 @@ CREATE ABSTRACT TYPE schema::Object EXTENDING std::BaseObject {
     CREATE REQUIRED PROPERTY builtin -> std::bool {
         SET default := false;
     };
+    CREATE PROPERTY computed_fields -> array<std::str>;
 };
 
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -28,7 +28,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_12_11_00_00
+EDGEDB_CATALOG_VERSION = 2020_12_16_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3470,13 +3470,15 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''
-            SELECT schema::Function {name, volatility}
+            SELECT schema::Function {name, volatility, computed_fields}
             FILTER .name LIKE 'test::%'
             ORDER BY .name;
             ''',
             [
-                {"name": "test::bar", "volatility": "Stable"},
-                {"name": "test::foo", "volatility": "Stable"},
+                {"name": "test::bar", "volatility": "Stable",
+                 "computed_fields": ["volatility"]},
+                {"name": "test::foo", "volatility": "Stable",
+                 "computed_fields": []},
             ]
         )
 
@@ -3488,13 +3490,15 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''
-            SELECT schema::Function {name, volatility}
+            SELECT schema::Function {name, volatility, computed_fields}
             FILTER .name LIKE 'test::%'
             ORDER BY .name;
             ''',
             [
-                {"name": "test::bar", "volatility": "Immutable"},
-                {"name": "test::foo", "volatility": "Immutable"},
+                {"name": "test::bar", "volatility": "Immutable",
+                 "computed_fields": ["volatility"]},
+                {"name": "test::foo", "volatility": "Immutable",
+                 "computed_fields": ["volatility"]},
             ]
         )
 


### PR DESCRIPTION
inherited_fields is there, and I'm going to want it for some tests.