### PR TITLE
Fix RESET of OPTIONALITY/CARDINALITY

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2907,6 +2907,9 @@ class AlterProperty(
         if self.metadata_only:
             return schema
 
+        if prop.is_pure_computable(orig_schema):
+            return schema
+
         with context(
                 s_props.PropertyCommandContext(schema, self, prop)) as ctx:
             ctx.original_schema = orig_schema

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1344,18 +1344,8 @@ class FunctionCommand(
             # opportunity to raise exceptions or give warnings.
             self.set_attribute_value('has_dml', True)
 
-        is_alter = isinstance(self, sd.AlterObject)
-
-        spec_volatility = self.get_attribute_value('volatility')
-        if is_alter:
-            cfs = self.scls.get_computed_fields(schema)
-            if (
-                spec_volatility is None
-                and not self.has_attribute_value('volatility')
-                and 'volatility' not in cfs
-            ):
-                spec_volatility = self.scls.get_explicit_field_value(
-                    schema, 'volatility', default=None)
+        spec_volatility: Optional[ft.Volatility] = (
+            self.get_specified_attribute_value('volatility', schema, context))
 
         if spec_volatility is None:
             self.set_attribute_value('volatility', ir.volatility,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -890,6 +890,22 @@ class PointerCommandOrFragment(
         target_ref = self.get_local_attribute_value('target')
         inf_target_ref: Optional[s_types.TypeShell]
 
+        # When cardinality/required is altered, we need to force a
+        # reconsideration of expr if it exists in order to check
+        # it against the new specifier or compute them on a
+        # RESET. This is kind of unfortunate.
+        if (
+            isinstance(self, sd.AlterObject)
+            and (self.has_attribute_value('cardinality')
+                 or self.has_attribute_value('required'))
+            and not self.has_attribute_value('expr')
+            and (expr := self.scls.get_expr(schema)) is not None
+        ):
+            self.set_attribute_value(
+                'expr',
+                s_expr.Expression.not_compiled(expr)
+            )
+
         if isinstance(target_ref, ComputableRef):
             schema, inf_target_ref, base = self._parse_computable(
                 target_ref.expr, schema, context)
@@ -1006,25 +1022,10 @@ class PointerCommandOrFragment(
         self.set_attribute_value('expr', expression)
         required, card = expression.irast.cardinality.to_schema_value()
 
-        is_alter = (
-            isinstance(self, sd.AlterObject)
-            or (
-                isinstance(self, sd.AlterObjectFragment)
-                and isinstance(self.get_parent_op(context), sd.AlterObject)
-            )
-        )
-
-        spec_required = self.get_attribute_value('required')
-        spec_card = self.get_attribute_value('cardinality')
-
-        if is_alter:
-            cfs = self.scls.get_computed_fields(schema)
-            if spec_required is None and 'required' not in cfs:
-                spec_required = self.scls.get_explicit_field_value(
-                    schema, 'required', default=None)
-            if spec_card is None and 'cardinality' not in cfs:
-                spec_card = self.scls.get_explicit_field_value(
-                    schema, 'cardinality', default=None)
+        spec_required: Optional[bool] = (
+            self.get_specified_attribute_value('required', schema, context))
+        spec_card: Optional[qltypes.SchemaCardinality] = (
+            self.get_specified_attribute_value('cardinality', schema, context))
 
         if spec_required and not required:
             srcctx = self.get_attribute_source_context('target')
@@ -1052,7 +1053,7 @@ class PointerCommandOrFragment(
         if spec_card is None:
             self.set_attribute_value('cardinality', card, computed=True)
 
-        if not spec_required and required != spec_required:
+        if spec_required is None:
             self.set_attribute_value('required', required, computed=True)
 
         self.set_attribute_value('computable', True)

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -4462,12 +4462,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 };
             """)
 
-    @test.xfail('''
-        edgedb.errors.InternalServerError: relation
-        "edgedb_fe4eeff4-..." does not exist
-
-        The error occurs at the second "migrate".
-    ''')
     async def test_edgeql_migration_eq_42(self):
         # testing schema alias
         await self.migrate(r"""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3417,7 +3417,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
-
     def test_schema_migrations_equivalence_computed_01(self):
         self._assert_migration_equivalence([r"""
             type Foo {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3417,6 +3417,37 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
+
+    def test_schema_migrations_equivalence_computed_01(self):
+        self._assert_migration_equivalence([r"""
+            type Foo {
+                property x := 10;
+            };
+        """, r"""
+            type Foo {
+                single property x := 10;
+            };
+        """, r"""
+            type Foo {
+                multi property x := 10;
+            };
+        """])
+
+    def test_schema_migrations_equivalence_computed_02(self):
+        self._assert_migration_equivalence([r"""
+            type Foo {
+                single property x := 10;
+            };
+        """, r"""
+            type Foo {
+                property x := 10;
+            };
+        """, r"""
+            type Foo {
+                multi property x := 10;
+            };
+        """])
+
     def test_schema_migrations_equivalence_linkprops_03(self):
         self._assert_migration_equivalence([r"""
             type Child;


### PR DESCRIPTION
expr needs to be reprocessed when cardinality/required are changed and
we need to avoid pulling the old value from the schema on a RESET. I
generalized the latter bit of logic into
`get_specified_attribute_value`.