### PR TITLE
Remove unused ptr_item_id column from pointer tables

### DIFF
--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -950,10 +950,6 @@ def process_link_update(
     )
 
     col_data = {
-        'ptr_item_id': pgast.TypeCast(
-            arg=pgast.StringConstant(val=str(mptrref.id)),
-            type_name=pgast.TypeName(name=('uuid',))
-        ),
         'source': pathctx.get_rvar_path_identity_var(
             dml_cte_rvar, ir_stmt.subject.path_id, env=ctx.env)
     }
@@ -1071,7 +1067,7 @@ def process_link_update(
         return data_cte
 
     cols = [pgast.ColumnRef(name=[col]) for col in specified_cols]
-    conflict_cols = ['source', 'target', 'ptr_item_id']
+    conflict_cols = ['source', 'target']
 
     if is_insert:
         conflict_clause = None

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -28,7 +28,7 @@ EDGEDB_ENCODING = 'utf-8'
 EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_12_16_00_00
+EDGEDB_CATALOG_VERSION = 2020_12_17_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs


### PR DESCRIPTION
The `ptr_item_id` column is an unused vestige of the past, when a single
table could contain links or properties from multiple types.  The only
reason it stayed around is for dump compatibility, but now that we have
a mechanism to elide columns from dumps, so `ptr_item_id` goes away.