### PR TITLE
Support computed link properties

### DIFF
--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -106,7 +106,7 @@ class CompilerOptions(GlobalCompilerOptions):
     #: Include __tname__ computable (.__type__.name) in every shape implicitly.
     implicit_tname_in_shapes: bool = False
 
-    #: A set of schema types that should be treated
+    #: A set of schema types and links that should be treated
     #: as singletons in the context of this compilation.
     singletons: FrozenSet[Union[s_types.Type, s_pointers.Pointer]] = (
         frozenset())

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from edb.schema import objects as s_obj
     from edb.schema import name as s_name
     from edb.schema import types as s_types
+    from edb.schema import pointers as s_pointers
 
 
 @dataclass
@@ -107,4 +108,5 @@ class CompilerOptions(GlobalCompilerOptions):
 
     #: A set of schema types that should be treated
     #: as singletons in the context of this compilation.
-    singletons: FrozenSet[s_types.Type] = frozenset()
+    singletons: FrozenSet[Union[s_types.Type, s_pointers.Pointer]] = (
+        frozenset())

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -47,6 +47,13 @@ def get_path_id(stype: s_types.Type, *,
         namespace=ctx.path_id_namespace)
 
 
+def get_pointer_path_id(ptr: s_pointers.Pointer, *,
+                        ctx: context.ContextLevel) -> irast.PathId:
+    src = ptr.get_source(ctx.env.schema)
+    assert isinstance(src, s_types.Type)
+    return extend_path_id(get_path_id(src, ctx=ctx), ptrcls=ptr, ctx=ctx)
+
+
 def get_tuple_indirection_path_id(
         tuple_path_id: irast.PathId, element_name: str,
         element_type: s_types.Type, *,

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -76,7 +76,9 @@ def init_context(
         # cardinality inference, so we set up the scope tree in
         # the necessary fashion.
         for singleton in options.singletons:
-            path_id = pathctx.get_path_id(singleton, ctx=ctx)
+            path_id = (pathctx.get_path_id(singleton, ctx=ctx)
+                       if isinstance(singleton, s_types.Type)
+                       else pathctx.get_pointer_path_id(singleton, ctx=ctx))
             ctx.env.path_scope.attach_path(path_id, context=None)
 
         ctx.path_scope = ctx.env.path_scope.attach_fence()
@@ -89,8 +91,8 @@ def init_context(
 
     if options.path_prefix_anchor is not None:
         path_prefix = options.anchors[options.path_prefix_anchor]
-        assert isinstance(path_prefix, s_types.Type)
-        ctx.partial_path_prefix = setgen.class_set(path_prefix, ctx=ctx)
+        ctx.partial_path_prefix = compile_anchor(
+            options.path_prefix_anchor, path_prefix, ctx=ctx)
         ctx.partial_path_prefix.anchor = options.path_prefix_anchor
         ctx.partial_path_prefix.show_as_anchor = options.path_prefix_anchor
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -71,10 +71,10 @@ def init_context(
     _ = context.CompilerContext(initial=ctx)
 
     if options.singletons:
-        # The caller wants us to treat these type references
-        # as singletons for the purposes of the overall expression
-        # cardinality inference, so we set up the scope tree in
-        # the necessary fashion.
+        # The caller wants us to treat these type and pointer
+        # references as singletons for the purposes of the overall
+        # expression cardinality inference, so we set up the scope
+        # tree in the necessary fashion.
         for singleton in options.singletons:
             path_id = (pathctx.get_path_id(singleton, ctx=ctx)
                        if isinstance(singleton, s_types.Type)

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -155,6 +155,16 @@ class Pointer(Source):
     def is_pointer(self) -> bool:
         return True
 
+    def getptr(
+        self,
+        schema: s_schema.Schema,
+        name: str,
+    ) -> Optional[Union[s_pointers.Pointer, Pointer]]:
+        if (not (res := super().getptr(schema, name))
+                and isinstance(self.target, (Source, s_sources.Source))):
+            res = self.target.getptr(schema, name)
+        return res
+
     def get_target(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -236,7 +236,10 @@ class PropertyCommand(
         if scls.is_special_pointer(schema):
             return
 
-        if scls.is_link_property(schema):
+        if (
+            scls.is_link_property(schema)
+            and not scls.is_pure_computable(schema)
+        ):
             # link properties cannot be required or multi
             if self.get_attribute_value('required'):
                 raise errors.InvalidPropertyDefinitionError(

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -25,7 +25,10 @@ abstract type Named {
 
 type User extending Named {
     multi link deck -> Card {
-        property count -> int64;
+        property count -> int64 {
+            default := 1;
+        };
+        property total_cost := @count * .cost;
     }
 
     property deck_cost := sum(.deck.cost);
@@ -42,6 +45,7 @@ type User extending Named {
 
     link avatar -> Card {
         property text -> str;
+        property tag := .name ++ (("-" ++ @text) ?? "");
     }
 }
 

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -1018,3 +1018,41 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
                 {"deck": [{"@count": 1}, {"@count": 1}], "name": "Dave"},
             ]
         )
+
+    async def test_edgeql_props_link_computed_01(self):
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT User {
+                    name,
+                    deck: {name, @total_cost} ORDER BY .name
+                } FILTER .name = 'Alice';
+            ''',
+            [
+                {
+                    "name": "Alice",
+                    "deck": [
+                        {"@total_cost": 6, "name": "Bog monster"},
+                        {"@total_cost": 10, "name": "Dragon"},
+                        {"@total_cost": 9, "name": "Giant turtle"},
+                        {"@total_cost": 2, "name": "Imp"}
+                    ],
+                }
+            ],
+        )
+
+    async def test_edgeql_props_link_computed_02(self):
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT User {
+                    name,
+                    avatar: { @tag },
+                }
+                FILTER .name IN {'Alice', 'Bob'} ORDER BY .name;
+            ''',
+            [
+                {"name": "Alice", "avatar": {"@tag": "Dragon-Best"}},
+                {"name": "Bob", "avatar": None}
+            ],
+        )


### PR DESCRIPTION
The biggest chunk of the diff in lines is just moving a
compile_expr_field function around and adding a little to it to
support computed props in abstract pointers.

Fixes #2003.