### PR TITLE
Fix a potential memory leak in taskgroup

### DIFF
--- a/edb/common/taskgroup.py
+++ b/edb/common/taskgroup.py
@@ -25,6 +25,7 @@ import itertools
 import sys
 import textwrap
 import traceback
+import weakref
 
 
 class TaskGroup:
@@ -41,7 +42,7 @@ class TaskGroup:
         self._loop = None
         self._parent_task = None
         self._parent_cancel_requested = False
-        self._tasks = set()
+        self._tasks = weakref.WeakSet()
         self._unfinished_tasks = 0
         self._errors = []
         self._base_error = None

--- a/tests/common/test_taskgroup.py
+++ b/tests/common/test_taskgroup.py
@@ -587,13 +587,12 @@ class TestTaskGroup(tb.TestCase):
 
         async def do_job(delay):
             await asyncio.sleep(delay)
-            return 1
 
-        async with TaskGroup() as tg:
+        async with taskgroup.TaskGroup() as g:
             for count in range(10):
                 await asyncio.sleep(0.1)
-                tg.create_task(do_job(0.3))
+                g.create_task(do_job(0.3))
                 if count == 5:
-                    self.assertLess(len(tg._tasks), 5)
+                    self.assertLess(len(g._tasks), 5)
             await asyncio.sleep(1.35)
-            self.assertEqual(len(tg._tasks), 0)
+            self.assertEqual(len(g._tasks), 0)

--- a/tests/common/test_taskgroup.py
+++ b/tests/common/test_taskgroup.py
@@ -583,7 +583,7 @@ class TestTaskGroup(tb.TestCase):
         with self.assertRaises(asyncio.CancelledError):
             await r
 
-    async def test_taskgroup_23():
+    async def test_taskgroup_23(self):
 
         async def do_job(delay):
             await asyncio.sleep(delay)
@@ -594,6 +594,6 @@ class TestTaskGroup(tb.TestCase):
                 await asyncio.sleep(0.1)
                 tg.create_task(do_job(0.3))
                 if count == 5:
-                    assert len(tg._tasks) < 5
-            await asyncio.sleep(1.1)
-            assert len(tg._tasks) == 0
+                    self.assertLess(len(tg._tasks), 5)
+            await asyncio.sleep(1.35)
+            self.assertEqual(len(tg._tasks), 0)

--- a/tests/common/test_taskgroup.py
+++ b/tests/common/test_taskgroup.py
@@ -582,3 +582,18 @@ class TestTaskGroup(tb.TestCase):
 
         with self.assertRaises(asyncio.CancelledError):
             await r
+
+    async def test_taskgroup_23():
+
+        async def do_job(delay):
+            await asyncio.sleep(delay)
+            return 1
+
+        async with TaskGroup() as tg:
+            for count in range(10):
+                await asyncio.sleep(0.1)
+                tg.create_task(do_job(0.3))
+                if count == 5:
+                    assert len(tg._tasks) < 5
+            await asyncio.sleep(1.1)
+            assert len(tg._tasks) == 0


### PR DESCRIPTION
refs edgedb/edgedb-python#140

* This change does not affect the existing behavior of short-lived
  task groups, but will improve memory usage of long-lived task groups
  when there are many tasks spawned repeatedly for a long time.

* In aiotools, the test case uses a virtual clock that makes
  asyncio.sleep to deterministically complete instantly, but here
  it seems not to have such thing.  I've reduced the number of
  repetitions and time scale, but not sure it's stable or not.
