### PR TITLE
Include migrations in dumps

### DIFF
--- a/edb/common/context.py
+++ b/edb/common/context.py
@@ -46,6 +46,11 @@ class SourcePoint:
         self.column = column
         self.pointer = pointer
 
+    def __repr__(self):
+        return f'source@({self.line}:{self.column}:{self.pointer})'
+
+    __str__ = __repr__
+
 
 class ParserContext(markup.MarkupExceptionContext):
     title = 'Source Context'

--- a/edb/edgeql-parser/src/keywords.rs
+++ b/edb/edgeql-parser/src/keywords.rs
@@ -5,6 +5,7 @@ pub const UNRESERVED_KEYWORDS: &[&str] = &[
     "allow",
     "all",
     "annotation",
+    "applied",
     "as",
     "asc",
     "assignment",

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -713,6 +713,7 @@ class CreateMigration(CreateObject, Migration):
     body: MigrationBody
     parent: typing.Optional[ObjectRef] = None
     message: typing.Optional[str] = None
+    metadata_only: bool = False
 
 
 class StartMigration(DDLCommand, Migration):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -989,13 +989,18 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self._visit_DropObject(node, 'ROLE')
 
     def visit_CreateMigration(self, node: qlast.CreateMigration) -> None:
-        self.write('CREATE MIGRATION')
+        self.write('CREATE')
+        if node.metadata_only:
+            self.write(' APPLIED')
+        self.write(' MIGRATION')
         if node.name is not None:
             self.write(' ')
             self.write(ident_to_str(node.name.name))
+            self.write(' ONTO ')
             if node.parent is not None:
-                self.write(' ONTO ')
                 self.write(ident_to_str(node.parent.name))
+            else:
+                self.write('initial')
         if node.body.commands:
             self._ddl_visit_body(node.body.commands)
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -766,6 +766,7 @@ def compile_DescribeStmt(
 
             verbose = ql.options.get_flag('VERBOSE')
 
+            method: Any
             if ql.language is qltypes.DescribeLanguage.DDL:
                 method = s_ddl.ddl_text_from_schema
             elif ql.language is qltypes.DescribeLanguage.SDL:

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -2346,7 +2346,7 @@ class OptMigrationNameParentName(Nonterm):
 
 class CreateMigrationStmt(Nonterm):
 
-    def reduce_CreateMigration_Commands(self, *kids):
+    def reduce_CreateMigration(self, *kids):
         r"""%reduce
             CREATE MIGRATION OptMigrationNameParentName OptCreateMigrationBody
         """
@@ -2355,6 +2355,19 @@ class CreateMigrationStmt(Nonterm):
             parent=kids[2].val.parent,
             message=kids[3].val.message,
             body=kids[3].val.body,
+        )
+
+    def reduce_CreateAppliedMigration(self, *kids):
+        r"""%reduce
+            CREATE APPLIED MIGRATION
+            OptMigrationNameParentName OptCreateMigrationBody
+        """
+        self.val = qlast.CreateMigration(
+            name=kids[3].val.name,
+            parent=kids[3].val.parent,
+            message=kids[4].val.message,
+            body=kids[4].val.body,
+            metadata_only=True,
         )
 
 

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -729,6 +729,7 @@ def ddl_text_from_schema(
     included_ref_classes: Iterable[so.ObjectMeta]=tuple(),
     include_module_ddl: bool=True,
     include_std_ddl: bool=False,
+    include_migrations: bool=False,
 ) -> str:
     diff = delta_schemas(
         schema_a=None,
@@ -740,6 +741,7 @@ def ddl_text_from_schema(
         include_module_diff=include_module_ddl,
         include_std_diff=include_std_ddl,
         include_derived_types=False,
+        include_migrations=include_migrations,
     )
     return ddl_text_from_delta(None, schema, diff)
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1941,7 +1941,8 @@ class Compiler(BaseCompiler):
     ) -> DumpDescriptor:
         schema = await self._introspect_schema_in_snapshot(tx_snapshot_id)
 
-        schema_ddl = s_ddl.ddl_text_from_schema(schema)
+        schema_ddl = s_ddl.ddl_text_from_schema(
+            schema, include_migrations=True)
 
         all_objects = schema.get_objects(exclude_stdlib=True)
         ids = []

--- a/tests/schemas/dump02_setup.edgeql
+++ b/tests/schemas/dump02_setup.edgeql
@@ -52,3 +52,8 @@ INSERT Łukasz {
         LIMIT 1
     )
 };
+
+CREATE MIGRATION m1bkvqo5h2o6zptgch4m3tg27xszrprq2mu2qdboe4g7jh5wi5nyfa
+ONTO m1n3v3eqsjlwqi7ebltfrdykhlzgoxvfi46o7mt443z6urwzetayka {
+    CREATE TYPE default::Migrated;
+};

--- a/tests/test_dump02.py
+++ b/tests/test_dump02.py
@@ -254,3 +254,10 @@ class TestDump02(tb.QueryTestCase, tb.CLITestCaseMixin):
                 {'Ł🤞': '你好🤞'},
             ]
         )
+
+        await self.assert_query_result(
+            r'''
+                SELECT count(schema::Migration)
+            ''',
+            [2],
+        )

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3029,11 +3029,22 @@ aa';
         CREATE MIGRATION m123123123 {
             CREATE TYPE Foo;
         };
+% OK %
+        CREATE MIGRATION m123123123 ONTO initial {
+            CREATE TYPE Foo;
+        };
         """
 
     def test_edgeql_syntax_ddl_create_migration_05(self):
         """
         CREATE MIGRATION m123123123 ONTO m134134134 {
+            CREATE TYPE Foo;
+        };
+        """
+
+    def test_edgeql_syntax_ddl_create_migration_06(self):
+        """
+        CREATE APPLIED MIGRATION m123123123 ONTO m134134134 {
             CREATE TYPE Foo;
         };
         """


### PR DESCRIPTION
Migrations objects are now dumped as part of the schema as `CREATE
APPLIED MIGRATION` commands, which simply record migration metadata to
reconstruct the migration log.

Issue: #2071