### PR TITLE
Implement auth cache

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -778,15 +778,19 @@ class DropModule(DropObject):
     pass
 
 
-class CreateRole(CreateObject, BasesMixin):
+class Role:
+    __abstract_node__ = True
+
+
+class CreateRole(CreateObject, BasesMixin, Role):
     superuser: bool = False
 
 
-class AlterRole(AlterObject):
+class AlterRole(AlterObject, Role):
     pass
 
 
-class DropRole(DropObject):
+class DropRole(DropObject, Role):
     pass
 
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -881,17 +881,16 @@ async def _compile_sys_queries(schema, compiler, cluster):
             name,
             is_superuser,
             password,
-        } FILTER .name = <str>$name;
+        };
     '''
     schema, sql = compile_bootstrap_script(
         compiler,
         schema,
         role_query,
-        expected_cardinality_one=True,
+        expected_cardinality_one=False,
         single_statement=True,
     )
-
-    queries['role'] = sql
+    queries['roles'] = sql
 
     tids_query = '''
         SELECT schema::ScalarType {

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -803,7 +803,8 @@ class Compiler(BaseCompiler):
             is_transactional=is_transactional,
             single_unit=(not is_transactional) or (drop_db is not None),
             new_types=new_types,
-            drop_db=drop_db
+            drop_db=drop_db,
+            has_role_ddl=isinstance(stmt, qlast.Role),
         )
 
     def _compile_ql_migration(self, ctx: CompileContext, ql: qlast.Migration):
@@ -1383,7 +1384,7 @@ class Compiler(BaseCompiler):
         self,
         ctx: CompileContext,
         ql: qlast.Base
-    ) -> (dbstate.BaseQuery, enums.Capability):
+    ) -> Tuple[dbstate.BaseQuery, enums.Capability]:
         if isinstance(ql, qlast.Migration):
             query = self._compile_ql_migration(ctx, ql)
             if isinstance(query, dbstate.MigrationControlQuery):
@@ -1545,6 +1546,7 @@ class Compiler(BaseCompiler):
                 unit.sql += comp.sql
                 unit.new_types = comp.new_types
                 unit.drop_db = comp.drop_db
+                unit.has_role_ddl = comp.has_role_ddl
                 if comp.drop_db:
                     units.append(unit)
                     unit = None

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -114,6 +114,7 @@ class DDLQuery(BaseQuery):
     is_transactional: bool = True
     single_unit: bool = False
     drop_db: Optional[str] = None
+    has_role_ddl: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -179,6 +180,9 @@ class QueryUnit:
 
     # True if this unit contains SET commands.
     has_set: bool = False
+
+    # True if this unit contains ALTER/DROP/CREATE ROLE commands.
+    has_role_ddl: bool = False
 
     # If tx_id is set, it means that the unit
     # starts a new transaction.

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -22,6 +22,7 @@ cpdef enum SideEffects:
     SchemaChanges = 1 << 0
     DatabaseConfigChanges = 1 << 1
     SystemConfigChanges = 1 << 2
+    RoleChanges = 1 << 3
 
 
 cdef class DatabaseIndex:
@@ -31,8 +32,6 @@ cdef class DatabaseIndex:
         object _server
 
         object _sys_config
-        object _sys_queries
-        object _instance_data
 
 
 cdef class Database:
@@ -68,6 +67,7 @@ cdef class DatabaseConnectionView:
         object _in_tx_config
         bint _in_tx
         bint _in_tx_with_ddl
+        bint _in_tx_with_role_ddl
         bint _in_tx_with_sysconfig
         bint _in_tx_with_dbconfig
         bint _in_tx_with_set

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -1277,6 +1277,8 @@ cdef class PGConnection:
                     self.server._on_remote_database_config_change(dbname)
                 elif event == 'system-config-changes':
                     self.server._on_remote_system_config_change()
+                elif event == 'role-changes':
+                    self.server._on_role_change()
                 else:
                     raise AssertionError(f'unexpected system event: {event!r}')
 

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -65,6 +65,7 @@ class TestServerOps(tb.TestCase):
             '--temp-dir',
             '--auto-shutdown',
             '--echo-runtime-info',
+            '--max-backend-connections', '5',
             f'--bootstrap-command={bootstrap_command}',
         ]
 
@@ -136,6 +137,7 @@ class TestServerOps(tb.TestCase):
             '--temp-dir',
             '--bootstrap-command=SELECT 1',
             '--bootstrap-only',
+            '--max-backend-connections', '5',
         ]
 
         # Note: for debug comment "stderr=subprocess.PIPE".


### PR DESCRIPTION
This eliminates querying Postgres when a client establishes a
new connection to EdgeDB, making the connection cost cheaper.

The downside of this approach is that auth data doesn't update
instantaneously after CREATE/ALTER/DROP ROLE.

ToDo:

- [x] add a test that the Role DDL signal is actually issued.