### PR TITLE
Bump the graphql-core version to 3.1.2

### DIFF
--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -173,7 +173,10 @@ def coerce_bigint(value: Any) -> int:
     return num
 
 
-def parse_int_literal(ast: gql_ast.Node) -> Optional[int]:
+def parse_int_literal(
+    ast: gql_ast.Node,
+    _variables: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
     if isinstance(ast, gql_ast.IntValueNode):
         return int(ast.value)
     else:
@@ -201,7 +204,10 @@ GraphQLBigint = GraphQLScalarType(
 )
 
 
-def parse_decimal_literal(ast: gql_ast.Node) -> Optional[float]:
+def parse_decimal_literal(
+    ast: gql_ast.Node,
+    _variables: Optional[Dict[str, Any]] = None,
+) -> Optional[float]:
     if isinstance(ast, (gql_ast.FloatValueNode, gql_ast.IntValueNode)):
         return float(ast.value)
     else:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ RUNTIME_DEPS = [
     'uvloop~=0.14.0',
     'wcwidth~=0.2.5',
 
-    'graphql-core~=3.0.3',
+    'graphql-core~=3.1.2',
     'promise~=2.2.0',
 
     'edgedb>=0.13.0a1',

--- a/tests/test_http_graphql_mutation.py
+++ b/tests/test_http_graphql_mutation.py
@@ -1239,7 +1239,7 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
     def test_graphql_mutation_insert_bad_02(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,
-            r"Field 'data' is not defined by type NestedInsertNamedObject"
+            r"Field 'data' is not defined by type 'NestedInsertNamedObject'"
         ):
             self.graphql_query(r"""
                 mutation insert_User {

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -390,7 +390,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_query_11(self):
         # Test that parse error marshal from the compiler correctly.
         with self.assertRaisesRegex(edgedb.QueryError,
-                                    r'Expected Name, found \}',
+                                    r"Expected Name, found '}'",
                                     _line=4, _col=21):
             self.graphql_query(r"""
                 query {
@@ -1296,7 +1296,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_arguments_21(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type Boolean, found 0\.',
+                r'Expected type Boolean, found 0',
                 _line=3, _col=48):
             self.graphql_query(r"""
                 query {
@@ -2529,7 +2529,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_12(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type Boolean, found 1\.',
+                r'Boolean cannot represent a non boolean value: 1',
                 _line=2, _col=39):
             self.graphql_query(r"""
                 query($val: Boolean = 1) {
@@ -2543,7 +2543,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_13(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type Boolean, found "1"\.',
+                r'Boolean cannot represent a non boolean value: "1"',
                 _line=2, _col=39):
             self.graphql_query(r"""
                 query($val: Boolean = "1") {
@@ -2557,7 +2557,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_14(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type Boolean, found 1\.3\.',
+                r'Boolean cannot represent a non boolean value: 1\.3',
                 _line=2, _col=39):
             self.graphql_query(r"""
                 query($val: Boolean = 1.3) {
@@ -2571,7 +2571,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_15(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type String, found 1\.',
+                r'String cannot represent a non string value: 1',
                 _line=2, _col=38):
             self.graphql_query(r"""
                 query($val: String = 1) {
@@ -2584,7 +2584,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_16(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type String, found 1\.1\.',
+                r'String cannot represent a non string value: 1\.1',
                 _line=2, _col=38):
             self.graphql_query(r"""
                 query($val: String = 1.1) {
@@ -2597,7 +2597,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_17(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type String, found true\.',
+                r'String cannot represent a non string value: true',
                 _line=2, _col=38):
             self.graphql_query(r"""
                 query($val: String = true) {
@@ -2610,7 +2610,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_18(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type Int, found 1\.1\.',
+                r'Int cannot represent non-integer value: 1\.1',
                 _line=2, _col=35):
             self.graphql_query(r"""
                 query($val: Int = 1.1) {
@@ -2623,7 +2623,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_19(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type Int, found "1".',
+                r'Int cannot represent non-integer value: "1"',
                 _line=2, _col=35):
             self.graphql_query(r"""
                 query($val: Int = "1") {
@@ -2636,7 +2636,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_20(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type Int, found true.',
+                r'Int cannot represent non-integer value: true',
                 _line=2, _col=35):
             self.graphql_query(r"""
                 query($val: Int = true) {
@@ -2649,7 +2649,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_21(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type Float, found "1".',
+                r'Float cannot represent non numeric value: "1"',
                 _line=2, _col=37):
             self.graphql_query(r"""
                 query($val: Float = "1") {
@@ -2662,7 +2662,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_22(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type Float, found true.',
+                r'Float cannot represent non numeric value: true',
                 _line=2, _col=37):
             self.graphql_query(r"""
                 query($val: Float = true) {
@@ -2686,7 +2686,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_25(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type ID, found 1\.1\.',
+                r'ID cannot represent a non-string and non-integer.+: 1\.1',
                 _line=2, _col=34):
             self.graphql_query(r"""
                 query($val: ID = 1.1) {
@@ -2699,7 +2699,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_26(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type ID, found true\.',
+                r'ID cannot represent a non-string and non-integer.+: true',
                 _line=2, _col=34):
             self.graphql_query(r"""
                 query($val: ID = true) {
@@ -2763,7 +2763,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_31(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r"Expected type String, found 123\.",
+                r"String cannot represent a non string value: 123",
                 _line=2, _col=48):
             self.graphql_query(r"""
                 query($val: [String] = ["Foo", 123]) {
@@ -2996,7 +2996,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_enum_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'Expected type String, found admin\.',
+                r'String cannot represent a non string value: admin',
                 _line=4, _col=51):
             self.graphql_query(r"""
                 query {

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -145,6 +145,30 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                             }
                         ]
                     },
+                    {
+                        "name": 'specifiedBy',
+                        "description":
+                            "Exposes a URL that specifies the behaviour of "
+                            "this scalar.",
+                        "locations": ['SCALAR'],
+                        "args": [
+                            {
+                                "name": 'url',
+                                "type": {
+                                    "kind": 'NON_NULL',
+                                    "name": None,
+                                    "ofType": {
+                                        "kind": 'SCALAR',
+                                        "name": 'String'
+                                    },
+                                },
+                                "description":
+                                    "The URL that specifies the behaviour of "
+                                    "this scalar.",
+                                "defaultValue": None
+                            }
+                        ],
+                    },
                 ]
             }
         }, sort={
@@ -225,7 +249,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
     def test_graphql_schema_base_05(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r"Unknown argument 'name' on field '__schema' of type 'Query'",
+                r"Unknown argument 'name' on field 'Query\.__schema'",
                 _line=3, _col=30):
             self.graphql_query(r"""
                 query {
@@ -383,7 +407,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                 "kind": "INTERFACE",
                 "name": "User",
                 "description": None,
-                "interfaces": None,
+                "interfaces": [],
                 "possibleTypes": [
                     {"name": "Person_Type"},
                     {"name": "User_Type"}
@@ -899,7 +923,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                         "deprecationReason": None
                     }
                 ],
-                "interfaces": None,
+                "interfaces": [],
                 "possibleTypes": [
                     {
                         "__typename": "__Type",
@@ -2372,5 +2396,24 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                 "description": None,
                 "inputFields": None,
                 "possibleTypes": None,
+            }
+        })
+
+    def test_graphql_schema_type_19(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                __type(name: "String") {
+                    __typename
+                    name
+                    kind
+                    specifiedByUrl
+                }
+            }
+        """, {
+            "__type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "__typename": "__Type",
+                "specifiedByUrl": None,
             }
         })


### PR DESCRIPTION
Mainly the changes involve some variations of the error messages.
However, a new directive is introduced in this version of graphql-core:
`specifiedBy`. This is intended to be used in GraphQL schema definitions
to annotate custom scalars, which is something that could become useful
to us in the future as it addresses the issue of client code identifying
which implementaiton a given custom scalar is actually using.

There's also a change of the signature of `parse_literal` for scalars,
but the extra parameter doesn't appear to be relevant for our use case
(handling different numeric scalars).