### PR TITLE
Make the error message for function variants more descriptive.

### DIFF
--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -139,7 +139,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
         for c in cases:
             with self.assertRaisesRegex(
                     edgedb.QueryError,
-                    r'could not find a function variant'):
+                    r'function .+ does not exist'):
                 async with self.con.transaction():
                     await self.con.execute(c)
 
@@ -315,7 +315,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
         for c in cases:
             with self.assertRaisesRegex(
                     edgedb.QueryError,
-                    r'could not find a function variant'):
+                    r'function .+ does not exist'):
                 async with self.con.transaction():
                     await self.con.execute(c)
 
@@ -507,7 +507,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
         for c in cases:
             with self.assertRaisesRegex(
                     edgedb.QueryError,
-                    r'could not find a function variant'):
+                    r'function .+ does not exist'):
                 async with self.con.transaction():
                     await self.con.execute(c)
 
@@ -766,7 +766,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'could not find a function variant'):
+                r'function .+ does not exist'):
 
             async with self.con.transaction():
                 await self.con.execute('SELECT test::call18(1, 2, "a");')
@@ -826,7 +826,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'could not find a function variant'):
+                r'function .+ does not exist'):
             async with self.con.transaction():
                 await self.con.execute('SELECT test::call20_1(1, "1");')
 
@@ -974,7 +974,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'could not find a function variant'):
+                r'function .+ does not exist'):
             async with self.con.transaction():
                 await self.con.execute('SELECT test::call26([(1, 2)]);')
 
@@ -1008,7 +1008,7 @@ class TestEdgeQLFuncCalls(tb.QueryTestCase):
         for c in cases:
             with self.assertRaisesRegex(
                     edgedb.QueryError,
-                    r'could not find a function variant'):
+                    r'function .+ does not exist'):
                 async with self.con.transaction():
                     await self.con.execute(c)
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -5011,7 +5011,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # make sure that the old one is gone
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'could not find a function variant hello11'):
+                r'function "hello11\(arg0: std::int64\)" does not exist'):
             await self.con.execute(
                 r"""SELECT hello11(1);"""
             )
@@ -5099,7 +5099,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # make sure that the other one is gone
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'could not find a function variant hello13'):
+                r'function "hello13\(arg0: std::str\)" does not exist'):
             await self.con.execute(
                 r"""SELECT hello13(' world');"""
             )
@@ -5137,7 +5137,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # make sure that the old one is gone
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'could not find a function variant hello14'):
+                r'function "hello14\(arg0: std::str, arg1: std::str\)" '
+                r'does not exist'):
             await self.assert_query_result(
                 r"""SELECT hello14('hello', '14');""",
                 ['hello14'],
@@ -5176,7 +5177,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # make sure that the old one is gone
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'could not find a function variant hello15'):
+                r'function "hello15\(arg0: std::str, arg1: std::str\)" '
+                r'does not exist'):
             await self.assert_query_result(
                 r"""SELECT hello15('hello', '15');""",
                 ['hello15'],

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -595,7 +595,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_array_get_03(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'could not find a function variant array_get'):
+                r'function "array_get.+" does not exist'):
 
             await self.con.query(r'''
                 SELECT array_get([1, 2, 3], 2^40);

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -2742,8 +2742,9 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ]}]
         )
 
-        with self.assertRaisesRegex(edgedb.QueryError,
-                                    'could not find a function variant'):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'function .+ does not exist'):
             async with self.con.transaction():
                 await self.con.query(
                     "SELECT test::concat1('aaa', 'bbb', 2);")
@@ -2758,8 +2759,9 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 USING SQL FUNCTION 'concat';
         ''')
 
-        with self.assertRaisesRegex(edgedb.QueryError,
-                                    'could not find a function'):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'function .+ does not exist'):
             await self.con.execute(r'SELECT test::concat2(123);')
 
     async def test_edgeql_select_func_07(self):
@@ -2826,13 +2828,15 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             }]
         )
 
-        with self.assertRaisesRegex(edgedb.QueryError,
-                                    'could not find a function'):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'function .+ does not exist'):
             async with self.con.transaction():
                 await self.con.query(r'SELECT test::concat3(123);')
 
-        with self.assertRaisesRegex(edgedb.QueryError,
-                                    'could not find a function'):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'function .+ does not exist'):
             async with self.con.transaction():
                 await self.con.query(r'SELECT test::concat3("a", 123);')
 


### PR DESCRIPTION
Update the error message to indicate that it's the function input and
not the missing function that's the issue. Also add a hint about what
can be done to view function variants.

Fixes #1994