### PR TITLE
Preserve original text representation of migrations in dumps

### DIFF
--- a/edb/common/ast/codegen.py
+++ b/edb/common/ast/codegen.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import *
 
 import itertools
+import textwrap
 
 from . import base
 from .visitor import NodeVisitor
@@ -120,3 +121,6 @@ class SourceGenerator(NodeVisitor):
                         pretty=pretty, **kwargs)
         generator.visit(node)
         return ''.join(generator.result)
+
+    def indent_text(self, text: str) -> str:
+        return textwrap.indent(text, self.indent_with * self.indentation)

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -691,6 +691,7 @@ class MigrationBody(DDL):
 class CreateMigration(CreateObject, Migration):
 
     body: MigrationBody
+    script: typing.Optional[str] = None
     parent: typing.Optional[ObjectRef] = None
     message: typing.Optional[str] = None
     metadata_only: bool = False

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1001,7 +1001,13 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 self.write(ident_to_str(node.parent.name))
             else:
                 self.write('initial')
-        if node.body.commands:
+        if node.script is not None:
+            self.write(' {')
+            self._block_ws(1)
+            self.write(self.indent_text(node.script))
+            self._block_ws(-1)
+            self.write('}')
+        elif node.body.commands:
             self._ddl_visit_body(node.body.commands)
 
     def visit_StartMigration(self, node: qlast.StartMigration) -> None:

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -211,6 +211,7 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
     ) -> None:
         assert isinstance(node, qlast.CreateMigration)
         if op.property == 'script':
+            node.script = op.new_value
             node.body = qlast.MigrationBody(
                 commands=qlparser.parse_block(op.new_value)
             )

--- a/tests/schemas/dump02_setup.edgeql
+++ b/tests/schemas/dump02_setup.edgeql
@@ -53,7 +53,8 @@ INSERT Łukasz {
     )
 };
 
-CREATE MIGRATION m1bkvqo5h2o6zptgch4m3tg27xszrprq2mu2qdboe4g7jh5wi5nyfa
+CREATE MIGRATION m1nwaxnkxpixj4ignmxg6kivmevnhv62aoa3nzxiotxmx4gmp65xhq
 ONTO m1n3v3eqsjlwqi7ebltfrdykhlzgoxvfi46o7mt443z6urwzetayka {
     CREATE TYPE default::Migrated;
+    create type default::Migrated2 {};
 };


### PR DESCRIPTION
Migration name is derived from the original token stream of the
migration body.  Hence, when a migration is dumped, the original tokens
must be used.

Fixes: #2089