### PR TITLE
Fix handling of implicit path prefix in the ELSE part of UNLESS CONFLICT

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -377,6 +377,7 @@ def compile_InsertQuery(
             bodyctx.banned_paths = ictx.banned_paths.copy()
             pathctx.ban_path(subject.path_id, ctx=bodyctx)
 
+            bodyctx.class_view_overrides = ictx.class_view_overrides.copy()
             bodyctx.implicit_id_in_shapes = False
             bodyctx.implicit_tid_in_shapes = False
             bodyctx.implicit_tname_in_shapes = False
@@ -459,6 +460,7 @@ def compile_UpdateQuery(
             stmt, expr.where, ctx=ictx)
 
         with ictx.new() as bodyctx:
+            bodyctx.class_view_overrides = ictx.class_view_overrides.copy()
             bodyctx.implicit_id_in_shapes = False
             bodyctx.implicit_tid_in_shapes = False
             bodyctx.implicit_tname_in_shapes = False

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -47,7 +47,7 @@ type Note {
 type Person {
     required single property name -> std::str {
         constraint std::exclusive;
-	default := "Nemo";
+        default := "Nemo";
     };
     optional single property tag -> std::str;
     optional multi link notes -> Note;


### PR DESCRIPTION
Currently, the implicit path prefix for the `ELSE` context would be
erroneously set to that of the `INSERT` shape type variant, thus picking
up computables from the `INSERT` shape instead of referring to the
physical properties of the existing object.

Per report from @tailhook.