### PR TITLE
Implement migration data safety annotations

### DIFF
--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -35,9 +35,13 @@ if TYPE_CHECKING:
     from . import schema as s_schema
 
 
-class Annotation(so.QualifiedObject,
-                 so.InheritingObject,
-                 qlkind=qltypes.SchemaObjectClass.ANNOTATION):
+class Annotation(
+    so.QualifiedObject,
+    so.InheritingObject,
+    qlkind=qltypes.SchemaObjectClass.ANNOTATION,
+    data_safe=True,
+):
+
     inheritable = so.SchemaField(
         bool, default=False, compcoef=0.2)
 
@@ -54,6 +58,7 @@ class AnnotationValue(
     qlkind=qltypes.SchemaObjectClass.ANNOTATION,
     reflection=so.ReflectionMethod.AS_LINK,
     reflection_link='annotation',
+    data_safe=True,
 ):
 
     subject = so.SchemaField(

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -167,6 +167,7 @@ class Cast(
     s_func.VolatilitySubject,
     s_abc.Cast,
     qlkind=qltypes.SchemaObjectClass.CAST,
+    data_safe=True,
 ):
 
     from_type = so.SchemaField(

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -77,9 +77,12 @@ def merge_constraint_params(
         return supers[0].get_explicit_field_value(schema, field_name, None)
 
 
-class Constraint(referencing.ReferencedInheritingObject,
-                 s_func.CallableObject, s_abc.Constraint,
-                 qlkind=ft.SchemaObjectClass.CONSTRAINT):
+class Constraint(
+    referencing.ReferencedInheritingObject,
+    s_func.CallableObject, s_abc.Constraint,
+    qlkind=ft.SchemaObjectClass.CONSTRAINT,
+    data_safe=True,
+):
 
     params = so.SchemaField(
         s_func.FuncParameterList,

--- a/edb/schema/database.py
+++ b/edb/schema/database.py
@@ -34,8 +34,13 @@ from . import objects as so
 from . import schema as s_schema
 
 
-class Database(so.GlobalObject, s_anno.AnnotationSubject, s_abc.Database,
-               qlkind=qltypes.SchemaObjectClass.DATABASE):
+class Database(
+    so.GlobalObject,
+    s_anno.AnnotationSubject,
+    s_abc.Database,
+    qlkind=qltypes.SchemaObjectClass.DATABASE,
+    data_safe=False,
+):
     pass
 
 

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -42,6 +42,7 @@ class Alias(
     so.QualifiedObject,
     s_anno.AnnotationSubject,
     qlkind=qltypes.SchemaObjectClass.ALIAS,
+    data_safe=True,
 ):
 
     expr = so.SchemaField(

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -339,6 +339,7 @@ class Parameter(
     so.ObjectFragment,
     ParameterLike,
     qlkind=ft.SchemaObjectClass.PARAMETER,
+    data_safe=True,
 ):
 
     num = so.SchemaField(
@@ -1104,8 +1105,13 @@ class DeleteCallableObject(
         return cmd
 
 
-class Function(CallableObject, VolatilitySubject, s_abc.Function,
-               qlkind=ft.SchemaObjectClass.FUNCTION):
+class Function(
+    CallableObject,
+    VolatilitySubject,
+    s_abc.Function,
+    qlkind=ft.SchemaObjectClass.FUNCTION,
+    data_safe=True,
+):
 
     # A backend_name that is shared between all overloads of the same
     # function, to make them independent from the actual name.

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -47,6 +47,7 @@ class Index(
     referencing.ReferencedInheritingObject,
     s_anno.AnnotationSubject,
     qlkind=qltypes.SchemaObjectClass.INDEX,
+    data_safe=True,
 ):
 
     subject = so.SchemaField(so.Object)

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -101,8 +101,13 @@ def merge_actions(
         return ours
 
 
-class Link(sources.Source, pointers.Pointer, s_abc.Link,
-           qlkind=qltypes.SchemaObjectClass.LINK):
+class Link(
+    sources.Source,
+    pointers.Pointer,
+    s_abc.Link,
+    qlkind=qltypes.SchemaObjectClass.LINK,
+    data_safe=False,
+):
 
     on_target_delete = so.SchemaField(
         LinkTargetDeleteAction,

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -42,8 +42,12 @@ if TYPE_CHECKING:
     from . import schema as s_schema
 
 
-class Property(pointers.Pointer, s_abc.Property,
-               qlkind=qltypes.SchemaObjectClass.PROPERTY):
+class Property(
+    pointers.Pointer,
+    s_abc.Property,
+    qlkind=qltypes.SchemaObjectClass.PROPERTY,
+    data_safe=False,
+):
 
     def derive_ref(
         self,

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -45,6 +45,7 @@ class Migration(
     so.Object,
     s_abc.Migration,
     qlkind=qltypes.SchemaObjectClass.MIGRATION,
+    data_safe=False,
 ):
 
     parents = so.SchemaField(

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -32,6 +32,7 @@ from . import schema as s_schema
 class Module(
     s_anno.AnnotationSubject,
     qlkind=qltypes.SchemaObjectClass.MODULE,
+    data_safe=False,
 ):
     pass
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -554,6 +554,10 @@ class ObjectMeta(type):
     _ql_class: Optional[qltypes.SchemaObjectClass]
     _reflection_method: ReflectionMethod
     _reflection_link: Optional[str]
+    #: Indicates that ALL changes to this object class are safe from the
+    #: standpoint of persistent data.  In other words, changes to the
+    #: object are fully reversible without possible data loss.
+    _data_safe: bool
 
     def __new__(
         mcls,
@@ -564,6 +568,7 @@ class ObjectMeta(type):
         qlkind: Optional[qltypes.SchemaObjectClass] = None,
         reflection: ReflectionMethod = ReflectionMethod.REGULAR,
         reflection_link: Optional[str] = None,
+        data_safe: bool = False,
     ) -> ObjectMeta:
         refdicts: collections.OrderedDict[str, RefDict]
 
@@ -613,6 +618,7 @@ class ObjectMeta(type):
                     for k, d in parent.get_own_refdicts().items()
                 })
 
+        cls._data_safe = data_safe
         cls._fields = fields
         cls._schema_fields = {
             fn: f for fn, f in fields.items()

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -50,6 +50,7 @@ class ObjectType(
     constraints.ConsistencySubject,
     s_abc.ObjectType,
     qlkind=qltypes.SchemaObjectClass.TYPE,
+    data_safe=False,
 ):
 
     union_of = so.SchemaField(

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -36,8 +36,13 @@ if TYPE_CHECKING:
     from edb.schema import schema as s_schema
 
 
-class Operator(s_func.CallableObject, s_func.VolatilitySubject,
-               s_abc.Operator, qlkind=ft.SchemaObjectClass.OPERATOR):
+class Operator(
+    s_func.CallableObject,
+    s_func.VolatilitySubject,
+    s_abc.Operator,
+    qlkind=ft.SchemaObjectClass.OPERATOR,
+    data_safe=True,
+):
 
     operator_kind = so.SchemaField(
         ft.OperatorKind, coerce=True, compcoef=0.4)

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -101,9 +101,7 @@ def linearize_delta(
         _trace_op(op, opbranch, depgraph, renames,
                   renames_r, strongrefs, old_schema, new_schema)
 
-    depgraph = dict(
-        filter(lambda i: i[1].item != (), depgraph.items()))
-
+    depgraph = dict(filter(lambda i: i[1].item != (), depgraph.items()))
     everything = set(depgraph)
     for item in depgraph.values():
         item.deps &= everything

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1468,6 +1468,9 @@ class SetPointerType(
         )
         return f'alter the type of {object_desc}'
 
+    def is_data_safe(self) -> bool:
+        return False
+
     def _alter_begin(
         self,
         schema: s_schema.Schema,
@@ -1563,6 +1566,17 @@ class AlterPointerUpperCardinality(
     PointerCommandOrFragment[Pointer_T],
 ):
     """Handler for the "cardinality" field changes."""
+
+    def is_data_safe(self) -> bool:
+        old_val = self.get_orig_attribute_value('cardinality')
+        new_val = self.get_attribute_value('cardinality')
+        if (
+            old_val is qltypes.SchemaCardinality.Many
+            and new_val is qltypes.SchemaCardinality.One
+        ):
+            return False
+        else:
+            return True
 
     def _alter_begin(
         self,

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -36,8 +36,13 @@ if TYPE_CHECKING:
     from edb.schema import schema as s_schema
 
 
-class Role(so.GlobalObject, so.InheritingObject,
-           s_anno.AnnotationSubject, qlkind=qltypes.SchemaObjectClass.ROLE):
+class Role(
+    so.GlobalObject,
+    so.InheritingObject,
+    s_anno.AnnotationSubject,
+    qlkind=qltypes.SchemaObjectClass.ROLE,
+    data_safe=True,
+):
 
     is_superuser = so.SchemaField(
         bool,

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -46,6 +46,7 @@ class ScalarType(
     constraints.ConsistencySubject,
     s_abc.ScalarType,
     qlkind=qltypes.SchemaObjectClass.SCALAR_TYPE,
+    data_safe=True,
 ):
 
     default = so.SchemaField(

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -960,6 +960,7 @@ class Compiler(BaseCompiler):
                         'confidence': top_op.get_annotation('confidence'),
                         'prompt': top_op.get_annotation('user_prompt'),
                         'operation_id': op_id,
+                        'data_safe': top_op.is_data_safe(),
                     }
                 else:
                     proposed_desc = None


### PR DESCRIPTION
Most migration operations now have a `data_safe` annotation that
indicates whether the operation is lossless.