### PR TITLE
Straighten internal exception-raising helpers

### DIFF
--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -178,7 +178,7 @@ sys::_advisory_lock(key: std::int64) -> std::bool
     SET volatility := 'VOLATILE';
     USING SQL $$
     SELECT CASE WHEN "key" < 0 THEN
-        edgedb._raise_exception('lock key cannot be negative', NULL::bool)
+        edgedb.raise(NULL::bool, msg => 'lock key cannot be negative')
     ELSE
         pg_advisory_lock("key") IS NOT NULL
     END;
@@ -195,7 +195,7 @@ sys::_advisory_unlock(key: std::int64) -> std::bool
     SET volatility := 'VOLATILE';
     USING SQL $$
     SELECT CASE WHEN "key" < 0 THEN
-        edgedb._raise_exception('lock key cannot be negative', NULL::bool)
+        edgedb.raise(NULL::bool, msg => 'lock key cannot be negative')
     ELSE
         pg_advisory_unlock("key")
     END;

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -41,17 +41,22 @@ cal::to_local_datetime(s: std::str, fmt: OPTIONAL str={})
         CASE WHEN "fmt" IS NULL THEN
             edgedb.local_datetime_in("s")
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::timestamp,
                 'invalid_parameter_value',
-                'to_local_datetime(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::timestamp)
+                msg => (
+                    'to_local_datetime(): '
+                    || '"fmt" argument must be a non-empty string'
+                )
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 edgedb.to_local_datetime("s", "fmt"),
                 'invalid_parameter_value',
-                'to_local_datetime(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => (
+                    'to_local_datetime(): '
+                    || 'format ''' || "fmt" || ''' is invalid'
+                )
             )
         END
     )
@@ -101,17 +106,21 @@ cal::to_local_date(s: std::str, fmt: OPTIONAL str={}) -> cal::local_date
         CASE WHEN "fmt" IS NULL THEN
             edgedb.local_date_in("s")
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::date,
                 'invalid_parameter_value',
-                'to_local_date(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::date)
+                msg => (
+                    'to_local_date(): '
+                    || '"fmt" argument must be a non-empty string'
+                )
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 edgedb.to_local_datetime("s", "fmt")::date,
                 'invalid_parameter_value',
-                'to_local_date(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => (
+                    'to_local_date(): format ''' || "fmt" || ''' is invalid'
+                )
             )
         END
     )
@@ -155,17 +164,22 @@ cal::to_local_time(s: std::str, fmt: OPTIONAL str={}) -> cal::local_time
         CASE WHEN "fmt" IS NULL THEN
             edgedb.local_time_in("s")
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::time,
                 'invalid_parameter_value',
-                'to_local_time(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::time)
+                msg => (
+                    'to_local_time(): '
+                    || '"fmt" argument must be a non-empty string'
+                )
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 edgedb.to_local_datetime("s", "fmt")::time,
                 'invalid_parameter_value',
-                'to_local_time(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => (
+                    'to_local_time(): '
+                    || 'format ''' || "fmt" || ''' is invalid'
+                )
             )
         END
     )
@@ -212,13 +226,16 @@ cal::time_get(dt: cal::local_time, el: std::str) -> std::float64
         WHEN "el" = 'midnightseconds'
         THEN date_part('epoch', "dt")
         ELSE
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::float,
                 'invalid_datetime_format',
-                'invalid unit for std::time_get: '
-                    || quote_literal("el"),
-                '{"hint":"Supported units: hour, microseconds, ' ||
-                'midnightseconds, milliseconds, minutes, seconds."}',
-                NULL::float
+                msg => (
+                    'invalid unit for std::time_get: ' || quote_literal("el")
+                ),
+                detail => (
+                    '{"hint":"Supported units: hour, microseconds, ' ||
+                    'midnightseconds, milliseconds, minutes, seconds."}'
+                )
             )
         END
     $$;
@@ -238,14 +255,17 @@ cal::date_get(dt: cal::local_date, el: std::str) -> std::float64
             'month', 'quarter', 'week', 'year')
         THEN date_part("el", "dt")
         ELSE
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::float,
                 'invalid_datetime_format',
-                'invalid unit for std::date_get: '
-                    || quote_literal("el"),
-                '{"hint":"Supported units: century, day, ' ||
-                'decade, dow, doy, isodow, isoyear, ' ||
-                'millenium, month, quarter, seconds, week, year."}',
-                NULL::float
+                msg => (
+                    'invalid unit for std::date_get: ' || quote_literal("el")
+                ),
+                detail => (
+                    '{"hint":"Supported units: century, day, ' ||
+                    'decade, dow, doy, isodow, isoyear, ' ||
+                    'millenium, month, quarter, seconds, week, year."}'
+                )
             )
         END
     $$;
@@ -666,15 +686,19 @@ std::datetime_get(dt: cal::local_datetime, el: std::str) -> std::float64
         WHEN "el" = 'epochseconds'
         THEN date_part('epoch', "dt")
         ELSE
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::float,
                 'invalid_datetime_format',
-                'invalid unit for std::datetime_get: '
-                    || quote_literal("el"),
-                '{"hint":"Supported units: epochseconds, century, day, ' ||
-                'decade, dow, doy, hour, isodow, isoyear, microseconds, ' ||
-                'millenium, milliseconds, minutes, month, quarter, ' ||
-                'seconds, week, year."}',
-                NULL::float
+                msg => (
+                    'invalid unit for std::datetime_get: '
+                    || quote_literal("el")
+                ),
+                detail => (
+                    '{"hint":"Supported units: epochseconds, century, '
+                    || 'day, decade, dow, doy, hour, isodow, isoyear, '
+                    || 'microseconds, millenium, milliseconds, minutes, '
+                    || 'month, quarter, seconds, week, year."}'
+                )
             )
         END
     $$;
@@ -693,17 +717,16 @@ std::to_str(dt: cal::local_datetime, fmt: OPTIONAL str={}) -> std::str
         CASE WHEN "fmt" IS NULL THEN
             trim(to_json("dt")::text, '"')
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::text,
                 'invalid_parameter_value',
-                'to_str(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::text)
+                msg => 'to_str(): "fmt" argument must be a non-empty string'
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_char("dt", "fmt"),
                 'invalid_parameter_value',
-                'to_str(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_str(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -723,17 +746,16 @@ std::to_str(d: cal::local_date, fmt: OPTIONAL str={}) -> std::str
         CASE WHEN "fmt" IS NULL THEN
             "d"::text
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::text,
                 'invalid_parameter_value',
-                'to_str(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::text)
+                msg => 'to_str(): "fmt" argument must be a non-empty string'
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_char("d", "fmt"),
                 'invalid_parameter_value',
-                'to_str(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_str(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -759,17 +781,16 @@ std::to_str(nt: cal::local_time, fmt: OPTIONAL str={}) -> std::str
         CASE WHEN "fmt" IS NULL THEN
             "nt"::text
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::text,
                 'invalid_parameter_value',
-                'to_str(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::text)
+                msg => 'to_str(): "fmt" argument must be a non-empty string'
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_char(date_trunc('day', localtimestamp) + "nt", "fmt"),
                 'invalid_parameter_value',
-                'to_str(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_str(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )

--- a/edb/lib/std/25-numoperators.edgeql
+++ b/edb/lib/std/25-numoperators.edgeql
@@ -2035,11 +2035,10 @@ CREATE CAST FROM std::float32 TO std::decimal {
             THEN
                 val::numeric
             ELSE
-                edgedb._raise_specific_exception(
+                edgedb.raise(
+                    NULL::numeric,
                     'invalid_text_representation',
-                    'invalid value for numeric: ' || quote_literal(val),
-                    '',
-                    NULL::numeric
+                    msg => 'invalid value for numeric: ' || quote_literal(val)
                 )
             END)
         ;
@@ -2081,11 +2080,10 @@ CREATE CAST FROM std::float64 TO std::decimal {
             THEN
                 val::numeric
             ELSE
-                edgedb._raise_specific_exception(
+                edgedb.raise(
+                    NULL::numeric,
                     'invalid_text_representation',
-                    'invalid value for numeric: ' || quote_literal(val),
-                    '',
-                    NULL::numeric
+                    msg => 'invalid value for numeric: ' || quote_literal(val)
                 )
             END)
         ;

--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -67,15 +67,19 @@ std::datetime_get(dt: std::datetime, el: std::str) -> std::float64
         WHEN "el" = 'epochseconds'
         THEN date_part('epoch', "dt")
         ELSE
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::float,
                 'invalid_datetime_format',
-                'invalid unit for std::datetime_get: '
-                    || quote_literal("el"),
-                '{"hint":"Supported units: epochseconds, century, day, ' ||
-                'decade, dow, doy, hour, isodow, isoyear, microseconds, ' ||
-                'millenium, milliseconds, minutes, month, quarter, ' ||
-                'seconds, week, year."}',
-                NULL::float
+                msg => (
+                    'invalid unit for std::datetime_get: '
+                    || quote_literal("el")
+                ),
+                detail => (
+                    '{"hint":"Supported units: epochseconds, century, day, '
+                    || 'decade, dow, doy, hour, isodow, isoyear, '
+                    || 'microseconds, millenium, milliseconds, minutes, '
+                    || 'month, quarter, seconds, week, year."}'
+                )
             )
         END
     $$;
@@ -98,14 +102,18 @@ std::datetime_truncate(dt: std::datetime, unit: std::str) -> std::datetime
         WHEN "unit" = 'quarters'
         THEN date_trunc('quarter', "dt")
         ELSE
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::timestamptz,
                 'invalid_datetime_format',
-                'invalid unit for std::datetime_truncate: '
-                    || quote_literal("unit"),
-                '{"hint":"Supported units: microseconds, milliseconds, ' ||
-                'seconds, minutes, hours, days, weeks, months, quarters, ' ||
-                'years, decades, centuries."}',
-                NULL::timestamptz
+                msg => (
+                    'invalid unit for std::datetime_truncate: '
+                    || quote_literal("unit")
+                ),
+                detail => (
+                    '{"hint":"Supported units: microseconds, milliseconds, '
+                    || 'seconds, minutes, hours, days, weeks, months, '
+                    || 'quarters, years, decades, centuries."}'
+                )
             )
         END
     $$;
@@ -123,13 +131,17 @@ std::duration_truncate(dt: std::duration, unit: std::str) -> std::duration
                                 'seconds', 'minutes', 'hours')
         THEN date_trunc("unit", "dt")
         ELSE
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::interval,
                 'invalid_datetime_format',
-                'invalid unit for std::duration_truncate: '
-                    || quote_literal("unit"),
-                '{"hint":"Supported units: microseconds, milliseconds, ' ||
-                'seconds, minutes, hours."}',
-                NULL::interval
+                msg => (
+                    'invalid unit for std::duration_truncate: '
+                    || quote_literal("unit")
+                ),
+                detail => (
+                    '{"hint":"Supported units: microseconds, milliseconds, '
+                    || 'seconds, minutes, hours."}'
+                )
             )
         END
     $$;

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -42,17 +42,16 @@ std::to_str(dt: std::datetime, fmt: OPTIONAL str={}) -> std::str
         CASE WHEN "fmt" IS NULL THEN
             trim(to_json("dt")::text, '"')
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::text,
                 'invalid_parameter_value',
-                'to_str(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::text)
+                msg => 'to_str(): "fmt" argument must be a non-empty string'
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_char("dt", "fmt"),
                 'invalid_parameter_value',
-                'to_str(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_str(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -72,17 +71,16 @@ std::to_str(td: std::duration, fmt: OPTIONAL str={}) -> std::str
         CASE WHEN "fmt" IS NULL THEN
             trim(to_json("td")::text, '"')
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::text,
                 'invalid_parameter_value',
-                'to_str(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::text)
+                msg => 'to_str(): "fmt" argument must be a non-empty string'
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_char("td", "fmt"),
                 'invalid_parameter_value',
-                'to_str(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_str(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -107,17 +105,16 @@ std::to_str(i: std::int64, fmt: OPTIONAL str={}) -> std::str
         CASE WHEN "fmt" IS NULL THEN
             "i"::text
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::text,
                 'invalid_parameter_value',
-                'to_str(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::text)
+                msg => 'to_str(): "fmt" argument must be a non-empty string'
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_char("i", "fmt"),
                 'invalid_parameter_value',
-                'to_str(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_str(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -137,17 +134,16 @@ std::to_str(f: std::float64, fmt: OPTIONAL str={}) -> std::str
         CASE WHEN "fmt" IS NULL THEN
             "f"::text
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::text,
                 'invalid_parameter_value',
-                'to_str(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::text)
+                msg => 'to_str(): "fmt" argument must be a non-empty string'
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_char("f", "fmt"),
                 'invalid_parameter_value',
-                'to_str(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_str(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -167,17 +163,16 @@ std::to_str(d: std::bigint, fmt: OPTIONAL str={}) -> std::str
         CASE WHEN "fmt" IS NULL THEN
             "d"::text
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::text,
                 'invalid_parameter_value',
-                'to_str(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::text)
+                msg => 'to_str(): "fmt" argument must be a non-empty string'
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_char("d", "fmt"),
                 'invalid_parameter_value',
-                'to_str(): format ''' || "fmt" || ''' is invalid',
-                ''
+                'to_str(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -197,17 +192,16 @@ std::to_str(d: std::decimal, fmt: OPTIONAL str={}) -> std::str
         CASE WHEN "fmt" IS NULL THEN
             "d"::text
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::text,
                 'invalid_parameter_value',
-                'to_str(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::text)
+                msg => 'to_str(): "fmt" argument must be a non-empty string'
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_char("d", "fmt"),
                 'invalid_parameter_value',
-                'to_str(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_str(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -247,17 +241,16 @@ std::to_str(json: std::json, fmt: OPTIONAL str={}) -> std::str
         WHEN "fmt" = 'pretty' THEN
             jsonb_pretty("json")
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::text,
                 'invalid_parameter_value',
-                'to_str(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::text)
+                msg => 'to_str(): "fmt" argument must be a non-empty string'
+            )
         ELSE
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::text,
                 'invalid_parameter_value',
-                'to_str(): format ''' || "fmt" || ''' is invalid',
-                NULL,
-                NULL::text
+                msg => 'to_str(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -289,17 +282,18 @@ std::to_datetime(s: std::str, fmt: OPTIONAL str={}) -> std::datetime
         CASE WHEN "fmt" IS NULL THEN
             edgedb.datetime_in("s")
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::timestamptz,
                 'invalid_parameter_value',
-                'to_datetime(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::timestamptz)
+                msg => (
+                    'to_datetime(): "fmt" argument must be a non-empty string'
+                )
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 edgedb.to_datetime("s", "fmt"),
                 'invalid_parameter_value',
-                'to_datetime(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_datetime(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -392,17 +386,18 @@ std::to_bigint(s: std::str, fmt: OPTIONAL str={}) -> std::bigint
         CASE WHEN "fmt" IS NULL THEN
             edgedb.str_to_bigint("s")
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::edgedb.bigint_t,
                 'invalid_parameter_value',
-                'to_bigint(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::edgedb.bigint_t)
+                msg => (
+                    'to_bigint(): "fmt" argument must be a non-empty string'
+                )
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_number("s", "fmt")::edgedb.bigint_t,
                 'invalid_parameter_value',
-                'to_bigint(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_bigint(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -421,17 +416,18 @@ std::to_decimal(s: std::str, fmt: OPTIONAL str={}) -> std::decimal
         CASE WHEN "fmt" IS NULL THEN
             edgedb.str_to_decimal("s")
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::numeric,
                 'invalid_parameter_value',
-                'to_decimal(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::numeric)
+                msg => (
+                    'to_decimal(): "fmt" argument must be a non-empty string'
+                )
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_number("s", "fmt")::numeric,
                 'invalid_parameter_value',
-                'to_decimal(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_decimal(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -452,17 +448,16 @@ std::to_int64(s: std::str, fmt: OPTIONAL str={}) -> std::int64
             -- the overeager function inliner from crashing
             edgedb.str_to_int64_noinline("s")
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::bigint,
                 'invalid_parameter_value',
-                'to_int64(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::bigint)
+                msg => 'to_int64(): "fmt" argument must be a non-empty string'
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_number("s", "fmt")::bigint,
                 'invalid_parameter_value',
-                'to_int64(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_int64(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -483,17 +478,16 @@ std::to_int32(s: std::str, fmt: OPTIONAL str={}) -> std::int32
             -- the overeager function inliner from crashing
             edgedb.str_to_int32_noinline("s")
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::int,
                 'invalid_parameter_value',
-                'to_int32(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::int)
+                msg => 'to_int32(): "fmt" argument must be a non-empty string'
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_number("s", "fmt")::int,
                 'invalid_parameter_value',
-                'to_int32(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_int32(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -514,17 +508,16 @@ std::to_int16(s: std::str, fmt: OPTIONAL str={}) -> std::int16
             -- the overeager function inliner from crashing
             edgedb.str_to_int16_noinline("s")
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::smallint,
                 'invalid_parameter_value',
-                'to_int16(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::smallint)
+                msg => 'to_int16(): "fmt" argument must be a non-empty string'
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_number("s", "fmt")::smallint,
                 'invalid_parameter_value',
-                'to_int16(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_int16(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -543,17 +536,18 @@ std::to_float64(s: std::str, fmt: OPTIONAL str={}) -> std::float64
         CASE WHEN "fmt" IS NULL THEN
             edgedb.str_to_float64_noinline("s")
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::float8,
                 'invalid_parameter_value',
-                'to_float64(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::float8)
+                msg => (
+                    'to_float64(): "fmt" argument must be a non-empty string'
+                )
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_number("s", "fmt")::float8,
                 'invalid_parameter_value',
-                'to_float64(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_float64(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )
@@ -572,17 +566,18 @@ std::to_float32(s: std::str, fmt: OPTIONAL str={}) -> std::float32
         CASE WHEN "fmt" IS NULL THEN
             edgedb.str_to_float32_noinline("s")
         WHEN "fmt" = '' THEN
-            edgedb._raise_specific_exception(
+            edgedb.raise(
+                NULL::float4,
                 'invalid_parameter_value',
-                'to_float32(): "fmt" argument must be a non-empty string',
-                '',
-                NULL::float4)
+                msg => (
+                    'to_float32(): "fmt" argument must be a non-empty string'
+                )
+            )
         ELSE
-            edgedb._raise_exception_on_null(
+            edgedb.raise_on_null(
                 to_number("s", "fmt")::float4,
                 'invalid_parameter_value',
-                'to_float32(): format ''' || "fmt" || ''' is invalid',
-                ''
+                msg => 'to_float32(): format ''' || "fmt" || ''' is invalid'
             )
         END
     )

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -245,7 +245,7 @@ def compile_TypeCast(
 
     if expr.cardinality_mod is qlast.CardinalityModifier.Required:
         res = pgast.FuncCall(
-            name=('edgedb', '_raise_exception_on_null'),
+            name=('edgedb', 'raise_on_null'),
             args=[
                 res,
                 pgast.StringConstant(
@@ -254,7 +254,6 @@ def compile_TypeCast(
                 pgast.StringConstant(
                     val='invalid null value in cast',
                 ),
-                pgast.StringConstant(val=''),
             ]
         )
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2131,7 +2131,7 @@ def process_set_as_func_expr(
 
         if expr.error_on_null_result:
             set_expr = pgast.FuncCall(
-                name=('edgedb', '_raise_exception_on_null'),
+                name=('edgedb', 'raise_on_null'),
                 args=[
                     set_expr,
                     pgast.StringConstant(
@@ -2289,7 +2289,7 @@ def process_set_as_agg_expr(
 
         if expr.error_on_null_result:
             set_expr = pgast.FuncCall(
-                name=('edgedb', '_raise_exception_on_null'),
+                name=('edgedb', 'raise_on_null'),
                 args=[
                     set_expr,
                     pgast.StringConstant(

--- a/edb/pgsql/dbops/operators.py
+++ b/edb/pgsql/dbops/operators.py
@@ -90,12 +90,13 @@ class CreateOperatorAlias(ddl.SchemaObjectOperation):
         else:
             commutator_decl = textwrap.indent(textwrap.dedent(f'''\
                 ', COMMUTATOR = ' || (
-                    SELECT edgedb._raise_specific_exception(
+                    SELECT edgedb.raise(
+                        NULL::text,
                         'invalid_object_definition',
-                        'missing required commutator for operator '
-                        || {ql(oper_name)},
-                        NULL,
-                        NULL::text
+                        msg => (
+                            'missing required commutator for operator '
+                            || {ql(oper_name)}
+                        )
                     )
                 )
             '''), ' ' * 8).strip()
@@ -110,12 +111,13 @@ class CreateOperatorAlias(ddl.SchemaObjectOperation):
         else:
             negator_decl = textwrap.indent(textwrap.dedent(f'''\
                 ', NEGATOR = ' || (
-                    SELECT edgedb._raise_specific_exception(
+                    SELECT edgedb.raise(
+                        NULL::text,
                         'invalid_object_definition',
-                        'missing required negator for operator '
-                        || {ql(oper_name)},
-                        NULL,
-                        NULL::text
+                        msg => (
+                            'missing required negator for operator '
+                            || {ql(oper_name)}
+                        )
                     )
                 )
             '''), ' ' * 8).strip()

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -258,11 +258,13 @@ def generate_structure(
                                     typ.typname = "typeid"::text || '_domain'
                             ),
 
-                            edgedb._raise_specific_exception(
+                            edgedb.raise(
+                                NULL::bigint,
                                 'invalid_parameter_value',
-                                'cannot determine OID of ' || typeid::text,
-                                '',
-                                NULL::bigint
+                                msg => (
+                                    'cannot determine OID of '
+                                    || typeid::text
+                                )
                             )
                         )::bigint
                 $$;

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -31,7 +31,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2020_12_25_00_00
+EDGEDB_CATALOG_VERSION = 2021_01_06_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs


### PR DESCRIPTION
Reduce the current three "raise" functions to one by relying on
polymorphism and named arguments more.  While at it, rename the
functions to just `raise()` (and variants, `raise_on_null()`,
`raise_on_empty()`).