### PR TITLE
Produce a more appropriate error for bad fields.

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3524,7 +3524,12 @@ class AlterObjectProperty(Command):
         ):
             return Nop()
         else:
-            field = parent_cls.get_field(propname)
+            try:
+                field = parent_cls.get_field(propname)
+            except LookupError:
+                raise errors.SchemaDefinitionError(
+                    f'{propname!r} is not a valid field',
+                    context=astnode.context)
 
         if not (
             astnode.special_syntax

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -9009,6 +9009,28 @@ type test::Foo {
                 INSERT Foo;
             """)
 
+    async def test_edgeql_ddl_bad_field_01(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaDefinitionError,
+            "'ha' is not a valid field",
+        ):
+            await self.con.execute(r"""
+                CREATE TYPE test::Lol {SET ha := "crash"};
+            """)
+
+    async def test_edgeql_ddl_bad_field_02(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaDefinitionError,
+            "'ha' is not a valid field",
+        ):
+            await self.con.execute(r"""
+                START MIGRATION TO {
+                    type test::Lol {
+                        ha := "crash"
+                    }
+                }
+            """)
+
     async def test_edgeql_ddl_adjust_computed_01(self):
         await self.con.execute(r"""
             SET MODULE test;


### PR DESCRIPTION
Attempting to set a non-existent field now produces a
SchemaDefinitionError to be consistent with other errors related to
fields.

Fixes #1936