### PR TITLE
Add support for type coercion expression in `ALTER ... SET TYPE`

### DIFF
--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -227,7 +227,8 @@ Change the definition of a :ref:`link <ref_datamodel_links>`.
       SET SINGLE
       SET MULTI
       RESET CARDINALITY
-      SET TYPE <typename> [, ...]
+      SET TYPE <typename> [USING (<conversion-expr)]
+      RESET TYPE
       USING (<computable-expr>)
       CREATE ANNOTATION <annotation-name> := <value>
       ALTER ANNOTATION <annotation-name> := <value>
@@ -308,9 +309,18 @@ The following subcommands are allowed in the ``ALTER LINK`` block:
     (``SINGLE``), or, if the link is inherited, to the value inherited
     from links in supertypes.
 
-:eql:synopsis:`SET TYPE <typename> [, ...]`
-    Change the target type of the link to the specified type or
-    a union of types.  Only valid for concrete links.
+:eql:synopsis:`SET TYPE <typename> [USING (<conversion-expr)]`
+    Change the type of the link to the specified
+    :eql:synopsis:`<typename>`.  The optional ``USING`` clause specifies
+    a conversion expression that computes the new link value from the old.
+    The conversion expression must return a singleton set and is evaluated
+    on each element of ``MULTI`` links.  A ``USING`` clause must be provided
+    if there is no implicit or assignment cast from old to new type.
+
+:eql:synopsis:`RESET TYPE`
+    Reset the type of the link to the type inherited from links of the same
+    name in supertypes.  It is an error to ``RESET TYPE`` on a link that is
+    not inherited.
 
 :eql:synopsis:`USING (<computable-expr>)`
     Change the expression of a :ref:`computable <ref_datamodel_computables>`

--- a/docs/edgeql/ddl/props.rst
+++ b/docs/edgeql/ddl/props.rst
@@ -199,7 +199,8 @@ Change the definition of a :ref:`property <ref_datamodel_props>`.
       SET SINGLE
       SET MULTI
       RESET CARDINALITY
-      SET TYPE <typename> [, ...]
+      SET TYPE <typename> [USING (<conversion-expr)]
+      RESET TYPE
       USING (<computable-expr>)
       CREATE ANNOTATION <annotation-name> := <value>
       ALTER ANNOTATION <annotation-name> := <value>
@@ -287,9 +288,18 @@ The following subcommands are allowed in the ``ALTER LINK`` block:
     (``SINGLE``), or, if the property is inherited, to the value inherited
     from properties in supertypes.
 
-:eql:synopsis:`SET TYPE <typename> [, ...]`
-    Change the target type of the property to the specified type or
-    a union of types.  Only valid for concrete properties.
+:eql:synopsis:`SET TYPE <typename> [USING (<conversion-expr)]`
+    Change the type of the property to the specified
+    :eql:synopsis:`<typename>`.  The optional ``USING`` clause specifies
+    a conversion expression that computes the new property value from the old.
+    The conversion expression must return a singleton set and is evaluated
+    on each element of ``MULTI`` properties.  A ``USING`` clause must be
+    provided if there is no implicit or assignment cast from old to new type.
+
+:eql:synopsis:`RESET TYPE`
+    Reset the type of the property to the type inherited from properties
+    of the same name in supertypes.  It is an error to ``RESET TYPE`` on
+    a property that is not inherited.
 
 :eql:synopsis:`USING (<computable-expr>)`
     Change the expression of a :ref:`computable <ref_datamodel_computables>`

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -631,6 +631,7 @@ class SetPointerType(SetField):
     name: str = 'target'
     special_syntax: bool = True
     value: TypeExpr
+    cast_expr: typing.Optional[Expr]
 
 
 class NamedDDL(DDLCommand):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1538,6 +1538,10 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
     def visit_SetPointerType(self, node: qlast.SetPointerType) -> None:
         self.write('SET TYPE ')
         self.visit(node.value)
+        if node.cast_expr is not None:
+            self.write(' USING (')
+            self.visit(node.cast_expr)
+            self.write(')')
 
     def visit_OnTargetDelete(self, node: qlast.OnTargetDelete) -> None:
         self._write_keywords('ON TARGET DELETE ', node.cascade.to_edgeql())

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -217,15 +217,21 @@ class Environment:
     functions) that appear in a function body.
     """
 
+    #: A list of bindings that should be assumed to be singletons.
+    singletons: List[irast.PathId]
+
     def __init__(
         self,
         *,
         schema: s_schema.Schema,
-        path_scope: irast.ScopeTreeNode,
-        options: Optional[GlobalCompilerOptions]=None,
+        path_scope: Optional[irast.ScopeTreeNode] = None,
+        options: Optional[GlobalCompilerOptions] = None,
     ) -> None:
         if options is None:
             options = GlobalCompilerOptions()
+
+        if path_scope is None:
+            path_scope = irast.new_scope_tree()
 
         self.options = options
         self.schema = schema
@@ -249,6 +255,7 @@ class Environment:
         self.dml_exprs = []
         self.pointer_derivation_map = collections.defaultdict(list)
         self.pointer_specified_info = {}
+        self.singletons = []
 
     def add_schema_ref(
             self, sobj: s_obj.Object, expr: Optional[qlast.Base]) -> None:

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -498,7 +498,7 @@ def compile_TypeCast(
             )
         else:
             param_first_type = ctx.env.query_parameters[param_name].schema_type
-            if not param_first_type.explicitly_castable_to(pt, ctx.env.schema):
+            if not param_first_type.castable_to(pt, ctx.env.schema):
                 raise errors.QueryError(
                     f'cannot cast '
                     f'{param_first_type.get_displayname(ctx.env.schema)} to '

--- a/edb/edgeql/compiler/inference/context.py
+++ b/edb/edgeql/compiler/inference/context.py
@@ -45,7 +45,7 @@ def make_ctx(env: context.Environment) -> InfCtx:
         env=env,
         inferred_cardinality={},
         inferred_multiplicity={},
-        singletons={},
+        singletons=frozenset(env.singletons),
         bindings={},
         volatile_uses={},
         in_for_body=False,

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -62,11 +62,8 @@ def init_context(
             schema,
             name=s_name.UnqualName('__derived__'),
         )
-    env = context.Environment(
-        schema=schema,
-        path_scope=irast.new_scope_tree(),
-        options=options,
-    )
+
+    env = context.Environment(schema=schema, options=options)
     ctx = context.ContextLevel(None, context.ContextSwitchMode.NEW, env=env)
     _ = context.CompilerContext(initial=ctx)
 
@@ -80,8 +77,7 @@ def init_context(
                        if isinstance(singleton, s_types.Type)
                        else pathctx.get_pointer_path_id(singleton, ctx=ctx))
             ctx.env.path_scope.attach_path(path_id, context=None)
-
-        ctx.path_scope = ctx.env.path_scope.attach_fence()
+            ctx.env.singletons.append(path_id)
 
     ctx.modaliases.update(options.modaliases)
 
@@ -233,7 +229,7 @@ def fini_expression(
         params=list(ctx.env.query_parameters.values()),
         views=ctx.view_nodes,
         source_map=ctx.source_map,
-        scope_tree=ctx.path_scope,
+        scope_tree=ctx.env.path_scope,
         cardinality=cardinality,
         volatility=volatility,
         multiplicity=multiplicity,

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -990,17 +990,27 @@ class DropIndexStmt(Nonterm):
         )
 
 
+class OptAlterUsingClause(Nonterm):
+    def reduce_USING_ParenExpr(self, *kids):
+        self.val = kids[1].val
+
+    def reduce_empty(self):
+        self.val = None
+
+
 class SetPropertyTypeStmt(Nonterm):
-    def reduce_SETTYPE_FullTypeExpr(self, *kids):
+    def reduce_SETTYPE_FullTypeExpr_OptAlterUsingClause(self, *kids):
         self.val = qlast.SetPointerType(
             value=kids[1].val,
+            cast_expr=kids[2].val,
         )
 
 
 class SetLinkTypeStmt(Nonterm):
-    def reduce_SETTYPE_FullTypeExpr(self, *kids):
+    def reduce_SETTYPE_FullTypeExpr_OptAlterUsingClause(self, *kids):
         self.val = qlast.SetPointerType(
             value=kids[1].val,
+            cast_expr=kids[2].val,
         )
 
 

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -128,6 +128,9 @@ class Cardinality(s_enum.StrEnum):
     def is_multi(self) -> bool:
         return not self.is_single()
 
+    def can_be_zero(self) -> bool:
+        return self not in {Cardinality.ONE, Cardinality.AT_LEAST_ONE}
+
     def to_schema_value(self) -> Tuple[bool, SchemaCardinality]:
         return _CARD_TO_TUPLE[self]
 

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -128,6 +128,10 @@ def get_module_backend_name(module):
     return "edgedbstd" if module in s_schema.STD_MODULES else "edgedbpub"
 
 
+def get_unique_random_name() -> str:
+    return base64.b64encode(uuidgen.uuid1mc().bytes).rstrip(b'=').decode()
+
+
 @functools.lru_cache()
 def _edgedb_name_to_pg_name(name: str, prefix_length: int = 0) -> str:
     # Note: PostgreSQL doesn't have a sha1 implementation as a

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -63,6 +63,9 @@ class OutputFormat(enum.Enum):
     #: Script mode: query result not returned, cardinality of result set
     #: is returned instead.
     SCRIPT = enum.auto()
+    #: Like NATIVE, but objects without an explicit shape are serialized
+    #: as UUIDs.
+    NATIVE_INTERNAL = enum.auto()
 
 
 NO_STMT = pgast.SelectStmt()
@@ -329,6 +332,7 @@ class Environment:
     singleton_mode: bool
     query_params: List[irast.Param]
     type_rewrites: Dict[uuid.UUID, irast.Set]
+    external_rvars: Mapping[Tuple[irast.PathId, str], pgast.PathRangeVar]
 
     def __init__(
         self,
@@ -341,6 +345,9 @@ class Environment:
         explicit_top_cast: Optional[irast.TypeRef],
         query_params: List[irast.Param],
         type_rewrites: Dict[uuid.UUID, irast.Set],
+        external_rvars: Optional[
+            Mapping[Tuple[irast.PathId, str], pgast.PathRangeVar]
+        ] = None,
     ) -> None:
         self.aliases = aliases.AliasGenerator()
         self.output_format = output_format
@@ -352,6 +359,7 @@ class Environment:
         self.explicit_top_cast = explicit_top_cast
         self.query_params = query_params
         self.type_rewrites = type_rewrites
+        self.external_rvars = external_rvars or {}
 
 
 # XXX: this context hack is necessary until pathctx is converted

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -665,7 +665,9 @@ def get_path_rvar(
 def maybe_get_path_rvar(
         stmt: pgast.Query, path_id: irast.PathId, *, aspect: str,
         env: context.Environment) -> Optional[pgast.PathRangeVar]:
-    rvar = stmt.path_rvar_map.get((path_id, aspect))
+    rvar = env.external_rvars.get((path_id, aspect))
+    if rvar is None:
+        rvar = stmt.path_rvar_map.get((path_id, aspect))
     if rvar is None and aspect == 'identity':
         rvar = stmt.path_rvar_map.get((path_id, 'value'))
     return rvar

--- a/edb/pgsql/dbops/base.py
+++ b/edb/pgsql/dbops/base.py
@@ -246,6 +246,7 @@ class PLBlock(SQLBlock):
 class PLTopBlock(PLBlock):
     def __init__(self):
         super().__init__(top_block=None, level=0)
+        self.declare_var('text', var_name='_dummy_text', shared=True)
 
     def add_block(self):
         block = PLBlock(top_block=self, level=self.level + 1)

--- a/edb/pgsql/dbops/composites.py
+++ b/edb/pgsql/dbops/composites.py
@@ -130,14 +130,19 @@ class AlterCompositeDropAttribute(CompositeAttributeCommand):
 
 
 class AlterCompositeAlterAttributeType:
-    def __init__(self, attribute_name, new_type):
+    def __init__(self, attribute_name, new_type, *, using_expr=None):
         self.attribute_name = attribute_name
         self.new_type = new_type
+        self.using_expr = using_expr
 
     def code(self, block: base.PLBlock) -> str:
         attrterm = self.get_attribute_term()  # type: ignore
         attrname = common.quote_ident(str(self.attribute_name))
-        return f'ALTER {attrterm} {attrname} SET DATA TYPE {self.new_type}'
+        code = f'ALTER {attrterm} {attrname} SET DATA TYPE {self.new_type}'
+        if self.using_expr is not None:
+            code += f' USING ({self.using_expr})'
+
+        return code
 
     def __repr__(self):
         cls = self.__class__

--- a/edb/pgsql/dbops/dml.py
+++ b/edb/pgsql/dbops/dml.py
@@ -94,10 +94,11 @@ class Insert(DMLOperation):
 class Update(DMLOperation):
     def __init__(
             self, table, record, condition, returning=None, *,
-            include_children=True, priority=0):
+            include_children=True, priority=0, table_alias=None):
         super().__init__(priority=priority)
 
         self.table = table
+        self.table_alias = table_alias
         self.record = record
         self.fields = [f for f, v in record.items() if v is not base.Default]
         self.condition = condition
@@ -155,6 +156,9 @@ class Update(DMLOperation):
         tabname = qn(*self.table.name)
         if not self.include_children:
             tabname = 'ONLY {}'.format(tabname)
+
+        if self.table_alias:
+            tabname = f'{tabname} AS {qi(self.table_alias)}'
 
         code = 'UPDATE {} SET {} {}'.format(
             tabname, ', '.join(placeholders), where)

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -452,7 +452,13 @@ class RaiseExceptionFunction(dbops.Function):
         RAISE EXCEPTION USING
             ERRCODE = "exc",
             MESSAGE = "msg",
-            DETAIL = COALESCE("detail", '');
+            DETAIL = COALESCE("detail", ''),
+            HINT = COALESCE("hint", ''),
+            COLUMN = COALESCE("column", ''),
+            CONSTRAINT = COALESCE("constraint", ''),
+            DATATYPE = COALESCE("datatype", ''),
+            TABLE = COALESCE("table", ''),
+            SCHEMA = COALESCE("schema", '');
         RETURN "rtype";
     END;
     '''
@@ -465,6 +471,12 @@ class RaiseExceptionFunction(dbops.Function):
                 ('exc', ('text',), "'raise_exception'"),
                 ('msg', ('text',), "''"),
                 ('detail', ('text',), "''"),
+                ('hint', ('text',), "''"),
+                ('column', ('text',), "''"),
+                ('constraint', ('text',), "''"),
+                ('datatype', ('text',), "''"),
+                ('table', ('text',), "''"),
+                ('schema', ('text',), "''"),
             ],
             returns=('anyelement',),
             # NOTE: The main reason why we don't want this function to be
@@ -485,7 +497,18 @@ class RaiseExceptionOnNullFunction(dbops.Function):
     text = '''
         SELECT coalesce(
             val,
-            edgedb.raise(val, exc, msg => msg, detail => detail)
+            edgedb.raise(
+                val,
+                exc,
+                msg => msg,
+                detail => detail,
+                hint => hint,
+                "column" => "column",
+                "constraint" => "constraint",
+                "datatype" => "datatype",
+                "table" => "table",
+                "schema" => "schema"
+            )
         )
     '''
 
@@ -497,6 +520,12 @@ class RaiseExceptionOnNullFunction(dbops.Function):
                 ('exc', ('text',)),
                 ('msg', ('text',)),
                 ('detail', ('text',), "''"),
+                ('hint', ('text',), "''"),
+                ('column', ('text',), "''"),
+                ('constraint', ('text',), "''"),
+                ('datatype', ('text',), "''"),
+                ('table', ('text',), "''"),
+                ('schema', ('text',), "''"),
             ],
             returns=('anyelement',),
             # Same volatility as raise()

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -147,6 +147,32 @@ def is_assignment_castable(
     return False
 
 
+@functools.lru_cache()
+def is_castable(
+    schema: s_schema.Schema,
+    source: s_types.Type,
+    target: s_types.Type,
+) -> bool:
+
+    # Implicitly castable
+    if is_implicitly_castable(schema, source, target):
+        return True
+
+    elif is_assignment_castable(schema, source, target):
+        return True
+
+    else:
+        casts = schema.get_casts_to_type(target)
+        if not casts:
+            return False
+        else:
+            for c in casts:
+                if c.get_from_type(schema) == source:
+                    return True
+            else:
+                return False
+
+
 def get_cast_fullname(
     schema: s_schema.Schema,
     module: str,

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1350,6 +1350,13 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         dict,  # type: ignore
         default=None,
     )
+    #: When this command is produced by a breakup of a larger command
+    #: subtree, *orig_cmd_type* would contain the type of the original
+    #: command.
+    orig_cmd_type = struct.Field(
+        CommandMeta,
+        default=None,
+    )
 
     scls: so.Object_T
     _delta_action: ClassVar[str]

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -346,9 +346,38 @@ class CreateLink(
                         node.target = utils.typeref_to_ast(schema, t)
             else:
                 assert isinstance(op.new_value, (so.Object, so.ObjectShell))
+                top_op = self.get_top_referrer_op(context)
+                conv_expr: Optional[qlast.Expr]
+                if (
+                    top_op is not None
+                    and (
+                        isinstance(top_op, sd.CreateObject)
+                        or (
+                            top_op.orig_cmd_type is not None
+                            and issubclass(
+                                top_op.orig_cmd_type, sd.CreateObject)
+                        )
+                    )
+                ):
+                    # This op is part of CREATE TYPE, so avoid tripping up
+                    # the DDL check on SET TYPE by generating an appropriate
+                    # conversion expression: USING (.foo[IS Type]).
+                    lname = sn.shortname_from_fullname(self.classname).name
+                    conv_expr = qlast.Path(
+                        partial=True,
+                        steps=[
+                            qlast.Ptr(ptr=qlast.ObjectRef(name=lname)),
+                            qlast.TypeIntersection(
+                                type=utils.typeref_to_ast(schema, op.new_value)
+                            )
+                        ],
+                    )
+                else:
+                    conv_expr = None
                 node.commands.append(
                     qlast.SetPointerType(
-                        value=utils.typeref_to_ast(schema, op.new_value)
+                        value=utils.typeref_to_ast(schema, op.new_value),
+                        expr=conv_expr,
                     )
                 )
         elif op.property == 'on_target_delete':

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -837,6 +837,7 @@ def _extract_op(stack: Sequence[sd.Command]) -> List[sd.Command]:
             ddl_identity=stack_op.ddl_identity,
             aux_object_data=stack_op.aux_object_data,
             annotations=stack_op.annotations,
+            orig_cmd_type=type(stack_op),
         )
         parent_op.add(alter_delta)
         parent_op = alter_delta

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -119,7 +119,10 @@ class ScalarType(
         other: s_types.Type,
         schema: s_schema.Schema,
     ) -> bool:
-        assert isinstance(other, ScalarType)
+        if not isinstance(other, ScalarType):
+            return False
+        if self.is_polymorphic(schema) or other.is_polymorphic(schema):
+            return False
         left = self.get_base_for_cast(schema)
         right = other.get_base_for_cast(schema)
         return s_casts.is_assignment_castable(schema, left, right)
@@ -138,6 +141,22 @@ class ScalarType(
         assert isinstance(left, s_types.Type)
         assert isinstance(right, s_types.Type)
         return s_casts.is_implicitly_castable(schema, left, right)
+
+    def castable_to(
+        self,
+        other: s_types.Type,
+        schema: s_schema.Schema,
+    ) -> bool:
+        """Determine if any cast exists between self and *other*."""
+        if not isinstance(other, ScalarType):
+            return False
+        if self.is_polymorphic(schema) or other.is_polymorphic(schema):
+            return False
+        left = self.get_topmost_concrete_base(schema)
+        right = other.get_topmost_concrete_base(schema)
+        assert isinstance(left, s_types.Type)
+        assert isinstance(right, s_types.Type)
+        return s_casts.is_castable(schema, left, right)
 
     def get_implicit_cast_distance(
         self,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -414,18 +414,18 @@ class Compiler(BaseCompiler):
             debug.header('Canonical Delta Plan')
             debug.dump(delta, schema=schema)
 
-        delta = pg_delta.CommandMeta.adapt(delta)
+        pgdelta = pg_delta.CommandMeta.adapt(delta)
         context = self._new_delta_context(ctx)
-        schema = delta.apply(schema, context)
+        schema = pgdelta.apply(schema, context)
         current_tx.update_schema(schema)
 
         if debug.flags.delta_pgsql_plan:
             debug.header('PgSQL Delta Plan')
-            debug.dump(delta, schema=schema)
+            debug.dump(pgdelta, schema=schema)
 
         db_cmd = any(
             isinstance(c, s_db.DatabaseCommand)
-            for c in delta.get_subcommands()
+            for c in pgdelta.get_subcommands()
         )
 
         if db_cmd:
@@ -433,15 +433,15 @@ class Compiler(BaseCompiler):
             new_types = frozenset()
         else:
             block = pg_dbops.PLTopBlock()
-            new_types = frozenset(str(tid) for tid in delta.new_types)
+            new_types = frozenset(str(tid) for tid in pgdelta.new_types)
 
         # Generate SQL DDL for the delta.
-        delta.generate(block)
+        pgdelta.generate(block)
 
         # Generate schema storage SQL (DML into schema storage tables).
         subblock = block.add_block()
         self._compile_schema_storage_in_delta(
-            ctx, delta, subblock, context=context)
+            ctx, pgdelta, subblock, context=context)
 
         return block, new_types
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2312,11 +2312,11 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         """, r"""
             type Base {
                 # change property type
-                property foo -> str;
+                property foo -> int32;
             }
 
             type Derived extending Base {
-                overloaded required property foo -> str;
+                overloaded required property foo -> int32;
             }
         """])
 
@@ -2713,18 +2713,18 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             # derive a type
             type DerivedParent extending Parent;
         """, r"""
-            type Child;
+            type GenericChild;
 
-            type DerivedChild extending Child;
+            type Child extending GenericChild;
 
-            type Parent {
-                link bar -> Child;
+            type GenericParent {
+                link bar -> GenericChild;
             }
 
-            # derive a type with a more restrictive link
-            type DerivedParent extending Parent {
-                overloaded link bar -> DerivedChild;
+            type Parent extending GenericParent {
+                overloaded link bar -> Child;
             }
+
         """])
 
     def test_schema_migrations_equivalence_27(self):
@@ -2936,23 +2936,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """, r"""
             # empty schema
-        """])
-
-    def test_schema_migrations_equivalence_33(self):
-        self._assert_migration_equivalence([r"""
-            type Child;
-
-            type Base {
-                link foo -> Child;
-            }
-        """, r"""
-            type Child;
-            type Child2;
-
-            type Base {
-                # change link type
-                link foo -> Child2;
-            }
         """])
 
     def test_schema_migrations_equivalence_34(self):
@@ -3395,7 +3378,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                 )
         """, r"""
             type Foo {
-                property bar -> str;
+                property bar -> array<float64>;
             };
 
             function hello16() -> int64
@@ -3421,7 +3404,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                 )
         """, r"""
             type Foo {
-                property bar -> str;
+                property bar -> array<float64>;
             };
 
             type Bar;
@@ -3527,7 +3510,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             type Base {
                 link foo -> Child {
                     # change the link property type
-                    property bar -> str
+                    property bar -> int32
                 }
             };
         """])
@@ -3819,7 +3802,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         """, r"""
             type Base {
                 # change the indexed property type
-                property name -> str;
+                property name -> int32;
                 index on (.name);
             }
         """])
@@ -3926,30 +3909,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
-    def test_schema_migrations_equivalence_collections_05(self):
-        self._assert_migration_equivalence([r"""
-            type Base {
-                property foo -> float32;
-            }
-        """, r"""
-            type Base {
-                # convert property type to array
-                property foo -> array<float32>;
-            }
-        """])
-
-    def test_schema_migrations_equivalence_collections_05b(self):
-        self._assert_migration_equivalence([r"""
-            type Base {
-                property foo -> array<float32>;
-            }
-        """, r"""
-            type Base {
-                # convert property type to array
-                property foo -> float32;
-            }
-        """])
-
     def test_schema_migrations_equivalence_collections_06(self):
         self._assert_migration_equivalence([r"""
             type Base {
@@ -3958,20 +3917,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         """, r"""
             type Base {
                 # change the array type (old type is castable into new)
-                property foo -> array<float32>;
-            }
-        """])
-
-    def test_schema_migrations_equivalence_collections_07(self):
-        self._assert_migration_equivalence([r"""
-            type Base {
-                # convert property type to tuple
-                property foo -> tuple<str, int32>;
-            }
-        """, r"""
-            type Base {
-                # convert property type to a bigger tuple
-                property foo -> tuple<str, int32, int32>;
+                property foo -> array<float64>;
             }
         """])
 
@@ -3984,7 +3930,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             type Base {
                 # convert property type to a tuple with different (but
                 # cast-compatible) element types
-                property foo -> tuple<str, int32>;
+                property foo -> tuple<int64, int32>;
             }
         """])
 
@@ -4279,7 +4225,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         """, r"""
             type Foo {
-                property bar -> str;
+                property bar -> array<float64>;
             };
 
             type Bar {
@@ -4300,22 +4246,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             scalar type MyScalar extending str;
 
             type User {
-                required property tup -> array<x:MyScalar>;
-            };
-        """])
-
-    def test_schema_migrations_equivalence_collections_24(self):
-        self._assert_migration_equivalence([r"""
-            scalar type MyScalar extending str;
-
-            type User {
-                required property arr -> array<x:MyScalar>;
-            };
-        """, r"""
-            scalar type MyScalar extending str;
-
-            type User {
-                required property arr -> tuple<x:MyScalar>;
+                required property tup -> tuple<x:str>;
             };
         """])
 


### PR DESCRIPTION
`ALTER {PROPERTY|LINK} .. SET TYPE` now requires an explicit conversion 
expression specified in the `USING` clause, if the new type is not 
assignment-castable from the old type.

This doesn't include the documentation updates, but is otherwise ready
for review.