### PR TITLE
Make sure Postgres system settings are not duplicated in sysconf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ RUNTIME_DEPS = [
     'immutables>=0.13',
     'parsing~=1.6.1',
     'prompt_toolkit==3.0.3',
-    'psutil~=5.6.1',
     'Pygments~=2.3.0',
     'setproctitle~=1.1.10',
     'setuptools-rust==0.10.3',


### PR DESCRIPTION
The values of actual PostgreSQL system settings are read from the system catalog and the configuration files.

Additionally, stop fiddling with Postgres memory settings on bootstrap.

Fixes: #1533