### PR TITLE
Improve migration prompts

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -428,16 +428,6 @@ class ConstraintCommand(
 
         return args
 
-    def get_verbosename(self, parent: Optional[str] = None) -> str:
-        mcls = self.get_schema_metaclass()
-        vname = mcls.get_verbosename_static(self.classname)
-        if self.get_attribute_value('is_abstract'):
-            vname = f'abstract {vname}'
-        if parent is not None:
-            return f'{vname} of {parent}'
-        else:
-            return vname
-
     def compile_expr_field(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -406,15 +406,6 @@ class AlterProperty(
                         value=utils.typeref_to_ast(schema, op.new_value),
                     ),
                 )
-        elif op.property == 'computable':
-            if not op.new_value:
-                node.commands.append(
-                    qlast.SetField(
-                        name='expr',
-                        value=None,
-                        special_syntax=True,
-                    ),
-                )
         else:
             super()._apply_field_ast(schema, context, node, op)
 

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -122,27 +122,6 @@ class Property(
     def is_property(self, schema: s_schema.Schema) -> bool:
         return True
 
-    @classmethod
-    def merge_targets(
-        cls,
-        schema: s_schema.Schema,
-        ptr: pointers.Pointer,
-        t1: s_types.Type,
-        t2: s_types.Type,
-        *,
-        allow_contravariant: bool = False,
-    ) -> Tuple[s_schema.Schema, Optional[s_types.Type]]:
-        if ptr.is_endpoint_pointer(schema):
-            return schema, t1
-        else:
-            return super().merge_targets(
-                schema,
-                ptr,
-                t1,
-                t2,
-                allow_contravariant=allow_contravariant
-            )
-
     def scalar(self) -> bool:
         return True
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1554,10 +1554,6 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         )
 
         if context.generate_prompts:
-            svn = self.get_verbosename(schema, with_parent=True)
-            prompt = f'did you create {svn}?'
-            delta.set_annotation('user_prompt', prompt)
-            delta.set_annotation('op_id', sd.get_object_command_id(delta))
             delta.set_annotation('orig_cmdclass', type(delta))
 
         # IDs are assigned once when the object is created and
@@ -1633,18 +1629,9 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         delta.set_annotation('confidence', confidence)
 
         if context.generate_prompts:
-            svn = self.get_verbosename(self_schema, with_parent=True)
-            self_name = self.get_name(self_schema)
             other_name = other.get_name(other_schema)
-            if self_name != other_name:
-                ovn = other.get_displayname(other_schema)
-                prompt = f'did you rename {svn} to {ovn!r}?'
-            else:
-                prompt = f'did you alter {svn}?'
-
-            delta.set_annotation('user_prompt', prompt)
-            delta.set_annotation('new_name', other_name)
-            delta.set_annotation('op_id', sd.get_object_command_id(delta))
+            if self.get_name(self_schema) != other_name:
+                delta.set_annotation('new_name', other_name)
             delta.set_annotation('orig_cmdclass', type(delta))
 
         ff = cls.get_fields(sorted=True).items()
@@ -1715,6 +1702,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
                     oldcoll_idx,
                     newcoll_idx,
                     sclass=refdict.ref_cls,
+                    parent_confidence=confidence,
                     context=context,
                     old_schema=self_schema,
                     new_schema=other_schema,
@@ -1739,10 +1727,6 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         )
 
         if context.generate_prompts:
-            svn = self.get_verbosename(schema, with_parent=True)
-            prompt = f'did you drop {svn}?'
-            delta.set_annotation('user_prompt', prompt)
-            delta.set_annotation('op_id', sd.get_object_command_id(delta))
             delta.set_annotation('orig_cmdclass', type(delta))
 
         context.deletions[type(self), delta.classname] = delta

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -417,7 +417,11 @@ class Pointer(referencing.ReferencedInheritingObject,
     # defining them.
     expr = so.SchemaField(
         s_expr.Expression,
-        default=None, coerce=True, compcoef=0.909)
+        default=None,
+        coerce=True,
+        compcoef=0.909,
+        special_ddl_syntax=True,
+    )
 
     default = so.SchemaField(
         s_expr.Expression,
@@ -1538,21 +1542,8 @@ class SetPointerType(
 
     cast_expr = struct.Field(s_expr.Expression, default=None)
 
-    def get_friendly_description(
-        self,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-        *,
-        object: Optional[Pointer_T] = None,
-        object_desc: Optional[str] = None,
-    ) -> str:
-        object_desc = self.get_friendly_object_name_for_description(
-            schema,
-            context,
-            object=object,
-            object_desc=object_desc,
-        )
-        return f'alter the type of {object_desc}'
+    def get_verb(self) -> str:
+        return 'alter the type of'
 
     def is_data_safe(self) -> bool:
         return False
@@ -1647,7 +1638,7 @@ class SetPointerType(
             schema = self._propagate_if_expr_refs(
                 schema,
                 context,
-                action=self.get_friendly_description(schema, context),
+                action=self.get_friendly_description(schema=schema),
             )
 
             if (

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -54,6 +54,23 @@ class ReferencedObject(so.DerivableObject):
         special_ddl_syntax=True,
     )
 
+    @classmethod
+    def get_verbosename_static(
+        cls,
+        name: sn.Name,
+        *,
+        parent: Optional[str] = None,
+    ) -> str:
+        clsname = cls.get_schema_class_displayname()
+        dname = cls.get_displayname_static(name)
+        sn = cls.get_shortname_static(name)
+        if sn == name:
+            clsname = f'abstract {clsname}'
+        if parent is not None:
+            return f"{clsname} '{dname}' of {parent}"
+        else:
+            return f"{clsname} '{dname}'"
+
     def get_subject(self, schema: s_schema.Schema) -> Optional[so.Object]:
         # NB: classes that inherit ReferencedObject define a `get_subject`
         # method dynamically, with `subject = SchemaField`
@@ -870,8 +887,7 @@ class ReferencedInheritingObjectCommand(
 
                 vn = scls.get_verbosename(schema, with_parent=True)
                 desc = self.get_friendly_description(
-                    schema,
-                    context,
+                    schema=schema,
                     object_desc=f'inherited {vn}',
                 )
 

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -240,6 +240,24 @@ class QueryUnit:
 #############################
 
 
+class ProposedMigrationStep(NamedTuple):
+
+    statements: Tuple[str, ...]
+    confidence: float
+    prompt: str
+    prompt_id: str
+    data_safe: bool
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            'statements': [{'text': stmt} for stmt in self.statements],
+            'confidence': self.confidence,
+            'prompt': self.prompt,
+            'prompt_id': self.prompt_id,
+            'data_safe': self.data_safe,
+        }
+
+
 class MigrationState(NamedTuple):
 
     parent_migration: Optional[s_migrations.Migration]
@@ -248,6 +266,7 @@ class MigrationState(NamedTuple):
     target_schema: s_schema.Schema
     guidance: s_obj.DeltaGuidance
     current_ddl: Tuple[qlast.DDLOperation, ...]
+    last_proposed: Tuple[ProposedMigrationStep, ...]
 
 
 class TransactionState(NamedTuple):

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -74,7 +74,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             self.add_fail_notes(serialization='json')
             raise
 
-    async def fast_forward_describe_migration(self):
+    async def fast_forward_describe_migration(self, *, limit=None):
         '''Repeatedly get the next step from DESCRIBE and execute it.
 
         The point of this as opposed to just using "POPULATE
@@ -87,6 +87,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         prevddl = ''
 
         try:
+            step = 0
             while True:
                 mig = await self.con.query_one(
                     'DESCRIBE CURRENT MIGRATION AS JSON;')
@@ -113,7 +114,9 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                             f"Error while processing {curddl!r}"
                         ) from exc
                     prevddl = curddl
-
+                step += 1
+                if limit is not None and step == limit:
+                    break
         except Exception:
             self.add_fail_notes(serialization='json')
             raise
@@ -296,7 +299,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text': 'CREATE TYPE test::Type0;'
                 }],
-                'operation_id': 'CREATE TYPE test::Type0',
                 'prompt': "did you create object type 'test::Type0'?",
             },
         })
@@ -350,7 +352,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text': 'ALTER TYPE other::Test RENAME TO other::Test3;',
                 }],
-                'operation_id': 'ALTER TYPE other::Test',
                 'prompt': (
                     "did you rename object type 'other::Test' to "
                     "'other::Test3'?"
@@ -369,7 +370,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text': 'ALTER TYPE other::Test RENAME TO test::Test2;',
                 }],
-                'operation_id': 'ALTER TYPE other::Test',
                 'prompt': (
                     "did you rename object type 'other::Test' to "
                     "'test::Test2'?"
@@ -390,7 +390,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text': 'ALTER TYPE test::Test RENAME TO other::Test3;',
                 }],
-                'operation_id': 'ALTER TYPE test::Test',
                 'prompt': (
                     "did you rename object type 'test::Test' to "
                     "'other::Test3'?"
@@ -411,7 +410,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text': 'CREATE TYPE other::Test3;',
                 }],
-                'operation_id': 'CREATE TYPE other::Test3',
                 'prompt': (
                     "did you create object type 'other::Test3'?"
                 ),
@@ -459,7 +457,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         '};'
                     )
                 }],
-                'operation_id': 'CREATE TYPE test::Type1',
                 'prompt': "did you create object type 'test::Type1'?",
             },
         })
@@ -613,7 +610,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         'CREATE TYPE test::Type1;'
                     )
                 }],
-                'operation_id': 'CREATE TYPE test::Type1',
                 'prompt': "did you create object type 'test::Type1'?",
             },
         })
@@ -640,7 +636,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         'ALTER TYPE test::Type1 RENAME TO test::Type01;'
                     )
                 }],
-                'operation_id': 'ALTER TYPE test::Type1',
                 'prompt': (
                     "did you rename object type 'test::Type1' to "
                     "'test::Type01'?"
@@ -674,7 +669,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         'CREATE TYPE test::Type02;'
                     )
                 }],
-                'operation_id': 'CREATE TYPE test::Type02',
                 'prompt': "did you create object type 'test::Type02'?",
             },
         })
@@ -701,7 +695,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         'DROP TYPE test::Type02;'
                     )
                 }],
-                'operation_id': 'DROP TYPE test::Type02',
                 'prompt': (
                     "did you drop object type 'test::Type02'?"
                 ),
@@ -736,7 +729,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         'CREATE TYPE test::Type02;'
                     )
                 }],
-                'operation_id': 'CREATE TYPE test::Type02',
                 'prompt': "did you create object type 'test::Type02'?",
             },
         })
@@ -767,7 +759,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text': "ALTER TYPE test::Type0 RENAME TO test::Type1;"
                 }],
-                'operation_id': "ALTER TYPE test::Type0",
                 'prompt': (
                     "did you rename object type 'test::Type0' to "
                     "'test::Type1'?"
@@ -814,7 +805,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text': 'ALTER TYPE test::Test RENAME TO test::Test2;',
                 }],
-                'operation_id': 'ALTER TYPE test::Test',
                 'prompt': (
                     "did you rename object type 'test::Test' to 'test::Test2'?"
                 ),
@@ -833,7 +823,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text': 'ALTER TYPE test::Test RENAME TO test::Test3;',
                 }],
-                'operation_id': 'ALTER TYPE test::Test',
                 'prompt': (
                     "did you rename object type 'test::Test' to 'test::Test3'?"
                 ),
@@ -852,7 +841,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 'statements': [{
                     'text': 'CREATE TYPE test::Test2;',
                 }],
-                'operation_id': 'CREATE TYPE test::Test2',
                 'prompt': (
                     "did you create object type 'test::Test2'?"
                 ),
@@ -883,7 +871,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         '};'
                     )
                 }],
-                'operation_id': 'CREATE TYPE test::Type01',
                 'prompt': "did you create object type 'test::Type01'?",
             },
         })
@@ -919,9 +906,9 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         '};'
                     )
                 }],
-                'operation_id': 'ALTER TYPE test::Type01',
                 'prompt': (
-                    "did you alter object type 'test::Type01'?"
+                    "did you rename property 'field1' of object type"
+                    " 'test::Type01' to 'field01'?"
                 ),
             },
         })
@@ -958,7 +945,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         '};'
                     )
                 }],
-                'operation_id': 'CREATE TYPE test::Type02',
                 'prompt': "did you create object type 'test::Type02'?",
             },
         })
@@ -991,9 +977,9 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         '};'
                     )
                 }],
-                'operation_id': 'ALTER TYPE test::Type02',
                 'prompt': (
-                    "did you alter object type 'test::Type02'?"
+                    "did you drop property 'field02'"
+                    " of object type 'test::Type02'?"
                 ),
             },
         })
@@ -1032,9 +1018,9 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         '};'
                     )
                 }],
-                'operation_id': 'ALTER TYPE test::Type02',
                 'prompt': (
-                    "did you alter object type 'test::Type02'?"
+                    "did you create property 'field02'"
+                    " of object type 'test::Type02'?"
                 ),
             },
         })
@@ -1079,7 +1065,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         '};'
                     )
                 }],
-                'operation_id': 'CREATE TYPE test::Type01',
                 'prompt': "did you create object type 'test::Type01'?",
             },
         })
@@ -1121,9 +1106,9 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         '};'
                     )
                 }],
-                'operation_id': 'ALTER TYPE test::Type01',
                 'prompt': (
-                    "did you alter object type 'test::Type01'?"
+                    "did you rename link 'foo1' of object type"
+                    " 'test::Type01' to 'foo01'?"
                 ),
             },
         })
@@ -1166,7 +1151,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         '};'
                     )
                 }],
-                'operation_id': 'CREATE TYPE test::Type02',
                 'prompt': "did you create object type 'test::Type02'?",
             },
         })
@@ -1205,9 +1189,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         '};'
                     )
                 }],
-                'operation_id': 'ALTER TYPE test::Type02',
                 'prompt': (
-                    "did you alter object type 'test::Type02'?"
+                    "did you drop link 'foo02' of object type 'test::Type02'?"
                 ),
             },
         })
@@ -1254,9 +1237,9 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         '};'
                     )
                 }],
-                'operation_id': 'ALTER TYPE test::Type02',
                 'prompt': (
-                    "did you alter object type 'test::Type02'?"
+                    "did you create link 'foo02'"
+                    " of object type 'test::Type02'?"
                 ),
             },
         })
@@ -1294,7 +1277,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         'CREATE ABSTRACT LINK test::foo3;'
                     )
                 }],
-                'operation_id': 'CREATE LINK test::foo3',
                 'prompt': "did you create abstract link 'test::foo3'?",
             },
         })
@@ -1319,7 +1301,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         'RENAME TO test::foo03;'
                     )
                 }],
-                'operation_id': 'ALTER LINK test::foo3',
                 'prompt': (
                     "did you rename abstract link 'test::foo3' to "
                     "'test::foo03'?"
@@ -1345,7 +1326,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         'DROP ABSTRACT LINK test::foo03;'
                     )
                 }],
-                'operation_id': 'DROP LINK test::foo03',
                 'prompt': (
                     "did you drop abstract link 'test::foo03'?"
                 ),
@@ -1374,7 +1354,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         ' EXTENDING std::int64;'
                     )
                 }],
-                'operation_id': 'CREATE SCALAR TYPE test::ScalarType1',
                 'prompt': "did you create scalar type 'test::ScalarType1'?",
             },
         })
@@ -1403,7 +1382,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         ' RENAME TO test::ScalarType01;'
                     )
                 }],
-                'operation_id': 'ALTER SCALAR TYPE test::ScalarType1',
                 'prompt': (
                     "did you rename scalar type 'test::ScalarType1' to "
                     "'test::ScalarType01'?"
@@ -1437,7 +1415,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         ' EXTENDING std::str;'
                     )
                 }],
-                'operation_id': 'CREATE SCALAR TYPE test::ScalarType02',
                 'prompt': "did you create scalar type 'test::ScalarType02'?",
             },
         })
@@ -1465,7 +1442,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         'DROP SCALAR TYPE test::ScalarType02;'
                     )
                 }],
-                'operation_id': 'DROP SCALAR TYPE test::ScalarType02',
                 'prompt': (
                     "did you drop scalar type 'test::ScalarType02'?"
                 ),
@@ -1500,7 +1476,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         ' EXTENDING std::str;'
                     )
                 }],
-                'operation_id': 'CREATE SCALAR TYPE test::ScalarType02',
                 'prompt': "did you create scalar type 'test::ScalarType02'?",
             },
         })
@@ -1531,8 +1506,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         " EXTENDING enum<foo, bar>;"
                     )
                 }],
-                'operation_id': 'CREATE SCALAR TYPE test::EnumType1',
-                'prompt': "did you create enumerated type 'test::EnumType1'?",
+                'prompt': "did you create scalar type 'test::EnumType1'?",
             },
         })
         # Auto-complete migration
@@ -1560,9 +1534,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         ' RENAME TO test::EnumType01;'
                     )
                 }],
-                'operation_id': 'ALTER SCALAR TYPE test::EnumType1',
                 'prompt': (
-                    "did you rename enumerated type 'test::EnumType1' to "
+                    "did you rename scalar type 'test::EnumType1' to "
                     "'test::EnumType01'?"
                 ),
             },
@@ -1594,8 +1567,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         " EXTENDING enum<foo, bar>;"
                     )
                 }],
-                'operation_id': 'CREATE SCALAR TYPE test::EnumType02',
-                'prompt': "did you create enumerated type 'test::EnumType02'?",
+                'prompt': "did you create scalar type 'test::EnumType02'?",
             },
         })
         # Auto-complete migration
@@ -1622,9 +1594,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         'DROP SCALAR TYPE test::EnumType02;'
                     )
                 }],
-                'operation_id': 'DROP SCALAR TYPE test::EnumType02',
                 'prompt': (
-                    "did you drop enumerated type 'test::EnumType02'?"
+                    "did you drop scalar type 'test::EnumType02'?"
                 ),
             },
         })
@@ -1657,8 +1628,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         " EXTENDING enum<foo, bar>;"
                     )
                 }],
-                'operation_id': 'CREATE SCALAR TYPE test::EnumType02',
-                'prompt': "did you create enumerated type 'test::EnumType02'?",
+                'prompt': "did you create scalar type 'test::EnumType02'?",
             },
         })
         # Auto-complete migration
@@ -2080,7 +2050,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                         '};'
                     ),
                 }],
-                'operation_id': 'CREATE CONSTRAINT test::my_one_of',
             },
         })
         # Auto-complete migration
@@ -7908,6 +7877,58 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         })
 
         await self.fast_forward_describe_migration()
+
+    async def test_edgeql_migration_prompt_id_01(self):
+        await self.con.execute('''
+            START MIGRATION TO {
+                module test {
+                    type Bar { link spam -> Spam };
+                    type Spam { link bar -> Bar };
+                };
+            };
+        ''')
+
+        await self.assert_describe_migration({
+            'proposed': {
+                'prompt_id': 'CreateObjectType TYPE test::Bar',
+                'statements': [{
+                    'text': 'CREATE TYPE test::Bar;'
+                }],
+                'confidence': 1.0,
+            },
+        })
+
+        await self.fast_forward_describe_migration(limit=1)
+
+        await self.assert_describe_migration({
+            'proposed': {
+                'prompt_id': 'CreateObjectType TYPE test::Spam',
+                'statements': [{
+                    'text': """
+                        CREATE TYPE test::Spam {
+                            CREATE LINK bar -> test::Bar;
+                        };
+                    """,
+                }],
+                'confidence': 1.0,
+            },
+        })
+
+        await self.fast_forward_describe_migration(limit=1)
+
+        await self.assert_describe_migration({
+            'proposed': {
+                'prompt_id': 'CreateObjectType TYPE test::Bar',
+                'statements': [{
+                    'text': """
+                        ALTER TYPE test::Bar {
+                            CREATE LINK spam -> test::Spam;
+                        };
+                    """,
+                }],
+                'confidence': 1.0,
+            },
+        })
 
 
 class TestEdgeQLDataMigrationNonisolated(tb.DDLTestCase):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1913,9 +1913,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         ''')
 
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
-                "cannot redefine link 'foo' of object type 'test::Derived' "
-                "as object type 'test::B'"):
+            edgedb.SchemaError,
+            "inherited link 'foo' of object type 'test::Derived' has a "
+            "type conflict"
+        ):
             await self.con.execute('''
                 CREATE TYPE Derived EXTENDING Base0, Base1;
             ''')
@@ -1937,9 +1938,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         ''')
 
         with self.assertRaisesRegex(
-                edgedb.SchemaError,
-                "cannot redefine link 'foo' of object type 'test::Derived' "
-                "as object type 'test::C'"):
+            edgedb.SchemaError,
+            "inherited link 'foo' of object type 'test::Derived' "
+            "has a type conflict"
+        ):
             await self.con.execute('''
                 CREATE TYPE Derived EXTENDING Base0, Base1;
             ''')
@@ -2046,8 +2048,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_link_target_alter_02(self):
         with self.assertRaisesRegex(
             edgedb.SchemaError,
-            "cannot redefine property 'foo' of object type 'test::Child' "
-            "as scalar type 'std::int16'",
+            "inherited property 'foo' of object type 'test::Child'"
+            " has a type conflict",
         ):
             await self.con.execute("""
                 CREATE TYPE test::Parent01 {


### PR DESCRIPTION
Add collection of improvements intended to improve overall fidelity of
migration prompts in `DESCRIBE MIGRATION`.

Teach the delta tree reordering to take delta confidence into account, and
only gather subcommands if their `confidence` is `1.0`.  Further, use the
innermost command in a simple-chain command tree to determine user prompts,
for example in `ALTER TYPE Foo ALTER PROPERTY bar` the prompt will address
property `bar` and not just type `Foo`.

Finally, the optimize the client/server `DESCRIBE MIGRATION` loop for the
common case of client's acceptance of proposed DDL.  This removes the need
to rederive the proposed plan on every step and results in better prompts.