### PR TITLE
Implement required user input feedback in DESCRIBE MIGRATION

### DIFF
--- a/docs/edgeql/ddl/migrations.rst
+++ b/docs/edgeql/ddl/migrations.rst
@@ -248,15 +248,20 @@ in the current migration block in the specified output format:
           // the migration script.
           "proposed": {
             "statements": [{
-              "text": "<stmt text template>",
-              "required-user-input": [{
-                "name": "<placeholder variable>",
-                "prompt": "<statement prompt>",
-              }]
+              "text": "<stmt text template>"
             }],
+            "required-user-input": [
+              {
+                "placeholder": "<placeholder variable>",
+                "prompt": "<statement prompt>",
+              },
+              ...
+            ],
             "confidence": (0..1), // confidence coefficient
-            "prompt": "<variant prompt>",
-            "safe": {true|false}
+            "prompt": "<operation prompt>",
+            "prompt_id": "<prompt id>",
+            // Whether the operation is considered to be non-destructive.
+            "data_safe": {true|false}
           }
         }
 
@@ -266,7 +271,7 @@ in the current migration block in the specified output format:
         Regular statement text.
 
     :eql:synopsis:`<stmt text template>`
-        Statement text template with interpolation points using the \(name)
+        Statement text template with interpolation points using the ``\(name)``
         syntax.
 
     :eql:synopsis:`<placeholder variable>`
@@ -276,9 +281,12 @@ in the current migration block in the specified output format:
     :eql:synopsis:`<statement prompt>`
         The text of a user prompt for an interpolation variable.
 
-    :eql:synopsis:`<variant prompt>`
-        Prompt for the proposed migration step variant.
+    :eql:synopsis:`<operation prompt>`
+        Prompt for the proposed migration step.
 
+    :eql:synopsis:`<prompt id>`
+        An opaque string identifier for a particular operation prompt.
+        The client should not repeat prompts with the same prompt id.
 
 
 COMMIT MIGRATION

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -137,6 +137,11 @@ class Options(Base):
         return len(self.options)
 
 
+class Placeholder(Base):
+    """An interpolation placeholder used in expression templates."""
+    name: str
+
+
 class Expr(Base):
     """Abstract parent for all query expressions."""
     __abstract_node__ = True

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -588,6 +588,11 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
     def visit_Parameter(self, node: qlast.Parameter) -> None:
         self.write(param_to_str(node.name))
 
+    def visit_Placeholder(self, node: qlast.Placeholder) -> None:
+        self.write('\\(')
+        self.write(node.name)
+        self.write(')')
+
     def visit_StringConstant(self, node: qlast.StringConstant) -> None:
         if not _NON_PRINTABLE_RE.search(node.value):
             for d in ("'", '"', '$$'):
@@ -1536,12 +1541,15 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self._visit_DropObject(node, 'LINK', unqualified=True)
 
     def visit_SetPointerType(self, node: qlast.SetPointerType) -> None:
-        self.write('SET TYPE ')
-        self.visit(node.value)
-        if node.cast_expr is not None:
-            self.write(' USING (')
-            self.visit(node.cast_expr)
-            self.write(')')
+        if node.value is None:
+            self.write('RESET TYPE')
+        else:
+            self.write('SET TYPE ')
+            self.visit(node.value)
+            if node.cast_expr is not None:
+                self.write(' USING (')
+                self.visit(node.cast_expr)
+                self.write(')')
 
     def visit_OnTargetDelete(self, node: qlast.OnTargetDelete) -> None:
         self._write_keywords('ON TARGET DELETE ', node.cascade.to_edgeql())

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -710,9 +710,13 @@ def top_output_as_value(
         # into a JSON array.
         return aggregate_json_output(stmt, ir_set, env=env)
 
-    elif (env.output_format is context.OutputFormat.NATIVE and
-            env.explicit_top_cast is not None):
-
+    elif (
+        env.explicit_top_cast is not None
+        and (
+            env.output_format is context.OutputFormat.NATIVE
+            or env.output_format is context.OutputFormat.NATIVE_INTERNAL
+        )
+    ):
         typecast = pgast.TypeCast(
             arg=stmt.target_list[0].val,
             type_name=pgast.TypeName(

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1032,6 +1032,25 @@ def get_path_serialized_output(
 
     ref = get_path_serialized_or_value_var(rel, path_id, env=env)
 
+    if (
+        isinstance(ref, pgast.TupleVarBase)
+        and not isinstance(ref, pgast.TupleVar)
+    ):
+        elements = []
+
+        for el in ref.elements:
+            assert el.path_id is not None
+            val = get_path_serialized_or_value_var(rel, el.path_id, env=env)
+            elements.append(
+                pgast.TupleElement(
+                    path_id=el.path_id, name=el.name, val=val))
+
+        ref = pgast.TupleVar(
+            elements,
+            named=ref.named,
+            typeref=ref.typeref,
+        )
+
     refexpr = output.serialize_expr(ref, path_id=path_id, env=env)
     alias = get_path_output_alias(path_id, aspect, env=env)
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -798,15 +798,6 @@ def process_set_as_link_property_ref(
         rvars.append(SetRVar(
             link_rvar, link_path_id, aspects=['value', 'source']))
 
-        target_rvar = pathctx.maybe_get_path_rvar(
-            source_scope_stmt, link_path_id.tgt_path(),
-            aspect='value', env=ctx.env)
-
-        if target_rvar is None:
-            target_rvar = relctx.new_root_rvar(ir_source, ctx=newctx)
-
-        rvars.append(SetRVar(target_rvar, link_path_id.tgt_path()))
-
     return SetRVars(main=SetRVar(link_rvar, ir_set.path_id), new=rvars)
 
 

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -111,12 +111,14 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
         cls: Type[Expression],
         qltree: qlast_.Base,
         schema: s_schema.Schema,
-        modaliases: Mapping[Optional[str], str],
+        modaliases: Optional[Mapping[Optional[str], str]] = None,
         localnames: AbstractSet[str] = frozenset(),
         *,
         as_fragment: bool = False,
         orig_text: Optional[str] = None,
     ) -> Expression:
+        if modaliases is None:
+            modaliases = {}
         if orig_text is None:
             orig_text = qlcodegen.generate_source(qltree, pretty=False)
         if not as_fragment:

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -247,14 +247,23 @@ class ProposedMigrationStep(NamedTuple):
     prompt: str
     prompt_id: str
     data_safe: bool
+    required_user_input: Tuple[Tuple[str, str]]
 
     def to_json(self) -> Dict[str, Any]:
+        user_input_list = []
+        for var_name, var_desc in self.required_user_input:
+            user_input_list.append({
+                'placeholder': var_name,
+                'prompt': var_desc,
+            })
+
         return {
             'statements': [{'text': stmt} for stmt in self.statements],
             'confidence': self.confidence,
             'prompt': self.prompt,
             'prompt_id': self.prompt_id,
             'data_safe': self.data_safe,
+            'required_user_input': user_input_list,
         }
 
 


### PR DESCRIPTION
Teach `DESCRIBE CURRENT MIGRATION AS JSON` to include a list of client 
prompts for expressions required to complete the migration.  The proposed
statement text will now include placeholders in the form of
`\(placeholder)` where the client response should be inserted.

This patch implements client input requests for `SET TYPE` operations
(`AlterPointerType`).