### PR TITLE
Implement syntax to specify a fill expression in SET REQUIRED

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -639,6 +639,12 @@ class SetPointerType(SetField):
     cast_expr: typing.Optional[Expr]
 
 
+class SetPointerOptionality(SetField):
+    name: str = 'required'
+    special_syntax: bool = True
+    fill_expr: typing.Optional[Expr]
+
+
 class NamedDDL(DDLCommand):
     __abstract_node__ = True
     name: ObjectRef

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1551,6 +1551,22 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 self.visit(node.cast_expr)
                 self.write(')')
 
+    def visit_SetPointerOptionality(
+        self,
+        node: qlast.SetPointerOptionality,
+    ) -> None:
+        if node.value is None:
+            self.write('RESET OPTIONALITY')
+        else:
+            if self._eval_bool_expr(node.value):
+                self.write('SET REQUIRED')
+            else:
+                self.write('SET OPTIONAL')
+            if node.fill_expr is not None:
+                self.write(' USING (')
+                self.visit(node.fill_expr)
+                self.write(')')
+
     def visit_OnTargetDelete(self, node: qlast.OnTargetDelete) -> None:
         self._write_keywords('ON TARGET DELETE ', node.cascade.to_edgeql())
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -998,22 +998,6 @@ class OptAlterUsingClause(Nonterm):
         self.val = None
 
 
-class SetPropertyTypeStmt(Nonterm):
-    def reduce_SETTYPE_FullTypeExpr_OptAlterUsingClause(self, *kids):
-        self.val = qlast.SetPointerType(
-            value=kids[1].val,
-            cast_expr=kids[2].val,
-        )
-
-
-class SetLinkTypeStmt(Nonterm):
-    def reduce_SETTYPE_FullTypeExpr_OptAlterUsingClause(self, *kids):
-        self.val = qlast.SetPointerType(
-            value=kids[1].val,
-            cast_expr=kids[2].val,
-        )
-
-
 #
 # CREATE PROPERTY
 #
@@ -1167,15 +1151,16 @@ class SetCardinalityStmt(Nonterm):
 
 class SetRequiredStmt(Nonterm):
 
-    def reduce_SET_REQUIRED(self, *kids):
-        self.val = qlast.SetField(
+    def reduce_SET_REQUIRED_OptAlterUsingClause(self, *kids):
+        self.val = qlast.SetPointerOptionality(
             name='required',
             value=qlast.BooleanConstant.from_python(True),
             special_syntax=True,
+            fill_expr=kids[2].val,
         )
 
     def reduce_SET_OPTIONAL(self, *kids):
-        self.val = qlast.SetField(
+        self.val = qlast.SetPointerOptionality(
             name='required',
             value=qlast.BooleanConstant.from_python(False),
             special_syntax=True,
@@ -1183,10 +1168,19 @@ class SetRequiredStmt(Nonterm):
 
     def reduce_DROP_REQUIRED(self, *kids):
         # TODO: Raise a DeprecationWarning once we have facility for that.
-        self.val = qlast.SetField(
+        self.val = qlast.SetPointerOptionality(
             name='required',
             value=qlast.BooleanConstant.from_python(False),
             special_syntax=True,
+        )
+
+
+class SetPointerTypeStmt(Nonterm):
+
+    def reduce_SETTYPE_FullTypeExpr_OptAlterUsingClause(self, *kids):
+        self.val = qlast.SetPointerType(
+            value=kids[1].val,
+            cast_expr=kids[2].val,
         )
 
 
@@ -1200,7 +1194,7 @@ commands_block(
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
-    SetPropertyTypeStmt,
+    SetPointerTypeStmt,
     SetCardinalityStmt,
     SetRequiredStmt,
     AlterSimpleExtending,
@@ -1415,7 +1409,7 @@ commands_block(
     DropAnnotationValueStmt,
     SetCardinalityStmt,
     SetRequiredStmt,
-    SetLinkTypeStmt,
+    SetPointerTypeStmt,
     AlterSimpleExtending,
     CreateConcreteConstraintStmt,
     AlterConcreteConstraintStmt,

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -958,23 +958,28 @@ class CreateConstraint(
     @classmethod
     def as_inherited_ref_cmd(
         cls,
+        *,
         schema: s_schema.Schema,
         context: sd.CommandContext,
         astnode: qlast.ObjectDDL,
-        parents: Any,
+        bases: Any,
+        referrer: so.Object,
     ) -> sd.ObjectCommand[Constraint]:
-        cmd = super().as_inherited_ref_cmd(schema, context, astnode, parents)
+        cmd = super().as_inherited_ref_cmd(
+            schema=schema,
+            context=context,
+            astnode=astnode,
+            bases=bases,
+            referrer=referrer,
+        )
 
         args = cls._constraint_args_from_ast(schema, astnode, context)
         if args:
             cmd.set_attribute_value('args', args)
 
-        subj_expr = parents[0].get_subjectexpr(schema)
+        subj_expr = bases[0].get_subjectexpr(schema)
         if subj_expr is not None:
             cmd.set_attribute_value('subjectexpr', subj_expr)
-
-        cmd.set_attribute_value(
-            'bases', so.ObjectList.create(schema, parents))
 
         return cmd
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -561,6 +561,16 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
         else:
             return False
 
+    def is_attribute_computed(
+        self,
+        attr_name: str,
+    ) -> bool:
+        op = self._get_attribute_set_cmd(attr_name)
+        if op is not None:
+            return op.new_computed
+        else:
+            return False
+
     def get_attribute_source_context(
         self,
         attr_name: str,

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -379,7 +379,12 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
 
         for create_cmd, astnode, bases in refs.values():
             cmd = create_cmd.as_inherited_ref_cmd(
-                schema, context, astnode, bases)
+                schema=schema,
+                context=context,
+                astnode=astnode,
+                bases=bases,
+                referrer=scls,
+            )
 
             obj = schema.get(cmd.classname, default=None)
             if obj is None:
@@ -810,9 +815,14 @@ class CreateInheritingObject(
         refs = self.get_inherited_ref_layout(schema, context, refdict)
         group = sd.CommandGroup()
 
-        for create_cmd, astnode, parents in refs.values():
+        for create_cmd, astnode, bases in refs.values():
             cmd = create_cmd.as_inherited_ref_cmd(
-                schema, context, astnode, parents)
+                schema=schema,
+                context=context,
+                astnode=astnode,
+                bases=bases,
+                referrer=scls,
+            )
 
             cmd.set_attribute_value(refdict.backref_attr, scls)
 

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -279,8 +279,8 @@ class LinkCommand(
 
 
 class CreateLink(
+    pointers.CreatePointer[Link],
     LinkCommand,
-    referencing.CreateReferencedInheritingObject[Link],
 ):
     astnode = [qlast.CreateConcreteLink, qlast.CreateLink]
     referenced_astnode = qlast.CreateConcreteLink
@@ -517,6 +517,14 @@ class AlterLinkUpperCardinality(
     pointers.AlterPointerUpperCardinality[Link],
     referrer_context_class=LinkSourceCommandContext,
     field='cardinality',
+):
+    pass
+
+
+class AlterLinkLowerCardinality(
+    pointers.AlterPointerLowerCardinality[Link],
+    referrer_context_class=LinkSourceCommandContext,
+    field='required',
 ):
     pass
 

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -357,6 +357,14 @@ class AlterPropertyUpperCardinality(
     pass
 
 
+class AlterPropertyLowerCardinality(
+    pointers.AlterPointerLowerCardinality[Property],
+    referrer_context_class=PropertySourceContext,
+    field='required',
+):
+    pass
+
+
 class AlterPropertyOwned(
     referencing.AlterOwned[Property],
     referrer_context_class=PropertySourceContext,

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -580,15 +580,16 @@ class CreateReferencedObject(
     @classmethod
     def as_inherited_ref_cmd(
         cls,
+        *,
         schema: s_schema.Schema,
         context: sd.CommandContext,
         astnode: qlast.ObjectDDL,
-        parents: Any,
+        bases: Any,
+        referrer: so.Object,
     ) -> sd.ObjectCommand[ReferencedT]:
         cmd = cls(classname=cls._classname_from_ast(schema, astnode, context))
         cmd.set_attribute_value('name', cmd.classname)
-        cmd.set_attribute_value(
-            'bases', so.ObjectList.create(schema, parents))
+        cmd.set_attribute_value('bases', so.ObjectList.create(schema, bases))
         return cmd
 
     @classmethod
@@ -1128,7 +1129,12 @@ class CreateReferencedInheritingObject(
                 # containing Alter(if_exists) and Create(if_not_exists)
                 # to postpone that check until the application time.
                 ref_create = ref_create_cmd.as_inherited_ref_cmd(
-                    schema, context, astnode, [self.scls])
+                    schema=schema,
+                    context=context,
+                    astnode=astnode,
+                    bases=[self.scls],
+                    referrer=child,
+                )
                 assert isinstance(ref_create, sd.CreateObject)
                 ref_create.if_not_exists = True
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -4112,6 +4112,24 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_type_15(self):
+        """
+        ALTER TYPE Foo {
+            ALTER LINK bar {
+                SET TYPE int64 USING (SELECT (.bar, 1));
+            };
+        };
+        """
+
+    def test_edgeql_syntax_ddl_type_16(self):
+        """
+        ALTER TYPE Foo {
+            ALTER LINK bar {
+                SET REQUIRED USING (SELECT '123');
+            };
+        };
+        """
+
     def test_edgeql_syntax_set_command_01(self):
         """
         SET MODULE default;


### PR DESCRIPTION
When an existing link or property is altered to become `required`,
existing objects must be updated for the new constraint to be valid.
This implements a `USING` clause for `SET REQUIRED` which acts similarly
to the analogous clause of the `SET TYPE` operation.