### PR TITLE
Implement parsing `\(expr)` token

### DIFF
--- a/edb/edgeql-parser/tests/tokenizer.rs
+++ b/edb/edgeql-parser/tests/tokenizer.rs
@@ -747,3 +747,19 @@ fn invalid_suffix() {
     assert_eq!(tok_err("SELECT 1d;"), "Unexpected `suffix \"d\" \
         is invalid for numbers, perhaps you wanted `1n` (bigint)?`");
 }
+
+#[test]
+fn test_substitution() {
+    assert_eq!(tok_str("SELECT \\(expr);"),
+                       ["SELECT", "\\(expr)", ";"]);
+    assert_eq!(tok_typ("SELECT \\(expr);"),
+                       [Keyword, Substitution, Semicolon]);
+    assert_eq!(tok_str("SELECT \\(other_Name1);"),
+                       ["SELECT", "\\(other_Name1)", ";"]);
+    assert_eq!(tok_typ("SELECT \\(other_Name1);"),
+                       [Keyword, Substitution, Semicolon]);
+    assert_eq!(tok_err("SELECT \\(some-name);"),
+        "Unexpected `only alphanumerics are allowed in \\(name) token`");
+    assert_eq!(tok_err("SELECT \\(some_name"),
+        "Unexpected `unclosed \\(name) token`");
+}

--- a/edb/edgeql-rust/src/normalize.rs
+++ b/edb/edgeql-rust/src/normalize.rs
@@ -289,6 +289,7 @@ fn is_operator(token: &CowToken) -> bool {
         | BacktickName
         | Keyword
         | Ident
+        | Substitution
         => false,
     }
 }

--- a/edb/edgeql-rust/src/tokenizer.rs
+++ b/edb/edgeql-rust/src/tokenizer.rs
@@ -89,6 +89,7 @@ pub struct Tokens {
     argument: PyString,
     eof: PyString,
     empty: PyString,
+    substitution: PyString,
 
     named_only: PyString,
     named_only_val: PyString,
@@ -256,6 +257,7 @@ impl Tokens {
             argument: PyString::new(py, "ARGUMENT"),
             eof: PyString::new(py, "EOF"),
             empty: PyString::new(py, ""),
+            substitution: PyString::new(py, "SUBSTITUTION"),
             named_only: PyString::new(py, "NAMEDONLY"),
             named_only_val: PyString::new(py, "NAMED ONLY"),
             set_annotation: PyString::new(py, "SETANNOTATION"),
@@ -610,6 +612,12 @@ fn convert(py: Python, tokens: &Tokens, cache: &mut Cache,
                     },
                 }
             }
+        }
+        Substitution => {
+            let content = &value[2..value.len()-1];
+            Ok((tokens.substitution.clone_ref(py),
+                PyString::new(py, value),
+                PyString::new(py, content).into_object()))
         }
     }
 }


### PR DESCRIPTION
This is intended to be used only for command-line tools (to create migrations), but this has to be done in a tokenizer.

See #2119 and RFC1000 for more information