### PR TITLE
Add expression check utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "serde",
  "sha2",
  "snafu",
+ "thiserror",
  "twoway",
  "wasm-bindgen",
 ]
@@ -511,9 +512,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -522,18 +523,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/edb/edgeql-parser/Cargo.toml
+++ b/edb/edgeql-parser/Cargo.toml
@@ -13,6 +13,7 @@ combine = "4.0.0-beta.1"
 twoway = "0.2.1"
 wasm-bindgen = {version="0.2", features=["serde-serialize"], optional=true}
 serde = {version="1.0.106", features=["derive"], optional=true}
+thiserror = "1.0.23"
 
 [features]
 default = []

--- a/edb/edgeql-parser/src/expr.rs
+++ b/edb/edgeql-parser/src/expr.rs
@@ -5,7 +5,7 @@ use crate::tokenizer::{Kind, TokenStream};
 ///
 /// See [check][].
 #[derive(Debug, thiserror::Error)]
-pub enum ExpressionError {
+pub enum Error {
     #[error("{}: tokenizer error: {}", _1, _0)]
     Tokenizer(String, Pos),
     #[error(
@@ -64,9 +64,9 @@ fn matching_bracket(tok: Kind) -> Kind {
 /// semicolon `;` outside of brackets.
 ///
 /// This is NOT a security measure.
-pub fn check(text: &str) -> Result<(), ExpressionError> {
+pub fn check(text: &str) -> Result<(), Error> {
     use crate::tokenizer::Kind::*;
-    use ExpressionError::*;
+    use Error::*;
 
     let mut brackets = Vec::new();
     let mut parser = &mut TokenStream::new(text);

--- a/edb/edgeql-parser/src/expr.rs
+++ b/edb/edgeql-parser/src/expr.rs
@@ -1,0 +1,119 @@
+use crate::position::Pos;
+use crate::tokenizer::{Kind, TokenStream};
+
+/// Error of expression checking
+///
+/// See [check][].
+#[derive(Debug, thiserror::Error)]
+pub enum ExpressionError {
+    #[error("{}: tokenizer error: {}", _1, _0)]
+    Tokenizer(String, Pos),
+    #[error(
+        "{}: closing bracket mismatch, opened {:?} at {}, encountered {:?}",
+        closing_pos, opened, opened_pos, encountered)]
+    BracketMismatch {
+        opened: &'static str,
+        encountered: &'static str,
+        opened_pos: Pos,
+        closing_pos: Pos,
+    },
+    #[error("{}: extra closing bracket {:?}", _1, _0)]
+    ExtraBracket(&'static str, Pos),
+    #[error("{}: bracket {:?} has never been closed", _1, _0)]
+    MissingBracket(&'static str, Pos),
+    #[error("{}: token {:?} is not allowed in expression \
+             (try parenthesize the expression)", _1, _0)]
+    UnexpectedToken(String, Pos),
+    #[error("expression is empty")]
+    Empty,
+}
+
+fn bracket_str(tok: Kind) -> &'static str {
+    use crate::tokenizer::Kind::*;
+
+    match tok {
+        OpenBracket => "[",
+        CloseBracket => "]",
+        OpenBrace => "{",
+        CloseBrace => "}",
+        OpenParen => "(",
+        CloseParen => ")",
+        _ => unreachable!("token is not a bracket"),
+    }
+}
+
+fn matching_bracket(tok: Kind) -> Kind {
+    use crate::tokenizer::Kind::*;
+
+    match tok {
+        OpenBracket => CloseBracket,
+        OpenBrace => CloseBrace,
+        OpenParen => CloseParen,
+        _ => unreachable!("token is not a bracket"),
+    }
+}
+
+/// Minimal validation of expression
+///
+/// This is used for substitutions in migrations. This check merely ensures
+/// that overall structure of the statement is not ruined. Mostly checks for
+/// matching brackets and quotes closed.
+///
+/// More specificaly current implementation checks that expression is not
+/// empty, checks for valid tokens, matching braces and disallows comma `,`and
+/// semicolon `;` outside of brackets.
+///
+/// This is NOT a security measure.
+pub fn check(text: &str) -> Result<(), ExpressionError> {
+    use crate::tokenizer::Kind::*;
+    use ExpressionError::*;
+
+    let mut brackets = Vec::new();
+    let mut parser = &mut TokenStream::new(text);
+    let mut empty = true;
+    for token in &mut parser {
+        let (token, pos) = match token {
+            Ok(t) => (t.token, t.start),
+            Err(combine::easy::Error::Unexpected(s)) => {
+                return Err(Tokenizer(
+                    s.to_string(), parser.current_pos()));
+            }
+            Err(e) => {
+                return Err(Tokenizer(
+                    e.to_string(), parser.current_pos()));
+            }
+        };
+        empty = false;
+        match token.kind {
+            Comma | Semicolon if brackets.is_empty() => {
+                return Err(UnexpectedToken(token.value.to_string(), pos));
+            }
+            OpenParen | OpenBracket | OpenBrace => {
+                brackets.push((token.kind, pos));
+            }
+            CloseParen | CloseBracket | CloseBrace => match brackets.pop() {
+                Some((opened, opened_pos)) => {
+                    if matching_bracket(opened) != token.kind {
+                        return Err(BracketMismatch {
+                            opened: bracket_str(opened),
+                            opened_pos,
+                            encountered: bracket_str(token.kind),
+                            closing_pos: pos,
+                        });
+                    }
+                }
+                None => {
+                    return Err(ExtraBracket(bracket_str(token.kind), pos));
+                }
+            },
+            _ => {}
+        }
+    };
+    if let Some((bracket, pos)) = brackets.pop() {
+        return Err(MissingBracket(bracket_str(bracket), pos));
+    }
+    if empty {
+        return Err(Empty);
+    }
+    Ok(())
+}

--- a/edb/edgeql-parser/src/lib.rs
+++ b/edb/edgeql-parser/src/lib.rs
@@ -4,3 +4,4 @@ pub mod tokenizer;
 pub mod helpers;
 pub mod keywords;
 pub mod hash;
+pub mod expr;

--- a/edb/edgeql-parser/tests/expr.rs
+++ b/edb/edgeql-parser/tests/expr.rs
@@ -1,0 +1,83 @@
+use edgeql_parser::expr::check;
+
+#[test]
+fn test_valid() {
+    check("1").unwrap();
+    check(" 42    ").unwrap();
+    check("42 # )").unwrap();
+    check("33 ++ 44").unwrap();
+    check("33 ++ '44'").unwrap();
+    check("(1, 2) # tuple").unwrap();
+    check("# next line\n 2+2").unwrap();
+    check("{}").unwrap();
+    check("()").unwrap();
+    check(".user.name").unwrap();
+    check("call(me.maybe)").unwrap();
+    check("bad +/- grammar **** but --- allowed").unwrap();
+}
+
+fn check_err(s: &str) -> String {
+    check(s).unwrap_err().to_string()
+}
+
+#[test]
+fn test_empty() {
+    assert_eq!(check_err(""), "expression is empty");
+    assert_eq!(check_err("   "), "expression is empty");
+    assert_eq!(check_err("# xxx + yyy"), "expression is empty");
+}
+
+#[test]
+fn bad_token() {
+    assert_eq!(check_err("'quote"),
+        "1:1: tokenizer error: unterminated string, quoted by `'`");
+    assert_eq!(check_err("\\(quote"),
+        "1:1: tokenizer error: unclosed \\(name) token");
+}
+
+#[test]
+fn bracket_mismatch() {
+    assert_eq!(check_err("(a[12)]"),
+        "1:6: closing bracket mismatch, \
+            opened \"[\" at 1:3, encountered \")\"");
+    assert_eq!(check_err("(a12]"),
+        "1:5: closing bracket mismatch, \
+            opened \"(\" at 1:1, encountered \"]\"");
+    assert_eq!(check_err("{'}']"),
+        "1:5: closing bracket mismatch, \
+            opened \"{\" at 1:1, encountered \"]\"");
+}
+
+#[test]
+fn extra_brackets() {
+    assert_eq!(check_err("func())"),
+        "1:7: extra closing bracket \")\"");
+    assert_eq!(check_err("{} + x]"),
+        "1:7: extra closing bracket \"]\"");
+    assert_eq!(check_err("{'xxx(yyy'})"),
+        "1:12: extra closing bracket \")\"");
+}
+
+#[test]
+fn missing_brackets() {
+    assert_eq!(check_err("func((1, 2)"),
+        "1:5: bracket \"(\" has never been closed");
+    assert_eq!(check_err("{(1, 2), (3, '}')"),
+        "1:1: bracket \"{\" has never been closed");
+    assert_eq!(check_err("{((())[[()"),
+        "1:8: bracket \"[\" has never been closed");
+}
+
+#[test]
+fn delimiter() {
+    assert_eq!(check_err("1, 2"),
+        "1:2: token \",\" is not allowed in expression \
+         (try parenthesize the expression)");
+    check("(1, 2)").unwrap();
+
+    assert_eq!(check_err("create type Type1;"),
+        "1:18: token \";\" is not allowed in expression \
+         (try parenthesize the expression)");
+    // this doesn't work, but is fun to see
+    check("{create if not exists type Type1; SELECT Type1}").unwrap();
+}


### PR DESCRIPTION
This is needed for command-line tools to accept expression input for the
migrations (see edgedb/edgedb-cli#216)
 
While technically this can be done in the CLI itself, I think this belongs here, similarly to other utilities in `edgeql-parser` module.