### PR TITLE
Make scope tree unique_ids actually be unique

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -218,7 +218,7 @@ def _check_binding_volatility(
                 "be used inside FOR bodies",
                 context=ir.context)
 
-        if bind_scope and scope_tree.parent_fence != bind_scope.fence:
+        if bind_scope and scope_tree.fence != bind_scope.fence:
             if (
                 path_id in ctx.volatile_uses
                 and ctx.volatile_uses[path_id] != scope_tree
@@ -610,7 +610,7 @@ def _infer_set_inner(
     if (node := _find_visible(ir, scope_tree)) is not None:
         return AT_MOST_ONE if node.optional else ONE
 
-    _check_binding_volatility(ir, scope_tree=new_scope, ctx=ctx)
+    _check_binding_volatility(ir, scope_tree=scope_tree, ctx=ctx)
 
     if rptr is not None:
         if isinstance(rptrref, irast.TypeIntersectionPointerRef):

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -129,9 +129,18 @@ def compile_ForQuery(
 
         ictx = iterator_ctx or sctx
 
+        contains_dml = qlutils.contains_dml(qlstmt.result)
+        # If the body contains DML, then we need to prohibit
+        # correlation between the iterator and the enclosing
+        # query, since the correlation imposes compilation issues
+        # we aren't willing to tackle.
+        if contains_dml:
+            ictx.path_scope.factoring_allowlist.update(
+                ctx.iterator_path_ids)
         iterator_view = stmtctx.declare_view(
             iterator,
             s_name.UnqualName(qlstmt.iterator_alias),
+            factoring_fence=contains_dml,
             path_id_namespace=ictx.path_id_namespace,
             ctx=ictx,
         )
@@ -168,13 +177,12 @@ def compile_ForQuery(
         sctx.iterator_path_ids |= {stmt.iterator_stmt.path_id}
         node = ictx.path_scope.find_descendant(iterator_stmt.path_id)
         if node is not None:
-            # If the body contains DML, then we need to prohibit
-            # correlation between the iterator and the enclosing
-            # query, since the correlation imposes compilation issues
-            # we aren't willing to tackle.
+            # See above about why we need a factoring fence.
+            # We need to do this again when we move the branch so
+            # as to preserve the fencing.
             # Do this by sticking the iterator subtree onto a branch
             # with a factoring fence.
-            if qlutils.contains_dml(qlstmt.result):
+            if contains_dml:
                 node = node.attach_branch()
                 node.factoring_fence = True
                 node = node.attach_branch()

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -398,7 +398,7 @@ def declare_view(
 
     pinned_pid_ns = path_id_namespace
 
-    with ctx.newscope(temporary=False, fenced=True) as subctx:
+    with ctx.newscope(fenced=True) as subctx:
         subctx.path_scope.factoring_fence = factoring_fence
         if path_id_namespace is not None:
             subctx.path_id_namespace = path_id_namespace

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -143,6 +143,8 @@ def fini_expression(
             if node.path_id.namespace:
                 node.path_id = node.path_id.strip_weak_namespaces()
 
+        ctx.path_scope.validate_unique_ids()
+
     if isinstance(ir, irast.Command):
         if isinstance(ir, irast.ConfigCommand):
             ir.scope_tree = ctx.path_scope
@@ -387,6 +389,7 @@ def declare_view(
     expr: qlast.Expr,
     alias: s_name.Name,
     *,
+    factoring_fence: bool=False,
     fully_detached: bool=False,
     must_be_used: bool=False,
     path_id_namespace: Optional[FrozenSet[str]]=None,
@@ -395,7 +398,8 @@ def declare_view(
 
     pinned_pid_ns = path_id_namespace
 
-    with ctx.newscope(temporary=True, fenced=True) as subctx:
+    with ctx.newscope(temporary=False, fenced=True) as subctx:
+        subctx.path_scope.factoring_fence = factoring_fence
         if path_id_namespace is not None:
             subctx.path_id_namespace = path_id_namespace
 
@@ -481,7 +485,8 @@ def declare_view_from_schema(
 
         vc = subctx.aliased_views[viewcls_name]
         assert vc is not None
-        ctx.env.schema_view_cache[viewcls] = vc
+        if not ctx.in_temp_scope:
+            ctx.env.schema_view_cache[viewcls] = vc
         ctx.source_map.update(subctx.source_map)
         ctx.aliased_views[viewcls_name] = subctx.aliased_views[viewcls_name]
         ctx.view_nodes[vc.get_name(ctx.env.schema)] = vc

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -125,6 +125,20 @@ class ScopeTreeNode:
 
         return cp
 
+    def find_dupe_unique_ids(self) -> Set[int]:
+        seen = set()
+        dupes = set()
+        for node in self.root.descendants:
+            if node.unique_id is not None:
+                if node.unique_id in seen:
+                    dupes.add(node.unique_id)
+                seen.add(node.unique_id)
+        return dupes
+
+    def validate_unique_ids(self) -> None:
+        dupes = self.find_dupe_unique_ids()
+        assert not dupes, f'Duplicate "unique" ids seen {dupes}'
+
     @property
     def name(self) -> str:
         return self._name(debug=False)

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -964,6 +964,54 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_aliases_subqueries_01(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test
+                SELECT count((
+                    (SELECT EarthOrFireCard.name),
+                    (EarthOrFireCard.name)
+                ))
+            """,
+            [4]
+        )
+
+    async def test_edgeql_aliases_subqueries_02(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test
+                SELECT count((
+                    (EarthOrFireCard.name),
+                    (SELECT EarthOrFireCard.name)
+                ))
+            """,
+            [4]
+        )
+
+    async def test_edgeql_aliases_subqueries_03(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test
+                SELECT count((
+                    (EarthOrFireCard.name),
+                    (EarthOrFireCard.name)
+                ))
+            """,
+            [4]
+        )
+
+    async def test_edgeql_aliases_subqueries_04(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test
+                SELECT count((
+                    (SELECT EarthOrFireCard.name),
+                    (SELECT EarthOrFireCard.name)
+                ))
+            """,
+            [16]
+        )
+
     async def test_edgeql_aliases_introspection(self):
         await self.assert_query_result(
             r"""

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -442,6 +442,28 @@ class TestEdgeQLFor(tb.QueryTestCase):
             [2],
         )
 
+    async def test_edgeql_for_correlated_02(self):
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT count((Card.name,
+                              (FOR x in {Card} UNION (SELECT x.name)),
+                ));
+            ''',
+            [9],
+        )
+
+    async def test_edgeql_for_correlated_03(self):
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT count(((FOR x in {Card} UNION (SELECT x.name)),
+                               Card.name,
+                ));
+            ''',
+            [9],
+        )
+
     async def test_edgeql_for_empty_01(self):
         with self.assertRaisesRegex(
             edgedb.errors.QueryError,

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -166,12 +166,13 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::Card)",
             "(test::User)",
             "FENCE": {
-                "(__derived__::__derived__|U@w~1)": {
-                    "FENCE": {
-                        "(test::User)"
-                    }
-                },
+                "(__derived__::__derived__|U@w~1)",
                 "(test::Card).>users[IS test::User]"
+            },
+            "FENCE": {
+                "FENCE": {
+                    "(test::User)"
+                }
             }
         }
         """
@@ -227,12 +228,13 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "(__derived__::expr~5).>friends[IS test::User]": {
-                "(__derived__::expr~5)": {
+                "(__derived__::expr~5)"
+            },
+            "FENCE": {
+                "FENCE": {
+                    "(test::User)",
                     "FENCE": {
-                        "(test::User)",
-                        "FENCE": {
-                            "(test::User).>name[IS std::str]"
-                        }
+                        "(test::User).>name[IS std::str]"
                     }
                 }
             }
@@ -267,10 +269,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(schema::Type)",
             "FENCE": {
                 "(schema::Type).>element_type[IS schema::Type]",
+                "(schema::Type).>indirection[IS schema::Array]",
                 "(schema::Type).>indirection[IS schema::Array]\
-.>element_type[IS schema::Type]": {
-                    "(schema::Type).>indirection[IS schema::Array]"
-                }
+.>element_type[IS schema::Type]"
             }
         }
         """
@@ -402,20 +403,12 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(__derived__::__derived__|U@w~1).>cards[IS test::Card]\
-.>foo[IS std::float64]": {
+            "(__derived__::__derived__|U@w~1)\
+.>cards[IS test::Card].>foo[IS std::float64]": {
                 "BRANCH": {
-                    "(__derived__::__derived__|U@w~1)\
-.>cards[IS test::Card]": {
+                    "(__derived__::__derived__|U@w~1).>cards[IS test::Card]": {
                         "BRANCH": {
-                            "(__derived__::__derived__|U@w~1)": {
-                                "FENCE": {
-                                    "(test::User)",
-                                    "FENCE": {
-                                        "(test::User).>name[IS std::str]"
-                                    }
-                                }
-                            }
+                            "(__derived__::__derived__|U@w~1)"
                         },
                         "FENCE": {
                             "(test::Card)",
@@ -426,6 +419,14 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                                 }
                             }
                         }
+                    }
+                }
+            },
+            "FENCE": {
+                "FENCE": {
+                    "(test::User)",
+                    "FENCE": {
+                        "(test::User).>name[IS std::str]"
                     }
                 }
             }
@@ -466,14 +467,15 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::User)",
             "FENCE": {
                 "(__derived__::expr~7).>name[IS std::str]": {
-                    "(__derived__::expr~7)": {
+                    "(__derived__::expr~7)"
+                },
+                "FENCE": {
+                    "FENCE": {
                         "FENCE": {
+                            "(test::User).>friends[IS test::User]",
                             "FENCE": {
-                                "(test::User).>friends[IS test::User]",
-                                "FENCE": {
-                                    "(test::User)\
+                                "(test::User)\
 .>friends[IS test::User]@nickname[IS std::str]"
-                                }
                             }
                         }
                     }
@@ -494,20 +496,24 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(__derived__::__derived__|x@w~1)": {
+            "(__derived__::__derived__|x@w~1)",
+            "FENCE": {
+                "(__derived__::__derived__|x@w~1).>0[IS std::float64]"
+            },
+            "FENCE": {
                 "FENCE": {
                     "(test::User).>friends[IS test::User]": {
                         "(test::User)"
                     },
-                    "(test::User).>friends[IS test::User]\
-.>deck_cost[IS std::int64]": {
+                    "(test::User).>friends[IS test::User].>\
+deck_cost[IS std::int64]": {
                         "FENCE": {
                             "FENCE": {
                                 "FENCE": {
-                                    "ns~2@@(test::User).>friends\
-[IS test::User].>deck[IS test::Card].>cost[IS std::int64]": {
-                                        "ns~2@@(test::User).>friends\
-[IS test::User].>deck[IS test::Card]"
+                                    "ns~2@@(test::User)\
+.>friends[IS test::User].>deck[IS test::Card].>cost[IS std::int64]": {
+                                        "ns~2@@(test::User)\
+.>friends[IS test::User].>deck[IS test::Card]"
                                     }
                                 }
                             }
@@ -518,10 +524,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 .>deck[IS test::Card]"
                     }
                 }
-            },
-            "FENCE": {
-                "(__derived__::__derived__|x@w~1)\
-.>0[IS std::float64]"
             }
         }
         """
@@ -622,14 +624,15 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(__derived__::__derived__|x@w~2)": {
-                    "FENCE": {
-                        "(test::User).>deck[IS test::Card]"
-                    }
-                },
+                "(__derived__::__derived__|x@w~2)",
                 "(test::User).>deck[IS test::Card]",
                 "FENCE": {
                     "(__derived__::__derived__|x@w~2).>name[IS std::str]"
+                },
+                "FENCE": {
+                    "FENCE": {
+                        "(test::User).>deck[IS test::Card]"
+                    }
                 }
             }
         }
@@ -644,7 +647,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(__derived__::__derived__|_@w~2)": {
+            "(__derived__::__derived__|_@w~2)",
+            "FENCE": {
                 "FENCE": {
                     "(__derived__::__derived__|A@w~1)",
                     "(test::User)"
@@ -707,27 +711,28 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         } FILTER .name = 'Alice'
 
 % OK %
-    "FENCE": {
-        "(test::User)",
         "FENCE": {
-            "(__derived__::__derived__|letter@w~1)",
-            "(test::User).>select_deck[IS test::Card]",
+            "(test::User)",
             "FENCE": {
-                "(__derived__::__derived__|foo@w~2)": {
+                "(__derived__::__derived__|letter@w~1)",
+                "(test::User).>select_deck[IS test::Card]",
+                "FENCE": {
+                    "(__derived__::__derived__|foo@w~2)",
                     "FENCE": {
-                        "(test::User).>deck[IS test::Card]",
                         "FENCE": {
-                            "(test::User).>deck[IS test::Card].>\
-name[IS std::str]"
+                            "(test::User).>deck[IS test::Card]",
+                            "FENCE": {
+                                "(test::User).>deck[IS test::Card]\
+.>name[IS std::str]"
+                            }
                         }
                     }
                 }
+            },
+            "FENCE": {
+                "(test::User).>name[IS std::str]"
             }
-        },
-        "FENCE": {
-            "(test::User).>name[IS std::str]"
         }
-    }
         """
 
     def test_edgeql_ir_scope_tree_27(self):

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -227,8 +227,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(__derived__::expr~5).>friends[IS test::User]": {
-                "(__derived__::expr~5)"
+            "(__derived__::expr~6).>friends[IS test::User]": {
+                "(__derived__::expr~6)"
             },
             "FENCE": {
                 "FENCE": {
@@ -466,8 +466,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(__derived__::expr~7).>name[IS std::str]": {
-                    "(__derived__::expr~7)"
+                "(__derived__::expr~8).>name[IS std::str]": {
+                    "(__derived__::expr~8)"
                 },
                 "FENCE": {
                     "FENCE": {
@@ -561,8 +561,8 @@ deck_cost[IS std::int64]": {
 
 % OK %
         "FENCE": {
-            "(__derived__::expr~6).>name[IS std::str]": {
-                "(__derived__::expr~6)"
+            "(__derived__::expr~7).>name[IS std::str]": {
+                "(__derived__::expr~7)"
             },
             "(test::Card)",
             "(test::Card).>element[IS std::str]"

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -703,6 +703,18 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_scope_with_subquery_01(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test
+                SELECT count((
+                    Card.name,
+                    (WITH X := (SELECT Card) SELECT X.name),
+                ));
+            """,
+            [9],
+        )
+
     async def test_edgeql_scope_filter_01(self):
         await self.assert_query_result(
             r'''
@@ -1326,6 +1338,20 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ''',
             {'1Imp', '2Dragon', '4Bog monster', '4Giant turtle', '2Dwarf',
              '3Golem', '2Sprite', '2Giant eagle', '2Djinn'},
+        )
+
+        await self.assert_query_result(
+            r'''
+                # semantically same as control query Q3, except that some
+                # aliases are introduced
+                WITH MODULE test
+                SELECT (Card.name,
+                        count((WITH A := Card SELECT A).owners));
+            ''',
+            [["Bog monster", 4], ["Djinn", 2], ["Dragon", 2], ["Dwarf", 2],
+             ["Giant eagle", 2], ["Giant turtle", 4], ["Golem", 3],
+             ["Imp", 1], ["Sprite", 2]],
+            sort=True,
         )
 
     async def test_edgeql_scope_nested_12(self):

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1846,6 +1846,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
+    @test.xfail('We invalidly produce duplicates now as a result of #2137')
     async def test_edgeql_select_tvariant_04(self):
         await self.assert_query_result(
             r"""

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1846,7 +1846,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
-    @test.xfail('We invalidly produce duplicates now as a result of #2137')
     async def test_edgeql_select_tvariant_04(self):
         await self.assert_query_result(
             r"""
@@ -1970,6 +1969,19 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                     'foo': ['test::User'],
                 },
             ],
+        )
+
+    async def test_edgeql_select_tvariant_09(self):
+        await self.assert_query_result(
+            r"""
+                WITH
+                    MODULE test,
+                SELECT
+                    (((SELECT Issue {
+                        x := .number ++ "!"
+                    }), Issue).0.x ++ (SELECT Issue.number));
+            """,
+            {"1!1", "2!2", "3!3", "4!4"},
         )
 
     async def test_edgeql_select_tvariant_bad_01(self):
@@ -2452,7 +2464,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
-    async def test_edgeql_select_setops_13(self):
+    async def test_edgeql_select_setops_13a(self):
         await self.assert_query_result(
             r"""
             WITH
@@ -2460,6 +2472,33 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 L := LogEntry  # there happens to only be 1 entry
             SELECT
                 (Issue.time_spent_log UNION L, Issue).0 {
+                    body
+                };
+            """,
+            [
+                # not only do we expect duplicates, but we actually
+                # expect 5 entries here:
+                # - 1 for the actual `time_spent_log' links from Issue
+                # - 4 from the UNION for each Issue.time_spent_log
+                {'body': 'Rewriting everything.'},
+                {'body': 'Rewriting everything.'},
+                {'body': 'Rewriting everything.'},
+                {'body': 'Rewriting everything.'},
+                {'body': 'Rewriting everything.'},
+            ],
+        )
+
+    @test.xfail('The results get deduplicated')
+    async def test_edgeql_select_setops_13b(self):
+        # This should be equivalent to the above test, but actually we
+        # end up deduplicating.
+        await self.assert_query_result(
+            r"""
+            WITH
+                MODULE test,
+                L := LogEntry  # there happens to only be 1 entry
+            SELECT
+                (SELECT (Issue.time_spent_log UNION L, Issue)).0 {
                     body
                 };
             """,

--- a/tests/test_edgeql_tree.py
+++ b/tests/test_edgeql_tree.py
@@ -784,6 +784,11 @@ class TestTree(tb.QueryTestCase):
             ]
         )
 
+    @test.xfail('''
+        Fails with a SQL reference to a nonexistant alias.
+        Introduced in #2137, but I think that the issue is #1381
+        (weak namespace stripping being bogus).
+    ''')
     async def test_edgeql_tree_update_05(self):
         # Swap around a tree node and its first child as an atomic operation.
         #

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -374,6 +374,13 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
                     ''',
                 )
 
+    @test.xfail('''
+        Broken by #2137.
+        We need to be a little smarter about tracking volatility in
+        WITH bindings.
+    ''')
+    async def test_edgeql_volatility_with_02(self):
+        # We would eventually like to compute this correctly instead
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                     edgedb.QueryError,


### PR DESCRIPTION
We do this by getting rid of the use of "temporary" scopes in
declare_view (an approach that I previewed in #1806).

The purpose of using the temporary scopes was I think to allow the use
of the extra_scope mechanism to place the scope tree for a WITH
binding *underneath* the scope tree of a use of it. Unfortunately this
could cause duplication of unique_ids when it got grafted into two
independent subqueries, as well as some of other issues when the
fusing didn't behave right.

Fortunately, all that extra_scope machinery wasn't really needed. It
seems to work basically just fine to stick it in the scope tree where
it appears.

This fixes a handful of bugs, but also introduces some failures:
 * test_edgeql_tree_update_05 (flipping two nodes) generates invalid
   SQL, but I think fixing weak namespace stripping should fix this.
 * test_edgeql_volatility_with_01 (now split into a new test)
   fails because we now fail to detect volatile WITH bindings
   in situations like `X := random(), Y := X`. Fixing this should
   be straightforward.
 * test_edgeql_select_tvariant_04 fails because we now fail to
   deduplicate computed link sets in some cases. I haven't dug
   into this one yet.

This is work towards fixing #1381.

I'm putting this up now to get eyes on it, but if we want to wait on
landing it for me to fix some of the remaining problems, that would
make sense.

This wound up being a very long and painful journey to a pretty small
patch.