### PR TITLE
Properly handle non-DDL commands in migration blocks

### DIFF
--- a/edb/common/markup/elements/lang.py
+++ b/edb/common/markup/elements/lang.py
@@ -38,6 +38,10 @@ class String(LangMarkup):
     str = Field(str, default=None, coerce=True)
 
 
+class MultilineString(LangMarkup):
+    str = Field(str, default=None, coerce=True)
+
+
 class Ref(LangMarkup):
     ref = Field(int, coerce=True)
     refname = Field(str, default=None)

--- a/edb/common/markup/renderers/terminal.py
+++ b/edb/common/markup/renderers/terminal.py
@@ -82,6 +82,12 @@ class Buffer:
         yield
         self.data.append((FOLDABLE_LINES_END, ))
 
+    @contextlib.contextmanager
+    def non_foldable_lines(self):
+        self.data.append((FOLDABLE_LINES_END, ))
+        yield
+        self.data.append((FOLDABLE_LINES_START, ))
+
     def mark_line_break(self):
         self.data.append((LINE_BREAK, ))
 
@@ -428,6 +434,18 @@ class LangRenderer(BaseRenderer):
     def _render_lang_String(self, element):
         self.buffer.write(
             xrepr(element.str, max_len=120), style=self.styles.literal)
+
+    def _render_lang_MultilineString(self, element):
+        with self.buffer.non_foldable_lines():
+            for line in element.str.splitlines():
+                self.buffer.new_line()
+                self.buffer.write(
+                    line,
+                    style=self.styles.literal
+                )
+            self.buffer.data.append((DEDENT_NO_NL, ))
+            self.buffer.new_line()
+            self.buffer.data.append((INDENT_NO_NL, ))
 
     def _render_lang_Number(self, element):
         self.buffer.write(element.num, style=self.styles.literal)

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -515,7 +515,11 @@ class Shape(Expr):
     elements: typing.List[ShapeElement]
 
 
-class SelectQuery(Statement, ReturningMixin, SelectClauseMixin):
+class Query(Statement):
+    __abstract_node__ = True
+
+
+class SelectQuery(Query, ReturningMixin, SelectClauseMixin):
     pass
 
 
@@ -525,22 +529,22 @@ class GroupQuery(SelectQuery, SubjectMixin):
     into: str
 
 
-class InsertQuery(Statement, SubjectMixin):
+class InsertQuery(Query, SubjectMixin):
     subject: Path
     shape: typing.List[ShapeElement]
     unless_conflict: typing.Optional[
         typing.Tuple[typing.Optional[Expr], typing.Optional[Expr]]]
 
 
-class UpdateQuery(Statement, SubjectMixin, FilterMixin):
+class UpdateQuery(Query, SubjectMixin, FilterMixin):
     shape: typing.List[ShapeElement]
 
 
-class DeleteQuery(Statement, SubjectMixin, SelectClauseMixin):
+class DeleteQuery(Query, SubjectMixin, SelectClauseMixin):
     pass
 
 
-class ForQuery(Statement, ReturningMixin):
+class ForQuery(Query, ReturningMixin):
     iterator: Expr
     iterator_alias: str
 
@@ -743,7 +747,6 @@ class GlobalObjectCommand(ObjectDDL):
 
 
 class DatabaseCommand(GlobalObjectCommand):
-
     __abstract_node__ = True
     object_class: qltypes.SchemaObjectClass = (
         qltypes.SchemaObjectClass.DATABASE)
@@ -782,7 +785,6 @@ class DropModule(DropObject, ModuleCommand):
 
 
 class RoleCommand(GlobalObjectCommand):
-
     __abstract_node__ = True
     object_class: qltypes.SchemaObjectClass = (
         qltypes.SchemaObjectClass.ROLE)

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -651,7 +651,9 @@ class NamedDDL(DDLCommand):
 
 
 class ObjectDDL(NamedDDL):
+
     __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass
 
 
 class CreateObject(ObjectDDL):
@@ -680,8 +682,11 @@ class Rename(NamedDDL):
         return self.new_name
 
 
-class Migration:
+class MigrationCommand:
+
     __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.MIGRATION)
 
 
 class MigrationBody(DDL):
@@ -689,7 +694,7 @@ class MigrationBody(DDL):
     commands: typing.List[DDLOperation]
 
 
-class CreateMigration(CreateObject, Migration):
+class CreateMigration(CreateObject, MigrationCommand):
 
     body: MigrationBody
     script: typing.Optional[str] = None
@@ -698,123 +703,169 @@ class CreateMigration(CreateObject, Migration):
     metadata_only: bool = False
 
 
-class StartMigration(DDLCommand, Migration):
+class StartMigration(DDLCommand, MigrationCommand):
 
     target: Schema
 
 
-class AbortMigration(DDLCommand, Migration):
+class AbortMigration(DDLCommand, MigrationCommand):
     pass
 
 
-class PopulateMigration(DDLCommand, Migration):
+class PopulateMigration(DDLCommand, MigrationCommand):
     pass
 
 
-class AlterCurrentMigrationRejectProposed(DDLCommand, Migration):
+class AlterCurrentMigrationRejectProposed(DDLCommand, MigrationCommand):
     pass
 
 
-class DescribeCurrentMigration(DDLCommand, Migration):
+class DescribeCurrentMigration(DDLCommand, MigrationCommand):
 
     language: qltypes.DescribeLanguage
 
 
-class CommitMigration(DDLCommand, Migration):
+class CommitMigration(DDLCommand, MigrationCommand):
     pass
 
 
-class AlterMigration(AlterObject, Migration):
+class AlterMigration(AlterObject, MigrationCommand):
     pass
 
 
-class DropMigration(DropObject, Migration):
+class DropMigration(DropObject, MigrationCommand):
     pass
 
 
-class Database:
+class GlobalObjectCommand(ObjectDDL):
+
     __abstract_node__ = True
 
 
-class CreateDatabase(CreateObject, Database):
+class DatabaseCommand(GlobalObjectCommand):
+
+    __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.DATABASE)
+
+
+class CreateDatabase(CreateObject, DatabaseCommand):
 
     template: typing.Optional[ObjectRef] = None
 
 
-class AlterDatabase(AlterObject, Database):
+class AlterDatabase(AlterObject, DatabaseCommand):
     pass
 
 
-class DropDatabase(DropObject, Database):
+class DropDatabase(DropObject, DatabaseCommand):
     pass
 
 
-class CreateModule(CreateObject):
-    pass
+class ModuleCommand(ObjectDDL):
 
-
-class AlterModule(AlterObject):
-    pass
-
-
-class DropModule(DropObject):
-    pass
-
-
-class Role:
     __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.MODULE)
 
 
-class CreateRole(CreateObject, BasesMixin, Role):
+class CreateModule(CreateObject, ModuleCommand):
+    pass
+
+
+class AlterModule(AlterObject, ModuleCommand):
+    pass
+
+
+class DropModule(DropObject, ModuleCommand):
+    pass
+
+
+class RoleCommand(GlobalObjectCommand):
+
+    __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.ROLE)
+
+
+class CreateRole(CreateObject, BasesMixin, RoleCommand):
     superuser: bool = False
 
 
-class AlterRole(AlterObject, Role):
+class AlterRole(AlterObject, RoleCommand):
     pass
 
 
-class DropRole(DropObject, Role):
+class DropRole(DropObject, RoleCommand):
     pass
 
 
-class CreateAnnotation(CreateExtendingObject):
+class AnnotationCommand(ObjectDDL):
+
+    __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.ANNOTATION)
+
+
+class CreateAnnotation(CreateExtendingObject, AnnotationCommand):
     type: typing.Optional[TypeExpr]
     inheritable: bool
 
 
-class AlterAnnotation(AlterObject):
+class AlterAnnotation(AlterObject, AnnotationCommand):
     pass
 
 
-class DropAnnotation(DropObject):
+class DropAnnotation(DropObject, AnnotationCommand):
     pass
 
 
-class CreatePseudoType(CreateObject):
+class PseudoTypeCommand(ObjectDDL):
+
+    __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.PSEUDO_TYPE)
+
+
+class CreatePseudoType(CreateObject, PseudoTypeCommand):
     pass
 
 
-class CreateScalarType(CreateExtendingObject):
+class ScalarTypeCommand(ObjectDDL):
+
+    __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.SCALAR_TYPE)
+
+
+class CreateScalarType(CreateExtendingObject, ScalarTypeCommand):
     pass
 
 
-class AlterScalarType(AlterObject):
+class AlterScalarType(AlterObject, ScalarTypeCommand):
     pass
 
 
-class DropScalarType(DropObject):
+class DropScalarType(DropObject, ScalarTypeCommand):
     pass
 
 
-class CreateProperty(CreateExtendingObject):
+class PropertyCommand(ObjectDDL):
+
+    __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.PROPERTY)
+
+
+class CreateProperty(CreateExtendingObject, PropertyCommand):
     pass
 
 
-class AlterProperty(AlterObject):
+class AlterProperty(AlterObject, PropertyCommand):
     pass
 
 
-class DropProperty(DropObject):
+class DropProperty(DropObject, PropertyCommand):
     pass
 
 
@@ -825,128 +876,169 @@ class CreateConcretePointer(CreateObject, BasesMixin):
     cardinality: qltypes.SchemaCardinality
 
 
-class CreateConcreteProperty(CreateConcretePointer):
+class CreateConcreteProperty(CreateConcretePointer, PropertyCommand):
     pass
 
 
-class AlterConcreteProperty(AlterObject):
+class AlterConcreteProperty(AlterObject, PropertyCommand):
     pass
 
 
-class DropConcreteProperty(DropObject):
+class DropConcreteProperty(DropObject, PropertyCommand):
     pass
 
 
-class CreateObjectType(CreateExtendingObject):
+class ObjectTypeCommand(ObjectDDL):
+
+    __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.TYPE)
+
+
+class CreateObjectType(CreateExtendingObject, ObjectTypeCommand):
     pass
 
 
-class AlterObjectType(AlterObject):
+class AlterObjectType(AlterObject, ObjectTypeCommand):
     pass
 
 
-class DropObjectType(DropObject):
+class DropObjectType(DropObject, ObjectTypeCommand):
     pass
 
 
-class CreateAlias(CreateObject):
+class AliasCommand(ObjectDDL):
+
+    __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.ALIAS)
+
+
+class CreateAlias(CreateObject, AliasCommand):
     pass
 
 
-class AlterAlias(AlterObject):
+class AlterAlias(AlterObject, AliasCommand):
     pass
 
 
-class DropAlias(DropObject):
+class DropAlias(DropObject, AliasCommand):
     pass
 
 
-class CreateLink(CreateExtendingObject):
+class LinkCommand(ObjectDDL):
+
+    __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.LINK)
+
+
+class CreateLink(CreateExtendingObject, LinkCommand):
     pass
 
 
-class AlterLink(AlterObject):
+class AlterLink(AlterObject, LinkCommand):
     pass
 
 
-class DropLink(DropObject):
+class DropLink(DropObject, LinkCommand):
     pass
 
 
-class CreateConcreteLink(CreateExtendingObject, CreateConcretePointer):
+class CreateConcreteLink(
+    CreateExtendingObject,
+    CreateConcretePointer,
+    LinkCommand,
+):
     pass
 
 
-class AlterConcreteLink(AlterObject):
+class AlterConcreteLink(AlterObject, LinkCommand):
     pass
 
 
-class DropConcreteLink(DropObject):
+class DropConcreteLink(DropObject, LinkCommand):
     pass
 
 
-class CallableObject(ObjectDDL):
+class CallableObjectCommand(ObjectDDL):
+
     __abstract_node__ = True
     params: typing.List[FuncParam]
 
 
-class CreateConstraint(CreateExtendingObject, CallableObject):
+class ConstraintCommand(ObjectDDL):
+
+    __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.CONSTRAINT)
+
+
+class CreateConstraint(
+    CreateExtendingObject,
+    CallableObjectCommand,
+    ConstraintCommand,
+):
     subjectexpr: typing.Optional[Expr]
     is_abstract: bool = True
 
 
-class AlterConstraint(AlterObject):
+class AlterConstraint(AlterObject, ConstraintCommand):
     pass
 
 
-class DropConstraint(DropObject):
+class DropConstraint(DropObject, ConstraintCommand):
     pass
 
 
-class ConstraintOp(ObjectDDL):
+class ConcreteConstraintOp(ConstraintCommand):
+
     __abstract_node__ = True
     args: typing.List[Expr]
     subjectexpr: typing.Optional[Expr]
 
 
-class CreateConcreteConstraint(CreateObject, ConstraintOp):
+class CreateConcreteConstraint(CreateObject, ConcreteConstraintOp):
     delegated: bool = False
 
 
-class AlterConcreteConstraint(AlterObject, ConstraintOp):
+class AlterConcreteConstraint(AlterObject, ConcreteConstraintOp):
     pass
 
 
-class DropConcreteConstraint(DropObject, ConstraintOp):
+class DropConcreteConstraint(DropObject, ConcreteConstraintOp):
     pass
 
 
-class IndexOp(ObjectDDL):
+class IndexCommand(ObjectDDL):
+
     __abstract_node__ = True
     expr: Expr
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.INDEX)
 
 
-class CreateIndex(CreateObject, IndexOp):
+class CreateIndex(CreateObject, IndexCommand):
     pass
 
 
-class AlterIndex(AlterObject, IndexOp):
+class AlterIndex(AlterObject, IndexCommand):
     pass
 
 
-class DropIndex(DropObject, IndexOp):
+class DropIndex(DropObject, IndexCommand):
     pass
 
 
-class CreateAnnotationValue(CreateObject):
+class CreateAnnotationValue(CreateObject, AnnotationCommand):
     value: Expr
 
 
-class AlterAnnotationValue(AlterObject):
+class AlterAnnotationValue(AlterObject, AnnotationCommand):
     value: Expr
 
 
-class DropAnnotationValue(DropObject):
+class DropAnnotationValue(DropObject, AnnotationCommand):
     pass
 
 
@@ -963,7 +1055,15 @@ class FunctionCode(Clause):
     from_expr: bool
 
 
-class CreateFunction(CreateObject, CallableObject):
+class FunctionCommand(CallableObjectCommand):
+
+    __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.FUNCTION)
+
+
+class CreateFunction(CreateObject, FunctionCommand):
+
     returning: TypeExpr
     code: FunctionCode
     nativecode: typing.Optional[Expr]
@@ -971,12 +1071,13 @@ class CreateFunction(CreateObject, CallableObject):
         qltypes.TypeModifier.SingletonType
 
 
-class AlterFunction(AlterObject, CallableObject):
+class AlterFunction(AlterObject, FunctionCommand):
+
     code: FunctionCode
     nativecode: typing.Optional[Expr]
 
 
-class DropFunction(DropObject, CallableObject):
+class DropFunction(DropObject, FunctionCommand):
     pass
 
 
@@ -988,8 +1089,11 @@ class OperatorCode(Clause):
     code: str
 
 
-class OperatorCommand(CallableObject):
+class OperatorCommand(CallableObjectCommand):
+
     __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.OPERATOR)
     kind: qltypes.OperatorKind
 
 
@@ -1017,7 +1121,10 @@ class CastCode(Clause):
 
 
 class CastCommand(ObjectDDL):
+
     __abstract_node__ = True
+    object_class: qltypes.SchemaObjectClass = (
+        qltypes.SchemaObjectClass.CAST)
     from_type: TypeName
     to_type: TypeName
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -393,7 +393,7 @@ class ConstraintCommand(
         for arg in args:
             exprs.append(arg.text)
 
-        assert isinstance(astnode, qlast.ConstraintOp)
+        assert isinstance(astnode, qlast.ConcreteConstraintOp)
         if astnode.subjectexpr:
             # use the normalized text directly from the expression
             expr = s_expr.Expression.from_ast(
@@ -418,7 +418,7 @@ class ConstraintCommand(
         context: sd.CommandContext,
     ) -> List[s_expr.Expression]:
         args = []
-        assert isinstance(astnode, qlast.ConstraintOp)
+        assert isinstance(astnode, qlast.ConcreteConstraintOp)
 
         if astnode.args:
             for arg in astnode.args:
@@ -631,7 +631,7 @@ class CreateConstraint(
         *,
         param_offset: int=0
     ) -> List[s_func.ParameterDesc]:
-        if not isinstance(astnode, qlast.CallableObject):
+        if not isinstance(astnode, qlast.CallableObjectCommand):
             # Concrete constraint.
             return []
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -911,7 +911,7 @@ class CallableCommand(sd.QualifiedObjectCommand[CallableObjectT]):
             # Some Callables, like the concrete constraints,
             # have no params in their AST.
             return []
-        assert isinstance(astnode, qlast.CallableObject)
+        assert isinstance(astnode, qlast.CallableObjectCommand)
         return cls._get_param_desc_from_params_ast(
             schema, modaliases, astnode.params, param_offset=param_offset)
 
@@ -986,9 +986,9 @@ class AlterCallableObject(
         context: sd.CommandContext,
         *,
         parent_node: Optional[qlast.DDLOperation] = None,
-    ) -> Optional[qlast.CallableObject]:
+    ) -> Optional[qlast.CallableObjectCommand]:
         node = cast(
-            qlast.CallableObject,
+            qlast.CallableObjectCommand,
             super()._get_ast(schema, context, parent_node=parent_node)
         )
 

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -167,7 +167,7 @@ class IndexCommand(
         referrer_name: sn.QualName,
         context: sd.CommandContext,
     ) -> Tuple[str, ...]:
-        assert isinstance(astnode, qlast.IndexOp)
+        assert isinstance(astnode, qlast.IndexCommand)
         # use the normalized text directly from the expression
         expr = s_expr.Expression.from_ast(
             astnode.expr, schema, context.modaliases)
@@ -241,7 +241,7 @@ class IndexCommand(
         astnode: qlast.DDLOperation,
         context: sd.CommandContext,
     ) -> sd.ObjectCommand[Index]:
-        assert isinstance(astnode, qlast.IndexOp)
+        assert isinstance(astnode, qlast.IndexCommand)
         cmd = super()._cmd_from_ast(schema, astnode, context)
         orig_text = cls.get_orig_expr_text(schema, astnode, 'expr')
         cmd.set_ddl_identity(

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -939,3 +939,17 @@ def write_meta_nop(
     stdmode: bool,
 ) -> None:
     pass
+
+
+@write_meta.register
+def write_meta_query(
+    cmd: sd.Query,
+    *,
+    classlayout: Dict[Type[so.Object], sr_struct.SchemaTypeLayout],
+    schema: s_schema.Schema,
+    context: sd.CommandContext,
+    blocks: List[Tuple[str, Dict[str, Any]]],
+    internal_schema_mode: bool,
+    stdmode: bool,
+) -> None:
+    pass

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -829,10 +829,14 @@ class Compiler(BaseCompiler):
             single_unit=(not is_transactional) or (drop_db is not None),
             new_types=new_types,
             drop_db=drop_db,
-            has_role_ddl=isinstance(stmt, qlast.Role),
+            has_role_ddl=isinstance(stmt, qlast.RoleCommand),
         )
 
-    def _compile_ql_migration(self, ctx: CompileContext, ql: qlast.Migration):
+    def _compile_ql_migration(
+        self,
+        ctx: CompileContext,
+        ql: qlast.MigrationCommand,
+    ):
         current_tx = ctx.state.current_tx()
         schema = current_tx.get_schema()
 
@@ -1430,13 +1434,13 @@ class Compiler(BaseCompiler):
         ctx: CompileContext,
         ql: qlast.Base
     ) -> Tuple[dbstate.BaseQuery, enums.Capability]:
-        if isinstance(ql, qlast.Migration):
+        if isinstance(ql, qlast.MigrationCommand):
             query = self._compile_ql_migration(ctx, ql)
             if isinstance(query, dbstate.MigrationControlQuery):
                 return (query, enums.Capability.DDL)
             else:  # DESCRIBE CURRENT MIGRATION
                 return (query, enums.Capability(0))
-        elif isinstance(ql, qlast.Database):
+        elif isinstance(ql, qlast.DatabaseCommand):
             return (
                 self._compile_and_apply_ddl_stmt(ctx, ql),
                 enums.Capability.DDL,

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -69,6 +69,14 @@ class BaseQuery:
 
 
 @dataclasses.dataclass(frozen=True)
+class NullQuery(BaseQuery):
+
+    sql: Tuple[bytes, ...] = tuple()
+    is_transactional: bool = True
+    has_dml: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
 class Query(BaseQuery):
 
     sql_hash: bytes
@@ -274,7 +282,7 @@ class MigrationState(NamedTuple):
     initial_savepoint: Optional[str]
     target_schema: s_schema.Schema
     guidance: s_obj.DeltaGuidance
-    current_ddl: Tuple[qlast.DDLOperation, ...]
+    accepted_cmds: Tuple[qlast.Command, ...]
     last_proposed: Tuple[ProposedMigrationStep, ...]
 
 

--- a/edb/server/compiler/status.py
+++ b/edb/server/compiler/status.py
@@ -32,17 +32,17 @@ def get_status(ql: qlast.Base) -> bytes:
 
 @get_status.register(qlast.CreateObject)
 def _ddl_create(ql):
-    return b'CREATE'
+    return f'CREATE {ql.object_class}'.encode()
 
 
 @get_status.register(qlast.AlterObject)
 def _ddl_alter(ql):
-    return b'ALTER'
+    return f'ALTER {ql.object_class}'.encode()
 
 
 @get_status.register(qlast.DropObject)
 def _ddl_drop(ql):
-    return b'DROP'
+    return f'DROP {ql.object_class}'.encode()
 
 
 @get_status.register(qlast.StartMigration)

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -194,13 +194,13 @@ class TestServerProto(tb.QueryTestCase):
             };
         ''')
         self.assertEqual(r, [])
-        self.assertEqual(self.con._get_last_status(), 'CREATE')
+        self.assertEqual(self.con._get_last_status(), 'CREATE TYPE')
 
         r = await self.con.query('''
             DROP TYPE test::server_fetch_single_command_01;
         ''')
         self.assertEqual(r, [])
-        self.assertEqual(self.con._get_last_status(), 'DROP')
+        self.assertEqual(self.con._get_last_status(), 'DROP TYPE')
 
         r = await self.con.query('''
             CREATE TYPE test::server_fetch_single_command_01 {


### PR DESCRIPTION
RFC 1000 prescribes that a non-DDL command, like `INSERT`, inside a
`START MIGRATION` block should not be executed right away and should be 
recorded as part of the migration script instead.  This patch basically 
implements that by adding the new `Query` delta command, which simply 
compiles a given EdgeQL statement.

Also, while at it, add proper checks around which statements can and cannot
appear in migration blocks.