### PR TITLE
Fix interaction of type renames with compound and collection types

### DIFF
--- a/edb/common/topological.py
+++ b/edb/common/topological.py
@@ -182,9 +182,9 @@ def sort(
     graph: Mapping[K, DepGraphEntry[K, V, T]],
     *,
     allow_unresolved: bool = False,
-) -> Iterator[V]:
+) -> Tuple[V, ...]:
     items = sort_ex(graph, allow_unresolved=allow_unresolved)
-    return (i[1].item for i in items)
+    return tuple(i[1].item for i in items)
 
 
 if TYPE_CHECKING:

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -197,7 +197,10 @@ def derive_view(
 
     if isinstance(stype, s_abc.Collection):
         ctx.env.schema, derived = stype.derive_subtype(
-            ctx.env.schema, name=derived_name)
+            ctx.env.schema,
+            name=derived_name,
+            attrs=attrs,
+        )
 
     elif isinstance(stype, s_obj.DerivableInheritingObject):
         ctx.env.schema, derived = stype.derive_subtype(

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -138,6 +138,11 @@ class UnionType(Type):
     ) -> None:
         self.types = types
 
+    def get_name(self, schema: s_schema.Schema) -> sn.QualName:
+        component_ids = sorted(str(t.get_name(schema)) for t in self.types)
+        nqname = f"({' | '.join(component_ids)})"
+        return sn.QualName(name=nqname, module='__derived__')
+
 
 class Pointer(Source):
 

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -1305,14 +1305,7 @@ class GQLCoreSchema:
 
         if not name.startswith('stdgraphql::'):
             if edb_base is None:
-                type_id = s_types.type_id_from_name(
-                    s_name.name_from_string(name))
-                if type_id is not None:
-                    edb_base = self.edb_schema.get_by_id(
-                        type_id,
-                        type=s_types.Type,
-                    )
-                elif '::' in name:
+                if '::' in name:
                     edb_base = self.edb_schema.get(
                         name,
                         type=s_types.Type,
@@ -1326,6 +1319,17 @@ class GQLCoreSchema:
                         )
                         if edb_base:
                             break
+
+                    # XXX: find a better way to do this
+                    if edb_base is None:
+                        edb_base = self.edb_schema.get_global(
+                            s_types.Array, name, default=None
+                        )
+
+                    if edb_base is None:
+                        edb_base = self.edb_schema.get_global(
+                            s_types.Tuple, name, default=None
+                        )
 
                     if edb_base is None:
                         raise AssertionError(

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -330,6 +330,14 @@ class CreateTuple(TupleCommand, adapts=s_types.CreateTuple):
         return schema
 
 
+class AlterTuple(TupleCommand, adapts=s_types.AlterTuple):
+    pass
+
+
+class RenameTuple(TupleCommand, adapts=s_types.RenameTuple):
+    pass
+
+
 class DeleteTuple(TupleCommand, adapts=s_types.DeleteTuple):
 
     def apply(
@@ -434,6 +442,14 @@ class CreateArray(ArrayCommand, adapts=s_types.CreateArray):
         schema = self.__class__.get_adaptee().apply(self, schema, context)
         schema = ArrayCommand.apply(self, schema, context)
         return schema
+
+
+class AlterArray(ArrayCommand, adapts=s_types.AlterArray):
+    pass
+
+
+class RenameArray(ArrayCommand, adapts=s_types.RenameArray):
+    pass
 
 
 class DeleteArray(ArrayCommand, adapts=s_types.DeleteArray):
@@ -2465,7 +2481,7 @@ class PointerMetaCommand(MetaCommand, sd.ObjectCommand,
         if (
             is_link
             and using_eql_expr is None
-            and orig_target.issubclass(schema, new_target)
+            and orig_target.issubclass(orig_schema, new_target)
         ):
             return
 
@@ -3042,8 +3058,8 @@ class RenameLink(LinkMetaCommand, adapts=s_links.RenameLink):
         schema = LinkMetaCommand.apply(self, schema, context)
         return schema
 
-    def _rename_begin(self, schema, context):
-        schema = super()._rename_begin(schema, context)
+    def _alter_begin(self, schema, context):
+        schema = super()._alter_begin(schema, context)
         scls = self.scls
 
         self.attach_alter_table(context)

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -422,7 +422,8 @@ def get_expr_referrers(schema: s_schema.Schema,
                        obj: so.Object) -> Dict[so.Object, List[str]]:
     """Return schema referrers with refs in expressions."""
 
-    refs = schema.get_referrers_ex(obj)
+    refs: Dict[Tuple[Type[so.Object], str], FrozenSet[so.Object]] = (
+        schema.get_referrers_ex(obj))
     result: Dict[so.Object, List[str]] = {}
 
     for (mcls, fn), referrers in refs.items():

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -237,6 +237,8 @@ class AliasCommand(
 
         for vt in coll_expr_aliases:
             new_schema = vt.set_field_value(new_schema, 'expr', expr)
+            new_schema = vt.set_field_value(
+                new_schema, 'alias_is_persistent', True)
             ct = vt.as_shell(new_schema).as_create_delta(
                 # not "new_schema", to ensure the nested collection types
                 # are picked up properly.
@@ -248,7 +250,6 @@ class AliasCommand(
                     'expr_type': s_types.ExprType.Select,
                 },
             )
-            new_schema = ct.apply(new_schema, context)
             derived_delta.add(ct)
 
         derived_delta = s_ordering.linearize_delta(
@@ -327,7 +328,7 @@ class CreateAlias(
 
 class RenameAlias(AliasCommand, sd.RenameObject[Alias]):
 
-    def _rename_begin(
+    def _alter_begin(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
@@ -344,7 +345,7 @@ class RenameAlias(AliasCommand, sd.RenameObject[Alias]):
             alter_cmd.add(rename_cmd)
             self.add_prerequisite(alter_cmd)
 
-        return super()._rename_begin(schema, context)
+        return super()._alter_begin(schema, context)
 
 
 class AlterAlias(

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -701,6 +701,7 @@ def _trace_op(
             item = get_deps(('rename', ref_name_str))
             item.deps.add(('create', this_name_str))
             item.deps.add(('alter', this_name_str))
+            item.deps.add(('rename', this_name_str))
 
             if isinstance(ref, s_pointers.Pointer):
                 # The current item is a type referred to by
@@ -802,9 +803,7 @@ def get_object(
         if isinstance(name, sn.QualName):
             return schema.get(name)
         else:
-            t_id = s_types.type_id_from_name(name)
-            assert t_id is not None
-            return schema.get_by_id(t_id)
+            return schema.get_global(metaclass, name)
     elif not issubclass(metaclass, so.QualifiedObject):
         obj = schema.get_global(metaclass, name)
         assert isinstance(obj, so.Object)

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -418,7 +418,7 @@ class CreateScalarType(
             super()._apply_field_ast(schema, context, node, op)
 
 
-class RenameScalarType(ScalarTypeCommand, sd.RenameObject[ScalarType]):
+class RenameScalarType(ScalarTypeCommand, s_types.RenameType[ScalarType]):
     pass
 
 

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -108,12 +108,6 @@ class TypeSerializer:
         string_id += f'{has_implicit_fields!r};{links_props!r};{links!r}'
         return uuidgen.uuid5(s_types.TYPE_ID_NAMESPACE, string_id)
 
-    def _get_union_type_id(self, union_type):
-        base_type_id = ','.join(
-            str(c.id) for c in union_type.children(self.schema))
-
-        return uuidgen.uuid5(s_types.TYPE_ID_NAMESPACE, base_type_id)
-
     @classmethod
     def _get_set_type_id(cls, basetype_id):
         return uuidgen.uuid5(s_types.TYPE_ID_NAMESPACE,

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -31,7 +31,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_01_26_00_00
+EDGEDB_CATALOG_VERSION = 2021_01_26_10_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -19,7 +19,6 @@
 
 import difflib
 import os.path
-import re
 import textwrap
 
 from edb import errors
@@ -35,16 +34,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'cards.esdl')
-
-    UNION_NAME_RE = re.compile(
-        r'''
-            (?:opaque:\s)?
-            ([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}
-                           -[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})
-            (\s \| \s \1)*
-        ''',
-        re.X,
-    )
 
     def run_test(self, *, source, spec, expected):
         qltree = qlparser.parse(source)
@@ -65,11 +54,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             )
 
         scope_tree = next(iter(root.children))
-
-        path_scope = self.UNION_NAME_RE.sub(
-            '@SID@',
-            textwrap.indent(scope_tree.pformat(), '    '),
-        )
+        path_scope = textwrap.indent(
+            scope_tree.pformat(), '    ')
         expected_scope = textwrap.indent(
             textwrap.dedent(expected).strip(' \n'), '    ')
 
@@ -116,9 +102,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "(test::Card)",
-            "(test::Card).<deck[IS __derived__::(@SID@)]\
+            "(test::Card).<deck[IS __derived__::(opaque: test:User)]\
 .>indirection[IS test::User]": {
-                "(test::Card).<deck[IS __derived__::(@SID@)]"
+                "(test::Card).<deck[IS __derived__::(opaque: test:User)]"
             },
             "FENCE": {
                 "(test::Card).>owner[IS test::User]"
@@ -139,9 +125,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "(test::Card)",
-            "(test::Card).<deck[IS __derived__::(@SID@)]\
+            "(test::Card).<deck[IS __derived__::(opaque: test:User)]\
 .>indirection[IS test::User]": {
-                "(test::Card).<deck[IS __derived__::(@SID@)]"
+                "(test::Card).<deck[IS __derived__::(opaque: test:User)]"
             },
             "FENCE": {
                 "(test::Card).>owner[IS test::User]"
@@ -314,9 +300,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 "(test::User).>friends[IS test::User]",
                 "FENCE": {
                     "[ns~1]@[ns~2]@@(test::User).>deck[IS test::Card]\
-.<deck[IS __derived__::(@SID@)].>indirection[IS test::User]": {
+.<deck[IS __derived__::(opaque: test:User)].>indirection[IS test::User]": {
                         "[ns~1]@[ns~2]@@(test::User).>deck[IS test::Card]\
-.<deck[IS __derived__::(@SID@)]": {
+.<deck[IS __derived__::(opaque: test:User)]": {
                             "[ns~1]@[ns~2]@@(test::User).>deck[IS test::Card]"
                         }
                     }
@@ -346,9 +332,10 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                     "(test::Card)"
                 },
                 "FENCE": {
-                    "ns~1@@(test::Card).<deck[IS __derived__::(@SID@)]\
-.>indirection[IS test::User]": {
-                        "ns~1@@(test::Card).<deck[IS __derived__::(@SID@)]": {
+                    "ns~1@@(test::Card).<deck[IS __derived__::\
+(opaque: test:User)].>indirection[IS test::User]": {
+                        "ns~1@@(test::Card).<deck[IS __derived__::\
+(opaque: test:User)]": {
                             "(test::Card)"
                         }
                     }
@@ -542,9 +529,10 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "FENCE": {
                 "(test::Card).>owners[IS test::User]": {
                     "FENCE": {
-                        "ns~1@@(test::Card).<deck[IS __derived__::(@SID@)]\
-.>indirection[IS test::User]": {
-                            "ns~1@@(test::Card).<deck[IS __derived__::(@SID@)]"
+                        "ns~1@@(test::Card).<deck\
+[IS __derived__::(opaque: test:User)].>indirection[IS test::User]": {
+                            "ns~1@@(test::Card).<deck\
+[IS __derived__::(opaque: test:User)]"
                         }
                     }
                 }
@@ -782,9 +770,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                     },
                     "FENCE": {
                         "ns~2@@(__derived__::__derived__|A@w~1)\
-.<deck[IS __derived__::(@SID@)].>indirection[IS test::User]": {
+.<deck[IS __derived__::(opaque: test:User)].>indirection[IS test::User]": {
                             "ns~2@@(__derived__::__derived__|A@w~1)\
-.<deck[IS __derived__::(@SID@)]": {
+.<deck[IS __derived__::(opaque: test:User)]": {
                                 "(__derived__::__derived__|A@w~1)"
                             }
                         }


### PR DESCRIPTION
The original approach to handling the renames of the component types
of compound and collection types was to basically side-step the issue by
deriving the internal name of the compound or collection type from the
ids of the component types.  Unfortunately, because ids are
non-deterministic, this leads to the need for a bunch of unreliable hacks
to control schema diffing to avoid spurious diffs.

This patch abandons the id-based internal naming for compound and
collection types and adapts the straightforward use of component names
instead, coupled with careful rename propagation when any of the
component types gets renamed.  This is also a good opportunity to
cleanup the `RenameObject` flow in general, and so I took it, removing a
bunch of duplicative code and making `RenameObject` behave much closer
to other `AlterObjectFragment` commands.  Most significantly,
`RenameObject._canonicalize` is no longer a custom referrer recursion,
and does a regular "descend into immediate referrers and let them
propagate" action that most other commands do.

Fixes: #2002.