### PR TITLE
Update schema tests for constraints.

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -1130,7 +1130,8 @@ class CreateConstraint(
     ) -> None:
         if (
             op.property == 'args'
-            and isinstance(node, qlast.CreateConcreteConstraint)
+            and isinstance(node, (qlast.CreateConcreteConstraint,
+                                  qlast.AlterConcreteConstraint))
         ):
             assert isinstance(op.new_value, s_expr.ExpressionList)
             args = []

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -7139,6 +7139,19 @@ type test::Foo {
                         ON (len(__subject__));
         """)
 
+    async def test_edgeql_ddl_constraint_12(self):
+        with self.assertRaisesRegex(
+                edgedb.errors.SchemaError,
+                r'Constraint .+ is already present in the schema'):
+            await self.con.execute(r"""
+                CREATE TYPE Base {
+                    CREATE PROPERTY firstname -> str {
+                        CREATE CONSTRAINT max_len_value(10);
+                        CREATE CONSTRAINT max_len_value(10);
+                    }
+                }
+            """)
+
     async def test_edgeql_ddl_constraint_alter_01(self):
         await self.con.execute(r"""
             CREATE TYPE test::ConTest01 {
@@ -7382,6 +7395,26 @@ type test::Foo {
                 }]
             }]
         )
+
+    async def test_edgeql_ddl_constraint_alter_05(self):
+        await self.con.execute(r"""
+            CREATE TYPE Base {
+                CREATE PROPERTY firstname -> str {
+                    CREATE CONSTRAINT max_len_value(10);
+                }
+            }
+        """)
+
+        with self.assertRaisesRegex(
+                edgedb.errors.SchemaError,
+                r'Constraint .+ is already present in the schema'):
+            await self.con.execute(r"""
+                ALTER TYPE Base {
+                    ALTER PROPERTY firstname {
+                        CREATE CONSTRAINT max_len_value(10);
+                    }
+                }
+            """)
 
     async def test_edgeql_ddl_drop_inherited_link(self):
         await self.con.execute(r"""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2015,6 +2015,67 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    @test.xfail('''
+        The error is not raised.
+    ''')
+    def test_schema_get_migration_41(self):
+        schema = r'''
+        type Base {
+            property firstname -> str {
+                constraint max_len_value(10);
+                # Test that it's illegal to restate the constraint,
+                # just like in DDL.
+                constraint max_len_value(10);
+            }
+        }
+        '''
+
+        with self.assertRaisesRegex(
+                errors.SchemaError,
+                r'Constraint .+ is already present in the schema'):
+            self._assert_migration_consistency(schema)
+
+    def test_schema_get_migration_42(self):
+        schema = r'''
+        type Base {
+            property firstname -> str {
+                constraint max_len_value(10);
+            }
+        }
+
+        type Derived extending Base {
+            overloaded property firstname -> str {
+                # Same constraint, but stricter.
+                constraint max_len_value(5);
+            }
+        }
+        '''
+
+        self._assert_migration_consistency(schema)
+
+    @test.xfail('''
+        edb.errors.InvalidReferenceError:
+        constraint 'std::max_len_value' does not exist
+    ''')
+    def test_schema_get_migration_43(self):
+        schema = r'''
+        type Base {
+            property firstname -> str {
+                constraint max_len_value(10);
+            }
+        }
+
+        type Derived extending Base {
+            overloaded property firstname -> str {
+                # Test that it's legal to restate the constraint when
+                # overloading.
+                constraint max_len_value(10);
+            }
+        }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_schema_get_migration_multi_module_01(self):
         schema = r'''
             # The two declared types declared are from different
@@ -4169,10 +4230,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             type Derived extending Base;
         """])
 
-    @test.xfail('''
-        edb.edgeql.codegen.EdgeQLSourceGeneratorError:
-        No method to generate code for Expression
-    ''')
     def test_schema_migrations_equivalence_constraint_03(self):
         self._assert_migration_equivalence([r"""
             type Base {
@@ -4183,7 +4240,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
             type Derived extending Base {
                 overloaded property firstname -> str {
-                    constraint max_len_value(10);
                     # add another constraint to make the prop overloaded
                     constraint min_len_value(5);
                 }
@@ -4198,7 +4254,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
             type Derived extending Base {
                 overloaded property first_name -> str {
-                    constraint max_len_value(10);
                     constraint min_len_value(5);
                 }
             }


### PR DESCRIPTION
Restating the same constraint causes issues when overloading. I factored
out that from a tests that was checking that renaming a constrained
property worked properly.