### PR TITLE
Replace weak namespace stripping with smarter rewriting

### DIFF
--- a/edb/common/ast/visitor.py
+++ b/edb/common/ast/visitor.py
@@ -170,7 +170,7 @@ class NodeVisitor:
         for _field, value in base.iter_fields(node, include_meta=False):
             if typeutils.is_container(value):
                 for item in value:
-                    if base.is_ast_node(item):
+                    if base.is_ast_node(item) or typeutils.is_container(item):
                         res = self.visit(item)
                         if res is not None:
                             field_results.append(res)

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -229,12 +229,12 @@ def compile_FunctionCall(
         nested_path_ids = []
         for n, st in rtype.iter_subtypes(ctx.env.schema):
             elem_path_id = pathctx.get_tuple_indirection_path_id(
-                path_id, n, st, ctx=ctx).strip_weak_namespaces()
+                path_id, n, st, ctx=ctx)
 
             if isinstance(st, s_types.Tuple):
                 nested_path_ids.append([
                     pathctx.get_tuple_indirection_path_id(
-                        elem_path_id, nn, sst, ctx=ctx).strip_weak_namespaces()
+                        elem_path_id, nn, sst, ctx=ctx)
                     for nn, sst in st.iter_subtypes(ctx.env.schema)
                 ])
 

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -206,7 +206,7 @@ def _check_binding_volatility(
         and ir.expr
         and volatility.infer_volatility(ir.expr, env=ctx.env) == VOLATILE
     ):
-        path_id = ir.path_id.strip_weak_namespaces()
+        path_id = ir.path_id
         if path_id not in ctx.bindings:
             return
 

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -48,7 +48,8 @@ def amend_empty_set_type(
     alias = es.path_id.target_name_hint.name
     typename = s_name.QualName(module='__derived__', name=alias)
     es.path_id = irast.PathId.from_type(
-        env.schema, t, env=env, typename=typename
+        env.schema, t, env=env, typename=typename,
+        namespace=es.path_id.namespace,
     )
 
 

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -168,12 +168,11 @@ def ban_path(
         path_id: irast.PathId, *,
         ctx: context.ContextLevel) -> None:
 
-    ctx.banned_paths.add(path_id.strip_weak_namespaces())
+    ctx.banned_paths.add(path_id)
 
 
 def path_is_banned(
         path_id: irast.PathId, *,
         ctx: context.ContextLevel) -> bool:
 
-    s_path_id = path_id.strip_weak_namespaces()
-    return s_path_id in ctx.banned_paths and ctx.path_scope.is_visible(path_id)
+    return path_id in ctx.banned_paths and ctx.path_scope.is_visible(path_id)

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -184,7 +184,7 @@ def new_tuple_set(
     for elem in elements:
         elem_path_id = pathctx.get_tuple_indirection_path_id(
             result_path_id, elem.name, get_set_type(elem.val, ctx=ctx),
-            ctx=ctx).strip_weak_namespaces()
+            ctx=ctx)
         final_elems.append(irast.TupleElement(
             name=elem.name,
             val=elem.val,

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -337,11 +337,12 @@ def compile_insert_unless_conflict(
         else_ir = dispatch.compile(
             astutils.ensure_qlstmt(else_branch), ctx=ctx)
         assert isinstance(else_ir, irast.Set)
-        else_info = irast.OnConflictElse(select_ir, else_ir)
+        else_info = irast.OnConflictElse(select=select_ir, body=else_ir)
 
     return irast.OnConflictClause(
-        irast.ConstraintRef(id=ex_cnstrs[0].id, module_id=module_id),
-        else_info
+        constraint=irast.ConstraintRef(
+            id=ex_cnstrs[0].id, module_id=module_id),
+        else_ir=else_info
     )
 
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -349,7 +349,6 @@ def _elide_derived_ancestors(
     obj: Union[s_types.InheritingType, s_pointers.Pointer], *,
     ctx: context.ContextLevel
 ) -> None:
-
     """Collapse references to derived objects in bases.
 
     When compiling a schema view expression, make sure we don't

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -447,6 +447,7 @@ def _normalize_view_ptr_expr(
         )
 
         base_cardinality = _get_base_ptr_cardinality(base_ptrcls, ctx=ctx)
+        base_is_singleton = False
         if base_cardinality is not None and base_cardinality.is_known():
             base_is_singleton = base_cardinality.is_single()
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -745,12 +745,12 @@ class MutatingStmt(Stmt):
     subject: Set
 
 
-class OnConflictElse(typing.NamedTuple):
+class OnConflictElse(Base):
     select: Set
     body: Set
 
 
-class OnConflictClause(typing.NamedTuple):
+class OnConflictClause(Base):
     constraint: typing.Optional[ConstraintRef]
     else_ir: typing.Optional[OnConflictElse]
 

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -383,23 +383,6 @@ class PathId:
         else:
             return self
 
-    def strip_weak_namespaces(self) -> PathId:
-        """Return a copy of this ``PathId`` with weak namespace portion
-           removed."""
-        if self._namespace is not None:
-            stripped_ns = {bit for bit in self._namespace
-                           if not isinstance(bit, WeakNamespace)}
-            result = self.replace_namespace(stripped_ns)
-
-            if result._prefix is not None:
-                result._prefix = result._get_minimal_prefix(
-                    result._prefix.strip_weak_namespaces())
-
-        else:
-            result = self
-
-        return result
-
     def strip_namespace(self, namespace: AbstractSet[AnyNamespace]) -> PathId:
         """Return a copy of this ``PathId`` with a given portion of the
            namespace id removed."""
@@ -644,7 +627,7 @@ class PathId:
         if self.startswith(prefix):
             prefix_len = len(prefix)
             if prefix_len < len(self):
-                result = self.__class__()
+                result = self.__class__(self)
                 result._path = replacement._path + self._path[prefix_len:]
                 result._norm_path = \
                     replacement._norm_path + self._norm_path[prefix_len:]

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -133,7 +133,7 @@ def init_dml_stmt(
     else_cte = None
     if (
         isinstance(ir_stmt, irast.InsertStmt)
-        and ir_stmt.on_conflict and ir_stmt.on_conflict[1] is not None
+        and ir_stmt.on_conflict and ir_stmt.on_conflict.else_ir is not None
     ):
         dml_cte = pgast.CommonTableExpr(
             query=pgast.SelectStmt(),
@@ -660,7 +660,8 @@ def compile_insert_else_body(
     )
 
     if on_conflict.else_ir:
-        else_select, else_branch = on_conflict.else_ir
+        else_select = on_conflict.else_ir.select
+        else_branch = on_conflict.else_ir.body
 
         subject_id = ir_stmt.subject.path_id
 

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -166,12 +166,12 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::Card)",
             "(test::User)",
             "FENCE": {
-                "(__derived__::__derived__|U@w~1)",
-                "(test::Card).>users[IS test::User]"
+                "(test::Card).>users[IS test::User]",
+                "[ns~2]@[ns~3]@@(__derived__::__derived__|U@w~1)"
             },
             "FENCE": {
                 "FENCE": {
-                    "(test::User)"
+                    "[ns~1]@@(test::User)"
                 }
             }
         }
@@ -270,7 +270,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "FENCE": {
                 "(schema::Type).>element_type[IS schema::Type]",
                 "(schema::Type).>indirection[IS schema::Array]",
-                "(schema::Type).>indirection[IS schema::Array]\
+                "[ns~1]@[ns~2]@@(schema::Type).>indirection[IS schema::Array]\
 .>element_type[IS schema::Type]"
             }
         }
@@ -289,10 +289,10 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(__derived__::expr~3)",
             "FENCE": {
-                "(__derived__::expr~3).>foo[IS std::str]"
+                "(schema::Type)"
             },
             "FENCE": {
-                "(schema::Type)"
+                "[ns~2]@[ns~3]@@(__derived__::expr~3).>foo[IS std::str]"
             }
         }
         """
@@ -313,19 +313,19 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "FENCE": {
                 "(test::User).>friends[IS test::User]",
                 "FENCE": {
-                    "(test::User).>deck[IS test::Card].\
-<deck[IS __derived__::(@SID@)].>indirection[IS test::User]": {
-                        "(test::User).>deck[IS test::Card].\
-<deck[IS __derived__::(@SID@)]": {
-                            "(test::User).>deck[IS test::Card]"
+                    "[ns~1]@[ns~2]@@(test::User).>deck[IS test::Card]\
+.<deck[IS __derived__::(@SID@)].>indirection[IS test::User]": {
+                        "[ns~1]@[ns~2]@@(test::User).>deck[IS test::Card]\
+.<deck[IS __derived__::(@SID@)]": {
+                            "[ns~1]@[ns~2]@@(test::User).>deck[IS test::Card]"
                         }
                     }
                 },
                 "FENCE": {
-                    "(test::User).>friends[IS test::User]"
+                    "[ns~1]@[ns~2]@@(test::User).>friends[IS test::User]"
                 },
                 "FENCE": {
-                    "(test::User).>friends[IS test::User]"
+                    "[ns~1]@[ns~2]@@(test::User).>friends[IS test::User]"
                 }
             },
             "FENCE": {
@@ -403,31 +403,31 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(__derived__::__derived__|U@w~1)\
-.>cards[IS test::Card].>foo[IS std::float64]": {
+            "(__derived__::__derived__|U@w~1).>cards[IS test::Card]\
+.>foo[IS std::float64]": {
                 "BRANCH": {
                     "(__derived__::__derived__|U@w~1).>cards[IS test::Card]": {
                         "BRANCH": {
                             "(__derived__::__derived__|U@w~1)"
                         },
                         "FENCE": {
-                            "(test::Card)",
                             "FENCE": {
-                                "(__derived__::__derived__|U@w~1)\
+                                "[ns~2]@@(__derived__::__derived__|U@w~1)\
 .>deck[IS test::Card]": {
                                     "(__derived__::__derived__|U@w~1)"
                                 }
-                            }
+                            },
+                            "[ns~2]@@(test::Card)"
                         }
                     }
                 }
             },
             "FENCE": {
                 "FENCE": {
-                    "(test::User)",
                     "FENCE": {
-                        "(test::User).>name[IS std::str]"
-                    }
+                        "[ns~1]@@(test::User).>name[IS std::str]"
+                    },
+                    "[ns~1]@@(test::User)"
                 }
             }
         }
@@ -502,26 +502,26 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             },
             "FENCE": {
                 "FENCE": {
-                    "(test::User).>friends[IS test::User]": {
-                        "(test::User)"
+                    "FENCE": {
+                        "[ns~1]@@(test::User).>friends[IS test::User]\
+.>deck[IS test::Card]"
                     },
-                    "(test::User).>friends[IS test::User].>\
-deck_cost[IS std::int64]": {
+                    "[ns~1]@@(test::User).>friends[IS test::User]": {
+                        "[ns~1]@@(test::User)"
+                    },
+                    "[ns~1]@@(test::User).>friends[IS test::User]\
+.>deck_cost[IS std::int64]": {
                         "FENCE": {
                             "FENCE": {
                                 "FENCE": {
-                                    "ns~2@@(test::User)\
+                                    "[ns~1]@ns~2@@(test::User)\
 .>friends[IS test::User].>deck[IS test::Card].>cost[IS std::int64]": {
-                                        "ns~2@@(test::User)\
+                                        "[ns~1]@ns~2@@(test::User)\
 .>friends[IS test::User].>deck[IS test::Card]"
                                     }
                                 }
                             }
                         }
-                    },
-                    "FENCE": {
-                        "(test::User).>friends[IS test::User]\
-.>deck[IS test::Card]"
                     }
                 }
             }
@@ -584,26 +584,27 @@ deck_cost[IS std::int64]": {
             "(test::User)",
             "FENCE": {
                 "(test::User).>deck[IS test::Card]",
-                "(test::User).>deck[IS test::Card]",
                 "FENCE": {
-                    "(test::User).>deck[IS test::Card]@count[IS std::int64]"
-                }
+                    "[ns~1]@[ns~2]@@(test::User)\
+.>deck[IS test::Card]@count[IS std::int64]"
+                },
+                "[ns~1]@[ns~2]@@(test::User).>deck[IS test::Card]"
             },
             "FENCE": {
                 "(test::User).>deck[IS test::Card]": {
                     "FENCE": {
-                        "(test::User).>deck[IS test::Card]",
                         "FENCE": {
-                            "(test::User).>deck[IS test::Card]\
-@count[IS std::int64]"
-                        }
+                            "[ns~1]@[ns~3]@@(test::User)\
+.>deck[IS test::Card]@count[IS std::int64]"
+                        },
+                        "[ns~1]@[ns~3]@@(test::User).>deck[IS test::Card]"
                     },
                     "FENCE": {
-                        "(test::User).>deck[IS test::Card]",
                         "FENCE": {
-                            "(test::User).>deck[IS test::Card]\
-@count[IS std::int64]"
-                        }
+                            "[ns~1]@[ns~4]@@(test::User)\
+.>deck[IS test::Card]@count[IS std::int64]"
+                        },
+                        "[ns~1]@[ns~4]@@(test::User).>deck[IS test::Card]"
                     }
                 },
                 "(test::User).>deck[IS test::Card].>cost[IS std::int64]",
@@ -624,16 +625,18 @@ deck_cost[IS std::int64]": {
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(__derived__::__derived__|x@w~2)",
                 "(test::User).>deck[IS test::Card]",
                 "FENCE": {
-                    "(__derived__::__derived__|x@w~2).>name[IS std::str]"
+                    "FENCE": {
+                        "[ns~1]@[ns~3]@[ns~4]@@(test::User)\
+.>deck[IS test::Card]"
+                    }
                 },
                 "FENCE": {
-                    "FENCE": {
-                        "(test::User).>deck[IS test::Card]"
-                    }
-                }
+                    "[ns~1]@[ns~3]@@(__derived__::__derived__|x@w~2)\
+.>name[IS std::str]"
+                },
+                "[ns~1]@[ns~3]@@(__derived__::__derived__|x@w~2)"
             }
         }
         """
@@ -650,8 +653,8 @@ deck_cost[IS std::int64]": {
             "(__derived__::__derived__|_@w~2)",
             "FENCE": {
                 "FENCE": {
-                    "(__derived__::__derived__|A@w~1)",
-                    "(test::User)"
+                    "[ns~2]@@(__derived__::__derived__|A@w~1)",
+                    "[ns~2]@@(test::User)"
                 }
             }
         }
@@ -674,24 +677,25 @@ deck_cost[IS std::int64]": {
         } FILTER .name = 'Alice'
 
 % OK %
-    "FENCE": {
-        "(test::User)",
         "FENCE": {
-            "(__derived__::__derived__|letter@w~1)",
-            "(test::User).>select_deck[IS test::Card]",
+            "(test::User)",
             "FENCE": {
+                "(test::User).>name[IS std::str]"
+            },
+            "FENCE": {
+                "(test::User).>select_deck[IS test::Card]",
                 "FENCE": {
-                    "(test::User).>deck[IS test::Card]",
                     "FENCE": {
-                        "(test::User).>deck[IS test::Card].>name[IS std::str]"
+                        "FENCE": {
+                            "[ns~1]@[ns~4]@@(test::User).>deck[IS test::Card]\
+.>name[IS std::str]"
+                        },
+                        "[ns~1]@[ns~4]@@(test::User).>deck[IS test::Card]"
                     }
-                }
+                },
+                "[ns~1]@[ns~4]@@(__derived__::__derived__|letter@w~1)"
             }
-        },
-        "FENCE": {
-            "(test::User).>name[IS std::str]"
         }
-    }
         """
 
     def test_edgeql_ir_scope_tree_26(self):
@@ -714,23 +718,24 @@ deck_cost[IS std::int64]": {
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(__derived__::__derived__|letter@w~1)",
-                "(test::User).>select_deck[IS test::Card]",
-                "FENCE": {
-                    "(__derived__::__derived__|foo@w~2)",
-                    "FENCE": {
-                        "FENCE": {
-                            "(test::User).>deck[IS test::Card]",
-                            "FENCE": {
-                                "(test::User).>deck[IS test::Card]\
-.>name[IS std::str]"
-                            }
-                        }
-                    }
-                }
+                "(test::User).>name[IS std::str]"
             },
             "FENCE": {
-                "(test::User).>name[IS std::str]"
+                "(test::User).>select_deck[IS test::Card]",
+                "FENCE": {
+                    "FENCE": {
+                        "FENCE": {
+                            "FENCE": {
+                                "[ns~1]@[ns~5]@[ns~7]@@(test::User)\
+.>deck[IS test::Card].>name[IS std::str]"
+                            },
+                            "[ns~1]@[ns~5]@[ns~7]@@(test::User)\
+.>deck[IS test::Card]"
+                        }
+                    },
+                    "[ns~1]@[ns~5]@@(__derived__::__derived__|foo@w~2)"
+                },
+                "[ns~1]@[ns~5]@@(__derived__::__derived__|letter@w~1)"
             }
         }
         """
@@ -749,15 +754,14 @@ deck_cost[IS std::int64]": {
         "FENCE": {
             "(test::User)",
             "FENCE": {
-                "(test::Card)",
                 "(test::User).>deck[IS test::Card]",
                 "FENCE": {
-                    "(test::Card).>element[IS std::str]"
+                    "(test::User).>deck[IS test::Card].>cost[IS std::int64]"
                 },
                 "FENCE": {
-                    "(test::User).>deck[IS test::Card]\
-.>cost[IS std::int64]"
-                }
+                    "[ns~1]@[ns~5]@@(test::Card).>element[IS std::str]"
+                },
+                "[ns~1]@[ns~5]@@(test::Card)"
             }
         }
         """
@@ -804,18 +808,18 @@ deck_cost[IS std::int64]": {
             "(test::Card)",
             "FENCE": {
                 "(test::Card).>alice[IS test::User]",
-                "(test::User)",
                 "FENCE": {
-                    "(test::User).>name[IS std::str]"
-                }
+                    "[ns~1]@[ns~2]@@(test::User).>name[IS std::str]"
+                },
+                "[ns~1]@[ns~2]@@(test::User)"
             },
             "FENCE": {
                 "(test::Card).>alice[IS test::User]": {
                     "FENCE": {
-                        "(test::User)",
                         "FENCE": {
-                            "(test::User).>name[IS std::str]"
-                        }
+                            "[ns~1]@[ns~3]@@(test::User).>name[IS std::str]"
+                        },
+                        "[ns~1]@[ns~3]@@(test::User)"
                     }
                 },
                 "(test::Card).>name[IS std::str]",

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2082,6 +2082,33 @@ class TestEdgeQLScope(tb.QueryTestCase):
             {'Fire', 'Water', 'Earth', 'Air'},
         )
 
+    async def test_edgeql_scope_with_02(self):
+        # Test a WITH binding that depends on a previous one is still
+        # independent
+        await self.assert_query_result(
+            r"""
+                WITH
+                    MODULE test,
+                    X := {1, 2},
+                    Y := X + 1,
+                SELECT _ := (X, Y) ORDER BY _;
+            """,
+            [[1, 2], [1, 3], [2, 2], [2, 3]]
+        )
+
+    async def test_edgeql_scope_with_03(self):
+        # Test that a WITH binding used in a computable doesn't have its
+        # reference to that type captured
+        await self.assert_query_result(
+            r"""
+                WITH
+                    MODULE test,
+                    a := count({Card.name})
+                SELECT Card {name, a := a} FILTER .name = 'Imp';
+            """,
+            [{"name": "Imp", "a": 9}],
+        )
+
     async def test_edgeql_scope_unused_with_def_01(self):
 
         with self.assertRaisesRegex(

--- a/tests/test_edgeql_tree.py
+++ b/tests/test_edgeql_tree.py
@@ -784,11 +784,6 @@ class TestTree(tb.QueryTestCase):
             ]
         )
 
-    @test.xfail('''
-        Fails with a SQL reference to a nonexistant alias.
-        Introduced in #2137, but I think that the issue is #1381
-        (weak namespace stripping being bogus).
-    ''')
     async def test_edgeql_tree_update_05(self):
         # Swap around a tree node and its first child as an atomic operation.
         #


### PR DESCRIPTION
Instead of "stripping" weak namespaces from all paths, instead rewrite
weak namespaces to be "absolute" by removing namespaces that don't
appear at the binding site for the path.

Fixes #1381.