### PR TITLE
Fix a collection of issues with DML inheritance and overlays

### DIFF
--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -224,7 +224,8 @@ def type_to_typeref(
     )
     include_ancestors = (
         expr_type is s_types.ExprType.Insert
-        or include_descendants
+        or expr_type is s_types.ExprType.Update
+        or expr_type is s_types.ExprType.Delete
     )
     return irtyputils.type_to_typeref(
         schema,

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -222,9 +222,14 @@ def type_to_typeref(
         expr_type is s_types.ExprType.Update
         or expr_type is s_types.ExprType.Delete
     )
+    include_ancestors = (
+        expr_type is s_types.ExprType.Insert
+        or include_descendants
+    )
     return irtyputils.type_to_typeref(
         schema,
         t,
         include_descendants=include_descendants,
+        include_ancestors=include_ancestors,
         cache=cache,
     )

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -127,6 +127,9 @@ class TypeRef(ImmutableBase):
     # A set of type descendant descriptors, if necessary for
     # this type description.
     descendants: typing.Optional[typing.FrozenSet[TypeRef]]
+    # A set of type ancestor descriptors, if necessary for
+    # this type description.
+    ancestors: typing.Optional[typing.FrozenSet[TypeRef]]
     # If this is a union type, this would be a set of
     # union elements.
     union: typing.FrozenSet[TypeRef]

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1038,8 +1038,8 @@ def rel_filter_out(
             qry, path_id, rvar, env=ctx.env)
     pathctx.put_path_bond(qry, path_id)
 
-    # The useful work: grab the identity from the LHS and do a negated
-    # semi join against the RHS.
+    # The useful work: grab the identity from the LHS and do an
+    # anti-join against the RHS.
     src_ref = pathctx.get_path_identity_var(
         qry, path_id=path_id, env=ctx.env)
     pathctx.get_path_identity_output(

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -43,6 +43,7 @@ type Note {
     property note -> str;
     link subject -> Object;
 }
+type DerivedNote extending Note;
 
 type Person {
     required single property name -> std::str {


### PR DESCRIPTION
* Make WITH bound DML operations appear in the returned values
   (by tracking the stack of current DML statements explicitly instead
    of through parent_stmt)
 * Make subtypes of a link type be returned by nested DML operations.
   (By tracking ancestors in the TypeRefs and updating their type
   overlays also).
 * Make the results of nested UPDATEs appear in returned values.
   (By constructing an overlay that filters out the updated objects
   and then unions them back in.)

There's also a refactor of the overlay datastructure to use nested
dicts, which is groundwork for making WITH overlays keep working in a
soon forthcoming PR to make WITH bound DML be executed the correct
number of times.