### PR TITLE
Refactor handling of context/error span handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "snafu",
  "thiserror",
  "twoway",
+ "unicode-width",
  "wasm-bindgen",
 ]
 
@@ -576,6 +577,12 @@ name = "unchecked-index"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"

--- a/docs/internals/protocol/messages.rst
+++ b/docs/internals/protocol/messages.rst
@@ -126,6 +126,43 @@ Format:
 See the :ref:`list of error codes <ref_protocol_error_codes>` for all possible
 error codes.
 
+Known headers:
+
+* 0x0001 ``HINT``: ``str`` -- error hint.
+* 0x0002 ``DETAILS``: ``str`` -- error details.
+* 0x0101 ``SERVER_TRACEBACK``: ``str`` -- error traceback from server
+  (is only sent in dev mode).
+* 0xFFF1 ``POSITION_START`` -- byte offset of the start of the error span.
+* 0xFFF2 ``POSITION_END`` -- byte offset of the end of the error span.
+* 0xFFF3 ``LINE_START`` -- one-based line number of the start of the
+  error span.
+* 0xFFF4 ``COLUMN_START`` -- one-based column number of the start of the
+  error span.
+* 0xFFF5 ``UTF16_COLUMN_START`` -- zero-based column number in UTF-16
+  encoding of the start of the error span.
+* 0xFFF6 ``LINE_END`` -- one-based line number of the start of the
+  error span.
+* 0xFFF7 ``COLUMN_END`` -- one-based column number of the start of the
+  error span.
+* 0xFFF8 ``UTF16_COLUMN_END`` -- zero-based column number in UTF-16
+  encoding of the end of the error span.
+* 0xFFF9 ``CHARACTER_START`` -- zero-based offset of the error span in
+  terms of Unicode code points.
+* 0xFFFA ``CHARACTER_END`` -- zero-based offset of the end of the error
+  span.
+
+Notes:
+
+1. Error span is the range of characters (or equivalent bytes) of the
+   original query that compiler points to as the source of the error.
+2. ``COLUMN_*`` is defined in terms of width of characters defined by
+   Unicode Standard Annex #11, in other words, the column number in the
+   text if rendered with monospace font, e.g. in a terminal.
+3. ``UTF16_COLUMN_*`` is defined as number of UTF-16 code units (i.e. two
+   byte-pairs) that precede target character on the same line.
+4. ``*_END`` points to a next character after the last character of the
+   error span.
+
 
 .. _ref_protocol_msg_log:
 

--- a/edb/common/context.py
+++ b/edb/common/context.py
@@ -33,29 +33,23 @@ contexts through the AST structure.
 
 from __future__ import annotations
 
+import re
 import bisect
+
+from edb import _edgeql_rust
 
 from edb.common import ast
 from edb.common import markup
 from edb.common import typeutils
 
 
-class SourcePoint:
-    def __init__(self, line, column, pointer):
-        self.line = line
-        self.column = column
-        self.pointer = pointer
-
-    def __repr__(self):
-        return f'source@({self.line}:{self.column}:{self.pointer})'
-
-    __str__ = __repr__
+NEW_LINE = re.compile(br'\r\n?|\n')
 
 
 class ParserContext(markup.MarkupExceptionContext):
     title = 'Source Context'
 
-    def __init__(self, name, buffer, start, end, document=None, *,
+    def __init__(self, name, buffer, start: int, end: int, document=None, *,
                  filename=None):
         self.name = name
         self.buffer = buffer
@@ -63,45 +57,32 @@ class ParserContext(markup.MarkupExceptionContext):
         self.end = end
         self.document = document
         self.filename = filename
-        if start.line is None and start.pointer is not None:
-            start.line, start.column = self.line_col_from_offset(start.pointer)
-        if end.line is None and end.pointer is not None:
-            end.line, end.column = self.line_col_from_offset(end.pointer)
-        if start.pointer is None and start.column is None:
-            start.pointer, start.column = self.offset_col_from_line(start.line)
-        if end.pointer is None and end.column is None:
-            end.pointer, end.column = self.offset_col_from_line(end.line)
+        self._points = None
+        assert start is not None
+        assert end is not None
 
-    def line_col_from_offset(self, offset):
-        line_no = 1
-        col_no = 1
-        remaining = offset
+    def __getstate__(self):
+        dic = self.__dict__.copy()
+        dic.pop('_points')
+        return dic
 
-        for line in self.buffer.split('\n'):
-            line_length = len(line) + 1
-            if line_length < remaining:
-                remaining -= line_length
-            else:
-                col_no = remaining
-                break
-            line_no += 1
+    def _calc_points(self):
+        self._points = _edgeql_rust.SourcePoint.from_offsets(
+            self.buffer.encode('utf-8'),
+            [self.start, self.end]
+        )
 
-        return line_no, col_no
+    @property
+    def start_point(self):
+        if self._points is None:
+            self._calc_points()
+        return self._points[0]
 
-    def offset_col_from_line(self, line_no):
-        offset = 0
-        col_no = 1
-
-        for i, line in enumerate(self.buffer.split('\n'), start=1):
-            line_length = len(line) + 1
-
-            if i == line_no:
-                col_no = line_length - len(line.lstrip())
-                break
-
-            offset += line_length
-
-        return offset, col_no
+    @property
+    def end_point(self):
+        if self._points is None:
+            self._calc_points()
+        return self._points[1]
 
     @classmethod
     @markup.serializer.no_ref_detect
@@ -112,37 +93,39 @@ class ParserContext(markup.MarkupExceptionContext):
 
         lines = []
         line_numbers = []
+        start = self.start_point
 
-        buf_lines = self.buffer.split('\n')
+        offset = 0
+        buf_lines = []
         line_offsets = []
-        i = 0
-        for line in buf_lines:
-            line_offsets.append(i)
-            i += len(line) + 1
+        for match in NEW_LINE.finditer(self.buffer):
+            line_offsets.append(offset)
+            buf_lines.append(self.buffer[offset:match.start()])
+            offset = match.end()
 
-        if self.start.line > 1:
-            ctx_line, _ = self.get_line_snippet(
-                self.start, offset=-1, line_offsets=line_offsets)
+        if start.line > 1:
+            ctx_line, _ = self._get_line_snippet(
+                start, offset=-1, line_offsets=line_offsets)
             lines.append(ctx_line)
-            line_numbers.append(self.start.line - 1)
+            line_numbers.append(start.line - 1)
 
-        snippet, offset = self.get_line_snippet(
-            self.start, line_offsets=line_offsets)
+        snippet, _ = self._get_line_snippet(
+            start, line_offsets=line_offsets)
         lines.append(snippet)
-        line_numbers.append(self.start.line)
+        line_numbers.append(start.line)
 
         try:
-            ctx_line, _ = self.get_line_snippet(
-                self.start, offset=1, line_offsets=line_offsets)
+            ctx_line, _ = self._get_line_snippet(
+                start, offset=1, line_offsets=line_offsets)
         except ValueError:
             pass
         else:
             lines.append(ctx_line)
-            line_numbers.append(self.start.line + 1)
+            line_numbers.append(start.line + 1)
 
         tbp = me.lang.TracebackPoint(
-            name=self.name, filename=self.name, lineno=self.start.line,
-            colno=self.start.column, lines=lines, line_numbers=line_numbers,
+            name=self.name, filename=self.name, lineno=start.line,
+            colno=start.column, lines=lines, line_numbers=line_numbers,
             context=True)
 
         body.append(tbp)
@@ -156,7 +139,7 @@ class ParserContext(markup.MarkupExceptionContext):
             else:
                 return 0, len(self.buffer)
 
-        line_no = bisect.bisect_right(line_offsets, point.pointer) - 1 + offset
+        line_no = bisect.bisect_right(line_offsets, point.offset) - 1 + offset
         if line_no >= len(line_offsets):
             raise ValueError('not enough lines in buffer')
 
@@ -168,21 +151,21 @@ class ParserContext(markup.MarkupExceptionContext):
 
         return linestart, lineend
 
-    def get_line_snippet(
+    def _get_line_snippet(
             self, point, max_length=120, *, offset=0, line_offsets):
         line_start, line_end = self._find_line(
             point, offset=offset, line_offsets=line_offsets)
         line_len = line_end - line_start
 
         if line_len > max_length:
-            before = min(max_length // 2, point.pointer - line_start)
+            before = min(max_length // 2, point.offset - line_start)
             after = max_length - before
         else:
-            before = point.pointer - line_start
+            before = point.offset - line_start
             after = line_len - before
 
-        start = point.pointer - before
-        end = point.pointer + after
+        start = point.offset - before
+        end = point.offset + after
 
         return self.buffer[start:end], before
 
@@ -211,8 +194,8 @@ def empty_context():
     return ParserContext(
         name='<empty>',
         buffer='',
-        start=SourcePoint(0, 0, 0),
-        end=SourcePoint(0, 0, 0),
+        start=0,
+        end=0,
     )
 
 
@@ -224,25 +207,24 @@ def get_context(*kids):
         return None
 
     return ParserContext(
-        name=start_ctx.name, buffer=start_ctx.buffer,
-        start=SourcePoint(
-            start_ctx.start.line, start_ctx.start.column,
-            start_ctx.start.pointer), end=SourcePoint(
-                end_ctx.end.line, end_ctx.end.column, end_ctx.end.pointer))
+        name=start_ctx.name,
+        buffer=start_ctx.buffer,
+        start=start_ctx.start,
+        end=end_ctx.end,
+    )
 
 
 def merge_context(ctxlist):
-    ctxlist.sort(key=lambda x: (x.start.pointer, x.end.pointer))
+    ctxlist.sort(key=lambda x: (x.start, x.end))
 
     # assume same name and buffer apply to all
     #
     return ParserContext(
-        name=ctxlist[0].name, buffer=ctxlist[0].buffer,
-        start=SourcePoint(
-            ctxlist[0].start.line, ctxlist[0].start.column,
-            ctxlist[0].start.pointer), end=SourcePoint(
-                ctxlist[-1].end.line, ctxlist[-1].end.column,
-                ctxlist[-1].end.pointer))
+        name=ctxlist[0].name,
+        buffer=ctxlist[0].buffer,
+        start=ctxlist[0].start,
+        end=ctxlist[-1].end,
+    )
 
 
 def force_context(node, context):
@@ -283,42 +265,8 @@ def has_context(func):
     return wrapper
 
 
-def rebase_context(base, context, *, offset_column=0, indent=0):
-    if not context:
-        return
-
-    context.name = base.name
-    context.buffer = base.buffer
-
-    if context.start.line == 1:
-        context.start.column += base.start.column - 1 + offset_column
-    # indentation is always added
-    context.start.column += indent
-    context.start.line += base.start.line - 1
-    context.start.pointer += base.start.pointer + offset_column + indent
-
-
 class ContextVisitor(ast.NodeVisitor):
     pass
-
-
-class ContextRebaser(ContextVisitor):
-    def __init__(self, base, *, offset_column=0, indent=0):
-        super().__init__()
-        self._base = base
-        self._offset_column = offset_column
-        self._indent = indent
-
-    def generic_visit(self, node):
-        rebase_context(self._base, node.context,
-                       offset_column=self._offset_column,
-                       indent=self._indent)
-        super().generic_visit(node)
-
-
-def rebase_ast_context(base, root, *, offset_column=0, indent=0):
-    return ContextRebaser.run(root, base=base, offset_column=offset_column,
-                              indent=indent)
 
 
 class ContextPropagator(ContextVisitor):

--- a/edb/common/context.py
+++ b/edb/common/context.py
@@ -63,7 +63,7 @@ class ParserContext(markup.MarkupExceptionContext):
 
     def __getstate__(self):
         dic = self.__dict__.copy()
-        dic.pop('_points')
+        dic['_points'] = None
         return dic
 
     def _calc_points(self):
@@ -95,13 +95,14 @@ class ParserContext(markup.MarkupExceptionContext):
         line_numbers = []
         start = self.start_point
 
+        buf_bytes = self.buffer.encode('utf-8')
         offset = 0
         buf_lines = []
-        line_offsets = []
-        for match in NEW_LINE.finditer(self.buffer):
-            line_offsets.append(offset)
-            buf_lines.append(self.buffer[offset:match.start()])
+        line_offsets = [0]
+        for match in NEW_LINE.finditer(buf_bytes):
+            buf_lines.append(buf_bytes[offset:match.start()].decode('utf-8'))
             offset = match.end()
+            line_offsets.append(offset)
 
         if start.line > 1:
             ctx_line, _ = self._get_line_snippet(

--- a/edb/common/lexer.py
+++ b/edb/common/lexer.py
@@ -25,8 +25,6 @@ import collections
 import re
 import types
 
-from edb.common import context as pctx
-
 
 class LexError(Exception):
     def __init__(
@@ -156,7 +154,7 @@ class Lexer:
 
         Update the lexer lineno, column, and start.
         """
-        start_pos = pctx.SourcePoint(self.lineno, self.column, self.start)
+        start_pos = self.start
         len_txt = len(txt)
 
         if rule_token is self.NL:
@@ -173,7 +171,7 @@ class Lexer:
             self.column += len_txt
 
         self.start += len_txt
-        end_pos = pctx.SourcePoint(self.lineno, self.column, self.start)
+        end_pos = self.start
 
         return Token(txt, type=rule_token, text=txt,
                      start=start_pos, end=end_pos,

--- a/edb/common/parsing.py
+++ b/edb/common/parsing.py
@@ -431,15 +431,14 @@ class Parser:
         if tok is None:
             if pos is None:
                 pos = lex.end_of_input
-            position = pctx.SourcePoint(*pos)
             context = pctx.ParserContext(
                 name=name, buffer=lex.inputstr,
-                start=position, end=position)
+                start=pos[2], end=pos[2])
         else:
             context = pctx.ParserContext(
                 name=name, buffer=lex.inputstr,
-                start=pctx.SourcePoint(*tok.start()),
-                end=pctx.SourcePoint(*tok.end()))
+                start=tok.start()[2],
+                end=tok.end()[2])
 
         return context
 

--- a/edb/edgeql-parser/Cargo.toml
+++ b/edb/edgeql-parser/Cargo.toml
@@ -14,6 +14,7 @@ twoway = "0.2.1"
 wasm-bindgen = {version="0.2", features=["serde-serialize"], optional=true}
 serde = {version="1.0.106", features=["derive"], optional=true}
 thiserror = "1.0.23"
+unicode-width = "0.1.8"
 
 [features]
 default = []

--- a/edb/edgeql-parser/src/position.rs
+++ b/edb/edgeql-parser/src/position.rs
@@ -167,6 +167,7 @@ mod test {
         assert_eq!(count("line1\r\nline2\r\nline3"), 2);
         assert_eq!(count("line1\rline2\r\nline3\n"), 3);
         assert_eq!(count("line1\nline2\rline3\r\n"), 3);
+        assert_eq!(count("line1\n\rline2\r\rline3\r"), 5);
     }
 
     #[test]

--- a/edb/edgeql-parser/src/position.rs
+++ b/edb/edgeql-parser/src/position.rs
@@ -1,4 +1,7 @@
 use std::fmt;
+use std::str::{from_utf8, Utf8Error};
+
+use unicode_width::UnicodeWidthStr;
 
 /// Original position of element in source code
 #[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Default, Hash)]
@@ -14,6 +17,33 @@ pub struct Pos {
     pub offset: u64,
 }
 
+
+/// This contains position in all forms that EdgeDB needs
+#[derive(Clone, Copy, Debug)]
+pub struct InflatedPos {
+    /// Zero-based line number
+    pub line: u64,
+    /// Zero-based column number
+    pub column: u64,
+    /// Zero-based Utf16 column offset
+    ///
+    /// (this is required by language server protocol, LSP)
+    pub utf16column: u64,
+    /// Bytes offset in the orignal (utf-8 encoded) byte buffer
+    pub offset: u64,
+    /// Character offset in the whole string
+    pub char_offset: u64,
+}
+
+/// Error calculating InflatedPos
+#[derive(Debug, thiserror::Error)]
+pub enum InflatingError {
+    #[error(transparent)]
+    Utf8(Utf8Error),
+    #[error("offset out of range")]
+    OutOfRange,
+}
+
 impl fmt::Debug for Pos {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Pos({}:{})", self.line, self.column)
@@ -23,5 +53,185 @@ impl fmt::Debug for Pos {
 impl fmt::Display for Pos {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}:{}", self.line, self.column)
+    }
+}
+
+fn new_lines_in_fragment(data: &[u8]) -> u64 {
+    let mut was_lf = false;
+    let mut lines = 0;  // this assumes line found by rfind
+    for byte in data {
+        match byte {
+            b'\n' if was_lf => {
+                was_lf = false;
+            }
+            b'\n' => {
+                lines += 1;
+            }
+            b'\r' => {
+                lines += 1;
+                was_lf = true;
+            }
+            _ => {
+                was_lf = false;
+            }
+        }
+    }
+    return lines;
+}
+
+
+impl InflatedPos {
+
+    pub fn from_offsets(data: &[u8], offsets: &[usize])
+        -> Result<Vec<InflatedPos>, InflatingError>
+    {
+        let mut result = Vec::with_capacity(offsets.len());
+        // TODO(tailhook) optimize calculation if offsets are growing
+        for &offset in offsets {
+            if offset > data.len() {
+                return Err(InflatingError::OutOfRange);
+            }
+            let prefix = &data[..offset];
+            let prefix_s = from_utf8(prefix)
+                .map_err(InflatingError::Utf8)?;
+            let line_offset;
+            let line;
+            if let Some(loff) = prefix_s.rfind(|c| c == '\r' || c == '\n')
+            {
+                line_offset = loff+1;
+                let mut lines = &prefix[..loff];
+                if data[loff] == b'\n' && loff > 0 && data[loff-1] == b'\r' {
+                    lines = &lines[..lines.len()-1];
+                }
+                line = new_lines_in_fragment(lines) + 1;
+            } else {
+                line = 0;
+                line_offset = 0;
+            };
+            let col_s = &prefix_s[line_offset..offset];
+            result.push(InflatedPos {
+                line,
+                column: UnicodeWidthStr::width(col_s) as u64,
+                utf16column: col_s.chars().map(|c| c.len_utf16() as u64).sum(),
+                offset: offset as u64,
+                char_offset: prefix_s.chars().count() as u64,
+            });
+        }
+        return Ok(result);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{InflatedPos, new_lines_in_fragment};
+
+    fn mkpos(s: &str, off: usize) -> InflatedPos {
+        InflatedPos::from_offsets(s.as_bytes(), &[off]).unwrap()[0]
+    }
+
+    #[test]
+    fn ascii_line() {
+        let line = "Lorem ipsum dolor sit amet, consectetur adipiscing elit,";
+        for off in 0..line.len() {
+            let pos = mkpos(line, off);
+            let off = off as u64;
+            assert_eq!(pos.line, 0);
+            assert_eq!(pos.column, off);
+            assert_eq!(pos.utf16column, off);
+            assert_eq!(pos.offset, off);
+            assert_eq!(pos.char_offset, off);
+        }
+    }
+
+    #[test]
+    fn ascii_multi_line() {
+        let line = "line1\nline2";
+        for off in 6..line.len() {
+            let pos = mkpos(line, off);
+            let off = off as u64;
+            assert_eq!(pos.line, 1);
+            assert_eq!(pos.column, off-6);
+            assert_eq!(pos.utf16column, off-6);
+            assert_eq!(pos.offset, off);
+            assert_eq!(pos.char_offset, off);
+        }
+    }
+
+    #[test]
+    fn line_endings() {
+        fn count(s: &str) -> u64 {
+            new_lines_in_fragment(s.as_bytes())
+        }
+        assert_eq!(count("line1\nline2\nline3"), 2);
+        assert_eq!(count("line1\rline2\rline3"), 2);
+        assert_eq!(count("line1\r\nline2\r\nline3"), 2);
+        assert_eq!(count("line1\rline2\r\nline3\n"), 3);
+        assert_eq!(count("line1\nline2\rline3\r\n"), 3);
+    }
+
+    #[test]
+    fn char_offsets() {
+        let pos = mkpos("bomb = '💣'", 12);
+        assert_eq!(pos.line, 0);
+        assert_eq!(pos.column, 10);       // bomb is 2 char width
+        assert_eq!(pos.utf16column, 10);  // and also 2 utf8 codepoints
+        assert_eq!(pos.offset, 12);
+        assert_eq!(pos.char_offset, 9);
+
+        let pos = mkpos("line1\nbomb = '💣'", 18);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.column, 10);
+        assert_eq!(pos.utf16column, 10);
+        assert_eq!(pos.offset, 18);
+        assert_eq!(pos.char_offset, 15);
+
+        let pos = mkpos("bomb = '💣'\nline1", 18);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.column, 4);
+        assert_eq!(pos.utf16column, 4);
+        assert_eq!(pos.offset, 18);
+        assert_eq!(pos.char_offset, 15);
+
+        let pos = mkpos("letter = 'Ф'", 12);
+        assert_eq!(pos.line, 0);
+        assert_eq!(pos.column, 11);
+        assert_eq!(pos.utf16column, 11);
+        assert_eq!(pos.offset, 12);
+        assert_eq!(pos.char_offset, 11);
+
+        let pos = mkpos("line1\nletter = 'Ф'", 18);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.column, 11);
+        assert_eq!(pos.utf16column, 11);
+        assert_eq!(pos.offset, 18);
+        assert_eq!(pos.char_offset, 17);
+
+        let pos = mkpos("letter = 'Ф'\nline1", 18);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.column, 4);
+        assert_eq!(pos.utf16column, 4);
+        assert_eq!(pos.offset, 18);
+        assert_eq!(pos.char_offset, 17);
+
+        let pos = mkpos("letter = 'Ｈ'", 13);
+        assert_eq!(pos.line, 0);
+        assert_eq!(pos.column, 12);
+        assert_eq!(pos.utf16column, 11);
+        assert_eq!(pos.offset, 13);
+        assert_eq!(pos.char_offset, 11);
+
+        let pos = mkpos("line1\nletter = 'Ｈ'", 19);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.column, 12);
+        assert_eq!(pos.utf16column, 11);
+        assert_eq!(pos.offset, 19);
+        assert_eq!(pos.char_offset, 17);
+
+        let pos = mkpos("letter = 'Ｈ'\nline1", 19);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.column, 4);
+        assert_eq!(pos.utf16column, 4);
+        assert_eq!(pos.offset, 19);
+        assert_eq!(pos.char_offset, 17);
     }
 }

--- a/edb/edgeql-parser/src/position.rs
+++ b/edb/edgeql-parser/src/position.rs
@@ -58,7 +58,7 @@ impl fmt::Display for Pos {
 
 fn new_lines_in_fragment(data: &[u8]) -> u64 {
     let mut was_lf = false;
-    let mut lines = 0;  // this assumes line found by rfind
+    let mut lines = 0;
     for byte in data {
         match byte {
             b'\n' if was_lf => {

--- a/edb/edgeql-rust/src/lib.rs
+++ b/edb/edgeql-rust/src/lib.rs
@@ -9,10 +9,12 @@ mod tokenizer;
 pub mod normalize;
 mod pynormalize;
 mod hash;
+mod position;
 
 use errors::TokenizerError;
 use tokenizer::{Token, tokenize, get_unpickle_fn};
 use pynormalize::normalize;
+use position::SourcePoint;
 
 
 py_module_initializer!(
@@ -27,6 +29,7 @@ py_module_initializer!(
         m.add(py, "Token", py.get_type::<Token>())?;
         m.add(py, "TokenizerError", py.get_type::<TokenizerError>())?;
         m.add(py, "Entry", py.get_type::<pynormalize::Entry>())?;
+        m.add(py, "SourcePoint", py.get_type::<SourcePoint>())?;
         m.add(py, "normalize", py_fn!(py, normalize(query: &PyString)))?;
         m.add(py, "Hasher", py.get_type::<hash::Hasher>())?;
         m.add(py, "unreserved_keywords", keywords.unreserved)?;

--- a/edb/edgeql-rust/src/lib.rs
+++ b/edb/edgeql-rust/src/lib.rs
@@ -14,7 +14,7 @@ mod position;
 use errors::TokenizerError;
 use tokenizer::{Token, tokenize, get_unpickle_fn};
 use pynormalize::normalize;
-use position::SourcePoint;
+use position::{SourcePoint, offset_of_line};
 
 
 py_module_initializer!(
@@ -31,6 +31,8 @@ py_module_initializer!(
         m.add(py, "Entry", py.get_type::<pynormalize::Entry>())?;
         m.add(py, "SourcePoint", py.get_type::<SourcePoint>())?;
         m.add(py, "normalize", py_fn!(py, normalize(query: &PyString)))?;
+        m.add(py, "offset_of_line",
+            py_fn!(py, offset_of_line(text: &str, line: usize)))?;
         m.add(py, "Hasher", py.get_type::<hash::Hasher>())?;
         m.add(py, "unreserved_keywords", keywords.unreserved)?;
         m.add(py, "future_reserved_keywords", keywords.future)?;

--- a/edb/edgeql-rust/src/position.rs
+++ b/edb/edgeql-rust/src/position.rs
@@ -1,7 +1,7 @@
 
-use cpython::exc::{RuntimeError};
+use cpython::exc::{RuntimeError, IndexError};
 use cpython::{py_class, PyErr, PyResult, PyInt, PyBytes, PyList, ToPyObject};
-use cpython::{PyObject};
+use cpython::{Python, PyObject};
 
 use edgeql_parser::position::InflatedPos;
 
@@ -39,3 +39,80 @@ py_class!(pub class SourcePoint |py| {
         Ok((self._position(py).char_offset).to_py_object(py))
     }
 });
+
+fn _offset_of_line(text: &str, target: usize) -> Option<usize> {
+    let mut was_lf = false;
+    let mut line = 0;  // this assumes line found by rfind
+    for (idx, &byte) in text.as_bytes().iter().enumerate() {
+        if line >= target {
+            return Some(idx);
+        }
+        match byte {
+            b'\n' => {
+                line += 1;
+                was_lf = false;
+            }
+            _ if was_lf => {
+                line += 1;
+                if line >= target {
+                    return Some(idx);
+                }
+                was_lf = byte == b'\r';
+            }
+            b'\r' => {
+                was_lf = true;
+            }
+            _ => {}
+        }
+    }
+    if was_lf {
+        line += 1;
+    }
+    if target > line {
+        return None;
+    }
+    Some(text.len())
+}
+
+pub fn offset_of_line(py: Python, text: &str, target: usize) -> PyResult<usize>
+{
+    match _offset_of_line(text, target) {
+        Some(offset) => Ok(offset),
+        None => {
+            Err(PyErr::new::<IndexError, _>(py, "line number is too large"))
+        }
+    }
+}
+
+#[test]
+fn line_offsets() {
+    assert_eq!(_offset_of_line("line1\nline2\nline3", 0), Some(0));
+    assert_eq!(_offset_of_line("line1\nline2\nline3", 1), Some(6));
+    assert_eq!(_offset_of_line("line1\nline2\nline3", 2), Some(12));
+    assert_eq!(_offset_of_line("line1\nline2\nline3", 3), None);
+    assert_eq!(_offset_of_line("line1\rline2\rline3", 0), Some(0));
+    assert_eq!(_offset_of_line("line1\rline2\rline3", 1), Some(6));
+    assert_eq!(_offset_of_line("line1\rline2\rline3", 2), Some(12));
+    assert_eq!(_offset_of_line("line1\rline2\rline3", 3), None);
+    assert_eq!(_offset_of_line("line1\r\nline2\r\nline3", 0), Some(0));
+    assert_eq!(_offset_of_line("line1\r\nline2\r\nline3", 1), Some(7));
+    assert_eq!(_offset_of_line("line1\r\nline2\r\nline3", 2), Some(14));
+    assert_eq!(_offset_of_line("line1\r\nline2\r\nline3", 3), None);
+    assert_eq!(_offset_of_line("line1\rline2\r\nline3\n", 0), Some(0));
+    assert_eq!(_offset_of_line("line1\rline2\r\nline3\n", 1), Some(6));
+    assert_eq!(_offset_of_line("line1\rline2\r\nline3\n", 2), Some(13));
+    assert_eq!(_offset_of_line("line1\rline2\r\nline3\n", 3), Some(19));
+    assert_eq!(_offset_of_line("line1\rline2\r\nline3\n", 4), None);
+    assert_eq!(_offset_of_line("line1\nline2\rline3\r\n", 0), Some(0));
+    assert_eq!(_offset_of_line("line1\nline2\rline3\r\n", 1), Some(6));
+    assert_eq!(_offset_of_line("line1\nline2\rline3\r\n", 2), Some(12));
+    assert_eq!(_offset_of_line("line1\nline2\rline3\r\n", 3), Some(19));
+    assert_eq!(_offset_of_line("line1\nline2\rline3\r\n", 4), None);
+    assert_eq!(_offset_of_line("line1\n\rline2\r\rline3\r", 0), Some(0));
+    assert_eq!(_offset_of_line("line1\n\rline2\r\rline3\r", 1), Some(6));
+    assert_eq!(_offset_of_line("line1\n\rline2\r\rline3\r", 2), Some(7));
+    assert_eq!(_offset_of_line("line1\n\rline2\r\rline3\r", 3), Some(13));
+    assert_eq!(_offset_of_line("line1\n\rline2\r\rline3\r", 4), Some(14));
+    assert_eq!(_offset_of_line("line1\n\rline2\r\rline3\r", 5), Some(20));
+    assert_eq!(_offset_of_line("line1\n\rline2\r\rline3\r", 6), None);
+}

--- a/edb/edgeql-rust/src/position.rs
+++ b/edb/edgeql-rust/src/position.rs
@@ -1,0 +1,41 @@
+
+use cpython::exc::{RuntimeError};
+use cpython::{py_class, PyErr, PyResult, PyInt, PyBytes, PyList, ToPyObject};
+use cpython::{PyObject};
+
+use edgeql_parser::position::InflatedPos;
+
+py_class!(pub class SourcePoint |py| {
+    data _position: InflatedPos;
+    @classmethod def from_offsets(cls, data: PyBytes, offsets: PyObject)
+        -> PyResult<PyList>
+    {
+        let mut list: Vec<usize> = offsets.extract(py)?;
+        let data: &[u8] = data.data(py);
+        list.sort();
+        let result = InflatedPos::from_offsets(data, &list)
+            .map_err(|e| PyErr::new::<RuntimeError, _>(py, e.to_string()))?;
+        Ok(result.into_iter()
+            .map(|pos| SourcePoint::create_instance(py, pos))
+            .collect::<Result<Vec<_>, _>>()?
+            .to_py_object(py))
+    }
+    @property def line(&self) -> PyResult<PyInt> {
+        Ok((self._position(py).line + 1).to_py_object(py))
+    }
+    @property def zero_based_line(&self) -> PyResult<PyInt> {
+        Ok((self._position(py).line).to_py_object(py))
+    }
+    @property def column(&self) -> PyResult<PyInt> {
+        Ok((self._position(py).column + 1).to_py_object(py))
+    }
+    @property def utf16column(&self) -> PyResult<PyInt> {
+        Ok((self._position(py).utf16column).to_py_object(py))
+    }
+    @property def offset(&self) -> PyResult<PyInt> {
+        Ok((self._position(py).offset).to_py_object(py))
+    }
+    @property def char_offset(&self) -> PyResult<PyInt> {
+        Ok((self._position(py).char_offset).to_py_object(py))
+    }
+});

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -113,12 +113,13 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
             self._attrs[FIELD_DETAILS] = details
 
     def set_source_context(self, context):
-        self.set_linecol(context.start.line, context.start.column)
+        start = context.start_point
+        end = context.end_point
+        self.set_linecol(start.line, start.column)
         ex.replace_context(self, context)
 
-        if context.start is not None:
-            self._attrs[FIELD_POSITION_START] = str(context.start.pointer)
-            self._attrs[FIELD_POSITION_END] = str(context.end.pointer)
+        self._attrs[FIELD_POSITION_START] = str(start.offset)
+        self._attrs[FIELD_POSITION_END] = str(end.offset)
 
     def set_position(self, line: int, column: int, pointer: int):
         self.set_linecol(line, column)

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -100,8 +100,8 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
         return cls._code
 
     def set_linecol(self, line, col):
-        self._attrs[FIELD_LINE] = str(line)
-        self._attrs[FIELD_COLUMN] = str(col)
+        self._attrs[FIELD_LINE_START] = str(line)
+        self._attrs[FIELD_COLUMN_START] = str(col)
 
     def set_hint_and_details(self, hint, details=None):
         ex.replace_context(
@@ -115,11 +115,18 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
     def set_source_context(self, context):
         start = context.start_point
         end = context.end_point
-        self.set_linecol(start.line, start.column)
         ex.replace_context(self, context)
 
         self._attrs[FIELD_POSITION_START] = str(start.offset)
         self._attrs[FIELD_POSITION_END] = str(end.offset)
+        self._attrs[FIELD_CHARACTER_START] = str(start.char_offset)
+        self._attrs[FIELD_CHARACTER_END] = str(end.char_offset)
+        self._attrs[FIELD_LINE_START] = str(start.line)
+        self._attrs[FIELD_COLUMN_START] = str(start.column)
+        self._attrs[FIELD_UTF16_COLUMN_START] = str(start.utf16column)
+        self._attrs[FIELD_LINE_END] = str(end.line)
+        self._attrs[FIELD_COLUMN_END] = str(end.column)
+        self._attrs[FIELD_UTF16_COLUMN_END] = str(end.utf16column)
 
     def set_position(self, line: int, column: int, pointer: int):
         self.set_linecol(line, column)
@@ -128,11 +135,11 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
 
     @property
     def line(self):
-        return int(self._attrs.get(FIELD_LINE, -1))
+        return int(self._attrs.get(FIELD_LINE_START, -1))
 
     @property
     def col(self):
-        return int(self._attrs.get(FIELD_COLUMN, -1))
+        return int(self._attrs.get(FIELD_COLUMN_START, -1))
 
     @property
     def position(self):
@@ -154,5 +161,11 @@ FIELD_SERVER_TRACEBACK = 0x_01_01
 # XXX: Subject to be changed/deprecated.
 FIELD_POSITION_START = 0x_FF_F1
 FIELD_POSITION_END = 0x_FF_F2
-FIELD_LINE = 0x_FF_F3
-FIELD_COLUMN = 0x_FF_F4
+FIELD_LINE_START = 0x_FF_F3
+FIELD_COLUMN_START = 0x_FF_F4
+FIELD_UTF16_COLUMN_START = 0x_FF_F5
+FIELD_LINE_END = 0x_FF_F6
+FIELD_COLUMN_END = 0x_FF_F7
+FIELD_UTF16_COLUMN_END = 0x_FF_F8
+FIELD_CHARACTER_START = 0x_FF_F9
+FIELD_CHARACTER_END = 0x_FF_FA

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -221,8 +221,9 @@ def get_source_context_as_json(
     details: Optional[str]
     if expr.context:
         details = json.dumps({
-            'line': expr.context.start.line,
-            'column': expr.context.start.column,
+            # TODO(tailhook) should we add offset, utf16column here?
+            'line': expr.context.start_point.line,
+            'column': expr.context.start_point.column,
             'name': expr.context.name,
             'code': exctype.get_code(),
         })

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -25,6 +25,8 @@ from typing import *
 import re
 import textwrap
 
+from edb import _edgeql_rust
+
 from edb.common import context as parser_context
 from edb.common import debug
 from edb.common import exceptions
@@ -4084,24 +4086,18 @@ async def _execute_sql_script(
         point = None
 
         if position is not None:
-            position = int(position)
-            point = parser_context.SourcePoint(
-                None, None, position)
+            point = int(position)
             text = getattr(e, 'query', None)
             if text is None:
                 # Parse errors
                 text = sql_text
 
         elif internal_position is not None:
-            internal_position = int(internal_position)
-            point = parser_context.SourcePoint(
-                None, None, internal_position)
+            point = int(internal_position)
             text = getattr(e, 'internal_query', None)
 
         elif pl_func_line:
-            point = parser_context.SourcePoint(
-                pl_func_line, None, None
-            )
+            point = _edgeql_rust.offset_of_line(sql_text, pl_func_line)
             text = sql_text
 
         if point is not None:

--- a/edb/repl/render.py
+++ b/edb/repl/render.py
@@ -103,8 +103,8 @@ def render_exception(
             print(f'Hint: {exc_hint}')
 
         if query:
-            exc_line = int(read_str_field(base_errors.FIELD_LINE, '-1'))
-            exc_col = int(read_str_field(base_errors.FIELD_COLUMN, '-1'))
+            exc_line = int(read_str_field(base_errors.FIELD_LINE_START, '-1'))
+            exc_col = int(read_str_field(base_errors.FIELD_COLUMN_START, '-1'))
             if exc_line >= 0 and exc_col >= 0:
                 for lineno, line in enumerate(query.split('\n'), 1):
                     print('###', line)

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -135,8 +135,8 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
         hasher = qlhasher.Hasher.start_migration(str(parent_name))
         if astnode.body.context is not None:
             # This is an explicitly specified CREATE MIGRATION
-            src_start = astnode.body.context.start.pointer
-            src_end = astnode.body.context.end.pointer
+            src_start = astnode.body.context.start
+            src_end = astnode.body.context.end
             # XXX: Workaround the rust lexer issue of returning
             # byte token offsets instead of character offsets.
             buffer = astnode.context.buffer.encode('utf-8')

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -32,6 +32,7 @@ import immutables
 from edb import errors
 
 from edb import edgeql
+from edb import _edgeql_rust
 from edb.edgeql import ast as qlast
 
 from edb.common import context as parser_context
@@ -746,24 +747,18 @@ async def _execute_ddl(conn, sql_text):
         point = None
 
         if position is not None:
-            position = int(position)
-            point = parser_context.SourcePoint(
-                None, None, position)
+            point = int(position)
             text = e.query
             if text is None:
                 # Parse errors
                 text = sql_text
 
         elif internal_position is not None:
-            internal_position = int(internal_position)
-            point = parser_context.SourcePoint(
-                None, None, internal_position)
+            point = int(internal_position)
             text = e.internal_query
 
         elif pl_func_line:
-            point = parser_context.SourcePoint(
-                pl_func_line, None, None
-            )
+            point = _edgeql_rust.offset_of_line(sql_text, pl_func_line)
             text = sql_text
 
         if point is not None:

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -221,9 +221,9 @@ class GraphQLTestCase(BaseHttpTest, server.QueryTestCase):
 
         if 'locations' in err:
             # XXX Fix this when LSP "location" objects are implemented
-            ex._attrs[base_errors.FIELD_LINE] = str(
+            ex._attrs[base_errors.FIELD_LINE_START] = str(
                 err['locations'][0]['line']).encode()
-            ex._attrs[base_errors.FIELD_COLUMN] = str(
+            ex._attrs[base_errors.FIELD_COLUMN_START] = str(
                 err['locations'][0]['column']).encode()
 
         raise ex

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -112,6 +112,12 @@ class TestHttpNotebook(tb.BaseHttpTest, tb.server.QueryTestCase):
                                 '65524': '8',
                                 '65521': '7',
                                 '65522': '17',
+                                '65525': '7',
+                                '65526': '1',
+                                '65527': '18',
+                                '65528': '17',
+                                '65529': '7',
+                                '65530': '17',
                                 '1': 'Consider using an explicit type '
                                      'cast or a conversion function.'
                             }


### PR DESCRIPTION
1. Track integer byte offsets thorough code
2. Only convert when error must be printed or sent to the client
3. Use Rust for position conversion

Notes:
1. It looks like `rebase_context` is unused anymore, right?
2. No test has failed when `as_markup` was broken. Where is it used?
3. We still use strings for queries internally, using bytes instead will be in a separate PR
4. We send byte offsets to the client (there are probably two users of these offsets currently: Rust client, which is fine, and Javascript tutorial, which is unreleased yet).
5. `column` is now calculated using [unicode-width](https://crates.io/crates/unicode-width) previously was in terms of unicode codepoints. But it is unused in Rust for rendering anyway (only may show up in errors that don't show snippet), so should not break anything.
6. utf16column and char_offset are currently unused. The former is intended for language server protocol (LSP) support and the latter we might consider sending to the client so that slicing string in python is easier.

Also I think that https://github.com/edgedb/ui/commit/4b97505abeffaf909346d5ffa4f7dc407edc0573 does it wrong: it uses byte offsets sent from server as a utf-16 offsets that JS expects. @jaclarke, should we also have `utf16offset` sent from server? Or should you overlay just target line(s) and use `utf16column` for slicing?