### PR TITLE
Make sure that WITH bound DML statements execute the correct number of times

### DIFF
--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -292,7 +292,7 @@ def get_iterator_sets(stmt: irast.Stmt) -> Sequence[irast.Set]:
     return iterators
 
 
-def contains_dml(stmt: irast.Stmt) -> bool:
+def contains_dml(stmt: irast.Base) -> bool:
     """Check whether a statement contains any DML in a subtree."""
     # If this ends up being a perf problem, we can use a visitor
     # directly and cache.

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -88,7 +88,10 @@ class CompilerContextLevel(compiler.ContextLevel):
     toplevel_stmt: pgast.Query
 
     #: Record of DML CTEs generated for the corresponding IR DML.
-    dml_stmts: Dict[irast.MutatingStmt, pgast.CommonTableExpr]
+    #: CTEs generated for DML-containing FOR statements are keyed
+    #: by their iterator set.
+    dml_stmts: Dict[Union[irast.MutatingStmt, irast.Set],
+                    pgast.CommonTableExpr]
 
     #: SQL statement corresponding to the IR statement
     #: currently being compiled.

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -55,6 +55,7 @@ type Person {
     optional multi property multi_prop -> std::str {
         constraint std::exclusive;
     };
+    optional single link note -> Note;
 }
 
 type PersonWrapper {


### PR DESCRIPTION
This requires compiling them when we see with binding, so the
compilation happens in the correct context. The CTE will be picked up
dml_stmts when the variable is encountered.

To make FOR work, we need to also track it in dml_stmts and reuse
iterator CTEs when necessary.

Type and pointer overlays then also need to be updated whenever a DML
containing variable is used inside other DML.