### PR TITLE
A small assortment of migration fixes

### DIFF
--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -345,7 +345,10 @@ class AlterAnnotationValue(
         astnode: qlast.DDLOperation,
         context: sd.CommandContext
     ) -> AlterAnnotationValue:
-        assert isinstance(astnode, qlast.AlterAnnotationValue)
+        assert isinstance(
+            astnode,
+            (qlast.CreateAnnotationValue, qlast.AlterAnnotationValue),
+        )
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
         assert isinstance(cmd, AlterAnnotationValue)
 

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -478,7 +478,10 @@ class CreateLink(
         return cmd
 
 
-class RenameLink(LinkCommand, sd.RenameObject[Link]):
+class RenameLink(
+    LinkCommand,
+    referencing.RenameReferencedInheritingObject[Link],
+):
     pass
 
 

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -24,6 +24,7 @@ from typing import *
 import functools
 import json
 import numbers
+import textwrap
 
 from edb.edgeql import qltypes
 
@@ -681,7 +682,7 @@ def write_meta_alter_object(
         shape, variables = _build_object_mutation_shape(
             cmd,
             classlayout=classlayout,
-            internal_schema_mode=False,
+            internal_schema_mode=internal_schema_mode,
             stdmode=stdmode,
             schema=schema,
             context=context,
@@ -743,7 +744,11 @@ def _update_lprops(
     if not lprops:
         return
 
-    if mcls.get_reflection_method() is so.ReflectionMethod.AS_LINK:
+    reflect_as_link = (
+        mcls.get_reflection_method() is so.ReflectionMethod.AS_LINK
+    )
+
+    if reflect_as_link:
         target_link = mcls.get_reflection_link()
         assert target_link is not None
         target_field = mcls.get_field(target_link)
@@ -780,38 +785,95 @@ def _update_lprops(
     if shape:
         parent_variables = {}
         parent_variables[f'__{target_link}'] = json.dumps(str(target_ref))
+        ref_name = context.get_referrer_name(refctx)
+        parent_variables['__parent_classname'] = json.dumps(str(ref_name))
 
         # XXX: we have to do a -= followed by a += because
         # support for filtered nested link property updates
         # is currently broken.
 
-        parent_update_query = f'''
+        assignments = []
+
+        assignments.append(textwrap.dedent(
+            f'''\
+            {refdict.attr} -= (
+                SELECT DETACHED (schema::{target_clsname})
+                FILTER .name__internal = <str>$__{target_link}
+            )'''
+        ))
+
+        if reflect_as_link:
+            parent_variables[f'__{target_link}_shadow'] = (
+                json.dumps(str(cmd.classname)))
+
+            assignments.append(textwrap.dedent(
+                f'''\
+                {refdict.attr}__internal -= (
+                    SELECT DETACHED (schema::{mcls.__name__})
+                    FILTER .name__internal = <str>$__{target_link}_shadow
+                )'''
+            ))
+
+        update_shape = textwrap.indent(
+            '\n' + ',\n'.join(assignments), '    ' * 4)
+
+        parent_update_query = textwrap.dedent(f'''\
             UPDATE schema::{refcls.__name__}
             FILTER .name__internal = <str>$__parent_classname
-            SET {{
-                {refdict.attr} -= (
-                    SELECT DETACHED (schema::{target_clsname})
-                    FILTER .name__internal = <str>$__{target_link}
-                )
+            SET {{{update_shape}
             }}
-        '''
-
-        ref_name = context.get_referrer_name(refctx)
-        parent_variables['__parent_classname'] = json.dumps(str(ref_name))
+        ''')
 
         blocks.append((parent_update_query, parent_variables))
 
-        parent_update_query = f'''
+        assignments = []
+
+        shape = textwrap.indent(f'\n{shape}', '    ' * 5)
+
+        assignments.append(textwrap.dedent(
+            f'''\
+            {refdict.attr} += (
+                SELECT schema::{target_clsname} {{{shape}
+                }} FILTER .name__internal = <str>$__{target_link}
+            )'''
+        ))
+
+        if reflect_as_link:
+            shadow_clslayout = classlayout[refcls]
+            shadow_link_layout = shadow_clslayout[f'{refdict.attr}__internal']
+            shadow_shape, shadow_variables = _build_object_mutation_shape(
+                cmd,
+                classlayout=classlayout,
+                internal_schema_mode=internal_schema_mode,
+                lprop_fields=shadow_link_layout.properties,
+                lprops_only=True,
+                stdmode=stdmode,
+                var_prefix='shadow_',
+                schema=schema,
+                context=context,
+            )
+
+            shadow_shape = textwrap.indent(f'\n{shadow_shape}', '    ' * 6)
+
+            assignments.append(textwrap.dedent(
+                f'''\
+                {refdict.attr}__internal += (
+                    SELECT schema::{mcls.__name__} {{{shadow_shape}
+                    }} FILTER .name__internal = <str>$__{target_link}_shadow
+                )'''
+            ))
+
+            parent_variables.update(shadow_variables)
+
+        update_shape = textwrap.indent(
+            '\n' + ',\n'.join(assignments), '    ' * 4)
+
+        parent_update_query = textwrap.dedent(f'''
             UPDATE schema::{refcls.__name__}
             FILTER .name__internal = <str>$__parent_classname
-            SET {{
-                {refdict.attr} += (
-                    SELECT schema::{target_clsname} {{
-                        {shape}
-                    }} FILTER .name__internal = <str>$__{target_link}
-                )
+            SET {{{update_shape}
             }}
-        '''
+        ''')
 
         parent_variables.update(append_variables)
         blocks.append((parent_update_query, parent_variables))

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4071,10 +4071,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             type Derived extending Base;
         """])
 
-    @test.xfail('''
-        AssertionError:
-        assert isinstance(astnode, qlast.AlterAnnotationValue)
-    ''')
     def test_schema_migrations_equivalence_annotation_05(self):
         self._assert_migration_equivalence([r"""
             abstract inheritable annotation my_anno;

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4049,10 +4049,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             type Derived extending Base;
         """])
 
-    @test.xfail('''
-        edb.errors.InvalidReferenceError:
-        schema item 'default::default|foo_anno@default|Derived' does not exist
-    ''')
     def test_schema_migrations_equivalence_annotation_04(self):
         self._assert_migration_equivalence([r"""
             type Base;

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4103,10 +4103,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
-    @test.xfail('''
-        AssertionError:
-        assert isinstance(astnode, qlast.AlterAnnotationValue)
-    ''')
     def test_schema_migrations_equivalence_annotation_06(self):
         self._assert_migration_equivalence([r"""
             abstract inheritable annotation my_anno;


### PR DESCRIPTION
* Fix link rename propagation in overloaded inheritance hierarchy
* Fix handling of overloaded annotation values
* Fix metadata reflection of overloaded annotation values
* Fix abstract annotation rename