### PR TITLE
Fix a never-ending loop in DESCRIBE/REJECT

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -198,8 +198,10 @@ def delta_objects(
             y_name = y.get_name(old_schema)
             if (
                 0.6 < s < 1.0
-                or not can_create(x_name)
-                or not can_delete(y_name)
+                or (
+                    (not can_create(x_name) or not can_delete(y_name))
+                    and can_alter(y_name, x_name)
+                )
                 or x_name in renames_x
             ):
                 if (


### PR DESCRIPTION
In a simple `ALTER` scenario, if both `ALTER` and `CREATE`/`DROP` are
rejected, `DESCRIBE MIGRATION` would erroneously suggest `ALTER` again.
This is a fix.

Reported by @tailhook.