### PR TITLE
Don't execute nested DML when UNLESS CONFLICT ON fails

### DIFF
--- a/edb/common/ast/visitor.py
+++ b/edb/common/ast/visitor.py
@@ -42,6 +42,8 @@ def find_children(node, test_func, *args, force_traversal=False,
 
         for field, value in base.iter_fields(node, include_meta=False):
             field_spec = node._fields[field]
+            if field_spec.hidden:
+                continue
 
             if isinstance(value, (list, set, frozenset)):
                 for n in value:
@@ -109,6 +111,8 @@ class NodeVisitor:
     allows modifications.
     """
 
+    skip_hidden = False
+
     def __init__(self, *, context=None, memo=None):
         if memo is not None:
             self._memo = memo
@@ -167,7 +171,11 @@ class NodeVisitor:
     def generic_visit(self, node, *, combine_results=None):
         field_results = []
 
-        for _field, value in base.iter_fields(node, include_meta=False):
+        for field, value in base.iter_fields(node, include_meta=False):
+            field_spec = node._fields[field]
+            if self.skip_hidden and field_spec.hidden:
+                continue
+
             if typeutils.is_container(value):
                 for item in value:
                     if base.is_ast_node(item) or typeutils.is_container(item):

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -1035,10 +1035,10 @@ def __infer_insert_stmt(
         ir.result, is_mutation=True, scope_tree=new_scope, ctx=ctx
     )
 
-    if ir.on_conflict and ir.on_conflict.else_ir:
-        for part in [ir.on_conflict.else_ir.select,
-                     ir.on_conflict.else_ir.body]:
-            infer_cardinality(part, scope_tree=scope_tree, ctx=ctx)
+    if ir.on_conflict:
+        for part in [ir.on_conflict.select_ir, ir.on_conflict.else_ir]:
+            if part:
+                infer_cardinality(part, scope_tree=scope_tree, ctx=ctx)
 
     assert not ir.iterator_stmt, "InsertStmt shouldn't ever have an iterator"
 

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -536,10 +536,10 @@ def __infer_insert_stmt(
         ir.result, is_mutation=True, scope_tree=new_scope, ctx=ctx
     )
 
-    if ir.on_conflict and ir.on_conflict.else_ir:
-        for part in [ir.on_conflict.else_ir.select,
-                     ir.on_conflict.else_ir.body]:
-            infer_multiplicity(part, scope_tree=scope_tree, ctx=ctx)
+    if ir.on_conflict:
+        for part in [ir.on_conflict.select_ir, ir.on_conflict.else_ir]:
+            if part:
+                infer_multiplicity(part, scope_tree=scope_tree, ctx=ctx)
 
     return ONE
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -314,23 +314,23 @@ def compile_insert_unless_conflict(
 
     ctx.env.schema = schema
 
-    # Compile an else branch
-    else_info = None
-    if else_branch:
-        # Produce a query that finds the conflicting objects
-        nobe = qlast.SelectQuery(
-            result=insert_subject,
-            where=qlast.BinOp(
-                op='=',
-                left=constraint_spec,
-                right=anchor
-            ),
-        )
-        select_ir = dispatch.compile(nobe, ctx=ctx)
-        select_ir = setgen.scoped_set(
-            select_ir, force_reassign=True, ctx=ctx)
-        assert isinstance(select_ir, irast.Set)
+    # Produce a query that finds the conflicting objects
+    nobe = qlast.SelectQuery(
+        result=insert_subject,
+        where=qlast.BinOp(
+            op='=',
+            left=constraint_spec,
+            right=anchor
+        ),
+    )
+    select_ir = dispatch.compile(nobe, ctx=ctx)
+    select_ir = setgen.scoped_set(
+        select_ir, force_reassign=True, ctx=ctx)
+    assert isinstance(select_ir, irast.Set)
 
+    # Compile an else branch
+    else_ir = None
+    if else_branch:
         # The ELSE needs to be able to reference the subject in an
         # UPDATE, even though that would normally be prohibited.
         ctx.path_scope.factoring_allowlist.add(stmt.subject.path_id)
@@ -339,12 +339,12 @@ def compile_insert_unless_conflict(
         else_ir = dispatch.compile(
             astutils.ensure_qlstmt(else_branch), ctx=ctx)
         assert isinstance(else_ir, irast.Set)
-        else_info = irast.OnConflictElse(select=select_ir, body=else_ir)
 
     return irast.OnConflictClause(
         constraint=irast.ConstraintRef(
             id=ex_cnstrs[0].id, module_id=module_id),
-        else_ir=else_info
+        select_ir=select_ir,
+        else_ir=else_ir
     )
 
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -759,14 +759,10 @@ class MutatingStmt(Stmt):
     subject: Set
 
 
-class OnConflictElse(Base):
-    select: Set
-    body: Set
-
-
 class OnConflictClause(Base):
     constraint: typing.Optional[ConstraintRef]
-    else_ir: typing.Optional[OnConflictElse]
+    select_ir: typing.Optional[Set]
+    else_ir: typing.Optional[Set]
 
 
 class InsertStmt(MutatingStmt):

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -733,6 +733,7 @@ class JoinExpr(BaseRangeVar):
 
 class SubLinkType(enum.IntEnum):
     EXISTS = enum.auto()
+    NOT_EXISTS = enum.auto()
     ALL = enum.auto()
     ANY = enum.auto()
 

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -629,6 +629,8 @@ class SQLSourceGenerator(codegen.SourceGenerator):
     def visit_SubLink(self, node):
         if node.type == pgast.SubLinkType.EXISTS:
             self.write('EXISTS')
+        elif node.type == pgast.SubLinkType.NOT_EXISTS:
+            self.write('NOT EXISTS')
         elif node.type == pgast.SubLinkType.ALL:
             self.write('ALL')
         elif node.type == pgast.SubLinkType.ANY:

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -51,6 +51,9 @@ type Person {
         default := "Nemo";
     };
     optional single property tag -> std::str;
+    required single property tag2 -> std::str {
+	default := "<n/a>";
+    };
     optional multi link notes -> Note;
     optional multi property multi_prop -> std::str {
         constraint std::exclusive;


### PR DESCRIPTION
We already avoid executing nested DML for pointers that are stored in
link fields (since those are populated *after* the insert is done),
but we need to make sure it works for pointers stored inline as well.

To make this work, we reuse the machinery for selecting conflicting
rows for the ELSE clause, but perform an anti-join on it to generate
an iterator that we use for the INSERT, containing only the rows that
won't conflict.

Progress on #1669, but we still need to support when ON is not
specified explicitly.