### PR TITLE
Fix lower cardinality checks on multi pointers

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -218,14 +218,10 @@ def _process_view(
                                     'std::sequence',
                                     type=s_objects.SubclassableObject)):
                             continue
-
-                        what = 'property'
-                    else:
-                        what = 'link'
+                    vn = ptrcls.get_verbosename(
+                        ctx.env.schema, with_parent=True)
                     raise errors.MissingRequiredError(
-                        f'missing value for required {what} '
-                        f'{stype.get_displayname(ctx.env.schema)}.'
-                        f'{ptrcls.get_displayname(ctx.env.schema)}')
+                        f'missing value for required {vn}')
                 else:
                     continue
 

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -157,7 +157,7 @@ def compile_InsertStmt(
         dml.process_insert_body(
             ir_stmt=stmt,
             insert_cte=insert_cte,
-            else_cte_rvar=parts.else_cte,
+            dml_parts=parts,
             ctx=ctx,
         )
 

--- a/tests/schemas/updates.esdl
+++ b/tests/schemas/updates.esdl
@@ -74,3 +74,11 @@ type CollectionTest {
     property some_tuple -> tuple<str, int64>;
     property str_array -> array<str>;
 }
+
+type MultiRequiredTest {
+    required property name -> str {
+        constraint exclusive;
+    };
+    required multi property prop -> str;
+    required multi link tags -> Tag;
+}

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -8606,18 +8606,20 @@ type test::Foo {
         """)
 
         with self.assertRaisesRegex(
-                edgedb.MissingRequiredError,
-                r'Base.foo'):
-
+            edgedb.MissingRequiredError,
+            f"missing value for required property"
+            r" 'foo' of object type 'test::Base'",
+        ):
             async with self.con.transaction():
                 await self.con.execute("""
                     INSERT Base;
                 """)
 
         with self.assertRaisesRegex(
-                edgedb.MissingRequiredError,
-                r'Derived.foo'):
-
+            edgedb.MissingRequiredError,
+            f"missing value for required property"
+            r" 'foo' of object type 'test::Derived'",
+        ):
             async with self.con.transaction():
                 await self.con.execute("""
                     INSERT Derived;
@@ -8642,9 +8644,10 @@ type test::Foo {
         )
 
         with self.assertRaisesRegex(
-                edgedb.MissingRequiredError,
-                r'Derived.foo'):
-
+            edgedb.MissingRequiredError,
+            f"missing value for required property"
+            r" 'foo' of object type 'test::Derived'",
+        ):
             async with self.con.transaction():
                 await self.con.execute("""
                     INSERT Derived;
@@ -8687,9 +8690,10 @@ type test::Foo {
         """)
 
         with self.assertRaisesRegex(
-                edgedb.MissingRequiredError,
-                r'Derived.foo'):
-
+            edgedb.MissingRequiredError,
+            f"missing value for required property"
+            r" 'foo' of object type 'test::Derived'",
+        ):
             async with self.con.transaction():
                 await self.con.execute("""
                     INSERT Derived;
@@ -8706,9 +8710,10 @@ type test::Foo {
         )
 
         with self.assertRaisesRegex(
-                edgedb.MissingRequiredError,
-                r'Derived.foo'):
-
+            edgedb.MissingRequiredError,
+            f"missing value for required property"
+            r" 'foo' of object type 'test::Derived'",
+        ):
             async with self.con.transaction():
                 await self.con.execute("""
                     INSERT Derived;
@@ -8732,9 +8737,6 @@ type test::Foo {
             [1],
         )
 
-    @test.xfail('''
-        MissingRequiredError not raised
-    ''')
     async def test_edgeql_ddl_required_10(self):
         # Test normal that required qualifier behavior.
 
@@ -8744,25 +8746,39 @@ type test::Foo {
             };
         """)
 
-        with self.assertRaisesRegex(
-                edgedb.MissingRequiredError,
-                r'Base.name'):
+        async with self.assertRaisesRegexTx(
+            edgedb.MissingRequiredError,
+            r"missing value for required property 'name'"
+            r" of object type 'test::Base'",
+        ):
             async with self.con.transaction():
                 await self.con.execute("""
                     INSERT test::Base;
                 """)
 
-        with self.assertRaisesRegex(
-                edgedb.MissingRequiredError,
-                r'Base.name'):
+        async with self.assertRaisesRegexTx(
+            edgedb.MissingRequiredError,
+            r"missing value for required property 'name'"
+            r" of object type 'test::Base'",
+        ):
             async with self.con.transaction():
                 await self.con.execute("""
                     INSERT test::Base {name := {}};
                 """)
 
-    @test.xfail('''
-        MissingRequiredError not raised
-    ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.MissingRequiredError,
+            r"missing value for required property 'name'"
+            r" of object type 'test::Base'",
+        ):
+            async with self.con.transaction():
+                await self.con.execute("""
+                    WITH names := {'A', 'B'}
+                    INSERT test::Base {
+                        name := (SELECT names FILTER names = 'C'),
+                    };
+                """)
+
     async def test_edgeql_ddl_required_11(self):
         # Test normal that required qualifier behavior.
 
@@ -8774,19 +8790,35 @@ type test::Foo {
         """)
 
         with self.assertRaisesRegex(
-                edgedb.MissingRequiredError,
-                r'Base.children'):
+            edgedb.MissingRequiredError,
+            r"missing value for required link 'children'"
+            r" of object type 'test::Base'"
+        ):
             async with self.con.transaction():
                 await self.con.execute("""
                     INSERT test::Base;
                 """)
 
         with self.assertRaisesRegex(
-                edgedb.MissingRequiredError,
-                r'Base.children'):
+            edgedb.MissingRequiredError,
+            r"missing value for required link 'children'"
+            r" of object type 'test::Base'"
+        ):
             async with self.con.transaction():
                 await self.con.execute("""
                     INSERT test::Base {children := {}};
+                """)
+
+        with self.assertRaisesRegex(
+            edgedb.MissingRequiredError,
+            r"missing value for required link 'children'"
+            r" of object type 'test::Base'"
+        ):
+            async with self.con.transaction():
+                await self.con.execute("""
+                    INSERT test::Base {
+                        children := (SELECT test::Child FILTER false)
+                    };
                 """)
 
     async def test_edgeql_ddl_prop_alias(self):
@@ -9802,7 +9834,8 @@ type test::Foo {
 
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
-            'missing value for required property test::Foo.a',
+            r"missing value for required property"
+            r" 'a' of object type 'test::Foo'",
         ):
             await self.con.execute(r"""
                 INSERT Foo;

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -33,9 +33,11 @@ class TestInsert(tb.QueryTestCase):
                           'insert.esdl')
 
     async def test_edgeql_insert_fail_1(self):
-        err = 'missing value for required property ' + \
-              'test::InsertTest.l2'
-        with self.assertRaisesRegex(edgedb.MissingRequiredError, err):
+        with self.assertRaisesRegex(
+            edgedb.MissingRequiredError,
+            r"missing value for required property"
+            r" 'l2' of object type 'test::InsertTest'",
+        ):
             await self.con.execute('''
                 INSERT test::InsertTest;
             ''')


### PR DESCRIPTION
The `required` constraint is currently not being enforced properly on
`multi` links and properties in cases where the value expression in
`INSERT` or `UPDATE` returns an empty set.  Fix this by treating the value
expression as `OPTIONAL` and check for `NULL` explicitly.