### PR TITLE
Don't execute nested DML when UNLESS CONFLICT fails

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -42,6 +42,12 @@ ObjectDDL_T = typing.TypeVar(
 )
 
 
+Base_T = typing.TypeVar(
+    'Base_T',
+    bound='Base',
+)
+
+
 class SortOrder(s_enum.StrEnum):
     Asc = 'ASC'
     Desc = 'DESC'

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -232,10 +232,8 @@ def compile_GroupQuery(
         context=expr.context)
 
 
-TBase = TypeVar('TBase', bound=qlast.Base)
-
-
-def subject_substitute(ast: TBase, new_subject: qlast.Expr) -> TBase:
+def subject_substitute(
+        ast: qlast.Base_T, new_subject: qlast.Expr) -> qlast.Base_T:
     ast = copy.deepcopy(ast)
     paths: List[qlast.Path] = ast_visitor.find_children(
         ast,

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -727,7 +727,8 @@ def compile_insert_else_body(
     else_branch = on_conflict.else_ir
 
     assert not (needs_conflict_cte and not else_select), (
-        "Nested DML into single pointers requires UNLESS CONFLICT ON for now")
+        "Nested DML into single pointers with UNLESS CONFLICT doesn't support "
+        "object constraints yet")
 
     if not else_select:
         return None

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -59,6 +59,9 @@ type Person {
         constraint std::exclusive;
     };
     optional single link note -> Note;
+    property case_name -> str {
+        constraint exclusive on (str_lower(__subject__));
+    }
 }
 
 type PersonWrapper {


### PR DESCRIPTION
We accomplish this by synthesizing a SELECT that matches all
conflicting objects based on inspection of the exclusive constraints
in the object schema.

While I'm at it, I also made it work when there are subjectexprs,
which was an outstanding bug even with ON.

This still doesn't support object constraints, which will be a little
more hairy but still should be doable; I'll tackle that in a
follow-up.

Most of the way on #1669.