### PR TITLE
Separate global objects into a separate schema layer

### DIFF
--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -681,7 +681,7 @@ class ObjectMeta(type):
                         ftype.schema_restore
                     ),
                 ) -> Any:
-                    data = schema.get_obj_data_raw(self.id)
+                    data = schema.get_obj_data_raw(self)
                     v = data[_fi]
                     if v is not None:
                         return _sr(v)
@@ -706,7 +706,7 @@ class ObjectMeta(type):
                     _fn: str = field.name,
                     _fi: int = findex,
                 ) -> Any:
-                    data = schema.get_obj_data_raw(self.id)
+                    data = schema.get_obj_data_raw(self)
                     v = data[_fi]
                     if v is not None:
                         return v
@@ -1129,7 +1129,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         field = type(self).get_field(field_name)
 
         if isinstance(field, SchemaField):
-            data = schema.get_obj_data_raw(self.id)
+            data = schema.get_obj_data_raw(self)
             val = data[field.index]
             if val is not None:
                 if field.is_reducible:
@@ -1159,7 +1159,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         field = type(self).get_field(field_name)
 
         if isinstance(field, SchemaField):
-            data = schema.get_obj_data_raw(self.id)
+            data = schema.get_obj_data_raw(self)
             val = data[field.index]
             if val is not None:
                 if field.is_reducible:
@@ -1189,10 +1189,10 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         assert field.is_schema_field
 
         if value is None:
-            return schema.unset_obj_field(self.id, name)
+            return schema.unset_obj_field(self, name)
         else:
             value = field.coerce_value(schema, value)
-            return schema.set_obj_field(self.id, name, value)
+            return schema.set_obj_field(self, name, value)
 
     def update(
         self, schema: s_schema.Schema, updates: Dict[str, Any]
@@ -1209,7 +1209,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
                 new_val = field.coerce_value(schema, new_val)
                 updates[field_name] = new_val
 
-        return schema.update_obj(self.id, updates)
+        return schema.update_obj(self, updates)
 
     def is_type(self) -> bool:
         return False

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -19,7 +19,8 @@
 
 from __future__ import annotations
 
-from .compiler import Compiler, BaseCompiler, CompilerDatabaseState
+from .compiler import Compiler, BaseCompiler
+from .compiler import CompileContext, CompilerDatabaseState
 from .compiler import compile_edgeql_script
 from .compiler import load_std_schema
 from .compiler import new_compiler, new_compiler_context
@@ -29,7 +30,10 @@ from .enums import IoFormat
 
 
 __all__ = (
-    'Compiler', 'BaseCompiler', 'CompilerDatabaseState',
+    'Compiler',
+    'CompileContext',
+    'BaseCompiler',
+    'CompilerDatabaseState',
     'QueryUnit',
     'Capability', 'CompileStatementMode', 'ResultCardinality', 'IoFormat',
     'compile_edgeql_script',

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -270,10 +270,12 @@ def _load_reflection_schema():
             reflschema, classlayout = cache
         else:
             std_schema = _load_std_schema()
-            refldelta, classlayout, _ = s_refl.generate_structure(std_schema)
+            reflection = s_refl.generate_structure(std_schema)
+            classlayout = reflection.class_layout
             context = sd.CommandContext()
             context.stdmode = True
-            reflschema = refldelta.apply(std_schema, context)
+            reflschema = reflection.intro_schema_delta.apply(
+                std_schema, context)
 
             if devmode.is_in_dev_mode():
                 buildmeta.write_data_cache(


### PR DESCRIPTION
Global objects, such as roles and databases, are shared across all
schemas in an instance, and so an addition, removal, or alteration of a
global object should become visible in all sessions.  In order to make
the introspection and maintenance of the global object set easier,
separate it into a separate `FlatSchema` layer.  Subsequent work will
build on this to make global schema synchronization more efficient.