### PR TITLE
Fix several bugs related to `RESET OPTIONALITY`

### DIFF
--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -101,9 +101,7 @@ class AliasCommand(
             schema=schema,
             options=qlcompiler.CompilerOptions(
                 derived_target_module=classname.module,
-                result_view_name=classname,
                 modaliases=context.modaliases,
-                schema_view_mode=True,
                 in_ddl_context_name='alias definition',
                 track_schema_ref_exprs=track_schema_ref_exprs,
             ),

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -7501,6 +7501,29 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             ['newtest']
         )
 
+    async def test_edgeql_migration_inherited_optionality_01(self):
+        await self.migrate(r"""
+            type User;
+
+            type Message {
+                required link author -> User;
+                required property body -> str;
+            };
+        """)
+
+        await self.start_migration(r"""
+            type User;
+
+            type BaseMessage {
+                required link author -> User;
+                required property body -> str;
+            }
+
+            type Message extending BaseMessage;
+        """)
+
+        await self.fast_forward_describe_migration()
+
     async def test_edgeql_migration_rename_type_02(self):
         await self.migrate(r"""
             type Note {
@@ -8179,7 +8202,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                     'placeholder': 'conv_expr',
                     'prompt': (
                         "Please specify an expression in order to convert"
-                        " property 'foo' to 'single' cardinality"
+                        " property 'foo' of object type 'test::Bar' to"
+                        " 'single' cardinality"
                     ),
                 }],
             },

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5123,6 +5123,57 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
+    def test_schema_migrations_computed_optionality_01(self):
+        self._assert_migration_equivalence([r"""
+            abstract type Removable {
+                optional single property removed := EXISTS(
+                    .<element[IS Tombstone]
+                );
+            };
+            type Topic extending Removable {
+                multi link defs := .<topic[IS Definition];
+            };
+            alias VisibleTopic := (
+                SELECT Topic {
+                    defs := (
+                        SELECT .<topic[IS Definition] FILTER NOT .removed
+                    ),
+                }
+                FILTER NOT .removed
+            );
+            type Definition extending Removable {
+                required link topic -> Topic;
+            };
+            type Tombstone {
+                required link element -> Removable {
+                    constraint exclusive;
+                }
+            };
+        """, r"""
+            abstract type Removable {
+                property removed := EXISTS(.<element[IS Tombstone]);
+            };
+            type Topic extending Removable {
+                multi link defs := .<topic[IS Definition];
+            };
+            alias VisibleTopic := (
+                SELECT Topic {
+                    defs := (
+                        SELECT .<topic[IS Definition] FILTER NOT .removed
+                    ),
+                }
+                FILTER NOT .removed
+            );
+            type Definition extending Removable {
+                required link topic -> Topic;
+            };
+            type Tombstone {
+                required link element -> Removable {
+                    constraint exclusive;
+                }
+            };
+        """])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
A small cluster of bugs related to the changes of optionality and
inheritance:

- alias recompiles due to changes no longer fail with "alias already
  exists";
- if a computed cardinality or optionality is inherited, the inherited
  status takes priority since there's no need to re-evaluate the
  inherited expression, which was already processed in a parent;
- only request a conversion expression if the value of `required`
  actually changed (and not just its inherited or computed status).

Fixes: #2174.