### PR TITLE
Improve "Unexpected token" type of error message.

### DIFF
--- a/edb/edgeql/parser/parser.py
+++ b/edb/edgeql/parser/parser.py
@@ -21,7 +21,14 @@ from __future__ import annotations
 from edb import errors
 from edb.common import debug, parsing
 
-from .grammar import rust_lexer
+from .grammar import rust_lexer, tokens
+from .grammar import expressions as gr_exprs
+from .grammar import commondl as gr_commondl
+
+
+def a(word):
+    article = 'an' if word[0] in 'aeiou' else 'a'
+    return f'{article} {word}'
 
 
 class EdgeQLParserBase(parsing.Parser):
@@ -30,23 +37,157 @@ class EdgeQLParserBase(parsing.Parser):
 
     def get_exception(self, native_err, context, token=None):
         msg = native_err.args[0]
+        hint = None
 
         if isinstance(native_err, errors.EdgeQLSyntaxError):
             return native_err
         else:
             if msg.startswith('Unexpected token: '):
                 token = token or getattr(native_err, 'token', None)
+                token_kind = token.kind()
+                ltok = self.parser._stack[-1][0]
 
-                if not token or token.kind() == 'EOF':
+                # Look at the parsing stack and use tokens and
+                # non-terminals to infer the parser rule when the
+                # error occurred.
+                rule = ''
+                # The last valid token was a closing
+                # brace/parent/bracket, so we need to find a match for
+                # it before deciding what rule context we're in.
+                need_match = isinstance(ltok, (tokens.T_RBRACE,
+                                               tokens.T_RPAREN,
+                                               tokens.T_RBRACKET))
+                for i, (el, _) in enumerate(reversed(self.parser._stack)):
+                    if isinstance(el, tokens.Token):
+                        # We'll need the element right before "{", "[", or "(".
+                        prevel = self.parser._stack[-2 - i][0]
+
+                        if isinstance(el, tokens.T_LBRACE):
+                            if need_match and isinstance(ltok,
+                                                         tokens.T_RBRACE):
+                                # This is matched, while we're looking
+                                # for unmatched braces.
+                                need_match = False
+                                continue
+
+                            elif isinstance(prevel, gr_commondl.OptExtending):
+                                # This is some SDL/DDL
+                                rule = 'definition'
+                            elif (
+                                isinstance(prevel, gr_exprs.Expr) or
+                                (
+                                    isinstance(prevel, tokens.T_COLON) and
+                                    isinstance(self.parser._stack[-3 - i][0],
+                                               gr_exprs.ShapePointer)
+                                )
+                            ):
+                                # This is some kind of shape.
+                                rule = 'shape'
+                            break
+                        elif isinstance(el, tokens.T_LPAREN):
+                            if need_match and isinstance(ltok,
+                                                         tokens.T_RPAREN):
+                                # This is matched, while we're looking
+                                # for unmatched parentheses.
+                                need_match = False
+                                continue
+                            # This could be an argument list or a tuple.
+                            elif isinstance(prevel, gr_exprs.NodeName):
+                                rule = 'list of arguments'
+                            else:
+                                rule = 'tuple'
+                            break
+                        elif isinstance(el, tokens.T_LBRACKET):
+                            if need_match and isinstance(ltok,
+                                                         tokens.T_RBRACKET):
+                                # This is matched, while we're looking
+                                # for unmatched brackets.
+                                need_match = False
+                                continue
+                            # This is either an array literal or
+                            # array index.
+                            elif isinstance(prevel, gr_exprs.Expr):
+                                rule = 'array slice'
+                            else:
+                                rule = 'array'
+                            break
+
+                if not token or token_kind == 'EOF':
                     msg = 'Unexpected end of line'
+                elif (
+                    rule == 'shape' and
+                    token_kind == 'IDENT' and
+                    isinstance(ltok, parsing.Nonterm)
+                ):
+                    # Make sure that the previous element in the stack
+                    # is some kind of Nonterminal, because if it's
+                    # not, this is probably not an issue of a missing
+                    # COMMA.
+                    hint = (f"It appears that a ',' is missing in {a(rule)} "
+                            f"before {token.text()!r}")
+                elif (
+                    rule == 'list of arguments' and
+                    # The stack is like <NodeName> LPAREN <AnyIdentifier>
+                    i == 1 and
+                    isinstance(ltok, (gr_exprs.AnyIdentifier,
+                                      tokens.T_WITH,
+                                      tokens.T_SELECT,
+                                      tokens.T_FOR,
+                                      tokens.T_INSERT,
+                                      tokens.T_UPDATE,
+                                      tokens.T_DELETE))
+                ):
+                    hint = ("Statement used as an expression must be "
+                            "enclosed in a set of parentheses")
+                    # We want the error context correspond to the
+                    # statement keyword
+                    context = ltok.context
+                    token = None
+                elif (
+                    rule == 'array slice' and
+                    # The offending token was something that could
+                    # make an expression
+                    token_kind in {'IDENT', 'ICONST'} and
+                    not isinstance(ltok, tokens.T_COLON)
+                ):
+                    hint = (f"It appears that a ':' is missing in {a(rule)} "
+                            f"before {token.text()!r}")
+                elif (
+                    rule in {'list of arguments', 'tuple', 'array'} and
+                    # The offending token was something that could
+                    # make an expression
+                    token_kind in {
+                        'IDENT', 'TRUE', 'FALSE',
+                        'ICONST', 'FCONST', 'NICONST', 'NFCONST',
+                        'BCONST', 'SCONST',
+                    } and
+                    not isinstance(ltok, tokens.T_COMMA)
+                ):
+                    hint = (f"It appears that a ',' is missing in {a(rule)} "
+                            f"before {token.text()!r}")
+                elif (
+                    rule == 'definition' and
+                    token_kind == 'IDENT'
+                ):
+                    # Something went wrong in a definition, so check
+                    # if the last successful token is a keyword.
+                    if (
+                        isinstance(ltok, gr_exprs.Identifier) and
+                        ltok.val.upper() == 'INDEX'
+                    ):
+                        msg = (f"Expected 'ON', but got {token.text()!r} "
+                               f"instead")
+                    else:
+                        msg = f'Unexpected {token.text()!r}'
                 elif hasattr(token, 'val'):
                     msg = f'Unexpected {token.val!r}'
-                elif token.kind() == 'NL':
+                elif token_kind == 'NL':
                     msg = 'Unexpected end of line'
                 else:
                     msg = f'Unexpected {token.text()!r}'
 
-        return errors.EdgeQLSyntaxError(msg, context=context, token=token)
+        return errors.EdgeQLSyntaxError(
+            msg, hint=hint, context=context, token=token)
 
     def get_lexer(self):
         return rust_lexer.EdgeQLLexer()

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2825,6 +2825,16 @@ class TestExpressions(tb.QueryTestCase):
                 SELECT [];
             """)
 
+    async def test_edgeql_expr_array_05(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r"index indirection cannot be applied to "
+                r"scalar type 'std::int64'"):
+
+            await self.con.query_json("""
+                SELECT [0, 1, 2][[1][0] [2][0]];
+            """)
+
     async def test_edgeql_expr_array_concat_01(self):
         await self.assert_query_result(
             '''

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1455,7 +1455,10 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"Unexpected 'foo'", line=3, col=27)
+                  r'Unexpected token:.+foo',
+                  hint=r"It appears that a ',' is missing in a shape "
+                       r"before 'foo'",
+                  line=3, col=27)
     def test_edgeql_syntax_shape_44(self):
         """
         SELECT Foo {
@@ -1499,6 +1502,191 @@ aa';
         SET {
             foo -= Bar
         };
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+name',
+                  hint=r"It appears that a ',' is missing in a shape "
+                       r"before 'name'",
+                  line=4, col=13)
+    def test_edgeql_syntax_shape_49(self):
+        """
+        SELECT Foo {
+            id
+            name
+        };
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+name',
+                  hint=r"It appears that a ',' is missing in a shape "
+                       r"before 'name'",
+                  line=6, col=13)
+    def test_edgeql_syntax_shape_50(self):
+        """
+        SELECT Foo {
+            bar: {
+                id
+            }
+            name
+        };
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+name',
+                  hint=r"It appears that a ',' is missing in a shape "
+                       r"before 'name'",
+                  line=4, col=13)
+    def test_edgeql_syntax_shape_51(self):
+        """
+        SELECT Foo {
+            bar := .id
+            name
+        };
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+name',
+                  hint=r"It appears that a ',' is missing in a shape "
+                       r"before 'name'",
+                  line=5, col=17)
+    def test_edgeql_syntax_shape_52(self):
+        """
+        SELECT Foo {
+            bar: {
+                @linkprop
+                name
+            }
+        };
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Unexpected 'Bar'", line=3, col=18)
+    def test_edgeql_syntax_shape_53(self):
+        """
+        INSERT Foo {
+            bar: Bar {
+                val := 1
+            }
+        };
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+Foo',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before 'Foo'",
+                  line=2, col=19)
+    def test_edgeql_syntax_shape_54(self):
+        """
+        SELECT (1 Foo {
+            foo
+            bar
+        });
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+bar',
+                  hint=r"It appears that a ',' is missing in a shape "
+                       r"before 'bar'",
+                  line=4, col=13)
+    def test_edgeql_syntax_shape_55(self):
+        """
+        SELECT (Foo {
+            foo
+            bar
+        } 2);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+Foo',
+                  hint=r"It appears that a ',' is missing in an array "
+                       r"before 'Foo'",
+                  line=2, col=19)
+    def test_edgeql_syntax_shape_56(self):
+        """
+        SELECT [1 Foo {
+            foo
+            bar := .foo + 1
+        }.bar];
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+bar',
+                  hint=r"It appears that a ',' is missing in a shape "
+                       r"before 'bar'",
+                  line=4, col=13)
+    def test_edgeql_syntax_shape_57(self):
+        """
+        SELECT [Foo {
+            foo
+            bar := .foo + 1
+        }.bar 2];
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+Foo',
+                  hint=r"It appears that a ',' is missing in a list of "
+                       r"arguments before 'Foo'",
+                  line=2, col=27)
+    def test_edgeql_syntax_shape_58(self):
+        """
+        SELECT somefunc(1 Foo {
+            foo
+            bar
+        });
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+bar',
+                  hint=r"It appears that a ',' is missing in a shape "
+                       r"before 'bar'",
+                  line=4, col=13)
+    def test_edgeql_syntax_shape_59(self):
+        """
+        SELECT somefunc(Foo {
+            foo
+            bar
+        } 2);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+2',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before '2'",
+                  line=2, col=25)
+    def test_edgeql_syntax_shape_60(self):
+        """
+        SELECT (Foo{id} 2);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+bar',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before 'bar'",
+                  line=2, col=25)
+    def test_edgeql_syntax_shape_61(self):
+        """
+        SELECT (Foo{id} bar);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+2',
+                  hint=r"It appears that a ',' is missing in an array "
+                       r"before '2'",
+                  line=2, col=25)
+    def test_edgeql_syntax_shape_62(self):
+        """
+        SELECT [Foo{id} 2];
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+bar',
+                  hint=r"It appears that a ',' is missing in an array "
+                       r"before 'bar'",
+                  line=2, col=25)
+    def test_edgeql_syntax_shape_63(self):
+        """
+        SELECT [Foo{id} bar];
         """
 
     def test_edgeql_syntax_struct_01(self):
@@ -1964,6 +2152,104 @@ aa';
     def test_edgeql_syntax_array_05(self):
         """
         SELECT (get_nested_obj())['a']['b']['c'];
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+User',
+                  hint=r"It appears that a ',' is missing in an array "
+                       r"before 'User'",
+                  line=4, col=13)
+    def test_edgeql_syntax_array_06(self):
+        """
+        SELECT [
+            1
+            User
+        ];
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+1',
+                  hint=r"It appears that a ',' is missing in an array "
+                       r"before '1'",
+                  line=4, col=13)
+    def test_edgeql_syntax_array_07(self):
+        """
+        SELECT [
+            User
+            1
+        ];
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+True',
+                  hint=r"It appears that a ',' is missing in an array "
+                       r"before 'True'",
+                  line=4, col=13)
+    def test_edgeql_syntax_array_08(self):
+        """
+        SELECT [
+            False
+            True
+        ];
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+b',
+                  hint=r'''It appears that a ',' is missing in an array '''
+                       r'''before "'b'"''',
+                  line=4, col=13)
+    def test_edgeql_syntax_array_09(self):
+        """
+        SELECT [
+            'a'
+            'b'
+        ];
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+x',
+                  hint=r"It appears that a ':' is missing in an array "
+                       r"slice before 'x'",
+                  line=3, col=28)
+    def test_edgeql_syntax_array_10(self):
+        """
+        WITH x := 2
+        SELECT [1, 2, 3][1 x];
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+1',
+                  hint=r"It appears that a ':' is missing in an array "
+                       r"slice before '1'",
+                  line=3, col=28)
+    def test_edgeql_syntax_array_11(self):
+        """
+        WITH x := 2
+        SELECT [1, 2, 3][x 1];
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+2',
+                  hint=r"It appears that a ',' is missing in a list of "
+                       r"arguments before '2'",
+                  line=2, col=31)
+    def test_edgeql_syntax_array_12(self):
+        """
+        SELECT [1, 2, 3][x (1 2).1];
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Unexpected '\('", line=2, col=24)
+    def test_edgeql_syntax_array_13(self):
+        """
+        SELECT [(1, 2) (2, 3)];
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Unexpected '\('", line=2, col=24)
+    def test_edgeql_syntax_array_14(self):
+        """
+        SELECT [([1],) ([2],)];
         """
 
     def test_edgeql_syntax_cast_01(self):
@@ -2764,7 +3050,10 @@ aa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"Unexpected '1'", line=2, col=26)
+                  r'Unexpected token:.+1',
+                  hint=r"It appears that a ',' is missing in a list of "
+                       r"arguments before '1'",
+                  line=2, col=26)
     def test_edgeql_syntax_function_05(self):
         """
         SELECT count(ALL 1);
@@ -2810,6 +3099,205 @@ aa';
         SELECT baz(age := User.age, of := User.name, `select` := 1);
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+User',
+                  hint=r"It appears that a ',' is missing in a list of "
+                       r"arguments before 'User'",
+                  line=2, col=22)
+    def test_edgeql_syntax_function_10(self):
+        """
+        SELECT foo(1 User);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+y',
+                  hint=r"It appears that a ',' is missing in a list of "
+                       r"arguments before 'y'",
+                  line=2, col=34)
+    def test_edgeql_syntax_function_11(self):
+        """
+        SELECT baz(x := User.age y := User.name);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token',
+                  hint=r"Statement used as an expression must be enclosed "
+                       r"in a set of parentheses",
+                  line=2, col=22)
+    def test_edgeql_syntax_function_12(self):
+        """
+        SELECT count(SELECT 1);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token',
+                  hint=r"Statement used as an expression must be enclosed "
+                       r"in a set of parentheses",
+                  line=2, col=22)
+    def test_edgeql_syntax_function_13(self):
+        """
+        SELECT count(INSERT Foo);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token',
+                  hint=r"Statement used as an expression must be enclosed "
+                       r"in a set of parentheses",
+                  line=2, col=22)
+    def test_edgeql_syntax_function_14(self):
+        """
+        SELECT count(UPDATE Foo SET {bar := 1});
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token',
+                  hint=r"Statement used as an expression must be enclosed "
+                       r"in a set of parentheses",
+                  line=2, col=22)
+    def test_edgeql_syntax_function_15(self):
+        """
+        SELECT count(DELETE Foo);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token',
+                  hint=r"Statement used as an expression must be enclosed "
+                       r"in a set of parentheses",
+                  line=2, col=22)
+    def test_edgeql_syntax_function_16(self):
+        """
+        SELECT count(FOR X IN {Foo} UNION X);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token',
+                  hint=r"Statement used as an expression must be enclosed "
+                       r"in a set of parentheses",
+                  line=2, col=22)
+    def test_edgeql_syntax_function_17(self):
+        """
+        SELECT count(WITH X := 1 SELECT Foo FILTER .bar = X);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token',
+                  hint=r"Statement used as an expression must be enclosed "
+                       r"in a set of parentheses",
+                  line=2, col=23)
+    def test_edgeql_syntax_function_18(self):
+        """
+        SELECT (count(SELECT 1) 1);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token',
+                  hint=r"Statement used as an expression must be enclosed "
+                       r"in a set of parentheses",
+                  line=2, col=26)
+    def test_edgeql_syntax_function_19(self):
+        """
+        SELECT ((((count(SELECT 1)))));
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+1',
+                  hint=r"It appears that a ',' is missing in a list of "
+                       r"arguments before '1'",
+                  line=2, col=30)
+    def test_edgeql_syntax_function_20(self):
+        """
+        SELECT ((((count(foo 1)))));
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+bar',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before 'bar'",
+                  line=2, col=35)
+    def test_edgeql_syntax_function_21(self):
+        """
+        SELECT ((((count(foo, 1)) bar)));
+        """
+
+    def test_edgeql_syntax_function_22(self):
+        """
+        SELECT count((((((((((SELECT 1))))))))));
+
+% OK %
+
+        SELECT count((SELECT 1));
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+2',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before '2'",
+                  line=2, col=35)
+    def test_edgeql_syntax_function_23(self):
+        """
+        SELECT (count((SELECT 1)) 2);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+2',
+                  hint=r"It appears that a ',' is missing in an array "
+                       r"before '2'",
+                  line=2, col=35)
+    def test_edgeql_syntax_function_24(self):
+        """
+        SELECT [count((SELECT 1)) 2];
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+2',
+                  hint=r"It appears that a ',' is missing in a list of "
+                       r"arguments before '2'",
+                  line=2, col=29)
+    def test_edgeql_syntax_function_25(self):
+        """
+        SELECT count((0, 1) 2);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+foo',
+                  hint=r"It appears that a ',' is missing in a list of "
+                       r"arguments before 'foo'",
+                  line=2, col=29)
+    def test_edgeql_syntax_function_26(self):
+        """
+        SELECT count((0, 1) foo);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+2',
+                  hint=r"It appears that a ',' is missing in a list of "
+                       r"arguments before '2'",
+                  line=2, col=29)
+    def test_edgeql_syntax_function_27(self):
+        """
+        SELECT count([0, 1] 2);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+foo',
+                  hint=r"It appears that a ',' is missing in a list of "
+                       r"arguments before 'foo'",
+                  line=2, col=29)
+    def test_edgeql_syntax_function_28(self):
+        """
+        SELECT count([0, 1] foo);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+2',
+                  hint=r"It appears that a ',' is missing in a list of "
+                       r"arguments before '2'",
+                  line=2, col=28)
+    def test_edgeql_syntax_function_29(self):
+        """
+        SELECT count(([1]) 2);
+        """
+
     def test_edgeql_syntax_tuple_01(self):
         """
         SELECT ('foo', 42).0;
@@ -2825,6 +3313,147 @@ aa';
     def test_edgeql_syntax_tuple_03(self):
         """
         SELECT ();
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+User',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before 'User'",
+                  line=4, col=13)
+    def test_edgeql_syntax_tuple_04(self):
+        """
+        SELECT (
+            1
+            User
+        );
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+1',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before '1'",
+                  line=4, col=13)
+    def test_edgeql_syntax_tuple_05(self):
+        """
+        SELECT (
+            User
+            1
+        );
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+True',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before 'True'",
+                  line=4, col=13)
+    def test_edgeql_syntax_tuple_06(self):
+        """
+        SELECT (
+            False
+            True
+        );
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+b',
+                  hint=r'''It appears that a ',' is missing in a tuple '''
+                       r'''before "'b'"''',
+                  line=4, col=13)
+    def test_edgeql_syntax_tuple_07(self):
+        """
+        SELECT (
+            'a'
+            'b'
+        );
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+2',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before '2'",
+                  line=2, col=22)
+    def test_edgeql_syntax_tuple_08(self):
+        """
+        SELECT ((((1 2))));
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Unexpected '\('", line=2, col=24)
+    def test_edgeql_syntax_tuple_09(self):
+        """
+        SELECT ((1, 2) (3, 4));
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Unexpected '\('", line=2, col=19)
+    def test_edgeql_syntax_tuple_10(self):
+        """
+        SELECT (0 (1, 2));
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r"Unexpected '\('", line=2, col=19)
+    def test_edgeql_syntax_tuple_11(self):
+        """
+        SELECT (0 (((1 2) 3)) 4);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+2',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before '2'",
+                  line=2, col=25)
+    def test_edgeql_syntax_tuple_12(self):
+        """
+        SELECT (0, (((1 2) 3)) 4);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+3',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before '3'",
+                  line=2, col=29)
+    def test_edgeql_syntax_tuple_13(self):
+        """
+        SELECT (0, (((1, 2) 3)) 4);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+4',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before '4'",
+                  line=2, col=34)
+    def test_edgeql_syntax_tuple_14(self):
+        """
+        SELECT (0, (((1, 2), 3)) 4);
+        """
+
+    def test_edgeql_syntax_tuple_15(self):
+        """
+        SELECT (0, (((1, 2), 3)), 4);
+
+% OK %
+
+        SELECT (0, ((1, 2), 3), 4);
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+2',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before '2'",
+                  line=2, col=26)
+    def test_edgeql_syntax_tuple_16(self):
+        """
+        SELECT (foo (((1 2) 3)) 4);
+        """
+
+    def test_edgeql_syntax_tuple_17(self):
+        """
+        SELECT ((((1, 2))));
+
+% OK %
+
+        SELECT (1, 2);
         """
 
     def test_edgeql_syntax_introspect_01(self):

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -666,9 +666,8 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         };
         """
 
-    # FIXME: obscure error message
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r"Unexpected 'prop'", line=4, col=23)
+                  r"Expected 'ON', but got 'prop' instead", line=4, col=23)
     def test_eschema_syntax_index_03(self):
         """
         module test {
@@ -1480,6 +1479,19 @@ abstract property test::foo {
         };
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+b',
+                  hint=r"It appears that a ',' is missing in a list of "
+                       r"arguments before 'b'",
+                  line=3, col=34)
+    def test_eschema_syntax_function_21(self):
+        """
+        module test {
+            function len1(a: str b: str) ->  std::str {
+                using SQL function 'length1'
+            }
+        """
+
     def test_eschema_syntax_alias_01(self):
         """
         module test {
@@ -1518,6 +1530,46 @@ abstract property test::foo {
                 SELECT Foo
                 FILTER Foo.bar = 'baz'
             );
+        };
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+baz',
+                  hint=r"It appears that a ',' is missing in a shape "
+                       r"before 'baz'",
+                  line=5, col=17)
+    def test_eschema_syntax_alias_04(self):
+        """
+        module test {
+            alias FooBaz := Foo {
+                val := 1
+                baz := .bar + 2
+            }
+            );
+        };
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+2',
+                  hint=r"It appears that a ',' is missing in a tuple "
+                       r"before '2'",
+                  line=3, col=32)
+    def test_eschema_syntax_alias_05(self):
+        """
+        module test {
+            alias FooBaz := (1 2);
+        };
+        """
+
+    @tb.must_fail(errors.EdgeQLSyntaxError,
+                  r'Unexpected token:.+2',
+                  hint=r"It appears that a ',' is missing in an array "
+                       r"before '2'",
+                  line=3, col=32)
+    def test_eschema_syntax_alias_06(self):
+        """
+        module test {
+            alias FooBaz := [1 2];
         };
         """
 


### PR DESCRIPTION
There are some error patterns where "unexpected token" is better
expressed as a different error message.