### PR TITLE
Allow omitting `-> type` in SDL block decls of computed pointers

### DIFF
--- a/docs/edgeql/sdl/links.rst
+++ b/docs/edgeql/sdl/links.rst
@@ -84,7 +84,18 @@ commands <ref_eql_ddl_links>`.
     [{required | optional}] [{single | multi}]
       link <name> := <expression>;
 
-    # Abstract link form:
+    # Computable link form used inside type declaration (extended):
+    [ overloaded ] [{required | optional}] [{single | multi}]
+      link <name>
+      [ extending <base> [, ...] ] [-> <type>]
+      [ "{"
+          USING (<expression>) ;
+          [ <annotation-declarations> ]
+          [ <constraint-declarations> ]
+          ...
+        "}" ]
+
+   # Abstract link form:
     abstract link <name> [extending <base> [, ...]]
     [ "{"
         [ readonly := {true | false} ; ]

--- a/docs/edgeql/sdl/props.rst
+++ b/docs/edgeql/sdl/props.rst
@@ -76,6 +76,17 @@ commands <ref_eql_ddl_props>`.
     [{required | optional}] [{single | multi}]
       property <name> := <expression>;
 
+    # Computable property form used inside type declaration (extended):
+    [ overloaded ] [{required | optional}] [{single | multi}]
+      property <name>
+      [ extending <base> [, ...] ] [-> <type>]
+      [ "{"
+          USING (<expression>) ;
+          [ <annotation-declarations> ]
+          [ <constraint-declarations> ]
+          ...
+        "}" ]
+
     # Abstract property form:
     abstract property [<module>::]<name> [extending <base> [, ...]]
     [ "{"

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1103,7 +1103,6 @@ class CreateConcretePropertyStmt(Nonterm):
             OptCreateConcretePropertyCommandsBlock
         """
         cmds = kids[4].val
-        new_cmds = []
         target = None
 
         for cmd in cmds:
@@ -1113,8 +1112,6 @@ class CreateConcretePropertyStmt(Nonterm):
                         f'computable property with more than one expression',
                         context=kids[3].context)
                 target = cmd.value
-            else:
-                new_cmds.append(cmd)
 
         if target is None:
             raise EdgeQLSyntaxError(
@@ -1126,7 +1123,7 @@ class CreateConcretePropertyStmt(Nonterm):
             is_required=kids[1].val.required,
             cardinality=kids[1].val.cardinality,
             target=target,
-            commands=new_cmds,
+            commands=cmds,
         )
 
 
@@ -1404,7 +1401,6 @@ class CreateConcreteLinkStmt(Nonterm):
             OptCreateConcreteLinkCommandsBlock
         """
         cmds = kids[4].val
-        new_cmds = []
         target = None
 
         for cmd in cmds:
@@ -1414,8 +1410,6 @@ class CreateConcreteLinkStmt(Nonterm):
                         f'computable link with more than one expression',
                         context=kids[3].context)
                 target = cmd.value
-            else:
-                new_cmds.append(cmd)
 
         if target is None:
             raise EdgeQLSyntaxError(
@@ -1427,7 +1421,7 @@ class CreateConcreteLinkStmt(Nonterm):
             is_required=kids[1].val.required,
             cardinality=kids[1].val.cardinality,
             target=target,
-            commands=new_cmds,
+            commands=cmds,
         )
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2285,6 +2285,22 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema, multi_module=True)
 
+    def test_schema_get_migration_default_ptrs_01(self):
+        schema = r'''
+        type Foo {
+            property name {
+                using (1);
+                annotation title := "foo";
+            };
+            link everything {
+                using (Object);
+                annotation title := "bar";
+            };
+        }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_schema_migrations_equivalence_01(self):
         self._assert_migration_equivalence([r"""
             type Base;

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -206,6 +206,15 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
                 };
 
                 property due_date -> datetime;
+
+                property real_time_estimate {
+                    using ((.time_estimate * 2));
+                    annotation title := 'Ha.';
+                };
+                link start_date2 {
+                    using (SELECT datetime::datetime_current());
+                    annotation title := 'awk.';
+                };
             };
         };
         """
@@ -591,6 +600,19 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
             type Bar {
                 property name -> str;
             };
+        };
+        """
+
+    def test_eschema_syntax_type_32(self):
+        """
+        type test::Foo {
+            property lurr {
+                using (20);
+            };
+        }
+% OK %
+        type test::Foo {
+            property lurr := (20);
         };
         """
 


### PR DESCRIPTION
This matches how DDL works and the existing output of
`describe ... as sdl`.

I removed some logic where the USING got dropped from the block of
commands because it messed up parse/codegen tests and doesn't seem to
cause any trouble on the schema side.