### PR TITLE
Make UNLESS CONFLICT's handling of nested DML work with object/computed cnstrs

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -25,11 +25,9 @@ from typing import *
 
 from collections import defaultdict
 import textwrap
-import copy
 
 from edb import errors
 from edb.common import context as pctx
-from edb.common.ast import visitor as ast_visitor
 
 from edb.ir import ast as irast
 from edb.ir import typeutils

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -145,6 +145,10 @@ def evaluate_OperatorCall(
             raise UnsupportedExpressionError(
                 f'non-singleton operations are not supported',
                 context=opcall.context)
+        if arg_val is None:
+            raise UnsupportedExpressionError(
+                f'empty operations are not supported',
+                context=opcall.context)
 
         args.append(arg_val)
 

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -206,10 +206,12 @@ class SchemaConstraintTableConstraint(ConstraintCommon, dbops.TableConstraint):
                           SCHEMA = '{schemaname}',
                           CONSTRAINT = '{constr}',
                           MESSAGE = '{errmsg}',
-                          DETAIL = 'Key ({plain_expr}) already exists.';
+                          DETAIL = 'Key ({esc_plain_expr}) already exists.';
                 END IF;
             '''.format(
                 plain_expr=origin_exprdata['plain'],
+                # XXX: do we want plain_expr here at all??
+                esc_plain_expr=origin_exprdata['plain'].replace("'", "''"),
                 new_expr=exprdata['new'],
                 table=common.qname(
                     schemaname,

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -206,12 +206,13 @@ class SchemaConstraintTableConstraint(ConstraintCommon, dbops.TableConstraint):
                           SCHEMA = '{schemaname}',
                           CONSTRAINT = '{constr}',
                           MESSAGE = '{errmsg}',
-                          DETAIL = 'Key ({esc_plain_expr}) already exists.';
+                          DETAIL = {detail};
                 END IF;
             '''.format(
                 plain_expr=origin_exprdata['plain'],
-                # XXX: do we want plain_expr here at all??
-                esc_plain_expr=origin_exprdata['plain'].replace("'", "''"),
+                detail=common.quote_literal(
+                    f"Key ({origin_exprdata['plain']}) already exists."
+                ),
                 new_expr=exprdata['new'],
                 table=common.qname(
                     schemaname,

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -64,6 +64,26 @@ type Person {
     }
 }
 
+type Person2 {
+    required single property first -> std::str;
+    optional single link note -> Note;
+    optional multi link notes -> Note;
+}
+
+type Person2a extending Person2 {
+    required single property last -> std::str;
+    constraint exclusive on ((__subject__.first, __subject__.last));
+}
+
+type Person2b extending Person2 {
+    optional single property last -> std::str;
+    property namespace := .first ++ " "; # har, har
+    property name {
+	using (.namespace ++ .last);
+	constraint exclusive;
+    }
+}
+
 type PersonWrapper {
     required single link person -> Person;
 }

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -79,8 +79,8 @@ type Person2b extending Person2 {
     optional single property last -> std::str;
     property namespace := .first ++ " "; # har, har
     property name {
-	using (.namespace ++ .last);
-	constraint exclusive;
+        using (.namespace ++ .last);
+        constraint exclusive;
     }
 }
 

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -3267,6 +3267,154 @@ class TestInsert(tb.QueryTestCase):
             [1],
         )
 
+    async def test_edgeql_insert_dependent_23(self):
+        await self.con.execute('''
+            WITH MODULE test
+            INSERT Person2a {
+                first := "Madeline",
+                last := "Hatch1",
+            }
+        ''')
+
+        # test with something that has an object constraint
+        query = r'''
+            WITH MODULE test
+            SELECT (
+                INSERT Person2a {
+                    first := "Phil",
+                    last := "Emarg",
+                    note := (INSERT Note {name := "tag!" }),
+                } UNLESS CONFLICT
+            ) {first, last};
+        '''
+
+        await self.assert_query_result(
+            query,
+            [{"first": "Phil", "last": "Emarg"}]
+        )
+
+        await self.assert_query_result(
+            query,
+            [],
+        )
+
+        # Make sure only 1 insert into Note happened
+        await self.assert_query_result(
+            r'''SELECT count(test::Note)''',
+            [1],
+        )
+
+    async def test_edgeql_insert_dependent_24(self):
+        # test with something that has a computed constraint
+        await self.con.execute('''
+            WITH MODULE test
+            INSERT Person2b {
+                first := "Madeline",
+                last := "Hatch2",
+            }
+        ''')
+
+        query = r'''
+            WITH MODULE test
+            SELECT (
+                INSERT Person2b {
+                    first := "Phil",
+                    last := "Emarg",
+                    note := (INSERT Note {name := "tag!" }),
+                } UNLESS CONFLICT
+            ) {name};
+        '''
+
+        await self.assert_query_result(
+            query,
+            [{"name": "Phil Emarg"}]
+        )
+
+        await self.assert_query_result(
+            query,
+            [],
+        )
+
+        # Make sure only 1 insert into Note happened
+        await self.assert_query_result(
+            r'''SELECT count(test::Note)''',
+            [1],
+        )
+
+    async def test_edgeql_insert_dependent_25(self):
+        await self.con.execute('''
+            WITH MODULE test
+            INSERT Person2b {
+                first := "Madeline",
+                last := "Hatch3",
+            }
+        ''')
+        # test with something that has a computed constraint using ON
+        query = r'''
+            WITH MODULE test
+            SELECT (
+                INSERT Person2b {
+                    first := "Phil",
+                    last := "Emarg",
+                    note := (INSERT Note {name := "tag!" }),
+                }
+                UNLESS CONFLICT ON (.name)
+                ELSE (SELECT Person2b)
+            ) {name};
+        '''
+
+        await self.assert_query_result(
+            query,
+            [{"name": "Phil Emarg"}]
+        )
+
+        await self.assert_query_result(
+            query,
+            [{"name": "Phil Emarg"}]
+        )
+
+        # Make sure only 1 insert into Note happened
+        await self.assert_query_result(
+            r'''SELECT count(test::Note)''',
+            [1],
+        )
+
+    async def test_edgeql_insert_dependent_26(self):
+        # test that it works with an empty value in a computed prop
+        await self.con.execute('''
+            WITH MODULE test
+            INSERT Person2b {
+                first := "Madeline",
+                last := "Hatch4",
+            }
+        ''')
+
+        query = r'''
+            WITH MODULE test
+            SELECT (
+                INSERT Person2b {
+                    first := "Phil",
+                    note := (INSERT Note {name := "tag!" }),
+                } UNLESS CONFLICT
+            ) {first, name};
+        '''
+
+        await self.assert_query_result(
+            query,
+            [{"first": "Phil", "name": None}]
+        )
+
+        await self.assert_query_result(
+            query,
+            [{"first": "Phil", "name": None}]
+        )
+
+        # No conflict (because last was empty), so two inserts
+        await self.assert_query_result(
+            r'''SELECT count(test::Note)''',
+            [2],
+        )
+
     async def test_edgeql_insert_nested_volatile_01(self):
         await self.con.execute('''
             INSERT test::Subordinate {


### PR DESCRIPTION
We do this by collecting all the pointers that are actually needed and
then substuting them into the definition of computed pointers/object
constraints.

Also fix a silly bug where we would generate bogus SQL DDL if a
constraint key contained a space.

Fixes #1669.

I think we could make it so that ELSE works for UNLESS CONFLICT
without needing ON, now. I think it's probably worth it to do that.