### PR TITLE
Fixes tests broken by edgedb-python 0.13.0a2

### DIFF
--- a/edb/testbase/protocol/protocol.pyx
+++ b/edb/testbase/protocol/protocol.pyx
@@ -110,7 +110,8 @@ async def new_connection(
     addrs, params, config = con_utils.parse_connect_arguments(
         dsn=dsn, host=host, port=port, user=user, password=password,
         admin=admin, database=database,
-        timeout=timeout, command_timeout=None, server_settings=None)
+        timeout=timeout, command_timeout=None, server_settings=None,
+        wait_until_available=timeout)
 
     loop = asyncio.get_running_loop()
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ RUNTIME_DEPS = [
     'graphql-core~=3.1.2',
     'promise~=2.2.0',
 
-    'edgedb>=0.13.0a1',
+    'edgedb>=0.13.0a4',
 ]
 
 CYTHON_DEPENDENCY = 'Cython==0.29.21'


### PR DESCRIPTION
This requires edgedb/edgedb-python#152 and releasing 0.13.0a2 after that.