### PR TITLE
Make INSERT UNLESS CONFLICT still fail when inserting two conflicting objs

### DIFF
--- a/docs/edgeql/statements/insert.rst
+++ b/docs/edgeql/statements/insert.rst
@@ -12,8 +12,8 @@ INSERT
 
     [ WITH <with-spec> [ ,  ... ] ]
     INSERT <expression> [ <insert-shape> ]
-    [ UNLESS CONFLICT ON <property>
-        [ ELSE <alternative> ]
+    [ UNLESS CONFLICT
+        [ ON <property> [ ELSE <alternative> ] ]
     ] ;
 
 
@@ -49,16 +49,22 @@ See :ref:`Usage of FOR statement <ref_eql_forstatement>` for more details.
         INSERT <expression>
         [ "{" <link> := <insert-value-expr> [, ...]  "}" ]
 
-:eql:synopsis:`UNLESS CONFLICT ON <property>`
+:eql:synopsis:`UNLESS CONFLICT [ ON <property> ]`
     :index: unless conflict
 
     Handler of conflicts.
 
     This clause allows to handle specific conflicts arising during
     execution of ``INSERT`` without producing an error.  If the
-    conflict arises due to constraints on the specified *property*,
-    then instead of failing with an error the ``INSERT`` statement
-    produces an empty set (or an alternative result).
+    conflict arises due to exclusive constraints on the specified
+    *property*, then instead of failing with an error the ``INSERT``
+    statement produces an empty set (or an alternative result).
+
+    A caveat, however, is that ``UNLESS CONFLICT`` will not prevent
+    conflicts caused between multiple DML operations in the same
+    query; inserting two conflicting objects (through use of ``FOR``
+    or simply with two ``INSERT`` statements) will cause a constraint
+    error.
 
     Example:
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -37,7 +37,6 @@ from edb.schema import ddl as s_ddl
 from edb.schema import functions as s_func
 from edb.schema import links as s_links
 from edb.schema import lproperties as s_lprops
-from edb.schema import modules as s_mod
 from edb.schema import name as s_name
 from edb.schema import objects as s_obj
 from edb.schema import objtypes as s_objtypes
@@ -457,9 +456,6 @@ def compile_insert_unless_conflict_on(
             context=constraint_spec.context,
         )
 
-    module_id = schema.get_global(
-        s_mod.Module, ptr.get_name(schema).module).id
-
     field_name = cspec_res.rptr.ptrref.shortname
     ds = {field_name.name: (ptr, ex_cnstrs)}
     select_ir = compile_insert_unless_conflict_select(
@@ -479,8 +475,7 @@ def compile_insert_unless_conflict_on(
         assert isinstance(else_ir, irast.Set)
 
     return irast.OnConflictClause(
-        constraint=irast.ConstraintRef(
-            id=ex_cnstrs[0].id, module_id=module_id),
+        constraint=irast.ConstraintRef(id=ex_cnstrs[0].id),
         select_ir=select_ir,
         else_ir=else_ir
     )

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -761,7 +761,7 @@ class MutatingStmt(Stmt):
 
 class OnConflictClause(Base):
     constraint: typing.Optional[ConstraintRef]
-    select_ir: typing.Optional[Set]
+    select_ir: Set
     else_ir: typing.Optional[Set]
 
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -719,6 +719,16 @@ def insert_needs_conflict_cte(
     *,
     ctx: context.CompilerContextLevel,
 ) -> bool:
+    # We need to generate a conflict CTE if it is possible that
+    # the query might generate two conflicting objects.
+    # For now, we calculate that conservatively and generate a conflict
+    # CTE if there are iterators or other DML statements that we have
+    # seen already.
+    # A more fine-grained scheme would check if there are enclosing
+    # iterators or INSERT/UPDATEs to types that could conflict.
+    if ctx.dml_stmts:
+        return True
+
     for shape_el, _ in ir_stmt.subject.shape:
         assert shape_el.rptr is not None
         ptrref = shape_el.rptr.ptrref
@@ -745,27 +755,40 @@ def compile_insert_else_body(
         *,
         ctx: context.CompilerContextLevel) -> Optional[pgast.IteratorCTE]:
 
-    infer = None
-    if on_conflict.constraint:
-        constraint_name = f'"{on_conflict.constraint.id};schemaconstr"'
-        infer = pgast.InferClause(conname=constraint_name)
-
-    insert_stmt.on_conflict = pgast.OnConflictClause(
-        action='nothing',
-        infer=infer,
-    )
-
+    # We need to generate a "conflict CTE" that filters out
+    # objects-to-insert that would conflict with existing objects in
+    # two scenarios:
+    #  1) When there is a nested DML operation as part of the value
+    #     of a pointer that is stored inline with the object.
+    #     This is because we need to prevent that DML from executing
+    #     before we have a chance to see what ON CONFLICT does.
+    #  2) When there could be a conflict with an object INSERT/UPDATEd
+    #     in this same query. (Either because of FOR or other DML statements.)
+    #     This is because we need that to raise a ConstraintError,
+    #     which means we can't use ON CONFLICT, and so we need to prevent
+    #     the insertion of objects that conflict with existing ones ourselves.
+    #
+    # When we need a conflict CTE, we don't use SQL ON CONFLICT. In
+    # case 2, that is the whole point, while in case 1 it would just
+    # be superfluous to do so.
+    #
+    # When neither case obtains, we use ON CONFLICT because it ought
+    # to be more performant.
     needs_conflict_cte = insert_needs_conflict_cte(ir_stmt, ctx=ctx)
+    if not needs_conflict_cte:
+        infer = None
+        if on_conflict.constraint:
+            constraint_name = f'"{on_conflict.constraint.id};schemaconstr"'
+            infer = pgast.InferClause(conname=constraint_name)
+
+        insert_stmt.on_conflict = pgast.OnConflictClause(
+            action='nothing',
+            infer=infer,
+        )
 
     else_select = on_conflict.select_ir
     else_branch = on_conflict.else_ir
 
-    assert not (needs_conflict_cte and not else_select), (
-        "Nested DML into single pointers with UNLESS CONFLICT doesn't support "
-        "object constraints yet")
-
-    if not else_select:
-        return None
     if not else_branch and not needs_conflict_cte:
         return None
 


### PR DESCRIPTION
Currently we do not fail, but also will spuriously executed nested DML
and ELSE does not work.

This is probably worth revisiting at some point. I'll open a follow-up
issue with my writeup of the rationale and an implementation sketch of
one way to correctly implement this.