### PR TITLE
Support UNLESS CONFLICT ELSE without an ON

### DIFF
--- a/docs/edgeql/statements/insert.rst
+++ b/docs/edgeql/statements/insert.rst
@@ -12,7 +12,8 @@ INSERT
 
     [ WITH <with-spec> [ ,  ... ] ]
     INSERT <expression> [ <insert-shape> ]
-    [ UNLESS CONFLICT ON <property>
+    [ UNLESS CONFLICT
+        [ ON <property> ]
         [ ELSE <alternative> ]
     ] ;
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -221,9 +221,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 self.write(' ON ')
                 self.visit(on_expr)
 
-                if else_expr:
-                    self.write(' ELSE ')
-                    self.visit(else_expr)
+            if else_expr:
+                self.write(' ELSE ')
+                self.visit(else_expr)
 
         if parenthesise:
             self.write(')')

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -592,6 +592,9 @@ class UnlessConflictSpecifier(Nonterm):
     def reduce_ON_Expr(self, *kids):
         self.val = (kids[1].val, None)
 
+    def reduce_ELSE_Expr(self, *kids):
+        self.val = (None, kids[1].val)
+
     def reduce_empty(self, *kids):
         self.val = (None, None)
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2543,7 +2543,6 @@ aa';
         ELSE (SELECT Foo);
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=4, col=27)
     def test_edgeql_syntax_insert_21(self):
         """
         INSERT Foo {


### PR DESCRIPTION
This falls out really easily now because we needed all the
infrastucture in order to prevent nested DML from being executed.

It seems worth exposing. It will mean we can use ELSE with object
constraints, for one.