### PR TITLE
Revert "Support UNLESS CONFLICT ELSE without an ON (#2196)"

### DIFF
--- a/docs/edgeql/statements/insert.rst
+++ b/docs/edgeql/statements/insert.rst
@@ -12,8 +12,7 @@ INSERT
 
     [ WITH <with-spec> [ ,  ... ] ]
     INSERT <expression> [ <insert-shape> ]
-    [ UNLESS CONFLICT
-        [ ON <property> ]
+    [ UNLESS CONFLICT ON <property>
         [ ELSE <alternative> ]
     ] ;
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -221,9 +221,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 self.write(' ON ')
                 self.visit(on_expr)
 
-            if else_expr:
-                self.write(' ELSE ')
-                self.visit(else_expr)
+                if else_expr:
+                    self.write(' ELSE ')
+                    self.visit(else_expr)
 
         if parenthesise:
             self.write(')')

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -354,30 +354,9 @@ def compile_insert_unless_conflict_select(
     return select_ir
 
 
-def compile_insert_unless_conflict_else(
-    stmt: irast.InsertStmt,
-    else_branch: Optional[qlast.Expr],
-    *, ctx: context.ContextLevel,
-) -> Optional[irast.Set]:
-    # Compile an UNLESS CONFLICT ELSE branch
-    if else_branch:
-        # The ELSE needs to be able to reference the subject in an
-        # UPDATE, even though that would normally be prohibited.
-        ctx.path_scope.factoring_allowlist.add(stmt.subject.path_id)
-
-        # Compile else
-        else_ir = dispatch.compile(
-            astutils.ensure_qlstmt(else_branch), ctx=ctx)
-        assert isinstance(else_ir, irast.Set)
-        return else_ir
-    else:
-        return None
-
-
 def compile_insert_unless_conflict(
     stmt: irast.InsertStmt,
     insert_subject: qlast.Path,
-    else_branch: Optional[qlast.Expr],
     *, ctx: context.ContextLevel,
 ) -> irast.OnConflictClause:
     """Compile an UNLESS CONFLICT clause with no ON
@@ -413,10 +392,8 @@ def compile_insert_unless_conflict(
         obj_constrs=obj_constrs,
         parser_context=stmt.context, ctx=ctx)
 
-    else_ir = compile_insert_unless_conflict_else(stmt, else_branch, ctx=ctx)
-
     return irast.OnConflictClause(
-        constraint=None, select_ir=select_ir, else_ir=else_ir)
+        constraint=None, select_ir=select_ir, else_ir=None)
 
 
 def compile_insert_unless_conflict_on(
@@ -489,7 +466,17 @@ def compile_insert_unless_conflict_on(
         stmt, insert_subject, real_typ, constrs=ds, obj_constrs=[],
         parser_context=stmt.context, ctx=ctx)
 
-    else_ir = compile_insert_unless_conflict_else(stmt, else_branch, ctx=ctx)
+    # Compile an else branch
+    else_ir = None
+    if else_branch:
+        # The ELSE needs to be able to reference the subject in an
+        # UPDATE, even though that would normally be prohibited.
+        ctx.path_scope.factoring_allowlist.add(stmt.subject.path_id)
+
+        # Compile else
+        else_ir = dispatch.compile(
+            astutils.ensure_qlstmt(else_branch), ctx=ctx)
+        assert isinstance(else_ir, irast.Set)
 
     return irast.OnConflictClause(
         constraint=irast.ConstraintRef(
@@ -562,7 +549,7 @@ def compile_InsertQuery(
                     stmt, expr.subject, constraint_spec, else_branch, ctx=ictx)
             else:
                 stmt.on_conflict = compile_insert_unless_conflict(
-                    stmt, expr.subject, else_branch, ctx=ictx)
+                    stmt, expr.subject, ctx=ictx)
 
         stmt_subject_stype = setgen.get_set_type(subject, ctx=ictx)
 

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -592,9 +592,6 @@ class UnlessConflictSpecifier(Nonterm):
     def reduce_ON_Expr(self, *kids):
         self.val = (kids[1].val, None)
 
-    def reduce_ELSE_Expr(self, *kids):
-        self.val = (None, kids[1].val)
-
     def reduce_empty(self, *kids):
         self.val = (None, None)
 

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2559,115 +2559,12 @@ class TestInsert(tb.QueryTestCase):
             }]
         )
 
-    async def test_edgeql_insert_unless_conflict_11(self):
-        query = r'''
-            WITH MODULE test
-            SELECT (
-                INSERT Person {name := "test"}
-                UNLESS CONFLICT ELSE Person
-            ) {name};
-        '''
-
-        await self.assert_query_result(
-            query,
-            [{"name": "test"}],
-        )
-
-        await self.assert_query_result(
-            query,
-            [{"name": "test"}],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT count(test::Person)''',
-            [1],
-        )
-
-    async def test_edgeql_insert_unless_conflict_12(self):
-        # ELSE without ON, using computed property
-        query = r'''
-            WITH MODULE test
-            SELECT (
-                INSERT Person2b {first := "foo", last := "bar"}
-                UNLESS CONFLICT ELSE Person2b
-            ) {first, last, name};
-        '''
-
-        await self.assert_query_result(
-            query,
-            [{"first": "foo", "last": "bar", "name": "foo bar"}],
-        )
-
-        await self.assert_query_result(
-            query,
-            [{"first": "foo", "last": "bar", "name": "foo bar"}],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT count(test::Person2b)''',
-            [1],
-        )
-
-    async def test_edgeql_insert_unless_conflict_13(self):
-        # ELSE without ON, using computed property
-        await self.assert_query_result(
-            r'''
-            WITH MODULE test
-            SELECT (
-                INSERT Person2b {first := "foo ", last := "bar"}
-                UNLESS CONFLICT ELSE Person2b
-            ) {first, last, name};
-            ''',
-            [{"first": "foo ", "last": "bar", "name": "foo  bar"}],
-        )
-
-        await self.assert_query_result(
-            r'''
-            WITH MODULE test
-            SELECT (
-                INSERT Person2b {first := "foo", last := " bar"}
-                UNLESS CONFLICT ELSE Person2b
-            ) {first, last, name};
-            ''',
-            [{"first": "foo ", "last": "bar", "name": "foo  bar"}],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT count(test::Person2b)''',
-            [1],
-        )
-
-    async def test_edgeql_insert_unless_conflict_14(self):
-        # ELSE without ON, using object constraint
-        query = r'''
-            WITH MODULE test
-            SELECT (
-                INSERT Person2a {first := "foo", last := "bar"}
-                UNLESS CONFLICT ELSE Person2a
-            ) {first, last};
-        '''
-
-        await self.assert_query_result(
-            query,
-            [{"first": "foo", "last": "bar"}],
-        )
-
-        await self.assert_query_result(
-            query,
-            [{"first": "foo", "last": "bar"}],
-        )
-
-        await self.assert_query_result(
-            r'''SELECT count(test::Person2a)''',
-            [1],
-        )
-
     async def test_edgeql_insert_dependent_01(self):
         query = r'''
             WITH MODULE test
             SELECT (
                 INSERT Person {
-                    name := "Test",
+                    name :=  "Test",
                     notes := (INSERT Note {name := "tag!" })
                 } UNLESS CONFLICT
             ) {name};

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2543,6 +2543,7 @@ aa';
         ELSE (SELECT Foo);
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=4, col=27)
     def test_edgeql_syntax_insert_21(self):
         """
         INSERT Foo {


### PR DESCRIPTION
This reverts commit 992b8dcf7e5bae8654aa8f479b258d6df576daf6.

Like we discussed, we're reverting this now so we have a chance to
discuss it in more detail before it goes out as part of a release.

(I think that my revised proposal for this feature will be to disallow
the use of DML in the ELSE branch unless ON is specified. (Or maybe
perhaps just when ON is specified and the cardinality is MANY?))