### PR TITLE
Fix propagation of from_alias both in inheritance and structure

### DIFF
--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -449,6 +449,8 @@ class CreateLink(
         src_prop.set_attribute_value('readonly', True)
         src_prop.set_attribute_value('final', True)
         src_prop.set_attribute_value('owned', True)
+        src_prop.set_attribute_value('from_alias',
+                                     self.scls.get_from_alias(schema))
         src_prop.set_attribute_value('cardinality',
                                      qltypes.SchemaCardinality.One)
 
@@ -482,6 +484,8 @@ class CreateLink(
         tgt_prop.set_attribute_value('readonly', True)
         tgt_prop.set_attribute_value('final', True)
         tgt_prop.set_attribute_value('owned', True)
+        tgt_prop.set_attribute_value('from_alias',
+                                     self.scls.get_from_alias(schema))
         tgt_prop.set_attribute_value('cardinality',
                                      qltypes.SchemaCardinality.One)
 

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -250,7 +250,7 @@ class PropertyCommand(
 
 class CreateProperty(
     PropertyCommand,
-    referencing.CreateReferencedInheritingObject[Property],
+    pointers.CreatePointer[Property],
 ):
     astnode = [qlast.CreateConcreteProperty,
                qlast.CreateProperty]

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1563,7 +1563,15 @@ class CreatePointer(
             referrer=referrer,
         )
 
-        if isinstance(referrer, s_types.Type) and referrer.is_view(schema):
+        if (
+            (
+                isinstance(referrer, s_types.Type)
+                and referrer.is_view(schema)
+            ) or (
+                isinstance(referrer, Pointer)
+                and referrer.get_from_alias(schema)
+            )
+        ):
             cmd.set_attribute_value('from_alias', True)
 
         return cmd

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -913,11 +913,18 @@ class ReferencedInheritingObjectCommand(
             refname: sn.Name,
         ) -> None:
             s_t = type(self)(classname=alter_cmd.classname)
-            s_t.set_attribute_value(field_name, value)
+            orig_value = scls.get_explicit_field_value(
+                schema, field_name, default=None)
+            s_t.set_attribute_value(
+                field_name,
+                value,
+                orig_value=orig_value,
+                inherited=True,
+            )
             alter_cmd.add(s_t)
 
         schema = self._propagate_ref_op(
-            schema, context, self.scls, cb=_propagate)
+            schema, context, scls, cb=_propagate)
 
         return schema
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3360,12 +3360,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         """])
 
-    @test.xfail('''
-        unexpected difference in schema produced by incremental
-        migration on step 2:
-
-        Target types in UserAlias don't agree
-    ''')
     def test_schema_migrations_equivalence_44(self):
         # change a link used in a computable
         self._assert_migration_equivalence([r"""
@@ -3394,12 +3388,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         """])
 
-    @test.xfail('''
-        unexpected difference in schema produced by incremental
-        migration on step 2:
-
-        ... from_alias = None | True
-    ''')
     def test_schema_migrations_equivalence_45(self):
         # change a link used in a computable
         self._assert_migration_equivalence([r"""
@@ -3450,12 +3438,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         """])
 
-    @test.xfail('''
-        unexpected difference in schema produced by incremental
-        migration on step 2:
-
-        Target types in UserAlias don't agree
-    ''')
     def test_schema_migrations_equivalence_46(self):
         # change a link used in a computable
         self._assert_migration_equivalence([r"""


### PR DESCRIPTION
The `from_alias` field of `Pointer` indicates whether the pointer
originates from an alias type.  Currently, propagation of this field in
inheritance when the parent type of the alias type is altered is broken.
On top of that, `from_alias` should be transitive to link properties and
it isn't.  Finally, `_propagate_ref_field_alter_in_inheritance` should
actually make the propagated field value in descendants as `inherited`.