### PR TITLE
correct error message typo

### DIFF
--- a/edb/server/mng_port/edgecon.pyx
+++ b/edb/server/mng_port/edgecon.pyx
@@ -859,7 +859,7 @@ cdef class EdgeConnection:
         if self.protocol_version < minimum_version:
             raise errors.BinaryProtocolError(
                 f'{feature} is supported since protocol '
-                f'{minimum_version[0].minimum_version[1]}, current is '
+                f'{minimum_version[0]}.{minimum_version[1]}, current is '
                 f'{self.protocol_version[0]}.{self.protocol_version[1]}'
             )
 


### PR DESCRIPTION
I found this because I got this error:

```
edgedb.InternalServerError: 'int' object has no attribute 'minimum_version'
```