### PR TITLE
Remove schema objects created as reflection proxies on deletes

### DIFF
--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -956,7 +956,7 @@ def write_meta_delete_object(
 
             blocks.append((parent_update_query, parent_variables))
 
-        # We need to delete any links create via reflection_proxy
+        # We need to delete any links created via reflection_proxy
         layout = classlayout[mcls]
         proxy_links = [
             link for link, layout_entry in layout.items()

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -956,9 +956,27 @@ def write_meta_delete_object(
 
             blocks.append((parent_update_query, parent_variables))
 
+        # We need to delete any links create via reflection_proxy
+        layout = classlayout[mcls]
+        proxy_links = [
+            link for link, layout_entry in layout.items()
+            if layout_entry.reflection_proxy
+        ]
+
+        operations = []
+        if proxy_links:
+            # Link deletion triggers apparently don't work for the
+            # schema tables, and so we need to clear out the proxy
+            # links manually before we delete them.
+            sets = [f'{link} := {{}}' for link in proxy_links]
+            operations.append(f'(UPDATE D SET {{ {", ".join(sets)} }})')
+
+        to_delete = ['D'] + [f'D.{link}' for link in proxy_links]
+        operations += [f'(DELETE {x})' for x in to_delete]
         query = f'''
-            DELETE schema::{mcls.__name__}
-            FILTER .name__internal = <str>$__classname;
+            WITH D := (SELECT schema::{mcls.__name__}
+                       FILTER .name__internal = <str>$__classname),
+            SELECT {{{", ".join(operations)}}};
         '''
         variables = {'__classname': json.dumps(str(cmd.classname))}
         blocks.append((query, variables))

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -8358,3 +8358,20 @@ class TestEdgeQLDataMigrationNonisolated(tb.DDLTestCase):
             POPULATE MIGRATION;
             COMMIT MIGRATION;
         """)
+
+    async def test_edgeql_ddl_collection_cleanup_06(self):
+        await self.con.execute("SET MODULE test;")
+
+        for _ in range(2):
+            await self.con.execute(r"""
+                CREATE FUNCTION cleanup_06(
+                    a: int64
+                ) -> tuple<int64, tuple<int64>>
+                    USING EdgeQL $$
+                        SELECT (a, ((a + 1),))
+                    $$;
+            """)
+
+            await self.con.execute(r"""
+                DROP FUNCTION cleanup_06(a: int64)
+            """)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -9701,6 +9701,8 @@ type test::Foo {
     async def test_edgeql_ddl_collection_cleanup_03(self):
         count_query = "SELECT count(schema::CollectionType);"
         orig_count = await self.con.query_one(count_query)
+        elem_count_query = "SELECT count(schema::TupleElement);"
+        orig_elem_count = await self.con.query_one(elem_count_query)
 
         await self.con.execute(r"""
             SET MODULE test;
@@ -9722,6 +9724,8 @@ type test::Foo {
         """)
 
         self.assertEqual(await self.con.query_one(count_query), orig_count)
+        self.assertEqual(
+            await self.con.query_one(elem_count_query), orig_elem_count)
 
     async def test_edgeql_ddl_collection_cleanup_04(self):
         count_query = "SELECT count(schema::CollectionType);"


### PR DESCRIPTION
Leaving this around is incorrect, and combined with other factors (we
don't seem to fire link deletion triggers in the schema tables?)  and
the use of deterministic IDs for collection types to produce truly
bizarre results when a collection type is deleted and then recreated.