### PR TITLE
Revert cheatsheets title + make new title an alt title

### DIFF
--- a/docs/cheatsheet/index.rst
+++ b/docs/cheatsheet/index.rst
@@ -1,8 +1,10 @@
 .. eql:section-intro-page:: cheatsheet
 
-==============================
-Cheatsheets: EdgeDB by example
-==============================
+===========
+Cheatsheets
+===========
+
+:edb-alt-title: Cheatsheets: EdgeDB by example
 
 Just getting started? Keep an eye on this collection of cheatsheets with
 handy examples for what you'll need to get started with EdgeDB.


### PR DESCRIPTION
New cheatsheets title in #2126 is too long for the docs nav:
![image](https://user-images.githubusercontent.com/2085287/107637442-0ae25080-6c66-11eb-8d97-ad1e264547a7.png)

This reverts the title and makes the new title an alt title instead:
![image](https://user-images.githubusercontent.com/2085287/107637651-60b6f880-6c66-11eb-9c56-81966b04de56.png)
