### PR TITLE
Run test workflow in shards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,8 +4,12 @@ root = true
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{py,pyx,pxd,pxi,yml,h}]
+[*.{py,pyx,pxd,pxi,h}]
 indent_size = 4
+indent_style = space
+
+[*.yml]
+indent_size = 2
 indent_style = space
 
 [ext/*.{c,cpp,h}]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
     - cron: "0 */3 * * *"
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-18.04
 
     steps:
@@ -56,15 +56,166 @@ jobs:
       id: buildcache
       with:
         path: build
-        key: edbbuild-${{ hashFiles('.tmp/build_cache_key.txt') }}
+        key: edbbuild-v2-${{ hashFiles('.tmp/build_cache_key.txt') }}
         restore-keys: |
-          edbbuild-
+          edbbuild-v2-
+
+    - name: Prepare time stats file
+      run: |
+        curl \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/gists/c61fd6a07e31cbab221ec5bde378b316 \
+        | jq '.files."time_stats.csv".raw_url' \
+        | xargs curl > .tmp/time_stats.csv
+
+    - name: Upload cache key and time stats file
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-cache-key-and-time-stats
+        path: .tmp
+        retention-days: 1
 
     - name: Install system deps
       if: steps.buildcache.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y uuid-dev libreadline-dev bison flex
+
+    - name: Install rust toolchain
+      if: steps.buildcache.outputs.cache-hit != 'true'
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        default: true
+
+    - name: Build
+      if: steps.buildcache.outputs.cache-hit != 'true'
+      run: |
+        # --no-use-pep517 because we have explicitly installed all deps
+        # and don't want them to be reinstalled in an "isolated env".
+        pip install --no-use-pep517 --no-deps -e .[test,docs]
+
+    - name: Bootstrap EdgeDB Server
+      if: steps.buildcache.outputs.cache-hit != 'true'
+      run: |
+        edb server --bootstrap-only
+
+  cargo-test:
+    needs: build
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: false
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+        submodules: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - uses: actions/cache@v2
+      id: depcache
+      with:
+        path: deps
+        key: edbdeps-pip-${{ hashFiles('setup.py') }}
+
+    - name: Install Python deps
+      run: |
+        pip install -U --no-index --find-links=deps deps/*
+
+    - name: Download cache key
+      uses: actions/download-artifact@v2
+      with:
+        name: build-cache-key-and-time-stats
+        path: .tmp
+
+    - uses: actions/cache@v2
+      id: buildcache
+      with:
+        path: build
+        key: edbbuild-v2-${{ hashFiles('.tmp/build_cache_key.txt') }}
+
+    - name: Stop if we cannot retrieve the build cache
+      if: steps.buildcache.outputs.cache-hit != 'true'
+      run: |
+        echo ::error::Cannot retrieve build cache.
+        exit 1
+
+    - name: Install rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        default: true
+
+    - name: Cargo test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+
+  test:
+    needs: build
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        shard: [
+             1/16,  2/16,  3/16,  4/16,
+             5/16,  6/16,  7/16,  8/16,
+             9/16, 10/16, 11/16, 12/16,
+            13/16, 14/16, 15/16, 16/16,
+        ]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: false
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+        submodules: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - uses: actions/cache@v2
+      id: depcache
+      with:
+        path: deps
+        key: edbdeps-pip-${{ hashFiles('setup.py') }}
+
+    - name: Install Python deps
+      run: |
+        pip install -U --no-index --find-links=deps deps/*
+
+    - name: Download cache key and time stats file
+      uses: actions/download-artifact@v2
+      with:
+        name: build-cache-key-and-time-stats
+        path: .tmp
+
+    - uses: actions/cache@v2
+      id: buildcache
+      with:
+        path: build
+        key: edbbuild-v2-${{ hashFiles('.tmp/build_cache_key.txt') }}
+
+    - name: Stop if we cannot retrieve the build cache
+      if: steps.buildcache.outputs.cache-hit != 'true'
+      run: |
+        echo ::error::Cannot retrieve build cache.
+        exit 1
 
     - name: Install rust toolchain
       uses: actions-rs/toolchain@v1
@@ -79,10 +230,159 @@ jobs:
         # and don't want them to be reinstalled in an "isolated env".
         pip install --no-use-pep517 --no-deps -e .[test,docs]
 
-    - name: Cargo test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
     - name: Test
+      env:
+        SHARD: ${{ matrix.shard }}
       run: |
-        edb test -j2 -v
+        cp .tmp/time_stats.csv .tmp/time_stats_copy.csv
+        edb test -j2 -v -s ${SHARD} --time-file=.tmp/time_stats_copy.csv
+        mv .tmp/time_stats_copy.csv .tmp/new_${SHARD/\//_}.csv
+
+    - name: Upload updated time stats file
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-cache-key-and-time-stats
+        path: .tmp
+        retention-days: 1
+
+  collect:
+    needs: build
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: false
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+        submodules: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - uses: actions/cache@v2
+      id: depcache
+      with:
+        path: deps
+        key: edbdeps-pip-${{ hashFiles('setup.py') }}
+
+    - name: Install Python deps
+      run: |
+        pip install -U --no-index --find-links=deps deps/*
+
+    - name: Download cache key and time stats file
+      uses: actions/download-artifact@v2
+      with:
+        name: build-cache-key-and-time-stats
+        path: .tmp
+
+    - uses: actions/cache@v2
+      id: buildcache
+      with:
+        path: build
+        key: edbbuild-v2-${{ hashFiles('.tmp/build_cache_key.txt') }}
+
+    - name: Stop if we cannot retrieve the build cache
+      if: steps.buildcache.outputs.cache-hit != 'true'
+      run: |
+        echo ::error::Cannot retrieve build cache.
+        exit 1
+
+    - name: Install rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        default: true
+
+    - name: Build
+      run: |
+        # --no-use-pep517 because we have explicitly installed all deps
+        # and don't want them to be reinstalled in an "isolated env".
+        pip install --no-use-pep517 --no-deps -e .[test,docs]
+
+    - name: Generate complete list of tests for verification
+      env:
+        SHARD: ${{ matrix.shard }}
+      run: |
+        edb test --list > .tmp/all_tests.txt
+
+    - name: Upload complete list of tests
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-cache-key-and-time-stats
+        path: .tmp
+        retention-days: 1
+
+  verify:
+    needs: [test, collect]
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Python deps
+        run: |
+          pip install requests
+
+      - name: Download all time stats file
+        uses: actions/download-artifact@v2
+        with:
+          name: build-cache-key-and-time-stats
+          path: .tmp
+
+      - name: Merge stats and verify completion
+        shell: python
+        env:
+          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+          GIT_REF: ${{ github.ref }}
+        run: |
+          import csv
+          import glob
+          import io
+          import os
+          import requests
+
+          orig = {}
+          new = {}
+          all_tests = set()
+          with open(".tmp/time_stats.csv") as f:
+              for name, t, c in csv.reader(f):
+                  assert name not in orig, "duplicate test name in original stats!"
+                  orig[name] = (t, int(c))
+
+          with open(".tmp/all_tests.txt") as f:
+              for line in f:
+                  assert line not in all_tests, "duplicate test name in this run!"
+                  all_tests.add(line.strip())
+
+          for new_file in glob.glob(".tmp/new*.csv"):
+              with open(new_file) as f:
+                  for name, t, c in csv.reader(f):
+                      if int(c) > orig.get(name, (0, 0))[1]:
+                          assert name not in new, f"duplicate test! {name}"
+                          new[name] = (t, c)
+                          all_tests.remove(name)
+
+          assert not all_tests, "Tests not run! \n" + "\n".join(all_tests)
+
+          if os.environ["GIT_REF"] == "refs/heads/master":
+              buf = io.StringIO()
+              writer = csv.writer(buf)
+              orig.update(new)
+              for k, v in sorted(orig.items()):
+                  writer.writerow((k,) + v)
+
+              resp = requests.patch(
+                  "https://api.github.com/gists/c61fd6a07e31cbab221ec5bde378b316",
+                  headers={"Accept": "application/vnd.github.v3+json"},
+                  auth=("fantix", os.environ["GIST_TOKEN"]),
+                  json={"files": {"time_stats.csv": {"content": buf.getvalue()}}},
+              )
+              resp.raise_for_status()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,8 @@ jobs:
       with:
         python-version: 3.8
 
-    - uses: actions/cache@v2
+    - name: Handle Pip dependency cache
+      uses: actions/cache@v2
       id: depcache
       with:
         path: deps
@@ -52,7 +53,8 @@ jobs:
         mkdir -p .tmp
         python setup.py --quiet gen_build_cache_key >.tmp/build_cache_key.txt
 
-    - uses: actions/cache@v2
+    - name: Handle build cache
+      uses: actions/cache@v2
       id: buildcache
       with:
         path: build
@@ -60,15 +62,18 @@ jobs:
         restore-keys: |
           edbbuild-v2-
 
-    - name: Prepare time stats file
+    - name: Download the running times log file
+      env:
+        GIST_TOKEN: ${{ secrets.CI_BOT_GIST_TOKEN }}
       run: |
         curl \
           -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/gists/c61fd6a07e31cbab221ec5bde378b316 \
+          -u edgedb-ci:$GIST_TOKEN \
+          https://api.github.com/gists/8b722a65397f7c4c0df72f5394efa04c \
         | jq '.files."time_stats.csv".raw_url' \
         | xargs curl > .tmp/time_stats.csv
 
-    - name: Upload cache key and time stats file
+    - name: Upload shared artifacts
       uses: actions/upload-artifact@v2
       with:
         name: build-cache-key-and-time-stats
@@ -121,7 +126,8 @@ jobs:
       with:
         python-version: 3.8
 
-    - uses: actions/cache@v2
+    - name: Handle Pip dependency cache
+      uses: actions/cache@v2
       id: depcache
       with:
         path: deps
@@ -137,7 +143,8 @@ jobs:
         name: build-cache-key-and-time-stats
         path: .tmp
 
-    - uses: actions/cache@v2
+    - name: Handle build cache
+      uses: actions/cache@v2
       id: buildcache
       with:
         path: build
@@ -161,16 +168,20 @@ jobs:
       with:
         command: test
 
-  test:
+  python-test:
     needs: build
     runs-on: ubuntu-18.04
     strategy:
       matrix:
         shard: [
-             1/16,  2/16,  3/16,  4/16,
-             5/16,  6/16,  7/16,  8/16,
-             9/16, 10/16, 11/16, 12/16,
-            13/16, 14/16, 15/16, 16/16,
+             1/32,  2/32,  3/32,  4/32,
+             5/32,  6/32,  7/32,  8/32,
+             9/32, 10/32, 11/32, 12/32,
+            13/32, 14/32, 15/32, 16/32,
+            17/32, 18/32, 19/32, 20/32,
+            21/32, 22/32, 23/32, 24/32,
+            25/32, 26/32, 27/32, 28/32,
+            29/32, 30/32, 31/32, 32/32,
         ]
 
     steps:
@@ -189,7 +200,8 @@ jobs:
       with:
         python-version: 3.8
 
-    - uses: actions/cache@v2
+    - name: Handle Pip dependency cache
+      uses: actions/cache@v2
       id: depcache
       with:
         path: deps
@@ -199,13 +211,14 @@ jobs:
       run: |
         pip install -U --no-index --find-links=deps deps/*
 
-    - name: Download cache key and time stats file
+    - name: Download shared artifacts
       uses: actions/download-artifact@v2
       with:
         name: build-cache-key-and-time-stats
         path: .tmp
 
-    - uses: actions/cache@v2
+    - name: Handle build cache
+      uses: actions/cache@v2
       id: buildcache
       with:
         path: build
@@ -224,7 +237,7 @@ jobs:
         toolchain: stable
         default: true
 
-    - name: Build
+    - name: Install
       run: |
         # --no-use-pep517 because we have explicitly installed all deps
         # and don't want them to be reinstalled in an "isolated env".
@@ -234,11 +247,10 @@ jobs:
       env:
         SHARD: ${{ matrix.shard }}
       run: |
-        cp .tmp/time_stats.csv .tmp/time_stats_copy.csv
-        edb test -j2 -v -s ${SHARD} --time-file=.tmp/time_stats_copy.csv
-        mv .tmp/time_stats_copy.csv .tmp/new_${SHARD/\//_}.csv
+        cp .tmp/time_stats.csv .tmp/new_${SHARD/\//_}.csv
+        edb test -j2 -v -s ${SHARD} --running-times-log=.tmp/new_${SHARD/\//_}.csv
 
-    - name: Upload updated time stats file
+    - name: Update shared artifacts
       uses: actions/upload-artifact@v2
       with:
         name: build-cache-key-and-time-stats
@@ -264,7 +276,8 @@ jobs:
       with:
         python-version: 3.8
 
-    - uses: actions/cache@v2
+    - name: Handle Pip dependency cache
+      uses: actions/cache@v2
       id: depcache
       with:
         path: deps
@@ -274,13 +287,14 @@ jobs:
       run: |
         pip install -U --no-index --find-links=deps deps/*
 
-    - name: Download cache key and time stats file
+    - name: Download shared artifacts
       uses: actions/download-artifact@v2
       with:
         name: build-cache-key-and-time-stats
         path: .tmp
 
-    - uses: actions/cache@v2
+    - name: Handle build cache
+      uses: actions/cache@v2
       id: buildcache
       with:
         path: build
@@ -299,7 +313,7 @@ jobs:
         toolchain: stable
         default: true
 
-    - name: Build
+    - name: Install
       run: |
         # --no-use-pep517 because we have explicitly installed all deps
         # and don't want them to be reinstalled in an "isolated env".
@@ -311,15 +325,15 @@ jobs:
       run: |
         edb test --list > .tmp/all_tests.txt
 
-    - name: Upload complete list of tests
+    - name: Update shared artifacts
       uses: actions/upload-artifact@v2
       with:
         name: build-cache-key-and-time-stats
         path: .tmp
         retention-days: 1
 
-  verify:
-    needs: [test, collect]
+  test:
+    needs: [cargo-test, python-test, collect]
     runs-on: ubuntu-18.04
     steps:
       - name: Set up Python
@@ -331,16 +345,16 @@ jobs:
         run: |
           pip install requests
 
-      - name: Download all time stats file
+      - name: Download shared artifacts
         uses: actions/download-artifact@v2
         with:
           name: build-cache-key-and-time-stats
           path: .tmp
 
-      - name: Merge stats and verify completion
+      - name: Merge stats and verify tests completion
         shell: python
         env:
-          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+          GIST_TOKEN: ${{ secrets.CI_BOT_GIST_TOKEN }}
           GIT_REF: ${{ github.ref }}
         run: |
           import csv
@@ -380,9 +394,9 @@ jobs:
                   writer.writerow((k,) + v)
 
               resp = requests.patch(
-                  "https://api.github.com/gists/c61fd6a07e31cbab221ec5bde378b316",
+                  "https://api.github.com/gists/8b722a65397f7c4c0df72f5394efa04c",
                   headers={"Accept": "application/vnd.github.v3+json"},
-                  auth=("fantix", os.environ["GIST_TOKEN"]),
+                  auth=("edgedb-ci", os.environ["GIST_TOKEN"]),
                   json={"files": {"time_stats.csv": {"content": buf.getvalue()}}},
               )
               resp.raise_for_status()

--- a/edb/tools/test/__init__.py
+++ b/edb/tools/test/__init__.py
@@ -83,13 +83,14 @@ __all__ = ('not_implemented', 'xfail', 'skip')
               help='package name to measure code coverage for, '
                    'can be specified multiple times '
                    '(e.g --cov edb.common --cov edb.server)')
-@click.option('--time-file', type=click.File('a+'), metavar='FILEPATH',
-              help='Maintain a running time file at FILEPATH')
+@click.option('--running-times-log', 'running_times_log_file',
+              type=click.File('a+'), metavar='FILEPATH',
+              help='Maintain a running time log file at FILEPATH')
 @click.option('--list', 'list_tests', is_flag=True,
               help='list all the tests and exit')
 def test(*, files, jobs, shard, include, exclude, verbose, quiet, debug,
-         output_format, warnings, failfast, shuffle, cov, repeat, time_file,
-         list_tests):
+         output_format, warnings, failfast, shuffle, cov, repeat,
+         running_times_log_file, list_tests):
     """Run EdgeDB test suite.
 
     Discovers and runs tests in the specified files or directories.
@@ -160,7 +161,7 @@ def test(*, files, jobs, shard, include, exclude, verbose, quiet, debug,
         repeat=repeat,
         current_shard=current_shard,
         total_shards=total_shards,
-        time_file=time_file,
+        running_times_log_file=running_times_log_file,
         list_tests=list_tests,
     )
 
@@ -237,7 +238,7 @@ def _coverage_wrapper(paths):
 
 def _run(*, include, exclude, verbosity, files, jobs, output_format,
          warnings, failfast, shuffle, repeat, current_shard, total_shards,
-         time_file, list_tests):
+         running_times_log_file, list_tests):
     suite = unittest.TestSuite()
 
     total = 0
@@ -298,7 +299,9 @@ def _run(*, include, exclude, verbosity, files, jobs, output_format,
             warnings=warnings, num_workers=jobs,
             failfast=failfast, shuffle=shuffle)
 
-        result = test_runner.run(suite, current_shard, total_shards, time_file)
+        result = test_runner.run(
+            suite, current_shard, total_shards, running_times_log_file,
+        )
 
         if not result.wasSuccessful():
             return 1

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -732,14 +732,15 @@ class ParallelTextTestRunner:
         self.shuffle = shuffle
         self.output_format = output_format
 
-    def run(self, test, current_shard, total_shards, time_file):
+    def run(self, test, current_shard, total_shards, running_times_log_file):
         session_start = time.monotonic()
         cases = tb.get_test_cases([test])
         stats = {}
-        if time_file:
-            time_file.seek(0)
+        if running_times_log_file:
+            running_times_log_file.seek(0)
             stats = {
-                k: (float(v), int(c)) for k, v, c in csv.reader(time_file)
+                k: (float(v), int(c))
+                for k, v, c in csv.reader(running_times_log_file)
             }
         cases = tb.get_cases_by_shard(
             cases, current_shard, total_shards, self.verbosity, stats,
@@ -815,15 +816,15 @@ class ParallelTextTestRunner:
             self._echo()
             suite.run(result)
 
-            if time_file:
+            if running_times_log_file:
                 for test, stat in result.test_stats:
                     name = str(test)
                     t = stat['running-time']
                     at, c = stats.get(name, (0, 0))
                     stats[name] = (at + (t - at) / (c + 1), c + 1)
-                time_file.seek(0)
-                time_file.truncate()
-                writer = csv.writer(time_file)
+                running_times_log_file.seek(0)
+                running_times_log_file.truncate()
+                writer = csv.writer(running_times_log_file)
                 for k, v in stats.items():
                     writer.writerow((k, ) + v)
             tests_time_taken = time.monotonic() - start


### PR DESCRIPTION
This PR adds 3 new options to `edb test`:

* `edb test --shard 2/5` separates all collected tests into 5 shards, and run the 2nd shard only. The split is supposed to be deterministic.
* `edb test --time-file` generates a CSV file of time spent on each test. If the file exists, it'll be taken as an input for `--shard` to generate a more even split, and the CSV file will be updated after the run with new average running times.
* `edb test --list` outputs a list of all selected tests and exits.

The pipeline will fetch from a Gist for `--time-file`, and update that Gist if the tests pass in the master branch.

- [x] Replace the Gist URL with a new one by @edgedb-ci 
- [x] Add @edgedb-ci 's Github Personal Access Token with `gist` scope as Secret `GIST_TOKEN`
- [x] Update the branch protection rules to check for the `verify` job (or update the `test.yml` to rename the final job back to `test`?)

Fixes #2201