### PR TITLE
Disallow implicit and assignment casting between mismatched named tuples

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -325,10 +325,18 @@ def try_fold_associative_binop(
 def compile_NamedTuple(
         expr: qlast.NamedTuple, *, ctx: context.ContextLevel) -> irast.Set:
 
+    names = set()
     elements = []
     for el in expr.elements:
+        name = el.name.name
+        if name in names:
+            raise errors.QueryError(
+                f"named tuple has duplicate field '{name}'",
+                context=el.context)
+        names.add(name)
+
         element = irast.TupleElement(
-            name=el.name.name,
+            name=name,
             val=setgen.ensure_set(dispatch.compile(el.val, ctx=ctx), ctx=ctx)
         )
         elements.append(element)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1460,8 +1460,14 @@ class Tuple(
         return schema, result
 
     def get_displayname(self, schema: s_schema.Schema) -> str:
-        st_names = ', '.join(st.get_displayname(schema)
-                             for st in self.get_subtypes(schema))
+        if self.is_named(schema):
+            st_names = ', '.join(
+                f'{name}: {st.get_displayname(schema)}'
+                for name, st in self.get_element_types(schema).items(schema)
+            )
+        else:
+            st_names = ', '.join(st.get_displayname(schema)
+                                 for st in self.get_subtypes(schema))
         return f'tuple<{st_names}>'
 
     def is_tuple(self, schema: s_schema.Schema) -> bool:
@@ -1614,6 +1620,14 @@ class Tuple(
         if len(self_subtypes) != len(other_subtypes):
             return False
 
+        if (
+            self.is_named(schema)
+            and other.is_named(schema)
+            and (self.get_element_names(schema)
+                 != other.get_element_names(schema))
+        ):
+            return False
+
         for st, ot in zip(self_subtypes, other_subtypes):
             if not st.implicitly_castable_to(ot, schema):
                 return False
@@ -1632,6 +1646,14 @@ class Tuple(
         other_subtypes = other.get_subtypes(schema)
 
         if len(self_subtypes) != len(other_subtypes):
+            return -1
+
+        if (
+            self.is_named(schema)
+            and other.is_named(schema)
+            and (self.get_element_names(schema)
+                 != other.get_element_names(schema))
+        ):
             return -1
 
         total_dist = 0
@@ -1657,6 +1679,14 @@ class Tuple(
         other_subtypes = other.get_subtypes(schema)
 
         if len(self_subtypes) != len(other_subtypes):
+            return False
+
+        if (
+            self.is_named(schema)
+            and other.is_named(schema)
+            and (self.get_element_names(schema)
+                 != other.get_element_names(schema))
+        ):
             return False
 
         for st, ot in zip(self_subtypes, other_subtypes):

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -217,12 +217,19 @@ def ast_to_type_shell(
 
             subtypes: Dict[str, s_types.TypeShell] = {}
             # tuple declaration must either be named or unnamed, but not both
+            names = set()
             named = None
             unnamed = None
             for si, st in enumerate(node.subtypes):
                 if st.name:
                     named = True
                     type_name = st.name
+
+                    if type_name in names:
+                        raise errors.SchemaError(
+                            f"named tuple has duplicate field '{type_name}'",
+                            context=st.context)
+                    names.add(type_name)
                 else:
                     unnamed = True
                     type_name = str(si)

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -424,3 +424,15 @@ class TestEdgeQLDT(tb.QueryTestCase):
             [10.0**100],
             [decimal.Decimal('1e100')],
         )
+
+    async def test_edgeql_named_tuple_mismatch_01(self):
+        await self.con.execute(r"""
+            CREATE TYPE Foo { CREATE PROPERTY x -> tuple<a: int64, b: int64> };
+        """)
+
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                "invalid target for property 'x' of object type "
+                "'default::Foo': 'tuple<b: std::int64, a: std::int64>' "
+                "\\(expecting 'tuple<a: std::int64, b: std::int64>'"):
+            await self.con.execute("INSERT Foo { x := (b := 1, a := 2) };")


### PR DESCRIPTION
Also, include field names in the displayname of a named tuple, or else
the error message will just be total garbage.