### PR TITLE
Remove some dead code in edb.edgeql.compiler.stmt

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1201,39 +1201,16 @@ def compile_result_clause(
                 steps=[qlast.ObjectRef(name=result_alias)]
             )
 
-        if (view_rptr is not None and
-                (view_rptr.is_insert or view_rptr.is_update) and
-                view_rptr.ptrcls is not None) and False:
-            # If we have an empty set assigned to a pointer in an INSERT
-            # or UPDATE, there's no need to explicitly specify the
-            # empty set type and it can be assumed to match the pointer
-            # target type.
-            target_t = view_rptr.ptrcls.get_target(ctx.env.schema)
-
-            if astutils.is_ql_empty_set(result_expr):
-                expr = setgen.new_empty_set(
-                    stype=target_t,
-                    alias=ctx.aliases.get('e'),
-                    ctx=sctx,
-                    srcctx=result_expr.context,
-                )
-            else:
-                with sctx.new() as exprctx:
-                    exprctx.empty_result_type_hint = target_t
-                    expr = setgen.ensure_set(
-                        dispatch.compile(result_expr, ctx=exprctx),
-                        ctx=exprctx)
+        if astutils.is_ql_empty_set(result_expr):
+            expr = setgen.new_empty_set(
+                stype=sctx.empty_result_type_hint,
+                alias=ctx.aliases.get('e'),
+                ctx=sctx,
+                srcctx=result_expr.context,
+            )
         else:
-            if astutils.is_ql_empty_set(result_expr):
-                expr = setgen.new_empty_set(
-                    stype=sctx.empty_result_type_hint,
-                    alias=ctx.aliases.get('e'),
-                    ctx=sctx,
-                    srcctx=result_expr.context,
-                )
-            else:
-                expr = setgen.ensure_set(
-                    dispatch.compile(result_expr, ctx=sctx), ctx=sctx)
+            expr = setgen.ensure_set(
+                dispatch.compile(result_expr, ctx=sctx), ctx=sctx)
 
         ctx.partial_path_prefix = expr
 


### PR DESCRIPTION
This looks like it has been chilling with an `and False` at the end of
the condition since 2018.