### PR TITLE
Fix bare INSERT UNLESS CONFLICT when type name injection is on

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -568,6 +568,24 @@ def compile_InsertQuery(
 
         result = fini_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 
+        # If we have an ELSE clause, we need to compile_query_subject
+        # *again* on the outer query, in order to produce a view for
+        # the joined output, which we need to have to generate the
+        # proper type descriptor.
+        # This feels like somewhat of a hack; I think it might be
+        # possible to do something more general elsewhere.
+        if expr.unless_conflict and expr.unless_conflict[1]:
+            with ictx.new() as resultctx:
+                if ictx.stmt is ctx.toplevel_stmt:
+                    resultctx.expr_exposed = True
+
+                result = compile_query_subject(
+                    result,
+                    view_name=ctx.toplevel_result_view_name,
+                    compile_views=ictx.stmt is ctx.toplevel_stmt,
+                    ctx=resultctx,
+                    parser_context=result.context)
+
     return result
 
 

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2634,6 +2634,40 @@ class TestInsert(tb.QueryTestCase):
             [{"name": "Maddy"}],
         )
 
+    async def test_edgeql_insert_unless_conflict_12(self):
+        # An upsert where we don't wrap it in another shape
+        query = r'''
+            WITH MODULE test
+            INSERT Person {name := "Emmanuel Villip"} UNLESS CONFLICT
+            ON .name ELSE (UPDATE Person SET { tag := "redo" })
+        '''
+
+        res1 = await self.con._fetchall(
+            query, __typenames__=True,
+        )
+        res2 = await self.con._fetchall(
+            query, __typenames__=True,
+        )
+
+        self.assertEqual(list(res1)[0].id, list(res2)[0].id)
+
+    async def test_edgeql_insert_unless_conflict_13(self):
+        # An insert-or-select where we don't wrap it in another shape
+        query = r'''
+            WITH MODULE test
+            INSERT Person {name := "Emmanuel Villip"} UNLESS CONFLICT
+            ON .name ELSE (SELECT Person)
+        '''
+
+        res1 = await self.con._fetchall(
+            query, __typenames__=True,
+        )
+        res2 = await self.con._fetchall(
+            query, __typenames__=True,
+        )
+
+        self.assertEqual(list(res1)[0].id, list(res2)[0].id)
+
     async def test_edgeql_insert_dependent_01(self):
         query = r'''
             WITH MODULE test

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -6185,3 +6185,13 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ''',
             [True],
         )
+
+    @test.xfail("We produce results that don't decode properly")
+    async def test_edgeql_select_array_common_type_01(self):
+        res = await self.con._fetchall("""
+            WITH MODULE test
+            SELECT [User, Issue];
+        """, __typenames__=True)
+        for row in res:
+            self.assertEqual(row[0].__tname__, "test::User")
+            self.assertEqual(row[1].__tname__, "test::Issue")


### PR DESCRIPTION
Generate a view of the joined output from the INSERT and the ELSE
clause so that a proper type descriptor gets produced.