### PR TITLE
Use jsonb as the column type for session-local values

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -2191,7 +2191,7 @@ class SysConfigFullFunction(dbops.Function):
     config_sess AS (
         SELECT
             s.name AS name,
-            s.value::jsonb AS value,
+            s.value AS value,
             'session' AS source
         FROM
             _edgecon_state s
@@ -2449,7 +2449,7 @@ class SysConfigNoFileAccessFunction(dbops.Function):
     config_sess AS (
         SELECT
             s.name AS name,
-            s.value::jsonb AS value,
+            s.value AS value,
             'session' AS source
         FROM
             _edgecon_state s
@@ -2663,7 +2663,7 @@ class SysVersionFunction(dbops.Function):
     text = f'''
         BEGIN
         RETURN (
-            SELECT value::jsonb
+            SELECT value
             FROM _edgecon_state
             WHERE name = 'server_version' AND type = 'R'
         );

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1330,12 +1330,12 @@ class Compiler:
             INSERT INTO _edgecon_state(name, value, type)
             VALUES (
                 {pg_ql(alias or '')},
-                {pg_ql(module)},
+                to_jsonb({pg_ql(module)}::text),
                 'A'
             )
             ON CONFLICT (name, type) DO
             UPDATE
-                SET value = {pg_ql(module)};
+                SET value = to_jsonb({pg_ql(module)}::text);
         '''.encode()
 
         if isinstance(ql, qlast.SessionSetAliasDecl):

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -78,7 +78,7 @@ def _build_init_con_script() -> bytes:
     return (f'''
         CREATE TEMPORARY TABLE _edgecon_state (
             name text NOT NULL,
-            value text NOT NULL,
+            value jsonb NOT NULL,
             type text NOT NULL CHECK(type = 'C' OR type = 'A' OR type = 'R'),
             UNIQUE(name, type)
         );
@@ -98,7 +98,7 @@ def _build_init_con_script() -> bytes:
                 _edgecon_state(name, value, type)
             SELECT
                 e->>'name' AS name,
-                e->>'value' AS value,
+                e->'value' AS value,
                 e->>'type' AS type
             FROM
                 jsonb_array_elements($1::jsonb) AS e;

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -695,7 +695,7 @@ cdef class EdgeConnection:
             SELECT s1.name AS n, s1.value AS v, s1.type AS t
                 FROM _edgecon_state s1
             UNION ALL
-            SELECT '' AS n, s2.sp_id::text AS v, 'S' AS t
+            SELECT '' AS n, to_jsonb(s2.sp_id) AS v, 'S' AS t
                 FROM _edgecon_current_savepoint s2;
         ''', ignore_data=False)
 
@@ -720,7 +720,7 @@ cdef class EdgeConnection:
                 elif stype == b'A':
                     if not sname:
                         sname = None
-                    aliases = aliases.set(sname, svalue)
+                    aliases = aliases.set(sname, json.loads(svalue))
                 elif stype == b'S':
                     assert not sname
                     sp_id = int(svalue)

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -794,6 +794,10 @@ class TestServerConfig(tb.QueryTestCase, tb.OldCLITestCaseMixin):
     async def test_server_proto_configure_06(self):
         try:
             await self.con.execute('''
+                CONFIGURE SESSION SET singleprop := '42';
+            ''')
+
+            await self.con.execute('''
                 CONFIGURE SESSION SET multiprop := {'1', '2', '3'};
             ''')
 


### PR DESCRIPTION
The current use of `text` as the column type for `value` in
`_edgecon_state` leads to loss of type information when JSON gets
converted to text and back.