### PR TITLE
Record DDL statements as migrations

### DIFF
--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -335,5 +335,6 @@ CREATE TYPE schema::Migration
     EXTENDING schema::AnnotationSubject
 {
     CREATE MULTI LINK parents -> schema::Migration;
+    CREATE REQUIRED PROPERTY script -> str;
     CREATE PROPERTY message -> str;
 };

--- a/tests/schemas/dump02_setup.edgeql
+++ b/tests/schemas/dump02_setup.edgeql
@@ -19,6 +19,12 @@
 
 SET MODULE default;
 
+CREATE MIGRATION m14pt32wg7zijus7jmmnvbtf7dftt34xxgbkrtmys46pmrailnkcia
+ONTO m1bzqjsa6r7e3prynbm52zutm3jo42ybgulhsjlnxbd43m4sqdmcoq {
+    CREATE TYPE default::Migrated;
+    create type default::Migrated2 {};
+};
+
 # Not sure if the esdl filename will handle this on all systems, so
 # I'm adding stuff here.
 CREATE MODULE `💯💯💯`;
@@ -51,10 +57,4 @@ INSERT Łukasz {
         FILTER .`s p A m 🤞`.`🚀` = 42
         LIMIT 1
     )
-};
-
-CREATE MIGRATION m14pt32wg7zijus7jmmnvbtf7dftt34xxgbkrtmys46pmrailnkcia
-ONTO m1bzqjsa6r7e3prynbm52zutm3jo42ybgulhsjlnxbd43m4sqdmcoq {
-    CREATE TYPE default::Migrated;
-    create type default::Migrated2 {};
 };

--- a/tests/test_dump02.py
+++ b/tests/test_dump02.py
@@ -219,9 +219,9 @@ class DumpTestCaseMixin:
 
         await self.assert_query_result(
             r'''
-                SELECT count(schema::Migration)
+                SELECT count(schema::Migration) >= 2
             ''',
-            [2],
+            [True],
         )
 
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3168,6 +3168,11 @@ aa';
         CREATE SCALAR TYPE myenum EXTENDING enum<baz: int64, bar>;
         """
 
+    def test_edgeql_syntax_ddl_create_pseudo_type_01(self):
+        """
+        CREATE PSEUDO TYPE `anytype`;
+        """
+
     def test_edgeql_syntax_ddl_annotation_01(self):
         """
         CREATE ABSTRACT ANNOTATION std::paramtypes;
@@ -3801,6 +3806,18 @@ aa';
         std::`>=` (l: anytype, r: anytype) -> std::bool;
         """
 
+    def test_edgeql_syntax_ddl_operator_06(self):
+        """
+        ALTER INFIX OPERATOR std::`>=` (l: anytype, r: anytype) {
+            CREATE ANNOTATION description := 'gte';
+        };
+        """
+
+    def test_edgeql_syntax_ddl_operator_07(self):
+        """
+        DROP INFIX OPERATOR std::`>=` (l: anytype, r: anytype);
+        """
+
     def test_edgeql_syntax_ddl_cast_01(self):
         """
         CREATE CAST FROM std::str TO std::bool {
@@ -3853,6 +3870,18 @@ aa';
             SET volatility := 'IMMUTABLE';
             USING SQL EXPRESSION;
         };
+        """
+
+    def test_edgeql_syntax_ddl_cast_07(self):
+        """
+        ALTER CAST FROM std::BaseObject TO std::json {
+            CREATE ANNOTATION description := 'json';
+        };
+        """
+
+    def test_edgeql_syntax_ddl_cast_08(self):
+        """
+        DROP CAST FROM std::BaseObject TO std::json;
         """
 
     def test_edgeql_syntax_ddl_property_01(self):


### PR DESCRIPTION
All DDL is now implicitly wrapped into a `CREATE MIGRATION` block.  This
allows safe interoperation between SDL-driven `edgedb migration`
workflows and direct modifications of the schema with DDL.