### PR TITLE
taskgroup: Restore 3.8 compatibility

### DIFF
--- a/edb/common/taskgroup.py
+++ b/edb/common/taskgroup.py
@@ -207,9 +207,14 @@ class TaskGroup:
         # we need a flag to say if a task was cancelled or not.
         # We also need to be able to flip that flag.
 
-        def _task_cancel(self, msg=None):
-            self.__cancel_requested__ = True
-            return asyncio.Task.cancel(self, msg)
+        if sys.version_info >= (3, 9):
+            def _task_cancel(self, msg=None):
+                self.__cancel_requested__ = True
+                return asyncio.Task.cancel(self, msg)
+        else:
+            def _task_cancel(self):
+                self.__cancel_requested__ = True
+                return asyncio.Task.cancel(self)
 
         if hasattr(task, '__cancel_requested__'):
             return


### PR DESCRIPTION
Taskgroup patching code was made incompatible with 3.8 in a01ac6ff1b.

We're not quite ready to completely drop 3.8 compat, so restore
compatibility.