### PR TITLE
Do not perform SQL-level state sync on transaction commands

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1408,7 +1408,12 @@ cdef class EdgeConnection:
                 self.maybe_release_pgcon(conn)
             return
 
-        if not self.dbview.in_tx():
+        if (
+            not self.dbview.in_tx()
+            and not query_unit.tx_id
+            and not query_unit.tx_commit
+            and not query_unit.tx_rollback
+        ):
             state = self.dbview.serialize_state()
         new_types = None
         conn = await self.get_pgcon()

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1478,7 +1478,7 @@ class TestServerProto(tb.QueryTestCase):
         # Test that START TRANSACTION reflects its modes.
 
         try:
-            await self.con.execute('''
+            await self.con.query('''
                 START TRANSACTION ISOLATION SERIALIZABLE, READ ONLY,
                     DEFERRABLE;
             ''')
@@ -1487,13 +1487,13 @@ class TestServerProto(tb.QueryTestCase):
                     edgedb.TransactionError,
                     'read-only transaction'):
 
-                await self.con.execute('''
+                await self.con.query('''
                     INSERT test::Tmp {
                         tmp := 'aaa'
                     };
                 ''')
         finally:
-            await self.con.execute(f'''
+            await self.con.query(f'''
                 ROLLBACK;
             ''')
 


### PR DESCRIPTION
`START TRANSACTION`, `COMMIT` and `ROLLBACK` do not depend on anything
in the state, and running queries before `START TRANSACTION` in the same
`Sync` block breaks it if `START TRANSACTION` has qualifiers.