### PR TITLE
Fix error log spam when running `CREATE ROLE` in `--bootstrap-only`

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -663,6 +663,13 @@ class Server:
 
     async def _signal_sysevent(self, event, **kwargs):
         pgcon = await self._acquire_sys_pgcon()
+        if pgcon is None:
+            # No pgcon means that the server is going down.  This is very
+            # likely if we are doing "run_startup_script_and_exit()",
+            # but is also possible if the server was shut down with
+            # this coroutine as a background task in flight.
+            return
+
         try:
             await pgcon.signal_sysevent(event, **kwargs)
         finally:

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -95,8 +95,9 @@ class TestServerOps(tb.TestCase):
             '--port', 'auto',
             '--testmode',
             '--temp-dir',
-            '--bootstrap-command=SELECT 1',
+            '--bootstrap-command=CREATE SUPERUSER ROLE test_bootstrap;',
             '--bootstrap-only',
+            '--log-level=error',
             '--max-backend-connections', '10',
         ]
 
@@ -120,3 +121,8 @@ class TestServerOps(tb.TestCase):
                 f'server exited with code {proc.returncode}:\n'
                 f'STDERR: {stderr.decode()}',
             )
+
+            if stderr != b'':
+                self.fail(
+                    'Unexpected server error output:\n' + stderr.decode()
+                )


### PR DESCRIPTION
Running the server like this:

   edgedb-server --bootstrap-only --bootstrap-command=CREATE ROLE ...

will currently produce an unpleasant error printout resulting from the
background system event signaling task, which fails because it races
with the server shutdown.  Fix this by checking if we actually have a
live system connection before attempting to signal.