### PR TITLE
Temporarily silence transaction deprecation warnings

### DIFF
--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -107,6 +107,13 @@ class StreamingTestSuite(unittest.TestSuite):
             warnings.resetwarnings()
             warnings.simplefilter('default')
 
+            # This is temporary, until we implement `subtransaction`
+            # functionality of RFC1004
+            warnings.filterwarnings('ignore',
+                message=r'The "transaction\(\)" method is deprecated'
+                        r' and is scheduled to be removed',
+                category=DeprecationWarning)
+
             self._run(test, result)
 
             if ww:

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -109,7 +109,8 @@ class StreamingTestSuite(unittest.TestSuite):
 
             # This is temporary, until we implement `subtransaction`
             # functionality of RFC1004
-            warnings.filterwarnings('ignore',
+            warnings.filterwarnings(
+                'ignore',
                 message=r'The "transaction\(\)" method is deprecated'
                         r' and is scheduled to be removed',
                 category=DeprecationWarning)


### PR DESCRIPTION
Silenced deprecation warnings for `transaction()` until we implement subtransactions, as agreed on last meeting.