### PR TITLE
Mark allow_dml_in_functions as internal

### DIFF
--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -103,6 +103,7 @@ CREATE ABSTRACT TYPE cfg::AbstractConfig extending cfg::ConfigObject {
     CREATE PROPERTY allow_dml_in_functions -> std::bool {
         SET default := false;
         CREATE ANNOTATION cfg::affects_compilation := 'true';
+        CREATE ANNOTATION cfg::internal := 'true';
     };
 
     # Exposed backend settings follow.


### PR DESCRIPTION
`allow_dml_in_functions` is technically an internal stopgap, so we
better mark it accordingly.