### PR TITLE
Fix interactions between inheritance and link deletion policies

### DIFF
--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -146,7 +146,7 @@ CREATE ABSTRACT TYPE schema::AnnotationSubject EXTENDING schema::Object {
     CREATE MULTI LINK annotations EXTENDING schema::reference
     -> schema::Annotation {
         CREATE PROPERTY value -> std::str;
-	ON TARGET DELETE DEFERRED RESTRICT;
+	ON TARGET DELETE ALLOW;
     };
 };
 
@@ -176,7 +176,7 @@ CREATE ABSTRACT TYPE schema::CallableObject
     EXTENDING schema::AnnotationSubject
 {
     CREATE MULTI LINK params -> schema::Parameter {
-        ON TARGET DELETE DEFERRED RESTRICT;
+        ON TARGET DELETE ALLOW;
     };
 
     CREATE LINK return_type -> schema::Type {
@@ -213,7 +213,7 @@ CREATE ABSTRACT TYPE schema::ConsistencySubject EXTENDING schema::Object {
     CREATE MULTI LINK constraints EXTENDING schema::reference
     -> schema::Constraint {
         CREATE CONSTRAINT std::exclusive;
-	ON TARGET DELETE DEFERRED RESTRICT;
+	ON TARGET DELETE ALLOW;
     };
 };
 
@@ -231,7 +231,7 @@ CREATE TYPE schema::Index EXTENDING schema::AnnotationSubject {
 CREATE ABSTRACT TYPE schema::Source EXTENDING schema::Object {
     CREATE MULTI LINK indexes -> schema::Index {
         CREATE CONSTRAINT std::exclusive;
-	ON TARGET DELETE DEFERRED RESTRICT;
+	ON TARGET DELETE ALLOW;
     };
 };
 
@@ -252,7 +252,7 @@ CREATE ABSTRACT TYPE schema::Pointer
 ALTER TYPE schema::Source {
     CREATE MULTI LINK pointers EXTENDING schema::reference -> schema::Pointer {
         CREATE CONSTRAINT std::exclusive;
-	ON TARGET DELETE DEFERRED RESTRICT;
+	ON TARGET DELETE ALLOW;
     };
 };
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -146,6 +146,7 @@ CREATE ABSTRACT TYPE schema::AnnotationSubject EXTENDING schema::Object {
     CREATE MULTI LINK annotations EXTENDING schema::reference
     -> schema::Annotation {
         CREATE PROPERTY value -> std::str;
+	ON TARGET DELETE DEFERRED RESTRICT;
     };
 };
 
@@ -175,7 +176,7 @@ CREATE ABSTRACT TYPE schema::CallableObject
     EXTENDING schema::AnnotationSubject
 {
     CREATE MULTI LINK params -> schema::Parameter {
-        ON TARGET DELETE ALLOW;
+        ON TARGET DELETE DEFERRED RESTRICT;
     };
 
     CREATE LINK return_type -> schema::Type {
@@ -212,6 +213,7 @@ CREATE ABSTRACT TYPE schema::ConsistencySubject EXTENDING schema::Object {
     CREATE MULTI LINK constraints EXTENDING schema::reference
     -> schema::Constraint {
         CREATE CONSTRAINT std::exclusive;
+	ON TARGET DELETE DEFERRED RESTRICT;
     };
 };
 
@@ -229,6 +231,7 @@ CREATE TYPE schema::Index EXTENDING schema::AnnotationSubject {
 CREATE ABSTRACT TYPE schema::Source EXTENDING schema::Object {
     CREATE MULTI LINK indexes -> schema::Index {
         CREATE CONSTRAINT std::exclusive;
+	ON TARGET DELETE DEFERRED RESTRICT;
     };
 };
 
@@ -249,6 +252,7 @@ CREATE ABSTRACT TYPE schema::Pointer
 ALTER TYPE schema::Source {
     CREATE MULTI LINK pointers EXTENDING schema::reference -> schema::Pointer {
         CREATE CONSTRAINT std::exclusive;
+	ON TARGET DELETE DEFERRED RESTRICT;
     };
 };
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -109,13 +109,17 @@ CREATE ABSTRACT TYPE schema::CollectionType EXTENDING schema::Type;
 
 
 CREATE TYPE schema::Array EXTENDING schema::CollectionType {
-    CREATE REQUIRED LINK element_type -> schema::Type;
+    CREATE REQUIRED LINK element_type -> schema::Type {
+        ON TARGET DELETE DEFERRED RESTRICT;
+    };
     CREATE PROPERTY dimensions -> array<std::int16>;
 };
 
 
 CREATE TYPE schema::TupleElement {
-    CREATE REQUIRED LINK type -> schema::Type;
+    CREATE REQUIRED LINK type -> schema::Type {
+        ON TARGET DELETE DEFERRED RESTRICT;
+    };
     CREATE PROPERTY name -> std::str;
 };
 
@@ -157,7 +161,9 @@ EXTENDING schema::SubclassableObject {
 
 
 CREATE TYPE schema::Parameter EXTENDING schema::Object {
-    CREATE REQUIRED LINK type -> schema::Type;
+    CREATE REQUIRED LINK type -> schema::Type {
+        ON TARGET DELETE DEFERRED RESTRICT;
+    };
     CREATE REQUIRED PROPERTY typemod -> schema::TypeModifier;
     CREATE REQUIRED PROPERTY kind -> schema::ParameterKind;
     CREATE REQUIRED PROPERTY num -> std::int64;
@@ -172,7 +178,9 @@ CREATE ABSTRACT TYPE schema::CallableObject
         ON TARGET DELETE ALLOW;
     };
 
-    CREATE LINK return_type -> schema::Type;
+    CREATE LINK return_type -> schema::Type {
+        ON TARGET DELETE DEFERRED RESTRICT;
+    };
     CREATE PROPERTY return_typemod -> schema::TypeModifier;
 };
 
@@ -248,7 +256,9 @@ ALTER TYPE schema::Source {
 CREATE TYPE schema::Alias EXTENDING schema::AnnotationSubject
 {
     CREATE REQUIRED PROPERTY expr -> std::str;
-    CREATE REQUIRED LINK type -> schema::Type;
+    CREATE REQUIRED LINK type -> schema::Type {
+        ON TARGET DELETE DEFERRED RESTRICT;
+    };
 };
 
 
@@ -287,7 +297,9 @@ CREATE TYPE schema::Property EXTENDING schema::Pointer;
 
 ALTER TYPE schema::Pointer {
     CREATE LINK source -> schema::Source;
-    CREATE LINK target -> schema::Type;
+    CREATE LINK target -> schema::Type {
+        ON TARGET DELETE DEFERRED RESTRICT;
+    }
 };
 
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1243,6 +1243,11 @@ def process_link_update(
             #
             # The actual work is done via raise_on_null injection performed
             # by "process_link_values()" below (hence "enforce_cardinality").
+            #
+            # The other part of this enforcement is in doing it when a
+            # target is deleted and the link policy is ALLOW. This is
+            # handled in _get_outline_link_trigger_proc_text in
+            # pgsql/delta.py.
 
             # Turn `foo := <expr>` into just `foo`.
             ptr_ref_set = irast.Set(

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2064,7 +2064,11 @@ class CreateUnionType(
 
 class ObjectTypeMetaCommand(AliasCapableObjectMetaCommand,
                             CompositeObjectMetaCommand):
-    pass
+    def schedule_endpoint_delete_action_update(self, obj, schema, context):
+        endpoint_delete_actions = context.get(
+            sd.DeltaRootContext).op.update_endpoint_delete_actions
+        changed_targets = endpoint_delete_actions.changed_targets
+        changed_targets.add((self, obj))
 
 
 class CreateObjectType(ObjectTypeMetaCommand,
@@ -2088,6 +2092,8 @@ class CreateObjectType(ObjectTypeMetaCommand,
         if self.update_search_indexes:
             schema = self.update_search_indexes.apply(schema, context)
             self.pgops.add(self.update_search_indexes)
+
+        self.schedule_endpoint_delete_action_update(self.scls, schema, context)
 
         return schema
 
@@ -2183,6 +2189,8 @@ class RebaseObjectType(ObjectTypeMetaCommand,
         if has_table(result, schema):
             self.update_base_inhviews_on_rebase(
                 schema, orig_schema, context, self.scls)
+
+        self.schedule_endpoint_delete_action_update(self.scls, schema, context)
 
         return schema
 
@@ -3370,6 +3378,10 @@ class RebaseLink(LinkMetaCommand, adapts=s_links.RebaseLink):
             self.update_base_inhviews_on_rebase(
                 schema, orig_schema, context, source)
 
+        if not source.is_pure_computable(schema):
+            self.schedule_endpoint_delete_action_update(
+                source, orig_schema, schema, context)
+
         return schema
 
 
@@ -3478,7 +3490,12 @@ class AlterLink(LinkMetaCommand, adapts=s_links.AlterLink):
                 schema=schema,
                 context=context,
             )
-            if otd and not link.is_pure_computable(schema):
+            card = self.get_resolved_attribute_value(
+                'cardinality',
+                schema=schema,
+                context=context,
+            )
+            if (otd or card) and not link.is_pure_computable(schema):
                 self.schedule_endpoint_delete_action_update(
                     link, orig_schema, schema, context)
 
@@ -3536,9 +3553,8 @@ class DeleteLink(LinkMetaCommand, adapts=s_links.DeleteLink):
                         update_descendants=True,
                     )
 
-            if link.get_owned(orig_schema):
-                self.schedule_endpoint_delete_action_update(
-                    link, orig_schema, schema, context)
+            self.schedule_endpoint_delete_action_update(
+                link, orig_schema, schema, context)
 
             self.attach_alter_table(context)
 
@@ -3939,9 +3955,11 @@ class UpdateEndpointDeleteActions(MetaCommand):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.link_ops = []
+        self.changed_targets = set()
 
-    def _get_link_table_union(self, schema, links) -> str:
+    def _get_link_table_union(self, schema, links, include_children) -> str:
         selects = []
+        aspect = 'inhview' if include_children else None
         for link in links:
             selects.append(textwrap.dedent('''\
                 (SELECT
@@ -3953,13 +3971,19 @@ class UpdateEndpointDeleteActions(MetaCommand):
                 id=ql(str(link.id)),
                 src=common.quote_ident('source'),
                 tgt=common.quote_ident('target'),
-                table=common.get_backend_name(schema, link),
+                table=common.get_backend_name(
+                    schema,
+                    link,
+                    aspect=aspect,
+                ),
             ))
 
         return '(' + '\nUNION ALL\n    '.join(selects) + ') as q'
 
-    def _get_inline_link_table_union(self, schema, links) -> str:
+    def _get_inline_link_table_union(
+            self, schema, links, include_children) -> str:
         selects = []
+        aspect = 'inhview' if include_children else None
         for link in links:
             link_psi = types.get_pointer_storage_info(link, schema=schema)
             link_col = link_psi.column_name
@@ -3976,7 +4000,7 @@ class UpdateEndpointDeleteActions(MetaCommand):
                 table=common.get_backend_name(
                     schema,
                     link.get_source(schema),
-                    aspect='inhview',
+                    aspect=aspect,
                 ),
             ))
 
@@ -4052,7 +4076,11 @@ class UpdateEndpointDeleteActions(MetaCommand):
 
         for action, links in groups:
             if action is DA.Restrict or action is DA.DeferredRestrict:
-                tables = self._get_link_table_union(schema, links)
+                # Inherited link targets with restrict actions are
+                # elided by apply() to enable us to use inhviews here
+                # when looking for live references.
+                tables = self._get_link_table_union(
+                    schema, links, include_children=True)
 
                 text = textwrap.dedent('''\
                     SELECT
@@ -4117,7 +4145,8 @@ class UpdateEndpointDeleteActions(MetaCommand):
                     sources[link.get_source(schema)].append(link)
 
                 for source, source_links in sources.items():
-                    tables = self._get_link_table_union(schema, source_links)
+                    tables = self._get_link_table_union(
+                        schema, source_links, include_children=False)
 
                     text = textwrap.dedent('''\
                         DELETE FROM
@@ -4170,7 +4199,11 @@ class UpdateEndpointDeleteActions(MetaCommand):
 
         for action, links in groups:
             if action is DA.Restrict or action is DA.DeferredRestrict:
-                tables = self._get_inline_link_table_union(schema, links)
+                # Inherited link targets with restrict actions are
+                # elided by apply() to enable us to use inhviews here
+                # when looking for live references.
+                tables = self._get_inline_link_table_union(
+                    schema, links, include_children=True)
 
                 text = textwrap.dedent('''\
                     SELECT
@@ -4237,7 +4270,7 @@ class UpdateEndpointDeleteActions(MetaCommand):
 
                 for source, source_links in sources.items():
                     tables = self._get_inline_link_table_union(
-                        schema, source_links)
+                        schema, source_links, include_children=False)
 
                     text = textwrap.dedent('''\
                         DELETE FROM
@@ -4277,46 +4310,60 @@ class UpdateEndpointDeleteActions(MetaCommand):
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> s_schema.Schema:
-        if not self.link_ops:
+        if not self.link_ops and not self.changed_targets:
             return schema
 
         DA = s_links.LinkTargetDeleteAction
 
         affected_sources = set()
-        affected_targets = set()
-        deletions = False
+        affected_targets = {t for _, t in self.changed_targets}
+        modifications = any(
+            isinstance(op, RebaseObjectType) and op.removed_bases
+            for op, _ in self.changed_targets
+        )
 
         for link_op, link, orig_schema in self.link_ops:
+            # If our link has a restrict policy, we don't need to update
+            # the target on changes to inherited links.
+            # Most importantly, this optimization lets us avoid updating
+            # the triggers for every schema::Type subtype every time a
+            # new object type is created containing a __type__ link.
+            eff_schema = (
+                orig_schema if isinstance(link_op, DeleteLink) else schema)
+            action = link.get_on_target_delete(eff_schema)
+            target_is_affected = not (
+                (action is DA.Restrict or action is DA.DeferredRestrict)
+                and link.get_implicit_bases(eff_schema)
+            )
+
+            if (
+                link.generic(eff_schema)
+                or link.is_pure_computable(eff_schema)
+            ):
+                continue
+
+            source = link.get_source(eff_schema)
+            target = link.get_target(eff_schema)
+
+            if not isinstance(link_op, CreateLink):
+                modifications = True
+
             if isinstance(link_op, DeleteLink):
-                if (link.generic(orig_schema)
-                        or not link.get_owned(orig_schema)
-                        or link.is_pure_computable(orig_schema)):
-                    continue
-                source = link.get_source(orig_schema)
                 current_source = orig_schema.get_by_id(source.id, None)
                 if (current_source is not None
                         and not current_source.is_view(orig_schema)):
                     affected_sources.add((current_source, orig_schema))
-                target = link.get_target(orig_schema)
                 current_target = schema.get_by_id(target.id, None)
-                if current_target is not None:
+                if target_is_affected and current_target is not None:
                     affected_targets.add(current_target)
-                deletions = True
             else:
-                if (
-                    link.generic(schema)
-                    or not link.get_owned(schema)
-                    or link.is_pure_computable(schema)
-                ):
-                    continue
-                source = link.get_source(schema)
                 if source.is_view(schema):
                     continue
 
                 affected_sources.add((source, schema))
 
-                target = link.get_target(schema)
-                affected_targets.add(target)
+                if target_is_affected:
+                    affected_targets.add(target)
 
                 if isinstance(link_op, AlterLink):
                     orig_target = link.get_target(orig_schema)
@@ -4331,7 +4378,6 @@ class UpdateEndpointDeleteActions(MetaCommand):
 
             for link in source.get_pointers(src_schema).objects(src_schema):
                 if (not isinstance(link, s_links.Link)
-                        or not link.get_owned(src_schema)
                         or link.is_pure_computable(src_schema)):
                     continue
                 ptr_stor_info = types.get_pointer_storage_info(
@@ -4345,35 +4391,68 @@ class UpdateEndpointDeleteActions(MetaCommand):
                 key=lambda l: (l.get_on_target_delete(src_schema),
                                l.get_name(src_schema)))
 
-            if links or deletions:
+            if links or modifications:
                 self._update_action_triggers(
                     src_schema, source, links, disposition='source')
 
+        # All descendants of affected targets also need to have their
+        # triggers updated, so track them down.
+        all_affected_targets = set()
         for target in affected_targets:
+            union_of = target.get_union_of(schema)
+            if union_of:
+                objtypes = tuple(union_of.objects(schema))
+            else:
+                objtypes = (target,)
+
+            for objtype in objtypes:
+                all_affected_targets.add(objtype)
+                for descendant in objtype.descendants(schema):
+                    if has_table(descendant, schema):
+                        all_affected_targets.add(descendant)
+
+        for target in all_affected_targets:
             deferred_links = []
             deferred_inline_links = []
             links = []
             inline_links = []
 
-            for link in schema.get_referrers(target, scls_type=s_links.Link,
-                                             field_name='target'):
-                if (not link.get_owned(schema)
-                        or link.is_pure_computable(schema)):
+            inbound_links = schema.get_referrers(
+                target, scls_type=s_links.Link, field_name='target')
+
+            # We need to look at all inbound links to all ancestors
+            for ancestor in target.get_ancestors(schema).objects(schema):
+                inbound_links |= schema.get_referrers(
+                    ancestor, scls_type=s_links.Link, field_name='target')
+
+            for link in inbound_links:
+                if link.is_pure_computable(schema):
                     continue
+                action = link.get_on_target_delete(schema)
+
+                # Enforcing link deletion policies on targets are
+                # handled by looking at the inheritance views, when
+                # restrict is the policy.
+                # If the policy is allow or delete source, we need to
+                # actually process this for each link.
+                if (
+                    (action is DA.Restrict or action is DA.DeferredRestrict)
+                    and link.get_implicit_bases(schema)
+                ):
+                    continue
+
                 source = link.get_source(schema)
                 if source.is_view(schema):
                     continue
                 ptr_stor_info = types.get_pointer_storage_info(
                     link, schema=schema)
                 if ptr_stor_info.table_type != 'link':
-                    if (link.get_on_target_delete(schema)
-                            is DA.DeferredRestrict):
+                    if action is DA.DeferredRestrict:
                         deferred_inline_links.append(link)
                     else:
                         inline_links.append(link)
                 else:
-                    if (link.get_on_target_delete(schema)
-                            is DA.DeferredRestrict):
+                    if action is DA.DeferredRestrict:
                         deferred_links.append(link)
                     else:
                         links.append(link)
@@ -4392,21 +4471,21 @@ class UpdateEndpointDeleteActions(MetaCommand):
             deferred_inline_links.sort(
                 key=lambda l: l.get_name(schema))
 
-            if links or deletions:
+            if links or modifications:
                 self._update_action_triggers(
                     schema, target, links, disposition='target')
 
-            if inline_links or deletions:
+            if inline_links or modifications:
                 self._update_action_triggers(
                     schema, target, inline_links,
                     disposition='target', inline=True)
 
-            if deferred_links or deletions:
+            if deferred_links or modifications:
                 self._update_action_triggers(
                     schema, target, deferred_links,
                     disposition='target', deferred=True)
 
-            if deferred_inline_links or deletions:
+            if deferred_inline_links or modifications:
                 self._update_action_triggers(
                     schema, target, deferred_inline_links,
                     disposition='target', deferred=True,
@@ -4423,73 +4502,59 @@ class UpdateEndpointDeleteActions(MetaCommand):
             deferred: bool=False,
             inline: bool=False) -> None:
 
-        union_of = objtype.get_union_of(schema)
-        if union_of:
-            objtypes = tuple(union_of.objects(schema))
+        table_name = common.get_backend_name(
+            schema, objtype, catenate=False)
+
+        trigger_name = self.get_trigger_name(
+            schema, objtype, disposition=disposition,
+            deferred=deferred, inline=inline)
+
+        proc_name = self.get_trigger_proc_name(
+            schema, objtype, disposition=disposition,
+            deferred=deferred, inline=inline)
+
+        trigger = dbops.Trigger(
+            name=trigger_name, table_name=table_name,
+            events=('delete',), procedure=proc_name,
+            is_constraint=True, inherit=True, deferred=deferred)
+
+        if links:
+            proc_text = self.get_trigger_proc_text(
+                objtype, links, disposition=disposition,
+                inline=inline, schema=schema)
+
+            trig_func = dbops.Function(
+                name=proc_name, text=proc_text, volatility='volatile',
+                returns='trigger', language='plpgsql')
+
+            self.pgops.add(dbops.CreateOrReplaceFunction(trig_func))
+
+            self.pgops.add(dbops.CreateTrigger(
+                trigger, neg_conditions=[dbops.TriggerExists(
+                    trigger_name=trigger_name, table_name=table_name
+                )]
+            ))
         else:
-            objtypes = (objtype,)
-
-        all_objtypes = set()
-        for objtype in objtypes:
-            all_objtypes.add(objtype)
-            for descendant in objtype.descendants(schema):
-                if has_table(descendant, schema):
-                    all_objtypes.add(descendant)
-
-        for objtype in all_objtypes:
-            table_name = common.get_backend_name(
-                schema, objtype, catenate=False)
-
-            trigger_name = self.get_trigger_name(
-                schema, objtype, disposition=disposition,
-                deferred=deferred, inline=inline)
-
-            proc_name = self.get_trigger_proc_name(
-                schema, objtype, disposition=disposition,
-                deferred=deferred, inline=inline)
-
-            trigger = dbops.Trigger(
-                name=trigger_name, table_name=table_name,
-                events=('delete',), procedure=proc_name,
-                is_constraint=True, inherit=True, deferred=deferred)
-
-            if links:
-                proc_text = self.get_trigger_proc_text(
-                    objtype, links, disposition=disposition,
-                    inline=inline, schema=schema)
-
-                trig_func = dbops.Function(
-                    name=proc_name, text=proc_text, volatility='volatile',
-                    returns='trigger', language='plpgsql')
-
-                self.pgops.add(dbops.CreateOrReplaceFunction(trig_func))
-
-                self.pgops.add(dbops.CreateTrigger(
-                    trigger, neg_conditions=[dbops.TriggerExists(
-                        trigger_name=trigger_name, table_name=table_name
+            self.pgops.add(
+                dbops.DropTrigger(
+                    trigger,
+                    conditions=[dbops.TriggerExists(
+                        trigger_name=trigger_name,
+                        table_name=table_name,
                     )]
-                ))
-            else:
-                self.pgops.add(
-                    dbops.DropTrigger(
-                        trigger,
-                        conditions=[dbops.TriggerExists(
-                            trigger_name=trigger_name,
-                            table_name=table_name,
-                        )]
-                    )
                 )
+            )
 
-                self.pgops.add(
-                    dbops.DropFunction(
+            self.pgops.add(
+                dbops.DropFunction(
+                    name=proc_name,
+                    args=[],
+                    conditions=[dbops.FunctionExists(
                         name=proc_name,
                         args=[],
-                        conditions=[dbops.FunctionExists(
-                            name=proc_name,
-                            args=[],
-                        )]
-                    )
+                    )]
                 )
+            )
 
 
 @dataclasses.dataclass

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -582,17 +582,6 @@ def generate_structure(schema: s_schema.Schema) -> SchemaReflectionParts:
 
                 ref_ptr = schema_cls.getptr(
                     schema, sn.UnqualName(refdict.attr))
-            else:
-                schema = _run_ddl(
-                    f'''
-                        ALTER TYPE {rschema_name} {{
-                            ALTER LINK {refdict.attr}
-                            ON TARGET DELETE ALLOW;
-                        }}
-                    ''',
-                    schema=schema,
-                    delta=delta,
-                )
 
             assert isinstance(ref_ptr, s_links.Link)
 

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -963,16 +963,8 @@ def write_meta_delete_object(
             if layout_entry.reflection_proxy
         ]
 
-        operations = []
-        if proxy_links:
-            # Link deletion triggers apparently don't work for the
-            # schema tables, and so we need to clear out the proxy
-            # links manually before we delete them.
-            sets = [f'{link} := {{}}' for link in proxy_links]
-            operations.append(f'(UPDATE D SET {{ {", ".join(sets)} }})')
-
         to_delete = ['D'] + [f'D.{link}' for link in proxy_links]
-        operations += [f'(DELETE {x})' for x in to_delete]
+        operations = [f'(DELETE {x})' for x in to_delete]
         query = f'''
             WITH D := (SELECT schema::{mcls.__name__}
                        FILTER .name__internal = <str>$__classname),

--- a/tests/schemas/link_tgt_del.esdl
+++ b/tests/schemas/link_tgt_del.esdl
@@ -65,3 +65,11 @@ type ObjectType4 {
 type ObjectType5 {
     link foo -> Target1;
 }
+
+abstract type AbsSource1 extending Named {
+    link tgt1_del_source -> Target1 {
+        on target delete delete source;
+    }
+}
+
+type ChildSource1 extending AbsSource1;

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -10508,6 +10508,115 @@ type test::Foo {
             DELETE Tgt;
         """)
 
+    async def test_edgeql_ddl_link_policy_10(self):
+        # Make sure we NULL out the pointer on the delete, which will
+        # trigger the constraint
+        await self.con.execute(r"""
+            SET MODULE test;
+
+            CREATE TYPE Tgt;
+            CREATE TYPE Foo {
+                CREATE LINK tgt -> Tgt {
+                    ON TARGET DELETE ALLOW;
+                };
+                CREATE CONSTRAINT expression on (EXISTS .tgt);
+
+            };
+            CREATE TYPE Bar EXTENDING Foo;
+        """)
+
+        await self.con.execute(r"""
+            INSERT Bar { tgt := (INSERT Tgt) };
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            'invalid Bar',
+        ):
+            await self.con.execute("""
+                DELETE Tgt;
+            """)
+
+        await self.con.execute("""
+            DELETE Bar;
+            DELETE Tgt;
+        """)
+
+    @test.xfail('''
+        We can't properly compile the constraint here in the basic case,
+        let alone combined with DELETE ALLOW.
+
+        We probably should be rejecting the constraint.
+    ''')
+    async def test_edgeql_ddl_link_policy_11(self):
+        # Should we even be allowing (EXISTS .tgt) as a constraint?
+        await self.con.execute(r"""
+            SET MODULE test;
+
+            CREATE TYPE Tgt;
+            CREATE TYPE Foo {
+                CREATE MULTI LINK tgt -> Tgt {
+                    ON TARGET DELETE ALLOW;
+                };
+                CREATE CONSTRAINT expression on (EXISTS .tgt);
+
+            };
+            CREATE TYPE Bar EXTENDING Foo;
+        """)
+
+        await self.con.execute(r"""
+            INSERT Bar { tgt := (INSERT Tgt) };
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            'invalid Bar',
+        ):
+            await self.con.execute("""
+                DELETE Tgt;
+            """)
+
+        await self.con.execute("""
+            DELETE Bar;
+            DELETE Tgt;
+        """)
+
+    @test.xfail('''
+        We don't handle this correctly because we do REQUIRED MULTI
+        enforcement on the query end.
+
+        We should maybe disallow REQUIRED MULTI ON TARGET DELETE ALLOW.
+    ''')
+    async def test_edgeql_ddl_link_policy_12(self):
+        await self.con.execute(r"""
+            SET MODULE test;
+
+            CREATE TYPE Tgt;
+            CREATE TYPE Foo {
+                CREATE REQUIRED MULTI LINK tgt -> Tgt {
+                    ON TARGET DELETE ALLOW;
+                };
+            };
+            CREATE TYPE Bar EXTENDING Foo;
+        """)
+
+        await self.con.execute(r"""
+            INSERT Bar { tgt := (INSERT Tgt) };
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            "missing value for required link 'tgt'",
+        ):
+            await self.con.execute("""
+                DELETE Tgt;
+            """)
+
+        await self.con.execute("""
+            DELETE Bar;
+            DELETE Tgt;
+        """)
+
 
 class TestConsecutiveMigrations(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
Rework the creation of link deletion policies to ensure that the
proper triggers always get created and deleted in the presence of
inheritance, rebases, and changes to cardinality and link policies.

Actually creating all the proper triggers caused some grief updating
the reflection schema, so most links pointing to schema::Type now have
`ON TARGET DELETE DEFERRED RESTRICT`. (In addition to the magically
implicit `ON TARGET DELETE ALLOW` inserted for all refdicts.)

Fixes #2231. Fixes #2232.