### PR TITLE
Catch more errors in constraints and report them better

### DIFF
--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -326,3 +326,10 @@ def contains_dml(stmt: irast.Base, *, skip_bindings: bool=False) -> bool:
     visitor = ContainsDMLVisitor(skip_bindings=skip_bindings)
     res = visitor.visit(stmt) is True
     return res
+
+
+def contains_set_of_op(ir: irast.Base) -> bool:
+    flt = (lambda n: isinstance(n, irast.Call)
+           and any(x == ft.TypeModifier.SetOfType
+                   for x in n.params_typemods))
+    return bool(ast.find_children(ir, flt, terminate_early=True))

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1326,7 +1326,8 @@ class CreateConstraint(
             schemac_to_backendc = \
                 schemamech.ConstraintMech.\
                 schema_constraint_to_backend_constraint
-            bconstr = schemac_to_backendc(subject, constraint, schema, context)
+            bconstr = schemac_to_backendc(
+                subject, constraint, schema, context, self.source_context)
 
             op = dbops.CommandGroup(priority=1)
             op.add_command(bconstr.create_ops())
@@ -1352,11 +1353,13 @@ class RenameConstraint(
                 schemamech.ConstraintMech.\
                 schema_constraint_to_backend_constraint
 
-            bconstr = schemac_to_backendc(subject, constraint, schema, context)
+            bconstr = schemac_to_backendc(
+                subject, constraint, schema, context, self.source_context)
 
             orig_subject = constraint.get_subject(orig_schema)
             orig_bconstr = schemac_to_backendc(
-                orig_subject, constraint, orig_schema, context
+                orig_subject, constraint, orig_schema, context,
+                self.source_context,
             )
 
             op = dbops.CommandGroup(priority=1)
@@ -1403,13 +1406,15 @@ class AlterConstraint(
                 schemamech.ConstraintMech.\
                 schema_constraint_to_backend_constraint
 
-            bconstr = schemac_to_backendc(subject, constraint, schema, context)
+            bconstr = schemac_to_backendc(
+                subject, constraint, schema, context, self.source_context)
 
             orig_bconstr = schemac_to_backendc(
                 constraint.get_subject(orig_schema),
                 constraint,
                 orig_schema,
                 context,
+                self.source_context,
             )
 
             op = dbops.CommandGroup(priority=1)
@@ -1422,12 +1427,14 @@ class AlterConstraint(
                         child,
                         orig_schema,
                         context,
+                        self.source_context,
                     )
                     cbconstr = schemac_to_backendc(
                         child.get_subject(schema),
                         child,
                         schema,
                         context,
+                        self.source_context,
                     )
                     op.add_command(cbconstr.alter_ops(orig_cbconstr))
             elif not self.constraint_is_effective(schema, constraint):
@@ -1439,12 +1446,14 @@ class AlterConstraint(
                         child,
                         orig_schema,
                         context,
+                        self.source_context,
                     )
                     cbconstr = schemac_to_backendc(
                         child.get_subject(schema),
                         child,
                         schema,
                         context,
+                        self.source_context,
                     )
                     op.add_command(cbconstr.alter_ops(orig_cbconstr))
             else:
@@ -1473,7 +1482,8 @@ class DeleteConstraint(
                     schemamech.ConstraintMech.\
                     schema_constraint_to_backend_constraint
                 bconstr = schemac_to_backendc(
-                    subject, constraint, orig_schema, context)
+                    subject, constraint, orig_schema, context,
+                    self.source_context)
 
                 op = dbops.CommandGroup()
                 op.add_command(bconstr.delete_ops())

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -191,7 +191,7 @@ class ConstraintMech:
             raise errors.InvalidConstraintDefinitionError(
                 f'Constraint {constraint.get_displayname(schema)} on '
                 f'{subject.get_displayname(schema)} is not supported '
-                f'because it would depend on multiple tables',
+                f'because it would depend on multiple objects',
                 context=source_context,
             )
         elif ref_tables:

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -160,7 +160,7 @@ class ConstraintMech:
 
     @classmethod
     def schema_constraint_to_backend_constraint(
-            cls, subject, constraint, schema, context):
+            cls, subject, constraint, schema, context, source_context):
         assert constraint.get_subject(schema) is not None
 
         constraint_origin = cls._get_constraint_origin(schema, constraint)
@@ -188,8 +188,12 @@ class ConstraintMech:
         ref_tables = get_ref_storage_info(ir.schema, terminal_refs)
 
         if len(ref_tables) > 1:
-            raise ValueError(
-                'backend: multi-table constraints are not currently supported')
+            raise errors.InvalidConstraintDefinitionError(
+                f'Constraint {constraint.get_displayname(schema)} on '
+                f'{subject.get_displayname(schema)} is not supported '
+                f'because it would depend on multiple tables',
+                context=source_context,
+            )
         elif ref_tables:
             subject_db_name, _ = next(iter(ref_tables.items()))
         else:

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -949,7 +949,7 @@ class CreateConstraint(
                             and rptr.ptrref.source_ptr is None
                             and rptr.source.rptr is not None):
                         raise errors.InvalidConstraintDefinitionError(
-                            "Constraints may not traverse links",
+                            "constraints cannot contain paths with more than one hop",
                             context=ref.context,
                         )
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -965,8 +965,8 @@ class CreateConstraint(
             if has_multi and ir_utils.contains_set_of_op(
                     final_subjectexpr.irast):
                 raise errors.InvalidConstraintDefinitionError(
-                    "Constraint referencing MULTI links or properties "
-                    "may not use SET OF operations",
+                    "cannot use aggregate functions or operators "
+                    "in a non-aggregating constraint",
                     context=expr_context
                 )
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -957,8 +957,7 @@ class CreateConstraint(
 
             if has_multi and len(refs) > 1:
                 raise errors.InvalidConstraintDefinitionError(
-                    "Constraint referencing MULTI links or properties "
-                    "may not reference multiple ones",
+                    "cannot reference multiple links or properties in a constraint where at least one link or property is MULTI",
                     context=expr_context
                 )
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -949,7 +949,8 @@ class CreateConstraint(
                             and rptr.ptrref.source_ptr is None
                             and rptr.source.rptr is not None):
                         raise errors.InvalidConstraintDefinitionError(
-                            "constraints cannot contain paths with more than one hop",
+                            "constraints cannot contain paths with more "
+                            "than one hop",
                             context=ref.context,
                         )
 
@@ -957,7 +958,8 @@ class CreateConstraint(
 
             if has_multi and len(refs) > 1:
                 raise errors.InvalidConstraintDefinitionError(
-                    "cannot reference multiple links or properties in a constraint where at least one link or property is MULTI",
+                    "cannot reference multiple links or properties in a "
+                    "constraint where at least one link or property is MULTI",
                     context=expr_context
                 )
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1060,8 +1060,8 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidConstraintDefinitionError,
-            "Constraint referencing MULTI links or properties "
-            "may not reference multiple ones",
+            "cannot reference multiple links or properties in a "
+            "constraint where at least one link or property is MULTI",
         ):
             await self.con.execute("""
                 ALTER TYPE test::ObjCnstr2 {
@@ -1072,8 +1072,8 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidConstraintDefinitionError,
-            "Constraint referencing MULTI links or properties "
-            "may not use SET OF operations",
+            "cannot use aggregate functions or operators in a "
+            "non-aggregating constraint",
         ):
             await self.con.execute("""
                 ALTER TYPE test::ObjCnstr2 {
@@ -1083,8 +1083,8 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidConstraintDefinitionError,
-            "Constraint referencing MULTI links or properties "
-            "may not use SET OF operations",
+            "cannot use aggregate functions or operators in a "
+            "non-aggregating constraint",
         ):
             await self.con.execute("""
                 ALTER TYPE test::ObjCnstr2 {
@@ -1096,7 +1096,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidConstraintDefinitionError,
-            "Constraints may not traverse link",
+            "constraints cannot contain paths with more than one hop",
         ):
             await self.con.execute("""
                 ALTER TYPE test::ObjCnstr2 {
@@ -1106,7 +1106,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidConstraintDefinitionError,
-            "Constraints may not traverse link",
+            "constraints cannot contain paths with more than one hop",
         ):
             await self.con.execute("""
                 ALTER TYPE test::ObjCnstr2 {
@@ -1119,7 +1119,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidConstraintDefinitionError,
-            "not supported because it would depend on multiple tables",
+            "not supported because it would depend on multiple objects",
         ):
             await self.con.execute("""
                 ALTER TYPE test::ObjCnstr2 {


### PR DESCRIPTION
Disallow using EXISTS and other SET OF operations on MULTI pointers
(which was previously accepted but didn't work).

Produce a better error than "ISE: unexpectedly long path in simple
expr" for constraints that try to traverse links.

Turn the "multi-table constraints not supported" ISE into a real error
with a source context.

Fixes: #2207