### PR TITLE
Handle Terminate messages appropriately

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,7 +243,7 @@ jobs:
 
     - name: Install edgedb-server and populate egg-info
       env:
-        CACHE_HIT: ${{ steps.postgres-cache.outputs.cache-hit }}
+        CACHE_HIT: ${{ steps.venv-cache.outputs.cache-hit }}
         BUILD_EXT_MODE: skip
       run: |
         if [[ "$CACHE_HIT" == "true" ]]; then

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -309,19 +309,9 @@ class Compiler:
             raise AssertionError('compiler is not initialized')
         return self._std_schema
 
-    def _in_testmode(self, ctx: CompileContext):
-        current_tx = ctx.state.current_tx()
-        session_config = current_tx.get_session_config()
-
-        return config.lookup(
-            '__internal_testmode',
-            session_config,
-            allow_unrecognized=True,
-        )
-
     def _new_delta_context(self, ctx: CompileContext):
         context = s_delta.CommandContext()
-        context.testmode = self._in_testmode(ctx)
+        context.testmode = self.get_config_val(ctx, '__internal_testmode')
         context.stdmode = ctx.bootstrap_mode
         context.internal_schema_mode = ctx.internal_schema_mode
         context.schema_object_ids = ctx.schema_object_ids
@@ -745,7 +735,7 @@ class Compiler:
             stmt,
             schema=schema,
             modaliases=current_tx.get_modaliases(),
-            testmode=self._in_testmode(ctx),
+            testmode=self.get_config_val(ctx, '__internal_testmode'),
             allow_dml_in_functions=(
                 self.get_config_val(ctx, 'allow_dml_in_functions')),
             schema_object_ids=ctx.schema_object_ids,

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -54,6 +54,7 @@ cdef class Database:
     cdef _invalidate_caches(self)
     cdef _cache_compiled_query(self, key, query_unit)
     cdef _new_view(self, user, query_cache)
+    cdef _remove_view(self, view)
     cdef _update_backend_ids(self, new_types)
     cdef _set_and_signal_new_user_schema(
         self,

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -134,6 +134,9 @@ cdef class Database:
         self._views.add(view)
         return view
 
+    cdef _remove_view(self, view):
+        self._views.remove(view)
+
 
 cdef class DatabaseConnectionView:
 
@@ -662,3 +665,7 @@ cdef class DatabaseIndex:
     def new_view(self, dbname: str, *, user: str, query_cache: bool):
         db = self.get_db(dbname)
         return (<Database>db)._new_view(user, query_cache)
+
+    def remove_view(self, view: DatabaseConnectionView):
+        db = self.get_db(view.dbname)
+        return (<Database>db)._remove_view(view)

--- a/edb/server/protocol/binary.pxd
+++ b/edb/server/protocol/binary.pxd
@@ -84,6 +84,7 @@ cdef class EdgeConnection:
 
         object loop
         readonly dbview.DatabaseConnectionView dbview
+        str dbname
 
         ReadBuffer buffer
 
@@ -121,6 +122,8 @@ cdef class EdgeConnection:
     cdef write(self, WriteBuffer buf)
     cdef flush(self)
     cdef abort(self)
+
+    cdef abort_pinned_pgcon(self)
 
     cdef fallthrough(self)
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -295,6 +295,9 @@ class Server:
         return self._dbindex.new_view(
             dbname, user=user, query_cache=query_cache)
 
+    def remove_dbview(self, dbview):
+        return self._dbindex.remove_view(dbview)
+
     def get_global_schema(self):
         return self._dbindex.get_global_schema()
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ RUNTIME_DEPS = [
     'graphql-core~=3.1.2',
     'promise~=2.2.0',
 
-    'edgedb>=0.13.0a4',
+    'edgedb>=0.13.0a5',
 ]
 
 CYTHON_DEPENDENCY = 'Cython==0.29.21'

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -71,7 +71,11 @@ class TestServerOps(tb.TestCase):
                 # option, we expect this connection to be rejected
                 # and the cluster to be shutdown soon.
                 await edgedb.async_connect(
-                    user='edgedb', host=sd.host, port=sd.port)
+                    user='edgedb',
+                    host=sd.host,
+                    port=sd.port,
+                    wait_until_available=0,
+                )
 
             i = 600 * 5  # Give it up to 5 minutes to cleanup.
             while i > 0:


### PR DESCRIPTION
The `Terminate` protocol message (`b'X'`) is the "negotiated" connection 
termination, when the client asks the server to disconnect and waits for 
the connection to drop.  This ensures that both the client and the server
are in agreement with respect to whether a connection between them still
exists, which is important for cases when a command such as
`DROP DATABASE` immediately follows the client disconnect.

Depends on edgedb/edgedb-python#166

Fixes: #2246