### PR TITLE
Discard Postgres connections on cancellation

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -671,6 +671,12 @@ class Server:
         finally:
             self._release_sys_pgcon()
 
+    async def _cancel_and_discard_pgcon(self, pgcon, dbname) -> None:
+        try:
+            await self._cancel_pgcon_operation(pgcon)
+        finally:
+            self.release_pgcon(dbname, pgcon, discard=True)
+
     async def _signal_sysevent(self, event, **kwargs):
         pgcon = await self._acquire_sys_pgcon()
         if pgcon is None:


### PR DESCRIPTION
When we issue `pg_cancel_backend`, we must discard the Postgres
connection, because we cannot be completely sure about its state.
Postgres cancellation is based on Unix signals and is addressed to the whole
worker process and not a concrete operation.  The result is that we might be
racing with the currently running query and if that completes before the
cancellation signal reaches the backend, we'll be setting a trap for the
_next_ query that is unlucky enough to pick up this Postgres backend
from the connection pool.