### PR TITLE
Don't use exact comparison for floats in tests

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -710,7 +710,7 @@ class ConnectedTestCaseMixin:
             elif isinstance(shape, type):
                 return _assert_type_shape(path, data, shape)
             elif isinstance(shape, float):
-                if not math.isclose(data, shape, rel_tol=1e-04):
+                if not math.isclose(data, shape, rel_tol=1e-04, abs_tol=1e-15):
                     self.fail(
                         f'{message}: not isclose({data}, {shape}) '
                         f'{_format_path(path)}')

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -4258,12 +4258,12 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_math_stddev_pop_01(self):
         await self.assert_query_result(
             r'''SELECT math::stddev_pop(1);''',
-            {0},
+            {0.0},
         )
 
         await self.assert_query_result(
             r'''SELECT math::stddev_pop({1, 1, 1});''',
-            {0},
+            {0.0},
         )
 
         await self.assert_query_result(
@@ -4273,7 +4273,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''SELECT math::stddev_pop({0.1, 0.1, 0.1});''',
-            {0},
+            {0.0},
         )
 
         await self.assert_query_result(
@@ -4452,12 +4452,12 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_math_var_pop_01(self):
         await self.assert_query_result(
             r'''SELECT math::var_pop(1);''',
-            {0},
+            {0.0},
         )
 
         await self.assert_query_result(
             r'''SELECT math::var_pop({1, 1, 1});''',
-            {0},
+            {0.0},
         )
 
         await self.assert_query_result(
@@ -4467,7 +4467,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''SELECT math::var_pop({0.1, 0.1, 0.1});''',
-            {0},
+            {0.0},
         )
 
         await self.assert_query_result(
@@ -4512,7 +4512,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                 WITH
                     MODULE math,
                     X := {1, 2, 1, 2}
-                SELECT var_pop(X) = stddev_pop(X) ^ 2;
+                SELECT abs(var_pop(X) - stddev_pop(X) ^ 2) < 1.0e-15;
             ''',
             {True},
         )
@@ -4522,7 +4522,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                 WITH
                     MODULE math,
                     X := {0.1, 0.2, 0.1, 0.2}
-                SELECT var_pop(X) = stddev_pop(X) ^ 2;
+                SELECT abs(var_pop(X) - stddev_pop(X) ^ 2) < 1.0e-15;
             ''',
             {True},
         )


### PR DESCRIPTION
Floats are not supposed to be compared exactly, but we do that in a
couple of tests.  Fix that.