### PR TITLE
Make direct asyncpg connections to Postgres are consistent with server

### DIFF
--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -152,9 +152,6 @@ class BaseCluster:
                 f'SET ROLE {self._default_session_auth};'
             )
 
-        await conn.execute(
-            "SET IntervalStyle = 'sql_standard';"
-        )
         return conn
 
     def get_runtime_params(self) -> BackendRuntimeParams:
@@ -187,10 +184,19 @@ class BaseCluster:
         for k in ('user', 'password', 'database', 'ssl', 'server_settings'):
             v = getattr(params, k)
             if v is not None:
-                if k == 'server_settings':
-                    v = dict(v)
-                    v['search_path'] = 'edgedb'
                 conn_dict[k] = v
+
+        cluster_settings = conn_dict.get('server_settings', {})
+
+        edgedb_settings = {
+            'client_encoding': 'utf-8',
+            'search_path': 'edgedb',
+            'timezone': 'UTC',
+            'intervalstyle': 'sql_standard',
+            'jit': 'off',
+        }
+
+        conn_dict['server_settings'] = {**cluster_settings, **edgedb_settings}
 
         return conn_dict
 

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -1204,6 +1204,9 @@ cdef class PGConnection:
         buf.write_bytestring(b'intervalstyle')
         buf.write_bytestring(b'sql_standard')
 
+        buf.write_bytestring(b'jit')
+        buf.write_bytestring(b'off')
+
         buf.write_bytestring(b'user')
         buf.write_bytestring(self.pgaddr['user'].encode('utf-8'))
 


### PR DESCRIPTION
When connecting to the underlying Postgres cluster, make sure the same
set of configuration settings is used as the one used by the EdgeDB
server.

Also, disable Postgres JIT explicitly for now to avoid the risk of
runaway query planning costs on complex queries.