### PR TITLE
Update the docs.

### DIFF
--- a/docs/admin/configuration.rst
+++ b/docs/admin/configuration.rst
@@ -55,31 +55,6 @@ Connection Settings
     The TCP port the server listens on; ``5656`` by default.  Note that the
     same port number is used for all IP addresses the server listens on.
 
-:eql:synopsis:`Port`
-    A parameter class that allows configuring application ports with the
-    specified protocol.  Below are the properties of the ``Port`` class.
-    All are required.
-
-    :eql:synopsis:`address (SET OF str)`
-        The TCP/IP address(es) for the application port.
-
-    :eql:synopsis:`port (int16)`
-        The TCP port for the application port.
-
-    :eql:synopsis:`protocol (str)`
-        The protocol for the application port.  Valid values are:
-        ``'graphql+http'`` and ``'edgeql+http'``.
-
-    :eql:synopsis:`database (str)`
-        The name of the database the application port is attached to.
-
-    :eql:synopsis:`user (str)`
-        The name of the database role the application port is attached to.
-
-    :eql:synopsis:`concurrency (int64)`
-        The maximum number of backend connections available for this
-        application port.
-
 :eql:synopsis:`Auth`
     A parameter class that specifies the rules of client authentication.
     Below are the properties of the ``Auth`` class.
@@ -104,24 +79,31 @@ Connection Settings
 Resource Usage
 --------------
 
-:eql:synopsis:`shared_buffers (str)`
-    The amount of memory the database uses for shared memory buffers.
-    Corresponds to the PostgreSQL configuration parameter of the same name.
-    Changing this value requires server restart.
+:eql:synopsis:`effective_io_concurrency (int64)`
+    Sets the number of concurrent disk I/O operations that can be
+    executed simultaneously. Corresponds to the PostgreSQL
+    configuration parameter of the same name.
 
 :eql:synopsis:`query_work_mem (str)`
-    The amount of memory used by internal query operations such as sorting.
-    Corresponds to the PostgreSQL ``work_mem`` configuration parameter.
+    The amount of memory used by internal query operations such as
+    sorting. Corresponds to the PostgreSQL ``work_mem`` configuration
+    parameter.
+
+:eql:synopsis:`shared_buffers (str)`
+    The amount of memory the database uses for shared memory buffers.
+    Corresponds to the PostgreSQL configuration parameter of the same
+    name. Changing this value requires server restart.
 
 
 Query Planning
 --------------
 
-:eql:synopsis:`effective_cache_size (str)`
-    Sets the planner's assumption about the effective size of the disk cache
-    that is available to a single query. Corresponds to the PostgreSQL
-    configuration parameter of the same name
-
 :eql:synopsis:`default_statistics_target (str)`
     Sets the default data statistics target for the planner.
-    Corresponds to the PostgreSQL configuration parameter of the same name
+    Corresponds to the PostgreSQL configuration parameter of the same
+    name.
+
+:eql:synopsis:`effective_cache_size (str)`
+    Sets the planner's assumption about the effective size of the disk
+    cache that is available to a single query. Corresponds to the
+    PostgreSQL configuration parameter of the same name.

--- a/docs/changelog/1_0_b1.rst
+++ b/docs/changelog/1_0_b1.rst
@@ -36,7 +36,8 @@ Let's say we start with the following schema for a simple chat app:
 
 We create a directory ``app_schema`` and write the above into a
 ``app_schema/schema.esdl`` file inside it. Then we can initialize our
-project database by running ``edgedb create-migration``:
+project database by running :ref:`edgedb create-migration
+<ref_cli_edgedb_create_migration>`:
 
 .. code-block:: bash
 
@@ -101,8 +102,9 @@ schema to be:
         }
     };
 
-And we apply the changes by using ``create-migration`` and ``migrate``
-commands again:
+And we apply the changes by using :ref:`edgedb
+create-migration <ref_cli_edgedb_create_migration>` and :ref:`edgedb
+migrate <ref_cli_edgedb_migrate>` commands again:
 
 .. code-block:: bash
 
@@ -123,7 +125,8 @@ commands again:
 
 At this point we may want to actually create a default channel "Main"
 and make the ``channel`` link required. So we alter the schema to make
-the link required and run ``create-migration`` again:
+the link required and run :ref:`edgedb create-migration
+<ref_cli_edgedb_create_migration>` again:
 
 .. code-block:: bash
 
@@ -187,9 +190,10 @@ apply the changes:
 
 The above example shows some of the interactions with the EdgeDB
 migration management tools. We will keep improving the inference
-engine that guides the prompts of ``create-migration``. However, if
-the suggestion engine fails to provide a perfect fit, the option of
-adjusting the migration file is always available.
+engine that guides the prompts of :ref:`edgedb create-migration
+<ref_cli_edgedb_create_migration>`. However, if the suggestion engine
+fails to provide a perfect fit, the option of adjusting the migration
+file is always available.
 
 
 EdgeQL

--- a/docs/cheatsheet/admin.rst
+++ b/docs/cheatsheet/admin.rst
@@ -82,44 +82,6 @@ Remove a specific authentication method:
 ----------
 
 
-Configure a port for accessing ``my_new_project`` database using EdgeQL:
-
-.. code-block:: edgeql-repl
-
-    db> CONFIGURE SYSTEM INSERT Port {
-    ...     protocol := "edgeql+http",
-    ...     database := "my_new_project",
-    ...     address := "127.0.0.1",
-    ...     port := 8889,
-    ...     user := "http",
-    ...     concurrency := 4,
-    ... };
-    CONFIGURE SYSTEM
-
-
-----------
-
-
-.. _ref_cheatsheet_admin_graphql:
-
-Configure a port for accessing ``my_new_project`` database using GraphQL:
-
-.. code-block:: edgeql-repl
-
-    db> CONFIGURE SYSTEM INSERT Port {
-    ...     protocol := "graphql+http",
-    ...     database := "my_new_project",
-    ...     address := "127.0.0.1",
-    ...     port := 8888,
-    ...     user := "http",
-    ...     concurrency := 4,
-    ... };
-    CONFIGURE SYSTEM
-
-
-----------
-
-
 Run a script from command line:
 
 .. cli:synopsis::

--- a/docs/cheatsheet/cli.rst
+++ b/docs/cheatsheet/cli.rst
@@ -76,42 +76,6 @@ Configure access that checks password (with a higher priority):
 ----------
 
 
-Configure a port for accessing ``my_new_project`` database using EdgeQL:
-
-.. code-block:: bash
-
-    $ edgedb -I my_instance configure insert Port \
-    > --protocol edgeql+http \
-    > --database my_new_project \
-    > --address 127.0.0.1 \
-    > --port 8889 \
-    > --user project \
-    > --concurrency 4
-    OK: CONFIGURE SYSTEM
-
-
-----------
-
-
-.. _ref_cheatsheet_admin_graphql:
-
-Configure a port for accessing ``my_new_project`` database using GraphQL:
-
-.. code-block:: bash
-
-    $ edgedb -I my_instance configure insert Port \
-    > --protocol graphql+http \
-    > --database my_new_project \
-    > --address 127.0.0.1 \
-    > --port 8888 \
-    > --user project \
-    > --concurrency 4
-    OK: CONFIGURE SYSTEM
-
-
-----------
-
-
 Connect to the database:
 
 .. code-block:: bash

--- a/docs/cheatsheet/graphql.rst
+++ b/docs/cheatsheet/graphql.rst
@@ -11,9 +11,16 @@ GraphQL
 
 ----------
 
+In order to set up GraphQL access to the database add the following to
+the schema:
 
-For configuring :ref:`GraphQL <ref_graphql_index>` access, :ref:`see
-here <ref_cheatsheet_admin_graphql>`.
+.. code-block:: sdl
+
+    using extension graphql;
+
+Then create a new migration and apply it using :ref:`edgedb
+create-migration <ref_cli_edgedb_create_migration>` and :ref:`edgedb
+migrate <ref_cli_edgedb_migrate>`, respectively.
 
 Select all users in the system:
 

--- a/docs/cheatsheet/migrations.rst
+++ b/docs/cheatsheet/migrations.rst
@@ -5,103 +5,105 @@ Migrations
 
 Migrate to a new schema using SDL:
 
-.. code-block:: edgeql-repl
+.. code-block:: sdl
 
-    db> START MIGRATION TO {
-    ...     module default {
-    ...         abstract type HasImage {
-    ...             # just a URL to the image
-    ...             required property image -> str;
-    ...             index on (.image);
-    ...         }
-    ...         type User extending HasImage {
-    ...             required property name -> str;
-    ...         }
-    ...         type Review {
-    ...             required property body -> str;
-    ...             required property rating -> int64 {
-    ...                 constraint min_value(0);
-    ...                 constraint max_value(5);
-    ...             }
-    ...             required property flag -> bool {
-    ...                 default := False;
-    ...             }
-    ...             required link author -> User;
-    ...             required link movie -> Movie;
-    ...             required property creation_time -> datetime {
-    ...                 default := datetime_current();
-    ...             }
-    ...         }
-    ...         type Person extending HasImage {
-    ...             required property first_name -> str {
-    ...                 default := '';
-    ...             }
-    ...             required property middle_name -> str {
-    ...                 default := '';
-    ...             }
-    ...             required property last_name -> str;
-    ...             property full_name :=
-    ...                 (
-    ...                     (
-    ...                         (.first_name ++ ' ')
-    ...                         IF .first_name != '' ELSE
-    ...                         ''
-    ...                     ) ++
-    ...                     (
-    ...                         (.middle_name ++ ' ')
-    ...                         IF .middle_name != '' ELSE
-    ...                         ''
-    ...                     ) ++
-    ...                     .last_name
-    ...                 );
-    ...             property bio -> str;
-    ...         }
-    ...         abstract link crew {
-    ...             # Provide a way to specify some "natural"
-    ...             # ordering, as relevant to the movie. This
-    ...             # may be order of importance, appearance, etc.
-    ...             property list_order -> int64;
-    ...         }
-    ...         abstract link directors extending crew;
-    ...         abstract link actors extending crew;
-    ...         type Movie extending HasImage {
-    ...             required property title -> str;
-    ...             required property year -> int64;
-    ...             # Add an index for accessing movies by title and year,
-    ...             # separately and in combination.
-    ...             index on (.title);
-    ...             index on (.year);
-    ...             index on ((.title, .year));
-    ...             property description -> str;
-    ...             multi link directors extending crew -> Person;
-    ...             multi link actors extending crew -> Person;
-    ...             property avg_rating :=
-    ...                 math::mean(.<movie[IS Review].rating);
-    ...         }
-    ...         type Label {
-    ...             annotation description :=
-    ...                 'Special label to stick on reviews';
-    ...             required property comments -> str;
-    ...             link review -> Review {
-    ...                 annotation description :=
-    ...                     'This review needs some attention';
-    ...             };
-    ...         }
-    ...         alias ReviewAlias := Review {
-    ...             # It will already have all the Review
-    ...             # properties and links.
-    ...             author_name := .author.name,
-    ...             movie_title := .movie.title,
-    ...         };
-    ...         alias MovieAlias := Movie {
-    ...             # A computable link for accessing all the
-    ...             # reviews for this movie.
-    ...             reviews := .<movie[IS Review]
-    ...         };
-    ...     }
-    ... };
-    START MIGRATION
-    db> POPULATE MIGRATION;
-    POPULATE MIGRATION
-    db> COMMIT MIGRATION;
-    COMMIT MIGRATION
+    module default {
+        abstract type HasImage {
+            # just a URL to the image
+            required property image -> str;
+            index on (.image);
+        }
+        type User extending HasImage {
+            required property name -> str;
+        }
+        type Review {
+            required property body -> str;
+            required property rating -> int64 {
+                constraint min_value(0);
+                constraint max_value(5);
+            }
+            required property flag -> bool {
+                default := False;
+            }
+            required link author -> User;
+            required link movie -> Movie;
+            required property creation_time -> datetime {
+                default := datetime_current();
+            }
+        }
+        type Person extending HasImage {
+            required property first_name -> str {
+                default := '';
+            }
+            required property middle_name -> str {
+                default := '';
+            }
+            required property last_name -> str;
+            property full_name :=
+                (
+                    (
+                        (.first_name ++ ' ')
+                        IF .first_name != '' ELSE
+                        ''
+                    ) ++
+                    (
+                        (.middle_name ++ ' ')
+                        IF .middle_name != '' ELSE
+                        ''
+                    ) ++
+                    .last_name
+                );
+            property bio -> str;
+        }
+        abstract link crew {
+            # Provide a way to specify some "natural"
+            # ordering, as relevant to the movie. This
+            # may be order of importance, appearance, etc.
+            property list_order -> int64;
+        }
+        abstract link directors extending crew;
+        abstract link actors extending crew;
+        type Movie extending HasImage {
+            required property title -> str;
+            required property year -> int64;
+            # Add an index for accessing movies by title and year,
+            # separately and in combination.
+            index on (.title);
+            index on (.year);
+            index on ((.title, .year));
+            property description -> str;
+            multi link directors extending crew -> Person;
+            multi link actors extending crew -> Person;
+            property avg_rating :=
+                math::mean(.<movie[IS Review].rating);
+        }
+        type Label {
+            annotation description :=
+                'Special label to stick on reviews';
+            required property comments -> str;
+            link review -> Review {
+                annotation description :=
+                    'This review needs some attention';
+            };
+        }
+        alias ReviewAlias := Review {
+            # It will already have all the Review
+            # properties and links.
+            author_name := .author.name,
+            movie_title := .movie.title,
+        };
+        alias MovieAlias := Movie {
+            # A computable link for accessing all the
+            # reviews for this movie.
+            reviews := .<movie[IS Review]
+        };
+    };
+
+Create a ``dbschema`` directory, then put the above schema in it as an
+``.esdl`` file, e.g. ``dbschema/schema.esdl``.
+
+Then create a new migration using :ref:`edgedb -I my_instance
+create-migration <ref_cli_edgedb_create_migration>`.
+
+Apply the migration using :ref:`edgedb -I my_instance migrate
+<ref_cli_edgedb_migrate>`.

--- a/docs/cli/__toc__.rst
+++ b/docs/cli/__toc__.rst
@@ -13,4 +13,5 @@ CLI
     edgedb_dump
     edgedb_restore
     edgedb_connopts
+    edgedb_migration
     network

--- a/docs/cli/edgedb_migration.rst
+++ b/docs/cli/edgedb_migration.rst
@@ -1,0 +1,78 @@
+.. _ref_cli_edgedb_migration:
+
+
+===============
+Migration tools
+===============
+
+EdgeDB provides schema migration tools as server-side tools. This
+means that from the point of view of the application migrations are
+language- and platform-agnostic and don't require additional
+libraries.
+
+Using the migration tools is the recommended way to make schema changes.
+
+Setup
+=====
+
+First of all, the migration tools need a place to store the schema and
+migration information. By default they will look in ``dbschema``
+directory, but it's also possible to specify any other location by
+using :cli:synopsis:`schema-dir` option. Inside this directory there
+should be an ``.esdl`` file with :ref:`SDL <ref_eql_sdl>` schema
+description. It's also possible to split the schema definition across
+multiple ``.esdl`` files. The migration tools will read all of them
+and treat them as a single SDL document.
+
+.. _ref_cli_edgedb_create_migration:
+
+Create migration script
+=======================
+
+The next step after setting up the desired target schema is creating a
+migration script. This is done by invoking the following command:
+
+.. cli:synopsis::
+
+    edgedb -I <instance-name> create-migration [migration-option...]
+
+This will start an interactive tool that will provide the user with
+suggestions based on the differences between the current database and
+the schema file. The prompts will look something like this:
+
+.. code-block::
+
+    did you create object type 'default::User'? [y,n,l,c,b,s,q,?]
+    ?
+
+    y - confirm the prompt, use the DDL statements
+    n - reject the prompt
+    l - list the DDL statements associated with prompt
+    c - list already confirmed EdgeQL statements
+    b - revert back to previous save point, perhaps previous question
+    s - stop and save changes (splits migration into multiple)
+    q - quit without saving changes
+    h or ? - print help
+
+.. _ref_cli_edgedb_migrate:
+
+Apply migrations
+================
+
+Once the migration scripts are in place the changes can be applied to
+the database by this command:
+
+.. cli:synopsis::
+
+    edgedb -I <instance-name> migrate [migration-option...]
+
+The tool will find all the unapplied migrations in
+``dbschema/migrations/`` directory and sequentially run them on the
+target instance.
+
+Options
+=======
+
+:cli:synopsis:`schema-dir`
+    The directory that contains the ``.esdl`` schema files and
+    ``migrations`` sub-directory for individual scripts.

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -24,5 +24,7 @@ managing and using an EdgeDB instance.
     +---------------------------------+---------------------------------+
     | :ref:`ref_cli_edgedb_restore`   | Restore an EdgeDB database      |
     +---------------------------------+---------------------------------+
+    | :ref:`ref_cli_edgedb_migration` | EdgeDB migration tools          |
+    +---------------------------------+---------------------------------+
 
 :ref:`Notes on network usage <ref_cli_edgedb_network>`

--- a/docs/clients/90_edgeql/index.rst
+++ b/docs/clients/90_edgeql/index.rst
@@ -10,23 +10,21 @@ stateless protocol, no :ref:`DDL <ref_eql_ddl>`,
 can be executed using this endpoint.  Only one query per request can be
 executed.
 
-Here's an example of configuration that will set up EdgeQL over HTTP
-access to the database:
+In order to set up HTTP access to the database add the following to
+the schema:
 
-.. code-block:: edgeql-repl
+.. code-block:: sdl
 
-    tutorial> CONFIGURE SYSTEM INSERT Port {
-    .........     protocol := "edgeql+http",
-    .........     database := "your_database_name",
-    .........     address := "127.0.0.1",
-    .........     port := 8889,
-    .........     user := "http",
-    .........     concurrency := 4,
-    ......... };
-    CONFIGURE SYSTEM
+    using extension edgeql_http;
 
-This will expose EdgeQL API for the ``"your_database_name"`` database
-on port 8889 (or any other port that was specified).
+Then create a new migration and apply it using :ref:`edgedb
+create-migration <ref_cli_edgedb_create_migration>` and :ref:`edgedb
+migrate <ref_cli_edgedb_migrate>`, respectively.
+
+``http://127.0.0.1:<instance-port>/db/<database-name>/edgeql`` will
+expose GraphQL API. Check the credentials file for your instance at
+``$HOME/.edgedb/credentials`` to find out which port the instance is
+using.
 
 .. toctree::
     :maxdepth: 2

--- a/docs/clients/99_graphql/index.rst
+++ b/docs/clients/99_graphql/index.rst
@@ -6,33 +6,32 @@ GraphQL over HTTP
 
 EdgeDB supports `GraphQL queries`__ natively out of the box. Not
 everything that can be expressed in EdgeQL can easily be queried using
-GraphQL, but generally for complex queries it is useful to set up
-expression aliases and use GraphQL to query them.
+GraphQL, but generally setting up :ref:`aliases <ref_datamodel_aliases>`
+for complex expressions makes it possible to then use use GraphQL to
+query them.
 
 EdgeDB exposes the Types and :ref:`ref_datamodel_aliases` for GraphQL
 querying. Types and expression aliases from the ``default`` module are
 exposed using their short names, whereas items from another module use
 the module name as a prefix.
 
-Here's an example of configuration that will set up GraphQL access to
-the database:
+In order to set up GraphQL access to the database add the following to
+the schema:
 
-.. code-block:: edgeql-repl
+.. code-block:: sdl
 
-    tutorial> CONFIGURE SYSTEM INSERT Port {
-    .........     protocol := "graphql+http",
-    .........     database := "your_database_name",
-    .........     address := "127.0.0.1",
-    .........     port := 8888,
-    .........     user := "http",
-    .........     concurrency := 4,
-    ......... };
-    CONFIGURE SYSTEM
+    using extension graphql;
 
-This will expose the GraphQL API for the ``"your_database_name"`` on port 8888
-(or any other port that was specified).
+Then create a new migration and apply it using :ref:`edgedb
+create-migration <ref_cli_edgedb_create_migration>` and :ref:`edgedb
+migrate <ref_cli_edgedb_migrate>`, respectively.
 
-Pointing your browser to ``http://127.0.0.1:8888/explore``
+``http://127.0.0.1:<instance-port>/db/<database-name>/graphql`` will
+expose GraphQL API. Check the credentials file for your instance at
+``$HOME/.edgedb/credentials`` to find out which port the instance is
+using.
+
+``http://127.0.0.1:<instance-port>/db/<database-name>/graphql/explore``
 will bring up a `GraphiQL`_ interface to EdgeDB. This interface can be
 used to try out queries and explore the GraphQL capabilities.
 

--- a/docs/clients/99_graphql/limitations.rst
+++ b/docs/clients/99_graphql/limitations.rst
@@ -6,8 +6,8 @@ Known Limitations
 
 - Due to the differences between EdgeQL and GraphQL syntax
   :eql:type:`enum <std::enum>` types which have values that cannot be
-  represented as GraphQL identifiers (e.g. ``'N/A'`` or ``'NOT
-  APPLICABLE'``) cannot be properly reflected into GraphQL enums.
+  represented as GraphQL identifiers (e.g. ```N/A``` or ```NOT
+  APPLICABLE```) cannot be properly reflected into GraphQL enums.
 
 - EdgeDB :eql:type:`tuples <std::tuple>` are not supported in GraphQL
   reflection currently.

--- a/docs/edgeql/admin/configure.rst
+++ b/docs/edgeql/admin/configure.rst
@@ -80,18 +80,6 @@ Set the same parameter, but for the current database:
 
     CONFIGURE CURRENT DATABASE SET query_work_mem := '4MB';
 
-Start a new GraphQL app port:
-
-.. code-block:: edgeql
-
-    CONFIGURE SYSTEM INSERT Port {
-        port := 8080,
-        protocol := 'graphql+http',
-        database := 'mydatabase',
-        user := 'http',
-        concurrency := 4
-    };
-
 Remove all Trust authentication methods:
 
 .. code-block:: edgeql

--- a/docs/tutorial/graphql.rst
+++ b/docs/tutorial/graphql.rst
@@ -42,7 +42,12 @@ new migration and apply it:
     Applied m12exapirxxcs227zb2sruf7byvupbt6klkyl5ib6nyklyg3xo5s7a
     (00004.edgeql)
 
-This will expose :ref:`GraphQL API <ref_graphql_index>` on
+This will expose :ref:`GraphQL API <ref_graphql_index>` via ``http``.
+Each EdgeDB instance will be exposed on its corresponding port. Look
+at ``$HOME/.edgedb/credentials/tutorial.json`` file to find out the
+port for the tutorial instance. For the purpose of the example, we'll
+pretend that our tutorial instance is using port 5656 and so the
+GraphQL API is exposed on:
 ``http://127.0.0.1:5656/db/edgedb/graphql``. Pointing your browser to
 ``http://127.0.0.1:5656/db/edgedb/graphql/explore`` will bring up a
 `GraphiQL`_ interface to EdgeDB. This interface can be used to try out


### PR DESCRIPTION
GraphQL and EdgeQL HTTP API should be set-up via
`using extension graphql`.

Update cheatsheets.

Add "Migration tools" section to CLI. Currently it is very brief and
acts as more of a stub.

Issue #2230