### PR TITLE
Fix a bunch of invalid serializations involving shapes and collections

### DIFF
--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -90,6 +90,7 @@ def compile_ir_to_sql_tree(
 
         _ = context.CompilerContext(initial=ctx)
         ctx.singleton_mode = singleton_mode
+        ctx.expr_exposed = True
         qtree = dispatch.compile(ir_expr, ctx=ctx)
 
     except Exception as e:  # pragma: no cover

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -170,9 +170,6 @@ def compile_output(
         ir_set: irast.Set, *,
         ctx: context.CompilerContextLevel) -> pgast.OutputVar:
     with ctx.new() as newctx:
-        if newctx.expr_exposed is None:
-            newctx.expr_exposed = True
-
         dispatch.visit(ir_set, ctx=newctx)
 
         path_id = ir_set.path_id

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2463,7 +2463,8 @@ def process_set_as_agg_expr(
             ctx=xctx)
 
     # Though if the result type is a scalar, the value should be good
-    # enough, so don't generate bad code.
+    # enough, so don't generate a bunch of unnessecary code to produce
+    # a serialized value when we can use value.
     if (
         output.in_serialization_ctx(ctx=ctx)
         and not irtyputils.is_scalar(ir_set.typeref)

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -179,6 +179,13 @@ def get_set_rvar(
                 subctx.path_scope[path_id] = scope_stmt
             relctx.update_scope(ir_set, stmt, ctx=subctx)
 
+        # If the set is a binding, we need to treat it as exposed
+        # because we don't know at this point whether it will be
+        # reused in an exposed context.
+        # (We could avoid this with some more analysis, probably.)
+        if ir_set.is_binding:
+            subctx.expr_exposed = None
+
         rvars = _get_set_rvar(ir_set, ctx=subctx)
 
         if optional_wrapping:
@@ -1660,6 +1667,17 @@ def process_set_as_tuple(
     relctx.ensure_bond_for_expr(ir_set, stmt, ctx=ctx)
     pathctx.put_path_value_var(stmt, ir_set.path_id, set_expr, env=ctx.env)
 
+    # This is an unfortunate hack. If any of those types that we
+    # contain are an object, then force the computation of the
+    # serialized output now. This avoids issues where there may be
+    # references to tuple elements with the same path id but different
+    # shapes, and the delaying induced by a TupleBaseVar can cause the
+    # wrong one to be output. (See test_edgeql_scope_shape_03 for an example
+    # where this can come up.)
+    # (We only do it for objects as an optimization.)
+    if any(irtyputils.is_object(x) for x in ir_set.typeref.subtypes):
+        pathctx.get_path_serialized_output(stmt, ir_set.path_id, env=ctx.env)
+
     return new_stmt_set_rvar(
         ir_set, stmt, aspects=['value', 'source'], ctx=ctx)
 
@@ -2220,8 +2238,10 @@ def process_set_as_func_expr(
         ir_set, set_expr=set_expr, func_rel=func_rel, stmt=stmt, ctx=ctx)
 
 
-def process_set_as_agg_expr(
+def process_set_as_agg_expr_inner(
         ir_set: irast.Set, stmt: pgast.SelectStmt, *,
+        aspect: str,
+        wrapper: Optional[pgast.SelectStmt],
         ctx: context.CompilerContextLevel) -> SetRVars:
     expr = ir_set.expr
     assert isinstance(expr, irast.FunctionCall)
@@ -2258,7 +2278,7 @@ def process_set_as_agg_expr(
                 dispatch.visit(ir_arg, ctx=argctx)
 
                 arg_ref: pgast.BaseExpr
-                if output.in_serialization_ctx(ctx=argctx):
+                if aspect == 'serialized':
                     arg_ref = pathctx.get_path_serialized_or_value_var(
                         argctx.rel, ir_arg.path_id, env=argctx.env)
 
@@ -2386,32 +2406,77 @@ def process_set_as_agg_expr(
     if expr.func_initial_value is not None:
         iv_ir = expr.func_initial_value.expr
 
-        if newctx.expr_exposed and serialization_safe:
+        if serialization_safe and aspect == 'serialized':
             # Serialization has changed the output type.
             with newctx.new() as ivctx:
-                ivctx.expr_exposed = True
                 iv = dispatch.compile(iv_ir, ctx=ivctx)
+
                 iv = output.serialize_expr_if_needed(
                     iv, path_id=ir_set.path_id, ctx=ctx)
                 set_expr = output.serialize_expr_if_needed(
                     set_expr, path_id=ir_set.path_id, ctx=ctx)
         else:
-            iv = dispatch.compile(iv_ir, ctx=newctx)
+            with newctx.new() as ivctx:
+                iv = dispatch.compile(iv_ir, ctx=ivctx)
 
-        pathctx.put_path_value_var(stmt, ir_set.path_id, set_expr, env=ctx.env)
-        pathctx.get_path_value_output(stmt, ir_set.path_id, env=ctx.env)
+        pathctx.put_path_var(
+            stmt, ir_set.path_id, set_expr, aspect=aspect, env=ctx.env)
+        pathctx.get_path_output(
+            stmt, ir_set.path_id, aspect=aspect, env=ctx.env)
 
+        assert wrapper
+        set_expr = pgast.CoalesceExpr(
+            args=[stmt, iv], ser_safe=serialization_safe)
+
+        pathctx.put_path_var(
+            wrapper, ir_set.path_id, set_expr, aspect=aspect, env=ctx.env)
+        stmt = wrapper
+
+    pathctx.put_path_var_if_not_exists(
+        stmt, ir_set.path_id, set_expr, aspect=aspect, env=ctx.env)
+
+    return new_stmt_set_rvar(ir_set, stmt, ctx=ctx)
+
+
+def process_set_as_agg_expr(
+        ir_set: irast.Set, stmt: pgast.SelectStmt, *,
+        ctx: context.CompilerContextLevel) -> SetRVars:
+    expr = ir_set.expr
+    assert isinstance(expr, irast.FunctionCall)
+
+    # If the func has an initial val, we need to create a wrapper to put
+    # the coalesces we insert in
+    wrapper = None
+    if expr.func_initial_value is not None:
         with ctx.subrel() as subctx:
             wrapper = subctx.rel
-            set_expr = pgast.CoalesceExpr(
-                args=[stmt, iv], ser_safe=serialization_safe)
 
-            pathctx.put_path_value_var(
-                wrapper, ir_set.path_id, set_expr, env=ctx.env)
-            stmt = wrapper
+    # When in a serialization context, we need to compute both a value
+    # version and a serialized version of the aggregate function call,
+    # since we may need both (Consider `WITH X := array_agg(User), ...`).
 
-    pathctx.put_path_value_var_if_not_exists(
-        stmt, ir_set.path_id, set_expr, env=ctx.env)
+    cctx = ctx.subrel() if wrapper else ctx.new()
+    with cctx as xctx:
+        xctx.expr_exposed = False
+        process_set_as_agg_expr_inner(
+            ir_set, xctx.rel, aspect='value', wrapper=wrapper,
+            ctx=xctx)
+
+    # Though if the result type is a scalar, the value should be good
+    # enough, so don't generate bad code.
+    if (
+        output.in_serialization_ctx(ctx=ctx)
+        and not irtyputils.is_scalar(ir_set.typeref)
+    ):
+        cctx = ctx.subrel() if wrapper else ctx.new()
+        with cctx as xctx:
+            xctx.expr_exposed = True
+            process_set_as_agg_expr_inner(
+                ir_set, xctx.rel, aspect='serialized', wrapper=wrapper,
+                ctx=xctx)
+
+    if wrapper:
+        stmt = wrapper
 
     return new_stmt_set_rvar(ir_set, stmt, ctx=ctx)
 

--- a/edb/server/compiler_pool/worker.py
+++ b/edb/server/compiler_pool/worker.py
@@ -54,7 +54,7 @@ DBS: state.DatabasesState = immutables.Map()
 BACKEND_RUNTIME_PARAMS: pgcluster.BackendRuntimeParams = \
     pgcluster.get_default_runtime_params()
 COMPILER: compiler.Compiler
-LAST_STATE = None
+LAST_STATE: Optional[compiler.dbstate.CompilerConnectionState] = None
 STD_SCHEMA: s_schema.FlatSchema
 GLOBAL_SCHEMA: s_schema.FlatSchema
 SYSTEM_CONFIG: immutables.Map[str, config.SettingValue]

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -1217,7 +1217,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
             ]
         )
 
-    async def test_edgeql_calls_35(self):
+    async def test_edgeql_calls_35a(self):
         # Tuple return
 
         await self.con.execute('''
@@ -1238,6 +1238,36 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''SELECT test::call35(1).1.foo;''',
+            [
+                2
+            ]
+        )
+
+    @test.xfail('''
+       Fails with 'ISE: cannot cast type record to <stuff>', I think
+       because the subcomponents need to be cast also.
+    ''')
+    async def test_edgeql_calls_35b(self):
+        # Tuple return with a deep and unavoidable implicit cast
+
+        await self.con.execute('''
+            CREATE FUNCTION test::call35(
+                a: tuple<int64, tuple<int64>>
+            ) -> tuple<int64, tuple<foo: int64>>
+                USING EdgeQL $$
+                    SELECT a
+                $$;
+        ''')
+
+        await self.assert_query_result(
+            r'''SELECT test::call35((1, 2));''',
+            [
+                [1, {'foo': 2}]
+            ]
+        )
+
+        await self.assert_query_result(
+            r'''SELECT test::call35((1, 2)).1.foo;''',
             [
                 2
             ]

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -373,6 +373,25 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                 '''SELECT array_agg({})''',
             )
 
+    async def test_edgeql_functions_array_agg_19(self):
+        await self.assert_query_result(
+            r'''FOR X in {array_agg(0)} UNION (SELECT array_unpack(X));''',
+            [0],
+        )
+
+        await self.assert_query_result(
+            r'''
+                FOR X in {array_agg((0, 1))}
+                UNION (SELECT array_unpack(X));
+            ''',
+            [[0, 1]],
+        )
+
+        await self.assert_query_result(
+            r'''FOR X in {array_agg((0, 1))} UNION (X);''',
+            [[[0, 1]]],
+        )
+
     async def test_edgeql_functions_array_unpack_01(self):
         await self.assert_query_result(
             r'''SELECT [1, 2];''',

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -302,7 +302,6 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             [True],
         )
 
-    @test.xfail('triggers issue #1818')
     async def test_edgeql_volatility_select_clause_03(self):
         # Spurious failure probability: 1/2^100 I think
 


### PR DESCRIPTION
A common theme in these issues is an object being contained inside a
collection such that the shape can't be produced near the top-level
but instead must live inside the collection.

 * When injecting default props into a non-view object set (which
   feels sketchy, but we do it sometimes), make sure to only do it
   *once* if the set is referenced multiple times.
 * Make sure things work when an object is output with a shape and
   without a specified one in the same query, and type name injection
   is on.
 * Make sure things work when an object apears in a tuple and is
   is also referenced with a shape through tuple projection.
 * Fix array_agg and similar operating on shapes; something can
   be used as a value and serialized, so it isn't safe to
   put a serialized value as the value aspect. We need to
   compile *both*. Fixes #1818.

An earlier iteration of this PR broke test_edgeql_calls_35, because of
limitations in how we generate tuple casts. I added an xfailed test
for an already existing related failure to that bug.