### PR TITLE
Insert explicit casts when returning non-compatible tuples from a function

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -100,6 +100,10 @@ def compile_cast(
         return _cast_tuple(
             ir_set, orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
 
+    elif orig_stype.is_array():
+        return _cast_array(
+            ir_set, orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
+
     elif orig_stype.issubclass(ctx.env.schema, new_stype):
         # The new type is a supertype of the old type,
         # and is always a wider domain, so we simply reassign
@@ -114,10 +118,6 @@ def compile_cast(
         return _inheritance_cast_to_ir(
             ir_set, orig_stype, new_stype,
             cardinality_mod=cardinality_mod, ctx=ctx)
-
-    elif orig_stype.is_array():
-        return _cast_array(
-            ir_set, orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
 
     else:
         json_t = ctx.env.get_track_schema_type(

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -100,7 +100,11 @@ def compile_cast(
         return _cast_tuple(
             ir_set, orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
 
-    elif orig_stype.is_array():
+    elif (
+        orig_stype.is_array()
+        and not s_types.is_type_compatible(
+            orig_stype, new_stype, schema=ctx.env.schema)
+    ):
         return _cast_array(
             ir_set, orig_stype, new_stype, srcctx=srcctx, ctx=ctx)
 

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -805,10 +805,8 @@ def finalize_args(
 
         # Check if we need to cast the argument value before passing
         # it to the callable.
-        compatible = schemactx.is_type_compatible(
-            paramtype,
-            barg.valtype,
-            ctx=ctx,
+        compatible = s_types.is_type_compatible(
+            paramtype, barg.valtype, schema=ctx.env.schema,
         )
 
         if not compatible:

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -45,7 +45,6 @@ from edb.edgeql import qltypes
 from . import context
 
 
-# XXX: COME BACK TO THIS
 def get_schema_object(
     ref: qlast.BaseObjectRef,
     module: Optional[str]=None,
@@ -526,28 +525,3 @@ def get_union_pointer(
     ctx.env.created_schema_objects.add(ptr)
 
     return ptr
-
-
-def is_type_compatible(
-    type_a: s_types.Type,
-    type_b: s_types.Type,
-    *,
-    ctx: context.ContextLevel,
-) -> bool:
-
-    material_type_a = get_material_type(type_a, ctx=ctx)
-    material_type_b = get_material_type(type_b, ctx=ctx)
-
-    compatible = material_type_b.issubclass(ctx.env.schema, material_type_a)
-    if compatible:
-        if (
-            isinstance(material_type_a, s_types.Tuple)
-            and isinstance(material_type_b, s_types.Tuple)
-        ):
-            # For tuples, we also check that the element names match.
-            compatible = (
-                material_type_a.get_element_names(ctx.env.schema) ==
-                material_type_b.get_element_names(ctx.env.schema)
-            )
-
-    return compatible

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -714,10 +714,8 @@ def _normalize_view_ptr_expr(
                 # object type.
                 if not (
                     base_target.is_object_type()
-                    or schemactx.is_type_compatible(
-                        base_target,
-                        ptr_target,
-                        ctx=ctx
+                    or s_types.is_type_compatible(
+                        base_target, ptr_target, schema=ctx.env.schema
                     )
                 ):
                     qlexpr = astutils.ensure_qlstmt(qlast.TypeCast(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1918,7 +1918,7 @@ def _process_set_func_with_ordinality(
     coldeflist = []
     arg_is_tuple = irtyputils.is_tuple(inner_rtype)
 
-    if arg_is_tuple:
+    if arg_is_tuple and not irtyputils.is_persistent_tuple(inner_rtype):
         subtypes = {}
         for i, st in enumerate(inner_rtype.subtypes):
             colname = st.element_name or f'_t{i + 1}'

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1918,7 +1918,7 @@ def _process_set_func_with_ordinality(
     coldeflist = []
     arg_is_tuple = irtyputils.is_tuple(inner_rtype)
 
-    if arg_is_tuple and not irtyputils.is_persistent_tuple(inner_rtype):
+    if arg_is_tuple:
         subtypes = {}
         for i, st in enumerate(inner_rtype.subtypes):
             colname = st.element_name or f'_t{i + 1}'
@@ -1938,8 +1938,10 @@ def _process_set_func_with_ordinality(
         colnames = [ctx.env.aliases.get('v')]
         coldeflist = []
 
-    if expr.sql_func_has_out_params:
+    if (expr.sql_func_has_out_params
+            or irtyputils.is_persistent_tuple(inner_rtype)):
         # SQL functions declared with OUT params reject column definitions.
+        # Also persistent tuple types
         coldeflist = []
 
     fexpr = pgast.FuncCall(name=func_name, args=args, coldeflist=coldeflist)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2376,3 +2376,36 @@ def materialize_type_in_attribute(
         )
 
     return schema
+
+
+def is_type_compatible(
+    type_a: Type,
+    type_b: Type,
+    *,
+    schema: s_schema.Schema,
+) -> bool:
+
+    schema, material_type_a = type_a.material_type(schema)
+    schema, material_type_b = type_b.material_type(schema)
+
+    def labels_compatible(t_a: Type, t_b: Type) -> bool:
+        if isinstance(t_a, Tuple) and isinstance(t_b, Tuple):
+            # For tuples, we also (recursively) check that the element
+            # names match
+            return all(
+                name_a == name_b
+                and labels_compatible(st_a, st_b)
+                for (name_a, st_a), (name_b, st_b)
+                in zip(t_a.iter_subtypes(schema),
+                       t_b.iter_subtypes(schema))
+            )
+        elif isinstance(t_a, Array) and isinstance(t_b, Array):
+            return labels_compatible(
+                t_a.get_element_type(schema), t_b.get_element_type(schema))
+        else:
+            return True
+
+    return (
+        material_type_b.issubclass(schema, material_type_a)
+        and labels_compatible(material_type_a, material_type_b)
+    )

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2384,6 +2384,11 @@ def is_type_compatible(
     *,
     schema: s_schema.Schema,
 ) -> bool:
+    """Check whether two types have compatible SQL representations.
+
+    EdgeQL implicit casts need to be turned into explicit casts in
+    some places, since the semantics differ from SQL's.
+    """
 
     schema, material_type_a = type_a.material_type(schema)
     schema, material_type_b = type_b.material_type(schema)

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -1243,31 +1243,27 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
             ]
         )
 
-    @test.xfail('''
-       Fails with 'ISE: cannot cast type record to <stuff>', I think
-       because the subcomponents need to be cast also.
-    ''')
     async def test_edgeql_calls_35b(self):
         # Tuple return with a deep and unavoidable implicit cast
 
         await self.con.execute('''
             CREATE FUNCTION test::call35(
-                a: tuple<int64, tuple<int64>>
-            ) -> tuple<int64, tuple<foo: int64>>
+                a: tuple<int64, array<tuple<int64>>>
+            ) -> tuple<int64, array<tuple<foo: int64>>>
                 USING EdgeQL $$
                     SELECT a
                 $$;
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call35((1, 2));''',
+            r'''SELECT test::call35((1, [(2,)]));''',
             [
-                [1, {'foo': 2}]
+                [1, [{'foo': 2}]]
             ]
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call35((1, 2)).1.foo;''',
+            r'''SELECT test::call35((1, [(2,)])).1[0].foo;''',
             [
                 2
             ]


### PR DESCRIPTION
Also, update the type compatibility check to be recursive, in case
nested tuples don't match.