### PR TITLE
Make sure query source cache doesn't invalidate on COMMIT

### DIFF
--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -427,7 +427,7 @@ class Transaction:
         return self._current.user_schema
 
     def get_user_schema_if_updated(self) -> Optional[s_schema.FlatSchema]:
-        if self._current.user_schema == self._state0.user_schema:
+        if self._current.user_schema is self._state0.user_schema:
             return None
         else:
             return self._current.user_schema

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -426,8 +426,20 @@ class Transaction:
     def get_user_schema(self) -> s_schema.FlatSchema:
         return self._current.user_schema
 
+    def get_user_schema_if_updated(self) -> Optional[s_schema.FlatSchema]:
+        if self._current.user_schema == self._state0.user_schema:
+            return None
+        else:
+            return self._current.user_schema
+
     def get_global_schema(self) -> s_schema.FlatSchema:
         return self._current.global_schema
+
+    def get_global_schema_if_updated(self) -> Optional[s_schema.FlatSchema]:
+        if self._current.global_schema == self._state0.global_schema:
+            return None
+        else:
+            return self._current.global_schema
 
     def get_modaliases(self) -> immutables.Map:
         return self._current.modaliases

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -436,7 +436,7 @@ class Transaction:
         return self._current.global_schema
 
     def get_global_schema_if_updated(self) -> Optional[s_schema.FlatSchema]:
-        if self._current.global_schema == self._state0.global_schema:
+        if self._current.global_schema is self._state0.global_schema:
             return None
         else:
             return self._current.global_schema


### PR DESCRIPTION
The server schema state machinery determines if query source caches are
still valid by the presence of user or global schema in the returned
query units.  The `COMMIT` statement handler, however, is currently
_always_ including the schemas in the returned query unit, which results
in improper query source invalidation on every `COMMIT`.

Fixes: #2285.