### PR TITLE
Unbreak array aliasing

### DIFF
--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -878,6 +878,11 @@ class FlatSchema(Schema):
                 f'{sclass.__name__} {name!r} is already present '
                 f'in the schema {self!r}')
 
+        if id in self._id_to_data:
+            raise errors.SchemaError(
+                f'{sclass.__name__} ({str(id)!r}) is already present '
+                f'in the schema {self!r}')
+
         object_ref_fields = sclass.get_object_reference_fields()
         if not object_ref_fields:
             refs_to = None

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -986,7 +986,10 @@ class Array(
         schema: s_schema.Schema,
         data: Dict[str, Any],
     ) -> uuid.UUID:
-        if data.get('alias_is_persistent'):
+        if (
+            data.get('alias_is_persistent')
+            or isinstance(data.get('name'), s_name.QualName)
+        ):
             return super().generate_id(schema, data)
         else:
             return generate_array_type_id(
@@ -1232,15 +1235,15 @@ class Array(
         )
 
     def material_type(
-        self: Array_T,
+        self,
         schema: s_schema.Schema,
-    ) -> typing.Tuple[s_schema.Schema, Array_T]:
+    ) -> typing.Tuple[s_schema.Schema, Array]:
         # We need to resolve material types based on the subtype recursively.
 
         st = self.get_element_type(schema)
         schema, stm = st.material_type(schema)
-        if stm != st:
-            return self.__class__.from_subtypes(
+        if stm != st or isinstance(self, ArrayExprAlias):
+            return Array.from_subtypes(
                 schema,
                 [stm],
                 typemods=self.get_typemods(schema),

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4458,6 +4458,21 @@ aa \
             [4, 5],
         )
 
+    async def test_edgeql_expr_alias_09(self):
+        await self.assert_query_result(
+            r"""
+                WITH
+                    x := [1],
+                    y := [2]
+                SELECT
+                    'OK'
+                FILTER
+                    x[0] = 1
+                    AND y[0] = 2
+            """,
+            ['OK'],
+        )
+
     async def test_edgeql_expr_for_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
The collection type naming rework in 1ee59553667b59 made it so that all
array aliases of the same element type were erroneously derived as the
identical type, making aliases indistinguishable.  Fix this.

(The `TupleExprAlias` got proper treatment in the aforementioned rework,
so arrays were an unfortunate oversight.)

Fixes: #2287