### PR TITLE
fix typo

### DIFF
--- a/docs/edgeql/statements/insert.rst
+++ b/docs/edgeql/statements/insert.rst
@@ -175,7 +175,7 @@ clause.
 
 There's an important use-case where it is necessary to either insert a
 new object or update an existing one identified with some key. This is
-what ``UNLESS CONFLICT`` clause allows to do:
+what the ``UNLESS CONFLICT`` clause allows:
 
 .. code-block:: edgeql
 


### PR DESCRIPTION
This should probably either be `this is what the UNLESS CONFLICT clause allows` or `this is what the UNLESS CONFLICT clause allows you to do`.