### PR TITLE
Fix SDL handling of types with two indexes

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -181,6 +181,11 @@ class TraceContextBase:
 
             extra_name = '|'.join(qlcodegen.generate_source(e) for e in exprs)
 
+        elif isinstance(decl, qlast.CreateIndex):
+            # Indexes are defined by what they are an index over, so we need
+            # to add that to the "extra_name".
+            extra_name = f'({qlcodegen.generate_source(decl.expr)})'
+
         if extra_name:
             fq_name = s_name.QualName(
                 module=fq_name.module,

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -4707,6 +4707,31 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         """)
         await self.migrate(r"")
 
+    async def test_edgeql_migration_index_01(self):
+        await self.migrate('''
+            type Message {
+                required property text -> str;
+                index on (.text);
+            };
+        ''')
+
+        await self.migrate('''
+            type Message {
+                required property text -> str;
+                required property ts -> datetime;
+                index on (.text);
+                index on (.ts);
+            };
+        ''')
+
+        await self.assert_query_result(
+            r"""
+                SELECT count((SELECT schema::ObjectType
+                              FILTER .name = 'test::Message').indexes)
+            """,
+            [2],
+        )
+
     async def test_edgeql_migration_eq_function_01(self):
         await self.migrate(r"""
             function hello01(a: int64) -> str


### PR DESCRIPTION
It was just using "idx" as the name, which resulted in mass confusion.
Use the same "extra_name" machinery used for constraints and
functions.

Fixes #2300.