### PR TITLE
Implement get_verb for RebaseInheritingObject

### DIFF
--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -990,6 +990,15 @@ class RebaseInheritingObject(
                                  self.__class__.__name__,
                                  self.classname)
 
+    def get_verb(self) -> str:
+        # FIXME: We just say 'alter' because it is currently somewhat
+        # inconsistent whether an object rebase on its own will get
+        # placed in its own alter command or whether it will share one
+        # with all the associated rebases of pointers.  Ideally we'd
+        # say 'alter base types of', but with the current machinery it
+        # would still usually say 'alter', so just always do that.
+        return 'alter'
+
     def apply(
         self,
         schema: s_schema.Schema,

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -4732,6 +4732,31 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             [2],
         )
 
+    async def test_edgeql_migration_rebase_01(self):
+        await self.migrate(r"""
+            abstract type C;
+            abstract type P {
+                property p -> str;
+                property p2 -> str;
+                index on (.p);
+            };
+            type Foo extending C {
+                property foo -> str;
+            }
+        """)
+
+        await self.migrate(r"""
+            abstract type C;
+            abstract type P {
+                property p -> str;
+                property p2 -> str;
+                index on (.p);
+            };
+            type Foo extending C, P {
+                property foo -> str;
+            }
+        """)
+
     async def test_edgeql_migration_eq_function_01(self):
         await self.migrate(r"""
             function hello01(a: int64) -> str


### PR DESCRIPTION
Sometimes the vagaries of ordering result in an Alter that contains
nothing but a RebaseInheritingObject (with all of the other associated
changes to the object in another Alter), and then we would crash
producing a prompt because get_verb wasn't implemented.