### PR TITLE
Linearize the deletions generated when rebasing

### DIFF
--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -284,12 +284,13 @@ class LinkCommand(
         schema: s_schema.Schema,
         context: sd.CommandContext,
         refdict: so.RefDict,
-    ) -> s_schema.Schema:
+    ) -> Tuple[s_schema.Schema,
+               Dict[sn.Name, Type[sd.ObjectCommand[so.Object]]]]:
         if self.scls.get_computable(schema) and refdict.attr != 'pointers':
             # If the link is a computable, the inheritance would only
             # happen in the case of aliasing, and in that case we only
             # need to inherit the link properties and nothing else.
-            return schema
+            return schema, {}
 
         return super()._reinherit_classref_dict(schema, context, refdict)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5201,6 +5201,51 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
+    def test_schema_migrations_drop_parent_05(self):
+        self._assert_migration_equivalence([r"""
+            type Parent {
+                property x -> str;
+                index on (.x);
+            }
+            type Child extending Parent;
+        """, r"""
+            type Parent {
+                property x -> str;
+                index on (.x);
+            }
+            type Child;
+        """])
+
+    def test_schema_migrations_drop_parent_06(self):
+        self._assert_migration_equivalence([r"""
+            type Parent {
+                property x -> str;
+                constraint expression on (.x != "YOLO");
+            }
+            type Child extending Parent;
+        """, r"""
+            type Parent {
+                property x -> str;
+                constraint expression on (.x != "YOLO");
+            }
+            type Child;
+        """])
+
+    def test_schema_migrations_drop_parent_07(self):
+        self._assert_migration_equivalence([r"""
+            type Parent {
+                property x -> str;
+                property z := .x ++ "!";
+            }
+            type Child extending Parent;
+        """, r"""
+            type Parent {
+                property x -> str;
+                property z := .x ++ "!";
+            }
+            type Child;
+        """])
+
     def test_schema_migrations_computed_optionality_01(self):
         self._assert_migration_equivalence([r"""
             abstract type Removable {


### PR DESCRIPTION
Otherwise we can run into trouble when rebasing away from
types that have refs that refer to each other.