### PR TITLE
Fix DROP OWNED on pointers with defaults

### DIFF
--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -552,6 +552,7 @@ class AlterLinkLowerCardinality(
 
 class AlterLinkOwned(
     referencing.AlterOwned[Link],
+    pointers.PointerCommandOrFragment[Link],
     referrer_context_class=LinkSourceCommandContext,
     field='owned',
 ):

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -367,6 +367,7 @@ class AlterPropertyLowerCardinality(
 
 class AlterPropertyOwned(
     referencing.AlterOwned[Property],
+    pointers.PointerCommandOrFragment[Property],
     referrer_context_class=PropertySourceContext,
     field='owned',
 ):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5271,7 +5271,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             type Post extending Event;
         """])
 
-
     def test_schema_migrations_computed_optionality_01(self):
         self._assert_migration_equivalence([r"""
             abstract type Removable {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5246,6 +5246,32 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             type Child;
         """])
 
+    def test_schema_migrations_drop_owned_default_01(self):
+        self._assert_migration_equivalence([r"""
+            type Foo;
+            type Post {
+                required property createdAt -> datetime {
+                    default := datetime_current();
+                }
+                link whatever -> Foo {
+                    default := (SELECT Foo LIMIT 1);
+                }
+            }
+        """, r"""
+            type Foo;
+            abstract type Event {
+                required property createdAt -> datetime {
+                    default := datetime_current();
+                }
+                link whatever -> Foo {
+                    default := (SELECT Foo LIMIT 1);
+                }
+            }
+
+            type Post extending Event;
+        """])
+
+
     def test_schema_migrations_computed_optionality_01(self):
         self._assert_migration_equivalence([r"""
             abstract type Removable {


### PR DESCRIPTION
There's a mix-in for compiling the fields, we just need to mix it in.

Fixes #2306.