### PR TITLE
Refactor schema slightly for debugability

### DIFF
--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -1692,12 +1692,12 @@ class ChainedSchema(Schema):
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
     ) -> Tuple[s_func.Function, ...]:
-        try:
-            return self._top_schema.get_functions(
-                name, module_aliases=module_aliases)
-        except errors.InvalidReferenceError:
-            return self._base_schema.get_functions(
+        objs = self._top_schema.get_functions(
+            name, module_aliases=module_aliases, default=())
+        if not objs:
+            objs = self._base_schema.get_functions(
                 name, default=default, module_aliases=module_aliases)
+        return objs
 
     def get_operators(
         self,
@@ -1708,12 +1708,12 @@ class ChainedSchema(Schema):
         *,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
     ) -> Tuple[s_oper.Operator, ...]:
-        try:
-            return self._top_schema.get_operators(
-                name, module_aliases=module_aliases)
-        except errors.InvalidReferenceError:
-            return self._base_schema.get_operators(
+        objs = self._top_schema.get_operators(
+            name, module_aliases=module_aliases, default=())
+        if not objs:
+            objs = self._base_schema.get_operators(
                 name, default=default, module_aliases=module_aliases)
+        return objs
 
     def get_casts_to_type(
         self,
@@ -1875,11 +1875,11 @@ class ChainedSchema(Schema):
             return self._global_schema.get_global(  # type: ignore
                 objtype, name, default=default)
         else:
-            try:
-                return self._top_schema.get_global(objtype, name)
-            except errors.InvalidReferenceError:
-                return self._base_schema.get_global(
+            obj = self._top_schema.get_global(objtype, name, default=None)
+            if obj is None:
+                obj = self._base_schema.get_global(
                     objtype, name, default=default)
+            return obj
 
     def get_generic(  # NoQA: F811
         self,


### PR DESCRIPTION
Make ChainedSchema always use default=None to check if the top schema
has an object, instead of using exceptions. We already do this for
`get`; this does it for the other ones as well.

The motivation here is that it means I can set a breakpoint in
_raise_bad_reference and only have it fire on actual misses.