### PR TITLE
Fix a cluster of constraint and rename issues

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -139,7 +139,7 @@ class Constraint(
         obj = schema.get(name, type=Constraint)
 
         if not obj.generic(schema):
-            base = obj.get_bases(schema).objects(schema)[0]
+            base = obj.get_nearest_generic_parent(schema)
             base_name = context.get_obj_name(schema, base)
 
             quals = list(sn.quals_from_fullname(name))
@@ -424,6 +424,43 @@ class ConstraintCommand(
 
         return args
 
+    @classmethod
+    def as_inherited_ref_ast(
+        cls,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        name: sn.Name,
+        parent: so.Object,
+    ) -> qlast.ObjectDDL:
+        assert isinstance(parent, Constraint)
+        astnode_cls = cls.referenced_astnode  # type: ignore
+        nref = cls.get_inherited_ref_name(schema, context, parent, name)
+        args = []
+
+        parent_args = parent.get_args(schema)
+        if parent_args:
+            parent_args = parent.get_args(schema)
+            assert parent_args is not None
+            for arg_expr in parent_args:
+                arg = edgeql.parse_fragment(arg_expr.text)
+                args.append(arg)
+
+        subj_expr = parent.get_subjectexpr(schema)
+        if (
+            subj_expr is None
+            # Don't include subjectexpr if it was inherited from an
+            # abstract constraint.
+            or parent.get_nearest_generic_parent(
+                schema).get_subjectexpr(schema) is not None
+        ):
+            subj_expr_ql = None
+        else:
+            subj_expr_ql = edgeql.parse_fragment(subj_expr.text)
+
+        astnode = astnode_cls(name=nref, args=args, subjectexpr=subj_expr_ql)
+
+        return cast(qlast.ObjectDDL, astnode)
+
     def compile_expr_field(
         self,
         schema: s_schema.Schema,
@@ -534,6 +571,7 @@ class ConstraintCommand(
             if not b.get_abstract(schema)
             and b.generic(schema) and b.get_name(schema) != default_base
         ]
+        # assert not explicit_bases
 
         new_bases = implicit_bases + explicit_bases
         return inheriting.delta_bases(
@@ -809,6 +847,13 @@ class CreateConstraint(
         from edb.ir import ast as ir_ast
         from edb.ir import utils as ir_utils
 
+        bases = self.get_resolved_attribute_value(
+            'bases', schema=schema, context=context,
+        )
+        direct_base = bases.objects(schema)[0]
+        if not direct_base.generic(schema):
+            return
+
         constr_base = schema.get(name, type=Constraint)
 
         orig_subjectexpr = subjectexpr
@@ -966,10 +1011,9 @@ class CreateConstraint(
                     context=sourcectx
                 )
 
-        attrs['return_type'] = constr_base.get_return_type(schema)
-        attrs['return_typemod'] = constr_base.get_return_typemod(schema)
         attrs['finalexpr'] = final_expr
         attrs['params'] = constr_base.get_params(schema)
+        inherited['params'] = True
         attrs['abstract'] = False
 
         for k, v in attrs.items():
@@ -999,46 +1043,13 @@ class CreateConstraint(
 
         subj_expr = bases[0].get_subjectexpr(schema)
         if subj_expr is not None:
-            cmd.set_attribute_value('subjectexpr', subj_expr)
+            cmd.set_attribute_value('subjectexpr', subj_expr, inherited=True)
+
+        params = bases[0].get_params(schema)
+        if params is not None:
+            cmd.set_attribute_value('params', params, inherited=True)
 
         return cmd
-
-    @classmethod
-    def as_inherited_ref_ast(
-        cls,
-        schema: s_schema.Schema,
-        context: sd.CommandContext,
-        name: sn.Name,
-        parent: so.Object,
-    ) -> qlast.ObjectDDL:
-        assert isinstance(parent, Constraint)
-        astnode_cls = cls.referenced_astnode
-        nref = cls.get_inherited_ref_name(schema, context, parent, name)
-        args = []
-
-        parent_args = parent.get_args(schema)
-        if parent_args:
-            parent_args = parent.get_args(schema)
-            assert parent_args is not None
-            for arg_expr in parent_args:
-                arg = edgeql.parse_fragment(arg_expr.text)
-                args.append(arg)
-
-        subj_expr = parent.get_subjectexpr(schema)
-        if (
-            subj_expr is None
-            # Don't include subjectexpr if it was inherited from an
-            # abstract constraint. (Constraints will view it as
-            # not-inherited if it was copied from an implicit base.)
-            or 'subjectexpr' in parent.get_inherited_fields(schema)
-        ):
-            subj_expr_ql = None
-        else:
-            subj_expr_ql = edgeql.parse_fragment(subj_expr.text)
-
-        astnode = astnode_cls(name=nref, args=args, subjectexpr=subj_expr_ql)
-
-        return astnode
 
     @classmethod
     def _cmd_tree_from_ast(
@@ -1074,17 +1085,17 @@ class CreateConstraint(
                         'with defaults',
                         context=astnode.context)
 
-        if cmd.get_attribute_value('return_type') is None:
-            cmd.set_attribute_value(
-                'return_type',
-                schema.get('std::bool'),
-            )
+            if cmd.get_attribute_value('return_type') is None:
+                cmd.set_attribute_value(
+                    'return_type',
+                    schema.get('std::bool'),
+                )
 
-        if cmd.get_attribute_value('return_typemod') is None:
-            cmd.set_attribute_value(
-                'return_typemod',
-                ft.TypeModifier.SingletonType,
-            )
+            if cmd.get_attribute_value('return_typemod') is None:
+                cmd.set_attribute_value(
+                    'return_typemod',
+                    ft.TypeModifier.SingletonType,
+                )
 
         assert isinstance(astnode, (qlast.CreateConstraint,
                                     qlast.CreateConcreteConstraint))
@@ -1209,9 +1220,11 @@ class RenameConstraint(
         # Concrete constraints are children of abstract constraints
         # and have names derived from the abstract constraints. We
         # unfortunately need to go update their names.
-        children = scls.children(schema)
+        children = scls.descendants(schema)
         for ref in children:
             if ref.get_abstract(schema):
+                continue
+            if ref.get_nearest_generic_parent(schema) != scls:
                 continue
 
             ref_name = ref.get_name(schema)
@@ -1233,6 +1246,7 @@ class RenameConstraint(
 
 class AlterConstraintOwned(
     referencing.AlterOwned[Constraint],
+    ConstraintCommand,
     field='owned',
     referrer_context_class=ConsistencySubjectCommandContext,
 ):
@@ -1271,6 +1285,30 @@ class AlterConstraint(
 
         cls._validate_subcommands(astnode)
         return cmd
+
+    def _get_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        *,
+        parent_node: Optional[qlast.DDLOperation] = None,
+    ) -> Optional[qlast.DDLOperation]:
+        if self.scls.get_abstract(schema):
+            return super()._get_ast(schema, context, parent_node=parent_node)
+
+        # We need to make sure to include subjectexpr and args
+        # in the AST, since they are really part of the name.
+        op = self.as_inherited_ref_ast(
+            schema, context, self.scls.get_name(schema),
+            self.scls,
+        )
+        self._apply_fields_ast(schema, context, op)
+
+        if (op is not None and hasattr(op, 'commands') and
+                not op.commands):
+            return None
+
+        return op
 
     def validate_alter(
         self,
@@ -1327,4 +1365,10 @@ class RebaseConstraint(
     ConstraintCommand,
     referencing.RebaseReferencedInheritingObject[Constraint],
 ):
-    pass
+    def _get_bases_for_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        bases: Tuple[so.ObjectShell, ...],
+    ) -> Tuple[so.ObjectShell, ...]:
+        return ()

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -564,19 +564,9 @@ class ConstraintCommand(
     ) -> inheriting.BaseDelta_T:
         child_bases = refcls.get_bases(schema).objects(schema)
 
-        default_base = refcls.get_default_base_name()
-        explicit_bases = [
-            b for b in child_bases
-            # abstract constraints play a similar role to default_base
-            if not b.get_abstract(schema)
-            and b.generic(schema) and b.get_name(schema) != default_base
-        ]
-        assert not explicit_bases
-
-        new_bases = implicit_bases + explicit_bases
         return inheriting.delta_bases(
             [b.get_name(schema) for b in child_bases],
-            [b.get_name(schema) for b in new_bases],
+            [b.get_name(schema) for b in implicit_bases],
         )
 
     def get_ast_attr_for_field(

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -77,6 +77,36 @@ def merge_constraint_params(
         return supers[0].get_explicit_field_value(schema, field_name, None)
 
 
+def constraintname_from_fullname(name: sn.Name) -> sn.QualName:
+    assert isinstance(name, sn.QualName)
+    # the dict key for constraints drops the first qual, which makes
+    # it independent of where it is declared
+    short = sn.shortname_from_fullname(name)
+    quals = sn.quals_from_fullname(name)
+    return sn.QualName(
+        name=sn.get_specialized_name(short, *quals[1:]),
+        module='__',
+    )
+
+
+def _constraint_object_key(schema: s_schema.Schema, o: so.Object) -> sn.Name:
+    return constraintname_from_fullname(o.get_name(schema))
+
+
+class ObjectIndexByConstraintName(
+    so.ObjectIndexBase[sn.Name, so.Object_T],
+    key=_constraint_object_key,
+):
+
+    @classmethod
+    def get_key_for_name(
+        cls,
+        schema: s_schema.Schema,
+        name: sn.Name,
+    ) -> sn.Name:
+        return constraintname_from_fullname(name)
+
+
 class Constraint(
     referencing.ReferencedInheritingObject,
     s_func.CallableObject, s_abc.Constraint,
@@ -128,57 +158,13 @@ class Constraint(
     is_aggregate = so.SchemaField(
         bool, default=False, compcoef=0.971, allow_ddl_set=False)
 
-    @classmethod
-    def _maybe_fix_name(
-        cls,
-        name: sn.QualName,
-        *,
-        schema: s_schema.Schema,
-        context: so.ComparisonContext,
-    ) -> sn.Name:
-        obj = schema.get(name, type=Constraint)
-
-        if not obj.generic(schema):
-            base = obj.get_nearest_generic_parent(schema)
-            base_name = context.get_obj_name(schema, base)
-
-            quals = list(sn.quals_from_fullname(name))
-            name = sn.QualName(
-                name=sn.get_specialized_name(base_name, *quals),
-                module=name.module,
-            )
-
-        return name
-
-    @classmethod
-    def compare_field_value(
-        cls,
-        field: so.Field[Type[so.T]],
-        our_value: so.T,
-        their_value: so.T,
-        *,
-        our_schema: s_schema.Schema,
-        their_schema: s_schema.Schema,
-        context: so.ComparisonContext,
-    ) -> float:
-        # When comparing names, patch up the names to take into
-        # account renames of the base abstract constraints.
-        if field.name == 'name':
-            assert isinstance(our_value, sn.QualName)
-            assert isinstance(their_value, sn.QualName)
-            our_value = cls._maybe_fix_name(  # type: ignore
-                our_value, schema=our_schema, context=context)
-            their_value = cls._maybe_fix_name(  # type: ignore
-                their_value, schema=their_schema, context=context)
-
-        return super().compare_field_value(
-            field,
-            our_value,
-            their_value,
-            our_schema=our_schema,
-            their_schema=their_schema,
-            context=context,
-        )
+    def get_name_impacting_ancestors(
+        self, schema: s_schema.Schema,
+    ) -> List[Constraint]:
+        if self.generic(schema):
+            return []
+        else:
+            return [self.get_nearest_generic_parent(schema)]
 
     def get_verbosename(
         self,
@@ -314,7 +300,7 @@ class ConsistencySubject(
         ref_cls=Constraint)
 
     constraints = so.SchemaField(
-        so.ObjectIndexByFullname[Constraint],
+        ObjectIndexByConstraintName[Constraint],
         inheritable=False, ephemeral=True, coerce=True, compcoef=0.887,
         default=so.DEFAULT_CONSTRUCTOR
     )
@@ -1196,46 +1182,34 @@ class CreateConstraint(
 
 
 class RenameConstraint(
-    ConstraintCommand, s_func.RenameCallableObject[Constraint]
+    ConstraintCommand,
+    s_func.RenameCallableObject[Constraint],
+    referencing.RenameReferencedInheritingObject[Constraint],
 ):
-    def _canonicalize(
+    @classmethod
+    def _classname_quals_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.NamedDDL,
+        base_name: sn.Name,
+        referrer_name: sn.QualName,
+        context: sd.CommandContext,
+    ) -> Tuple[str, ...]:
+        parent_op = cls.get_parent_op(context)
+        assert isinstance(parent_op.classname, sn.QualName)
+        return cls._classname_quals_from_name(parent_op.classname)
+
+    def _alter_begin(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
-        scls: so.Object,
-    ) -> None:
-        super()._canonicalize(schema, context, scls)
+    ) -> s_schema.Schema:
+        schema = super()._alter_begin(schema, context)
 
-        assert isinstance(scls, Constraint)
-        # Don't do anything for concrete constraints
-        if not scls.get_abstract(schema):
-            return
+        if not context.canonical and self.scls.get_abstract(schema):
+            schema = self._propagate_ref_rename(schema, context, self.scls)
 
-        # Concrete constraints are children of abstract constraints
-        # and have names derived from the abstract constraints. We
-        # unfortunately need to go update their names.
-        children = scls.descendants(schema)
-        for ref in children:
-            if ref.get_abstract(schema):
-                continue
-            if ref.get_nearest_generic_parent(schema) != scls:
-                continue
-
-            ref_name = ref.get_name(schema)
-            quals = list(sn.quals_from_fullname(ref_name))
-            new_ref_name = sn.QualName(
-                name=sn.get_specialized_name(self.new_name, *quals),
-                module=ref_name.module,
-            )
-
-            self.add(self.init_rename_branch(
-                ref,
-                new_ref_name,
-                schema=schema,
-                context=context,
-            ))
-
-        return
+        return schema
 
 
 class AlterConstraintOwned(

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -571,7 +571,7 @@ class ConstraintCommand(
             if not b.get_abstract(schema)
             and b.generic(schema) and b.get_name(schema) != default_base
         ]
-        # assert not explicit_bases
+        assert not explicit_bases
 
         new_bases = implicit_bases + explicit_bases
         return inheriting.delta_bases(

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -851,6 +851,10 @@ class CreateConstraint(
             'bases', schema=schema, context=context,
         )
         direct_base = bases.objects(schema)[0]
+        # If we have a concrete base, then we should inherit all of
+        # these attrs through the normal inherit_fields() mechanisms,
+        # and populating them ourselves will just mess up
+        # inherited_fields.
         if not direct_base.generic(schema):
             return
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -843,6 +843,13 @@ class Command(struct.MixedStruct, metaclass=CommandMeta):
     ) -> Optional[qlast.DDLOperation]:
         raise NotImplementedError
 
+    def _log_all_renames(self, context: CommandContext) -> None:
+        if isinstance(self, RenameObject):
+            context.early_renames[self.classname] = self.new_name
+
+        for subcmd in self.get_subcommands():
+            subcmd._log_all_renames(context)
+
     @classmethod
     def get_orig_expr_text(
         cls,
@@ -2108,8 +2115,9 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         astnode = self._get_ast_node(schema, context)
 
         if astnode.get_field('name'):
+            name = context.early_renames.get(self.classname, self.classname)
             op = astnode(
-                name=self._deparse_name(schema, context, self.classname),
+                name=self._deparse_name(schema, context, name),
             )
         else:
             op = astnode()
@@ -3191,6 +3199,10 @@ class RenameObject(AlterObjectFragment[so.Object_T]):
         ref = self._deparse_name(schema, context, self.new_name)
         ref.itemclass = None
         orig_ref = self._deparse_name(schema, context, self.classname)
+
+        # Ha, ha! Do it recursively to force any renames in children!
+        self._log_all_renames(context)
+
         if (orig_ref.module, orig_ref.name) != (ref.module, ref.name):
             return astnode(new_name=ref)
         else:
@@ -3238,23 +3250,6 @@ class RenameObject(AlterObjectFragment[so.Object_T]):
             classname=parent_op.classname,
             new_name=new_name,
         )
-
-
-class RenameQualifiedObject(AlterObjectFragment[so.Object_T]):
-
-    new_name = struct.Field(sn.QualName)
-
-    def _get_ast(
-        self,
-        schema: s_schema.Schema,
-        context: CommandContext,
-        *,
-        parent_node: Optional[qlast.DDLOperation] = None,
-    ) -> Optional[qlast.DDLOperation]:
-        astnode = self._get_ast_node(schema, context)
-        new_name = self.new_name
-        ref = qlast.ObjectRef(name=new_name.name, module=new_name.module)
-        return astnode(new_name=ref)
 
 
 class AlterObject(AlterObjectOrFragment[so.Object_T], Generic[so.Object_T]):

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1654,13 +1654,14 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         assert prompt_id is not None
         return prompt_id, prompt_text
 
+    @classmethod
     def get_parent_op(
-        self,
+        cls,
         context: CommandContext,
     ) -> ObjectCommand[so.Object]:
         parent = context.parent()
         if parent is None:
-            raise AssertionError(f'{self!r} has no parent context')
+            raise AssertionError(f'{cls!r} has no parent context')
         op = parent.op
         assert isinstance(op, ObjectCommand)
         return op
@@ -3012,8 +3013,9 @@ class AlterObjectFragment(AlterObjectOrFragment[so.Object_T]):
 
         return schema
 
+    @classmethod
     def get_parent_op(
-        self,
+        cls,
         context: CommandContext,
     ) -> ObjectCommand[so.Object]:
         op = context.current().op

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -734,7 +734,7 @@ class CallableObject(
         ft.TypeModifier, compcoef=0.4, coerce=True)
 
     abstract = so.SchemaField(
-        bool, default=False, compcoef=0.909)
+        bool, default=False, inheritable=False, compcoef=0.909)
 
     def as_create_delta(
         self: CallableObjectT,

--- a/edb/schema/name.py
+++ b/edb/schema/name.py
@@ -221,7 +221,10 @@ def shortname_from_fullname(fullname: Name) -> Name:
 @functools.lru_cache(4096)
 def quals_from_fullname(fullname: QualName) -> List[str]:
     _, _, mangled_quals = fullname.name.partition('@')
-    return [unmangle_name(p) for p in mangled_quals.split('@')]
+    return (
+        [unmangle_name(p) for p in mangled_quals.split('@')]
+        if mangled_quals else []
+    )
 
 
 def get_specialized_name(basename: Name, *qualifiers: str) -> str:

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -3185,6 +3185,15 @@ class DerivableInheritingObject(DerivableObject, InheritingObject):
             obj = obj.get_bases(schema).first(schema)
         return obj
 
+    def get_nearest_generic_parent(
+        self: DerivableInheritingObjectT,
+        schema: s_schema.Schema,
+    ) -> DerivableInheritingObjectT:
+        obj = self
+        while not obj.generic(schema):
+            obj = obj.get_bases(schema).first(schema)
+        return obj
+
 
 @markup.serializer.serializer.register(Object)
 @markup.serializer.serializer.register(ObjectCollection)

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -198,6 +198,33 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 migration, populate=populate, module=module)
             await self.fast_forward_describe_migration(user_input=user_input)
 
+    async def interact(self, parts, check_complete=True):
+        for part in parts:
+            if isinstance(part, str):
+                prompt = part
+                ans = "y"
+                user_input = None
+            else:
+                prompt, ans = part[0:2]
+                user_input = part[2] if len(part) > 2 else None
+
+            await self.assert_describe_migration({
+                'proposed': {'prompt': prompt}
+            })
+
+            if ans == "y":
+                await self.fast_forward_describe_migration(
+                    limit=1, user_input=user_input)
+            else:
+                await self.con.execute('''
+                    ALTER CURRENT MIGRATION REJECT PROPOSED;
+                ''')
+
+        if check_complete:
+            await self.assert_describe_migration({
+                'complete': True
+            })
+
     async def test_edgeql_migration_simple_01(self):
         # Base case, ensuring a single SDL migration from a clean
         # state works.
@@ -4756,6 +4783,154 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 property foo -> str;
             }
         """)
+
+    async def test_edgeql_migration_rebase_02(self):
+        await self.migrate('''
+            type User;
+            abstract type Event {
+              required property createdAt -> datetime {
+                default := datetime_current();
+              }
+
+              required link user -> User;
+            }
+
+            type Post extending Event {
+              required property content -> str {
+                constraint min_len_value(1);
+                constraint max_len_value(280);
+              }
+            }
+        ''')
+
+        await self.start_migration('''
+            type User;
+            abstract type Event {
+              required property createdAt -> datetime {
+                default := datetime_current();
+              }
+
+              required link user -> User;
+            }
+
+            abstract type HasContent {
+              required property content -> str {
+                constraint min_len_value(1);
+                constraint max_len_value(280);
+              }
+            }
+
+            type Post extending Event, HasContent {
+            }
+
+            type Reply extending Event, HasContent {
+              required link post -> Post;
+            }
+        ''')
+
+        # N.B.: these prompts are OK but not canonical; if they are
+        # broken in favor of something better, just fix them.
+        await self.interact([
+            "did you create object type 'test::HasContent'?",
+            "did you alter object type 'test::Post'?",
+            "did you create object type 'test::Reply'?",
+        ])
+
+    async def test_edgeql_migration_rebase_03(self):
+        await self.migrate('''
+            abstract type Named {
+                required property name -> str;
+            };
+
+            type Org;
+
+            abstract type OrgBound {
+                required link org -> Org;
+            };
+
+            abstract type OrgUniquelyNamed
+                extending Named, OrgBound
+            {
+                constraint exclusive on ((.name, .org))
+            }
+        ''')
+
+        await self.start_migration('''
+            abstract type Named {
+                required property name -> str;
+            };
+
+            type Org;
+            abstract type Resource;
+
+            abstract type OrgBound {
+                required link org -> Org;
+            };
+
+            abstract type OrgUniquelyNamedResource
+                extending Named, Resource, OrgBound
+            {
+                delegated constraint exclusive on ((.name, .org))
+            }
+        ''')
+
+        # N.B.: these prompts are OK but not canonical; if they are
+        # broken in favor of something better, just fix them.
+        await self.interact([
+            ("did you drop object type 'test::OrgUniquelyNamed'?", "n"),
+            "did you create object type 'test::Resource'?",
+            "did you rename object type 'test::OrgUniquelyNamed' to "
+            "'test::OrgUniquelyNamedResource'?",
+
+            "did you alter constraint 'std::exclusive' of object type "
+            "'test::OrgUniquelyNamed'?",
+
+            "did you alter object type 'test::OrgUniquelyNamed'?",
+        ])
+
+    async def test_edgeql_migration_rename_01(self):
+        await self.migrate('''
+            type Foo;
+        ''')
+
+        await self.start_migration('''
+            type Bar {
+                property asdf -> str;
+            };
+        ''')
+
+        await self.interact([
+            "did you rename object type 'test::Foo' to 'test::Bar'?",
+            "did you create property 'asdf' of object type 'test::Foo'?",
+        ])
+
+    async def test_edgeql_migration_rename_02(self):
+        await self.migrate('''
+            type Foo {
+                property asdf -> str;
+            };
+            type Bar extending Foo {
+                overloaded property asdf -> str;
+            };
+        ''')
+
+        await self.start_migration('''
+            type Foo {
+                property womp -> str;
+            };
+            type Bar extending Foo {
+                overloaded property womp -> str {
+                    annotation title := "foo";
+                };
+            };
+        ''')
+
+        await self.interact([
+            "did you rename property 'asdf' of object type 'test::Foo' to "
+            "'womp'?" ,
+
+            "did you create annotation 'std::title' of property 'asdf'?",
+        ])
 
     async def test_edgeql_migration_eq_function_01(self):
         await self.migrate(r"""

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -4932,6 +4932,32 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             "did you create annotation 'std::title' of property 'asdf'?",
         ])
 
+    async def test_edgeql_migration_rename_03(self):
+        await self.migrate('''
+            abstract constraint Asdf { using (__subject__ < 10) };
+            type Foo {
+                property x -> int64 {
+                    constraint Asdf;
+                }
+            }
+            type Bar extending Foo;
+        ''')
+
+        await self.start_migration('''
+            abstract constraint Womp { using (__subject__ < 10) };
+            type Foo {
+                property x -> int64 {
+                    constraint Womp;
+                }
+            }
+            type Bar extending Foo;
+        ''')
+
+        await self.interact([
+            "did you rename abstract constraint 'test::Asdf' to "
+            "'test::Womp'?",
+        ])
+
     async def test_edgeql_migration_eq_function_01(self):
         await self.migrate(r"""
             function hello01(a: int64) -> str
@@ -8046,7 +8072,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                     'text':
                         'ALTER TYPE test::Obj1 RENAME TO test::NewObj1;'
                 }],
-                'confidence': 0.636174,
+                'confidence': 0.637027,
             },
         })
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -7499,6 +7499,27 @@ type test::Foo {
                 }
             """)
 
+    async def test_edgeql_ddl_constraint_13(self):
+        await self.con.execute(r"""
+            CREATE ABSTRACT CONSTRAINT Lol {
+                USING ((__subject__ < 10));
+            };
+            CREATE TYPE Foo {
+                CREATE PROPERTY x -> int64 {
+                    CREATE CONSTRAINT Lol;
+                };
+            };
+            CREATE TYPE Bar EXTENDING Foo;
+        """)
+
+        await self.con.execute(r"""
+            ALTER ABSTRACT CONSTRAINT Lol RENAME TO Lolol;
+        """)
+
+        await self.con.execute(r"""
+            ALTER TYPE Foo DROP PROPERTY x;
+        """)
+
     async def test_edgeql_ddl_constraint_alter_01(self):
         await self.con.execute(r"""
             CREATE TYPE test::ConTest01 {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4316,11 +4316,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             type Derived extending Base;
         """])
 
-    @test.xfail('''
-        Argh, this doesn't work because Bar's constraint gets a
-        nonsense rebase because we can't understand the rename of
-        Lol.
-    ''')
     def test_schema_migrations_equivalence_constraint_04(self):
         self._assert_migration_equivalence([r"""
             abstract constraint Lol { using (__subject__ < 10) };


### PR DESCRIPTION
Some things fixed:
 * Track renames while generating ASTs so we don't emit references
   to renamed objects
 * Make sure to include subjectexpr and args when generating
   ALTER CONSTRAINT asts
 * Correctly use the nearest *abstract* constraint when generating
   constraint names in all cases
 * Consistently handle which constraint properties are marked
   as inherited. (Though there is still something of a mess there.)
 * Handle renames of abstract constraints in situations with
   inheritance properly

Fixes #2307. Fixes #2311. Fixes some more not filed.