### PR TITLE
Fix tuples in multi props and IN expressions

### DIFF
--- a/edb/lib/std/25-setoperators.edgeql
+++ b/edb/lib/std/25-setoperators.edgeql
@@ -38,7 +38,7 @@ std::`NOT IN` (e: anytype, s: SET OF anytype) -> std::bool
 {
     USING SQL EXPRESSION;
     SET volatility := 'IMMUTABLE';
-    SET derivative_of := 'std::!=';
+    SET derivative_of := 'std::=';
 };
 
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1094,7 +1094,7 @@ def process_link_update(
     assert rptr is not None
     ptrref = rptr.ptrref
     assert isinstance(ptrref, irast.PointerRef)
-    target_is_scalar = irtyputils.is_scalar(ir_set.typeref)
+    target_is_scalar = not irtyputils.is_object(ir_set.typeref)
     path_id = ir_set.path_id
 
     # The links in the dml class shape have been derived,
@@ -1545,6 +1545,7 @@ def process_link_values(
 
     path_id = ir_expr.path_id
 
+    target_ref: pgast.BaseExpr
     if shape_tuple is not None:
         for element in shape_tuple.elements:
             if not element.path_id.is_linkprop_path():
@@ -1566,6 +1567,7 @@ def process_link_values(
         if target_is_scalar:
             target_ref = pathctx.get_rvar_path_value_var(
                 input_rvar, path_id, env=ctx.env)
+            target_ref = output.output_as_value(target_ref, env=ctx.env)
         else:
             target_ref = pathctx.get_rvar_path_identity_var(
                 input_rvar, path_id, env=ctx.env)

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,7 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_02_19_00_00
+EDGEDB_CATALOG_VERSION = 2021_03_05_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -194,6 +194,7 @@ type SelfRef {
 
 type CollectionTest {
     property some_tuple -> tuple<str, int64>;
+    multi property some_multi_tuple -> tuple<str, int64>;
     property str_array -> array<str>;
     property float_array -> array<float32>;
 }

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -452,6 +452,45 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [1],
         )
 
+    async def test_edgeql_functions_array_unpack_06(self):
+        # We have a special case optimization for "IN array_unpack" so
+        # it's worth testing it.
+
+        await self.assert_query_result(
+            r'''SELECT 1 IN array_unpack([1]);''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT 2 IN array_unpack([1]);''',
+            [False],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT 2 NOT IN array_unpack([1]);''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT 1 IN array_unpack({[1,2,3], [4,5,6]});''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT 0 IN array_unpack({[1,2,3], [4,5,6]});''',
+            [False],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT 1 NOT IN array_unpack({[1,2,3], [4,5,6]});''',
+            [False],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT 0 NOT IN array_unpack({[1,2,3], [4,5,6]});''',
+            [True],
+        )
+
     async def test_edgeql_functions_enumerate_01(self):
         await self.assert_query_result(
             r'''SELECT [10, 20];''',


### PR DESCRIPTION
When inserting tuples into multi properties, we need to output
them as values first.

Expressions like `(1, 2) IN Foo.multi_prop` were broken because if a
tuple literal appears on the LHS of an `= ANY (` operation, pgsql
wants the subquery to contain one column per tuple field, which it won't
if we're getting the tuple straight from a table.

Instead of worrying about making the two sides agree, I just sidestepped
the issue by changing the compilation approach to compile
`x IN y` as approximately `EXISTS (SELECT ... WHERE x_output = y_output)`.

(Do we think this will cause any performance regressions? If it will
be a problem, I could instead worry about making the two sides agree.)

Also while looking at this I noticed that the optimized special-case
for `IN array_unpack(` was broken if the argument had multi
cardinality, so I fixed that also.

Fixes #2255.