### PR TITLE
Fix SELECT DISTINCT on empty and nested tuples

### DIFF
--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -601,7 +601,8 @@ def get_rvar_output_var_as_col_list(
         cols = []
         for el in outvar.elements:
             col = get_rvar_path_var(rvar, el.path_id, aspect=aspect, env=env)
-            cols.append(col)
+            cols.extend(get_rvar_output_var_as_col_list(
+                rvar, col, aspect=aspect, env=env))
     else:
         raise RuntimeError(f'unexpected OutputVar: {outvar!r}')
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1350,6 +1350,11 @@ def process_set_as_distinct(
 
     stmt.distinct_clause = pathctx.get_rvar_output_var_as_col_list(
         subrvar, value_var, aspect='value', env=ctx.env)
+    # If there aren't any columns, we are doing DISTINCT on empty
+    # tuples. All empty tuples are equivalent, so we can just compile
+    # this by adding a LIMIT 1.
+    if not stmt.distinct_clause:
+        stmt.limit_count = pgast.NumericConstant(val="1")
 
     return new_stmt_set_rvar(ir_set, stmt, ctx=ctx)
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4177,6 +4177,11 @@ aa \
 
     async def test_edgeql_expr_setop_12(self):
         await self.assert_query_result(
+            r'''SELECT DISTINCT {(), ()};''',
+            [[]],
+        )
+
+        await self.assert_query_result(
             r'''SELECT DISTINCT (SELECT ({1,2,3}, ()) FILTER .0 > 1).1;''',
             [[]],
         )

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4175,6 +4175,22 @@ aa \
             len(everything), len(distinct),
             'DISTINCT len(ObjectType.name) failed to filter out dupplicates')
 
+    async def test_edgeql_expr_setop_12(self):
+        await self.assert_query_result(
+            r'''SELECT DISTINCT (SELECT ({1,2,3}, ()) FILTER .0 > 1).1;''',
+            [[]],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT DISTINCT (SELECT ({1,2,3}, ()) FILTER .0 > 3).1;''',
+            [],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT DISTINCT {(1,(2,3)), (1,(2,3))};''',
+            [[1, [2, 3]]],
+        )
+
     async def test_edgeql_expr_cardinality_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,


### PR DESCRIPTION
* For nested tuples, we need to pull out all the columns recursively,
   instead of just the top level ones.
 * For empty tuples, instead of trying to use DISTINCT, just set LIMIT 1.
   (Since the only question is whether the result is an empty set or a set
   containing the empty tuple.)

The addresses the actual bug in #2333, but there is some discussion of
potential error message improvements there also.