### PR TITLE
Fix crash on empty sets inside set literals

### DIFF
--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -188,8 +188,9 @@ def _evaluate_union(
             typeref=next(iter(elements)).typeref,
         )
     else:
-        # We can only get an empty result if one of the arguments
-        # was empty, so empty_set must have been set.
+        # We get an empty set if the UNION was exclusivly empty set
+        # literals. If that happens, grab one of the empty sets
+        # that we saw and return it.
         return empty_set
 
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -257,6 +257,27 @@ class TestExpressions(tb.QueryTestCase):
             [2],
         )
 
+    async def test_edgeql_expr_emptyset_05(self):
+        await self.assert_query_result(
+            r'''SELECT {False, <bool>{}};''',
+            [False],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT {False, {False, <bool>{}}};''',
+            [False, False],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT {<bool>{}, <bool>{}};''',
+            [],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT {False, {<bool>{}, <bool>{}}};''',
+            [False],
+        )
+
     async def test_edgeql_expr_idempotent_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
EmptySet is not a BaseConstant, so it shouldn't appear in a
ConstantSet. Filter out empty sets when evaluating unions in the
constant evaluator.

Fixes #2154.