### PR TITLE
Fix an ordering issue: implicit ancestors need to be deleted after referrers

### DIFF
--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -554,7 +554,7 @@ def _trace_op(
             ):
                 # If the referrer is enclosing the object
                 # (i.e. the reference is a refdict reference),
-                # we sort the referrer operation first.
+                # we sort the enclosed operation first.
                 ref_item = get_deps(('delete', ref_name_str))
                 ref_item.deps.add((tag, str(op.classname)))
 
@@ -591,6 +591,15 @@ def _trace_op(
                 # have been deleted or altered.
                 deps.add(('delete', ref_name_str))
                 deps.add(('rebase', ref_name_str))
+
+                # The deletion of any implicit ancestors needs to come after
+                # the deletion of any referrers also.
+                if isinstance(obj, referencing.ReferencedInheritingObject):
+                    for ancestor in obj.get_implicit_ancestors(old_schema):
+                        ancestor_name = ancestor.get_name(old_schema)
+
+                        anc_item = get_deps(('delete', str(ancestor_name)))
+                        anc_item.deps.add(('delete', ref_name_str))
 
         if isinstance(obj, referencing.ReferencedObject):
             referrer = obj.get_referrer(old_schema)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5362,6 +5362,35 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             scalar type foo extending enum<Foo, Bar, Baz>;
         """])
 
+    def test_schema_migrations_drop_depended_on_parent_01(self):
+        self._assert_migration_equivalence([r"""
+            type Person2 {
+                required single property first -> str;
+            }
+
+            type Person2a extending Person2 {
+                constraint exclusive on (__subject__.first);
+            }
+        """, r"""
+        """])
+
+    def test_schema_migrations_drop_depended_on_parent_02(self):
+        self._assert_migration_equivalence([r"""
+            type Person2;
+            type Person2a extending Person2;
+        """, r"""
+        """])
+
+    def test_schema_migrations_drop_depended_on_parent_03(self):
+        self._assert_migration_equivalence([r"""
+            type Person2 {
+                required single property first -> str;
+            };
+            type Person2a extending Person2;
+        """, r"""
+            type Person2a;
+        """])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
This is the bug that caused me to look into and file #2296, but it
doesn't actually fix any of the failures uncovered there...