### PR TITLE
Get rid of DeleteObject.expiring_refs

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3331,11 +3331,6 @@ class DeleteObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
     #: in the schema.
     if_unused = struct.Field(bool, default=False)
 
-    #: Potential references to this object that we know are being
-    #: deleted, which we use to resolve if_unused.
-    expiring_refs = struct.Field(AbstractSet[so.Object],
-                                 default=frozenset())
-
     def get_verb(self) -> str:
         return 'drop'
 
@@ -3432,7 +3427,6 @@ class DeleteObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
             if refs:
                 for ref in refs:
                     if (not context.is_deleting(ref)
-                            and ref not in self.expiring_refs
                             and ref.is_blocking_ref(orig_schema, self.scls)):
                         ref_strs.append(
                             ref.get_verbosename(orig_schema, with_parent=True))
@@ -3461,7 +3455,7 @@ class DeleteObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
         # (e.g. source backref in pointers of an object type).
         refs = [
             ref
-            for ref in schema.get_referrers(self.scls) - self.expiring_refs
+            for ref in schema.get_referrers(self.scls)
             if not ref.is_parent_ref(schema, self.scls)
             and not context.is_deleting(ref)
         ]

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -219,15 +219,10 @@ class AliasCommand(
         if prev_ir is not None:
             assert old_schema
             for vt in prev_coll_expr_aliases:
-                dt = vt.as_colltype_delete_delta(
-                    old_schema,
-                    view_name=classname,
-                )
+                dt = vt.as_colltype_delete_delta(old_schema)
                 derived_delta.prepend(dt)
             for vt in prev_ir.new_coll_types:
-                dt = vt.as_colltype_delete_delta(
-                    old_schema,
-                )
+                dt = vt.as_colltype_delete_delta(old_schema)
                 derived_delta.prepend(dt)
 
         for vt in coll_expr_aliases:
@@ -409,10 +404,7 @@ class DeleteAlias(
         if not context.canonical:
             alias_type = self.scls.get_type(schema)
             if isinstance(alias_type, s_types.Collection):
-                name = alias_type.get_name(schema)
-                assert isinstance(name, sn.QualName)
-                drop_type = alias_type.as_colltype_delete_delta(
-                    schema, view_name=name)
+                drop_type = alias_type.as_colltype_delete_delta(schema)
             else:
                 drop_type = alias_type.init_delta_command(
                     schema, sd.DeleteObject)

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -328,9 +328,7 @@ class ParameterDesc(ParameterLike):
         if isinstance(self.type, s_types.CollectionTypeShell):
             colltype = self.type.resolve(schema)
             assert isinstance(colltype, s_types.Collection)
-            obj = schema.get(param_name)
-            cmd.add(
-                colltype.as_colltype_delete_delta(schema, expiring_refs={obj}))
+            cmd.add(colltype.as_colltype_delete_delta(schema))
 
         return cmd
 
@@ -1143,8 +1141,7 @@ class DeleteCallableObject(
 
         return_type = obj.get_return_type(schema)
         if isinstance(return_type, s_types.Collection):
-            cmd.add(return_type.as_colltype_delete_delta(
-                schema, expiring_refs={obj}))
+            cmd.add(return_type.as_colltype_delete_delta(schema))
 
         return cmd
 

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -685,7 +685,6 @@ class DeleteLink(
             del_cmd = target.init_delta_command(
                 schema,
                 sd.DeleteObject,
-                expiring_refs={scls},
                 if_unused=True,
             )
             subcmds = del_cmd._canonicalize(schema, context, target)

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -453,8 +453,7 @@ class DeleteProperty(
         assert isinstance(scls, Property)
         target = scls.get_target(schema)
         if target is not None and isinstance(target, s_types.Collection):
-            cmds.append(
-                target.as_colltype_delete_delta(schema, expiring_refs={scls}))
+            cmds.append(target.as_colltype_delete_delta(schema))
 
         return cmds
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1793,8 +1793,7 @@ class SetPointerType(
             if orig_target is not None:
                 if isinstance(orig_target, s_types.Collection):
                     parent_op = self.get_parent_op(context)
-                    cleanup_op = orig_target.as_colltype_delete_delta(
-                        schema, expiring_refs={scls})
+                    cleanup_op = orig_target.as_colltype_delete_delta(schema)
                     parent_op.add(cleanup_op)
                     schema = cleanup_op.apply(schema, context)
                 elif orig_target.is_compound_type(schema):
@@ -1803,7 +1802,6 @@ class SetPointerType(
                         schema,
                         sd.DeleteObject,
                         if_unused=True,
-                        expiring_refs={scls},
                     )
                     parent_op.add(cleanup_op)
                     schema = cleanup_op.apply(schema, context)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -924,7 +924,6 @@ class Collection(Type, s_abc.Collection):
         self,
         schema: s_schema.Schema,
         *,
-        expiring_refs: AbstractSet[so.Object],
         view_name: Optional[s_name.QualName] = None,
     ) -> sd.Command:
         raise NotImplementedError
@@ -1254,7 +1253,6 @@ class Array(
         self,
         schema: s_schema.Schema,
         *,
-        expiring_refs: AbstractSet[so.Object] = frozenset(),
         view_name: Optional[s_name.QualName] = None,
     ) -> Union[DeleteArray, DeleteArrayExprAlias]:
         cmd: Union[DeleteArray, DeleteArrayExprAlias]
@@ -1263,18 +1261,16 @@ class Array(
                 classname=self.get_name(schema),
                 if_unused=True,
                 if_exists=True,
-                expiring_refs=expiring_refs,
             )
         else:
             cmd = DeleteArrayExprAlias(
                 classname=view_name,
                 if_exists=True,
-                expiring_refs=expiring_refs,
             )
 
         el = self.get_element_type(schema)
         if isinstance(el, Collection):
-            cmd.add(el.as_colltype_delete_delta(schema, expiring_refs={self}))
+            cmd.add(el.as_colltype_delete_delta(schema))
 
         return cmd
 
@@ -1847,7 +1843,6 @@ class Tuple(
         self,
         schema: s_schema.Schema,
         *,
-        expiring_refs: AbstractSet[so.Object] = frozenset(),
         view_name: Optional[s_name.QualName] = None,
     ) -> Union[DeleteTuple, DeleteTupleExprAlias]:
         cmd: Union[DeleteTuple, DeleteTupleExprAlias]
@@ -1856,19 +1851,16 @@ class Tuple(
                 classname=self.get_name(schema),
                 if_unused=True,
                 if_exists=True,
-                expiring_refs=expiring_refs,
             )
         else:
             cmd = DeleteTupleExprAlias(
                 classname=view_name,
                 if_exists=True,
-                expiring_refs=expiring_refs,
             )
 
         for el in self.get_subtypes(schema):
             if isinstance(el, Collection):
-                cmd.add(
-                    el.as_colltype_delete_delta(schema, expiring_refs={self}))
+                cmd.add(el.as_colltype_delete_delta(schema))
 
         return cmd
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -923,8 +923,6 @@ class Collection(Type, s_abc.Collection):
     def as_colltype_delete_delta(
         self,
         schema: s_schema.Schema,
-        *,
-        view_name: Optional[s_name.QualName] = None,
     ) -> sd.Command:
         raise NotImplementedError
 
@@ -1252,11 +1250,9 @@ class Array(
     def as_colltype_delete_delta(
         self,
         schema: s_schema.Schema,
-        *,
-        view_name: Optional[s_name.QualName] = None,
     ) -> Union[DeleteArray, DeleteArrayExprAlias]:
         cmd: Union[DeleteArray, DeleteArrayExprAlias]
-        if view_name is None:
+        if not isinstance(self, ArrayExprAlias):
             cmd = DeleteArray(
                 classname=self.get_name(schema),
                 if_unused=True,
@@ -1264,7 +1260,7 @@ class Array(
             )
         else:
             cmd = DeleteArrayExprAlias(
-                classname=view_name,
+                classname=self.get_name(schema),
                 if_exists=True,
             )
 
@@ -1842,11 +1838,9 @@ class Tuple(
     def as_colltype_delete_delta(
         self,
         schema: s_schema.Schema,
-        *,
-        view_name: Optional[s_name.QualName] = None,
     ) -> Union[DeleteTuple, DeleteTupleExprAlias]:
         cmd: Union[DeleteTuple, DeleteTupleExprAlias]
-        if view_name is None:
+        if not isinstance(self, TupleExprAlias):
             cmd = DeleteTuple(
                 classname=self.get_name(schema),
                 if_unused=True,
@@ -1854,7 +1848,7 @@ class Tuple(
             )
         else:
             cmd = DeleteTupleExprAlias(
-                classname=view_name,
+                classname=self.get_name(schema),
                 if_exists=True,
             )
 


### PR DESCRIPTION
After #2344, the only case where it was still needed was AlterAlias,
which arranges to do type deletion as a prerequisite. That's easy to
work around by just unsetting the type field.