### PR TITLE
Refactoring of some collection and function deletion stuff

### DIFF
--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -158,10 +158,9 @@ class RenameAnnotation(AnnotationCommand, sd.RenameObject[Annotation]):
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
-        scls: so.Object,
+        scls: Annotation,
     ) -> None:
         super()._canonicalize(schema, context, scls)
-        assert isinstance(scls, Annotation)
 
         # AnnotationValues have names derived from the abstract
         # annotations. We unfortunately need to go update their names.

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3163,7 +3163,7 @@ class RenameObject(AlterObjectFragment[so.Object_T]):
         self,
         schema: s_schema.Schema,
         context: CommandContext,
-        scls: so.Object,
+        scls: so.Object_T,
     ) -> None:
         mcls = self.get_schema_metaclass()
 
@@ -3365,10 +3365,10 @@ class DeleteObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
         self,
         schema: s_schema.Schema,
         context: CommandContext,
-        scls: so.Object,
-    ) -> Sequence[Command]:
+        scls: so.Object_T,
+    ) -> List[Command]:
         mcls = self.get_schema_metaclass()
-        commands = []
+        commands: List[Command] = []
 
         for refdict in mcls.get_refdicts():
             deleted_refs = set()

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -219,10 +219,10 @@ class AliasCommand(
         if prev_ir is not None:
             assert old_schema
             for vt in prev_coll_expr_aliases:
-                dt = vt.as_colltype_delete_delta(old_schema)
+                dt = vt.as_type_delete_if_dead(old_schema)
                 derived_delta.prepend(dt)
             for vt in prev_ir.new_coll_types:
-                dt = vt.as_colltype_delete_delta(old_schema)
+                dt = vt.as_type_delete_if_dead(old_schema)
                 derived_delta.prepend(dt)
 
         for vt in coll_expr_aliases:
@@ -403,11 +403,8 @@ class DeleteAlias(
     ) -> s_schema.Schema:
         if not context.canonical:
             alias_type = self.scls.get_type(schema)
-            if isinstance(alias_type, s_types.Collection):
-                drop_type = alias_type.as_colltype_delete_delta(schema)
-            else:
-                drop_type = alias_type.init_delta_command(
-                    schema, sd.DeleteObject)
+            drop_type = alias_type.init_delta_command(
+                schema, sd.DeleteObject)
             self.add_prerequisite(drop_type)
 
         return super()._delete_begin(schema, context)

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -446,14 +446,14 @@ class DeleteProperty(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
-        scls: so.Object,
-    ) -> Sequence[sd.Command]:
-        cmds = list(super()._canonicalize(schema, context, scls))
+        scls: Property,
+    ) -> List[sd.Command]:
+        cmds = super()._canonicalize(schema, context, scls)
 
-        assert isinstance(scls, Property)
         target = scls.get_target(schema)
-        if target is not None and isinstance(target, s_types.Collection):
-            cmds.append(target.as_colltype_delete_delta(schema))
+        if target is not None and not scls.is_special_pointer(schema):
+            if op := target.as_type_delete_if_dead(schema):
+                cmds.append(op)
 
         return cmds
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1791,18 +1791,8 @@ class SetPointerType(
             )
 
             if orig_target is not None:
-                if isinstance(orig_target, s_types.Collection):
+                if cleanup_op := orig_target.as_type_delete_if_dead(schema):
                     parent_op = self.get_parent_op(context)
-                    cleanup_op = orig_target.as_colltype_delete_delta(schema)
-                    parent_op.add(cleanup_op)
-                    schema = cleanup_op.apply(schema, context)
-                elif orig_target.is_compound_type(schema):
-                    parent_op = self.get_parent_op(context)
-                    cleanup_op = orig_target.init_delta_command(
-                        schema,
-                        sd.DeleteObject,
-                        if_unused=True,
-                    )
                     parent_op.add(cleanup_op)
                     schema = cleanup_op.apply(schema, context)
 


### PR DESCRIPTION
Have CollectionType and CallableType rely on _canonicalize to populate
deletions, and get rid of as_colltype_delete_delta in favor of an
Optional-returning as_type_delete_if_dead defined on Type.

This lets us drop most of our special cases on Collection and on
compound types.