### PR TITLE
Fix an issue with using ad-hoc aliases in SDL.

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -154,7 +154,8 @@ def compile_FunctionCall(
         # allowed.
         if ctx.env.options.in_ddl_context_name is not None:
             raise errors.SchemaDefinitionError(
-                f'invalid mutation in {ctx.env.options.in_ddl_context_name}',
+                f'mutations are invalid in '
+                f'{ctx.env.options.in_ddl_context_name}',
                 context=expr.context,
             )
         elif ((dv := ctx.defining_view) is not None and
@@ -164,7 +165,7 @@ def compile_FunctionCall(
             # DML is not allowed in the computable, but it may
             # be possible to refactor it.
             raise errors.QueryError(
-                f'invalid mutation in a shape computable',
+                f'mutations are invalid in a shape computable',
                 hint=(
                     f'To resolve this try to factor out the mutation '
                     f'expression into the top-level WITH block.'

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1030,7 +1030,8 @@ def init_stmt(
         # allowed.
         if ctx.env.options.in_ddl_context_name is not None:
             raise errors.SchemaDefinitionError(
-                f'invalid mutation in {ctx.env.options.in_ddl_context_name}',
+                f'mutations are invalid in '
+                f'{ctx.env.options.in_ddl_context_name}',
                 context=qlstmt.context,
             )
         elif ((dv := ctx.defining_view) is not None and
@@ -1040,7 +1041,7 @@ def init_stmt(
             # DML is not allowed in the computable, but it may
             # be possible to refactor it.
             raise errors.QueryError(
-                f'invalid mutation in a shape computable',
+                f'mutations are invalid in a shape computable',
                 hint=(
                     f'To resolve this try to factor out the mutation '
                     f'expression into the top-level WITH block.'

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -63,7 +63,7 @@ class TraceContextBase:
     module: str
     depstack: List[Tuple[qlast.DDLOperation, s_name.QualName]]
     modaliases: Dict[Optional[str], str]
-    objects: Dict[s_name.QualName, qltracer.ObjectLike]
+    objects: Dict[s_name.QualName, Optional[qltracer.ObjectLike]]
     parents: Dict[s_name.QualName, Set[s_name.QualName]]
     ancestors: Dict[s_name.QualName, Set[s_name.QualName]]
     defdeps: Dict[s_name.QualName, Set[s_name.QualName]]
@@ -236,7 +236,7 @@ class DepTraceContext(TraceContextBase):
         self,
         schema: s_schema.Schema,
         ddlgraph: DDLGraph,
-        objects: Dict[s_name.QualName, qltracer.ObjectLike],
+        objects: Dict[s_name.QualName, Optional[qltracer.ObjectLike]],
         parents: Dict[s_name.QualName, Set[s_name.QualName]],
         ancestors: Dict[s_name.QualName, Set[s_name.QualName]],
         defdeps: Dict[s_name.QualName, Set[s_name.QualName]],

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3040,7 +3040,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_bad_07(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
-                r"invalid mutation in computable link 'foo'"):
+                r"mutations are invalid in computable link 'foo'"):
             async with self.con.transaction():
                 await self.con.execute(r"""
                     CREATE TYPE test::Foo;
@@ -3053,7 +3053,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_bad_08(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
-                r"invalid mutation in computable link 'foo'"):
+                r"mutations are invalid in computable link 'foo'"):
             async with self.con.transaction():
                 await self.con.execute(r"""
                     CREATE TYPE test::Foo;
@@ -3069,7 +3069,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_bad_09(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
-                r"invalid mutation in computable property 'foo'"):
+                r"mutations are invalid in computable property 'foo'"):
             async with self.con.transaction():
                 await self.con.execute(r"""
                     CREATE TYPE test::Foo;
@@ -3082,7 +3082,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_bad_10(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
-                r"invalid mutation in alias definition"):
+                r"mutations are invalid in alias definition"):
             async with self.con.transaction():
                 await self.con.execute(r"""
                     CREATE TYPE test::Foo;
@@ -3096,7 +3096,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_bad_11(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
-                r"invalid mutation in alias definition"):
+                r"mutations are invalid in alias definition"):
             async with self.con.transaction():
                 await self.con.execute(r"""
                     CREATE TYPE test::Foo;
@@ -3110,7 +3110,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_bad_12(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
-                r"invalid mutation in alias definition"):
+                r"mutations are invalid in alias definition"):
             async with self.con.transaction():
                 await self.con.execute(r"""
                     CREATE TYPE test::Foo;
@@ -3128,7 +3128,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_bad_13(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
-                r"invalid mutation in alias definition"):
+                r"mutations are invalid in alias definition"):
             async with self.con.transaction():
                 await self.con.execute(r"""
                     CREATE TYPE test::Foo;

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2883,7 +2883,7 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_dependent_07(self):
         async with self.assertRaisesRegexTx(
                 edgedb.QueryError,
-                "invalid mutation in a shape computable"):
+                "mutations are invalid in a shape computable"):
             await self.con.execute(
                 r"""
                     WITH MODULE test

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3041,6 +3041,12 @@ aa';
         SELECT x;
         """
 
+    def test_edgeql_syntax_selectfor_05(self):
+        """
+        FOR x IN {1, 2, 3}
+        UNION y := (x + 2);
+        """
+
     def test_edgeql_syntax_deletefor_01(self):
         """
         FOR x IN {(('Alice', 'White') UNION ('Bob', 'Green'))}


### PR DESCRIPTION
Ad-hoc aliases inside WITH blocks or around SELECT results no longer
cause a tracer problem when appearing in expressions in SDL.

Fixes #1425
Fixes #2320