### PR TITLE
Make ordering understand that DROP OWNED will delete refs

### DIFF
--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -391,7 +391,10 @@ class AlterAnnotationValue(
         *,
         parent_node: Optional[qlast.DDLOperation] = None,
     ) -> Optional[qlast.DDLOperation]:
-        if not self.has_attribute_value('value'):
+        if (
+            not self.has_attribute_value('value')
+            and not self.has_attribute_value('owned')
+        ):
             return None
         # Skip AlterObject's _get_ast, because we *don't* want to
         # filter out things without subcommands!

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -532,7 +532,10 @@ def _trace_op(
     elif isinstance(op, sd.DeleteObject):
         tag = 'delete'
     elif isinstance(op, referencing.AlterOwned):
-        tag = 'alterowned'
+        if op.get_attribute_value('owned'):
+            tag = 'setowned'
+        else:
+            tag = 'dropowned'
     elif isinstance(op, (sd.AlterObjectProperty, sd.AlterSpecialObjectField)):
         tag = 'field'
     else:
@@ -609,17 +612,19 @@ def _trace_op(
                 if referrer_name in renames_r:
                     referrer_name = renames_r[referrer_name]
 
+                # A drop needs to come *before* drop owned on the referrer
+                # which will do it itself.
+                if tag == 'delete':
+                    ref_item = get_deps(('dropowned', str(referrer_name)))
+                    ref_item.deps.add(('delete', str(op.classname)))
+
                 # For SET OWNED, we need any rebase of the enclosing
                 # object to come *after*, because otherwise obj could
                 # get dropped before the SET OWNED takes effect.
                 # For DROP OWNED and DROP we want it after the rebase.
-                is_set_owned = (
-                    isinstance(op, referencing.AlterOwned)
-                    and op.get_attribute_value('owned')
-                )
-                if is_set_owned:
+                if tag == 'setowned':
                     ref_item = get_deps(('rebase', str(referrer_name)))
-                    ref_item.deps.add(('alterowned', str(op.classname)))
+                    ref_item.deps.add(('setowned', str(op.classname)))
                 else:
                     deps.add(('rebase', str(referrer_name)))
 
@@ -633,14 +638,15 @@ def _trace_op(
                     for ancestor in obj.get_implicit_ancestors(old_schema):
                         ancestor_name = ancestor.get_name(old_schema)
                         implicit_ancestors.append(ancestor_name)
-                        anc_item = get_deps(('delete', str(ancestor_name)))
-                        anc_item.deps.add(('alterowned', str(op.classname)))
 
-                        if is_set_owned:
+                        if isinstance(op, referencing.AlterOwned):
+                            anc_item = get_deps(('delete', str(ancestor_name)))
+                            anc_item.deps.add((tag, str(op.classname)))
+
+                        if tag == 'setowned':
                             # SET OWNED must come before ancestor rebases too
                             anc_item = get_deps(('rebase', str(ancestor_name)))
-                            anc_item.deps.add(
-                                ('alterowned', str(op.classname)))
+                            anc_item.deps.add(('setowned', str(op.classname)))
 
         graph_key = str(op.classname)
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -6124,6 +6124,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }],
         )
 
+        await self.migrate("")
+
     async def test_edgeql_migration_eq_linkprops_11(self):
         # merging a link with the same properties
         await self.migrate(r"""
@@ -7839,6 +7841,42 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                     SELECT Remark FILTER Remark.note = ComputeLink.foo);
             };
             alias Alias := Remark;
+        """)
+
+        await self.migrate("")
+
+    async def test_edgeql_migration_annotation_05(self):
+        await self.migrate(r"""
+            abstract inheritable annotation my_anno;
+
+            type Base {
+                property my_prop -> str {
+                    annotation my_anno := 'Base my_anno 05';
+                }
+            }
+
+            type Derived extending Base {
+                overloaded property my_prop -> str {
+                    annotation my_anno := 'Derived my_anno 05';
+                }
+            }
+        """)
+
+        await self.migrate(r"""
+            # rename annotated & inherited property
+            abstract inheritable annotation my_anno;
+
+            type Base {
+                property renamed_prop -> str {
+                    annotation my_anno := 'Base my_anno 05';
+                }
+            }
+
+            type Derived extending Base {
+                overloaded property renamed_prop -> str {
+                    annotation my_anno := 'Derived my_anno 05';
+                }
+            }
         """)
 
         await self.migrate("")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3909,6 +3909,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                     property foo -> str
                 }
             };
+        """, r"""
         """])
 
     def test_schema_migrations_equivalence_linkprops_09(self):
@@ -3965,6 +3966,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                     property foo -> str
                 }
             };
+        """, r"""
         """])
 
     def test_schema_migrations_equivalence_linkprops_11(self):
@@ -4024,6 +4026,32 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             type Owner extending Base;
 
             type Renter extending Base;
+        """])
+
+    def test_schema_migrations_equivalence_linkprops_13(self):
+        self._assert_migration_equivalence([r"""
+            type Child;
+
+            type Base {
+                link child -> Child
+            };
+
+            type Derived extending Base {
+                overloaded link child -> Child {
+                    property foo -> str
+                }
+            };
+        """, r"""
+            type Child;
+
+            type Base {
+                link child -> Child {
+                    property foo -> str
+                }
+            };
+
+            type Derived extending Base;
+        """, r"""
         """])
 
     def test_schema_migrations_equivalence_annotation_01(self):
@@ -4395,6 +4423,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                     constraint min_len_value(5);
                 }
             }
+        """, r"""
         """])
 
     # NOTE: array<str>, array<int16>, array<json> already exist in std


### PR DESCRIPTION
Doing this without introducing cycles in some situations required
splitting alterowned into separate setowned and dropowned actions,
from the perspective or ordering.

Also, fix the case where an annotation gets DROP OWNED and then it and
its abstract annotation is deleted. This worked in test_schema but hit
an issue in writer.

Work on #2296.