### PR TITLE
Fix object renames when affected refs have interdependencies.

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4985,6 +4985,27 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             alias Alias3 := Remark { command := .remark ++ "!" };
         """])
 
+    def test_schema_migrations_equivalence_rename_refs_07(self):
+        self._assert_migration_equivalence([r"""
+            type Obj1 {
+                 required property id1 -> str;
+                 required property id2 -> str;
+                 property exclusive_hack {
+                     using ((.id1, .id2));
+                     constraint exclusive;
+                 };
+             }
+        """, r"""
+            type Obj2 {
+                 required property id1 -> str;
+                 required property id2 -> str;
+                 property exclusive_hack {
+                     using ((.id1, .id2));
+                     constraint exclusive;
+                 };
+             }
+        """])
+
     def test_schema_migrations_equivalence_rename_alias_01(self):
         self._assert_migration_equivalence([r"""
             type Note {


### PR DESCRIPTION
Solve this by sorting the commands in _finalize_affected_refs
topologically.

Fixes #2353.