### PR TITLE
Add the ability to run test on remote Postgres

### DIFF
--- a/edb/tools/test/__init__.py
+++ b/edb/tools/test/__init__.py
@@ -88,9 +88,11 @@ __all__ = ('not_implemented', 'xfail', 'skip')
               help='Maintain a running time log file at FILEPATH')
 @click.option('--list', 'list_tests', is_flag=True,
               help='list all the tests and exit')
+@click.option('--postgres-dsn', type=str,
+              help='Test ')
 def test(*, files, jobs, shard, include, exclude, verbose, quiet, debug,
          output_format, warnings, failfast, shuffle, cov, repeat,
-         running_times_log_file, list_tests):
+         running_times_log_file, list_tests, postgres_dsn):
     """Run EdgeDB test suite.
 
     Discovers and runs tests in the specified files or directories.
@@ -163,6 +165,7 @@ def test(*, files, jobs, shard, include, exclude, verbose, quiet, debug,
         total_shards=total_shards,
         running_times_log_file=running_times_log_file,
         list_tests=list_tests,
+        postgres_dsn=postgres_dsn,
     )
 
     if cov:
@@ -238,7 +241,7 @@ def _coverage_wrapper(paths):
 
 def _run(*, include, exclude, verbosity, files, jobs, output_format,
          warnings, failfast, shuffle, repeat, selected_shard, total_shards,
-         running_times_log_file, list_tests):
+         running_times_log_file, list_tests, postgres_dsn):
     suite = unittest.TestSuite()
 
     total = 0
@@ -297,7 +300,7 @@ def _run(*, include, exclude, verbosity, files, jobs, output_format,
         test_runner = runner.ParallelTextTestRunner(
             verbosity=verbosity, output_format=output_format,
             warnings=warnings, num_workers=jobs,
-            failfast=failfast, shuffle=shuffle)
+            failfast=failfast, shuffle=shuffle, postgres_dsn=postgres_dsn)
 
         result = test_runner.run(
             suite, selected_shard, total_shards, running_times_log_file,

--- a/edb/tools/test/__init__.py
+++ b/edb/tools/test/__init__.py
@@ -89,7 +89,8 @@ __all__ = ('not_implemented', 'xfail', 'skip')
 @click.option('--list', 'list_tests', is_flag=True,
               help='list all the tests and exit')
 @click.option('--postgres-dsn', type=str,
-              help='Test ')
+              help='Use the specified Postgres cluster instead of starting a '
+                   'temporary local one.')
 def test(*, files, jobs, shard, include, exclude, verbose, quiet, debug,
          output_format, warnings, failfast, shuffle, cov, repeat,
          running_times_log_file, list_tests, postgres_dsn):

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -731,7 +731,7 @@ class ParallelTextTestRunner:
 
     def __init__(self, *, stream=None, num_workers=1, verbosity=1,
                  output_format=OutputFormat.auto, warnings=True,
-                 failfast=False, shuffle=False):
+                 failfast=False, shuffle=False, postgres_dsn=None):
         self.stream = stream if stream is not None else sys.stderr
         self.num_workers = num_workers
         self.verbosity = verbosity
@@ -739,6 +739,7 @@ class ParallelTextTestRunner:
         self.failfast = failfast
         self.shuffle = shuffle
         self.output_format = output_format
+        self.postgres_dsn = postgres_dsn
 
     def run(self, test, selected_shard, total_shards, running_times_log_file):
         session_start = time.monotonic()
@@ -777,7 +778,9 @@ class ParallelTextTestRunner:
                         nl=False,
                     )
 
-                cluster = tb._init_cluster(cleanup_atexit=False)
+                cluster = tb._init_cluster(
+                    postgres_dsn=self.postgres_dsn, cleanup_atexit=False
+                )
 
                 if self.verbosity > 1:
                     self._echo(' OK')


### PR DESCRIPTION
Refs a28a7762, added the `--postgres-dsn` option to `edb test` to configure the test suite to run with a remote Postgres cluster