### PR TITLE
Retry racing parallel tests with intervals

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -129,13 +129,16 @@ class TestCaseMeta(type(unittest.TestCase)):
                 except (edgedb.TransactionSerializationError,
                         edgedb.TransactionDeadlockError):
                     if (
-                        try_no == 3
+                        try_no == 6
                         # Only do a retry loop when we have a transaction
                         or not getattr(self, 'TRANSACTION_ISOLATION', False)
                     ):
                         raise
                     else:
                         self.loop.run_until_complete(self.xact.rollback())
+                        self.loop.run_until_complete(asyncio.sleep(
+                            (2 ** try_no) * 0.1 + random.randrange(100) * 0.001
+                        ))
                         self.xact = self.con.transaction()
                         self.loop.run_until_complete(self.xact.start())
 


### PR DESCRIPTION
Refs #2282, running the test suite on a Postgres without super user,`CREATE ROLE` may raise a serialization error if another test is racing for the same lock in parallel. We need some waiting time here to make sure the retry has a higher success rate. The backoff interval algorithm is similar to the one in edgedb-python, but waits for longer time.