### PR TITLE
Fix handling of collection types of non-builtin scalars in dumps

### DIFF
--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -100,6 +100,11 @@ def is_builtin_scalar(schema, scalar):
     return scalar.id in base_type_name_map
 
 
+def type_has_stable_oid(typ):
+    pg_type = base_type_name_map.get(typ.id)
+    return pg_type is not None and len(pg_type) == 1
+
+
 def get_scalar_base(schema, scalar) -> Tuple[str, ...]:
     base = base_type_name_map.get(scalar.id)
     if base is not None:

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -630,8 +630,7 @@ class Pointer(referencing.ReferencedInheritingObject,
 
     def is_dumpable(self, schema: s_schema.Schema) -> bool:
         return (
-            not self.is_endpoint_pointer(schema)
-            and not self.is_pure_computable(schema)
+            not self.is_pure_computable(schema)
         )
 
     def generic(self, schema: s_schema.Schema) -> bool:

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -254,40 +254,11 @@ def generate_structure(schema: s_schema.Schema) -> SchemaReflectionParts:
 
     schema = _run_ddl(
         '''
-            CREATE FUNCTION sys::_get_pg_type_for_scalar_type(
-                typeid: std::uuid
+            CREATE FUNCTION sys::_get_pg_type_for_edgedb_type(
+                typeid: std::uuid,
+                elemid: OPTIONAL std::uuid,
             ) -> std::int64 {
-                USING SQL $$
-                    SELECT
-                        coalesce(
-                            (
-                                SELECT
-                                    tn::regtype::oid
-                                FROM
-                                    edgedb._get_base_scalar_type_map()
-                                        AS m(tid uuid, tn text)
-                                WHERE
-                                    m.tid = "typeid"
-                            ),
-                            (
-                                SELECT
-                                    typ.oid
-                                FROM
-                                    pg_catalog.pg_type typ
-                                WHERE
-                                    typ.typname = "typeid"::text || '_domain'
-                            ),
-
-                            edgedb.raise(
-                                NULL::bigint,
-                                'invalid_parameter_value',
-                                msg => (
-                                    'cannot determine OID of '
-                                    || typeid::text
-                                )
-                            )
-                        )::bigint
-                $$;
+                USING SQL FUNCTION 'edgedb.get_pg_type_for_edgedb_type';
                 SET volatility := 'STABLE';
             };
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -401,7 +401,6 @@ class Type(
             return TypeShell(
                 name=name,
                 schemaclass=type(self),
-                is_abstract=self.get_abstract(schema),
             )
 
     def record_cmd_object_aux_data(
@@ -485,7 +484,6 @@ class TypeShell(so.ObjectShell):
         origname: Optional[s_name.Name] = None,
         displayname: Optional[str] = None,
         expr: Optional[str] = None,
-        is_abstract: bool = False,
         schemaclass: typing.Type[Type] = Type,
         sourcectx: Optional[parsing.ParserContext] = None,
     ) -> None:
@@ -497,7 +495,6 @@ class TypeShell(so.ObjectShell):
             sourcectx=sourcectx,
         )
 
-        self.is_abstract = is_abstract
         self.expr = expr
 
     def resolve(self, schema: s_schema.Schema) -> Type:
@@ -508,7 +505,7 @@ class TypeShell(so.ObjectShell):
         )
 
     def is_polymorphic(self, schema: s_schema.Schema) -> bool:
-        return self.is_abstract
+        return self.resolve(schema).is_polymorphic(schema)
 
     def as_create_delta(
         self,
@@ -1340,6 +1337,7 @@ class ArrayTypeShell(CollectionTypeShell):
         ca.set_attribute_value('name', ca.classname)
         ca.set_attribute_value('element_type', el)
         ca.set_attribute_value('is_persistent', True)
+        ca.set_attribute_value('abstract', self.is_polymorphic(schema))
         ca.set_attribute_value('dimensions', self.typemods[0])
 
         if attrs:
@@ -1918,6 +1916,7 @@ class TupleTypeShell(CollectionTypeShell):
         named = self.is_named()
         ct.set_attribute_value('name', ct.classname)
         ct.set_attribute_value('named', named)
+        ct.set_attribute_value('abstract', self.is_polymorphic(schema))
         ct.set_attribute_value('is_persistent', True)
         ct.set_attribute_value('element_types', self.subtypes)
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -272,7 +272,7 @@ cdef class DatabaseConnectionView:
             self._db._index._global_schema,
         )
 
-    def resolve_array_type_id(self, type_id):
+    def resolve_backend_type_id(self, type_id):
         type_id = str(type_id)
 
         if self._in_tx:
@@ -284,7 +284,7 @@ cdef class DatabaseConnectionView:
         tid = self._db.backend_ids.get(type_id)
         if tid is None:
             raise RuntimeError(
-                f'failed to resolve array OID for type {type_id}')
+                f'cannot resolve backend OID for type {type_id}')
         return tid
 
     cdef bytes serialize_state(self):

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,7 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_03_19_00_01
+EDGEDB_CATALOG_VERSION = 2021_03_19_00_02
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/server/pgcon/pgcon.pxd
+++ b/edb/server/pgcon/pgcon.pxd
@@ -26,6 +26,7 @@ from libc.stdint cimport int8_t, uint8_t, int16_t, uint16_t, \
 from edb.server.pgproto.pgproto cimport (
     WriteBuffer,
     ReadBuffer,
+    FRBuffer,
 )
 
 from edb.server.pgproto.debug cimport PG_DEBUG
@@ -104,11 +105,21 @@ cdef class PGConnection:
     cdef make_clean_stmt_message(self, bytes stmt_name)
     cdef make_auth_password_md5_message(self, bytes salt)
 
-    cdef _elide_copy_cols(
+    cdef _rewrite_copy_data(
         self,
         WriteBuffer wbuf,
-        char* data,
+        char *data,
         ssize_t data_len,
         ssize_t ncols,
         tuple elide_cols,
+        dict type_id_map,
+        tuple data_mending_desc,
+    )
+
+    cdef _mend_copy_datum(
+        self,
+        WriteBuffer wbuf,
+        FRBuffer *rbuf,
+        object mending_desc,
+        dict type_id_map,
     )

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -414,7 +414,7 @@ class Server:
                         "backend_id"
                     )::text
                 FROM
-                    edgedb."_SchemaScalarType"
+                    edgedb."_SchemaType"
                 ''',
                 b'__backend_ids_fetch',
                 dbver=0,

--- a/tests/schemas/dump03_default.esdl
+++ b/tests/schemas/dump03_default.esdl
@@ -1,0 +1,33 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+scalar type MyStr extending str;
+
+type Test {
+    required property name -> str {
+        constraint exclusive;
+    };
+    property array_of_tuples -> array<tuple<int64, MyStr, int64>>;
+    property tuple_of_arrays ->
+        tuple<
+            MyStr,
+            array<MyStr>,
+            tuple<int64, int64, array<MyStr>>,
+        >;
+};

--- a/tests/schemas/dump03_setup.edgeql
+++ b/tests/schemas/dump03_setup.edgeql
@@ -1,0 +1,26 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+SET MODULE default;
+
+INSERT Test {
+    name := 'test01',
+    array_of_tuples := [(1, '2', 3), (4, '5', 6)],
+    tuple_of_arrays := ('1', ['2', '3'], (4, 5, ['6'])),
+};

--- a/tests/test_dump03.py
+++ b/tests/test_dump03.py
@@ -1,0 +1,69 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os.path
+
+from edb.testbase import server as tb
+
+
+class DumpTestCaseMixin:
+
+    async def ensure_schema_data_integrity(self):
+        tx = self.con.transaction()
+        await tx.start()
+        try:
+            await self._ensure_schema_data_integrity()
+        finally:
+            await tx.rollback()
+
+    async def _ensure_schema_data_integrity(self):
+        await self.assert_query_result(
+            r'''
+                SELECT Test {
+                    array_of_tuples,
+                    tuple_of_arrays,
+                } FILTER .name = 'test01'
+            ''',
+            [
+                {
+                    'array_of_tuples': [
+                        [1, '2', 3],
+                        [4, '5', 6],
+                    ],
+                    'tuple_of_arrays': [
+                        '1',
+                        ['2', '3'],
+                        [4, 5, ['6']],
+                    ],
+                },
+            ]
+        )
+
+
+class TestDump03(tb.StableDumpTestCase, DumpTestCaseMixin):
+
+    SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
+                                  'dump03_default.esdl')
+
+    SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
+                         'dump03_setup.edgeql')
+
+    async def test_dump03_dump_restore(self):
+        await self.check_dump_restore(
+            DumpTestCaseMixin.ensure_schema_data_integrity)


### PR DESCRIPTION
PostgreSQL encodes internal OID of element types in array and tuple
binary data.  Since only the builtin pg_catalog types have stable OIDs,
the data of arrays and tuples of all other types must be patched with
correct OID values.  We already do this in a limited form for input data
of array arguments, but the dump angle was completely overlooked.

Fixes: #2349.