### PR TITLE
Fix failing ROLE DDL test on RDS

### DIFF
--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -34,7 +34,7 @@ import edgedb
 from edb.common import devmode
 from edb.edgeql import quote
 
-from edb.server import buildmeta
+from edb.server import buildmeta, pgconnparams
 from edb.server import defines as edgedb_defines
 
 from . import pgcluster
@@ -268,6 +268,9 @@ class BaseCluster:
             }
         ''')
 
+    def get_backend_runtime_params(self):
+        return self._pg_cluster.get_runtime_params()
+
 
 class Cluster(BaseCluster):
     def __init__(
@@ -288,7 +291,14 @@ class Cluster(BaseCluster):
         self._pg_connect_args['user'] = pg_superuser
 
     def _get_pg_cluster(self):
-        return pgcluster.get_local_pg_cluster(self._data_dir)
+        cluster = pgcluster.get_local_pg_cluster(self._data_dir)
+        cluster.set_connection_params(
+            pgconnparams.ConnectionParameters(
+                user=edgedb_defines.EDGEDB_SUPERUSER,
+                database=edgedb_defines.EDGEDB_TEMPLATE_DB,
+            ),
+        )
+        return cluster
 
     def get_data_dir(self):
         return self._data_dir

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -54,6 +54,7 @@ from edb import cli
 from edb.edgeql import quote as qlquote
 from edb.server import cluster as edgedb_cluster
 from edb.server import defines as edgedb_defines
+from edb.server import pgcluster
 
 from edb.common import taskgroup
 
@@ -872,6 +873,8 @@ class DatabaseTestCase(ClusterTestCase, ConnectedTestCaseMixin):
     BASE_TEST_CLASS = True
 
     con: Any  # XXX: the real type?
+
+    cluster_backend_params: pgcluster.BackendRuntimeParams
 
     def setUp(self):
         if self.INTERNAL_TESTMODE:

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -781,6 +781,9 @@ class ParallelTextTestRunner:
                 cluster = tb._init_cluster(
                     postgres_dsn=self.postgres_dsn, cleanup_atexit=False
                 )
+                cluster_backend_params = cluster.get_backend_runtime_params()
+                for case in cases:
+                    case.cluster_backend_params = cluster_backend_params
 
                 if self.verbosity > 1:
                     self._echo(' OK')

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6354,12 +6354,14 @@ type test::Foo {
         )
 
     async def test_edgeql_ddl_role_02(self):
+        from edb.server.pgcluster import BackendCapabilities
         await self.con.execute(r"""
             CREATE SUPERUSER ROLE foo2 {
                 SET password := 'secret';
             };
         """)
 
+        caps = self.cluster_backend_params.instance_params.capabilities
         await self.assert_query_result(
             r"""
                 SELECT sys::Role {
@@ -6369,7 +6371,7 @@ type test::Foo {
             """,
             [{
                 'name': 'foo2',
-                'superuser': True,
+                'superuser': caps & BackendCapabilities.SUPERUSER_ACCESS,
             }]
         )
 


### PR DESCRIPTION
`CREATE SUPERUSER ROLE` will create a non-super role on EdgeDB with backend Postgres that doesn't have super user like AWS RDS.