### PR TITLE
Auto-detect and set default --max-backend-connections

### DIFF
--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -97,6 +97,12 @@ ALTER TYPE cfg::AbstractConfig {
         CREATE ANNOTATION cfg::internal := 'true';
         SET default := '';
     };
+
+    CREATE PROPERTY __pg_max_connections -> std::str {
+        CREATE ANNOTATION cfg::internal := 'true';
+        CREATE ANNOTATION cfg::backend_setting := '"max_connections"';
+        SET default := '';
+    };
 };
 
 

--- a/edb/server/config/spec.py
+++ b/edb/server/config/spec.py
@@ -26,6 +26,7 @@ from typing import *
 
 from edb.edgeql import compiler as qlcompiler
 from edb.ir import staeval
+from edb.schema import name as sn
 
 from . import types
 
@@ -157,12 +158,14 @@ def load_spec_from_schema(schema):
             pn,
             type=pytype,
             set_of=set_of,
-            internal=attributes.get('cfg::internal', False),
-            system=attributes.get('cfg::system', False),
-            requires_restart=attributes.get('cfg::requires_restart', False),
-            backend_setting=attributes.get('cfg::backend_setting', None),
+            internal=attributes.get(sn.QualName('cfg', 'internal'), False),
+            system=attributes.get(sn.QualName('cfg', 'system'), False),
+            requires_restart=attributes.get(
+                sn.QualName('cfg', 'requires_restart'), False),
+            backend_setting=attributes.get(
+                sn.QualName('cfg', 'backend_setting'), None),
             affects_compilation=attributes.get(
-                'cfg::affects_compilation', False),
+                sn.QualName('cfg', 'affects_compilation'), False),
             default=deflt,
         )
 

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -270,7 +270,16 @@ def run_server(args: ServerConfig):
 
     cluster: Union[pgcluster.Cluster, pgcluster.RemoteCluster]
     if args.data_dir:
-        cluster = pgcluster.get_local_pg_cluster(args.data_dir)
+        if not args.max_backend_connections:
+            max_conns = _default_max_backend_connections()
+            new_args = args._asdict()
+            new_args['max_backend_connections'] = max_conns
+            args = ServerConfig(**new_args)
+            logger.info(f'Using {max_conns} max backend connections based on '
+                        f'total memory.')
+
+        cluster = pgcluster.get_local_pg_cluster(
+            args.data_dir, max_connections=args.max_backend_connections)
         default_runstate_dir = cluster.get_data_dir()
         cluster.set_connection_params(
             pgconnparams.ConnectionParameters(
@@ -280,6 +289,20 @@ def run_server(args: ServerConfig):
         )
     elif args.postgres_dsn:
         cluster = pgcluster.get_remote_pg_cluster(args.postgres_dsn)
+
+        instance_params = cluster.get_runtime_params().instance_params
+        max_conns = (
+            instance_params.max_connections -
+            instance_params.reserved_connections)
+        if not args.max_backend_connections:
+            new_args = args._asdict()
+            new_args['max_backend_connections'] = max_conns
+            args = ServerConfig(**new_args)
+            logger.info(f'Detected {max_conns} backend connections available.')
+        elif args.max_backend_connections > max_conns:
+            abort(f'--max-backend-connections is too large for this backend; '
+                  f'detected maximum available NUM: {max_conns}')
+
         default_runstate_dir = None
     else:
         # This should have been checked by main() already,
@@ -437,7 +460,7 @@ class ServerConfig(typing.NamedTuple):
     daemon_user: str
     daemon_group: str
     runstate_dir: pathlib.Path
-    max_backend_connections: int
+    max_backend_connections: Optional[int]
     compiler_pool_size: int
     echo_runtime_info: bool
     temp_dir: bool
@@ -487,11 +510,28 @@ def _protocol_version(
 
 
 def _validate_max_backend_connections(ctx, param, value):
-    if value < defines.BACKEND_CONNECTIONS_MIN:
+    if value is not None and value < defines.BACKEND_CONNECTIONS_MIN:
         raise click.BadParameter(
             f'the minimum number of backend connections '
             f'is {defines.BACKEND_CONNECTIONS_MIN}')
     return value
+
+
+def _default_max_backend_connections():
+    try:
+        import psutil
+    except ImportError:
+        total_mem = 1024 * 1024 * 1024
+        if sys.platform.startswith("linux"):
+            with open('/proc/meminfo', 'rb') as f:
+                for line in f:
+                    if line.startswith(b'MemTotal'):
+                        total_mem = int(line.split()[1]) * 1024
+                        break
+    else:
+        total_mem = psutil.virtual_memory().total
+
+    return int(total_mem / 1024 / 1024 / 100 * 8)
 
 
 def _validate_compiler_pool_size(ctx, param, value):
@@ -570,8 +610,13 @@ _server_options = [
              f'runtime files will be placed ({_get_runstate_dir_default()} '
              f'by default)'),
     click.option(
-        '--max-backend-connections', type=int,
-        default=defines.BACKEND_CONNECTIONS_DEFAULT,
+        '--max-backend-connections', type=int, metavar='NUM',
+        help=f'The maximum NUM of connections this EdgeDB instance could make '
+             f'to the backend PostgreSQL cluster. If not set, EdgeDB will '
+             f'detect and calculate the NUM: RAM/100Mb='
+             f'{_default_max_backend_connections()} for local Postgres or '
+             f'pg_settings.max_connections for remote Postgres, minus the NUM '
+             f'of --reserved-pg-connections.',
         callback=_validate_max_backend_connections),
     click.option(
         '--compiler-pool-size', type=int,

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -57,7 +57,7 @@ from . import pgcluster
 from . import protocol
 
 
-BYTES_OF_MEM_PER_CONN = 100 * 1024 * 1024 / 8  # 100Mb
+BYTES_OF_MEM_PER_CONN = 100 * 1024 * 1024  # 100MiB
 
 logger = logging.getLogger('edb.server')
 _server_initialized = False
@@ -518,7 +518,7 @@ def _validate_max_backend_connections(ctx, param, value):
 
 def _compute_default_max_backend_connections():
     total_mem = psutil.virtual_memory().total
-    return int(total_mem / BYTES_OF_MEM_PER_CONN)
+    return max(int(total_mem / BYTES_OF_MEM_PER_CONN), 2)
 
 
 def _validate_compiler_pool_size(ctx, param, value):
@@ -600,7 +600,7 @@ _server_options = [
         '--max-backend-connections', type=int, metavar='NUM',
         help=f'The maximum NUM of connections this EdgeDB instance could make '
              f'to the backend PostgreSQL cluster. If not set, EdgeDB will '
-             f'detect and calculate the NUM: RAM/100Mb='
+             f'detect and calculate the NUM: RAM/100MiB='
              f'{_compute_default_max_backend_connections()} for local '
              f'Postgres or pg_settings.max_connections for remote Postgres, '
              f'minus the NUM of --reserved-pg-connections.',

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -97,8 +97,8 @@ class BackendInstanceParams(NamedTuple):
 
     capabilities: BackendCapabilities
     base_superuser: Optional[str] = None
-    max_connections: Optional[int] = None
-    reserved_connections: Optional[int] = 0
+    max_connections: int = 500
+    reserved_connections: int = 0
 
 
 class BackendRuntimeParams(NamedTuple):
@@ -849,12 +849,14 @@ class RemoteCluster(BaseCluster):
 
 
 def get_local_pg_cluster(
-    data_dir: os.PathLike, *, max_connections: int = 500
+    data_dir: os.PathLike, *, max_connections: Optional[int] = None
 ) -> Cluster:
     pg_config = buildmeta.get_pg_config_path()
-    instance_params = get_default_runtime_params(
-        max_connections=max_connections
-    ).instance_params
+    instance_params = None
+    if max_connections is not None:
+        instance_params = get_default_runtime_params(
+            max_connections=max_connections
+        ).instance_params
     return Cluster(
         data_dir=data_dir,
         pg_config_path=str(pg_config),

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ RUNTIME_DEPS = [
     'immutables>=0.15',
     'parsing~=1.6.1',
     'prompt_toolkit==3.0.3',
+    'psutil>=5.8.0',
     'Pygments~=2.3.0',
     'setproctitle~=1.1.10',
     'setuptools-rust==0.10.3',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ RUNTIME_DEPS = [
     'immutables>=0.15',
     'parsing~=1.6.1',
     'prompt_toolkit==3.0.3',
-    'psutil>=5.8.0',
+    'psutil~=5.8.0',
     'Pygments~=2.3.0',
     'setproctitle~=1.1.10',
     'setuptools-rust==0.10.3',

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -21,11 +21,16 @@ from __future__ import annotations
 
 import asyncio
 import os.path
+import pathlib
+import random
 import subprocess
 import sys
+import tempfile
 
+import asyncpg
 import edgedb
 
+from edb.server import pgcluster, pgconnparams, cluster as edgedb_cluster
 from edb.testbase import server as tb
 
 
@@ -77,16 +82,6 @@ class TestServerOps(tb.TestCase):
                     wait_until_available=0,
                 )
 
-            i = 600 * 5  # Give it up to 5 minutes to cleanup.
-            while i > 0:
-                if not os.path.exists(sd.host):
-                    break
-                else:
-                    i -= 1
-                    await asyncio.sleep(0.1)
-            else:
-                self.fail('temp directory was not cleaned up')
-
     async def test_server_ops_bootstrap_script(self):
         # Test that "edgedb-server" works as expected with the
         # following arguments:
@@ -130,3 +125,82 @@ class TestServerOps(tb.TestCase):
                 self.fail(
                     'Unexpected server error output:\n' + stderr.decode()
                 )
+
+    async def test_server_ops_set_pg_max_connections(self):
+        bootstrap_command = (
+            r'CONFIGURE SYSTEM INSERT Auth '
+            r'{ priority := 0, method := (INSERT Trust) }'
+        )
+        actual = random.randint(50, 100)
+        async with tb.start_edgedb_server(
+            auto_shutdown=True,
+            bootstrap_command=bootstrap_command,
+            max_allowed_connections=actual,
+        ) as sd:
+            run_dir = sd.server_data['runstate_dir']
+            port = 0
+            for sock in pathlib.Path(run_dir).glob('.s.PGSQL.*'):
+                if sock.is_socket():
+                    port = int(sock.suffix[1:])
+                    break
+
+            con = await edgedb.async_connect(
+                user='edgedb', host=sd.host, port=sd.port)
+            self.assertEqual(await con.query_one('SELECT 1'), 1)
+
+            try:
+
+                conn = await asyncpg.connect(
+                    host=run_dir, port=port, user='postgres')
+                try:
+                    max_connectiosn = await conn.fetchval(
+                        "SELECT setting FROM pg_settings "
+                        "WHERE name = 'max_connections'")
+                    self.assertEqual(int(max_connectiosn), actual)
+                finally:
+                    await conn.close()
+
+            finally:
+                await con.aclose()
+
+    def test_server_ops_detect_postgres_pool_size(self):
+        port = edgedb_cluster.find_available_port()
+        actual = random.randint(50, 100)
+
+        async def test(host):
+            bootstrap_command = (
+                r'CONFIGURE SYSTEM INSERT Auth '
+                r'{ priority := 0, method := (INSERT Trust) }'
+            )
+            async with tb.start_edgedb_server(
+                auto_shutdown=True,
+                bootstrap_command=bootstrap_command,
+                max_allowed_connections=None,
+                postgres_dsn=f'postgres:///?user=postgres&port={port}&'
+                             f'host={host}',
+            ) as sd:
+                con = await edgedb.async_connect(
+                    user='edgedb', host=sd.host, port=sd.port)
+                try:
+                    max_connections = await con.query_one(
+                        'SELECT cfg::SystemConfig.__pg_max_connections '
+                        'LIMIT 1')
+                    self.assertEqual(int(max_connections), actual)
+                finally:
+                    await con.aclose()
+
+        with tempfile.TemporaryDirectory() as td:
+            cluster = pgcluster.get_local_pg_cluster(td,
+                                                     max_connections=actual)
+            cluster.set_connection_params(
+                pgconnparams.ConnectionParameters(
+                    user='postgres',
+                    database='template1',
+                ),
+            )
+            self.assertTrue(cluster.ensure_initialized())
+            cluster.start(port=port)
+            try:
+                self.loop.run_until_complete(test(td))
+            finally:
+                cluster.stop()

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -184,7 +184,7 @@ class TestServerOps(tb.TestCase):
                 try:
                     max_connections = await con.query_one(
                         'SELECT cfg::SystemConfig.__pg_max_connections '
-                        'LIMIT 1')
+                        'LIMIT 1')  # TODO: remove LIMIT 1 after #2402
                     self.assertEqual(int(max_connections), actual)
                 finally:
                     await con.aclose()


### PR DESCRIPTION
* For local Postgres, default is computed based on total memory
* Local Postgres is now started with `pg_settings.max_connections` being the same as `--max-backend-connections`, meaning all Postgres connections may be used by EdgeDB.
* For remote Postgres, default is computed based on remote `pg_settings.max_connections` minus `pg_settings.superuser_reserved_connections` and other possible reserved
  connections like the one on RDS.
* If specified, the value of this option will be validated against above default/max value for remote Postgres.

Refs [#2291](https://github.com/edgedb/edgedb/issues/2291#issuecomment-788109778)

- [x] Tests to be added