### PR TITLE
Fix querying BaseObject via GraphQL.

### DIFF
--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -1720,9 +1720,17 @@ class GQLBaseQuery(GQLBaseType):
         self.modules = schema.modules
         super().__init__(schema, name=name, edb_base=edb_base, dummy=dummy)
         self._shadow_fields = ('__typename',)
+        # Record names of std built-in object types
+        self._std_obj_names = [
+            t.get_name(self.edb_schema).name for t in
+            self.edb_schema.get_objects(
+                included_modules=[s_name.UnqualName('std')],
+                type=s_objtypes.ObjectType,
+            )
+        ]
 
     def get_module_and_name(self, name: str) -> Tuple[str, ...]:
-        if name == 'Object':
+        if name in self._std_obj_names:
             return ('std', name)
         elif '__' in name:
             return tuple(name.split('__', 1))

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -557,6 +557,28 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             }],
         })
 
+    def test_graphql_functional_query_19(self):
+        # Test built-in object types, by making sure we can query them
+        # and get some results.
+        res = self.graphql_query(r"""
+            {
+                Object {id}
+            }
+        """)
+        self.assertTrue(len(res) > 0,
+                        'querying "Object" returned no results')
+
+    def test_graphql_functional_query_20(self):
+        # Test built-in object types, by making sure we can query them
+        # and get some results.
+        res = self.graphql_query(r"""
+            {
+                BaseObject {id}
+            }
+        """)
+        self.assertTrue(len(res) > 0,
+                        'querying "BaseObject" returned no results')
+
     def test_graphql_functional_alias_01(self):
         self.assert_graphql_query_result(
             r"""


### PR DESCRIPTION
There's a special handler of built-in object types that was hard-coded
for "object" instead of reading all the "std" object types from the
schema.

Fixes #2214