### PR TITLE
Add separate debug flags for each of the major compilation stages

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -85,6 +85,21 @@ class flags(metaclass=FlagsMeta):
     edgeql_compile = Flag(
         doc="Dump EdgeQL/IR/SQL ASTs.")
 
+    edgeql_compile_edgeql_ast = Flag(
+        doc="Dump EdgeQL AST (subset of `edgeql_compile').")
+
+    edgeql_compile_scope = Flag(
+        doc="Dump EdgeQL scope tree (subset of `edgeql_compile').")
+
+    edgeql_compile_ir = Flag(
+        doc="Dump EdgeQL IR (subset of `edgeql_compile').")
+
+    edgeql_compile_sql_ast = Flag(
+        doc="Dump generated SQL AST (subset of `edgeql_compile').")
+
+    edgeql_compile_sql_text = Flag(
+        doc="Dump generated SQL text (subset of `edgeql_compile').")
+
     edgeql_disable_normalization = Flag(
         doc="Disable EdgeQL normalization (constant extraction etc)")
 

--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -214,11 +214,11 @@ def compile_ast_to_ir(
     if options is None:
         options = CompilerOptions()
 
-    if debug.flags.edgeql_compile:
-        debug.header('EdgeQL AST')
-        debug.dump(tree, schema=schema)
+    if debug.flags.edgeql_compile or debug.flags.edgeql_compile_edgeql_ast:
         debug.header('Compiler Options')
         debug.dump(options.__dict__)
+        debug.header('EdgeQL AST')
+        debug.dump(tree, schema=schema)
 
     ctx = stmtctx_mod.init_context(schema=schema, options=options)
 
@@ -237,12 +237,13 @@ def compile_ast_to_ir(
                     f'missing {missing_args_repr} positional argument'
                     f'{"s" if len(missing_args) > 1 else ""}')
 
-    if debug.flags.edgeql_compile:
+    if debug.flags.edgeql_compile or debug.flags.edgeql_compile_scope:
         debug.header('Scope Tree')
         if ctx.path_scope is not None:
             print(ctx.path_scope.pdebugformat())
         else:
             print('N/A')
+    if debug.flags.edgeql_compile or debug.flags.edgeql_compile_ir:
         debug.header('EdgeDB IR')
         debug.dump(ir_expr, schema=getattr(ir_expr, 'schema', None))
 

--- a/edb/graphql/compiler.py
+++ b/edb/graphql/compiler.py
@@ -109,7 +109,8 @@ def compile_graphql(
 
     sql_text, argmap = pg_compiler.compile_ir_to_sql(
         ir,
-        pretty=bool(debug.flags.edgeql_compile),
+        pretty=bool(debug.flags.edgeql_compile
+                    or debug.flags.edgeql_compile_sql_text),
         expected_cardinality_one=True,
         output_format=pg_compiler.OutputFormat.JSON)
 

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -121,7 +121,9 @@ def compile_ir_to_sql(
         use_named_params=use_named_params,
         expected_cardinality_one=expected_cardinality_one)
 
-    if debug.flags.edgeql_compile:  # pragma: no cover
+    if (  # pragma: no cover
+        debug.flags.edgeql_compile or debug.flags.edgeql_compile_sql_ast
+    ):
         debug.header('SQL Tree')
         debug.dump(qtree)
 
@@ -134,7 +136,9 @@ def compile_ir_to_sql(
     codegen = _run_codegen(qtree, pretty=pretty)
     sql_text = ''.join(codegen.result)
 
-    if debug.flags.edgeql_compile:  # pragma: no cover
+    if (  # pragma: no cover
+        debug.flags.edgeql_compile or debug.flags.edgeql_compile_sql_text
+    ):
         debug.header('SQL')
         debug.dump_code(sql_text, lexer='sql')
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -592,7 +592,11 @@ class Compiler:
 
         sql_text, argmap = pg_compiler.compile_ir_to_sql(
             ir,
-            pretty=debug.flags.edgeql_compile or debug.flags.delta_execute,
+            pretty=(
+                debug.flags.edgeql_compile
+                or debug.flags.edgeql_compile_sql_text
+                or debug.flags.delta_execute
+            ),
             expected_cardinality_one=ctx.expected_cardinality_one,
             output_format=_convert_format(ctx.output_format),
         )
@@ -1433,7 +1437,8 @@ class Compiler:
 
         sql_text, _ = pg_compiler.compile_ir_to_sql(
             ir,
-            pretty=debug.flags.edgeql_compile,
+            pretty=(debug.flags.edgeql_compile
+                    or debug.flags.edgeql_compile_sql_text),
         )
 
         sql = (sql_text.encode(),)


### PR DESCRIPTION
I hate having to scroll up past all the SQL ast stuff when I'm just
working on a scope tree thing, for example.