### PR TITLE
Update docs

### DIFF
--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -179,6 +179,31 @@ The standard library defines the following constraints:
             }
         }
 
+    Sometimes it's necessary to create a type where each combination
+    of properties is unique. This can be achieved by defining an
+    ``exclusive`` constraint for the type, rather than on each
+    property:
+
+    .. code-block:: sdl
+
+        type UniqueCoordinates {
+            required property x -> int64;
+            required property y -> int64;
+
+            # Each combination of x and y must be unique.
+            constraint exclusive on ( (.x, .y) );
+        }
+
+    In principle, many possible expressions can appear in the ``on
+    (<expr>)`` clause of the ``exclusive`` constraint with a few
+    caveats:
+
+    * The expression can only contain references to the immediate
+      properties or links of the type.
+    * No backward links or long paths are allowed.
+    * Only ``IMMUTABLE`` functions are allowed in the constraint
+      expression.
+
     .. note::
 
         This constraint also has an additional effect of creating an

--- a/docs/edgeql/ddl/aliases.rst
+++ b/docs/edgeql/ddl/aliases.rst
@@ -50,19 +50,17 @@ in the module.
 Parameters
 ----------
 
-:eql:synopsis:`<alias-name>`
-    The name (optionally module-qualified) of an alias to be created.
-
-:eql:synopsis:`<alias-expr>`
-    The aliased expression.  Can be any valid EdgeQL expression.
-
-:eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>;`
-    An optional list of annotation values for the alias.
-    See :eql:stmt:`CREATE ANNOTATION` for details.
+Most sub-commands and options of this command are identical to the
+:ref:`SDL alias declaration <ref_eql_sdl_aliases_syntax>`, with some
+additional features listed below:
 
 :eql:synopsis:`[ <module-alias> := ] MODULE <module-name>`
     An optional list of module alias declarations to be used in the
     alias definition.
+
+:eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>;`
+    An optional list of annotation values for the alias.
+    See :eql:stmt:`CREATE ANNOTATION` for details.
 
 
 Example

--- a/docs/edgeql/ddl/annotations.rst
+++ b/docs/edgeql/ddl/annotations.rst
@@ -41,8 +41,10 @@ has an annotation defined on it, the descendants of that schema item will
 not automatically inherit the annotation.  Normal inheritance behavior can
 be turned on by declaring the annotation with the *INHERITABLE* qualifier.
 
-The following subcommands are allowed in the
-``CREATE ABSTRACT ANNOTATION`` block:
+Most sub-commands and options of this command are identical to the
+:ref:`SDL annotation declaration <ref_eql_sdl_annotations_syntax>`.
+There's only one subcommand that is allowed in the ``CREATE
+ANNOTATION`` block:
 
 :eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>`
     Annotations can also have annotations. Set the

--- a/docs/edgeql/ddl/constraints.rst
+++ b/docs/edgeql/ddl/constraints.rst
@@ -26,7 +26,7 @@ CREATE ABSTRACT CONSTRAINT
 
     # where <argspec> is:
 
-      [ $<argname>: ] <argtype>
+      [ <argname>: ] <argtype>
 
     # where <subcommand> is one of
 
@@ -49,49 +49,21 @@ in the module.
 Parameters
 ----------
 
+Most sub-commands and options of this command are identical to the
+:ref:`SDL constraint declaration <ref_eql_sdl_constraints_syntax>`,
+with some additional features listed below:
+
 :eql:synopsis:`[ <module-alias> := ] MODULE <module-name>`
     An optional list of module alias declarations to be used in the
     migration definition.  When *module-alias* is not specified,
     *module-name* becomes the effective current module and is used
     to resolve all unqualified names.
 
-:eql:synopsis:`<name>`
-    The name (optionally module-qualified) of the new constraint.
-
-:eql:synopsis:`<argspec>`
-    An optional list of constraint arguments.
-    :eql:synopsis:`<argname>` optionally specifies
-    the argument name, and :eql:synopsis:`<argtype>`
-    specifies the argument type.
-
-:eql:synopsis:`ON ( <subject-expr> )`
-    An optional expression defining the *subject* of the constraint.
-    If not specified, the subject is the value of the schema item on
-    which the concrete constraint is defined.  The expression must
-    refer to the original subject of the constraint as
-    ``__subject__``.  Note also that ``<subject-expr>`` itself has to
-    be parenthesized.
-
-:eql:synopsis:`EXTENDING <base> [, ...]`
-    If specified, declares the *parent* constraints for this constraint.
-
-The following subcommands are allowed in the ``CERATE ABSTRACT
-CONSTRAINT`` block:
-
-:eql:synopsis:`USING <constr_expression>`
-    A boolean expression that returns ``true`` for valid data and
-    ``false`` for invalid data.  The expression may refer to the subject
-    of the constraint as ``__subject__``.
-
 :eql:synopsis:`SET errmessage := <error_message>`
-    An optional string literal defining the error message template that
-    is raised when the constraint is violated.  The template is a formatted
-    string that may refer to constraint context variables in curly braces.
-    The template may refer to the following:
-
-    - ``$argname`` -- the value of the specified constraint argument
-    - ``__subject__`` -- the value of the ``title`` annotation of the scalar
-      type, property or link on which the constraint is defined.
+    An optional string literal defining the error message template
+    that is raised when the constraint is violated. Other than a
+    slight syntactical difference this is the same as the
+    corresponding SDL declaration.
 
 :eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>;`
     Set constraint :eql:synopsis:`<annotation-name>` to
@@ -259,7 +231,7 @@ Define a concrete constraint on the specified schema item.
 
     # where <argspec> is:
 
-      [ $<argname>: ] <argtype>
+      [ <argname>: ] <argvalue>
 
     # where <subcommand> is one of
 
@@ -283,44 +255,21 @@ abstract constraint.
 Parameters
 ----------
 
+Most sub-commands and options of this command are identical to the
+:ref:`SDL constraint declaration <ref_eql_sdl_constraints_syntax>`,
+with some additional features listed below:
+
 :eql:synopsis:`[ <module-alias> := ] MODULE <module-name>`
     An optional list of module alias declarations to be used in the
     migration definition.  When *module-alias* is not specified,
     *module-name* becomes the effective current module and is used
     to resolve all unqualified names.
 
-:eql:synopsis:`DELEGATED`
-    If specified, the constraint is defined as *delegated*, which means
-    that it will not be enforced on the type it's declared on, and
-    the enforcement will be delegated to the subtypes of this type.
-    This is particularly useful for :eql:constraint:`exclusive`
-    constraints in abstract types.
-
-:eql:synopsis:`<name>`
-    The name (optionally module-qualified) of the abstract constraint
-    from which this constraint is derived.
-
-:eql:synopsis:`<argspec>`
-    An optional list of constraint arguments.  :eql:synopsis:`<argname>`
-    optionally specifies the argument name, and :eql:synopsis:`<argvalue>`
-    specifies the argument value.  The argument value specification must
-    match the parameter declaration of the abstract constraint.
-
-:eql:synopsis:`ON ( <subject-expr> )`
-    An optional expression defining the *subject* of the constraint.
-    If not specified, the subject is the value of the schema item on
-    which the concrete constraint is defined.  The expression must
-    refer to the original subject of the constraint as
-    ``__subject__``.  Note also that ``<subject-expr>`` itself has to
-    be parenthesized.
-
-The following subcommands are allowed in the ``CERATE CONSTRAINT`` block:
-
 :eql:synopsis:`SET errmessage := <error_message>`
-    An optional string literal defining the error message template that
-    is raised when the constraint is violated.  See the relevant
-    paragraph in :eql:stmt:`CREATE ABSTRACT CONSTRAINT` for the rules
-    of error message template syntax.
+    An optional string literal defining the error message template
+    that is raised when the constraint is violated. Other than a
+    slight syntactical difference this is the same as the
+    corresponding SDL declaration.
 
 :eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>;`
     An optional list of annotations for the constraint.

--- a/docs/edgeql/ddl/functions.rst
+++ b/docs/edgeql/ddl/functions.rst
@@ -50,7 +50,6 @@ CREATE FUNCTION
     # and <subcommand> is one of
 
       SET volatility := {'VOLATILE' | 'IMMUTABLE' | 'STABLE'} ;
-      RENAME TO <newname> ;
       CREATE ANNOTATION <annotation-name> := <value> ;
       USING ( <expr> ) ;
       USING <language> <functionbody> ;
@@ -72,106 +71,20 @@ are called *overloaded functions*.
 Parameters
 ----------
 
-:eql:synopsis:`<name>`
-    The name (optionally module-qualified) of the function to create.
-
-:eql:synopsis:`<argkind>`
-    The kind of an argument: ``VARIADIC`` or ``NAMED ONLY``.
-
-    If not specified, the argument is called *positional*.
-
-    The ``VARIADIC`` modifier indicates that the function takes an
-    arbitrary number of arguments of the specified type.  The passed
-    arguments will be passed as as array of the argument type.
-    Positional arguments cannot follow a ``VARIADIC`` argument.
-    ``VARIADIC`` parameters cannot have a default value.
-
-    The ``NAMED ONLY`` modifier indicates that the argument can only
-    be passed using that specific name.  Positional arguments cannot
-    follow a ``NAMED ONLY`` argument.
-
-:eql:synopsis:`<argname>`
-    The name of an argument.  If ``NAMED ONLY`` modifier is used this
-    argument *must* be passed using this name only.
-
-:eql:synopsis:`<typequal>`
-    The type qualifier: ``SET OF`` or ``OPTIONAL``.
-
-    The ``SET OF`` qualifier indicates that the function is taking the
-    argument as a *whole set*, as opposed to being called on the input
-    product element-by-element.
-
-    The ``OPTIONAL`` qualifier indicates that the function will be called
-    if the argument is an empty set.  The default behavior is to return
-    an empty set if the argument is not marked as ``OPTIONAL``.
-
-:eql:synopsis:`<argtype>`
-    The data type of the function's arguments
-    (optionally module-qualified).
-
-:eql:synopsis:`<default>`
-    An expression to be used as default value if the parameter is not
-    specified.  The expression has to be of a type compatible with the
-    type of the argument.
-
-:eql:synopsis:`<rettype>`
-    The return data type (optionally module-qualified).
-
-    The ``SET OF`` modifier indicates that the function will return
-    a non-singleton set.
-
-    The ``OPTIONAL`` qualifier indicates that the function may return
-    an empty set.
-
-:eql:synopsis:`USING ( <expr> )`
-    Specified the body of the function.  :eql:synopsis:`<expr>` is an
-    arbitrary EdgeQL expression.
-
-:eql:synopsis:`USING <language> <functionbody>`
-    A verbose version of the :eql:synopsis:`USING` clause that allows
-    to specify the language of the function body.
-
-    * :eql:synopsis:`<language>` is the name of the language that
-      the function is implemented in.  Currently can only be ``edgeql``.
-
-    * :eql:synopsis:`<functionbody>` is a string constant defining
-      the function.  It is often helpful to use
-      :ref:`dollar quoting <ref_eql_lexical_dollar_quoting>`
-      to write the function definition string.
-
-
-Subcommands
------------
-
-``CREATE FUNCTION`` allows specifying the following subcommands in its
-block:
+Most sub-commands and options of this command are identical to the
+:ref:`SDL function declaration <ref_eql_sdl_functions_syntax>`, with
+some additional features listed below:
 
 :eql:synopsis:`SET volatility := {'VOLATILE' | 'IMMUTABLE' | 'STABLE'}`
     Function volatility determines how aggressively the compiler can
-    optimize its invocations.
-
-    If not explicitly specified the function volatility is set to
-    ``IMMUTABLE`` by default.
-
-    * A ``VOLATILE`` function can modify the database and can return
-      different results on successive calls with the same arguments.
-
-    * A ``STABLE`` function cannot modify the database and is
-      guaranteed to return the same results given the same
-      arguments *within a single statement*.
-
-    * An ``IMMUTABLE`` function cannot modify the database and is
-      guaranteed to return the same results given the same arguments
-      *forever*.
+    optimize its invocations. Other than a slight syntactical
+    difference this is the same as the corresponding SDL declaration.
 
 :eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>`
     Set the function's :eql:synopsis:`<annotation-name>` to
     :eql:synopsis:`<value>`.
 
     See :eql:stmt:`CREATE ANNOTATION` for details.
-
-:eql:synopsis:`USING <language> <functionbody>`
-    See the meaning of *language* and *functionbody* above.
 
 
 Examples
@@ -229,7 +142,8 @@ Change the definition of a function.
     # and <subcommand> is one of
 
       SET volatility := {'VOLATILE' | 'IMMUTABLE' | 'STABLE'} ;
-      RESET volatility
+      RESET volatility ;
+      RENAME TO <newname> ;
       CREATE ANNOTATION <annotation-name> := <value> ;
       ALTER ANNOTATION <annotation-name> := <value> ;
       DROP ANNOTATION <annotation-name> ;
@@ -247,7 +161,28 @@ allows to change annotations, the volatility level, and other attributes.
 Subcommands
 -----------
 
-Refer to :eql:stmt:`CREATE FUNCTION` for details.
+The following subcommands are allowed in the ``ALTER FUNCTION`` block
+in addition to the commands common to the ``CREATE FUNCITON``:
+
+:eql:synopsis:`RESET volatility`
+    Remove explicitly specified volatility in favor of the volatility
+    inferred from the function body.
+
+:eql:synopsis:`RENAME TO <newname>`
+    Change the name of the function to *newname*.
+
+:eql:synopsis:`ALTER ANNOTATION <annotation-name>;`
+    Alter function :eql:synopsis:`<annotation-name>`.
+    See :eql:stmt:`ALTER ANNOTATION <ALTER ANNOTATION>` for details.
+
+:eql:synopsis:`DROP ANNOTATION <annotation-name>;`
+    Remove function :eql:synopsis:`<annotation-name>`.
+    See :eql:stmt:`DROP ANNOTATION <DROP ANNOTATION>` for details.
+
+:eql:synopsis:`RESET errmessage;`
+    Remove the error message from this abstract constraint.
+    The error message specified in the base abstract constraint
+    will be used instead.
 
 
 Example

--- a/docs/edgeql/ddl/indexes.rst
+++ b/docs/edgeql/ddl/indexes.rst
@@ -37,11 +37,9 @@ link using *index-expr*.
 Parameters
 ----------
 
-:sdl:synopsis:`ON ( <index-expr> )`
-    The specific expression for which the index is made.  Note also
-    that ``<index-expr>`` itself has to be parenthesized.
-
-The only subcommand that is allowed in the ``CREATE INDEX`` block:
+Most sub-commands and options of this command are identical to the
+:ref:`SDL index declaration <ref_eql_sdl_indexes_syntax>`. There's
+only one subcommand that is allowed in the ``CREATE INDEX`` block:
 
 :eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>`
     Set object type :eql:synopsis:`<annotation-name>` to

--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -75,54 +75,19 @@ are always created in the same module as the containing object type.
 Parameters
 ----------
 
-:eql:synopsis:`REQUIRED`
-    If specified, the link is considered *required* for the parent
-    object type.  It is an error for an object to have a required
-    link resolve to an empty value.  Child links **always** inherit
-    the *required* attribute, i.e it is not possible to make a
-    required link non-required by extending it.
-
-:eql:synopsis:`OPTIONAL`
-    This is the default qualifier assumed when no qualifier is
-    specified, but it can also be specified explicitly. The link is
-    considered *optional* for the parent object type, i.e. it is
-    possible for the link to resolve to an empty value.
-
-:eql:synopsis:`MULTI`
-    Specifies that there may be more than one instance of this link
-    in an object, in other words, ``Object.link`` may resolve to a set
-    of a size greater than one.
-
-:eql:synopsis:`SINGLE`
-    Specifies that there may be at most *one* instance of this link
-    in an object, in other words, ``Object.link`` may resolve to a set
-    of a size not greater than one.  ``SINGLE`` is assumed if nether
-    ``MULTI`` nor ``SINGLE`` qualifier is specified.
-
-:eql:synopsis:`EXTENDING <base> [, ...]`
-    Optional clause specifying the *parents* of the new link item.
-
-    Use of ``EXTENDING`` creates a persistent schema relationship
-    between the new link and its parents.  Schema modifications
-    to the parent(s) propagate to the child.
-
-    If the same *property* name exists in more than one parent, or
-    is explicitly defined in the new link and at least one parent,
-    then the data types of the property targets must be *compatible*.
-    If there is no conflict, the link properties are merged to form a
-    single property in the new link item.
-
-The following subcommands are allowed in the ``CREATE LINK`` block:
+Most sub-commands and options of this command are identical to the
+:ref:`SDL link declaration <ref_eql_sdl_links_syntax>`. The following
+subcommands are allowed in the ``CREATE LINK`` block:
 
 :eql:synopsis:`SET default := <expression>`
     Specifies the default value for the link as an EdgeQL expression.
-    The default value is used in an ``INSERT`` statement if an explicit
-    value for this link is not specified.
+    Other than a slight syntactical difference this is the same as the
+    corresponding SDL declaration.
 
 :eql:synopsis:`SET readonly := {true | false}`
-    If ``true``, the link is considered *read-only*.  Modifications
-    of this link are prohibited once an object is created.  All of the
-    derived links **must** preserve the original *read-only* value.
+    Specifies whether the link is considered *read-only*. Other than a
+    slight syntactical difference this is the same as the
+    corresponding SDL declaration.
 
 :eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>;`
     Add an annotation :eql:synopsis:`<annotation-name>`

--- a/docs/edgeql/ddl/migrations.rst
+++ b/docs/edgeql/ddl/migrations.rst
@@ -6,6 +6,12 @@ Migrations
 
 This section describes the DDL commands pertaining to migrations.
 
+.. note::
+
+    Like all DDL commands, ``START MIGRATION`` and other migration
+    commands are considered low-level. Users are encouraged to use the
+    built-in :ref:`migration tools <ref_cli_edgedb_migration>`
+    instead.
 
 START MIGRATION
 ===============

--- a/docs/edgeql/ddl/modules.rst
+++ b/docs/edgeql/ddl/modules.rst
@@ -26,9 +26,11 @@ include that module's content.
 Description
 -----------
 
-``CREATE MODULE`` defines a new module for the current database.
-The name of the new module must be distinct from any existing module
-in the current database.
+``CREATE MODULE`` defines a new module for the current database. The
+name of the new module must be distinct from any existing module in
+the current database. Unlike :ref:`SDL module declaration
+<ref_eql_sdl_modules>` the ``CREATE MODULE`` command does not have
+sub-commands, as module contents are created separately.
 
 Parameters
 ----------

--- a/docs/edgeql/ddl/objects.rst
+++ b/docs/edgeql/ddl/objects.rst
@@ -44,8 +44,9 @@ in the module.
 Parameters
 ----------
 
-:eql:synopsis:`ABSTRACT`
-    If specified, the created type will be *abstract*.
+Most sub-commands and options of this command are identical to the
+:ref:`SDL object type declaration <ref_eql_sdl_object_types_syntax>`,
+with some additional features listed below:
 
 :eql:synopsis:`WITH <with-item> [, ...]`
     Alias declarations.
@@ -53,25 +54,6 @@ Parameters
     The ``WITH`` clause allows specifying module aliases
     that can be referenced by the command.  See :ref:`ref_eql_with`
     for more information.
-
-:eql:synopsis:`<name>`
-    The name (optionally module-qualified) of the new type.
-
-:eql:synopsis:`EXTENDING <supertype> [, ...]`
-    Optional clause specifying the *supertypes* of the new type.
-
-    Use of ``EXTENDING`` creates a persistent type relationship
-    between the new subtype and its supertype(s).  Schema modifications
-    to the supertype(s) propagate to the subtype.
-
-    References to supertypes in queries will also include objects of
-    the subtype.
-
-    If the same *link* name exists in more than one supertype, or
-    is explicitly defined in the subtype and at least one supertype,
-    then the data types of the link targets must be *compatible*.
-    If there is no conflict, the links are merged to form a single
-    link in the new type.
 
 The following subcommands are allowed in the ``CREATE TYPE`` block:
 

--- a/docs/edgeql/ddl/props.rst
+++ b/docs/edgeql/ddl/props.rst
@@ -72,52 +72,19 @@ created in the same module as the containing object or property.
 Parameters
 ----------
 
-:eql:synopsis:`REQUIRED`
-    If specified, the property is considered *required* for the parent
-    object type.  It is an error for an object to have a required
-    property resolve to an empty value.  Child properties **always**
-    inherit the *required* attribute, i.e it is not possible to make a
-    required property non-required by extending it.
-
-:eql:synopsis:`OPTIONAL`
-    This is the default qualifier assumed when no qualifier is
-    specified, but it can also be specified explicitly. The property
-    is considered *optional* for the parent object type, i.e. it is
-    possible for the property to resolve to an empty value.
-
-:eql:synopsis:`MULTI`
-    Specifies that there may be more than one instance of this property
-    in an object, in other words, ``Object.property`` may resolve to a set
-    of a size greater than one.
-
-:eql:synopsis:`SINGLE`
-    Specifies that there may be at most *one* instance of this property
-    in an object, in other words, ``Object.property`` may resolve to a set
-    of a size not greater than one.  ``SINGLE`` is assumed if nether
-    ``MULTI`` nor ``SINGLE`` qualifier is specified.
-
-:eql:synopsis:`EXTENDING <base> [, ...]`
-    Optional clause specifying the *parents* of the new property item.
-
-    Use of ``EXTENDING`` creates a persistent schema relationship
-    between the new property and its parents.  Schema modifications
-    to the parent(s) propagate to the child.
-
-:eql:synopsis:`<type>`
-    The type must be a valid :ref:`type expression <ref_eql_types>`
-    denoting a non-abstract scalar or a container type.
-
-The following subcommands are allowed in the ``CREATE PROPERTY`` block:
+Most sub-commands and options of this command are identical to the
+:ref:`SDL property declaration <ref_eql_sdl_props_syntax>`. The
+following subcommands are allowed in the ``CREATE PROPERTY`` block:
 
 :eql:synopsis:`SET default := <expression>`
     Specifies the default value for the property as an EdgeQL expression.
-    The default value is used in an ``INSERT`` statement if an explicit
-    value for this property is not specified.
+    Other than a slight syntactical difference this is the same as the
+    corresponding SDL declaration.
 
 :eql:synopsis:`SET readonly := {true | false}`
-    If ``true``, the property is considered *read-only*.  Modifications
-    of this property are prohibited once an object is created.  All of the
-    derived properties **must** preserve the original *read-only* value.
+    Specifies whether the property is considered *read-only*. Other
+    than a slight syntactical difference this is the same as the
+    corresponding SDL declaration.
 
 :eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>`
     Set property :eql:synopsis:`<annotation-name>` to

--- a/docs/edgeql/ddl/scalars.rst
+++ b/docs/edgeql/ddl/scalars.rst
@@ -50,18 +50,10 @@ as its *supertype*.
 The most common use of ``CREATE SCALAR TYPE`` is to define a scalar
 subtype with constraints.
 
-:eql:synopsis:`EXTENDING <supertype>`
-    Optional clause specifying the *supertype* of the new type.
-
-    If :eql:synopsis:`<supertype>` is an
-    :eql:type:`enumerated type <std::enum>` declaration then
-    an enumerated scalar type is defined.
-
-    Use of ``EXTENDING`` creates a persistent type relationship
-    between the new subtype and its supertype(s).  Schema modifications
-    to the supertype(s) propagate to the subtype.
-
-The following subcommands are allowed in the ``CREATE SCALAR TYPE`` block:
+Most sub-commands and options of this command are identical to the
+:ref:`SDL scalar type declaration <ref_eql_sdl_scalars_syntax>`. The
+following subcommands are allowed in the ``CREATE SCALAR TYPE``
+block:
 
 :eql:synopsis:`CREATE ANNOTATION <annotation-name> := <value>;`
     Set scalar type's :eql:synopsis:`<annotation-name>` to

--- a/docs/edgeql/sdl/aliases.rst
+++ b/docs/edgeql/sdl/aliases.rst
@@ -21,6 +21,7 @@ via a :ref:`computable link <ref_datamodel_computables>` "friend_of":
         friend_of := User.<friends[IS User]
     };
 
+.. _ref_eql_sdl_aliases_syntax:
 
 Syntax
 ------
@@ -41,8 +42,15 @@ commands <ref_eql_ddl_aliases>`.
 Description
 -----------
 
-The core of the declaration is identical to :eql:stmt:`CREATE ALIAS`,
-while the valid SDL sub-declarations are listed below:
+This declaration defines a new alias with the following options:
+
+:eql:synopsis:`<alias-name>`
+    The name (optionally module-qualified) of an alias to be created.
+
+:eql:synopsis:`<alias-expr>`
+    The aliased expression.  Can be any valid EdgeQL expression.
+
+The valid SDL sub-declarations are listed below:
 
 :sdl:synopsis:`<annotation-declarations>`
     Set alias :ref:`annotation <ref_eql_sdl_annotations>`

--- a/docs/edgeql/sdl/annotations.rst
+++ b/docs/edgeql/sdl/annotations.rst
@@ -28,6 +28,7 @@ Specify the value of an annotation for a type:
         }
     }
 
+.. _ref_eql_sdl_annotations_syntax:
 
 Syntax
 ------
@@ -37,16 +38,45 @@ commands <ref_eql_ddl_annotations>`.
 
 .. sdl:synopsis::
 
-    [ abstract ] [ inheritable ] annotation <name>
+    # Abstract annotation form:
+    abstract [ inheritable ] annotation <name>
     [ "{" <annotation-declarations>; [...] "}" ] ;
+
+    # Concrete annotation (same as <annotation-declarations>) form:
+    annotation <name> := <value> ;
 
 
 Description
 -----------
 
-The core of the declaration is identical to
-:eql:stmt:`CREATE ABSTRACT ANNOTATION`, while the valid SDL
-sub-declarations are listed below:
+There are two forms of annotation declarations: abstract and concrete.
+The *abstract annotation* form is used for declaring new kinds of
+annotation in a module. The *concrete annotation* declarations are
+used as sub-declarations for all other declarations in order to
+actually annotate them.
+
+The annotation declaration options are as follows:
+
+:eql:synopsis:`abstract`
+    If specified, the annotation will be *abstract*.
+
+:eql:synopsis:`inheritable`
+    If specified, the annotation will be *inheritable*. The
+    annotations are non-inheritable by default. That is, if a schema
+    item has an annotation defined on it, the descendants of that
+    schema item will not automatically inherit the annotation. Normal
+    inheritance behavior can be turned on by declaring the annotation
+    with the ``inheritable`` qualifier. This is only valid for *abstract
+    annotation*.
+
+:eql:synopsis:`<name>`
+    The name (optionally module-qualified) of the annotation.
+
+:eql:synopsis:`<value>`
+    Any string value that the specified annotation is intended to have
+    for the given context.
+
+The only valid SDL sub-declarations are *concrete annotations*:
 
 :sdl:synopsis:`<annotation-declarations>`
     Annotations can also have annotations. Set the *annotation* of the

--- a/docs/edgeql/sdl/constraints.rst
+++ b/docs/edgeql/sdl/constraints.rst
@@ -42,6 +42,7 @@ Declare a *concrete* constraint on an object type:
         );
     }
 
+.. _ref_eql_sdl_constraints_syntax:
 
 Syntax
 ------
@@ -63,15 +64,70 @@ commands <ref_eql_ddl_constraints>`.
 
     # where <argspec> is:
 
-    [ $<argname>: ] <argtype>
+    [ <argname>: ] {<argtype> | <argvalue>}
 
 
 Description
 -----------
 
-The core of the declaration is identical to
-:eql:stmt:`CREATE CONSTRAINT <CREATE ABSTRACT CONSTRAINT>`,
-while the valid SDL sub-declarations are listed below:
+This declaration defines a new constraint with the following options:
+
+:eql:synopsis:`abstract`
+    If specified, the constraint will be *abstract*.
+
+:eql:synopsis:`delegated`
+    If specified, the constraint is defined as *delegated*, which
+    means that it will not be enforced on the type it's declared on,
+    and the enforcement will be delegated to the subtypes of this
+    type. This is particularly useful for :eql:constraint:`exclusive`
+    constraints in abstract types. This is only valid for *concrete
+    constraints*.
+
+:eql:synopsis:`<name>`
+    The name (optionally module-qualified) of the new constraint.
+
+:eql:synopsis:`<argspec>`
+    An optional list of constraint arguments.
+
+    For an *abstract constraint* :eql:synopsis:`<argname>` optionally
+    specifies the argument name and :eql:synopsis:`<argtype>`
+    specifies the argument type.
+
+    For a *concrete constraint* :eql:synopsis:`<argname>` optionally
+    specifies the argument name and :eql:synopsis:`<argvalue>`
+    specifies the argument value.  The argument value specification must
+    match the parameter declaration of the abstract constraint.
+
+:eql:synopsis:`on ( <subject-expr> )`
+    An optional expression defining the *subject* of the constraint.
+    If not specified, the subject is the value of the schema item on
+    which the concrete constraint is defined.  The expression must
+    refer to the original subject of the constraint as
+    ``__subject__``.  Note also that ``<subject-expr>`` itself has to
+    be parenthesized.
+
+:eql:synopsis:`extending <base> [, ...]`
+    If specified, declares the *parent* constraints for this abstract
+    constraint.
+
+The valid SDL sub-declarations are listed below:
+
+:eql:synopsis:`using <constr_expression>`
+    A boolean expression that returns ``true`` for valid data and
+    ``false`` for invalid data.  The expression may refer to the
+    subject of the constraint as ``__subject__``. This declaration is
+    only valid for *abstract constraints*.
+
+:eql:synopsis:`errmessage := <error_message>`
+    An optional string literal defining the error message template
+    that is raised when the constraint is violated.  The template is a
+    formatted string that may refer to constraint context variables in
+    curly braces. The template may refer to the following:
+
+    - ``$argname`` -- the value of the specified constraint argument
+    - ``__subject__`` -- the value of the ``title`` annotation of the
+      scalar type, property or link on which the constraint is
+      defined.
 
 :sdl:synopsis:`<annotation-declarations>`
     Set constraint :ref:`annotation <ref_eql_sdl_annotations>`

--- a/docs/edgeql/sdl/functions.rst
+++ b/docs/edgeql/sdl/functions.rst
@@ -21,6 +21,7 @@ the end of the that string:
             SELECT s ++ <str>len(a)
         );
 
+.. _ref_eql_sdl_functions_syntax:
 
 Syntax
 ------
@@ -39,8 +40,10 @@ commands <ref_eql_ddl_functions>`.
     function <name> ([ <argspec> ] [, ... ]) -> <returnspec>
     "{"
         [ <annotation-declarations> ]
-        using ( <expr> ) ;
-        using <language> <functionbody> ;
+        [ volatility := {'VOLATILE' | 'IMMUTABLE' | 'STABLE'} ]
+        [ using ( <expr> ) ; ]
+        [ using <language> <functionbody> ; ]
+        [ ... ]
     "}" ;
 
     # where <argspec> is:
@@ -63,9 +66,100 @@ commands <ref_eql_ddl_functions>`.
 Description
 -----------
 
-The core of the declaration is identical to :eql:stmt:`CREATE FUNCTION`,
-while the valid SDL sub-declarations are listed below:
+This declaration defines a new constraint with the following options:
+
+:eql:synopsis:`<name>`
+    The name (optionally module-qualified) of the function to create.
+
+:eql:synopsis:`<argkind>`
+    The kind of an argument: ``variadic`` or ``named only``.
+
+    If not specified, the argument is called *positional*.
+
+    The ``variadic`` modifier indicates that the function takes an
+    arbitrary number of arguments of the specified type.  The passed
+    arguments will be passed as as array of the argument type.
+    Positional arguments cannot follow a ``variadic`` argument.
+    ``variadic`` parameters cannot have a default value.
+
+    The ``named only`` modifier indicates that the argument can only
+    be passed using that specific name.  Positional arguments cannot
+    follow a ``named only`` argument.
+
+:eql:synopsis:`<argname>`
+    The name of an argument.  If ``named only`` modifier is used this
+    argument *must* be passed using this name only.
+
+:eql:synopsis:`<typequal>`
+    The type qualifier: ``set of`` or ``optional``.
+
+    The ``set of`` qualifier indicates that the function is taking the
+    argument as a *whole set*, as opposed to being called on the input
+    product element-by-element.
+
+    The ``optional`` qualifier indicates that the function will be called
+    if the argument is an empty set.  The default behavior is to return
+    an empty set if the argument is not marked as ``optional``.
+
+:eql:synopsis:`<argtype>`
+    The data type of the function's arguments
+    (optionally module-qualified).
+
+:eql:synopsis:`<default>`
+    An expression to be used as default value if the parameter is not
+    specified.  The expression has to be of a type compatible with the
+    type of the argument.
+
+:eql:synopsis:`<rettype>`
+    The return data type (optionally module-qualified).
+
+    The ``set of`` modifier indicates that the function will return
+    a non-singleton set.
+
+    The ``optional`` qualifier indicates that the function may return
+    an empty set.
+
+The valid SDL sub-declarations are listed below:
+
+:eql:synopsis:`volatility := {'VOLATILE' | 'IMMUTABLE' | 'STABLE'}`
+    Function volatility determines how aggressively the compiler can
+    optimize its invocations.
+
+    If not explicitly specified the function volatility is set to
+    ``IMMUTABLE`` by default.
+
+    * A ``VOLATILE`` function can modify the database and can return
+      different results on successive calls with the same arguments.
+
+    * A ``STABLE`` function cannot modify the database and is
+      guaranteed to return the same results given the same
+      arguments *within a single statement*.
+
+    * An ``IMMUTABLE`` function cannot modify the database and is
+      guaranteed to return the same results given the same arguments
+      *forever*.
+
+:eql:synopsis:`using ( <expr> )`
+    Specified the body of the function.  :eql:synopsis:`<expr>` is an
+    arbitrary EdgeQL expression.
+
+:eql:synopsis:`using <language> <functionbody>`
+    A verbose version of the :eql:synopsis:`using` clause that allows
+    to specify the language of the function body.
+
+    * :eql:synopsis:`<language>` is the name of the language that
+      the function is implemented in.  Currently can only be ``edgeql``.
+
+    * :eql:synopsis:`<functionbody>` is a string constant defining
+      the function.  It is often helpful to use
+      :ref:`dollar quoting <ref_eql_lexical_dollar_quoting>`
+      to write the function definition string.
 
 :sdl:synopsis:`<annotation-declarations>`
     Set function :ref:`annotation <ref_eql_sdl_annotations>`
     to a given *value*.
+
+The function name must be distinct from that of any existing function
+with the same argument types in the same module.  Functions of
+different argument types can share a name, in which case the functions
+are called *overloaded functions*.

--- a/docs/edgeql/sdl/index.rst
+++ b/docs/edgeql/sdl/index.rst
@@ -26,60 +26,46 @@ nested in their respective modules.
 Since SDL is declarative in nature, the specific order of
 declarations of module blocks or individual items does not matter.
 
-SDL is used to specify a :ref:`migration <ref_eql_ddl_migrations>` to a to a
-specific schema state. For example:
+The built-in :ref:`migration tools<ref_cli_edgedb_migration>` expect
+the schema to be given in SDL format. For example:
 
-.. code-block:: edgeql-repl
+.. code-block:: sdl
 
-    db> START MIGRATION TO {
-    ...     # "default" module block
-    ...     module default {
-    ...         type Movie {
-    ...             required property title -> str;
-    ...             # the year of release
-    ...             property year -> int64;
-    ...             required link director -> Person;
-    ...             required multi link actors -> Person;
-    ...         }
-    ...         type Person {
-    ...             required property first_name -> str;
-    ...             required property last_name -> str;
-    ...         }
-    ...     }
-    ... };
-    START MIGRATION
-    db> POPULATE MIGRATION;
-    POPULATE MIGRATION
-    db> COMMIT MIGRATION;
-    COMMIT MIGRATION
+    # "default" module block
+    module default {
+        type Movie {
+            required property title -> str;
+            # the year of release
+            property year -> int64;
+            required link director -> Person;
+            required multi link actors -> Person;
+        }
+        type Person {
+            required property first_name -> str;
+            required property last_name -> str;
+        }
+    }
 
 It is possible to also omit the module blocks, but then individual
 declarations must use :ref:`fully-qualified names
 <ref_eql_fundamentals_name_resolution>` so that they can be assigned
-to their respective modules. For example the following is equivalent
+to their respective modules. For example, the following is equivalent
 to the previous migration:
 
-.. code-block:: edgeql-repl
+.. code-block:: sdl
 
-    db> START MIGRATION TO {
-    ...     # no module block
-    ...     type default::Movie {
-    ...         required property title -> str;
-    ...         # the year of release
-    ...         property year -> int64;
-    ...         required link director -> default::Person;
-    ...         required multi link actors -> default::Person;
-    ...     }
-    ...     type default::Person {
-    ...         required property first_name -> str;
-    ...         required property last_name -> str;
-    ...     }
-    ... };
-    START MIGRATION
-    db> POPULATE MIGRATION;
-    POPULATE MIGRATION
-    db> COMMIT MIGRATION;
-    COMMIT MIGRATION
+    # no module block
+    type default::Movie {
+        required property title -> str;
+        # the year of release
+        property year -> int64;
+        required link director -> default::Person;
+        required multi link actors -> default::Person;
+    }
+    type default::Person {
+        required property first_name -> str;
+        required property last_name -> str;
+    }
 
 .. toctree::
     :maxdepth: 3

--- a/docs/edgeql/sdl/indexes.rst
+++ b/docs/edgeql/sdl/indexes.rst
@@ -28,6 +28,8 @@ Declare an index for a "User" based on the "name" property:
     }
 
 
+.. _ref_eql_sdl_indexes_syntax:
+
 Syntax
 ------
 
@@ -43,4 +45,14 @@ commands <ref_eql_ddl_indexes>`.
 Description
 -----------
 
-The core of the declaration is identical to :eql:stmt:`CREATE INDEX`.
+This declaration defines a new index with the following options:
+
+:sdl:synopsis:`on ( <index-expr> )`
+    The specific expression for which the index is made.  Note also
+    that ``<index-expr>`` itself has to be parenthesized.
+
+The valid SDL sub-declarations are listed below:
+
+:sdl:synopsis:`<annotation-declarations>`
+    Set index :ref:`annotation <ref_eql_sdl_annotations>`
+    to a given *value*.

--- a/docs/edgeql/sdl/links.rst
+++ b/docs/edgeql/sdl/links.rst
@@ -56,6 +56,7 @@ to prevent unintentional overloading due to name clashes:
         # ... other links and properties
     }
 
+.. _ref_eql_sdl_links_syntax:
 
 Syntax
 ------
@@ -109,8 +110,74 @@ commands <ref_eql_ddl_links>`.
 Description
 -----------
 
-The core of the declaration is identical to :eql:stmt:`CREATE LINK`,
-while the valid SDL sub-declarations are listed below:
+There are several forms of ``link`` declaration, as shown in the
+syntax synopsis above.  The first form is the canonical definition
+form, the second and third forms are used for defining a
+:ref:`computable link <ref_datamodel_computables>`, and the last one
+is a form to define an ``abstract link``.  The abstract form
+allows declaring the link directly inside a :ref:`module
+<ref_eql_sdl_modules>`.  Concrete link forms are always used as
+sub-declarations for an :ref:`object type <ref_eql_sdl_object_types>`.
+
+The following options are available:
+
+:eql:synopsis:`overloaded`
+    If specified, indicates that the link is inherited and that some
+    feature of it may be altered in the current object type.  It is an
+    error to declare a link as *overloaded* if it is not inherited.
+
+:eql:synopsis:`required`
+    If specified, the link is considered *required* for the parent
+    object type.  It is an error for an object to have a required
+    link resolve to an empty value.  Child links **always** inherit
+    the *required* attribute, i.e it is not possible to make a
+    required link non-required by extending it.
+
+:eql:synopsis:`optional`
+    This is the default qualifier assumed when no qualifier is
+    specified, but it can also be specified explicitly. The link is
+    considered *optional* for the parent object type, i.e. it is
+    possible for the link to resolve to an empty value.
+
+:eql:synopsis:`multi`
+    Specifies that there may be more than one instance of this link
+    in an object, in other words, ``Object.link`` may resolve to a set
+    of a size greater than one.
+
+:eql:synopsis:`single`
+    Specifies that there may be at most *one* instance of this link
+    in an object, in other words, ``Object.link`` may resolve to a set
+    of a size not greater than one.  ``single`` is assumed if nether
+    ``multi`` nor ``single`` qualifier is specified.
+
+:eql:synopsis:`extending <base> [, ...]`
+    Optional clause specifying the *parents* of the new link item.
+
+    Use of ``extending`` creates a persistent schema relationship
+    between the new link and its parents.  Schema modifications
+    to the parent(s) propagate to the child.
+
+    If the same *property* name exists in more than one parent, or
+    is explicitly defined in the new link and at least one parent,
+    then the data types of the property targets must be *compatible*.
+    If there is no conflict, the link properties are merged to form a
+    single property in the new link item.
+
+:eql:synopsis:`<type>`
+    The type must be a valid :ref:`type expression <ref_eql_types>`
+    denoting an object type.
+
+The valid SDL sub-declarations are listed below:
+
+:eql:synopsis:`default := <expression>`
+    Specifies the default value for the link as an EdgeQL expression.
+    The default value is used in an ``INSERT`` statement if an explicit
+    value for this link is not specified.
+
+:eql:synopsis:`readonly := {true | false}`
+    If ``true``, the link is considered *read-only*.  Modifications
+    of this link are prohibited once an object is created.  All of the
+    derived links **must** preserve the original *read-only* value.
 
 :sdl:synopsis:`<annotation-declarations>`
     Set link :ref:`annotation <ref_eql_sdl_annotations>`

--- a/docs/edgeql/sdl/modules.rst
+++ b/docs/edgeql/sdl/modules.rst
@@ -45,9 +45,9 @@ commands <ref_eql_ddl_modules>`.
 Description
 -----------
 
-The module block declaration defines a new module much like
-:eql:stmt:`CREATE MODULE`.  Unlike its DDL counterpart the module
-block can have sub-declarations:
+The module block declaration defines a new module similar to the
+:eql:stmt:`CREATE MODULE` command, but it also allows putting the
+module content as nested declarations:
 
 :sdl:synopsis:`<schema-declarations>`
     Define various schema items that belong to this module.

--- a/docs/edgeql/sdl/objects.rst
+++ b/docs/edgeql/sdl/objects.rst
@@ -54,6 +54,8 @@ Introducing abstract types opens up the possibility of
 :ref:`polymorphic queries <ref_eql_polymorphic_queries>`.
 
 
+.. _ref_eql_sdl_object_types_syntax:
+
 Syntax
 ------
 
@@ -75,8 +77,31 @@ commands <ref_eql_ddl_object_types>`.
 Description
 -----------
 
-The core of the declaration is identical to :eql:stmt:`CREATE TYPE`,
-while the valid SDL sub-declarations are listed below:
+This declaration defines a new object type with the following options:
+
+:eql:synopsis:`abstract`
+    If specified, the created type will be *abstract*.
+
+:eql:synopsis:`<TypeName>`
+    The name (optionally module-qualified) of the new type.
+
+:eql:synopsis:`extending <supertype> [, ...]`
+    Optional clause specifying the *supertypes* of the new type.
+
+    Use of ``extending`` creates a persistent type relationship
+    between the new subtype and its supertype(s).  Schema modifications
+    to the supertype(s) propagate to the subtype.
+
+    References to supertypes in queries will also include objects of
+    the subtype.
+
+    If the same *link* name exists in more than one supertype, or
+    is explicitly defined in the subtype and at least one supertype,
+    then the data types of the link targets must be *compatible*.
+    If there is no conflict, the links are merged to form a single
+    link in the new type.
+
+These sub-declarations are allowed in the ``Type`` block:
 
 :sdl:synopsis:`<annotation-declarations>`
     Set object type :ref:`annotation <ref_eql_sdl_annotations>`
@@ -85,12 +110,12 @@ while the valid SDL sub-declarations are listed below:
 :sdl:synopsis:`<property-declarations>`
     Define a concrete :ref:`property <ref_eql_sdl_props>` for this object type.
 
+:sdl:synopsis:`<link-declarations>`
+    Define a concrete :ref:`link <ref_eql_sdl_links>` for this object type.
+
 :sdl:synopsis:`<constraint-declarations>`
     Define a concrete :ref:`constraint <ref_eql_sdl_constraints>` for this
     object type.
-
-:sdl:synopsis:`<link-declarations>`
-    Define a concrete :ref:`link <ref_eql_sdl_links>` for this object type.
 
 :sdl:synopsis:`<index-declarations>`
     Define an :ref:`index <ref_eql_sdl_indexes>` for this object type.

--- a/docs/edgeql/sdl/props.rst
+++ b/docs/edgeql/sdl/props.rst
@@ -51,6 +51,7 @@ overloading due to name clashes:
         # ... other links and properties
     }
 
+.. _ref_eql_sdl_props_syntax:
 
 Syntax
 ------
@@ -98,8 +99,70 @@ commands <ref_eql_ddl_props>`.
 Description
 -----------
 
-The core of the declaration is identical to :eql:stmt:`CREATE PROPERTY`,
-while the valid SDL sub-declarations are listed below:
+There are several forms of ``property`` declaration, as shown in the
+syntax synopsis above.  The first form is the canonical definition
+form, the second and third forms are used for defining a
+:ref:`computable property <ref_datamodel_computables>`, and the last
+one is a form to define an ``abstract property``.  The abstract
+form allows declaring the property directly inside a :ref:`module
+<ref_eql_sdl_modules>`.  Concrete property forms are always used
+as sub-declarations for an :ref:`object type
+<ref_eql_sdl_object_types>` or a :ref:`link <ref_eql_sdl_links>`.
+
+The following options are available:
+
+:eql:synopsis:`overloaded`
+    If specified, indicates that the property is inherited and that some
+    feature of it may be altered in the current object type.  It is an
+    error to declare a property as *overloaded* if it is not inherited.
+
+:eql:synopsis:`required`
+    If specified, the property is considered *required* for the parent
+    object type.  It is an error for an object to have a required
+    property resolve to an empty value.  Child properties **always**
+    inherit the *required* attribute, i.e it is not possible to make a
+    required property non-required by extending it.
+
+:eql:synopsis:`optional`
+    This is the default qualifier assumed when no qualifier is
+    specified, but it can also be specified explicitly. The property
+    is considered *optional* for the parent object type, i.e. it is
+    possible for the property to resolve to an empty value.
+
+:eql:synopsis:`multi`
+    Specifies that there may be more than one instance of this
+    property in an object, in other words, ``Object.property`` may
+    resolve to a set of a size greater than one.
+
+:eql:synopsis:`single`
+    Specifies that there may be at most *one* instance of this
+    property in an object, in other words, ``Object.property`` may
+    resolve to a set of a size not greater than one.  ``single`` is
+    assumed if nether ``multi`` nor ``single`` qualifier is specified.
+
+:eql:synopsis:`extending <base> [, ...]`
+    Optional clause specifying the *parents* of the new property item.
+
+    Use of ``extending`` creates a persistent schema relationship
+    between the new property and its parents.  Schema modifications
+    to the parent(s) propagate to the child.
+
+:eql:synopsis:`<type>`
+    The type must be a valid :ref:`type expression <ref_eql_types>`
+    denoting a non-abstract scalar or a container type.
+
+The valid SDL sub-declarations are listed below:
+
+:eql:synopsis:`default := <expression>`
+    Specifies the default value for the property as an EdgeQL expression.
+    The default value is used in an ``INSERT`` statement if an explicit
+    value for this property is not specified.
+
+:eql:synopsis:`readonly := {true | false}`
+    If ``true``, the property is considered *read-only*.
+    Modifications of this property are prohibited once an object is
+    created.  All of the derived properties **must** preserve the
+    original *read-only* value.
 
 :sdl:synopsis:`<annotation-declarations>`
     Set property :ref:`annotation <ref_eql_sdl_annotations>`

--- a/docs/edgeql/sdl/scalars.rst
+++ b/docs/edgeql/sdl/scalars.rst
@@ -19,6 +19,7 @@ Declare a new non-negative integer type:
         constraint min_value(0);
     }
 
+.. _ref_eql_sdl_scalars_syntax:
 
 Syntax
 ------
@@ -39,9 +40,26 @@ commands <ref_eql_ddl_scalars>`.
 Description
 -----------
 
-The core of the declaration is identical to
-:eql:stmt:`CREATE SCALAR TYPE`, while the valid SDL sub-declarations
-are listed below:
+This declaration defines a new object type with the following options:
+
+:eql:synopsis:`abstract`
+    If specified, the created scalar type will be *abstract*.
+
+:eql:synopsis:`<TypeName>`
+    The name (optionally module-qualified) of the new scalar type.
+
+:eql:synopsis:`extending <supertype>`
+    Optional clause specifying the *supertype* of the new type.
+
+    If :eql:synopsis:`<supertype>` is an
+    :eql:type:`enumerated type <std::enum>` declaration then
+    an enumerated scalar type is defined.
+
+    Use of ``extending`` creates a persistent type relationship
+    between the new subtype and its supertype(s).  Schema modifications
+    to the supertype(s) propagate to the subtype.
+
+The valid SDL sub-declarations are listed below:
 
 :sdl:synopsis:`<annotation-declarations>`
     Set scalar type :ref:`annotation <ref_eql_sdl_annotations>`

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -256,10 +256,11 @@ class TestDocSnippets(unittest.TestCase):
                 if lang == 'edgeql':
                     ql_parser.parse_block(snippet)
                 elif lang == 'sdl':
-                    # Strip all the "using extension ..." lines as
-                    # they interfere with our module detection.
+                    # Strip all the "using extension ..." and comment
+                    # lines as they interfere with our module
+                    # detection.
                     sdl = re.sub(
-                        r'using\s+extension\s+\w+;',
+                        r'(using\s+extension\s+\w+;)|(#.*?\n)',
                         '',
                         snippet
                     ).strip()

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -1492,6 +1492,16 @@ abstract property test::foo {
             }
         """
 
+    def test_eschema_syntax_function_22(self):
+        """
+        module test {
+            function some_func(a: str) -> std::str {
+                volatility := 'IMMUTABLE';
+                using sql function 'some_other_func';
+            };
+        };
+        """
+
     def test_eschema_syntax_alias_01(self):
         """
         module test {


### PR DESCRIPTION
Add an explanation of how to create an exclusive constraint involving
more than one property. Give more details on the expressions that are
valid for constraints.

Clean up the reference to `START MIGRATION` in favor of deferring to the
migration tools in the SDL section.

Update the SDL/DDL documentation to emphasize SDL by moving the main
explanations there, and referring to them from DDL sections as opposed
to the other way around.

Fixes #2280
Fixes #2230