### PR TITLE
Fix use of union pointers with mixed storage type

### DIFF
--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -186,6 +186,18 @@ def convert_name(name, suffix='', catenate=True):
         return schema, dbname
 
 
+def update_aspect(name, aspect):
+    """Update the aspect on a non catenated name.
+
+    It also needs to be from an object that uses ids for names"""
+    suffix = get_aspect_suffix(aspect)
+    stripped = name[1].rsplit("_", 1)[0]
+    if suffix:
+        return (name[0], f'{stripped}_{suffix}')
+    else:
+        return (name[0], stripped)
+
+
 def get_scalar_backend_name(id, module_name, catenate=True, *, aspect=None):
     if aspect is None:
         aspect = 'domain'

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -676,10 +676,15 @@ def process_insert_body(
 
                 values.append(pgast.ResTarget(val=insvalue))
 
-            ptr_info = pg_types.get_ptrref_storage_info(
+            # Register all link table inserts to be run after the main
+            # insert.  Note that single links with link properties are
+            # processed both as a local link insert (for the inline
+            # pointer) and as a link table insert (because lprops are
+            # stored in link tables).
+            link_ptr_info = pg_types.get_ptrref_storage_info(
                 ptrref, resolve_type=False, link_bias=True)
 
-            if ptr_info and ptr_info.table_type == 'link':
+            if link_ptr_info and link_ptr_info.table_type == 'link':
                 external_inserts.append(shape_el)
 
         if iterator is not None:
@@ -1015,10 +1020,15 @@ def process_update_body(
 
                     update_stmt.targets.append(updtarget)
 
-            ptr_info = pg_types.get_ptrref_storage_info(
+            # Register all link table inserts to be run after the main
+            # insert.  Note that single links with link properties are
+            # processed both as a local link update (for the inline
+            # pointer) and as a link table update (because lprops are
+            # stored in link tables).
+            link_ptr_info = pg_types.get_ptrref_storage_info(
                 actual_ptrref, resolve_type=False, link_bias=True)
 
-            if ptr_info and ptr_info.table_type == 'link':
+            if link_ptr_info and link_ptr_info.table_type == 'link':
                 external_updates.append((shape_el, shape_op))
 
     if not update_stmt.targets:

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -938,13 +938,13 @@ def process_set_as_path(
             ctx=ctx)
 
     ptr_info = pg_types.get_ptrref_storage_info(
-        ptrref, resolve_type=False, link_bias=False)
+        ptrref, resolve_type=False, link_bias=False, allow_missing=True)
 
     # Path is a link property.
     is_linkprop = ptrref.source_ptr is not None
-    # Path is a reference to a relationship stored in the source table.
-    is_inline_ref = ptr_info.table_type == 'ObjectType'
     is_primitive_ref = not irtyputils.is_object(ptrref.out_target)
+    # Path is a reference to a relationship stored in the source table.
+    is_inline_ref = bool(ptr_info and ptr_info.table_type == 'ObjectType')
     is_inline_primitive_ref = is_inline_ref and is_primitive_ref
     is_id_ref_to_inline_source = False
 
@@ -988,9 +988,10 @@ def process_set_as_path(
             # __type__[IS Array].id, or if Foo is not visible in
             # this scope.
             source_ptr_info = pg_types.get_ptrref_storage_info(
-                source_rptr.ptrref, resolve_type=False, link_bias=False)
-            is_id_ref_to_inline_source = (
-                source_ptr_info.table_type == 'ObjectType')
+                source_rptr.ptrref, resolve_type=False, link_bias=False,
+                allow_missing=True)
+            is_id_ref_to_inline_source = bool(
+                source_ptr_info and source_ptr_info.table_type == 'ObjectType')
 
     if semi_join:
         with ctx.subrel() as srcctx:


### PR DESCRIPTION
We need to be able to handle union pointers where one only is stored
inline and one is only stored outline.

Fixes #2360.