### PR TITLE
Make schema::TupleElement extend std::BaseObject

### DIFF
--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -116,7 +116,7 @@ CREATE TYPE schema::Array EXTENDING schema::CollectionType {
 };
 
 
-CREATE TYPE schema::TupleElement {
+CREATE TYPE schema::TupleElement EXTENDING std::BaseObject {
     CREATE REQUIRED LINK type -> schema::Type {
         ON TARGET DELETE DEFERRED RESTRICT;
     };

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,7 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_03_19_00_00
+EDGEDB_CATALOG_VERSION = 2021_03_19_00_01
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -32,6 +32,18 @@ class TestIntrospection(tb.QueryTestCase):
     TEARDOWN = """
     """
 
+    async def test_edgeql_introspection_schema_not_objects_01(self):
+        # Test to make sure that no types in the schema are derived
+        # from std::Object.
+        await self.assert_query_result(
+            r"""
+            WITH MODULE schema
+            SELECT ObjectType { name, bases: {name}, ancestors: {name} }
+            FILTER .name LIKE 'schema::%' AND 'std::Object' IN .ancestors.name;
+            """,
+            []
+        )
+
     async def test_edgeql_introspection_objtype_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
Otherwise `SELECT Object` returns all the schema::TupleElements,
which is pretty silly.