### PR TITLE
Fix a staeval cast bug that produces bizarre results

### DIFF
--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -269,7 +269,12 @@ def cast_const_to_python(
     schema, stype = irtyputils.ir_typeref_to_type(schema, ir.to_type)
     pytype = scalar_type_to_python_type(stype, schema)
     sval = evaluate_to_python_val(ir.expr, schema=schema)
-    return pytype(sval)
+    if sval is None:
+        return None
+    elif isinstance(sval, tuple):
+        return tuple(pytype(elem) for elem in sval)
+    else:
+        return pytype(sval)
 
 
 def schema_type_to_python_type(

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4704,3 +4704,30 @@ aa \
             await self.con.query("""
                 SELECT Object ?? '';
             """)
+
+    async def test_edgeql_expr_static_eval_casts_01(self):
+        # The static evaluator produced some really silly results for
+        # these at one point.
+
+        await self.assert_query_result(
+            r'''
+                WITH x := {1, 2}, SELECT ("wtf" ++ <str>x);
+            ''',
+            ["wtf1", "wtf2"],
+            sort=True,
+        )
+
+        await self.assert_query_result(
+            r'''
+                FOR x in {1, 2} UNION (SELECT ("wtf" ++ <str>x));
+            ''',
+            ["wtf1", "wtf2"],
+            sort=True,
+        )
+
+        await self.assert_query_result(
+            r'''
+                WITH x := <int64>{}, SELECT ("wtf" ++ <str>x);
+            ''',
+            [],
+        )


### PR DESCRIPTION
const_to_python casting would directly apply the cast to the "python
value", which is wrong because tuples and None have special
meaning. Since operator eval uses a code path that uses
const_to_python on casts, this would result in concatenation of a cast
of a constant set to produce bizarre results.