### PR TITLE
Use SET ROLE instead of SET SESSION AUTHORIZATION

### DIFF
--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -109,7 +109,7 @@ class BaseCluster:
         try:
             conn = loop.run_until_complete(
                 self._pg_cluster.connect(
-                    database='template1', timeout=5, **self._pg_connect_args))
+                    timeout=5, **self._pg_connect_args))
 
             db_exists = loop.run_until_complete(
                 self._edgedb_template_exists(conn))
@@ -286,6 +286,7 @@ class Cluster(BaseCluster):
         )
         self._edgedb_cmd.extend(['-D', self._data_dir])
         self._pg_connect_args['user'] = pg_superuser
+        self._pg_connect_args['database'] = 'template1'
 
     def _get_pg_cluster(self):
         return pgcluster.get_local_pg_cluster(self._data_dir)

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -151,8 +151,12 @@ async def connect(connargs, dbname):
     await pgcon.connect()
 
     if connargs['user'] != defines.EDGEDB_SUPERUSER:
+        # We used to use SET SESSION AUTHORIZATION here, there're some security
+        # differences over SET ROLE, but as we don't allow accessing Postgres
+        # directly through EdgeDB, SET ROLE is mostly fine here. (Also hosted
+        # backends like Postgres on DigitalOcean support only SET ROLE)
         await pgcon.simple_query(
-            f'SET SESSION AUTHORIZATION {defines.EDGEDB_SUPERUSER}'.encode(),
+            f'SET ROLE {defines.EDGEDB_SUPERUSER}'.encode(),
             ignore_data=True,
         )
 


### PR DESCRIPTION
The motivation of this change is to support DigitalOcean backend who doesn't support `SET SESSION AUTHORIZATION`. Though `SET ROLE` is different than `SET SESSION AUTHORIZATION`, we should be fine as far as we don't allow direct SQL access to the backend Postgres.

Also moved a hard-coded database name `template1` to local pgcluster.