### PR TITLE
Fix a cluster of FOR and tuple binding bugs

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1162,6 +1162,11 @@ def computable_ptr_set(
         subctx.anchors[qlast.Source().name] = source_set
         subctx.empty_result_type_hint = ptrcls.get_target(ctx.env.schema)
         subctx.partial_path_prefix = source_set
+        # On a mutation, make the expr_exposed. This corresponds with
+        # a similar check on is_mutation in _normalize_view_ptr_expr.
+        if (source_scls.get_expr_type(ctx.env.schema)
+                != s_types.ExprType.Select):
+            subctx.expr_exposed = True
 
         if isinstance(qlexpr, qlast.Statement):
             subctx.stmt_metadata[qlexpr] = context.StatementMetadata(

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -156,8 +156,14 @@ def compile_ForQuery(
                 context=ctx.env.type_origins.get(anytype),
             )
 
-        if iterator_ctx is not None and iterator_ctx.stmt is not None:
-            iterator_ctx.stmt.hoisted_iterators.append(iterator_stmt)
+        # If this statement is exposed, and there is a shape-induced
+        # iterator context, then register the iterator as hoisted.
+        # This ensures that the pgsql compiler allows the iterator value
+        # to drift upward. Note that sctx.iterator_ctx.stmt may equal stmt
+        # and also that I think this whole mechanism is subtly wrong.
+        if (sctx.expr_exposed and sctx.iterator_ctx is not None
+                and sctx.iterator_ctx.stmt is not None):
+            sctx.iterator_ctx.stmt.hoisted_iterators.append(iterator_stmt)
 
         view_scope_info = sctx.path_scope_map[iterator_view]
 

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -292,7 +292,8 @@ def get_nearest_dml_stmt(ir_set: irast.Set) -> Optional[irast.MutatingStmt]:
 def get_iterator_sets(stmt: irast.Stmt) -> Sequence[irast.Set]:
     iterators = []
     if stmt.iterator_stmt is not None:
-        iterators.append(stmt.iterator_stmt)
+        if stmt.iterator_stmt not in stmt.hoisted_iterators:
+            iterators.append(stmt.iterator_stmt)
     if stmt.hoisted_iterators:
         iterators.extend(stmt.hoisted_iterators)
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -809,6 +809,7 @@ def compile_insert_else_body(
 
         dispatch.compile(else_select, ctx=ictx)
         pathctx.put_path_id_map(ictx.rel, subject_id, else_select.path_id)
+        ictx.rel.path_id_mask.discard(else_select.path_id)
 
         else_select_cte = pgast.CommonTableExpr(
             query=ictx.rel,
@@ -832,6 +833,7 @@ def compile_insert_else_body(
             ictx.volatility_ref = ()
             dispatch.compile(else_branch, ctx=ictx)
             pathctx.put_path_id_map(ictx.rel, subject_id, else_branch.path_id)
+            ictx.rel.path_id_mask.discard(else_branch.path_id)
 
             assert else_cte_rvar
             else_branch_cte = else_cte_rvar[0]

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -809,6 +809,8 @@ def compile_insert_else_body(
 
         dispatch.compile(else_select, ctx=ictx)
         pathctx.put_path_id_map(ictx.rel, subject_id, else_select.path_id)
+        # Discard else_branch from the path_id_mask to prevent subject_id
+        # from being masked.
         ictx.rel.path_id_mask.discard(else_select.path_id)
 
         else_select_cte = pgast.CommonTableExpr(
@@ -833,6 +835,8 @@ def compile_insert_else_body(
             ictx.volatility_ref = ()
             dispatch.compile(else_branch, ctx=ictx)
             pathctx.put_path_id_map(ictx.rel, subject_id, else_branch.path_id)
+            # Discard else_branch from the path_id_mask to prevent subject_id
+            # from being masked.
             ictx.rel.path_id_mask.discard(else_branch.path_id)
 
             assert else_cte_rvar

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -964,6 +964,7 @@ def process_set_as_path(
 
     source_rptr = ir_source.rptr
     if (irtyputils.is_id_ptrref(ptrref) and source_rptr is not None
+            and isinstance(source_rptr.ptrref, irast.PointerRef)
             and not irtyputils.is_inbound_ptrref(source_rptr.ptrref)
             and not irtyputils.is_computable_ptrref(source_rptr.ptrref)
             and not irutils.is_type_intersection_reference(ir_set)):

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -716,7 +716,7 @@ class ConnectedTestCaseMixin:
                 else:
                     shape = shape.value
 
-            if isinstance(shape, list):
+            if isinstance(shape, (list, tuple)):
                 return _assert_list_shape(path, data, shape)
             elif isinstance(shape, set):
                 return _assert_set_shape(path, data, shape)


### PR DESCRIPTION
The prototypical issues here that started this issue off are
test_edgeql_scope_binding_04 (a FOR test) and
test_edgeql_scope_binding_05 (a WITH/tuple test).

In test _04, a WITH bound FOR loop spuriously correlated with itself
when selected twice in subqueries, and in test _05, its translation to
WITH/tuples crashed in pgsql.

The cause of both involved path_id_mask:

 * For _05, the issue is that pull_path_namespace would pull a mapped
   path name even if its unmapped version was in path_id_mask. Since
   tuples do mapping, this would allow one name for a tuple element to
   escape incorrectly.

 * For _04, the issue is that all iterator statements were explicitly
   exempted from being placed into path_id_mask, which pretty
   straightforwardly causes them to spuriously correlate.
   Unfortunately this is required in a number of cases where
   FOR appears inside shape computables, so I tweaked the criteria
   to be closer to being correct.
   One key thing is that we don't want *all* FOR loops inside of
   shape computables to be exempted from path_id_mask
   (see test_edgeql_scope_binding_07)

Also to help write one of my tests, I made tuples equivalent to lists
for test case shapes, which lets us put them in sets.