### PR TITLE
Update the docs, tests, and other files to use canonical volatility.

### DIFF
--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -201,7 +201,7 @@ The standard library defines the following constraints:
     * The expression can only contain references to the immediate
       properties or links of the type.
     * No backward links or long paths are allowed.
-    * Only ``IMMUTABLE`` functions are allowed in the constraint
+    * Only ``Immutable`` functions are allowed in the constraint
       expression.
 
     .. note::

--- a/docs/edgeql/ddl/functions.rst
+++ b/docs/edgeql/ddl/functions.rst
@@ -49,7 +49,7 @@ CREATE FUNCTION
 
     # and <subcommand> is one of
 
-      SET volatility := {'VOLATILE' | 'IMMUTABLE' | 'STABLE'} ;
+      SET volatility := {'Immutable' | 'Stable' | 'Volatile'} ;
       CREATE ANNOTATION <annotation-name> := <value> ;
       USING ( <expr> ) ;
       USING <language> <functionbody> ;
@@ -75,7 +75,7 @@ Most sub-commands and options of this command are identical to the
 :ref:`SDL function declaration <ref_eql_sdl_functions_syntax>`, with
 some additional features listed below:
 
-:eql:synopsis:`SET volatility := {'VOLATILE' | 'IMMUTABLE' | 'STABLE'}`
+:eql:synopsis:`SET volatility := {'Immutable' | 'Stable' | 'Volatile'}`
     Function volatility determines how aggressively the compiler can
     optimize its invocations. Other than a slight syntactical
     difference this is the same as the corresponding SDL declaration.
@@ -141,7 +141,7 @@ Change the definition of a function.
 
     # and <subcommand> is one of
 
-      SET volatility := {'VOLATILE' | 'IMMUTABLE' | 'STABLE'} ;
+      SET volatility := {'Immutable' | 'Stable' | 'Volatile'} ;
       RESET volatility ;
       RENAME TO <newname> ;
       CREATE ANNOTATION <annotation-name> := <value> ;
@@ -198,7 +198,7 @@ Example
     };
 
     ALTER FUNCTION mysum(a: int64, b: int64) {
-        SET volatility := 'IMMUTABLE';
+        SET volatility := 'Immutable';
         DROP ANNOTATION title;
     };
 

--- a/docs/edgeql/sdl/functions.rst
+++ b/docs/edgeql/sdl/functions.rst
@@ -40,7 +40,7 @@ commands <ref_eql_ddl_functions>`.
     function <name> ([ <argspec> ] [, ... ]) -> <returnspec>
     "{"
         [ <annotation-declarations> ]
-        [ volatility := {'VOLATILE' | 'IMMUTABLE' | 'STABLE'} ]
+        [ volatility := {'Immutable' | 'Stable' | 'Volatile'} ]
         [ using ( <expr> ) ; ]
         [ using <language> <functionbody> ; ]
         [ ... ]
@@ -121,21 +121,21 @@ This declaration defines a new constraint with the following options:
 
 The valid SDL sub-declarations are listed below:
 
-:eql:synopsis:`volatility := {'VOLATILE' | 'IMMUTABLE' | 'STABLE'}`
+:eql:synopsis:`volatility := {'Immutable' | 'Stable' | 'Volatile'}`
     Function volatility determines how aggressively the compiler can
     optimize its invocations.
 
     If not explicitly specified the function volatility is set to
-    ``IMMUTABLE`` by default.
+    ``Immutable`` by default.
 
-    * A ``VOLATILE`` function can modify the database and can return
+    * A ``Volatile`` function can modify the database and can return
       different results on successive calls with the same arguments.
 
-    * A ``STABLE`` function cannot modify the database and is
+    * A ``Stable`` function cannot modify the database and is
       guaranteed to return the same results given the same
       arguments *within a single statement*.
 
-    * An ``IMMUTABLE`` function cannot modify the database and is
+    * An ``Immutable`` function cannot modify the database and is
       guaranteed to return the same results given the same arguments
       *forever*.
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -108,7 +108,7 @@ std::_gen_series(
     stop: std::int64
 ) -> SET OF std::int64
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'generate_series';
 };
 
@@ -119,7 +119,7 @@ std::_gen_series(
     step: std::int64
 ) -> SET OF std::int64
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'generate_series';
 };
 
@@ -129,7 +129,7 @@ std::_gen_series(
     stop: std::bigint
 ) -> SET OF std::bigint
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'generate_series';
 };
 
@@ -140,7 +140,7 @@ std::_gen_series(
     step: std::bigint
 ) -> SET OF std::bigint
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'generate_series';
 };
 
@@ -151,7 +151,7 @@ sys::_sleep(duration: std::float64) -> std::bool
     CREATE ANNOTATION std::description :=
         'Make the current session sleep for *duration* time.';
     # This function has side-effect.
-    SET volatility := 'VOLATILE';
+    SET volatility := 'Volatile';
     USING SQL $$
     SELECT pg_sleep("duration") IS NOT NULL;
     $$;
@@ -163,7 +163,7 @@ sys::_sleep(duration: std::duration) -> std::bool
     CREATE ANNOTATION std::description :=
         'Make the current session sleep for *duration* time.';
     # This function has side-effect.
-    SET volatility := 'VOLATILE';
+    SET volatility := 'Volatile';
     USING SQL $$
     SELECT pg_sleep_for("duration") IS NOT NULL;
     $$;
@@ -176,7 +176,7 @@ sys::_advisory_lock(key: std::int64) -> std::bool
     CREATE ANNOTATION std::description :=
         'Obtain an exclusive session-level advisory lock.';
     # This function has side-effect.
-    SET volatility := 'VOLATILE';
+    SET volatility := 'Volatile';
     USING SQL $$
     SELECT CASE WHEN "key" < 0 THEN
         edgedb.raise(NULL::bool, msg => 'lock key cannot be negative')
@@ -193,7 +193,7 @@ sys::_advisory_unlock(key: std::int64) -> std::bool
     CREATE ANNOTATION std::description :=
         'Release an exclusive session-level advisory lock.';
     # This function has side-effect.
-    SET volatility := 'VOLATILE';
+    SET volatility := 'Volatile';
     USING SQL $$
     SELECT CASE WHEN "key" < 0 THEN
         edgedb.raise(NULL::bool, msg => 'lock key cannot be negative')
@@ -210,7 +210,7 @@ sys::_advisory_unlock_all() -> std::bool
     CREATE ANNOTATION std::description :=
         'Release all session-level advisory locks held by the current session.';
     # This function has side-effect.
-    SET volatility := 'VOLATILE';
+    SET volatility := 'Volatile';
     USING SQL $$
     SELECT pg_advisory_unlock_all() IS NOT NULL;
     $$;

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -35,7 +35,7 @@ cal::to_local_datetime(s: std::str, fmt: OPTIONAL str={})
     CREATE ANNOTATION std::description :=
         'Create a `cal::local_datetime` value.';
     # Helper function to_local_datetime is VOLATILE.
-    SET volatility := 'VOLATILE';
+    SET volatility := 'Volatile';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -71,7 +71,7 @@ cal::to_local_datetime(year: std::int64, month: std::int64, day: std::int64,
 {
     CREATE ANNOTATION std::description :=
         'Create a `cal::local_datetime` value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT make_timestamp(
         "year"::int, "month"::int, "day"::int,
@@ -88,7 +88,7 @@ cal::to_local_datetime(dt: std::datetime, zone: std::str)
     CREATE ANNOTATION std::description :=
         'Create a `cal::local_datetime` value.';
     # The version of timezone with these arguments is IMMUTABLE.
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT timezone("zone", "dt")::edgedb.timestamp_t;
     $$;
@@ -100,7 +100,7 @@ cal::to_local_date(s: std::str, fmt: OPTIONAL str={}) -> cal::local_date
 {
     CREATE ANNOTATION std::description := 'Create a `cal::local_date` value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -134,7 +134,7 @@ cal::to_local_date(dt: std::datetime, zone: std::str)
 {
     CREATE ANNOTATION std::description := 'Create a `cal::local_date` value.';
     # The version of timezone with these arguments is IMMUTABLE.
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT timezone("zone", "dt")::edgedb.date_t;
     $$;
@@ -146,7 +146,7 @@ cal::to_local_date(year: std::int64, month: std::int64, day: std::int64)
     -> cal::local_date
 {
     CREATE ANNOTATION std::description := 'Create a `cal::local_date` value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT make_date("year"::int, "month"::int, "day"::int)::edgedb.date_t
     $$;
@@ -158,7 +158,7 @@ cal::to_local_time(s: std::str, fmt: OPTIONAL str={}) -> cal::local_time
 {
     CREATE ANNOTATION std::description := 'Create a `cal::local_time` value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -194,7 +194,7 @@ cal::to_local_time(dt: std::datetime, zone: std::str)
     CREATE ANNOTATION std::description := 'Create a `cal::local_time` value.';
     # The version of timezone with these arguments is IMMUTABLE and so
     # is the cast.
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT timezone("zone", "dt")::time;
     $$;
@@ -206,7 +206,7 @@ cal::to_local_time(hour: std::int64, min: std::int64, sec: std::float64)
     -> cal::local_time
 {
     CREATE ANNOTATION std::description := 'Create a `cal::local_time` value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT make_time("hour"::int, "min"::int, "sec")
     $$;
@@ -218,7 +218,7 @@ cal::time_get(dt: cal::local_time, el: std::str) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Extract a specific element of input time by name.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT CASE WHEN "el" IN ('hour', 'microseconds', 'milliseconds',
             'minutes', 'seconds')
@@ -247,7 +247,7 @@ cal::date_get(dt: cal::local_date, el: std::str) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Extract a specific element of input date by name.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT CASE WHEN "el" IN (
             'century', 'day', 'decade', 'dow', 'doy',
@@ -277,7 +277,7 @@ cal::date_get(dt: cal::local_date, el: std::str) -> std::float64
 
 CREATE INFIX OPERATOR
 std::`=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=(timestamp,timestamp)';
@@ -287,14 +287,14 @@ std::`=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL cal::local_datetime,
            r: OPTIONAL cal::local_datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>(timestamp,timestamp)';
@@ -304,14 +304,14 @@ std::`!=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL cal::local_datetime,
             r: OPTIONAL cal::local_datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>(timestamp,timestamp)';
@@ -320,7 +320,7 @@ std::`>` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=(timestamp,timestamp)';
@@ -329,7 +329,7 @@ std::`>=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<(timestamp,timestamp)';
@@ -338,7 +338,7 @@ std::`<` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=(timestamp,timestamp)';
@@ -347,7 +347,7 @@ std::`<=` (l: cal::local_datetime, r: cal::local_datetime) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`+` (l: cal::local_datetime, r: std::duration) -> cal::local_datetime {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
         SELECT ("l" + "r")::edgedb.timestamp_t
@@ -357,7 +357,7 @@ std::`+` (l: cal::local_datetime, r: std::duration) -> cal::local_datetime {
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: cal::local_datetime) -> cal::local_datetime {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL $$
         SELECT ("l" + "r")::edgedb.timestamp_t
@@ -367,7 +367,7 @@ std::`+` (l: std::duration, r: cal::local_datetime) -> cal::local_datetime {
 
 CREATE INFIX OPERATOR
 std::`-` (l: cal::local_datetime, r: std::duration) -> cal::local_datetime {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
         SELECT ("l" - "r")::edgedb.timestamp_t
     $$;
@@ -379,7 +379,7 @@ std::`-` (l: cal::local_datetime, r: std::duration) -> cal::local_datetime {
 
 CREATE INFIX OPERATOR
 std::`=` (l: cal::local_date, r: cal::local_date) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=(date,date)';
@@ -389,14 +389,14 @@ std::`=` (l: cal::local_date, r: cal::local_date) -> std::bool {
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL cal::local_date,
            r: OPTIONAL cal::local_date) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: cal::local_date, r: cal::local_date) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>(date,date)';
@@ -406,14 +406,14 @@ std::`!=` (l: cal::local_date, r: cal::local_date) -> std::bool {
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL cal::local_date,
             r: OPTIONAL cal::local_date) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: cal::local_date, r: cal::local_date) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>(date,date)';
@@ -422,7 +422,7 @@ std::`>` (l: cal::local_date, r: cal::local_date) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: cal::local_date, r: cal::local_date) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=(date,date)';
@@ -431,7 +431,7 @@ std::`>=` (l: cal::local_date, r: cal::local_date) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: cal::local_date, r: cal::local_date) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<(date,date)';
@@ -440,7 +440,7 @@ std::`<` (l: cal::local_date, r: cal::local_date) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: cal::local_date, r: cal::local_date) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=(date,date)';
@@ -450,7 +450,7 @@ std::`<=` (l: cal::local_date, r: cal::local_date) -> std::bool {
 CREATE INFIX OPERATOR
 std::`+` (l: cal::local_date, r: std::duration) -> cal::local_date
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     SET force_return_cast := true;
     USING SQL $$
@@ -462,7 +462,7 @@ std::`+` (l: cal::local_date, r: std::duration) -> cal::local_date
 CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: cal::local_date) -> cal::local_date
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     SET force_return_cast := true;
     USING SQL $$
@@ -474,7 +474,7 @@ std::`+` (l: std::duration, r: cal::local_date) -> cal::local_date
 CREATE INFIX OPERATOR
 std::`-` (l: cal::local_date, r: std::duration) -> cal::local_date
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET force_return_cast := true;
     USING SQL $$
         SELECT ("l" - "r")::edgedb.date_t
@@ -487,7 +487,7 @@ std::`-` (l: cal::local_date, r: std::duration) -> cal::local_date
 
 CREATE INFIX OPERATOR
 std::`=` (l: cal::local_time, r: cal::local_time) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -497,14 +497,14 @@ std::`=` (l: cal::local_time, r: cal::local_time) -> std::bool {
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL cal::local_time,
            r: OPTIONAL cal::local_time) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: cal::local_time, r: cal::local_time) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -514,14 +514,14 @@ std::`!=` (l: cal::local_time, r: cal::local_time) -> std::bool {
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL cal::local_time,
             r: OPTIONAL cal::local_time) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: cal::local_time, r: cal::local_time) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -530,7 +530,7 @@ std::`>` (l: cal::local_time, r: cal::local_time) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: cal::local_time, r: cal::local_time) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -539,7 +539,7 @@ std::`>=` (l: cal::local_time, r: cal::local_time) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: cal::local_time, r: cal::local_time) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -548,7 +548,7 @@ std::`<` (l: cal::local_time, r: cal::local_time) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: cal::local_time, r: cal::local_time) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -557,7 +557,7 @@ std::`<=` (l: cal::local_time, r: cal::local_time) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`+` (l: cal::local_time, r: std::duration) -> cal::local_time {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
@@ -565,7 +565,7 @@ std::`+` (l: cal::local_time, r: std::duration) -> cal::local_time {
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: cal::local_time) -> cal::local_time {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
@@ -573,7 +573,7 @@ std::`+` (l: std::duration, r: cal::local_time) -> cal::local_time {
 
 CREATE INFIX OPERATOR
 std::`-` (l: cal::local_time, r: std::duration) -> cal::local_time {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
@@ -582,80 +582,80 @@ std::`-` (l: cal::local_time, r: std::duration) -> cal::local_time {
 ## ---------------
 
 CREATE CAST FROM cal::local_datetime TO cal::local_date {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM cal::local_datetime TO cal::local_time {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM cal::local_date TO cal::local_datetime {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::str TO cal::local_datetime {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'edgedb.local_datetime_in';
 };
 
 
 CREATE CAST FROM std::str TO cal::local_date {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'edgedb.local_date_in';
 };
 
 
 CREATE CAST FROM std::str TO cal::local_time {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'edgedb.local_time_in';
 };
 
 
 CREATE CAST FROM cal::local_datetime TO std::str {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT trim(to_json(val)::text, '"');
     $$;
 };
 
 CREATE CAST FROM cal::local_date TO std::str {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM cal::local_time TO std::str {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM cal::local_datetime TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM cal::local_date TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM cal::local_time TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::json TO cal::local_datetime {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.local_datetime_in(
         edgedb.jsonb_extract_scalar(val, 'string'));
@@ -664,7 +664,7 @@ CREATE CAST FROM std::json TO cal::local_datetime {
 
 
 CREATE CAST FROM std::json TO cal::local_date {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.local_date_in(edgedb.jsonb_extract_scalar(val, 'string'));
     $$;
@@ -672,7 +672,7 @@ CREATE CAST FROM std::json TO cal::local_date {
 
 
 CREATE CAST FROM std::json TO cal::local_time {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.local_time_in(edgedb.jsonb_extract_scalar(val, 'string'));
     $$;
@@ -687,7 +687,7 @@ std::datetime_get(dt: cal::local_datetime, el: std::str) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Extract a specific element of input datetime by name.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT CASE WHEN "el" IN (
             'century', 'day', 'decade', 'dow', 'doy', 'hour',
@@ -723,7 +723,7 @@ std::to_str(dt: cal::local_datetime, fmt: OPTIONAL str={}) -> std::str
     CREATE ANNOTATION std::description :=
         'Return string representation of the input value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -752,7 +752,7 @@ std::to_str(d: cal::local_date, fmt: OPTIONAL str={}) -> std::str
     CREATE ANNOTATION std::description :=
         'Return string representation of the input value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -787,7 +787,7 @@ std::to_str(nt: cal::local_time, fmt: OPTIONAL str={}) -> std::str
     CREATE ANNOTATION std::description :=
         'Return string representation of the input value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -816,7 +816,7 @@ std::to_datetime(local: cal::local_datetime, zone: std::str)
 {
     CREATE ANNOTATION std::description := 'Create a `datetime` value.';
     # The version of timezone with these arguments is IMMUTABLE.
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT timezone("zone", "local")::edgedb.timestamptz_t;
     $$;
@@ -828,7 +828,7 @@ std::min(vals: SET OF cal::local_datetime) -> OPTIONAL cal::local_datetime
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'min';
 };
 
@@ -838,7 +838,7 @@ std::min(vals: SET OF cal::local_date) -> OPTIONAL cal::local_date
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'min';
 };
 
@@ -848,7 +848,7 @@ std::min(vals: SET OF cal::local_time) -> OPTIONAL cal::local_time
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'min';
 };
 
@@ -858,7 +858,7 @@ std::min(vals: SET OF array<cal::local_datetime>) -> OPTIONAL array<cal::local_d
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'min';
 };
 
@@ -868,7 +868,7 @@ std::min(vals: SET OF array<cal::local_date>) -> OPTIONAL array<cal::local_date>
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'min';
 };
 
@@ -878,7 +878,7 @@ std::min(vals: SET OF array<cal::local_time>) -> OPTIONAL array<cal::local_time>
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'min';
 };
 
@@ -888,7 +888,7 @@ std::max(vals: SET OF cal::local_datetime) -> OPTIONAL cal::local_datetime
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'max';
 };
 
@@ -898,7 +898,7 @@ std::max(vals: SET OF cal::local_date) -> OPTIONAL cal::local_date
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'max';
 };
 
@@ -908,7 +908,7 @@ std::max(vals: SET OF cal::local_time) -> OPTIONAL cal::local_time
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'max';
 };
 
@@ -918,7 +918,7 @@ std::max(vals: SET OF array<cal::local_datetime>) -> OPTIONAL array<cal::local_d
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'max';
 };
 
@@ -928,7 +928,7 @@ std::max(vals: SET OF array<cal::local_date>) -> OPTIONAL array<cal::local_date>
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'max';
 };
 
@@ -938,6 +938,6 @@ std::max(vals: SET OF array<cal::local_time>) -> OPTIONAL array<cal::local_time>
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'max';
 };

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -135,7 +135,7 @@ cfg::get_config_json(
 CREATE FUNCTION
 cfg::_quote(text: std::str) -> std::str
 {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     SET internal := true;
     USING SQL $$
         SELECT replace(quote_literal(text), '''''', '\\''')
@@ -146,7 +146,7 @@ CREATE FUNCTION
 cfg::_describe_system_config_as_ddl() -> str
 {
     # The results won't change within a single statement.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     SET internal := true;
     USING SQL FUNCTION 'edgedb._describe_system_config_as_ddl';
 };
@@ -156,7 +156,7 @@ CREATE FUNCTION
 cfg::_describe_database_config_as_ddl() -> str
 {
     # The results won't change within a single statement.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     SET internal := true;
     USING SQL FUNCTION 'edgedb._describe_database_config_as_ddl';
 };

--- a/edb/lib/ext/graphql.edgeql
+++ b/edb/lib/ext/graphql.edgeql
@@ -35,7 +35,7 @@ ALTER TYPE stdgraphql::Mutation {
 
 
 CREATE FUNCTION stdgraphql::short_name(name: str) -> str {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET internal := true;
     USING (
         SELECT (

--- a/edb/lib/math.edgeql
+++ b/edb/lib/math.edgeql
@@ -24,7 +24,7 @@ math::abs(x: std::anyreal) -> std::anyreal
 {
     CREATE ANNOTATION std::description :=
         'Return the absolute value of the input *x*.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'abs';
 };
 
@@ -33,7 +33,7 @@ CREATE FUNCTION
 math::ceil(x: std::int64) -> std::int64
 {
     CREATE ANNOTATION std::description := 'Round up to the nearest integer.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL 'SELECT "x";';
 };
 
@@ -42,7 +42,7 @@ CREATE FUNCTION
 math::ceil(x: std::float64) -> std::float64
 {
     CREATE ANNOTATION std::description := 'Round up to the nearest integer.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL 'SELECT ceil("x");'
 };
 
@@ -51,7 +51,7 @@ CREATE FUNCTION
 math::ceil(x: std::bigint) -> std::bigint
 {
     CREATE ANNOTATION std::description := 'Round up to the nearest integer.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL 'SELECT "x";'
 };
 
@@ -60,7 +60,7 @@ CREATE FUNCTION
 math::ceil(x: std::decimal) -> std::decimal
 {
     CREATE ANNOTATION std::description := 'Round up to the nearest integer.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL 'SELECT ceil("x");'
 };
 
@@ -69,7 +69,7 @@ CREATE FUNCTION
 math::floor(x: std::int64) -> std::int64
 {
     CREATE ANNOTATION std::description := 'Round down to the nearest integer.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL 'SELECT "x";';
 };
 
@@ -78,7 +78,7 @@ CREATE FUNCTION
 math::floor(x: std::float64) -> std::float64
 {
     CREATE ANNOTATION std::description := 'Round down to the nearest integer.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL 'SELECT floor("x");';
 };
 
@@ -87,7 +87,7 @@ CREATE FUNCTION
 math::floor(x: std::bigint) -> std::bigint
 {
     CREATE ANNOTATION std::description := 'Round down to the nearest integer.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL 'SELECT "x";'
 };
 
@@ -96,7 +96,7 @@ CREATE FUNCTION
 math::floor(x: std::decimal) -> std::decimal
 {
     CREATE ANNOTATION std::description := 'Round down to the nearest integer.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL 'SELECT floor("x");';
 };
 
@@ -106,7 +106,7 @@ math::ln(x: std::int64) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the natural logarithm of the input value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'ln';
 };
 
@@ -116,7 +116,7 @@ math::ln(x: std::float64) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the natural logarithm of the input value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'ln';
 };
 
@@ -126,7 +126,7 @@ math::ln(x: std::decimal) -> std::decimal
 {
     CREATE ANNOTATION std::description :=
         'Return the natural logarithm of the input value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'ln';
 };
 
@@ -136,7 +136,7 @@ math::lg(x: std::int64) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the base 10 logarithm of the input value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'log';
 };
 
@@ -146,7 +146,7 @@ math::lg(x: std::float64) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the base 10 logarithm of the input value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'log';
 };
 
@@ -156,7 +156,7 @@ math::lg(x: std::decimal) -> std::decimal
 {
     CREATE ANNOTATION std::description :=
         'Return the base 10 logarithm of the input value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'log';
 };
 
@@ -166,7 +166,7 @@ math::log(x: std::decimal, NAMED ONLY base: std::decimal) -> std::decimal
 {
     CREATE ANNOTATION std::description :=
         'Return the logarithm of the input value in the specified *base*.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT log("base", "x")
     $$;
@@ -182,7 +182,7 @@ math::mean(vals: SET OF std::decimal) -> std::decimal
 {
     CREATE ANNOTATION std::description :=
         'Return the arithmetic mean of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'avg';
     SET error_on_null_result := 'invalid input to mean(): not ' ++
                                 'enough elements in input set';
@@ -194,7 +194,7 @@ math::mean(vals: SET OF std::int64) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the arithmetic mean of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'avg';
     # SQL 'avg' returns numeric on integer inputs.
     SET force_return_cast := true;
@@ -208,7 +208,7 @@ math::mean(vals: SET OF std::float64) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the arithmetic mean of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'avg';
     SET error_on_null_result := 'invalid input to mean(): not ' ++
                                 'enough elements in input set';
@@ -222,7 +222,7 @@ math::stddev(vals: SET OF std::decimal) -> std::decimal
 {
     CREATE ANNOTATION std::description :=
         'Return the sample standard deviation of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'stddev';
     SET error_on_null_result := 'invalid input to stddev(): not ' ++
                                 'enough elements in input set';
@@ -234,7 +234,7 @@ math::stddev(vals: SET OF std::int64) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the sample standard deviation of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'stddev';
     # SQL 'stddev' returns numeric on integer inputs.
     SET force_return_cast := true;
@@ -248,7 +248,7 @@ math::stddev(vals: SET OF std::float64) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the sample standard deviation of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'stddev';
     SET error_on_null_result := 'invalid input to stddev(): not ' ++
                                 'enough elements in input set';
@@ -262,7 +262,7 @@ math::stddev_pop(vals: SET OF std::decimal) -> std::decimal
 {
     CREATE ANNOTATION std::description :=
         'Return the population standard deviation of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'stddev_pop';
     SET error_on_null_result := 'invalid input to stddev_pop(): not ' ++
                                 'enough elements in input set';
@@ -274,7 +274,7 @@ math::stddev_pop(vals: SET OF std::int64) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the population standard deviation of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'stddev_pop';
     # SQL 'stddev_pop' returns numeric on integer inputs.
     SET force_return_cast := true;
@@ -288,7 +288,7 @@ math::stddev_pop(vals: SET OF std::float64) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the population standard deviation of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'stddev_pop';
     SET error_on_null_result := 'invalid input to stddev_pop(): not ' ++
                                 'enough elements in input set';
@@ -302,7 +302,7 @@ math::var(vals: SET OF std::decimal) -> OPTIONAL std::decimal
 {
     CREATE ANNOTATION std::description :=
         'Return the sample variance of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'variance';
     SET error_on_null_result := 'invalid input to var(): not ' ++
                                 'enough elements in input set';
@@ -314,7 +314,7 @@ math::var(vals: SET OF std::int64) -> OPTIONAL std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the sample variance of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'variance';
     # SQL 'var' returns numeric on integer inputs.
     SET force_return_cast := true;
@@ -328,7 +328,7 @@ math::var(vals: SET OF std::float64) -> OPTIONAL std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the sample variance of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'variance';
     SET error_on_null_result := 'invalid input to var(): not ' ++
                                 'enough elements in input set';
@@ -342,7 +342,7 @@ math::var_pop(vals: SET OF std::decimal) -> OPTIONAL std::decimal
 {
     CREATE ANNOTATION std::description :=
         'Return the population variance of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'var_pop';
     SET error_on_null_result := 'invalid input to var_pop(): not ' ++
                                 'enough elements in input set';
@@ -354,7 +354,7 @@ math::var_pop(vals: SET OF std::int64) -> OPTIONAL std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the population variance of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'var_pop';
     # SQL 'var_pop' returns numeric on integer inputs.
     SET force_return_cast := true;
@@ -368,7 +368,7 @@ math::var_pop(vals: SET OF std::float64) -> OPTIONAL std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the population variance of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'var_pop';
     SET error_on_null_result := 'invalid input to var_pop(): not ' ++
                                 'enough elements in input set';

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -27,7 +27,7 @@ std::len(str: std::str) -> std::int64
 {
     CREATE ANNOTATION std::description :=
         'A polymorphic function to calculate a "length" of its first argument.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT char_length("str")::bigint
     $$;
@@ -39,7 +39,7 @@ std::len(bytes: std::bytes) -> std::int64
 {
     CREATE ANNOTATION std::description :=
         'A polymorphic function to calculate a "length" of its first argument.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT length("bytes")::bigint
     $$;
@@ -51,7 +51,7 @@ std::len(array: array<anytype>) -> std::int64
 {
     CREATE ANNOTATION std::description :=
         'A polymorphic function to calculate a "length" of its first argument.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT cardinality("array")::bigint
     $$;
@@ -66,7 +66,7 @@ std::sum(s: SET OF std::bigint) -> std::bigint
 {
     CREATE ANNOTATION std::description :=
         'Return the sum of the set of numbers.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET initial_value := 0;
     SET force_return_cast := true;
     USING SQL FUNCTION 'sum';
@@ -78,7 +78,7 @@ std::sum(s: SET OF std::decimal) -> std::decimal
 {
     CREATE ANNOTATION std::description :=
         'Return the sum of the set of numbers.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET initial_value := 0;
     USING SQL FUNCTION 'sum';
 };
@@ -89,7 +89,7 @@ std::sum(s: SET OF std::int32) -> std::int64
 {
     CREATE ANNOTATION std::description :=
         'Return the sum of the set of numbers.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET initial_value := 0;
     SET force_return_cast := true;
     USING SQL FUNCTION 'sum';
@@ -101,7 +101,7 @@ std::sum(s: SET OF std::int64) -> std::int64
 {
     CREATE ANNOTATION std::description :=
         'Return the sum of the set of numbers.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET initial_value := 0;
     SET force_return_cast := true;
     USING SQL FUNCTION 'sum';
@@ -113,7 +113,7 @@ std::sum(s: SET OF std::float32) -> std::float32
 {
     CREATE ANNOTATION std::description :=
         'Return the sum of the set of numbers.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET initial_value := 0;
     USING SQL FUNCTION 'sum';
 };
@@ -124,7 +124,7 @@ std::sum(s: SET OF std::float64) -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return the sum of the set of numbers.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET initial_value := 0;
     USING SQL FUNCTION 'sum';
 };
@@ -138,7 +138,7 @@ std::count(s: SET OF anytype) -> std::int64
 {
     CREATE ANNOTATION std::description :=
         'Return the number of elements in a set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET initial_value := 0;
     USING SQL FUNCTION 'count';
 };
@@ -152,7 +152,7 @@ std::random() -> std::float64
 {
     CREATE ANNOTATION std::description :=
         'Return a pseudo-random number in the range `0.0 <= x < 1.0`';
-    SET volatility := 'VOLATILE';
+    SET volatility := 'Volatile';
     USING SQL FUNCTION 'random';
 };
 
@@ -165,7 +165,7 @@ std::min(vals: SET OF anytype) -> OPTIONAL anytype
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET fallback := true;
     USING SQL EXPRESSION;
 };
@@ -187,7 +187,7 @@ std::min(vals: SET OF anyreal) -> OPTIONAL anyreal
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'min';
 };
 
@@ -197,7 +197,7 @@ std::min(vals: SET OF anyenum) -> OPTIONAL anyenum
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'min';
 };
 
@@ -207,7 +207,7 @@ std::min(vals: SET OF str) -> OPTIONAL str
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'min';
 };
 
@@ -217,7 +217,7 @@ std::min(vals: SET OF datetime) -> OPTIONAL datetime
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'min';
 };
 
@@ -227,7 +227,7 @@ std::min(vals: SET OF duration) -> OPTIONAL duration
 {
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'min';
 };
 
@@ -240,7 +240,7 @@ std::max(vals: SET OF anytype) -> OPTIONAL anytype
 {
     CREATE ANNOTATION std::description :=
         'Return the greatest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET fallback := true;
     USING SQL EXPRESSION;
 };
@@ -262,7 +262,7 @@ std::max(vals: SET OF anyreal) -> OPTIONAL anyreal
 {
     CREATE ANNOTATION std::description :=
         'Return the greatest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'max';
 };
 
@@ -272,7 +272,7 @@ std::max(vals: SET OF anyenum) -> OPTIONAL anyenum
 {
     CREATE ANNOTATION std::description :=
         'Return the greatest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'max';
 };
 
@@ -282,7 +282,7 @@ std::max(vals: SET OF str) -> OPTIONAL str
 {
     CREATE ANNOTATION std::description :=
         'Return the greatest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'max';
 };
 
@@ -292,7 +292,7 @@ std::max(vals: SET OF datetime) -> OPTIONAL datetime
 {
     CREATE ANNOTATION std::description :=
         'Return the greatest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'max';
 };
 
@@ -302,7 +302,7 @@ std::max(vals: SET OF duration) -> OPTIONAL duration
 {
     CREATE ANNOTATION std::description :=
         'Return the greatest value of the input set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'max';
 };
 
@@ -315,7 +315,7 @@ std::all(vals: SET OF std::bool) -> std::bool
 {
     CREATE ANNOTATION std::description :=
         'Generalized boolean `AND` applied to the set of *values*.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET initial_value := True;
     USING SQL FUNCTION 'bool_and';
 };
@@ -329,7 +329,7 @@ std::any(vals: SET OF std::bool) -> std::bool
 {
     CREATE ANNOTATION std::description :=
         'Generalized boolean `OR` applied to the set of *values*.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET initial_value := False;
     USING SQL FUNCTION 'bool_or';
 };
@@ -345,7 +345,7 @@ std::enumerate(
 {
     CREATE ANNOTATION std::description :=
         'Return a set of tuples of the form `(index, element)`.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
@@ -357,7 +357,7 @@ CREATE FUNCTION
 std::round(val: std::int64) -> std::int64
 {
     CREATE ANNOTATION std::description := 'Round to the nearest value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT "val"
     $$;
@@ -368,7 +368,7 @@ CREATE FUNCTION
 std::round(val: std::float64) -> std::float64
 {
     CREATE ANNOTATION std::description := 'Round to the nearest value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT round("val")
     $$;
@@ -379,7 +379,7 @@ CREATE FUNCTION
 std::round(val: std::bigint) -> std::bigint
 {
     CREATE ANNOTATION std::description := 'Round to the nearest value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT "val";
     $$;
@@ -390,7 +390,7 @@ CREATE FUNCTION
 std::round(val: std::decimal) -> std::decimal
 {
     CREATE ANNOTATION std::description := 'Round to the nearest value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT round("val");
     $$;
@@ -401,7 +401,7 @@ CREATE FUNCTION
 std::round(val: std::decimal, d: std::int64) -> std::decimal
 {
     CREATE ANNOTATION std::description := 'Round to the nearest value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT round("val", "d"::int4)
     $$;
@@ -416,7 +416,7 @@ std::contains(haystack: std::str, needle: std::str) -> std::bool
 {
     CREATE ANNOTATION std::description :=
         'A polymorphic function to test if a sequence contains a certain element.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT (
         -- There was a regression in 12.0 (fixed in 12.1): strpos
@@ -438,7 +438,7 @@ std::contains(haystack: std::bytes, needle: std::bytes) -> std::bool
 {
     CREATE ANNOTATION std::description :=
         'A polymorphic function to test if a sequence contains a certain element.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT position("needle" in "haystack") != 0
     $$;
@@ -450,7 +450,7 @@ std::contains(haystack: array<anytype>, needle: anytype) -> std::bool
 {
     CREATE ANNOTATION std::description :=
         'A polymorphic function to test if a sequence contains a certain element.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT
         CASE
@@ -469,7 +469,7 @@ std::find(haystack: std::str, needle: std::str) -> std::int64
 {
     CREATE ANNOTATION std::description :=
         'A polymorphic function to find index of an element in a sequence.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT (
         -- There was a regression in 12.0 (fixed in 12.1): strpos
@@ -491,7 +491,7 @@ std::find(haystack: std::bytes, needle: std::bytes) -> std::int64
 {
     CREATE ANNOTATION std::description :=
         'A polymorphic function to find index of an element in a sequence.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT (position("needle" in "haystack") - 1)::int8
     $$;
@@ -504,7 +504,7 @@ std::find(haystack: array<anytype>, needle: anytype,
 {
     CREATE ANNOTATION std::description :=
         'A polymorphic function to find index of an element in a sequence.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT COALESCE(
         array_position("haystack", "needle", ("from_pos"::int4 + 1)::int4) - 1,
@@ -518,7 +518,7 @@ std::find(haystack: array<anytype>, needle: anytype,
 
 CREATE INFIX OPERATOR
 std::`=` (l: anytuple, r: anytuple) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET recursive := true;
     SET commutator := 'std::=';
     SET negator := 'std::!=';
@@ -528,7 +528,7 @@ std::`=` (l: anytuple, r: anytuple) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL anytuple, r: OPTIONAL anytuple) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
     SET recursive := true;
 };
@@ -536,7 +536,7 @@ std::`?=` (l: OPTIONAL anytuple, r: OPTIONAL anytuple) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`!=` (l: anytuple, r: anytuple) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET recursive := true;
     SET commutator := 'std::!=';
     SET negator := 'std::=';
@@ -546,7 +546,7 @@ std::`!=` (l: anytuple, r: anytuple) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL anytuple, r: OPTIONAL anytuple) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
     SET recursive := true;
 };
@@ -554,7 +554,7 @@ std::`?!=` (l: OPTIONAL anytuple, r: OPTIONAL anytuple) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: anytuple, r: anytuple) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET recursive := true;
     SET commutator := 'std::<=';
     SET negator := 'std::<';
@@ -564,7 +564,7 @@ std::`>=` (l: anytuple, r: anytuple) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: anytuple, r: anytuple) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET recursive := true;
     SET commutator := 'std::<';
     SET negator := 'std::<=';
@@ -574,7 +574,7 @@ std::`>` (l: anytuple, r: anytuple) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: anytuple, r: anytuple) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET recursive := true;
     SET commutator := 'std::>=';
     SET negator := 'std::>';
@@ -584,7 +584,7 @@ std::`<=` (l: anytuple, r: anytuple) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: anytuple, r: anytuple) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET recursive := true;
     SET commutator := 'std::>';
     SET negator := 'std::>=';

--- a/edb/lib/std/25-booloperators.edgeql
+++ b/edb/lib/std/25-booloperators.edgeql
@@ -35,7 +35,7 @@
 # boolean expression in conjunction.
 CREATE INFIX OPERATOR
 std::`OR` (a: std::bool, b: std::bool) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT ("a" OR "b") AND ("a"::int | "b"::int)::bool
     $$;
@@ -46,21 +46,21 @@ std::`OR` (a: std::bool, b: std::bool) -> std::bool {
 # by the compiler into some SQL expression.
 CREATE INFIX OPERATOR
 std::`AND` (a: std::bool, b: std::bool) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE PREFIX OPERATOR
 std::`NOT` (v: std::bool) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::bool, r: std::bool) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -69,14 +69,14 @@ std::`=` (l: std::bool, r: std::bool) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::bool, r: OPTIONAL std::bool) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::bool, r: std::bool) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -85,14 +85,14 @@ std::`!=` (l: std::bool, r: std::bool) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::bool, r: OPTIONAL std::bool) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::bool, r: std::bool) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR '>=';
@@ -101,7 +101,7 @@ std::`>=` (l: std::bool, r: std::bool) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::bool, r: std::bool) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR '>';
@@ -110,7 +110,7 @@ std::`>` (l: std::bool, r: std::bool) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::bool, r: std::bool) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR '<=';
@@ -119,7 +119,7 @@ std::`<=` (l: std::bool, r: std::bool) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::bool, r: std::bool) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR '<';
@@ -130,12 +130,12 @@ std::`<` (l: std::bool, r: std::bool) -> std::bool {
 ## -------------
 
 CREATE CAST FROM std::str TO std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'edgedb.str_to_bool';
 };
 
 
 CREATE CAST FROM std::bool TO std::str {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };

--- a/edb/lib/std/25-enumoperators.edgeql
+++ b/edb/lib/std/25-enumoperators.edgeql
@@ -23,7 +23,7 @@
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::anyenum, r: std::anyenum) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -32,14 +32,14 @@ std::`=` (l: std::anyenum, r: std::anyenum) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::anyenum, r: OPTIONAL std::anyenum) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::anyenum, r: std::anyenum) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -48,14 +48,14 @@ std::`!=` (l: std::anyenum, r: std::anyenum) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::anyenum, r: OPTIONAL std::anyenum) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::anyenum, r: std::anyenum) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR '>=';
@@ -64,7 +64,7 @@ std::`>=` (l: std::anyenum, r: std::anyenum) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::anyenum, r: std::anyenum) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR '>';
@@ -73,7 +73,7 @@ std::`>` (l: std::anyenum, r: std::anyenum) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::anyenum, r: std::anyenum) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR '<=';
@@ -82,7 +82,7 @@ std::`<=` (l: std::anyenum, r: std::anyenum) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::anyenum, r: std::anyenum) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR '<';
@@ -95,24 +95,24 @@ std::`<` (l: std::anyenum, r: std::anyenum) -> std::bool {
 # The only way to create an enum is to cast a str into it, so it makes
 # sense to create an implicit assignment cast.
 CREATE CAST FROM std::str TO std::anyenum {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
     ALLOW ASSIGNMENT;
 };
 
 
 CREATE CAST FROM std::anyenum TO std::str {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 CREATE CAST FROM std::anyenum TO std::json {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL "SELECT to_jsonb(val::text)"
 };
 
 # Handled in compile_cast
 CREATE CAST FROM std::json TO std::anyenum {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };

--- a/edb/lib/std/25-numoperators.edgeql
+++ b/edb/lib/std/25-numoperators.edgeql
@@ -46,7 +46,7 @@
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int16, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -55,14 +55,14 @@ std::`=` (l: std::int16, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int16, r: OPTIONAL std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int16, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -71,14 +71,14 @@ std::`=` (l: std::int16, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int16, r: OPTIONAL std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int16, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -87,14 +87,14 @@ std::`=` (l: std::int16, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int16, r: OPTIONAL std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int32, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -103,14 +103,14 @@ std::`=` (l: std::int32, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int32, r: OPTIONAL std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int32, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -119,14 +119,14 @@ std::`=` (l: std::int32, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int32, r: OPTIONAL std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int32, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -135,14 +135,14 @@ std::`=` (l: std::int32, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int32, r: OPTIONAL std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int64, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -151,14 +151,14 @@ std::`=` (l: std::int64, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int64, r: OPTIONAL std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int64, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -167,14 +167,14 @@ std::`=` (l: std::int64, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int64, r: OPTIONAL std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::int64, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -183,14 +183,14 @@ std::`=` (l: std::int64, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::int64, r: OPTIONAL std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::float32, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -199,14 +199,14 @@ std::`=` (l: std::float32, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::float32, r: OPTIONAL std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::float32, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -215,14 +215,14 @@ std::`=` (l: std::float32, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::float32, r: OPTIONAL std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::float64, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -231,14 +231,14 @@ std::`=` (l: std::float64, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::float64, r: OPTIONAL std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::float64, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -247,14 +247,14 @@ std::`=` (l: std::float64, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::float64, r: OPTIONAL std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::bigint, r: std::bigint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=(numeric,numeric)';
@@ -263,7 +263,7 @@ std::`=` (l: std::bigint, r: std::bigint) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::decimal, r: std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -272,7 +272,7 @@ std::`=` (l: std::decimal, r: std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::decimal, r: std::anyint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -281,28 +281,28 @@ std::`=` (l: std::decimal, r: std::anyint) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::bigint, r: OPTIONAL std::bigint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::decimal, r: OPTIONAL std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::decimal, r: OPTIONAL std::anyint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::anyint, r: std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -311,7 +311,7 @@ std::`=` (l: std::anyint, r: std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::anyint, r: OPTIONAL std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
@@ -320,7 +320,7 @@ std::`?=` (l: OPTIONAL std::anyint, r: OPTIONAL std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int16, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -329,14 +329,14 @@ std::`!=` (l: std::int16, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int16, r: OPTIONAL std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int16, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -345,14 +345,14 @@ std::`!=` (l: std::int16, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int16, r: OPTIONAL std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int16, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -361,14 +361,14 @@ std::`!=` (l: std::int16, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int16, r: OPTIONAL std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int32, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -377,14 +377,14 @@ std::`!=` (l: std::int32, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int32, r: OPTIONAL std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int32, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -393,14 +393,14 @@ std::`!=` (l: std::int32, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int32, r: OPTIONAL std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int32, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -409,14 +409,14 @@ std::`!=` (l: std::int32, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int32, r: OPTIONAL std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int64, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -425,14 +425,14 @@ std::`!=` (l: std::int64, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int64, r: OPTIONAL std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int64, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -441,14 +441,14 @@ std::`!=` (l: std::int64, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int64, r: OPTIONAL std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::int64, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -457,14 +457,14 @@ std::`!=` (l: std::int64, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::int64, r: OPTIONAL std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::float32, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -473,14 +473,14 @@ std::`!=` (l: std::float32, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::float32, r: OPTIONAL std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::float32, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -489,14 +489,14 @@ std::`!=` (l: std::float32, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::float32, r: OPTIONAL std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::float64, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -505,14 +505,14 @@ std::`!=` (l: std::float64, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::float64, r: OPTIONAL std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::float64, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -521,14 +521,14 @@ std::`!=` (l: std::float64, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::float64, r: OPTIONAL std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::bigint, r: std::bigint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>(numeric,numeric)';
@@ -537,7 +537,7 @@ std::`!=` (l: std::bigint, r: std::bigint) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::decimal, r: std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -546,7 +546,7 @@ std::`!=` (l: std::decimal, r: std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::decimal, r: std::anyint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -555,28 +555,28 @@ std::`!=` (l: std::decimal, r: std::anyint) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::bigint, r: OPTIONAL std::bigint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::decimal, r: OPTIONAL std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::decimal, r: OPTIONAL std::anyint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::anyint, r: std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -585,7 +585,7 @@ std::`!=` (l: std::anyint, r: std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::anyint, r: OPTIONAL std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
@@ -595,7 +595,7 @@ std::`?!=` (l: OPTIONAL std::anyint, r: OPTIONAL std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int16, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -604,7 +604,7 @@ std::`>` (l: std::int16, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int16, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -613,7 +613,7 @@ std::`>` (l: std::int16, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int16, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -622,7 +622,7 @@ std::`>` (l: std::int16, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int32, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -631,7 +631,7 @@ std::`>` (l: std::int32, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int32, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -640,7 +640,7 @@ std::`>` (l: std::int32, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int32, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -649,7 +649,7 @@ std::`>` (l: std::int32, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int32, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR '>(float8,float8)';
@@ -658,7 +658,7 @@ std::`>` (l: std::int32, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int64, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -667,7 +667,7 @@ std::`>` (l: std::int64, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int64, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -676,7 +676,7 @@ std::`>` (l: std::int64, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int64, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -685,7 +685,7 @@ std::`>` (l: std::int64, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::int64, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>(float8,float8)';
@@ -694,7 +694,7 @@ std::`>` (l: std::int64, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::float32, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -703,7 +703,7 @@ std::`>` (l: std::float32, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::float32, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -712,7 +712,7 @@ std::`>` (l: std::float32, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::float32, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR '>(float8,float8)';
@@ -721,7 +721,7 @@ std::`>` (l: std::float32, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::float64, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -730,7 +730,7 @@ std::`>` (l: std::float64, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::float64, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -739,7 +739,7 @@ std::`>` (l: std::float64, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::float64, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>(float8,float8)';
@@ -748,7 +748,7 @@ std::`>` (l: std::float64, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::bigint, r: std::bigint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>(numeric,numeric)';
@@ -757,7 +757,7 @@ std::`>` (l: std::bigint, r: std::bigint) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::decimal, r: std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -766,7 +766,7 @@ std::`>` (l: std::decimal, r: std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::anyint, r: std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -775,7 +775,7 @@ std::`>` (l: std::anyint, r: std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::decimal, r: std::anyint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -786,7 +786,7 @@ std::`>` (l: std::decimal, r: std::anyint) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int16, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -795,7 +795,7 @@ std::`>=` (l: std::int16, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int16, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -804,7 +804,7 @@ std::`>=` (l: std::int16, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int16, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -813,7 +813,7 @@ std::`>=` (l: std::int16, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int32, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -822,7 +822,7 @@ std::`>=` (l: std::int32, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int32, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -831,7 +831,7 @@ std::`>=` (l: std::int32, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int32, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -840,7 +840,7 @@ std::`>=` (l: std::int32, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int32, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR '>=(float8,float8)';
@@ -849,7 +849,7 @@ std::`>=` (l: std::int32, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int64, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -858,7 +858,7 @@ std::`>=` (l: std::int64, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int64, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -867,7 +867,7 @@ std::`>=` (l: std::int64, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int64, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -876,7 +876,7 @@ std::`>=` (l: std::int64, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::int64, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=(float8,float8)';
@@ -885,7 +885,7 @@ std::`>=` (l: std::int64, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float32, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -894,7 +894,7 @@ std::`>=` (l: std::float32, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float32, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -903,7 +903,7 @@ std::`>=` (l: std::float32, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float32, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR '>=(float8,float8)';
@@ -912,7 +912,7 @@ std::`>=` (l: std::float32, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float64, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -921,7 +921,7 @@ std::`>=` (l: std::float64, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float64, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -930,7 +930,7 @@ std::`>=` (l: std::float64, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::float64, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=(float8,float8)';
@@ -939,7 +939,7 @@ std::`>=` (l: std::float64, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::bigint, r: std::bigint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=(numeric,numeric)';
@@ -948,7 +948,7 @@ std::`>=` (l: std::bigint, r: std::bigint) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::decimal, r: std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -957,7 +957,7 @@ std::`>=` (l: std::decimal, r: std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::anyint, r: std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -966,7 +966,7 @@ std::`>=` (l: std::anyint, r: std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::decimal, r: std::anyint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -977,7 +977,7 @@ std::`>=` (l: std::decimal, r: std::anyint) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int16, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -986,7 +986,7 @@ std::`<` (l: std::int16, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int16, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -995,7 +995,7 @@ std::`<` (l: std::int16, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int16, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1004,7 +1004,7 @@ std::`<` (l: std::int16, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int32, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1013,7 +1013,7 @@ std::`<` (l: std::int32, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int32, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1022,7 +1022,7 @@ std::`<` (l: std::int32, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int32, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1031,7 +1031,7 @@ std::`<` (l: std::int32, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int32, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR '<(float8,float8)';
@@ -1040,7 +1040,7 @@ std::`<` (l: std::int32, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int64, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1049,7 +1049,7 @@ std::`<` (l: std::int64, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int64, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1058,7 +1058,7 @@ std::`<` (l: std::int64, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int64, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1067,7 +1067,7 @@ std::`<` (l: std::int64, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::int64, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<(float8,float8)';
@@ -1076,7 +1076,7 @@ std::`<` (l: std::int64, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::float32, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1085,7 +1085,7 @@ std::`<` (l: std::float32, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::float32, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1094,7 +1094,7 @@ std::`<` (l: std::float32, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::float32, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR '<(float8,float8)';
@@ -1103,7 +1103,7 @@ std::`<` (l: std::float32, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::float64, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1112,7 +1112,7 @@ std::`<` (l: std::float64, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::float64, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1121,7 +1121,7 @@ std::`<` (l: std::float64, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::float64, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<(float8,float8)';
@@ -1130,7 +1130,7 @@ std::`<` (l: std::float64, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::bigint, r: std::bigint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<(numeric,numeric)';
@@ -1139,7 +1139,7 @@ std::`<` (l: std::bigint, r: std::bigint) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::decimal, r: std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1148,7 +1148,7 @@ std::`<` (l: std::decimal, r: std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::anyint, r: std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1157,7 +1157,7 @@ std::`<` (l: std::anyint, r: std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::decimal, r: std::anyint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -1168,7 +1168,7 @@ std::`<` (l: std::decimal, r: std::anyint) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int16, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1177,7 +1177,7 @@ std::`<=` (l: std::int16, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int16, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1186,7 +1186,7 @@ std::`<=` (l: std::int16, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int16, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1195,7 +1195,7 @@ std::`<=` (l: std::int16, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int32, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1204,7 +1204,7 @@ std::`<=` (l: std::int32, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int32, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1213,7 +1213,7 @@ std::`<=` (l: std::int32, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int32, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1222,7 +1222,7 @@ std::`<=` (l: std::int32, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int32, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR '<=(float8,float8)';
@@ -1231,7 +1231,7 @@ std::`<=` (l: std::int32, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int64, r: std::int16) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1240,7 +1240,7 @@ std::`<=` (l: std::int64, r: std::int16) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int64, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1249,7 +1249,7 @@ std::`<=` (l: std::int64, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int64, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1258,7 +1258,7 @@ std::`<=` (l: std::int64, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::int64, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=(float8,float8)';
@@ -1267,7 +1267,7 @@ std::`<=` (l: std::int64, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float32, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1276,7 +1276,7 @@ std::`<=` (l: std::float32, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float32, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1285,7 +1285,7 @@ std::`<=` (l: std::float32, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float32, r: std::int32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR '<=(float8,float8)';
@@ -1294,7 +1294,7 @@ std::`<=` (l: std::float32, r: std::int32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float64, r: std::float32) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1303,7 +1303,7 @@ std::`<=` (l: std::float64, r: std::float32) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float64, r: std::float64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1312,7 +1312,7 @@ std::`<=` (l: std::float64, r: std::float64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::float64, r: std::int64) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=(float8,float8)';
@@ -1321,7 +1321,7 @@ std::`<=` (l: std::float64, r: std::int64) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::bigint, r: std::bigint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=(numeric,numeric)';
@@ -1330,7 +1330,7 @@ std::`<=` (l: std::bigint, r: std::bigint) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::decimal, r: std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1339,7 +1339,7 @@ std::`<=` (l: std::decimal, r: std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::anyint, r: std::decimal) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1348,7 +1348,7 @@ std::`<=` (l: std::anyint, r: std::decimal) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::decimal, r: std::anyint) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -1359,7 +1359,7 @@ std::`<=` (l: std::decimal, r: std::anyint) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::int16, r: std::int16) -> std::int16 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
@@ -1367,7 +1367,7 @@ std::`+` (l: std::int16, r: std::int16) -> std::int16 {
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::int32, r: std::int32) -> std::int32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
@@ -1375,7 +1375,7 @@ std::`+` (l: std::int32, r: std::int32) -> std::int32 {
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::int64, r: std::int64) -> std::int64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
@@ -1383,7 +1383,7 @@ std::`+` (l: std::int64, r: std::int64) -> std::int64 {
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::float32, r: std::float32) -> std::float32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
@@ -1391,7 +1391,7 @@ std::`+` (l: std::float32, r: std::float32) -> std::float32 {
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::float64, r: std::float64) -> std::float64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
@@ -1399,7 +1399,7 @@ std::`+` (l: std::float64, r: std::float64) -> std::float64 {
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::bigint, r: std::bigint) -> std::bigint {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL OPERATOR r'+(numeric,numeric)';
 };
@@ -1407,7 +1407,7 @@ std::`+` (l: std::bigint, r: std::bigint) -> std::bigint {
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::decimal, r: std::decimal) -> std::decimal {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
@@ -1417,49 +1417,49 @@ std::`+` (l: std::decimal, r: std::decimal) -> std::decimal {
 
 CREATE PREFIX OPERATOR
 std::`+` (l: std::int16) -> std::int16 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'+';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`+` (l: std::int32) -> std::int32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'+';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`+` (l: std::int64) -> std::int64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'+';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`+` (l: std::float32) -> std::float32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'+';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`+` (l: std::float64) -> std::float64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'+';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`+` (l: std::bigint) -> std::bigint {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'+(,numeric)';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`+` (l: std::decimal) -> std::decimal {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'+';
 };
 
@@ -1469,49 +1469,49 @@ std::`+` (l: std::decimal) -> std::decimal {
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::int16, r: std::int16) -> std::int16 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::int32, r: std::int32) -> std::int32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::int64, r: std::int64) -> std::int64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::float32, r: std::float32) -> std::float32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::float64, r: std::float64) -> std::float64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::bigint, r: std::bigint) -> std::bigint {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-(numeric,numeric)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::decimal, r: std::decimal) -> std::decimal {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
@@ -1520,49 +1520,49 @@ std::`-` (l: std::decimal, r: std::decimal) -> std::decimal {
 
 CREATE PREFIX OPERATOR
 std::`-` (l: std::int16) -> std::int16 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (l: std::int32) -> std::int32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (l: std::int64) -> std::int64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (l: std::float32) -> std::float32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (l: std::float64) -> std::float64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (l: std::bigint) -> std::bigint {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-(,numeric)';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (l: std::decimal) -> std::decimal {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
@@ -1571,7 +1571,7 @@ std::`-` (l: std::decimal) -> std::decimal {
 
 CREATE INFIX OPERATOR
 std::`*` (l: std::int16, r: std::int16) -> std::int16 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::*';
     USING SQL OPERATOR r'*';
 };
@@ -1579,7 +1579,7 @@ std::`*` (l: std::int16, r: std::int16) -> std::int16 {
 
 CREATE INFIX OPERATOR
 std::`*` (l: std::int32, r: std::int32) -> std::int32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::*';
     USING SQL OPERATOR r'*';
 };
@@ -1587,7 +1587,7 @@ std::`*` (l: std::int32, r: std::int32) -> std::int32 {
 
 CREATE INFIX OPERATOR
 std::`*` (l: std::int64, r: std::int64) -> std::int64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::*';
     USING SQL OPERATOR r'*';
 };
@@ -1595,7 +1595,7 @@ std::`*` (l: std::int64, r: std::int64) -> std::int64 {
 
 CREATE INFIX OPERATOR
 std::`*` (l: std::float32, r: std::float32) -> std::float32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::*';
     USING SQL OPERATOR r'*';
 };
@@ -1603,7 +1603,7 @@ std::`*` (l: std::float32, r: std::float32) -> std::float32 {
 
 CREATE INFIX OPERATOR
 std::`*` (l: std::float64, r: std::float64) -> std::float64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::*';
     USING SQL OPERATOR r'*';
 };
@@ -1611,7 +1611,7 @@ std::`*` (l: std::float64, r: std::float64) -> std::float64 {
 
 CREATE INFIX OPERATOR
 std::`*` (l: std::bigint, r: std::bigint) -> std::bigint {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::*';
     USING SQL OPERATOR r'*(numeric,numeric)';
 };
@@ -1619,7 +1619,7 @@ std::`*` (l: std::bigint, r: std::bigint) -> std::bigint {
 
 CREATE INFIX OPERATOR
 std::`*` (l: std::decimal, r: std::decimal) -> std::decimal {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::*';
     USING SQL OPERATOR r'*';
 };
@@ -1630,7 +1630,7 @@ std::`*` (l: std::decimal, r: std::decimal) -> std::decimal {
 CREATE INFIX OPERATOR
 std::`/` (l: std::int64, r: std::int64) -> std::float64
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     # We need both USING SQL OPERATOR and USING SQL to copy
     # the common attributes of the SQL division operator while
     # overriding the main operator function.
@@ -1641,21 +1641,21 @@ std::`/` (l: std::int64, r: std::int64) -> std::float64
 
 CREATE INFIX OPERATOR
 std::`/` (l: std::float32, r: std::float32) -> std::float32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'/';
 };
 
 
 CREATE INFIX OPERATOR
 std::`/` (l: std::float64, r: std::float64) -> std::float64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'/';
 };
 
 
 CREATE INFIX OPERATOR
 std::`/` (l: std::decimal, r: std::decimal) -> std::decimal {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'/';
 };
 
@@ -1671,7 +1671,7 @@ std::`/` (l: std::decimal, r: std::decimal) -> std::decimal {
 CREATE INFIX OPERATOR
 std::`//` (n: std::int16, d: std::int16) -> std::int16
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     # We need both USING SQL OPERATOR and USING SQL FUNCTION to copy
     # the common attributes of the SQL division operator while
     # overriding the main operator function.
@@ -1683,7 +1683,7 @@ std::`//` (n: std::int16, d: std::int16) -> std::int16
 CREATE INFIX OPERATOR
 std::`//` (n: std::int32, d: std::int32) -> std::int32
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'/';
     USING SQL 'SELECT floor("n"::numeric / "d"::numeric)::int4';
 };
@@ -1692,7 +1692,7 @@ std::`//` (n: std::int32, d: std::int32) -> std::int32
 CREATE INFIX OPERATOR
 std::`//` (n: std::int64, d: std::int64) -> std::int64
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'/';
     USING SQL 'SELECT floor("n"::numeric / "d"::numeric)::int8';
 };
@@ -1701,7 +1701,7 @@ std::`//` (n: std::int64, d: std::int64) -> std::int64
 CREATE INFIX OPERATOR
 std::`//` (n: std::float32, d: std::float32) -> std::float32
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'/';
     USING SQL 'SELECT floor("n" / "d")::float4';
 };
@@ -1710,7 +1710,7 @@ std::`//` (n: std::float32, d: std::float32) -> std::float32
 CREATE INFIX OPERATOR
 std::`//` (n: std::float64, d: std::float64) -> std::float64
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'/';
     USING SQL 'SELECT floor("n" / "d")';
 };
@@ -1719,7 +1719,7 @@ std::`//` (n: std::float64, d: std::float64) -> std::float64
 CREATE INFIX OPERATOR
 std::`//` (n: std::bigint, d: std::bigint) -> std::bigint
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'/(numeric,numeric)';
     USING SQL 'SELECT floor("n" / "d")::edgedb.bigint_t;'
 };
@@ -1728,7 +1728,7 @@ std::`//` (n: std::bigint, d: std::bigint) -> std::bigint
 CREATE INFIX OPERATOR
 std::`//` (n: std::decimal, d: std::decimal) -> std::decimal
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'/';
     USING SQL 'SELECT floor("n" / "d");'
 };
@@ -1739,7 +1739,7 @@ std::`//` (n: std::decimal, d: std::decimal) -> std::decimal
 CREATE INFIX OPERATOR
 std::`%` (n: std::int16, d: std::int16) -> std::int16
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'%';
     USING SQL $$
         SELECT ((n % d) + d) % d;
@@ -1750,7 +1750,7 @@ std::`%` (n: std::int16, d: std::int16) -> std::int16
 CREATE INFIX OPERATOR
 std::`%` (n: std::int32, d: std::int32) -> std::int32
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'%';
     USING SQL $$
         SELECT ((n % d) + d) % d;
@@ -1761,7 +1761,7 @@ std::`%` (n: std::int32, d: std::int32) -> std::int32
 CREATE INFIX OPERATOR
 std::`%` (n: std::int64, d: std::int64) -> std::int64
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'%';
     USING SQL $$
         SELECT ((n % d) + d) % d;
@@ -1772,7 +1772,7 @@ std::`%` (n: std::int64, d: std::int64) -> std::int64
 CREATE INFIX OPERATOR
 std::`%` (n: std::float32, d: std::float32) -> std::float32
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     # We cheat here a bit by copying most of SQL operator metadata
     # from the `/` operator, since there is no float % in Postgres.
     USING SQL OPERATOR r'/';
@@ -1785,7 +1785,7 @@ std::`%` (n: std::float32, d: std::float32) -> std::float32
 CREATE INFIX OPERATOR
 std::`%` (n: std::float64, d: std::float64) -> std::float64
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'/';
     USING SQL $$
         SELECT n - floor(n / d) * d;
@@ -1796,7 +1796,7 @@ std::`%` (n: std::float64, d: std::float64) -> std::float64
 CREATE INFIX OPERATOR
 std::`%` (n: std::bigint, d: std::bigint) -> std::bigint
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'%(numeric,numeric)';
     USING SQL $$
         SELECT (((n % d) + d) % d)::edgedb.bigint_t;
@@ -1807,7 +1807,7 @@ std::`%` (n: std::bigint, d: std::bigint) -> std::bigint
 CREATE INFIX OPERATOR
 std::`%` (n: std::decimal, d: std::decimal) -> std::decimal
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'%';
     USING SQL $$
         SELECT ((n % d) + d) % d;
@@ -1820,7 +1820,7 @@ std::`%` (n: std::decimal, d: std::decimal) -> std::decimal
 CREATE INFIX OPERATOR
 std::`^` (n: std::int64, p: std::int64) -> std::float64
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     # We cheat here a bit by copying most of SQL operator metadata
     # from the `/` operator, since there is no int ^ in Postgres. The
     # power operator can behave like a division (negative power),
@@ -1835,7 +1835,7 @@ std::`^` (n: std::int64, p: std::int64) -> std::float64
 CREATE INFIX OPERATOR
 std::`^` (n: std::float32, p: std::float32) -> std::float32
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     # We cheat here a bit by copying most of SQL operator metadata
     # from the `/` operator, since there is no float4 ^ in Postgres.
     # The power operator can behave like a division (negative power),
@@ -1848,21 +1848,21 @@ std::`^` (n: std::float32, p: std::float32) -> std::float32
 
 CREATE INFIX OPERATOR
 std::`^` (n: std::float64, p: std::float64) -> std::float64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR '^';
 };
 
 
 CREATE INFIX OPERATOR
 std::`^` (n: std::bigint, p: std::bigint) -> std::decimal {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR '^(numeric,numeric)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`^` (n: std::decimal, p: std::decimal) -> std::decimal {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR '^';
 };
 
@@ -1874,56 +1874,56 @@ std::`^` (n: std::decimal, p: std::decimal) -> std::decimal {
 ## Implicit casts between numerics.
 
 CREATE CAST FROM std::int16 TO std::int32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
     ALLOW IMPLICIT;
 };
 
 
 CREATE CAST FROM std::int32 TO std::int64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
     ALLOW IMPLICIT;
 };
 
 
 CREATE CAST FROM std::int16 TO std::float32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
     ALLOW IMPLICIT;
 };
 
 
 CREATE CAST FROM std::int64 TO std::float64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
     ALLOW IMPLICIT;
 };
 
 
 CREATE CAST FROM std::int64 TO std::bigint {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
     ALLOW IMPLICIT;
 };
 
 
 CREATE CAST FROM std::int64 TO std::decimal {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
     ALLOW IMPLICIT;
 };
 
 
 CREATE CAST FROM std::bigint TO std::decimal {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
     ALLOW IMPLICIT;
 };
 
 
 CREATE CAST FROM std::float32 TO std::float64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
     ALLOW IMPLICIT;
 };
@@ -1932,101 +1932,101 @@ CREATE CAST FROM std::float32 TO std::float64 {
 ## Explicit and assignment casts.
 
 CREATE CAST FROM std::int32 TO std::int16 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::int64 TO std::int32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
     ALLOW ASSIGNMENT;
 };
 
 
 CREATE CAST FROM std::int64 TO std::int16 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
     ALLOW ASSIGNMENT;
 };
 
 
 CREATE CAST FROM std::int64 TO std::float32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
     ALLOW ASSIGNMENT;
 };
 
 
 CREATE CAST FROM std::float64 TO std::float32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
     ALLOW ASSIGNMENT;
 };
 
 
 CREATE CAST FROM std::decimal TO std::int16 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::decimal TO std::int32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::decimal TO std::int64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::decimal TO std::float64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::decimal TO std::float32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::decimal TO std::bigint {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL 'SELECT round($1)::edgedb.bigint_t';
 };
 
 
 CREATE CAST FROM std::float32 TO std::int16 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float32 TO std::int32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float32 TO std::int64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float32 TO std::bigint {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL 'SELECT round($1)::edgedb.bigint_t';
 };
 
 
 CREATE CAST FROM std::float32 TO std::decimal {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
         SELECT
             (CASE WHEN val != 'NaN'
@@ -2047,31 +2047,31 @@ CREATE CAST FROM std::float32 TO std::decimal {
 
 
 CREATE CAST FROM std::float64 TO std::int16 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float64 TO std::int32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float64 TO std::int64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float64 TO std::bigint {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL 'SELECT round($1)::edgedb.bigint_t';
 };
 
 
 CREATE CAST FROM std::float64 TO std::decimal {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
         SELECT
             (CASE WHEN val != 'NaN'
@@ -2094,78 +2094,78 @@ CREATE CAST FROM std::float64 TO std::decimal {
 ## String casts.
 
 CREATE CAST FROM std::str TO std::int16 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::str TO std::int32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::str TO std::int64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::str TO std::float32 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::str TO std::float64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::str TO std::bigint {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'edgedb.str_to_bigint';
 };
 
 
 CREATE CAST FROM std::str TO std::decimal {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'edgedb.str_to_decimal';
 };
 
 
 CREATE CAST FROM std::int16 TO std::str {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::int32 TO std::str {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::int64 TO std::str {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float32 TO std::str {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::float64 TO std::str {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::decimal TO std::str {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };

--- a/edb/lib/std/25-setoperators.edgeql
+++ b/edb/lib/std/25-setoperators.edgeql
@@ -28,7 +28,7 @@ CREATE INFIX OPERATOR
 std::`IN` (e: anytype, s: SET OF anytype) -> std::bool
 {
     USING SQL EXPRESSION;
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET derivative_of := 'std::=';
 };
 
@@ -37,35 +37,35 @@ CREATE INFIX OPERATOR
 std::`NOT IN` (e: anytype, s: SET OF anytype) -> std::bool
 {
     USING SQL EXPRESSION;
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET derivative_of := 'std::=';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`EXISTS` (s: SET OF anytype) -> bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE PREFIX OPERATOR
 std::`DISTINCT` (s: SET OF anytype) -> SET OF anytype {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`UNION` (s1: SET OF anytype, s2: SET OF anytype) -> SET OF anytype {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`??` (l: OPTIONAL anytype, r: SET OF anytype) -> SET OF anytype {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
@@ -73,6 +73,6 @@ std::`??` (l: OPTIONAL anytype, r: SET OF anytype) -> SET OF anytype {
 CREATE TERNARY OPERATOR
 std::`IF` (if_true: SET OF anytype, condition: bool,
            if_false: SET OF anytype) -> SET OF anytype {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };

--- a/edb/lib/std/30-arrayfuncs.edgeql
+++ b/edb/lib/std/30-arrayfuncs.edgeql
@@ -25,7 +25,7 @@ std::array_agg(s: SET OF anytype) -> array<anytype>
 {
     CREATE ANNOTATION std::description :=
         'Return the array made from all of the input set elements.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET initial_value := [];
     USING SQL FUNCTION 'array_agg';
 };
@@ -35,7 +35,7 @@ CREATE FUNCTION
 std::array_unpack(array: array<anytype>) -> SET OF anytype
 {
     CREATE ANNOTATION std::description := 'Return array elements as a set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'unnest';
 };
 
@@ -49,7 +49,7 @@ std::array_get(
 {
     CREATE ANNOTATION std::description :=
         'Return the element of *array* at the specified *index*.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT COALESCE(
         "array"[
@@ -66,7 +66,7 @@ CREATE FUNCTION
 std::array_join(array: array<std::str>, delimiter: std::str) -> std::str
 {
     CREATE ANNOTATION std::description := 'Render an array to a string.';
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT array_to_string("array", "delimiter");
     $$;
@@ -78,7 +78,7 @@ std::array_join(array: array<std::str>, delimiter: std::str) -> std::str
 
 CREATE INFIX OPERATOR
 std::`=` (l: array<anytype>, r: array<anytype>) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET recursive := true;
     SET commutator := 'std::=';
     SET negator := 'std::!=';
@@ -89,7 +89,7 @@ std::`=` (l: array<anytype>, r: array<anytype>) -> std::bool {
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL array<anytype>,
            r: OPTIONAL array<anytype>) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
     SET recursive := true;
 };
@@ -97,7 +97,7 @@ std::`?=` (l: OPTIONAL array<anytype>,
 
 CREATE INFIX OPERATOR
 std::`!=` (l: array<anytype>, r: array<anytype>) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET recursive := true;
     SET commutator := 'std::!=';
     SET negator := 'std::=';
@@ -108,14 +108,14 @@ std::`!=` (l: array<anytype>, r: array<anytype>) -> std::bool {
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL array<anytype>,
             r: OPTIONAL array<anytype>) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
     SET recursive := true;
 };
 
 CREATE INFIX OPERATOR
 std::`>=` (l: array<anytype>, r: array<anytype>) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET recursive := true;
     SET commutator := 'std::<=';
     SET negator := 'std::<';
@@ -124,7 +124,7 @@ std::`>=` (l: array<anytype>, r: array<anytype>) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: array<anytype>, r: array<anytype>) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET recursive := true;
     SET commutator := 'std::<';
     SET negator := 'std::<=';
@@ -133,7 +133,7 @@ std::`>` (l: array<anytype>, r: array<anytype>) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: array<anytype>, r: array<anytype>) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET recursive := true;
     SET commutator := 'std::>=';
     SET negator := 'std::>';
@@ -142,7 +142,7 @@ std::`<=` (l: array<anytype>, r: array<anytype>) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: array<anytype>, r: array<anytype>) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET recursive := true;
     SET commutator := 'std::>';
     SET negator := 'std::>=';
@@ -152,6 +152,6 @@ std::`<` (l: array<anytype>, r: array<anytype>) -> std::bool {
 # Concatenation
 CREATE INFIX OPERATOR
 std::`++` (l: array<anytype>, r: array<anytype>) -> array<anytype> {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR '||';
 };

--- a/edb/lib/std/30-bytesfuncs.edgeql
+++ b/edb/lib/std/30-bytesfuncs.edgeql
@@ -25,7 +25,7 @@ std::bytes_get_bit(bytes: std::bytes, num: int64) -> std::int64
 {
     CREATE ANNOTATION std::description :=
         'Get the *nth* bit of the *bytes* value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT get_bit("bytes", "num"::int)::bigint
     $$;
@@ -38,7 +38,7 @@ std::bytes_get_bit(bytes: std::bytes, num: int64) -> std::int64
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::bytes, r: std::bytes) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -47,14 +47,14 @@ std::`=` (l: std::bytes, r: std::bytes) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::bytes, r: OPTIONAL std::bytes) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::bytes, r: std::bytes) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -63,21 +63,21 @@ std::`!=` (l: std::bytes, r: std::bytes) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::bytes, r: OPTIONAL std::bytes) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`++` (l: std::bytes, r: std::bytes) -> std::bytes {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'||';
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::bytes, r: std::bytes) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR '>=';
@@ -86,7 +86,7 @@ std::`>=` (l: std::bytes, r: std::bytes) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::bytes, r: std::bytes) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR '>';
@@ -95,7 +95,7 @@ std::`>` (l: std::bytes, r: std::bytes) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::bytes, r: std::bytes) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR '<=';
@@ -104,7 +104,7 @@ std::`<=` (l: std::bytes, r: std::bytes) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::bytes, r: std::bytes) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR '<';

--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -25,7 +25,7 @@ std::datetime_current() -> std::datetime
 {
     CREATE ANNOTATION std::description :=
         'Return the current server date and time.';
-    SET volatility := 'VOLATILE';
+    SET volatility := 'Volatile';
     USING SQL FUNCTION 'clock_timestamp';
 };
 
@@ -35,7 +35,7 @@ std::datetime_of_transaction() -> std::datetime
 {
     CREATE ANNOTATION std::description :=
         'Return the date and time of the start of the current transaction.';
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'transaction_timestamp';
 };
 
@@ -45,7 +45,7 @@ std::datetime_of_statement() -> std::datetime
 {
     CREATE ANNOTATION std::description :=
         'Return the date and time of the start of the current statement.';
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'statement_timestamp';
 };
 
@@ -56,7 +56,7 @@ std::datetime_get(dt: std::datetime, el: std::str) -> std::float64
     CREATE ANNOTATION std::description :=
         'Extract a specific element of input datetime by name.';
     # date_part of timestamptz is STABLE in PostgreSQL
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT CASE WHEN "el" IN (
             'century', 'day', 'decade', 'dow', 'doy', 'hour',
@@ -92,7 +92,7 @@ std::datetime_truncate(dt: std::datetime, unit: std::str) -> std::datetime
     CREATE ANNOTATION std::description :=
         'Truncate the input datetime to a particular precision.';
     # date_trunc of timestamptz is STABLE in PostgreSQL
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT CASE WHEN "unit" IN (
             'microseconds', 'milliseconds', 'seconds',
@@ -125,7 +125,7 @@ std::duration_truncate(dt: std::duration, unit: std::str) -> std::duration
 {
     CREATE ANNOTATION std::description :=
         'Truncate the input duration to a particular precision.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT CASE WHEN "unit" in ('microseconds', 'milliseconds',
                                 'seconds', 'minutes', 'hours')
@@ -153,7 +153,7 @@ std::duration_to_seconds(dur: std::duration) -> std::decimal
 {
     CREATE ANNOTATION std::description :=
         'Return duration as total number of seconds in interval.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT EXTRACT(epoch FROM date_trunc('minute', dur))::bigint::decimal +
            '0.000001'::decimal*EXTRACT(microsecond FROM dur)::decimal
@@ -168,7 +168,7 @@ std::duration_to_seconds(dur: std::duration) -> std::decimal
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::datetime, r: std::datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=(timestamptz,timestamptz)';
@@ -177,14 +177,14 @@ std::`=` (l: std::datetime, r: std::datetime) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::datetime, r: OPTIONAL std::datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::datetime, r: std::datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>(timestamptz,timestamptz)';
@@ -193,14 +193,14 @@ std::`!=` (l: std::datetime, r: std::datetime) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::datetime, r: OPTIONAL std::datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::datetime, r: std::datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>(timestamptz,timestamptz)';
@@ -209,7 +209,7 @@ std::`>` (l: std::datetime, r: std::datetime) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::datetime, r: std::datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=(timestamptz,timestamptz)';
@@ -218,7 +218,7 @@ std::`>=` (l: std::datetime, r: std::datetime) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::datetime, r: std::datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<(timestamptz,timestamptz)';
@@ -227,7 +227,7 @@ std::`<` (l: std::datetime, r: std::datetime) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::datetime, r: std::datetime) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=(timestamptz,timestamptz)';
@@ -237,7 +237,7 @@ std::`<=` (l: std::datetime, r: std::datetime) -> std::bool {
 CREATE INFIX OPERATOR
 std::`+` (l: std::datetime, r: std::duration) -> std::datetime {
     # operators on timestamptz are STABLE in PostgreSQL
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     SET commutator := 'std::+';
     USING SQL $$
         SELECT ("l" + "r")::edgedb.timestamptz_t
@@ -248,7 +248,7 @@ std::`+` (l: std::datetime, r: std::duration) -> std::datetime {
 CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: std::datetime) -> std::datetime {
     # operators on timestamptz are STABLE in PostgreSQL
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     SET commutator := 'std::+';
     USING SQL $$
         SELECT ("l" + "r")::edgedb.timestamptz_t
@@ -259,7 +259,7 @@ std::`+` (l: std::duration, r: std::datetime) -> std::datetime {
 CREATE INFIX OPERATOR
 std::`-` (l: std::datetime, r: std::duration) -> std::datetime {
     # operators on timestamptz are STABLE in PostgreSQL
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
         SELECT ("l" - "r")::edgedb.timestamptz_t
     $$
@@ -268,7 +268,7 @@ std::`-` (l: std::datetime, r: std::duration) -> std::datetime {
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::datetime, r: std::datetime) -> std::duration {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
         SELECT EXTRACT(epoch FROM "l" - "r")::text::interval
     $$
@@ -279,7 +279,7 @@ std::`-` (l: std::datetime, r: std::datetime) -> std::duration {
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::duration, r: std::duration) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -288,14 +288,14 @@ std::`=` (l: std::duration, r: std::duration) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::duration, r: OPTIONAL std::duration) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::duration, r: std::duration) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -307,14 +307,14 @@ std::`?!=` (
         l: OPTIONAL std::duration,
         r: OPTIONAL std::duration
 ) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::duration, r: std::duration) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -323,7 +323,7 @@ std::`>` (l: std::duration, r: std::duration) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::duration, r: std::duration) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -332,7 +332,7 @@ std::`>=` (l: std::duration, r: std::duration) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::duration, r: std::duration) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -341,7 +341,7 @@ std::`<` (l: std::duration, r: std::duration) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::duration, r: std::duration) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -350,7 +350,7 @@ std::`<=` (l: std::duration, r: std::duration) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: std::duration) -> std::duration {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::+';
     USING SQL OPERATOR r'+';
 };
@@ -358,14 +358,14 @@ std::`+` (l: std::duration, r: std::duration) -> std::duration {
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::duration, r: std::duration) -> std::duration {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (v: std::duration) -> std::duration {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR r'-';
 };
 
@@ -377,13 +377,13 @@ std::`-` (v: std::duration) -> std::duration {
 # prohibit usage of timezone for non-timezone-aware types are actually
 # IMMUTABLE (as the corresponding casts from those types to text).
 CREATE CAST FROM std::str TO std::datetime {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'edgedb.datetime_in';
 };
 
 
 CREATE CAST FROM std::str TO std::duration {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'edgedb.duration_in';
 };
 
@@ -394,7 +394,7 @@ CREATE CAST FROM std::str TO std::duration {
 # and uses ' ' instead of 'T' as a separator between date
 # and time.
 CREATE CAST FROM std::datetime TO std::str {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT trim(to_json(val)::text, '"');
     $$;
@@ -402,7 +402,7 @@ CREATE CAST FROM std::datetime TO std::str {
 
 
 CREATE CAST FROM std::duration TO std::str {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT regexp_replace(val::text, '[[:<:]]mon(?=s?[[:>:]])', 'month');
     $$;

--- a/edb/lib/std/30-jsonfuncs.edgeql
+++ b/edb/lib/std/30-jsonfuncs.edgeql
@@ -25,7 +25,7 @@ std::json_typeof(json: std::json) -> std::str
 {
     CREATE ANNOTATION std::description :=
         'Return the type of the outermost JSON value as a string.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'jsonb_typeof';
 };
 
@@ -35,7 +35,7 @@ std::json_array_unpack(array: std::json) -> SET OF std::json
 {
     CREATE ANNOTATION std::description :=
         'Return elements of JSON array as a set of `json`.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'jsonb_array_elements';
 };
 
@@ -45,7 +45,7 @@ std::json_object_unpack(obj: std::json) -> SET OF tuple<std::str, std::json>
 {
     CREATE ANNOTATION std::description :=
         'Return set of key/value tuples that make up the JSON object.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'jsonb_each';
     # jsonb_each is defined as (jsonb, OUT key text, OUT value jsonb),
     # and, quite perprexingly, would reject a column definition list
@@ -65,7 +65,7 @@ std::json_get(
 {
     CREATE ANNOTATION std::description :=
         'Return the JSON value at the end of the specified path or an empty set.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT COALESCE(
         jsonb_extract_path("json", VARIADIC "path"),
@@ -77,7 +77,7 @@ std::json_get(
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::json, r: std::json) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -86,14 +86,14 @@ std::`=` (l: std::json, r: std::json) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::json, r: OPTIONAL std::json) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::json, r: std::json) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -102,14 +102,14 @@ std::`!=` (l: std::json, r: std::json) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::json, r: OPTIONAL std::json) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::json, r: std::json) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR '>=';
@@ -118,7 +118,7 @@ std::`>=` (l: std::json, r: std::json) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::json, r: std::json) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR '>';
@@ -127,7 +127,7 @@ std::`>` (l: std::json, r: std::json) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::json, r: std::json) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR '<=';
@@ -136,7 +136,7 @@ std::`<=` (l: std::json, r: std::json) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::json, r: std::json) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR '<';
@@ -148,7 +148,7 @@ std::`<` (l: std::json, r: std::json) -> std::bool {
 # This is only a container cast, and subject to element type cast
 # availability.
 CREATE CAST FROM array<anytype> TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
@@ -156,19 +156,19 @@ CREATE CAST FROM array<anytype> TO std::json {
 # This is only a container cast, and subject to element type cast
 # availability.
 CREATE CAST FROM anytuple TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE CAST FROM std::json TO anytuple {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE CAST FROM std::json TO array<json> {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
         SELECT array_agg(j)
         FROM jsonb_array_elements(val) AS j
@@ -177,7 +177,7 @@ CREATE CAST FROM std::json TO array<json> {
 
 
 CREATE CAST FROM std::json TO array<anytype> {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL EXPRESSION;
 };
 
@@ -185,73 +185,73 @@ CREATE CAST FROM std::json TO array<anytype> {
 # The function to_jsonb is STABLE in PostgreSQL, but this function is
 # generic and STABLE volatility may be an overestimation in many cases.
 CREATE CAST FROM std::bool TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::uuid TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::str TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::datetime TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::duration TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::int16 TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::int32 TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::int64 TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::float32 TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::float64 TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::decimal TO std::json {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'to_jsonb';
 };
 
 
 CREATE CAST FROM std::json TO std::bool  {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'boolean')::bool;
     $$;
@@ -259,7 +259,7 @@ CREATE CAST FROM std::json TO std::bool  {
 
 
 CREATE CAST FROM std::json TO std::uuid {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'string')::uuid;
     $$;
@@ -267,7 +267,7 @@ CREATE CAST FROM std::json TO std::uuid {
 
 
 CREATE CAST FROM std::json TO std::str {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'string');
     $$;
@@ -275,7 +275,7 @@ CREATE CAST FROM std::json TO std::str {
 
 
 CREATE CAST FROM std::json TO std::datetime {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.datetime_in(edgedb.jsonb_extract_scalar(val, 'string'));
     $$;
@@ -283,7 +283,7 @@ CREATE CAST FROM std::json TO std::datetime {
 
 
 CREATE CAST FROM std::json TO std::duration {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.duration_in(edgedb.jsonb_extract_scalar(val, 'string'));
     $$;
@@ -291,7 +291,7 @@ CREATE CAST FROM std::json TO std::duration {
 
 
 CREATE CAST FROM std::json TO std::int16 {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'number')::int2;
     $$;
@@ -299,7 +299,7 @@ CREATE CAST FROM std::json TO std::int16 {
 
 
 CREATE CAST FROM std::json TO std::int32 {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'number')::int4;
     $$;
@@ -307,7 +307,7 @@ CREATE CAST FROM std::json TO std::int32 {
 
 
 CREATE CAST FROM std::json TO std::int64 {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'number')::int8;
     $$;
@@ -315,7 +315,7 @@ CREATE CAST FROM std::json TO std::int64 {
 
 
 CREATE CAST FROM std::json TO std::float32 {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'number')::float4;
     $$;
@@ -323,7 +323,7 @@ CREATE CAST FROM std::json TO std::float32 {
 
 
 CREATE CAST FROM std::json TO std::float64 {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.jsonb_extract_scalar(val, 'number')::float8;
     $$;
@@ -331,7 +331,7 @@ CREATE CAST FROM std::json TO std::float64 {
 
 
 CREATE CAST FROM std::json TO std::decimal {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.str_to_decimal(
         edgedb.jsonb_extract_scalar(val, 'number')
@@ -341,7 +341,7 @@ CREATE CAST FROM std::json TO std::decimal {
 
 
 CREATE CAST FROM std::json TO std::bigint {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT edgedb.str_to_bigint(
         edgedb.jsonb_extract_scalar(val, 'number')

--- a/edb/lib/std/30-regexpfuncs.edgeql
+++ b/edb/lib/std/30-regexpfuncs.edgeql
@@ -25,7 +25,7 @@ std::re_match(pattern: std::str, str: std::str) -> array<std::str>
 {
     CREATE ANNOTATION std::description :=
         'Find the first regular expression match in a string.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT regexp_matches("str", "pattern");
     $$;
@@ -37,7 +37,7 @@ std::re_match_all(pattern: std::str, str: std::str) -> SET OF array<std::str>
 {
     CREATE ANNOTATION std::description :=
         'Find all regular expression matches in a string.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT regexp_matches("str", "pattern", 'g');
     $$;
@@ -49,7 +49,7 @@ std::re_test(pattern: std::str, str: std::str) -> std::bool
 {
     CREATE ANNOTATION std::description :=
         'Test if a regular expression has a match in a string.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT "str" ~ "pattern";
     $$;
@@ -65,7 +65,7 @@ std::re_replace(
 {
     CREATE ANNOTATION std::description :=
         'Replace matching substrings in a given string.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT regexp_replace("str", "pattern", "sub", "flags");
     $$;

--- a/edb/lib/std/30-strfuncs.edgeql
+++ b/edb/lib/std/30-strfuncs.edgeql
@@ -21,7 +21,7 @@
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::str, r: std::str) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -30,14 +30,14 @@ std::`=` (l: std::str, r: std::str) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::str, r: OPTIONAL std::str) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::str, r: std::str) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -46,7 +46,7 @@ std::`!=` (l: std::str, r: std::str) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::str, r: OPTIONAL std::str) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
@@ -54,42 +54,42 @@ std::`?!=` (l: OPTIONAL std::str, r: OPTIONAL std::str) -> std::bool {
 # Concatenation.
 CREATE INFIX OPERATOR
 std::`++` (l: std::str, r: std::str) -> std::str {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL OPERATOR '||';
 };
 
 
 CREATE INFIX OPERATOR
 std::`LIKE` (string: std::str, pattern: std::str) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`ILIKE` (string: std::str, pattern: std::str) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`NOT LIKE` (string: std::str, pattern: std::str) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`NOT ILIKE` (string: std::str, pattern: std::str) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::str, r: std::str) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR r'<';
@@ -98,7 +98,7 @@ std::`<` (l: std::str, r: std::str) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::str, r: std::str) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR r'<=';
@@ -107,7 +107,7 @@ std::`<=` (l: std::str, r: std::str) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::str, r: std::str) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR r'>';
@@ -116,7 +116,7 @@ std::`>` (l: std::str, r: std::str) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::str, r: std::str) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR r'>=';
@@ -131,7 +131,7 @@ std::str_repeat(s: std::str, n: std::int64) -> std::str
 {
     CREATE ANNOTATION std::description :=
         'Repeat the input *string* *n* times.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT repeat("s", "n"::int4)
     $$;
@@ -143,7 +143,7 @@ std::str_lower(s: std::str) -> std::str
 {
     CREATE ANNOTATION std::description :=
         'Return a lowercase copy of the input *string*.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'lower';
 };
 
@@ -153,7 +153,7 @@ std::str_upper(s: std::str) -> std::str
 {
     CREATE ANNOTATION std::description :=
         'Return an uppercase copy of the input *string*.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'upper';
 };
 
@@ -163,7 +163,7 @@ std::str_title(s: std::str) -> std::str
 {
     CREATE ANNOTATION std::description :=
         'Return a titlecase copy of the input *string*.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'initcap';
 };
 
@@ -173,7 +173,7 @@ std::str_pad_start(s: std::str, n: std::int64, fill: std::str=' ') -> std::str
 {
     CREATE ANNOTATION std::description :=
         'Return the input string padded at the start to the length *n*.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT lpad("s", "n"::int4, "fill")
     $$;
@@ -189,7 +189,7 @@ std::str_lpad(s: std::str, n: std::int64, fill: std::str=' ') -> std::str
         'This function is deprecated and is scheduled \
          to be removed before 1.0.\n\
          Use std::str_pad_start() instead.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING (std::str_pad_start(s, n, fill));
 };
 
@@ -199,7 +199,7 @@ std::str_pad_end(s: std::str, n: std::int64, fill: std::str=' ') -> std::str
 {
     CREATE ANNOTATION std::description :=
         'Return the input string padded at the end to the length *n*.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT rpad("s", "n"::int4, "fill")
     $$;
@@ -215,7 +215,7 @@ std::str_rpad(s: std::str, n: std::int64, fill: std::str=' ') -> std::str
         'This function is deprecated and is scheduled \
          to be removed before 1.0.\n\
          Use std::str_pad_end() instead.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING (std::str_pad_end(s, n, fill));
 };
 
@@ -226,7 +226,7 @@ std::str_trim_start(s: std::str, tr: std::str=' ') -> std::str
     CREATE ANNOTATION std::description :=
         'Return the input string with all *trim* characters removed from \
          its start.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'ltrim';
 };
 
@@ -240,7 +240,7 @@ std::str_ltrim(s: std::str, tr: std::str=' ') -> std::str
         'This function is deprecated and is scheduled \
          to be removed before 1.0.\n\
          Use std::str_trim_start() instead.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING (std::str_trim_start(s, tr));
 };
 
@@ -251,7 +251,7 @@ std::str_trim_end(s: std::str, tr: std::str=' ') -> std::str
     CREATE ANNOTATION std::description :=
         'Return the input string with all *trim* characters removed from \
          its end.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'rtrim';
 };
 
@@ -265,7 +265,7 @@ std::str_rtrim(s: std::str, tr: std::str=' ') -> std::str
         'This function is deprecated and is scheduled \
          to be removed before 1.0.\n\
          Use std::str_trim_end() instead.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING (std::str_trim_end(s, tr));
 };
 
@@ -276,7 +276,7 @@ std::str_trim(s: std::str, tr: std::str=' ') -> std::str
     CREATE ANNOTATION std::description :=
         'Return the input string with *trim* characters removed from \
          both ends.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL FUNCTION 'btrim';
 };
 
@@ -286,7 +286,7 @@ std::str_split(s: std::str, delimiter: std::str) -> array<std::str>
 {
     CREATE ANNOTATION std::description :=
         'Split string into array elements using the supplied delimiter.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
         SELECT (
             CASE WHEN "delimiter" != ''

--- a/edb/lib/std/30-uuidfuncs.edgeql
+++ b/edb/lib/std/30-uuidfuncs.edgeql
@@ -23,7 +23,7 @@
 CREATE FUNCTION
 std::uuid_generate_v1mc() -> std::uuid {
     CREATE ANNOTATION std::description := 'Return a version 1 UUID.';
-    SET volatility := 'VOLATILE';
+    SET volatility := 'Volatile';
     USING SQL $$
     SELECT edgedbext.uuid_generate_v1mc()
     $$;
@@ -32,7 +32,7 @@ std::uuid_generate_v1mc() -> std::uuid {
 
 CREATE INFIX OPERATOR
 std::`=` (l: std::uuid, r: std::uuid) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
     USING SQL OPERATOR r'=';
@@ -41,14 +41,14 @@ std::`=` (l: std::uuid, r: std::uuid) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?=` (l: OPTIONAL std::uuid, r: OPTIONAL std::uuid) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::uuid, r: std::uuid) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
     USING SQL OPERATOR r'<>';
@@ -57,14 +57,14 @@ std::`!=` (l: std::uuid, r: std::uuid) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`?!=` (l: OPTIONAL std::uuid, r: OPTIONAL std::uuid) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::uuid, r: std::uuid) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
     USING SQL OPERATOR '>=';
@@ -73,7 +73,7 @@ std::`>=` (l: std::uuid, r: std::uuid) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::uuid, r: std::uuid) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
     USING SQL OPERATOR '>';
@@ -82,7 +82,7 @@ std::`>` (l: std::uuid, r: std::uuid) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::uuid, r: std::uuid) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
     USING SQL OPERATOR '<=';
@@ -91,7 +91,7 @@ std::`<=` (l: std::uuid, r: std::uuid) -> std::bool {
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::uuid, r: std::uuid) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
     USING SQL OPERATOR '<';
@@ -101,12 +101,12 @@ std::`<` (l: std::uuid, r: std::uuid) -> std::bool {
 ## String casts.
 
 CREATE CAST FROM std::str TO std::uuid {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };
 
 
 CREATE CAST FROM std::uuid TO std::str {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL CAST;
 };

--- a/edb/lib/std/50-constraints.edgeql
+++ b/edb/lib/std/50-constraints.edgeql
@@ -23,7 +23,7 @@
 CREATE FUNCTION
 std::_is_exclusive(s: SET OF anytype) -> std::bool
 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     SET initial_value := True;
     SET internal := true;
     USING SQL EXPRESSION;

--- a/edb/lib/std/60-baseobject.edgeql
+++ b/edb/lib/std/60-baseobject.edgeql
@@ -60,7 +60,7 @@ CREATE ABSTRACT TYPE std::Object EXTENDING std::BaseObject {
 # clashing with the operators for uuid in Postgres.
 CREATE INFIX OPERATOR
 std::`=` (l: std::BaseObject, r: std::BaseObject) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
@@ -70,14 +70,14 @@ std::`?=` (
     l: OPTIONAL std::BaseObject,
     r: OPTIONAL std::BaseObject
 ) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`!=` (l: std::BaseObject, r: std::BaseObject) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
@@ -87,41 +87,41 @@ std::`?!=` (
     l: OPTIONAL std::BaseObject,
     r: OPTIONAL std::BaseObject
 ) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>=` (l: std::BaseObject, r: std::BaseObject) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`>` (l: std::BaseObject, r: std::BaseObject) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`<=` (l: std::BaseObject, r: std::BaseObject) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 CREATE INFIX OPERATOR
 std::`<` (l: std::BaseObject, r: std::BaseObject) -> std::bool {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };
 
 
 # The only possible Object cast is into json.
 CREATE CAST FROM std::BaseObject TO std::json {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL EXPRESSION;
 };

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -36,7 +36,7 @@ std::to_str(dt: std::datetime, fmt: OPTIONAL str={}) -> std::str
     CREATE ANNOTATION std::description :=
         'Return string representation of the input value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -65,7 +65,7 @@ std::to_str(td: std::duration, fmt: OPTIONAL str={}) -> std::str
     CREATE ANNOTATION std::description :=
         'Return string representation of the input value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -99,7 +99,7 @@ std::to_str(i: std::int64, fmt: OPTIONAL str={}) -> std::str
     CREATE ANNOTATION std::description :=
         'Return string representation of the input value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -128,7 +128,7 @@ std::to_str(f: std::float64, fmt: OPTIONAL str={}) -> std::str
     CREATE ANNOTATION std::description :=
         'Return string representation of the input value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -157,7 +157,7 @@ std::to_str(d: std::bigint, fmt: OPTIONAL str={}) -> std::str
     CREATE ANNOTATION std::description :=
         'Return string representation of the input value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -186,7 +186,7 @@ std::to_str(d: std::decimal, fmt: OPTIONAL str={}) -> std::str
     CREATE ANNOTATION std::description :=
         'Return string representation of the input value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -218,7 +218,7 @@ std::to_str(array: array<std::str>, delimiter: std::str) -> std::str
         'This converter function is deprecated and \
          is scheduled to be removed before 1.0.\n\
          Use std::array_join() instead.';
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING (
         SELECT std::array_join(array, delimiter)
     );
@@ -233,7 +233,7 @@ std::to_str(json: std::json, fmt: OPTIONAL str={}) -> std::str
     CREATE ANNOTATION std::description :=
         'Return string representation of the input value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -264,7 +264,7 @@ std::to_json(str: std::str) -> std::json
     CREATE ANNOTATION std::description :=
         'Return JSON value represented by the input *string*.';
     # Casting of jsonb to and from text in PostgreSQL is IMMUTABLE.
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT "str"::jsonb
     $$;
@@ -276,7 +276,7 @@ std::to_datetime(s: std::str, fmt: OPTIONAL str={}) -> std::datetime
 {
     CREATE ANNOTATION std::description := 'Create a `datetime` value.';
     # Helper function to_datetime is VOLATILE.
-    SET volatility := 'VOLATILE';
+    SET volatility := 'Volatile';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -308,7 +308,7 @@ std::to_datetime(year: std::int64, month: std::int64, day: std::int64,
 {
     CREATE ANNOTATION std::description := 'Create a `datetime` value.';
     # make_timestamptz is STABLE
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT make_timestamptz(
         "year"::int, "month"::int, "day"::int,
@@ -322,7 +322,7 @@ CREATE FUNCTION
 std::to_datetime(epochseconds: std::float64) -> std::datetime
 {
     CREATE ANNOTATION std::description := 'Create a `datetime` value.';
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT to_timestamp("epochseconds")::edgedb.timestamptz_t
     $$;
@@ -333,7 +333,7 @@ CREATE FUNCTION
 std::to_datetime(epochseconds: std::int64) -> std::datetime
 {
     CREATE ANNOTATION std::description := 'Create a `datetime` value.';
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT to_timestamp("epochseconds")::edgedb.timestamptz_t
     $$;
@@ -344,7 +344,7 @@ CREATE FUNCTION
 std::to_datetime(epochseconds: std::decimal) -> std::datetime
 {
     CREATE ANNOTATION std::description := 'Create a `datetime` value.';
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT to_timestamp("epochseconds")::edgedb.timestamptz_t
     $$;
@@ -360,7 +360,7 @@ std::to_duration(
     ) -> std::duration
 {
     CREATE ANNOTATION std::description := 'Create a `duration` value.';
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
     SELECT make_interval(
         0,
@@ -380,7 +380,7 @@ std::to_bigint(s: std::str, fmt: OPTIONAL str={}) -> std::bigint
 {
     CREATE ANNOTATION std::description := 'Create a `bigint` value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -410,7 +410,7 @@ std::to_decimal(s: std::str, fmt: OPTIONAL str={}) -> std::decimal
 {
     CREATE ANNOTATION std::description := 'Create a `decimal` value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -440,7 +440,7 @@ std::to_int64(s: std::str, fmt: OPTIONAL str={}) -> std::int64
 {
     CREATE ANNOTATION std::description := 'Create a `int64` value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -470,7 +470,7 @@ std::to_int32(s: std::str, fmt: OPTIONAL str={}) -> std::int32
 {
     CREATE ANNOTATION std::description := 'Create a `int32` value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -500,7 +500,7 @@ std::to_int16(s: std::str, fmt: OPTIONAL str={}) -> std::int16
 {
     CREATE ANNOTATION std::description := 'Create a `int16` value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -530,7 +530,7 @@ std::to_float64(s: std::str, fmt: OPTIONAL str={}) -> std::float64
 {
     CREATE ANNOTATION std::description := 'Create a `float64` value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN
@@ -560,7 +560,7 @@ std::to_float32(s: std::str, fmt: OPTIONAL str={}) -> std::float32
 {
     CREATE ANNOTATION std::description := 'Create a `float32` value.';
     # Helper functions raising exceptions are STABLE.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
     SELECT (
         CASE WHEN "fmt" IS NULL THEN

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -84,7 +84,7 @@ sys::__version_internal() -> tuple<major: std::int64,
                                    local: array<std::str>>
 {
     # This function reads from a table.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     SET internal := true;
     USING SQL $$
     SELECT
@@ -109,7 +109,7 @@ sys::get_version() -> tuple<major: std::int64,
 {
     CREATE ANNOTATION std::description :=
         'Return the server version as a tuple.';
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING (
         SELECT <tuple<major: std::int64,
                     minor: std::int64,
@@ -125,7 +125,7 @@ sys::get_version_as_str() -> std::str
 {
     CREATE ANNOTATION std::description :=
         'Return the server version as a string.';
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING (
         WITH v := sys::get_version()
         SELECT
@@ -145,7 +145,7 @@ sys::get_transaction_isolation() -> sys::TransactionIsolation
     CREATE ANNOTATION std::description :=
         'Return the isolation level of the current transaction.';
     # This function only reads from a table.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     SET force_return_cast := true;
     USING SQL FUNCTION 'edgedb._get_transaction_isolation';
 };
@@ -157,7 +157,7 @@ sys::get_current_database() -> str
     CREATE ANNOTATION std::description :=
         'Return the name of the current database as a string.';
     # The results won't change within a single statement.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL FUNCTION 'current_database';
 };
 
@@ -165,7 +165,7 @@ CREATE FUNCTION
 sys::_describe_roles_as_ddl() -> str
 {
     # The results won't change within a single statement.
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     SET internal := true;
     USING SQL FUNCTION 'edgedb._describe_roles_as_ddl';
 };

--- a/tests/schemas/dump01_default.esdl
+++ b/tests/schemas/dump01_default.esdl
@@ -25,21 +25,21 @@ function user_func_0(x: int64) -> str {
         SELECT 'func' ++ <str>x
     );
     annotation title := 'user_func(int64) -> str';
-    volatility := 'IMMUTABLE';
+    volatility := 'Immutable';
 };
 
 function user_func_1(x: array<int64>, y: str) -> str {
     using (
         SELECT array_join(<array<str>>x, y)
     );
-    volatility := 'STABLE';
+    volatility := 'Stable';
 };
 
 function user_func_2(x: OPTIONAL int64, y: str = 'x') -> SET OF str {
     using (
         SELECT {<str>x, y}
     );
-    volatility := 'IMMUTABLE';
+    volatility := 'Immutable';
 };
 
 type A {

--- a/tests/schemas/dump01_test.esdl
+++ b/tests/schemas/dump01_test.esdl
@@ -21,7 +21,7 @@ function user_func_3(x: int64) -> str {
     using (
         SELECT 'test' ++ <str>x
     );
-    volatility := 'IMMUTABLE';
+    volatility := 'Immutable';
 };
 
 # cross-module references

--- a/tests/schemas/dump02_default.esdl
+++ b/tests/schemas/dump02_default.esdl
@@ -26,7 +26,7 @@ function `💯`(NAMED ONLY `🙀`: int64) -> int64 {
     );
 
     annotation `🍿` := 'fun!🚀';
-    volatility := 'IMMUTABLE';
+    volatility := 'Immutable';
 }
 
 type `S p a M` {

--- a/tests/schemas/volatility_setup.edgeql
+++ b/tests/schemas/volatility_setup.edgeql
@@ -18,42 +18,42 @@
 
 
 CREATE FUNCTION test::vol_immutable() -> float64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
         SELECT random();
     $$;
 };
 
 CREATE FUNCTION test::vol_stable() -> float64 {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
         SELECT random();
     $$;
 };
 
 CREATE FUNCTION test::vol_volatile() -> float64 {
-    SET volatility := 'VOLATILE';
+    SET volatility := 'Volatile';
     USING SQL $$
         SELECT random();
     $$;
 };
 
 CREATE FUNCTION test::err_immutable() -> float64 {
-    SET volatility := 'IMMUTABLE';
+    SET volatility := 'Immutable';
     USING SQL $$
         SELECT random()/0;
     $$;
 };
 
 CREATE FUNCTION test::err_stable() -> float64 {
-    SET volatility := 'STABLE';
+    SET volatility := 'Stable';
     USING SQL $$
         SELECT random()/0;
     $$;
 };
 
 CREATE FUNCTION test::err_volatile() -> float64 {
-    SET volatility := 'VOLATILE';
+    SET volatility := 'Volatile';
     USING SQL $$
         SELECT random()/0;
     $$;

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1279,7 +1279,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
                 USING (
                     SELECT str_lower(s)
                 );
-                SET volatility := 'IMMUTABLE';
+                SET volatility := 'Immutable';
             };
 
             CREATE TYPE test::CompPropFunction {

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -9453,7 +9453,7 @@ type test::Foo {
                 await self.con.execute('''
                     WITH MODULE test
                     ALTER FUNCTION foo___1(a: int64)
-                    SET volatility := 'STABLE';
+                    SET volatility := 'Stable';
                 ''')
 
         async with self._run_and_rollback():

--- a/tests/test_edgeql_ir_volatility_inference.py
+++ b/tests/test_edgeql_ir_volatility_inference.py
@@ -47,7 +47,7 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
         WITH MODULE test
         SELECT Card
 % OK %
-        STABLE
+        Stable
         """
 
     def test_edgeql_ir_volatility_inference_01(self):
@@ -58,7 +58,7 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
         SELECT
             foo
 % OK %
-        VOLATILE
+        Volatile
         """
 
     def test_edgeql_ir_volatility_inference_02(self):
@@ -70,7 +70,7 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
         FILTER
             random() > 0.9
 % OK %
-        VOLATILE
+        Volatile
         """
 
     def test_edgeql_ir_volatility_inference_03(self):
@@ -82,7 +82,7 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
         ORDER BY
             random()
 % OK %
-        VOLATILE
+        Volatile
         """
 
     def test_edgeql_ir_volatility_inference_04(self):
@@ -94,7 +94,7 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
         LIMIT
             <int64>random()
 % OK %
-        VOLATILE
+        Volatile
         """
 
     def test_edgeql_ir_volatility_inference_05(self):
@@ -106,7 +106,7 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
         OFFSET
             <int64>random()
 % OK %
-        VOLATILE
+        Volatile
         """
 
     def test_edgeql_ir_volatility_inference_06(self):
@@ -120,7 +120,7 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
                 cost := 1,
             }
 % OK %
-        VOLATILE
+        Volatile
         """
 
     def test_edgeql_ir_volatility_inference_07(self):
@@ -133,7 +133,7 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
                 name := 'foo',
         }
 % OK %
-        VOLATILE
+        Volatile
         """
 
     def test_edgeql_ir_volatility_inference_08(self):
@@ -143,5 +143,5 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
         DELETE
             Card
 % OK %
-        VOLATILE
+        Volatile
         """

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -4242,7 +4242,7 @@ aa';
     def test_edgeql_syntax_ddl_function_26(self):
         """
         CREATE FUNCTION foo() -> std::str {
-            SET volatility := 'VOLATILE';
+            SET volatility := 'Volatile';
             CREATE ANNOTATION description := 'aaaa';
             USING SQL $a$SELECT $$foo$$$a$;
         };
@@ -4525,7 +4525,7 @@ aa';
         """
         CREATE INFIX OPERATOR
         std::`OR` (a: std::bool, b: std::bool) -> std::bool {
-            SET volatility := 'IMMUTABLE';
+            SET volatility := 'Immutable';
             USING SQL $$
             SELECT ("a" OR "b") AND ("a"::int | "b"::int)::bool
             $$;
@@ -4536,7 +4536,7 @@ aa';
         """
         CREATE INFIX OPERATOR
         std::`AND` (a: std::bool, b: std::bool) -> std::bool {
-            SET volatility := 'IMMUTABLE';
+            SET volatility := 'Immutable';
             USING SQL EXPRESSION;
         };
         """
@@ -4545,7 +4545,7 @@ aa';
         """
         CREATE INFIX OPERATOR
         std::`=` (l: std::bool, r: std::bool) -> std::bool {
-            SET volatility := 'IMMUTABLE';
+            SET volatility := 'Immutable';
             SET commutator := 'std::=';
             SET negator := 'std::!=';
             USING SQL OPERATOR '=';
@@ -4556,7 +4556,7 @@ aa';
         """
         CREATE INFIX OPERATOR
         std::`>` (l: std::int32, r: std::float32) -> std::bool {
-            SET volatility := 'IMMUTABLE';
+            SET volatility := 'Immutable';
             SET commutator := 'std::<';
             SET negator := 'std::<=';
             USING SQL OPERATOR '>(float8,float8)';
@@ -4584,7 +4584,7 @@ aa';
     def test_edgeql_syntax_ddl_cast_01(self):
         """
         CREATE CAST FROM std::str TO std::bool {
-            SET volatility := 'IMMUTABLE';
+            SET volatility := 'Immutable';
             USING SQL FUNCTION 'edgedb.str_to_bool';
         };
         """
@@ -4592,7 +4592,7 @@ aa';
     def test_edgeql_syntax_ddl_cast_02(self):
         """
         CREATE CAST FROM std::bool TO std::str {
-            SET volatility := 'IMMUTABLE';
+            SET volatility := 'Immutable';
             USING SQL CAST;
         };
         """
@@ -4600,7 +4600,7 @@ aa';
     def test_edgeql_syntax_ddl_cast_03(self):
         """
         CREATE CAST FROM std::json TO std::bigint {
-            SET volatility := 'STABLE';
+            SET volatility := 'Stable';
             USING SQL $$
             SELECT edgedb.str_to_bigint(
                 edgedb.jsonb_extract_scalar(val, 'number')
@@ -4612,7 +4612,7 @@ aa';
     def test_edgeql_syntax_ddl_cast_04(self):
         """
         CREATE CAST FROM std::int32 TO std::int64 {
-            SET volatility := 'IMMUTABLE';
+            SET volatility := 'Immutable';
             USING SQL CAST;
             ALLOW IMPLICIT;
         };
@@ -4621,7 +4621,7 @@ aa';
     def test_edgeql_syntax_ddl_cast_05(self):
         """
         CREATE CAST FROM std::int64 TO std::int16 {
-            SET volatility := 'IMMUTABLE';
+            SET volatility := 'Immutable';
             USING SQL CAST;
             ALLOW ASSIGNMENT;
         };
@@ -4630,7 +4630,7 @@ aa';
     def test_edgeql_syntax_ddl_cast_06(self):
         """
         CREATE CAST FROM std::BaseObject TO std::json {
-            SET volatility := 'IMMUTABLE';
+            SET volatility := 'Immutable';
             USING SQL EXPRESSION;
         };
         """

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -492,7 +492,7 @@ _123456789_123456789_123456789 -> str
         schema = self.run_ddl(schema, '''
             CREATE FUNCTION
             test::my_contains(arr: array<anytype>, val: anytype) -> bool {
-                SET volatility := 'STABLE';
+                SET volatility := 'Stable';
                 USING (
                     SELECT contains(arr, val)
                 );
@@ -1769,7 +1769,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         function idx(num: int64) -> bool {
             using (SELECT (num % 2) = 0);
-            volatility := 'IMMUTABLE';
+            volatility := 'Immutable';
         }
         '''
 
@@ -1828,7 +1828,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                     flags := 'g')
                 )
             );
-            volatility := 'IMMUTABLE';  # needed for the constraint
+            volatility := 'Immutable';  # needed for the constraint
         }
         '''
 
@@ -1928,7 +1928,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         schema = r'''
         function idx(num: int64) -> bool {
             using (SELECT (num % 2) = 0);
-            volatility := 'IMMUTABLE';
+            volatility := 'Immutable';
             annotation title := 'func anno';
         }
         '''
@@ -2415,7 +2415,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         function other::idx(num: int64) -> bool {
             using (SELECT (num % 2) = 0);
-            volatility := 'IMMUTABLE';
+            volatility := 'Immutable';
         }
         '''
 
@@ -5809,7 +5809,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             function std::array_agg(s: SET OF anytype) ->  array<anytype> {
-                volatility := 'IMMUTABLE';
+                volatility := 'Immutable';
                 annotation std::description := 'Return the array made from all
                     of the input set elements.';
                 using sql function 'array_agg';
@@ -5820,7 +5820,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             r"""
             function stdgraphql::short_name(name: std::str) -> std::str {
-                volatility := 'IMMUTABLE';
+                volatility := 'Immutable';
                 using (
                     SELECT (
                        ((name)[5:] IF (name LIKE 'std::%') ELSE
@@ -6829,7 +6829,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             # The following builtins are masked by the above:
 
             # function std::all(vals: SET OF std::bool) ->  std::bool {
-            #     volatility := 'IMMUTABLE';
+            #     volatility := 'Immutable';
             #     annotation std::description := 'Generalized boolean `AND`
                       applied to the set of *values*.';
             #     using sql function 'bool_and'

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -1496,7 +1496,7 @@ abstract property test::foo {
         """
         module test {
             function some_func(a: str) -> std::str {
-                volatility := 'IMMUTABLE';
+                volatility := 'Immutable';
                 using sql function 'some_other_func';
             };
         };


### PR DESCRIPTION
Volatility enum follows the standard recommendation of having
"TitleCase" formatting, but UPPERCASE was used in many definitions for
backwards compatibility. However, this exception will eventually be
dropped and the proper canonical 'Immutable', 'Stable', 'Volatile"
values will have to be used. So in order to promote correct usage, the
documentation, built-in library and tests are updated to use the
standard format for enums, so that users are exposed to the correct
example as opposed to the old backwards compatibility format.