### PR TITLE
Loosen the requirements on when we use object constraints

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -40,7 +40,6 @@ from edb.schema import types as s_types
 from edb.schema import objtypes as s_objtypes
 from edb.schema import pointers as s_pointers
 from edb.schema import constraints as s_constraints
-from edb.schema import expr as s_expr
 
 from edb.ir import ast as irast
 from edb.ir import utils as irutils
@@ -51,7 +50,6 @@ from . import volatility
 from . import context as inference_context
 
 from .. import context
-from .. import options
 
 
 AT_MOST_ONE = qltypes.Cardinality.AT_MOST_ONE
@@ -936,53 +934,15 @@ def extract_filters(
     return None
 
 
-def _get_object_constraint_pointers(
-    typ: s_objtypes.ObjectType,
-    constr: s_constraints.Constraint,
-    env: context.Environment,
-) -> Optional[Sequence[s_pointers.PointerLike]]:
-    subjectexpr = constr.get_subjectexpr(env.schema)
-    if not subjectexpr:
-        return None
-
-    # would it be worth it to cache this?
-    subjectexpr = s_expr.Expression.compiled(
-        subjectexpr,
-        schema=env.schema,
-        options=options.CompilerOptions(
-            anchors={'__subject__': typ},
-            path_prefix_anchor='__subject__',
-        ),
-    )
-    ptrrefs = irutils.extract_constraint_style_ptrs(
-        irutils.unwrap_set(subjectexpr.ir_statement.expr))
-    if ptrrefs is None:
-        return None
-
-    parts = []
-    for rptr in ptrrefs:
-        env.schema, ptrcls = typeutils.ptrcls_from_ptrref(
-            rptr.ptrref, schema=env.schema)
-        parts.append(ptrcls)
-
-    return parts
-
-
 def get_object_exclusive_constraints(
     typ: s_types.Type,
     ptr_set: Set[s_pointers.Pointer],
     env: context.Environment,
-) -> Sequence[Tuple[
-    s_constraints.Constraint, Sequence[s_pointers.PointerLike],
-]]:
-    """Collect any exclusive object constraints that could apply.
+) -> Sequence[s_constraints.Constraint]:
+    """Collect any exclusive object constraints that apply.
 
-    Object constraints that are just a single pointer reference or a
-    tuple of pointer references can be used for cardinality purposes.
-
-    Returns a sequence of (constraint, pointer sequence) pair,
-    where each pointer sequence lists all of the component pointers in
-    the exclusive object constraint.
+    An object constraint applies if all of the pointers referenced
+    in it are filtered on in the query.
     """
 
     if not isinstance(typ, s_objtypes.ObjectType):
@@ -998,16 +958,16 @@ def get_object_exclusive_constraints(
             constr.issubclass(schema, exclusive)
             and (subjectexpr := constr.get_subjectexpr(schema))
         ):
-            # as an optimization, make sure that all the referenced values
-            # appear in the query so we don't need to compile the subjectexpr
-            # if they don't
-            if subjectexpr.refs is not None and not all(
-                ref in ptr_set for ref in subjectexpr.refs.objects(schema)
-            ):
+            if subjectexpr.refs is None:
                 continue
-
-            if res := _get_object_constraint_pointers(typ, constr, env):
-                cnstrs.append((constr, res))
+            pointer_refs = {
+                x for x in subjectexpr.refs.objects(schema)
+                if isinstance(x, s_pointers.Pointer)
+            }
+            # If all of the referenced pointers are filtered on,
+            # we match.
+            if pointer_refs.issubset(ptr_set):
+                cnstrs.append(constr)
 
     return cnstrs
 
@@ -1040,9 +1000,8 @@ def _analyse_filter_clause(
         result_stype = ctx.env.set_types[result_set]
         obj_exclusives = get_object_exclusive_constraints(
             result_stype, ptr_set, ctx.env)
-        for _, exc_ptrs in obj_exclusives:
-            if not (set(exc_ptrs) - ptr_set):
-                return AT_MOST_ONE
+        if obj_exclusives:
+            return AT_MOST_ONE
 
     return result_card
 

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -272,32 +272,6 @@ def collapse_type_intersection(
     return source, result
 
 
-def extract_constraint_style_ptrs(
-        ir: irast.Set) -> Optional[List[irast.Pointer]]:
-    """Extract ptrrefs from a simple "constraint-style" expression.
-
-    This means that the expression can be a simple pointer reference
-    or a tuple of "constraint-style" expressions.
-    """
-    parts = []
-
-    def _extract(ir: irast.Set) -> bool:
-        if ir.rptr is not None:
-            parts.append(ir.rptr)
-            return True
-        elif isinstance(ir.expr, irast.Tuple):
-            return all(
-                _extract(elem.val) for elem in ir.expr.elements
-            )
-        else:
-            return False
-
-    if _extract(ir):
-        return parts
-    else:
-        return None
-
-
 def get_nearest_dml_stmt(ir_set: irast.Set) -> Optional[irast.MutatingStmt]:
     """For a given *ir_set* representing a Path, return the nearest path
        step that is a DML expression.

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -587,7 +587,7 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         WITH MODULE test
         SELECT Person FILTER .p = 7 AND .q = 3
 % OK %
-        MANY
+        AT_MOST_ONE
         """
 
     def test_edgeql_ir_card_inference_58(self):
@@ -621,4 +621,12 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         SELECT Person FILTER .first = "Phil" OR .last = "Emarg"
 % OK %
         MANY
+        """
+
+    def test_edgeql_ir_card_inference_62(self):
+        """
+        WITH MODULE test
+        SELECT Person FILTER .p = 7 AND .q = 3 AND .last = "Whatever"
+% OK %
+        AT_MOST_ONE
         """


### PR DESCRIPTION
As discussed in #2410, we don't need to actually concern ourselves
with the contents of the constraint, just what fields it depends on.