### PR TITLE
Support UNLESS CONFLICT ON with multiple pointers

### DIFF
--- a/docs/edgeql/statements/insert.rst
+++ b/docs/edgeql/statements/insert.rst
@@ -13,7 +13,7 @@ INSERT
     [ WITH <with-spec> [ ,  ... ] ]
     INSERT <expression> [ <insert-shape> ]
     [ UNLESS CONFLICT
-        [ ON <property> [ ELSE <alternative> ] ]
+        [ ON <property-expr> [ ELSE <alternative> ] ]
     ] ;
 
 
@@ -49,16 +49,21 @@ See :ref:`Usage of FOR statement <ref_eql_forstatement>` for more details.
         INSERT <expression>
         [ "{" <link> := <insert-value-expr> [, ...]  "}" ]
 
-:eql:synopsis:`UNLESS CONFLICT [ ON <property> ]`
+:eql:synopsis:`UNLESS CONFLICT [ ON <property-expr> ]`
     :index: unless conflict
 
     Handler of conflicts.
 
     This clause allows to handle specific conflicts arising during
     execution of ``INSERT`` without producing an error.  If the
-    conflict arises due to exclusive constraints on the specified
-    *property*, then instead of failing with an error the ``INSERT``
-    statement produces an empty set (or an alternative result).
+    conflict arises due to exclusive constraints on the properties
+    specified by *property-expr*, then instead of failing with an
+    error the ``INSERT`` statement produces an empty set (or an
+    alternative result).
+
+    The specified *property-expr* may be either a reference to a
+    property (or link) or a tuple of references to properties (or
+    links).
 
     A caveat, however, is that ``UNLESS CONFLICT`` will not prevent
     conflicts caused between multiple DML operations in the same
@@ -72,6 +77,11 @@ See :ref:`Usage of FOR statement <ref_eql_forstatement>` for more details.
 
         INSERT User { email := 'user@example.org' }
         UNLESS CONFLICT ON .email
+
+    .. code-block:: edgeql
+
+        INSERT User { first := 'Jason', last := 'Momoa' }
+        UNLESS CONFLICT ON (.first, .last)
 
 :eql:synopsis:`ELSE <alternative>`
     Alternative result in case of conflict.

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -73,6 +73,8 @@ type Person2 {
 type Person2a extending Person2 {
     required single property last -> std::str;
     constraint exclusive on ((__subject__.first, __subject__.last));
+    single link bff -> Person;
+    constraint exclusive on ((.first, .bff));
 }
 
 type Person2b extending Person2 {


### PR DESCRIPTION
This uses the infrastructure from #2410/#2414 to do the constraint
resolution, so it is mostly just a matter of putting some loops
in compile_insert_unless_conflict_on.

Fixes #1939.