### PR TITLE
Prohibit mixing computable and regular links/props.

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -535,23 +535,10 @@ def compile_operator(
         else:
             larg, _, rarg = (a.expr for a in final_args)
 
-        left_type = schemactx.get_material_type(
-            setgen.get_set_type(larg, ctx=ctx),
-            ctx=ctx,
-        )
-        right_type = schemactx.get_material_type(
-            setgen.get_set_type(rarg, ctx=ctx),
-            ctx=ctx,
-        )
-
-        if left_type.issubclass(env.schema, right_type):
-            rtype = right_type
-        elif right_type.issubclass(env.schema, left_type):
-            rtype = left_type
-        else:
-            assert isinstance(left_type, s_types.InheritingType)
-            assert isinstance(right_type, s_types.InheritingType)
-            rtype = schemactx.get_union_type([left_type, right_type], ctx=ctx)
+        left_type = setgen.get_set_type(larg, ctx=ctx)
+        right_type = setgen.get_set_type(rarg, ctx=ctx)
+        rtype = schemactx.get_union_type(
+            [left_type, right_type], preserve_derived=True, ctx=ctx)
 
     from_op = oper.get_from_operator(env.schema)
     sql_operator = None

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -346,11 +346,13 @@ def get_union_type(
     types: Iterable[s_types.Type],
     *,
     opaque: bool = False,
+    preserve_derived: bool = False,
     ctx: context.ContextLevel,
 ) -> s_types.Type:
 
     ctx.env.schema, union, created = s_utils.ensure_union_type(
-        ctx.env.schema, types, opaque=opaque)
+        ctx.env.schema, types,
+        opaque=opaque, preserve_derived=preserve_derived)
 
     if created:
         ctx.env.created_schema_objects.add(union)

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -2876,7 +2876,7 @@ class InheritingObject(SubclassableObject):
     def get_default_base_name(self) -> Optional[sn.Name]:
         return None
 
-    # Redefinining bases and ancestors accessors to make them generic
+    # Redefining bases and ancestors accessors to make them generic
     def get_bases(
         self: InheritingObjectT,
         schema: s_schema.Schema,

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -8790,21 +8790,27 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         )
 
     async def test_edgeql_migration_union_01(self):
-        await self.migrate('''
-            type Category {
-                required property title -> str;
-                required property deleted :=
-                    EXISTS(.<element[IS DeletionRecord]);
-            };
-            type Article {
-                required property title -> str;
-                required property deleted :=
-                    EXISTS(.<element[IS DeletionRecord]);
-            };
-            type DeletionRecord {
-                link element -> Article | Category;
-            }
-        ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "it is illegal to create a type union that causes a "
+            "computable property 'deleted' to mix with other versions of the "
+            "same property 'deleted'"
+        ):
+            await self.migrate('''
+                type Category {
+                    required property title -> str;
+                    required property deleted :=
+                        EXISTS(.<element[IS DeletionRecord]);
+                };
+                type Article {
+                    required property title -> str;
+                    required property deleted :=
+                        EXISTS(.<element[IS DeletionRecord]);
+                };
+                type DeletionRecord {
+                    link element -> Article | Category;
+                }
+            ''')
 
     async def test_edgeql_migration_misplaced_commands(self):
         async with self.assertRaisesRegexTx(


### PR DESCRIPTION
Overloading computables presents some complication, so for the moment we
prohibit overloading computables or overloading a regular link/prop with
a computable.

Fixes #2099