### PR TITLE
docs: fix cast in duration example & remove dupe str examples

### DIFF
--- a/docs/edgeql/expressions/overview.rst
+++ b/docs/edgeql/expressions/overview.rst
@@ -45,7 +45,7 @@ a cast string literal:
 
     SELECT <int16>'1' = <int16>1;
     SELECT <float32>'1.23';
-    SELECT <duration>'1 day';
+    SELECT <duration>'3 hours';
     SELECT <decimal>'1.23' = 1.23n;
 
 

--- a/docs/edgeql/funcops/string.rst
+++ b/docs/edgeql/funcops/string.rst
@@ -94,10 +94,6 @@ String
 
         db> SELECT 'some text'[1];
         {'o'}
-        db> SELECT 'some text'[1:3];
-        {'om'}
-        db> SELECT 'some text'[-4:];
-        {'text'}
 
 
 ----------


### PR DESCRIPTION
The existing cast errors on version 1.0b1:

```
edgedb> SELECT <duration>'1 day';
ERROR: InvalidValueError: invalid input syntax for type std::duration: '1 day'
  Hint: Units bigger than days cannot be used for std::duration.
```

vs:

```
edgedb> SELECT <duration>'3 hours';
{<duration>'3:00:00'}
```