### PR TITLE
Add TransactionConflictError

### DIFF
--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -111,8 +111,9 @@
 0x_05_02_00_03   MissingRequiredError
 
 0x_05_03_00_00   TransactionError
-0x_05_03_00_01   TransactionSerializationError  #SHOULD_RETRY
-0x_05_03_00_02   TransactionDeadlockError  #SHOULD_RETRY
+0x_05_03_01_00   TransactionConflictError  #SHOULD_RETRY
+0x_05_03_01_01   TransactionSerializationError
+0x_05_03_01_02   TransactionDeadlockError
 
 
 ####


### PR DESCRIPTION
TransactionConflictError is needed to make checking for retryable transaction errors simple.

See also the discussion following https://github.com/edgedb/edgedb-go/pull/123#pullrequestreview-625664587