### PR TITLE
Propagate backend pool connect errors.

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1482,6 +1482,8 @@ class _EdgeDBServer:
             '--echo-runtime-info',
             '--compiler-pool-size', str(self.compiler_pool_size),
         ]
+        if self.debug:
+            cmd.extend(['--log-level', 'd'])
         if self.max_allowed_connections is not None:
             cmd.extend([
                 '--max-backend-connections', str(self.max_allowed_connections),
@@ -1514,7 +1516,6 @@ class _EdgeDBServer:
         if self.auto_shutdown:
             cmd += ['--auto-shutdown']
 
-        # Note: for debug comment "stderr=subprocess.PIPE".
         self.proc: asyncio.Process = await asyncio.create_subprocess_exec(
             *cmd,
             stderr=subprocess.PIPE if not self.debug else None,


### PR DESCRIPTION
* Propagate the backend connect errors after 3 retries
* Detect and skip concurrently-dropped databases during EdgeDB startup introspection.
* This fixes the unstable test `test_server_proto_ddlprop_01` (together with another 2 PRs)

- [x] Add tests