### PR TITLE
add SHOULE_RETRY tag to transaction errors

### DIFF
--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -112,8 +112,8 @@
 
 0x_05_03_00_00   TransactionError
 0x_05_03_01_00   TransactionConflictError  #SHOULD_RETRY
-0x_05_03_01_01   TransactionSerializationError
-0x_05_03_01_02   TransactionDeadlockError
+0x_05_03_01_01   TransactionSerializationError  #SHOULD_RETRY
+0x_05_03_01_02   TransactionDeadlockError  #SHOULD_RETRY
 
 
 ####


### PR DESCRIPTION
These tags were erroneously left out of https://github.com/edgedb/edgedb/pull/2431.