### PR TITLE
Fix usage of enums as input variables in GraphQL.

### DIFF
--- a/tests/test_http_graphql_mutation.py
+++ b/tests/test_http_graphql_mutation.py
@@ -476,6 +476,63 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
             "other__Foo": []
         })
 
+    def test_graphql_mutation_insert_enum_02(self):
+        # This tests enum values in insertion, using variables.
+        data = {
+            'select': 'New EnumTest02',
+            'color': 'RED',
+        }
+
+        validation_query = r"""
+            query {
+                other__Foo(filter: {select: {eq: "New EnumTest02"}}) {
+                    select
+                    color
+                }
+            }
+        """
+
+        self.assert_graphql_query_result(r"""
+            mutation insert_other__Foo(
+                $select: String!,
+                $color: other__ColorEnum!
+            ) {
+                insert_other__Foo(
+                    data: [{
+                        select: $select,
+                        color: $color,
+                    }]
+                ) {
+                    select
+                    color
+                }
+            }
+        """, {
+            "insert_other__Foo": [data]
+        }, variables=data)
+
+        self.assert_graphql_query_result(validation_query, {
+            "other__Foo": [data]
+        })
+
+        self.assert_graphql_query_result(r"""
+            mutation delete_other__Foo {
+                delete_other__Foo(
+                    filter: {select: {eq: "New EnumTest02"}}
+                ) {
+                    select
+                    color
+                }
+            }
+        """, {
+            "delete_other__Foo": [data]
+        })
+
+        # validate that the deletion worked
+        self.assert_graphql_query_result(validation_query, {
+            "other__Foo": []
+        })
+
     def test_graphql_mutation_insert_nested_01(self):
         # Test nested insert.
         data = {
@@ -2127,6 +2184,66 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
         """, {
             "delete_other__Foo": [{
                 'select': 'Update EnumTest01',
+                'color': 'RED',
+            }]
+        })
+
+    def test_graphql_mutation_update_enum_02(self):
+        # This tests enum values in updates using variables.
+
+        self.assert_graphql_query_result(r"""
+            mutation insert_other__Foo {
+                insert_other__Foo(
+                    data: [{
+                        select: "Update EnumTest02",
+                        color: BLUE
+                    }]
+                ) {
+                    select
+                    color
+                }
+            }
+        """, {
+            "insert_other__Foo": [{
+                'select': 'Update EnumTest02',
+                'color': 'BLUE',
+            }]
+        })
+
+        self.assert_graphql_query_result(r"""
+            mutation update_other__Foo (
+                $color: other__ColorEnum!
+            ) {
+                update_other__Foo(
+                    filter: {select: {eq: "Update EnumTest02"}}
+                    data: {
+                        color: {set: $color}
+                    }
+                ) {
+                    select
+                    color
+                }
+            }
+        """, {
+            "update_other__Foo": [{
+                'select': 'Update EnumTest02',
+                'color': 'RED',
+            }]
+        }, variables={"color": "RED"})
+
+        # clean up
+        self.assert_graphql_query_result(r"""
+            mutation delete_other__Foo {
+                delete_other__Foo(
+                    filter: {select: {eq: "Update EnumTest02"}}
+                ) {
+                    select
+                    color
+                }
+            }
+        """, {
+            "delete_other__Foo": [{
+                'select': 'Update EnumTest02',
                 'color': 'RED',
             }]
         })

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -1421,6 +1421,21 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             }]
         })
 
+    def test_graphql_functional_enums_04(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r'String cannot represent a non string value: admin',
+                _line=4, _col=51):
+            self.graphql_query(r"""
+                query {
+                    # enum supplied instead of a string
+                    UserGroup(filter: {name: {eq: admin}}) {
+                        id,
+                        name,
+                    }
+                }
+            """)
+
     def test_graphql_functional_fragment_01(self):
         self.assert_graphql_query_result(r"""
             fragment groupFrag on UserGroup {
@@ -3015,20 +3030,44 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                 }
             """, variables={"f": {"name": {"eq": "Alice"}}})
 
-    def test_graphql_functional_enum_01(self):
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r'String cannot represent a non string value: admin',
-                _line=4, _col=51):
-            self.graphql_query(r"""
-                query {
-                    # enum supplied instead of a string
-                    UserGroup(filter: {name: {eq: admin}}) {
-                        id,
-                        name,
+    def test_graphql_functional_variables_44(self):
+        self.assert_graphql_query_result(
+            r"""
+                query foo($color: other__ColorEnum!) {
+                    other__Foo(
+                        filter: {color: {eq: $color}},
+                    ) {
+                        select
+                        color
                     }
                 }
-            """)
+            """, {
+                "other__Foo": [{
+                    "select": "a",
+                    "color": "RED",
+                }]
+            },
+            variables={"color": "RED"},
+        )
+
+    def test_graphql_functional_variables_45(self):
+        self.assert_graphql_query_result(
+            r"""
+                query foo($color: other__ColorEnum! = GREEN) {
+                    other__Foo(
+                        filter: {color: {eq: $color}},
+                    ) {
+                        select
+                        color
+                    }
+                }
+            """, {
+                "other__Foo": [{
+                    "select": "b",
+                    "color": "GREEN",
+                }]
+            },
+        )
 
     def test_graphql_functional_inheritance_01(self):
         # ISSUE: #709


### PR DESCRIPTION
Enums are sufficiently scalar-like to be valid input variables and not
to cause any issues that objects and arrays currently cause.

Fixes #2415