### PR TITLE
Add pool simulation automation

### DIFF
--- a/.github/workflows/test-pool.yml
+++ b/.github/workflows/test-pool.yml
@@ -1,0 +1,70 @@
+name: Pool Simulation Test
+
+on:
+  push:
+    branches:
+      - master
+      - pool-test
+    paths:
+      - 'edb/server/connpool/**'
+      - 'tests/test_server_pool.py'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'edb/server/connpool/**'
+      - 'tests/test_server_pool.py'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    concurrency: pool-test
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: false
+
+    - uses: actions/checkout@v2
+      if: startsWith(github.ref, 'refs/heads')
+      with:
+        repository: edgedb/edgedb-pool-simulation
+        path: pool-simulation
+        token: ${{ secrets.GITHUB_CI_BOT_TOKEN }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Generate requirements.txt
+      run: |
+        echo 'uvloop==0.15.2' > requirements.txt
+        mkdir -p pool-simulation/reports
+
+    - name: Handle virtualenv
+      uses: syphar/restore-virtualenv@v1.1
+      id: venv-cache
+
+    - name: Install Python dependencies
+      if: steps.venv-cache.outputs.cache-hit != 'true'
+      run: |
+        pip install -r requirements.txt
+
+    - name: Run the pool simulation test
+      env:
+        PYTHONPATH: .
+        SIMULATION_CI: yes
+        TIME_SCALE: 10
+      run: |
+        python tests/test_server_pool.py
+
+    - uses: EndBug/add-and-commit@v7.0.0
+      if: ${{ always() }}
+      continue-on-error: true
+      with:
+        branch: main
+        cwd: pool-simulation
+        author_name: github-actions
+        author_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/tests/test_server_pool.py
+++ b/tests/test_server_pool.py
@@ -270,6 +270,14 @@ class SimulatedCase(unittest.TestCase, metaclass=SimulatedCaseMeta):
         self.assertEqual(pool.failed_disconnects, 0)
         self.assertEqual(pool.failed_connects, 0)
 
+        try:
+            for db in sim.latencies:
+                int(db[1:])
+        except ValueError:
+            key_func = lambda x: x
+        else:
+            key_func = lambda x: int(x[0][1:])
+
         if collect_stats:
             pn = f'{type(pool).__module__}.{type(pool).__qualname__}'
             js_data = {
@@ -277,7 +285,7 @@ class SimulatedCase(unittest.TestCase, metaclass=SimulatedCaseMeta):
                 'total_lats': self.calc_total_percentiles(sim.latencies),
                 'lats': {
                     db: self.calc_percentiles(lats)
-                    for db, lats in sim.latencies.items()
+                    for db, lats in sorted(sim.latencies.items(), key=key_func)
                 },
                 'pool_name': pn,
                 'stats': sim.stats,

--- a/tests/test_server_pool.py
+++ b/tests/test_server_pool.py
@@ -53,6 +53,9 @@ import unittest.mock
 from edb.common import taskgroup
 from edb.server import connpool
 
+# TIME_SCALE is used to run the simulation for longer time, the default is 1x.
+TIME_SCALE = int(os.environ.get("TIME_SCALE", '1'))
+
 
 @dataclasses.dataclass
 class DBSpec:
@@ -75,6 +78,13 @@ class Spec:
     desc: str = ''
     disconn_cost_base: float = 0.006
     disconn_cost_var: float = 0.0015
+
+    def __post_init__(self):
+        self.timeout *= TIME_SCALE
+        self.duration *= TIME_SCALE
+        for db in self.dbs:
+            db.start_at *= TIME_SCALE
+            db.end_at *= TIME_SCALE
 
 
 @dataclasses.dataclass

--- a/tests/test_server_pool.py
+++ b/tests/test_server_pool.py
@@ -222,7 +222,7 @@ class LatencyRatio(ScoreMethod):
 @dataclasses.dataclass
 class Spec:
     timeout: float
-    duration: int
+    duration: float
     capacity: int
     conn_cost_base: float
     conn_cost_var: float
@@ -412,10 +412,7 @@ class SimulatedCase(unittest.TestCase, metaclass=SimulatedCaseMeta):
                         continue
 
                     qpt = db.qps * TICK_EVERY
-                    if qpt >= 1:
-                        qpt = round(qpt)
-                    else:
-                        qpt = int(random.random() <= qpt)
+                    qpt = int(random.random() <= qpt - int(qpt)) + int(qpt)
 
                     for _ in range(qpt):
                         dur = max(


### PR DESCRIPTION
This PR adds QoS score to the simulation tests. Running for 10x time makes the score relatively stable and sensitive to major changes to the pool. Therefore, this simulation is made a workflow, configured to run on every commit or PR that touches the pool or the test. The generated reports are published here: https://edgedb.github.io/edgedb-pool-simulation/. The workflow will report failure if the total score is under 80 out of 100. For now it's stablized at about 93.

~In the following steps, I'll do the following:~

- [x] 1. Adjust the simulation pressure based on detected host performance. (done in #2480)
- [x] 2. Run the simulation for longer time in this workflow (like simply time x 10) for a more reliable result.
- [x] 3. Yield a QoS score (relative to host performance) for each simulation, and warn about a sudden score drop.
- [x] 4. (final goal) Add more simulations, and optimize the pool for non-starving situations like connection garbage collection, reusability, rebalancing, etc. (done in #2480)