### PR TITLE
Add `runstate_dir` option to `tb.start_edgedb_server()`

### DIFF
--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -168,7 +168,7 @@ class TestServerOps(tb.TestCase):
         port = edgedb_cluster.find_available_port()
         actual = random.randint(50, 100)
 
-        async def test(host):
+        async def test(pgdata_path):
             bootstrap_command = (
                 r'CONFIGURE SYSTEM INSERT Auth '
                 r'{ priority := 0, method := (INSERT Trust) }'
@@ -178,8 +178,8 @@ class TestServerOps(tb.TestCase):
                 bootstrap_command=bootstrap_command,
                 max_allowed_connections=None,
                 postgres_dsn=f'postgres:///?user=postgres&port={port}&'
-                             f'host={host}',
-                runstate_dir=None if devmode.is_in_dev_mode() else host,
+                             f'host={pgdata_path}',
+                runstate_dir=None if devmode.is_in_dev_mode() else pgdata_path,
             ) as sd:
                 con = await edgedb.async_connect(
                     user='edgedb', host=sd.host, port=sd.port)

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -30,6 +30,7 @@ import tempfile
 import asyncpg
 import edgedb
 
+from edb.common import devmode
 from edb.server import pgcluster, pgconnparams, cluster as edgedb_cluster
 from edb.testbase import server as tb
 
@@ -178,6 +179,7 @@ class TestServerOps(tb.TestCase):
                 max_allowed_connections=None,
                 postgres_dsn=f'postgres:///?user=postgres&port={port}&'
                              f'host={host}',
+                runstate_dir=None if devmode.is_in_dev_mode() else host,
             ) as sd:
                 con = await edgedb.async_connect(
                     user='edgedb', host=sd.host, port=sd.port)


### PR DESCRIPTION
When devmode is off, starting EdgeDB server with --postgres-dsn requires a valid runstate_dir (default `[/var]/run/edgedb` needs permission, and EdgeDB won't remove the directory). That caused the failure of the test `test_server_ops_detect_postgres_pool_size`, and breaking our nightly builds.

Refs #2069