### PR TITLE
Add a way to check server health via an HTTP request

### DIFF
--- a/edb/server/protocol/system_api.py
+++ b/edb/server/protocol/system_api.py
@@ -1,0 +1,153 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import http
+import json
+
+import immutables as immu
+
+from edb import errors
+from edb import edgeql
+
+from edb.common import debug
+from edb.common import markup
+
+from edb.schema import schema as s_schema
+
+from edb.server import compiler
+from edb.server.compiler import IoFormat
+from edb.server.compiler import enums
+from edb.server import defines as edbdef
+
+
+ALLOWED_CAPABILITIES = (
+    enums.Capability.MODIFICATIONS
+)
+
+
+async def handle_request(
+    request,
+    response,
+    path_parts,
+    server,
+):
+    try:
+        if path_parts == ['status', 'ready'] and request.method == b'GET':
+            await handle_status_request(request, response, server)
+        else:
+            response.body = b'Unknown path'
+            response.status = http.HTTPStatus.NOT_FOUND
+            response.close_connection = True
+
+        return
+    except Exception as ex:
+        if debug.flags.server:
+            markup.dump(ex)
+
+        ex_type = type(ex)
+        if not issubclass(ex_type, errors.EdgeDBError):
+            # XXX Fix this when LSP "location" objects are implemented
+            ex_type = errors.InternalServerError
+
+        err_dct = {
+            'message': str(ex),
+            'type': str(ex_type.__name__),
+            'code': ex_type.get_code(),
+        }
+
+        response.body = json.dumps({'error': err_dct}).encode()
+        response.status = http.HTTPStatus.INTERNAL_SERVER_ERROR
+        response.close_connection = True
+        return
+
+
+async def handle_status_request(
+    request,
+    response,
+    server,
+):
+    result = await execute(server, "SELECT 'OK'", {})
+    response.status = http.HTTPStatus.OK
+    response.content_type = b'application/json'
+    response.body = result
+    return
+
+
+async def compile(server, query):
+    compiler_pool = server.get_compiler_pool()
+
+    units, _ = await compiler_pool.compile(
+        edbdef.EDGEDB_SYSTEM_DB,
+        s_schema.FlatSchema(),  # user schema
+        server.get_global_schema(),
+        immu.Map(),             # reflection cache
+        immu.Map(),             # database config
+        server.get_compilation_system_config(),
+        edgeql.Source.from_string(query),
+        None,           # modaliases
+        None,           # session config
+        IoFormat.JSON_ELEMENTS,  # json mode
+        False,          # expected cardinality is MANY
+        0,              # no implicit limit
+        False,          # no inlining of type IDs
+        False,          # no inlining of type names
+        compiler.CompileStatementMode.SINGLE,
+        True,           # json parameters
+    )
+    return units[0]
+
+
+async def execute(server, query, variables):
+    query_unit = await compile(server, query)
+    if query_unit.capabilities & ~ALLOWED_CAPABILITIES:
+        raise query_unit.capabilities.make_error(
+            ALLOWED_CAPABILITIES,
+            errors.UnsupportedCapabilityError,
+        )
+
+    args = []
+    if query_unit.in_type_args:
+        for param in query_unit.in_type_args:
+            if variables is None or param.name not in variables:
+                raise errors.QueryError(
+                    f'no value for the ${param.name} query parameter')
+            else:
+                value = variables[param.name]
+                if value is None and param.required:
+                    raise errors.QueryError(
+                        f'parameter ${param.name} is required')
+                args.append(value)
+
+    pgcon = await server.acquire_pgcon(edbdef.EDGEDB_SYSTEM_DB)
+    try:
+        data = await pgcon.parse_execute_json(
+            query_unit.sql[0],
+            query_unit.sql_hash,
+            1,
+            True,
+            args,
+        )
+    finally:
+        server.release_pgcon(edbdef.EDGEDB_SYSTEM_DB, pgcon)
+
+    if data is None:
+        raise errors.InternalServerError(
+            f'no data received for a JSON query {query_unit.sql[0]!r}')
+
+    return data

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -25,7 +25,7 @@ import urllib
 from edb.testbase import http as tb
 
 
-class TestHttpNotebook(tb.BaseHttpTest, tb.server.QueryTestCase):
+class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
 
     # EdgeQL/HTTP queries cannot run in a transaction
     TRANSACTION_ISOLATION = False

--- a/tests/test_http_system_api.py
+++ b/tests/test_http_system_api.py
@@ -1,0 +1,36 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from edb.testbase import http as tb
+from edb.testbase import server as tb_server
+
+
+class TestHttpSystemAPI(tb.BaseHttpTest, tb_server.ConnectedTestCase):
+
+    @classmethod
+    def get_api_path(cls) -> str:
+        return '/server'
+
+    def test_http_sys_api_status(self):
+        with self.http_con() as con:
+            data, _, status = self.http_con_request(
+                con, {}, path='status/ready')
+
+            self.assertEqual(status, 200)
+            self.assertIn(b'OK', data)


### PR DESCRIPTION
This adds a new `/server/status/ready` HTTP endpoint, which responds
with "OK" if things are OK.  This is intended to be used as a simple
check target for service control plane.