### PR TITLE
Fix C.UTF-8 detection on remote Postgres

### DIFF
--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -932,7 +932,8 @@ def get_remote_pg_cluster(dsn: str) -> RemoteCluster:
             caps |= BackendCapabilities.SUPERUSER_ACCESS
 
         coll = await conn.fetchval('''
-            SELECT collname FROM pg_collation WHERE lower(collname) = 'c.utf8';
+            SELECT collname FROM pg_collation
+            WHERE lower(replace(collname, '-', '')) = 'c.utf8' LIMIT 1;
         ''')
 
         if coll is not None:


### PR DESCRIPTION
On Debian/Ubuntu, this locale is written `C.UTF-8` with the dash, while on other platforms like CentOS or hosted Postgres like DigitalOcean, it's `C.utf8` without the dash. This caused our nightly builds to fail when testing with a locally-started remote Postgres on Debian/Ubuntu.

Refs: https://github.com/edgedb/edgedb-pkg/commit/e89832b09ef7cc747e8becc79301efa6cc665666