### PR TITLE
Push shapes further down in the IR tree when possible

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -100,7 +100,7 @@ class OffsetLimitMixin(Base):
 
 class OrderByMixin(Base):
     __abstract_node__ = True
-    orderby: typing.Optional[typing.List[SortExpr]]
+    orderby: typing.List[SortExpr]
 
 
 class FilterMixin(Base):

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -565,7 +565,8 @@ def _infer_set(
     # since sometimes the shape will refer to the enclosing set.
     ctx.inferred_cardinality[ir, scope_tree] = result
 
-    _infer_shape(ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx)
+    _infer_shape(
+        ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx)
 
     return result
 

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -565,8 +565,7 @@ def _infer_set(
     # since sometimes the shape will refer to the enclosing set.
     ctx.inferred_cardinality[ir, scope_tree] = result
 
-    _infer_shape(
-        ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx)
+    _infer_shape(ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx)
 
     return result
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -156,7 +156,7 @@ def compile_ForQuery(
                 context=ctx.env.type_origins.get(anytype),
             )
 
-        # If this statement is exposed, and there is a shape-induced
+        # If this statement is exposed, and there is a DML shape-induced
         # iterator context, then register the iterator as hoisted.
         # This ensures that the pgsql compiler allows the iterator value
         # to drift upward. Note that sctx.iterator_ctx.stmt may equal stmt

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -161,9 +161,9 @@ def compile_ForQuery(
         # This ensures that the pgsql compiler allows the iterator value
         # to drift upward. Note that sctx.iterator_ctx.stmt may equal stmt
         # and also that I think this whole mechanism is subtly wrong.
-        if (sctx.expr_exposed and sctx.iterator_ctx is not None
-                and sctx.iterator_ctx.stmt is not None):
-            sctx.iterator_ctx.stmt.hoisted_iterators.append(iterator_stmt)
+        # if (sctx.expr_exposed and sctx.iterator_ctx is not None
+        #         and sctx.iterator_ctx.stmt is not None):
+        #     sctx.iterator_ctx.stmt.hoisted_iterators.append(iterator_stmt)
 
         view_scope_info = sctx.path_scope_map[iterator_view]
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -156,15 +156,6 @@ def compile_ForQuery(
                 context=ctx.env.type_origins.get(anytype),
             )
 
-        # If this statement is exposed, and there is a DML shape-induced
-        # iterator context, then register the iterator as hoisted.
-        # This ensures that the pgsql compiler allows the iterator value
-        # to drift upward. Note that sctx.iterator_ctx.stmt may equal stmt
-        # and also that I think this whole mechanism is subtly wrong.
-        # if (sctx.expr_exposed and sctx.iterator_ctx is not None
-        #         and sctx.iterator_ctx.stmt is not None):
-        #     sctx.iterator_ctx.stmt.hoisted_iterators.append(iterator_stmt)
-
         view_scope_info = sctx.path_scope_map[iterator_view]
 
         pathctx.register_set_in_scope(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -654,9 +654,10 @@ def _normalize_view_ptr_expr(
                 shape_expr_ctx.empty_result_type_hint = \
                     ptrcls.get_target(ctx.env.schema)
 
-            shape_expr_ctx.stmt_metadata[qlexpr] = context.StatementMetadata(
-                iterator_target=True,
-            )
+            if is_mutation:
+                shape_expr_ctx.stmt_metadata[qlexpr] = (
+                    context.StatementMetadata(iterator_target=True)
+                )
             irexpr = dispatch.compile(qlexpr, ctx=shape_expr_ctx)
 
             if (
@@ -1234,6 +1235,8 @@ def _compile_view_shapes_in_set(
     # (and thus this shape would be selecting link properties),
     # because getting process_link_values to extract link properties
     # from a nested shape was nontrivial.
+    # (If we could get rid of that lifting, I think we could also get rid
+    # of hoisted_iterators!)
     parent_is_mutation = parent_view_type in {
         s_types.ExprType.Update, s_types.ExprType.Insert}
     if (isinstance(ir_set.expr, irast.SelectStmt)

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1140,16 +1140,7 @@ def _get_shape_configuration(
 
     for source in sources:
         for ptr, shape_op in ctx.env.view_shapes[source]:
-            if ptr.is_link_property(ctx.env.schema):
-                assert rptr is not None
-                if ir_set.path_id != rptr.target.path_id:
-                    path_tip = rptr.target
-                else:
-                    path_tip = ir_set
-            else:
-                path_tip = ir_set
-
-            shape_ptrs.append((path_tip, ptr, shape_op))
+            shape_ptrs.append((ir_set, ptr, shape_op))
 
     if is_objtype:
         assert isinstance(stype, s_objtypes.ObjectType)
@@ -1229,6 +1220,41 @@ def _compile_view_shapes_in_set(
     shape_ptrs = _get_shape_configuration(
         ir_set, rptr=rptr, parent_view_type=parent_view_type, ctx=ctx)
 
+    # For queries where there is not a parent view that is a mutation,
+    # we push down the shape to better correspond with where it
+    # appears in the query (rather than lifting it up to the first
+    # place the view_type appears---this is a little hacky, because
+    # letting it be lifted up is the natural thing with our view type-driven
+    # shape compilation).
+    #
+    # This is to avoid losing subquery distinctions (in cases
+    # like test_edgeql_scope_tuple_15), and generally seems more natural.
+    #
+    # We unfortunately still do lifting for when the parent is DML
+    # (and thus this shape would be selecting link properties),
+    # because getting process_link_values to extract link properties
+    # from a nested shape was nontrivial.
+    parent_is_mutation = parent_view_type in {
+        s_types.ExprType.Update, s_types.ExprType.Insert}
+    if (isinstance(ir_set.expr, irast.SelectStmt)
+            and not parent_is_mutation
+            and (setgen.get_set_type(ir_set, ctx=ctx) ==
+                 setgen.get_set_type(ir_set.expr.result, ctx=ctx))):
+
+        set_scope = pathctx.get_set_scope(ir_set, ctx=ctx)
+
+        if shape_ptrs:
+            pathctx.register_set_in_scope(ir_set, ctx=ctx)
+        with ctx.new() as scopectx:
+            if set_scope is not None:
+                scopectx.path_scope = set_scope
+            compile_view_shapes(
+                ir_set.expr.result,
+                rptr=rptr or ir_set.rptr,
+                parent_view_type=parent_view_type,
+                ctx=scopectx)
+        return
+
     if shape_ptrs:
         pathctx.register_set_in_scope(ir_set, ctx=ctx)
         stype = setgen.get_set_type(ir_set, ctx=ctx)
@@ -1290,7 +1316,8 @@ def _compile_view_shapes_in_select(
         rptr: Optional[irast.Pointer]=None,
         parent_view_type: Optional[s_types.ExprType]=None,
         ctx: context.ContextLevel) -> None:
-    compile_view_shapes(stmt.result, ctx=ctx)
+    compile_view_shapes(
+        stmt.result, rptr=rptr, parent_view_type=parent_view_type, ctx=ctx)
 
 
 @compile_view_shapes.register(irast.FunctionCall)

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -732,7 +732,6 @@ class Stmt(Expr):
     result: Set
     parent_stmt: typing.Optional[Stmt]
     iterator_stmt: typing.Optional[Set]
-    hoisted_iterators: typing.List[Set]
     bindings: typing.List[Set]
 
 

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -292,11 +292,7 @@ def get_nearest_dml_stmt(ir_set: irast.Set) -> Optional[irast.MutatingStmt]:
 def get_iterator_sets(stmt: irast.Stmt) -> Sequence[irast.Set]:
     iterators = []
     if stmt.iterator_stmt is not None:
-        if stmt.iterator_stmt not in stmt.hoisted_iterators:
-            iterators.append(stmt.iterator_stmt)
-    if stmt.hoisted_iterators:
-        iterators.extend(stmt.hoisted_iterators)
-
+        iterators.append(stmt.iterator_stmt)
     return iterators
 
 

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -289,13 +289,6 @@ def get_nearest_dml_stmt(ir_set: irast.Set) -> Optional[irast.MutatingStmt]:
     return None
 
 
-def get_iterator_sets(stmt: irast.Stmt) -> Sequence[irast.Set]:
-    iterators = []
-    if stmt.iterator_stmt is not None:
-        iterators.append(stmt.iterator_stmt)
-    return iterators
-
-
 class ContainsDMLVisitor(ast.NodeVisitor):
     skip_hidden = True
 

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -190,6 +190,10 @@ class CompilerContextLevel(compiler.ContextLevel):
     #: ELSE select clauses) currently being compiled.
     enclosing_cte_iterator: Optional[pgast.IteratorCTE]
 
+    #: Sets to force shape compilation on, because the values are
+    #: needed by DML.
+    shapes_needed_by_dml: Set[irast.Set]
+
     def __init__(
         self,
         prevlevel: Optional[CompilerContextLevel],
@@ -235,6 +239,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.ptr_rel_overlays = collections.defaultdict(
                 lambda: collections.defaultdict(list))
             self.enclosing_cte_iterator = None
+            self.shapes_needed_by_dml = set()
 
         else:
             self.env = prevlevel.env
@@ -268,6 +273,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.type_rel_overlays = prevlevel.type_rel_overlays
             self.ptr_rel_overlays = prevlevel.ptr_rel_overlays
             self.enclosing_cte_iterator = prevlevel.enclosing_cte_iterator
+            self.shapes_needed_by_dml = prevlevel.shapes_needed_by_dml
 
             if mode is ContextSwitchMode.SUBSTMT:
                 if self.pending_query is not None:

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -330,6 +330,17 @@ class CompilerContextLevel(compiler.ContextLevel):
     ) -> compiler.CompilerContextManager[CompilerContextLevel]:
         return self.new(ContextSwitchMode.NEWSCOPE)
 
+    def up_hierarchy(
+        self,
+        n: int, q: Optional[pgast.Query]=None
+    ) -> Optional[pgast.Query]:
+        # mostly intended as a debugging helper
+        q = q or self.rel
+        for _ in range(n):
+            if q:
+                q = self.rel_hierarchy.get(q)
+        return q
+
 
 class CompilerContext(compiler.CompilerContext[CompilerContextLevel]):
     ContextLevelClass = CompilerContextLevel

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1491,7 +1491,7 @@ def process_link_values(
             input_rel_ctx.shapes_needed_by_dml.add(shape_expr)
 
             if ptr_is_required and enforce_cardinality:
-                input_rel_ctx.force_optional.add(shape_expr.path_id)
+                input_rel_ctx.force_optional.add(ir_expr.path_id)
 
             dispatch.visit(ir_expr, ctx=input_rel_ctx)
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -637,6 +637,8 @@ def process_insert_body(
         for shape_el, shape_op in ir_stmt.subject.shape:
             assert shape_op is qlast.ShapeOp.ASSIGN
 
+            # If the shape element is a linkprop, we do nothing.
+            # It will be picked up by the enclosing DML.
             if shape_el.path_id.is_linkprop_path():
                 continue
 
@@ -645,10 +647,6 @@ def process_insert_body(
             ptrref = rptr.ptrref
             if ptrref.material_ptr is not None:
                 ptrref = ptrref.material_ptr
-
-            if (ptrref.source_ptr is not None and
-                    rptr.source.path_id != ir_stmt.subject.path_id):
-                continue
 
             ptr_info = pg_types.get_ptrref_storage_info(
                 ptrref, resolve_type=True, link_bias=False)

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -55,7 +55,6 @@ from . import output
 from . import pathctx
 from . import relctx
 from . import relgen
-from . import shapecomp
 
 
 class DMLParts(NamedTuple):

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -637,6 +637,9 @@ def process_insert_body(
         for shape_el, shape_op in ir_stmt.subject.shape:
             assert shape_op is qlast.ShapeOp.ASSIGN
 
+            if shape_el.path_id.is_linkprop_path():
+                continue
+
             rptr = shape_el.rptr
             assert rptr is not None
             ptrref = rptr.ptrref

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -599,6 +599,17 @@ def _compile_set(
             shape=[expr for expr, _ in ir_set.shape],
             ctx=ctx,
         )
+    elif ir_set.shape and ir_set in ctx.shapes_needed_by_dml:
+        # hoo, boy.
+        shape_tuple = shapecomp.compile_shape(
+            ir_set,
+            shape=[expr for expr, _ in ir_set.shape],
+            ctx=ctx,
+        )
+        for element in shape_tuple.elements:
+            pathctx.put_path_var_if_not_exists(
+                ctx.rel, element.path_id, element.val,
+                aspect='value', env=ctx.env)
 
 
 def _compile_shape(

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -718,17 +718,10 @@ def update_scope(
         assert p.path_id is not None
         ctx.path_scope[p.path_id] = stmt
 
-    if isinstance(ir_set.expr, irast.Stmt):
-        iterators = ir_set.expr.hoisted_iterators
-        iter_paths = {it.path_id for it in iterators}
-    else:
-        iter_paths = set()
-
     for child_path in scope_tree.get_all_paths():
         parent_scope = scope_tree.parent
-        if ((parent_scope is None or
-                not parent_scope.is_visible(child_path)) and
-                child_path not in iter_paths):
+        if (parent_scope is None or
+                not parent_scope.is_visible(child_path)):
             stmt.path_id_mask.add(child_path)
 
 

--- a/edb/pgsql/compiler/shapecomp.py
+++ b/edb/pgsql/compiler/shapecomp.py
@@ -44,7 +44,6 @@ def compile_shape(
         shapectx.disable_semi_join.add(ir_set.path_id)
 
         if isinstance(ir_set.expr, irast.Stmt):
-            iterators = irutils.get_iterator_sets(ir_set.expr)
             # The source set for this shape is a FOR statement,
             # which is special in that besides set path_id it
             # should also expose the path_id of the FOR iterator
@@ -58,9 +57,9 @@ def compile_shape(
             #
             # the path scope when processing the shape of Bar.foo
             # should be {'Bar.foo', 'x'}.
-            if iterators:
-                for iterator in iterators:
-                    shapectx.path_scope[iterator.path_id] = ctx.rel
+            iterator = ir_set.expr.iterator_stmt
+            if iterator:
+                shapectx.path_scope[iterator.path_id] = ctx.rel
 
         for el in shape:
             rptr = el.rptr

--- a/edb/pgsql/compiler/shapecomp.py
+++ b/edb/pgsql/compiler/shapecomp.py
@@ -23,6 +23,9 @@ from __future__ import annotations
 
 from typing import *
 
+from edb.edgeql import ast as qlast
+
+
 from edb.ir import ast as irast
 from edb.ir import utils as irutils
 
@@ -36,7 +39,8 @@ from . import relgen
 
 
 def compile_shape(
-        ir_set: irast.Set, shape: List[irast.Set], *,
+        ir_set: irast.Set,
+        shape: List[Tuple[irast.Set, qlast.ShapeOp]], *,
         ctx: context.CompilerContextLevel) -> pgast.TupleVar:
     elements = []
 
@@ -61,7 +65,7 @@ def compile_shape(
             if iterator:
                 shapectx.path_scope[iterator.path_id] = ctx.rel
 
-        for el in shape:
+        for el, _ in shape:
             rptr = el.rptr
             assert rptr is not None
             ptrref = rptr.ptrref

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -59,21 +59,21 @@ def compile_SelectStmt(
 
         query = ctx.stmt
 
-        iterators = irutils.get_iterator_sets(stmt)
+        iterator_set = stmt.iterator_stmt
         last_iterator: Optional[irast.Set] = None
-        if iterators and irutils.contains_dml(stmt):
+        if iterator_set and irutils.contains_dml(stmt):
             # If we have iterators and we contain nested DML
             # statements, we need to hoist the iterators into CTEs and
             # then explicitly join them back into the query.
-            iterator = dml.compile_iterator_ctes(iterators, ctx=ctx)
+            iterator = dml.compile_iterator_cte(iterator_set, ctx=ctx)
             ctx.path_scope = ctx.path_scope.new_child()
             dml.merge_iterator(iterator, ctx.rel, ctx=ctx)
 
             ctx.enclosing_cte_iterator = iterator
-            last_iterator = iterators[-1]
+            last_iterator = stmt.iterator_stmt
 
         else:
-            for iterator_set in iterators:
+            if iterator_set:
                 # Process FOR clause.
                 with ctx.new() as ictx:
                     clauses.setup_iterator_volatility(last_iterator, ctx=ictx)

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -749,7 +749,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 },
                 "(test::User).>deck[IS test::Card]",
                 "FENCE": {
-                    "(test::User).>deck[IS test::Card].>cost[IS std::int64]"
+                    "[ns~1]@[ns~2]@[ns~5]@[ns~6]@@(test::Card)\
+.>cost[IS std::int64]"
                 }
             }
         }

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -311,7 +311,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 "FENCE": {
                     "[ns~1]@[ns~2]@@(test::User).>friends[IS test::User]"
                 },
-                "(test::User).>friends[IS test::User]"
+                "(test::User).>friends[IS test::User]",
+                "[ns~1]@[ns~2]@@(__derived__::expr~13)"
             },
             "FENCE": {
                 "(test::User).>name[IS std::str]"
@@ -677,7 +678,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                         }
                     }
                 },
-                "(test::User).>select_deck[IS test::Card]"
+                "(test::User).>select_deck[IS test::Card]",
+                "[ns~1]@[ns~4]@@(__derived__::expr~26)"
             },
             "FENCE": {
                 "(test::User).>name[IS std::str]"
@@ -716,10 +718,10 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 .>deck[IS test::Card].>name[IS std::str]"
                             }
                         }
-                    },
-                    "[ns~1]@[ns~5]@@(__derived__::__derived__|foo@w~2)"
+                    }
                 },
-                "(test::User).>select_deck[IS test::Card]"
+                "(test::User).>select_deck[IS test::Card]",
+                "[ns~1]@[ns~5]@@(__derived__::__derived__|foo@w~2)"
             },
             "FENCE": {
                 "(test::User).>name[IS std::str]"

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -703,6 +703,16 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_scope_tuple_15(self):
+        res = await self.con.query(r"""
+            WITH MODULE test
+            SELECT ((SELECT User {deck}), User.deck);
+        """)
+
+        # The deck shape ought to contain just the correlated element
+        for row in res:
+            self.assertEqual(row[0].deck, [row[1]])
+
     async def test_edgeql_scope_binding_01(self):
         await self.assert_query_result(
             r"""

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -2356,14 +2356,9 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     {
                         "name": "of_group",
                         "type": {
-                            "kind": "NON_NULL",
-                            "name": None,
-                            "ofType": {
-                                "kind": "OBJECT",
-                                "name":
-                                    "_edb__SettingAliasAugmented__of_group",
-                                "__typename": "__Type"
-                            },
+                            "kind": "OBJECT",
+                            "name": "_edb__SettingAliasAugmented__of_group",
+                            "ofType": None,
                             "__typename": "__Type"
                         },
                         "__typename": "__Field",


### PR DESCRIPTION
This avoids bugs with queries like
`SELECT ((SELECT User {deck}), User.deck)`,
which was being miscompiled as if it was
`SELECT ((SELECT User) {deck}, User.deck)`