### PR TITLE
Directly track nested "shape sources" in the IR

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1228,7 +1228,7 @@ def _compile_view_shapes_in_set(
     if (isinstance(ir_set.expr, irast.SelectStmt)
             and (setgen.get_set_type(ir_set, ctx=ctx) ==
                  setgen.get_set_type(ir_set.expr.result, ctx=ctx))):
-
+        child = ir_set.expr.result
         set_scope = pathctx.get_set_scope(ir_set, ctx=ctx)
 
         if shape_ptrs:
@@ -1237,10 +1237,12 @@ def _compile_view_shapes_in_set(
             if set_scope is not None:
                 scopectx.path_scope = set_scope
             compile_view_shapes(
-                ir_set.expr.result,
+                child,
                 rptr=rptr or ir_set.rptr,
                 parent_view_type=parent_view_type,
                 ctx=scopectx)
+
+        ir_set.shape_source = child if child.shape else child.shape_source
         return
 
     if shape_ptrs:

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -431,6 +431,9 @@ class Set(Base):
     anchor: typing.Optional[str]
     show_as_anchor: typing.Optional[str]
     shape: typing.List[typing.Tuple[Set, qlast.ShapeOp]]
+    # A pointer to a set nested within this one has a shape and the same
+    # typeref, if such a set exists.
+    shape_source: typing.Optional[Set]
     is_binding: bool
 
     def __repr__(self) -> str:

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1617,19 +1617,9 @@ def process_link_values(
                     row_query, ir_stmt.subject.path_id,
                     env=input_rel_ctx.env),)
 
-            # Look for a shape that might provide link property values
-            # for this link. We have to dig down into the expression,
-            # because the shape might be wrapped a few times (because
-            # of iterators, filters, etc)
-            shape_expr = ir_expr
-            while (
-                not shape_expr.shape
-                and isinstance(shape_expr.expr, irast.SelectStmt)
-                and shape_expr.typeref == shape_expr.expr.result.typeref
-            ):
-                shape_expr = shape_expr.expr.result
-            if not shape_expr.shape:
-                shape_expr = ir_expr
+            # Check if some nested Set provides a shape that is
+            # visible here.
+            shape_expr = ir_expr.shape_source or ir_expr
             # Register that this shape needs to be compiled for use by DML,
             # so that the values will be there for us to grab later.
             input_rel_ctx.shapes_needed_by_dml.add(shape_expr)


### PR DESCRIPTION
This lets us dispense with the grungy while loop in
`process_link_values` and (for better or worse) makes the information
more easily available.