### PR TITLE
server: Implement the --emit-server-status=<DEST> server option

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -105,6 +105,7 @@ class Server:
         netport,
         auto_shutdown: bool=False,
         echo_runtime_info: bool = False,
+        status_sink: Optional[Callable[[str], None]] = None,
         startup_script: Optional[StartupScript] = None,
     ):
 
@@ -145,6 +146,7 @@ class Server:
         self._auto_shutdown = auto_shutdown
 
         self._echo_runtime_info = echo_runtime_info
+        self._status_sink = status_sink
 
         self._startup_script = startup_script
 
@@ -846,6 +848,14 @@ class Server:
                 "runstate_dir": str(self._runstate_dir),
             }
             print(f'\nEDGEDB_SERVER_DATA:{json.dumps(ri)}\n', flush=True)
+
+        if self._status_sink is not None:
+            status = {
+                "port": self._listen_port,
+                "socket_dir": str(self._runstate_dir),
+                "main_pid": os.getpid(),
+            }
+            self._status_sink(f'READY={json.dumps(status)}')
 
     async def stop(self):
         try:

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1896,9 +1896,7 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
             adjacent_to=self.con, postgres_dsn=self.postgres_dsn
         ) as sd:
 
-            con2 = await edgedb.async_connect(
-                host=sd.host,
-                port=sd.port,
+            con2 = await sd.connect(
                 user=conargs.get('user'),
                 password=conargs.get('password'),
                 database=self.get_database_name(),
@@ -1956,9 +1954,7 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
                 ignore=edgedb.AuthenticationError
             ):
                 async with tr:
-                    con3 = await edgedb.async_connect(
-                        host=sd.host,
-                        port=sd.port,
+                    con3 = await sd.connect(
                         user='ddlprop01',
                         password='aaaa',
                         database=self.get_database_name(),


### PR DESCRIPTION
The new `--emit-server-status=<DEST>` option replaces
`--echo-runtime-info`.  Unlike the latter, `--emit-server-status`
accepts an explicit file path or a file descriptor to emit server
information to.  This lets server `stdout` be undisturbed, and adds
a way for future additions such as reporting server status via a
socket, which might be useful for a service supervisor.

This also does a bunch of cleanups in the `server_ops` tests.