### PR TITLE
Add support for EdgeDB multitenancy on a single Postgres cluster

### DIFF
--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -158,7 +158,7 @@ sys::get_current_database() -> str
         'Return the name of the current database as a string.';
     # The results won't change within a single statement.
     SET volatility := 'Stable';
-    USING SQL FUNCTION 'current_database';
+    USING SQL FUNCTION 'edgedb.get_current_database';
 };
 
 CREATE FUNCTION

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -186,6 +186,14 @@ def convert_name(name, suffix='', catenate=True):
         return schema, dbname
 
 
+def get_database_backend_name(db_name: str, *, tenant_id: str) -> str:
+    return f'{tenant_id}_{db_name}'
+
+
+def get_role_backend_name(role_name: str, *, tenant_id: str) -> str:
+    return f'{tenant_id}_{role_name}'
+
+
 def update_aspect(name, aspect):
     """Update the aspect on a non catenated name.
 

--- a/edb/schema/database.py
+++ b/edb/schema/database.py
@@ -53,14 +53,11 @@ class DatabaseCommand(
     context_class=DatabaseCommandContext,
 ):
 
-    def _create_begin(
+    def _validate_name(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
-    ) -> s_schema.Schema:
-        schema = super()._create_begin(schema, context)
-
-        # Validate that the database name is fewer than 64 characters
+    ) -> None:
         name = self.get_attribute_value('name')
         if len(str(name)) > s_def.MAX_NAME_LENGTH:
             source_context = self.get_attribute_source_context('name')
@@ -69,8 +66,6 @@ class DatabaseCommand(
                 f'characters are not supported',
                 context=source_context,
             )
-
-        return schema
 
 
 class CreateDatabase(DatabaseCommand, sd.CreateExternalObject[Database]):
@@ -99,9 +94,25 @@ class CreateDatabase(DatabaseCommand, sd.CreateExternalObject[Database]):
 
         return cmd
 
+    def validate_create(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> None:
+        super().validate_create(schema, context)
+        self._validate_name(schema, context)
+
 
 class AlterDatabase(DatabaseCommand, sd.AlterObject[Database]):
     astnode = qlast.AlterDatabase
+
+    def validate_alter(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> None:
+        super().validate_alter(schema, context)
+        self._validate_name(schema, context)
 
 
 class DropDatabase(DatabaseCommand, sd.DeleteExternalObject[Database]):

--- a/edb/schema/defines.py
+++ b/edb/schema/defines.py
@@ -20,14 +20,12 @@
 from __future__ import annotations
 
 # Maximum length of Postgres tenant ID.
-MAX_TENANT_ID_LENGTH = 1 + 10
-#                      ^    ^
-#          tenant scheme    tenant ID
+MAX_TENANT_ID_LENGTH = 10
 
 # Maximum length of names that are reflected 1:1 to Postgres:
-MAX_NAME_LENGTH = 63 - MAX_TENANT_ID_LENGTH - 1
-#                 ^                           ^
-#         max Postgres name len        tenant_id separator
+MAX_NAME_LENGTH = 63 - MAX_TENANT_ID_LENGTH - 1 - 1
+#                 ^                           ^   ^
+#    max Postgres name len     tenant_id scheme   tenant_id separator
 
 # Maximum number of arguments supported by SQL functions.
 MAX_FUNC_ARG_COUNT = 100

--- a/edb/schema/defines.py
+++ b/edb/schema/defines.py
@@ -19,9 +19,15 @@
 
 from __future__ import annotations
 
-# Maximum length of column name in Postgres. This limits the database
-# name length and affects column name mangling.
-MAX_NAME_LENGTH = 63
+# Maximum length of Postgres tenant ID.
+MAX_TENANT_ID_LENGTH = 1 + 10
+#                      ^    ^
+#          tenant scheme    tenant ID
+
+# Maximum length of names that are reflected 1:1 to Postgres:
+MAX_NAME_LENGTH = 63 - MAX_TENANT_ID_LENGTH - 1
+#                 ^                           ^
+#         max Postgres name len        tenant_id separator
 
 # Maximum number of arguments supported by SQL functions.
 MAX_FUNC_ARG_COUNT = 100

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -35,7 +35,6 @@ from edb.edgeql import quote as qlquote
 from . import abc as s_abc
 from . import annos as s_anno
 from . import constraints
-from . import defines as s_def
 from . import delta as sd
 from . import expr as s_expr
 from . import inheriting
@@ -1437,13 +1436,6 @@ class PointerCommand(
         else:
             name = super()._classname_from_ast(schema, astnode, context)
 
-        sname = sn.shortname_from_fullname(name)
-        assert isinstance(sname, sn.QualName), "expected qualified name"
-        if len(sname.name) > s_def.MAX_NAME_LENGTH:
-            raise errors.SchemaDefinitionError(
-                f'link or property name length exceeds the maximum of '
-                f'{s_def.MAX_NAME_LENGTH} characters',
-                context=astnode.context)
         return name
 
     @classmethod

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -74,6 +74,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger('edb.server')
 
 
+class BootstrapContext(NamedTuple):
+
+    cluster: pgcluster.BaseCluster
+    conn: asyncpg_con.Connection
+
+
 async def _execute(conn, query):
     return await metaschema._execute_sql_script(conn, query)
 
@@ -107,15 +113,14 @@ async def _execute_edgeql_ddl(
 
 
 async def _ensure_edgedb_supergroup(
-    cluster,
-    conn,
-    username,
+    ctx: BootstrapContext,
+    role_name: str,
     *,
-    member_of=(),
-    members=(),
+    member_of: Iterable[str] = (),
+    members: Iterable[str] = (),
 ) -> None:
     member_of = set(member_of)
-    instance_params = cluster.get_runtime_params().instance_params
+    instance_params = ctx.cluster.get_runtime_params().instance_params
     superuser_role = instance_params.base_superuser
     if superuser_role:
         # If the cluster is exposing an explicit superuser role,
@@ -123,8 +128,10 @@ async def _ensure_edgedb_supergroup(
         # role directly.
         member_of.add(superuser_role)
 
+    pg_role_name = ctx.cluster.get_role_name(role_name)
+
     role = dbops.Role(
-        name=username,
+        name=pg_role_name,
         superuser=bool(
             instance_params.capabilities
             & pgcluster.BackendCapabilities.SUPERUSER_ACCESS
@@ -138,24 +145,23 @@ async def _ensure_edgedb_supergroup(
 
     create_role = dbops.CreateRole(
         role,
-        neg_conditions=[dbops.RoleExists(username)],
+        neg_conditions=[dbops.RoleExists(pg_role_name)],
     )
 
     block = dbops.PLTopBlock()
     create_role.generate(block)
 
-    await _execute_block(conn, block)
+    await _execute_block(ctx.conn, block)
 
 
 async def _ensure_edgedb_role(
-    cluster,
-    conn,
-    username,
+    ctx: BootstrapContext,
+    role_name: str,
     *,
-    superuser=False,
-    builtin=False,
-    objid=None,
-) -> None:
+    superuser: bool = False,
+    builtin: bool = False,
+    objid: Optional[uuid.UUID] = None,
+) -> uuid.UUID:
     member_of = set()
     if superuser:
         member_of.add(edbdef.EDGEDB_SUPERGROUP)
@@ -164,13 +170,15 @@ async def _ensure_edgedb_role(
         objid = uuidgen.uuid1mc()
 
     members = set()
-    login_role = cluster.get_connection_params().user
-    if login_role != edbdef.EDGEDB_SUPERUSER:
+    login_role = ctx.cluster.get_connection_params().user
+    sup_role = ctx.cluster.get_role_name(edbdef.EDGEDB_SUPERUSER)
+    if login_role != sup_role:
         members.add(login_role)
 
-    instance_params = cluster.get_runtime_params().instance_params
+    instance_params = ctx.cluster.get_runtime_params().instance_params
+    pg_role_name = ctx.cluster.get_role_name(role_name)
     role = dbops.Role(
-        name=username,
+        name=pg_role_name,
         superuser=(
             superuser
             and bool(
@@ -181,46 +189,59 @@ async def _ensure_edgedb_role(
         allow_login=True,
         allow_createdb=True,
         allow_createrole=True,
-        membership=member_of,
+        membership=[ctx.cluster.get_role_name(m) for m in member_of],
         members=members,
         metadata=dict(
             id=str(objid),
+            name=role_name,
+            tenant_id=instance_params.tenant_id,
             builtin=builtin,
         ),
     )
 
     create_role = dbops.CreateRole(
         role,
-        neg_conditions=[dbops.RoleExists(username)],
+        neg_conditions=[dbops.RoleExists(pg_role_name)],
     )
 
     block = dbops.PLTopBlock()
     create_role.generate(block)
 
-    await _execute_block(conn, block)
+    await _execute_block(ctx.conn, block)
 
     return objid
 
 
-async def _get_db_info(conn, dbname):
-    result = await conn.fetchrow('''
-        SELECT
-            r.rolname,
-            datistemplate,
-            datallowconn
-        FROM
-            pg_catalog.pg_database d
-            INNER JOIN pg_catalog.pg_roles r
-                ON (d.datdba = r.oid)
-        WHERE
-            d.datname = $1
-    ''', dbname)
+async def _is_pristine_cluster(ctx: BootstrapContext) -> bool:
+    tenant_id = ctx.cluster.get_runtime_params().instance_params.tenant_id
+    is_default_tenant = tenant_id == buildmeta.get_default_tenant_id()
 
-    return result
+    if is_default_tenant:
+        result = await ctx.conn.fetchrow('''
+            SELECT
+                True
+            FROM
+                pg_catalog.pg_roles AS r
+            WHERE
+                r.rolname LIKE ('%_' || $1)
+        ''', edbdef.EDGEDB_SUPERGROUP)
+    else:
+        result = await ctx.conn.fetchrow('''
+            SELECT
+                True
+            FROM
+                pg_catalog.pg_roles AS r
+            WHERE
+                r.rolname = $1
+        ''', ctx.cluster.get_role_name(edbdef.EDGEDB_SUPERGROUP))
+
+    return not result
 
 
-async def _create_edgedb_template_database(cluster, conn):
-    instance_params = cluster.get_runtime_params().instance_params
+async def _create_edgedb_template_database(
+    ctx: BootstrapContext,
+) -> uuid.UUID:
+    instance_params = ctx.cluster.get_runtime_params().instance_params
     capabilities = instance_params.capabilities
     have_c_utf8 = (
         capabilities & pgcluster.BackendCapabilities.C_UTF8_LOCALE)
@@ -229,25 +250,30 @@ async def _create_edgedb_template_database(cluster, conn):
     block = dbops.SQLBlock()
     dbid = uuidgen.uuid1mc()
     db = dbops.Database(
-        edbdef.EDGEDB_TEMPLATE_DB,
-        owner=edbdef.EDGEDB_SUPERUSER,
+        ctx.cluster.get_db_name(edbdef.EDGEDB_TEMPLATE_DB),
+        owner=ctx.cluster.get_role_name(edbdef.EDGEDB_SUPERUSER),
         is_template=True,
-        template='template0',
         lc_collate='C',
         lc_ctype='C.UTF-8' if have_c_utf8 else 'en_US.UTF-8',
         encoding='UTF8',
         metadata=dict(
             id=str(dbid),
+            tenant_id=instance_params.tenant_id,
+            name=edbdef.EDGEDB_TEMPLATE_DB,
             builtin=True,
         ),
     )
 
-    dbops.CreateDatabase(db).generate(block)
-    await _execute_block(conn, block)
+    dbops.CreateDatabase(db, template='template0').generate(block)
+    await _execute_block(ctx.conn, block)
     return dbid
 
 
-async def _store_static_bin_cache(cluster, key: str, data: bytes) -> None:
+async def _store_static_bin_cache(
+    ctx: BootstrapContext,
+    key: str,
+    data: bytes,
+) -> None:
 
     text = f"""\
         INSERT INTO edgedbinstdata.instdata (key, bin)
@@ -257,17 +283,14 @@ async def _store_static_bin_cache(cluster, key: str, data: bytes) -> None:
         )
     """
 
-    dbconn = await cluster.connect(
-        database=edbdef.EDGEDB_TEMPLATE_DB,
-    )
-
-    try:
-        await _execute(dbconn, text)
-    finally:
-        await dbconn.close()
+    await _execute(ctx.conn, text)
 
 
-async def _store_static_text_cache(cluster, key: str, data: str) -> None:
+async def _store_static_text_cache(
+    ctx: BootstrapContext,
+    key: str,
+    data: str,
+) -> None:
 
     text = f"""\
         INSERT INTO edgedbinstdata.instdata (key, text)
@@ -277,17 +300,14 @@ async def _store_static_text_cache(cluster, key: str, data: str) -> None:
         )
     """
 
-    dbconn = await cluster.connect(
-        database=edbdef.EDGEDB_TEMPLATE_DB,
-    )
-
-    try:
-        await _execute(dbconn, text)
-    finally:
-        await dbconn.close()
+    await _execute(ctx.conn, text)
 
 
-async def _store_static_json_cache(cluster, key: str, data: str) -> None:
+async def _store_static_json_cache(
+    ctx: BootstrapContext,
+    key: str,
+    data: str,
+) -> None:
 
     text = f"""\
         INSERT INTO edgedbinstdata.instdata (key, json)
@@ -297,17 +317,10 @@ async def _store_static_json_cache(cluster, key: str, data: str) -> None:
         )
     """
 
-    dbconn = await cluster.connect(
-        database=edbdef.EDGEDB_TEMPLATE_DB,
-    )
-
-    try:
-        await _execute(dbconn, text)
-    finally:
-        await dbconn.close()
+    await _execute(ctx.conn, text)
 
 
-def _process_delta(delta, schema):
+def _process_delta(ctx, delta, schema):
     """Adapt and process the delta command."""
 
     if debug.flags.delta_plan:
@@ -322,8 +335,10 @@ def _process_delta(delta, schema):
         sd.apply(delta, schema=schema)
 
     delta = delta_cmds.CommandMeta.adapt(delta)
-    context = sd.CommandContext()
-    context.stdmode = True
+    context = sd.CommandContext(
+        stdmode=True,
+        backend_runtime_params=ctx.cluster.get_runtime_params(),
+    )
     schema = sd.apply(delta, schema=schema, context=context)
 
     if debug.flags.delta_pgsql_plan:
@@ -386,7 +401,11 @@ class StdlibBits(NamedTuple):
     global_intro_query: str
 
 
-async def _make_stdlib(testmode: bool, global_ids) -> StdlibBits:
+async def _make_stdlib(
+    ctx: BootstrapContext,
+    testmode: bool,
+    global_ids: Mapping[str, uuid.UUID],
+) -> StdlibBits:
     schema = s_schema.ChainedSchema(
         s_schema.FlatSchema(),
         s_schema.FlatSchema(),
@@ -421,14 +440,14 @@ async def _make_stdlib(testmode: bool, global_ids) -> StdlibBits:
 
         # Apply and adapt delta, build native delta plan, which
         # will also update the schema.
-        schema, plan = _process_delta(delta_command, schema)
+        schema, plan = _process_delta(ctx, delta_command, schema)
         std_plans.append(delta_command)
 
         types.update(plan.new_types)
         plan.generate(current_block)
 
     _, schema_version = s_std.make_schema_version(schema)
-    schema, plan = _process_delta(schema_version, schema)
+    schema, plan = _process_delta(ctx, schema_version, schema)
     std_plans.append(schema_version)
     plan.generate(current_block)
 
@@ -441,13 +460,13 @@ async def _make_stdlib(testmode: bool, global_ids) -> StdlibBits:
     schema = await _execute_edgeql_ddl(schema, stdglobals)
 
     _, global_schema_version = s_std.make_global_schema_version(schema)
-    schema, plan = _process_delta(global_schema_version, schema)
+    schema, plan = _process_delta(ctx, global_schema_version, schema)
     std_plans.append(global_schema_version)
     plan.generate(current_block)
 
     reflection = s_refl.generate_structure(schema)
     reflschema, reflplan = _process_delta(
-        reflection.intro_schema_delta, schema)
+        ctx, reflection.intro_schema_delta, schema)
 
     assert current_block is not None
     reflplan.generate(current_block)
@@ -495,7 +514,7 @@ async def _make_stdlib(testmode: bool, global_ids) -> StdlibBits:
 
     # The introspection query bits are returned in chunks
     # because it's a large UNION and we currently generate SQL
-    # that is much harder for Posgres to plan as opposed to a
+    # that is much harder for Postgres to plan as opposed to a
     # straight flat UNION.
     sql_intro_local_parts = []
     sql_intro_global_parts = []
@@ -542,6 +561,7 @@ async def _make_stdlib(testmode: bool, global_ids) -> StdlibBits:
 
 
 async def _amend_stdlib(
+    ctx: BootstrapContext,
     ddl_text: str,
     stdlib: StdlibBits,
 ) -> Tuple[StdlibBits, str]:
@@ -565,7 +585,7 @@ async def _amend_stdlib(
 
         # Apply and adapt delta, build native delta plan, which
         # will also update the schema.
-        schema, plan = _process_delta(delta_command, schema)
+        schema, plan = _process_delta(ctx, delta_command, schema)
         reflschema = delta_command.apply(reflschema, context)
         plan.generate(topblock)
         plans.append(plan)
@@ -591,17 +611,24 @@ async def _amend_stdlib(
     return stdlib._replace(stdschema=schema, reflschema=reflschema), sqltext
 
 
-async def _init_stdlib(cluster, conn, testmode, global_ids):
+async def _init_stdlib(
+    ctx: BootstrapContext,
+    testmode: bool,
+    global_ids: Mapping[str, uuid.UUID],
+) -> Tuple[StdlibBits, edbcompiler.Compiler]:
     in_dev_mode = devmode.is_in_dev_mode()
+    conn = ctx.conn
+    cluster = ctx.cluster
 
     specified_cache_dir = os.environ.get('_EDGEDB_WRITE_DATA_CACHE_TO')
-    if specified_cache_dir:
-        cache_dir = pathlib.Path(specified_cache_dir)
-    else:
+    if not specified_cache_dir:
         cache_dir = None
+    else:
+        cache_dir = pathlib.Path(specified_cache_dir)
 
-    stdlib_cache = 'backend-stdlib.pickle'
-    tpldbdump_cache = 'backend-tpldbdump.sql'
+    stdlib_cache = f'backend-stdlib.pickle'
+    tpldbdump_cache = f'backend-tpldbdump.sql'
+
     src_hash = buildmeta.hash_dirs(
         buildmeta.get_cache_src_dirs(), extra_files=[__file__],
     )
@@ -613,7 +640,7 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
 
     if stdlib is None:
         logger.info('Compiling the standard library...')
-        stdlib = await _make_stdlib(in_dev_mode or testmode, global_ids)
+        stdlib = await _make_stdlib(ctx, in_dev_mode or testmode, global_ids)
 
     logger.info('Creating the necessary PostgreSQL extensions...')
     await metaschema.create_pg_extensions(conn)
@@ -625,9 +652,14 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
         await _execute_ddl(conn, stdlib.sqltext)
 
         if in_dev_mode or specified_cache_dir:
+            tpl_db_name = edbdef.EDGEDB_TEMPLATE_DB
+            tpl_pg_db_name = cluster.get_db_name(tpl_db_name)
+            tpl_pg_db_name_dyn = (
+                f"edgedb.get_database_backend_name({ql(tpl_db_name)})")
             tpldbdump = cluster.dump_database(
-                edbdef.EDGEDB_TEMPLATE_DB,
+                tpl_pg_db_name,
                 exclude_schemas=['edgedbinstdata', 'edgedbext'],
+                dump_object_owners=False,
             )
 
             # Excluding the "edgedbext" schema above apparently
@@ -642,22 +674,23 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
             )
 
             global_metadata = await conn.fetchval(
-                f'''\
-                SELECT edgedb.shobj_metadata(
-                    (SELECT oid FROM pg_database
-                     WHERE datname = {ql(edbdef.EDGEDB_TEMPLATE_DB)}),
-                    'pg_database'
-                )'''
+                f'SELECT edgedb.get_database_metadata({ql(tpl_db_name)})',
             )
 
             pl_block = dbops.PLTopBlock()
 
             dbops.SetMetadata(
-                dbops.Database(name=edbdef.EDGEDB_TEMPLATE_DB),
+                dbops.Database(name='__dummy_placeholder_database__'),
                 json.loads(global_metadata),
             ).generate(pl_block)
 
-            tpldbdump += b'\n' + pl_block.to_string().encode('utf-8')
+            text = pl_block.to_string()
+            text = text.replace(
+                '__dummy_placeholder_database__',
+                f"' || quote_ident({tpl_pg_db_name_dyn}) || '",
+            )
+
+            tpldbdump += b'\n' + text.encode('utf-8')
 
             buildmeta.write_data_cache(
                 tpldbdump,
@@ -680,7 +713,8 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
     if not in_dev_mode and testmode:
         # Running tests on a production build.
         stdlib, testmode_sql = await _amend_stdlib(
-            s_std.get_std_module_text('_testmode'),
+            ctx,
+            s_std.get_std_module_text(sn.UnqualName('_testmode')),
             stdlib,
         )
         await conn.execute(testmode_sql)
@@ -715,37 +749,37 @@ async def _init_stdlib(cluster, conn, testmode, global_ids):
     stdlib = stdlib._replace(stdschema=schema)
 
     await _store_static_bin_cache(
-        cluster,
+        ctx,
         'stdschema',
         pickle.dumps(schema, protocol=pickle.HIGHEST_PROTOCOL),
     )
 
     await _store_static_bin_cache(
-        cluster,
+        ctx,
         'reflschema',
         pickle.dumps(stdlib.reflschema, protocol=pickle.HIGHEST_PROTOCOL),
     )
 
     await _store_static_bin_cache(
-        cluster,
+        ctx,
         'global_schema',
         pickle.dumps(stdlib.global_schema, protocol=pickle.HIGHEST_PROTOCOL),
     )
 
     await _store_static_bin_cache(
-        cluster,
+        ctx,
         'classlayout',
         pickle.dumps(stdlib.classlayout, protocol=pickle.HIGHEST_PROTOCOL),
     )
 
     await _store_static_text_cache(
-        cluster,
+        ctx,
         'local_intro_query',
         stdlib.local_intro_query,
     )
 
     await _store_static_text_cache(
-        cluster,
+        ctx,
         'global_intro_query',
         stdlib.global_intro_query,
     )
@@ -890,9 +924,9 @@ async def _populate_data(schema, compiler, conn):
 
 
 async def _configure(
+    ctx: BootstrapContext,
     schema: s_schema.Schema,
     compiler: edbcompiler.Compiler,
-    conn: asyncpg_con.Connection,
     *,
     insecure: bool = False,
 ) -> None:
@@ -921,7 +955,7 @@ async def _configure(
             debug.header('Bootstrap')
             debug.dump_code(sql, lexer='sql')
 
-        config_op_data = await conn.fetchval(sql)
+        config_op_data = await ctx.conn.fetchval(sql)
         if config_op_data is not None and isinstance(config_op_data, str):
             config_op = config.Operation.from_json(config_op_data)
             settings = config_op.apply(config_spec, immutables.Map())
@@ -929,14 +963,18 @@ async def _configure(
     config_json = config.to_json(config_spec, settings, include_source=False)
     block = dbops.PLTopBlock()
     dbops.UpdateMetadata(
-        dbops.Database(name=edbdef.EDGEDB_SYSTEM_DB),
+        dbops.Database(name=ctx.cluster.get_db_name(edbdef.EDGEDB_SYSTEM_DB)),
         {'sysconfig': json.loads(config_json)},
     ).generate(block)
 
-    await _execute_block(conn, block)
+    await _execute_block(ctx.conn, block)
 
 
-async def _compile_sys_queries(schema, compiler, cluster):
+async def _compile_sys_queries(
+    ctx: BootstrapContext,
+    schema: s_schema.Schema,
+    compiler: edbcompiler.Compiler,
+) -> None:
     queries = {}
 
     _, sql = compile_bootstrap_script(
@@ -1012,13 +1050,15 @@ async def _compile_sys_queries(schema, compiler, cluster):
     queries['backend_tids'] = sql
 
     await _store_static_json_cache(
-        cluster,
+        ctx,
         'sysqueries',
         json.dumps(queries),
     )
 
 
-async def _populate_misc_instance_data(cluster, conn):
+async def _populate_misc_instance_data(
+    ctx: BootstrapContext,
+) -> Dict[str, Any]:
 
     commands = dbops.CommandGroup()
     commands.add_commands([
@@ -1054,7 +1094,7 @@ async def _populate_misc_instance_data(cluster, conn):
 
     block = dbops.PLTopBlock()
     commands.generate(block)
-    await _execute_block(conn, block)
+    await _execute_block(ctx.conn, block)
 
     mock_auth_nonce = scram.generate_nonce()
     json_instance_data = {
@@ -1064,14 +1104,14 @@ async def _populate_misc_instance_data(cluster, conn):
     }
 
     await _store_static_json_cache(
-        cluster,
+        ctx,
         'instancedata',
         json.dumps(json_instance_data),
     )
 
-    instance_params = cluster.get_runtime_params().instance_params
+    instance_params = ctx.cluster.get_runtime_params().instance_params
     await _store_static_json_cache(
-        cluster,
+        ctx,
         'backend_instance_params',
         json.dumps(instance_params._asdict()),
     )
@@ -1080,9 +1120,9 @@ async def _populate_misc_instance_data(cluster, conn):
 
 
 async def _create_edgedb_database(
-    conn,
-    database,
-    owner,
+    ctx: BootstrapContext,
+    database: str,
+    owner: str,
     *,
     builtin: bool = False,
     objid: Optional[uuid.UUID] = None,
@@ -1091,25 +1131,32 @@ async def _create_edgedb_database(
     block = dbops.SQLBlock()
     if objid is None:
         objid = uuidgen.uuid1mc()
+    instance_params = ctx.cluster.get_runtime_params().instance_params
     db = dbops.Database(
-        database,
-        owner=owner,
+        ctx.cluster.get_db_name(database),
+        owner=ctx.cluster.get_role_name(owner),
         metadata=dict(
             id=str(objid),
+            tenant_id=instance_params.tenant_id,
+            name=database,
             builtin=builtin,
         ),
     )
-    dbops.CreateDatabase(db).generate(block)
-    await _execute_block(conn, block)
+    tpl_db = ctx.cluster.get_db_name(edbdef.EDGEDB_TEMPLATE_DB)
+    dbops.CreateDatabase(db, template=tpl_db).generate(block)
+    await _execute_block(ctx.conn, block)
     return objid
 
 
-async def _bootstrap_config_spec(schema, cluster):
+async def _bootstrap_config_spec(
+    ctx: BootstrapContext,
+    schema: s_schema.Schema,
+) -> None:
     config_spec = config.load_spec_from_schema(schema)
     config.set_settings(config_spec)
 
     await _store_static_json_cache(
-        cluster,
+        ctx,
         'configspec',
         config.spec_to_json(config_spec),
     )
@@ -1132,52 +1179,88 @@ async def _get_instance_data(conn: Any) -> Dict[str, Any]:
     return json.loads(data)
 
 
-async def _check_data_dir_compatibility(conn):
-    instancedata = await _get_instance_data(conn)
-    datadir_version = instancedata.get('version')
-    if datadir_version:
-        datadir_major = datadir_version.get('major')
+async def _check_catalog_compatibility(
+    ctx: BootstrapContext,
+) -> asyncpg_con.Connection:
+    tenant_id = ctx.cluster.get_runtime_params().instance_params.tenant_id
+    is_default_tenant = tenant_id == buildmeta.get_default_tenant_id()
 
-    expected_ver = buildmeta.get_version()
+    if is_default_tenant:
+        sys_db = await ctx.conn.fetchval(f'''
+            SELECT datname
+            FROM pg_database
+            WHERE datname LIKE '%_' || $1
+            LIMIT 1
+        ''', edbdef.EDGEDB_SYSTEM_DB)
+    else:
+        sys_db = await ctx.conn.fetchval(f'''
+            SELECT datname
+            FROM pg_database
+            WHERE datname = $1
+        ''', ctx.cluster.get_db_name(edbdef.EDGEDB_SYSTEM_DB))
 
-    if datadir_major != expected_ver.major:
+    if not sys_db:
         raise errors.ConfigurationError(
-            'database instance incompatible with this version of EdgeDB',
+            'database instance is corrupt',
             details=(
-                f'The database instance was initialized with '
-                f'EdgeDB version {datadir_major}, '
-                f'which is incompatible with this version '
-                f'{expected_ver.major}'
-            ),
-            hint=(
-                f'You need to recreate the instance and upgrade '
-                f'using dump/restore.'
+                f'The database instance does not appear to have been fully '
+                f'initialized or has been corrupted.'
             )
         )
 
-    datadir_catver = instancedata.get('catver')
-    expected_catver = edbdef.EDGEDB_CATALOG_VERSION
+    conn = await ctx.cluster.connect(database=sys_db)
 
-    if datadir_catver != expected_catver:
-        raise errors.ConfigurationError(
-            'database instance incompatible with this version of EdgeDB',
-            details=(
-                f'The database instance was initialized with '
-                f'EdgeDB format version {datadir_catver}, '
-                f'but this version of the server expects '
-                f'format version {expected_catver}'
-            ),
-            hint=(
-                f'You need to recreate the instance and upgrade '
-                f'using dump/restore.'
-            )
-        )
-
-
-async def _init_config(cluster: pgcluster.BaseCluster) -> None:
-    conn = await cluster.connect(database=edbdef.EDGEDB_TEMPLATE_DB)
     try:
-        await _check_data_dir_compatibility(conn)
+        instancedata = await _get_instance_data(conn)
+        datadir_version = instancedata.get('version')
+        if datadir_version:
+            datadir_major = datadir_version.get('major')
+
+        expected_ver = buildmeta.get_version()
+
+        if datadir_major != expected_ver.major:
+            raise errors.ConfigurationError(
+                'database instance incompatible with this version of EdgeDB',
+                details=(
+                    f'The database instance was initialized with '
+                    f'EdgeDB version {datadir_major}, '
+                    f'which is incompatible with this version '
+                    f'{expected_ver.major}'
+                ),
+                hint=(
+                    f'You need to recreate the instance and upgrade '
+                    f'using dump/restore.'
+                )
+            )
+
+        datadir_catver = instancedata.get('catver')
+        expected_catver = edbdef.EDGEDB_CATALOG_VERSION
+
+        if datadir_catver != expected_catver:
+            raise errors.ConfigurationError(
+                'database instance incompatible with this version of EdgeDB',
+                details=(
+                    f'The database instance was initialized with '
+                    f'EdgeDB format version {datadir_catver}, '
+                    f'but this version of the server expects '
+                    f'format version {expected_catver}'
+                ),
+                hint=(
+                    f'You need to recreate the instance and upgrade '
+                    f'using dump/restore.'
+                )
+            )
+    except Exception:
+        await conn.close()
+        raise
+
+    return conn
+
+
+async def _start(ctx: BootstrapContext) -> None:
+    conn = await _check_catalog_compatibility(ctx)
+
+    try:
         compiler = edbcompiler.Compiler()
         await compiler.initialize_from_pg(conn)
         std_schema = compiler.get_std_schema()
@@ -1191,75 +1274,92 @@ async def _init_config(cluster: pgcluster.BaseCluster) -> None:
 
 
 async def _bootstrap(
-    cluster: pgcluster.BaseCluster,
-    pgconn: asyncpg_con.Connection,
+    ctx: BootstrapContext,
     args: Dict[str, Any],
 ) -> None:
     await _ensure_edgedb_supergroup(
-        cluster,
-        pgconn,
+        ctx,
         edbdef.EDGEDB_SUPERGROUP,
     )
 
     superuser_uid = await _ensure_edgedb_role(
-        cluster,
-        pgconn,
+        ctx,
         edbdef.EDGEDB_SUPERUSER,
         superuser=True,
         builtin=True,
     )
 
-    await _execute(
-        pgconn,
-        f'SET ROLE {qi(edbdef.EDGEDB_SUPERUSER)};',
-    )
-    cluster.set_default_session_authorization(edbdef.EDGEDB_SUPERUSER)
+    superuser = ctx.cluster.get_role_name(edbdef.EDGEDB_SUPERUSER)
 
-    new_template_db_id = await _create_edgedb_template_database(
-        cluster, pgconn)
+    cluster = ctx.cluster
+    await _execute(ctx.conn, f'SET ROLE {qi(superuser)}')
+    cluster.set_default_session_authorization(superuser)
 
-    conn = await cluster.connect(database=edbdef.EDGEDB_TEMPLATE_DB)
+    in_dev_mode = devmode.is_in_dev_mode()
+    # Protect against multiple EdgeDB tenants from trying to bootstrap
+    # on the same cluster in devmode, as that is both a waste of resources
+    # and might result in broken stdlib cache.
+    if in_dev_mode:
+        bootstrap_lock = 0xEDB00001
+        await ctx.conn.execute('SELECT pg_advisory_lock($1)', bootstrap_lock)
+
+    new_template_db_id = await _create_edgedb_template_database(ctx)
+
+    tpl_db = cluster.get_db_name(edbdef.EDGEDB_TEMPLATE_DB)
+    conn = await cluster.connect(database=tpl_db)
 
     try:
+        tpl_ctx = ctx._replace(conn=conn)
         conn.add_log_listener(_pg_log_listener)
 
-        await _populate_misc_instance_data(cluster, conn)
+        await _populate_misc_instance_data(tpl_ctx)
 
         stdlib, compiler = await _init_stdlib(
-            cluster,
-            conn,
+            tpl_ctx,
             testmode=args['testmode'],
             global_ids={
                 edbdef.EDGEDB_SUPERUSER: superuser_uid,
                 edbdef.EDGEDB_TEMPLATE_DB: new_template_db_id,
             }
         )
-        await _bootstrap_config_spec(stdlib.stdschema, cluster)
-        await _compile_sys_queries(stdlib.reflschema, compiler, cluster)
+        await _bootstrap_config_spec(tpl_ctx, stdlib.stdschema)
+        await _compile_sys_queries(tpl_ctx, stdlib.reflschema, compiler)
 
         schema = s_schema.FlatSchema()
         schema = await _init_defaults(schema, compiler, conn)
         schema = await _populate_data(schema, compiler, conn)
     finally:
+        if in_dev_mode:
+            await ctx.conn.execute(
+                'SELECT pg_advisory_unlock($1)',
+                bootstrap_lock,
+            )
+
         await conn.close()
 
     await _create_edgedb_database(
-        pgconn,
+        ctx,
         edbdef.EDGEDB_SYSTEM_DB,
         edbdef.EDGEDB_SUPERUSER,
         builtin=True,
     )
 
-    conn = await cluster.connect(database=edbdef.EDGEDB_SYSTEM_DB)
+    conn = await cluster.connect(
+        database=cluster.get_db_name(edbdef.EDGEDB_SYSTEM_DB))
 
     try:
         conn.add_log_listener(_pg_log_listener)
-        await _configure(schema, compiler, conn, insecure=args['insecure'])
+        await _configure(
+            ctx._replace(conn=conn),
+            schema=schema,
+            compiler=compiler,
+            insecure=args['insecure'],
+        )
     finally:
         await conn.close()
 
     await _create_edgedb_database(
-        pgconn,
+        ctx,
         edbdef.EDGEDB_SUPERUSER_DB,
         edbdef.EDGEDB_SUPERUSER,
     )
@@ -1269,23 +1369,20 @@ async def _bootstrap(
         and args['default_database_user'] != edbdef.EDGEDB_SUPERUSER
     ):
         await _ensure_edgedb_role(
-            cluster,
-            pgconn,
+            ctx,
             args['default_database_user'],
             superuser=True,
         )
 
-        await _execute(
-            pgconn,
-            f"SET ROLE {qi(args['default_database_user'])};",
-        )
+        def_role = ctx.cluster.get_role_name(args['default_database_user'])
+        await _execute(ctx.conn, f"SET ROLE {qi(def_role)}")
 
     if (
         args['default_database']
         and args['default_database'] != edbdef.EDGEDB_SUPERUSER_DB
     ):
         await _create_edgedb_database(
-            pgconn,
+            ctx,
             args['default_database'],
             args['default_database_user'] or edbdef.EDGEDB_SUPERUSER,
         )
@@ -1298,14 +1395,14 @@ async def ensure_bootstrapped(
     pgconn = await cluster.connect()
     pgconn.add_log_listener(_pg_log_listener)
 
+    ctx = BootstrapContext(cluster=cluster, conn=pgconn)
+
     try:
-
-        if await _get_db_info(pgconn, edbdef.EDGEDB_TEMPLATE_DB):
-            await _init_config(cluster)
-            return False
-        else:
-            await _bootstrap(cluster, pgconn, args)
+        if await _is_pristine_cluster(ctx):
+            await _bootstrap(ctx, args)
             return True
-
+        else:
+            await _start(ctx)
+            return False
     finally:
         await pgconn.close()

--- a/edb/server/buildmeta.py
+++ b/edb/server/buildmeta.py
@@ -141,7 +141,7 @@ def hash_dirs(
 
 def read_data_cache(
     cache_key: bytes,
-    path: os.PathLike,
+    path: str,
     *,
     pickled: bool=True,
     source_dir: Optional[pathlib.Path] = None,
@@ -167,7 +167,7 @@ def read_data_cache(
 def write_data_cache(
     obj: Any,
     cache_key: bytes,
-    path: os.PathLike,
+    path: str,
     *,
     pickled: bool = True,
     target_dir: Optional[pathlib.Path] = None,
@@ -355,3 +355,8 @@ def get_cache_src_dirs():
         (pathlib.Path(find_spec('edb.lib').origin).parent, '.edgeql'),
         (pathlib.Path(find_spec('edb.pgsql.metaschema').origin).parent, '.py'),
     )
+
+
+def get_default_tenant_id() -> str:
+    catver = defines.EDGEDB_CATALOG_VERSION
+    return f'V{catver:x}'

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -561,6 +561,8 @@ cdef class DatabaseIndex:
         try:
             return self._dbs[dbname]
         except KeyError:
+            import traceback
+            traceback.print_stack()
             raise errors.UnknownDatabaseError(
                 f'database {dbname!r} does not exist')
 
@@ -617,7 +619,9 @@ cdef class DatabaseIndex:
         )
         block = dbops.PLTopBlock()
         dbops.UpdateMetadata(
-            dbops.Database(name=defines.EDGEDB_SYSTEM_DB),
+            dbops.Database(
+                name=self._server.get_pg_dbname(defines.EDGEDB_SYSTEM_DB),
+            ),
             {'sysconfig': json.loads(data)},
         ).generate(block)
         await conn.simple_query(block.to_string().encode(), True)

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,7 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_03_24_00_00
+EDGEDB_CATALOG_VERSION = 2021_04_18_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -422,7 +422,7 @@ cdef class EdgeConnection:
             pgaddr = dict(self.server._get_pgaddr())
             if pgaddr.get('password'):
                 pgaddr['password'] = '********'
-            pgaddr['database'] = self.dbview.dbname
+            pgaddr['database'] = self.server.get_pg_dbname(self.dbview.dbname)
             pgaddr.pop('ssl', None)
             if 'sslmode' in pgaddr:
                 pgaddr['sslmode'] = pgaddr['sslmode'].name

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1453,6 +1453,7 @@ class _EdgeDBServer:
         postgres_dsn: Optional[str] = None,
         runstate_dir: Optional[str] = None,
         reset_auth: Optional[bool] = None,
+        tenant_id: Optional[str] = None,
     ) -> None:
         self.auto_shutdown = auto_shutdown
         self.bootstrap_command = bootstrap_command
@@ -1463,6 +1464,7 @@ class _EdgeDBServer:
         self.postgres_dsn = postgres_dsn
         self.runstate_dir = runstate_dir
         self.reset_auth = reset_auth
+        self.tenant_id = tenant_id
         self.proc = None
         self.data = None
 
@@ -1573,6 +1575,9 @@ class _EdgeDBServer:
         if self.runstate_dir:
             cmd += ['--runstate-dir', self.runstate_dir]
 
+        if self.tenant_id:
+            cmd += ['--postgres-tenant-id', self.tenant_id]
+
         if self.debug:
             print(f'Starting EdgeDB cluster with the following params: {cmd}')
 
@@ -1621,6 +1626,7 @@ def start_edgedb_server(
     postgres_dsn: Optional[str] = None,
     runstate_dir: Optional[str] = None,
     reset_auth: Optional[bool] = None,
+    tenant_id: Optional[str] = None,
 ):
     if not devmode.is_in_dev_mode() and not runstate_dir:
         if postgres_dsn or adjacent_to:
@@ -1637,6 +1643,7 @@ def start_edgedb_server(
         compiler_pool_size=compiler_pool_size,
         debug=debug,
         postgres_dsn=postgres_dsn,
+        tenant_id=tenant_id,
         runstate_dir=runstate_dir,
         reset_auth=reset_auth,
     )

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3167,26 +3167,22 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     );
                 """)
 
-    async def test_edgeql_ddl_link_bad_01(self):
-        with self.assertRaisesRegex(
-                edgedb.SchemaDefinitionError,
-                f'link or property name length exceeds the maximum'):
-            async with self.con.transaction():
-                await self.con.execute("""
-                    CREATE ABSTRACT LINK test::f123456789_123456789_123456789_\
-123456789_123456789_123456789_123456789_123456789;
-                """)
+    async def test_edgeql_ddl_link_long_01(self):
+        link_name = (
+            'f123456789_123456789_123456789_123456789'
+            '_123456789_123456789_123456789_123456789'
+        )
+        await self.con.execute(f"""
+            CREATE ABSTRACT LINK test::{link_name};
+        """)
 
-        with self.assertRaisesRegex(
-                edgedb.SchemaDefinitionError,
-                f'link or property name length exceeds the maximum'):
-            async with self.con.transaction():
-                await self.con.execute("""
-                    CREATE TYPE test::Foo {
-                        CREATE LINK f123456789_123456789_123456789_\
-123456789_123456789_123456789_123456789_123456789 -> test::Foo;
-                    };
-                """)
+        await self.con.execute(f"""
+            CREATE TYPE test::Foo {{
+                CREATE LINK {link_name} -> test::Foo;
+            }};
+        """)
+
+        await self.con.query(f"SELECT test::Foo.{link_name}")
 
     async def test_edgeql_ddl_link_bad_02(self):
         with self.assertRaisesRegex(
@@ -3210,26 +3206,22 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     };
                 """)
 
-    async def test_edgeql_ddl_property_bad_01(self):
-        with self.assertRaisesRegex(
-                edgedb.SchemaDefinitionError,
-                f'link or property name length exceeds the maximum'):
-            async with self.con.transaction():
-                await self.con.execute("""
-                    CREATE ABSTRACT PROPERTY test::f123456789_123456789_\
-23456789_123456789_123456789_123456789_123456789_123456789;
-                """)
+    async def test_edgeql_ddl_property_long_01(self):
+        prop_name = (
+            'f123456789_123456789_123456789_123456789'
+            '_123456789_123456789_123456789_123456789'
+        )
+        await self.con.execute(f"""
+            CREATE ABSTRACT PROPERTY test::{prop_name}
+        """)
 
-        with self.assertRaisesRegex(
-                edgedb.SchemaDefinitionError,
-                f'link or property name length exceeds the maximum'):
-            async with self.con.transaction():
-                await self.con.execute("""
-                    CREATE TYPE test::Foo {
-                        CREATE PROPERTY f123456789_123456789_123456789_\
-123456789_123456789_123456789_123456789_123456789 -> std::str;
-                    };
-                """)
+        await self.con.execute(f"""
+            CREATE TYPE test::Foo {{
+                CREATE PROPERTY {prop_name} -> std::str;
+            }};
+        """)
+
+        await self.con.query(f"SELECT test::Foo.{prop_name}")
 
     async def test_edgeql_ddl_property_bad_02(self):
         with self.assertRaisesRegex(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -105,17 +105,6 @@ class TestSchema(tb.BaseSchemaLoadTest):
             };
         """
 
-    @tb.must_fail(errors.SchemaDefinitionError,
-                  'link or property name length exceeds the maximum.*',
-                  position=57)
-    def test_schema_bad_link_03(self):
-        """
-            type Object {
-                link f123456789_123456789_123456789_123456789_123456789\
-_123456789_123456789_123456789 -> Object
-            };
-        """
-
     @tb.must_fail(errors.InvalidPropertyTargetError,
                   "invalid property type: expected a scalar type, "
                   "or a scalar collection, got object type 'test::Object'",
@@ -135,17 +124,6 @@ _123456789_123456789_123456789 -> Object
         """
             type Object {
                 property foo := (SELECT Object)
-            };
-        """
-
-    @tb.must_fail(errors.SchemaDefinitionError,
-                  'link or property name length exceeds the maximum.*',
-                  position=57)
-    def test_schema_bad_prop_03(self):
-        """
-            type Object {
-                property f123456789_123456789_123456789_123456789_123456789\
-_123456789_123456789_123456789 -> str
             };
         """
 

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -18,6 +18,7 @@
 
 import edgedb
 
+from edb.schema import defines as s_def
 from edb.testbase import server as tb
 
 
@@ -156,3 +157,11 @@ class TestServerAuth(tb.ConnectedTestCase):
 
         finally:
             await self.con.query("DROP ROLE bar")
+
+    async def test_long_role_name(self):
+        with self.assertRaisesRegex(
+                edgedb.SchemaDefinitionError,
+                r'Role names longer than \d+ '
+                r'characters are not supported'):
+            await self.con.execute(
+                f'CREATE SUPERUSER ROLE myrole_{"x" * s_def.MAX_NAME_LENGTH};')


### PR DESCRIPTION
It is currently not possible to host multiple instances of EdgeDB on the
same Postgres cluster.  This complicates upgrades, since it is not always
convenient to spin up a parallel Postgres cluster just to upgrade EdgeDB,
especially if the upgrade needs to happen automatically.

Solve this by introducing a concept of EdgeDB *tenant*.  Each tenant is 
given a unique identifier, which is then used to qualify all globally 
visible Postgres objects (databases and roles).  It is possible to specify
the tenant id explicitly via the new `--postgres-tenant-id` server
command-line parameter.  The default tenant ID is derived from EdgeDB
catalog version, so it is now technically possible to start multiple 
incompatible EdgeDB versions on the same cluster.  Currently, the server 
would still refuse to do so, but upcoming work will introduce a mode where
this is allowed, and that'll make upgrades of EdgeDB running on a remote
cluster a much simpler story.