### PR TITLE
Fix duplicate pointers returned when using +=

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -171,6 +171,11 @@ def dump_code(*args, **kwargs):
     _markup.dump_code(*args, **kwargs)
 
 
+def dump_sql(sql, *args, **kwargs):
+    import edb.pgsql.codegen
+    dump_code(edb.pgsql.codegen.generate_source(sql))
+
+
 def set_trace(**kwargs):
     """Debugger hook that works inside worker processes.
 

--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -173,7 +173,7 @@ def dump_code(*args, **kwargs):
 
 def dump_sql(sql, *args, **kwargs):
     import edb.pgsql.codegen
-    dump_code(edb.pgsql.codegen.generate_source(sql))
+    dump_code(edb.pgsql.codegen.generate_source(sql), *args, **kwargs)
 
 
 def set_trace(**kwargs):

--- a/edb/ir/staeval.py
+++ b/edb/ir/staeval.py
@@ -84,7 +84,7 @@ def evaluate_SelectStmt(
         ir_stmt: irast.SelectStmt,
         schema: s_schema.Schema) -> irast.ConstExpr:
 
-    if irutils.is_trivial_select(ir_stmt):
+    if irutils.is_trivial_select(ir_stmt) and not ir_stmt.result.is_binding:
         return evaluate(ir_stmt.result, schema)
     else:
         raise UnsupportedExpressionError(

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -180,6 +180,7 @@ class CompilerContextLevel(compiler.ContextLevel):
                 Tuple[
                     str,
                     Union[pgast.BaseRelation, pgast.CommonTableExpr],
+                    irast.PathId,
                 ]
             ],
         ],

--- a/tests/schemas/updates.esdl
+++ b/tests/schemas/updates.esdl
@@ -27,6 +27,9 @@ type Tag {
     required property name -> str {
         constraint exclusive;
     }
+    required property flag -> int64 {
+        default := 0;
+    }
 }
 
 type UpdateTest {

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -500,6 +500,39 @@ class TestInsert(tb.QueryTestCase):
             }
         }])
 
+    async def test_edgeql_insert_nested_11(self):
+        await self.con.execute('''
+            WITH MODULE test
+            INSERT Subordinate {
+                name := 'linkprop test target 6'
+            };
+        ''')
+
+        await self.assert_query_result(
+            '''
+                WITH MODULE test
+                SELECT (
+                    INSERT InsertTest {
+                        name := 'insert nested 6',
+                        l2 := 0,
+                        subordinates := (
+                            SELECT (SELECT Subordinate LIMIT 1) {
+                                @comment := 'comment 6'
+                            }
+                        )
+                    }
+                ) {
+                    subordinates: { name, @comment }
+                }
+            ''',
+            [{
+                'subordinates': [{
+                    'name': 'linkprop test target 6',
+                    '@comment': 'comment 6'
+                }]
+            }]
+        )
+
     async def test_edgeql_insert_returning_01(self):
         await self.con.execute('''
             WITH MODULE test


### PR DESCRIPTION
Fixes #2455.

Also fixes a related issue of crashes when trying to return link
properties from DML, and a bad bug where FOR wouldn't be correlated
properly for multi pointers in UPDATEs.

Also fixes an annoying static eval bug I hit during testing this.