### PR TITLE
Disallow use of volatile functions in schema-defined computables

### DIFF
--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -118,13 +118,24 @@ def __infer_set(
     env: context.Environment,
 ) -> qltypes.Volatility:
     if ir.is_binding:
-        return STABLE
-    elif ir.rptr is not None:
-        return infer_volatility(ir.rptr.source, env)
+        vol = STABLE
     elif ir.expr is not None:
-        return infer_volatility(ir.expr, env)
+        vol = infer_volatility(ir.expr, env)
+    elif ir.rptr is not None:
+        vol = infer_volatility(ir.rptr.source, env)
     else:
-        return STABLE
+        vol = STABLE
+
+    # Cache our best-known as to this point volatility, to prevent
+    # infinite recursion.
+    env.inferred_volatility[ir] = vol
+
+    if ir.shape:
+        vol = _max_volatility([
+            _common_volatility((el for el, _ in ir.shape), env),
+            vol,
+        ])
+    return vol
 
 
 @_infer_volatility.register

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -119,10 +119,10 @@ def __infer_set(
 ) -> qltypes.Volatility:
     if ir.is_binding:
         vol = STABLE
-    elif ir.expr is not None:
-        vol = infer_volatility(ir.expr, env)
     elif ir.rptr is not None:
         vol = infer_volatility(ir.rptr.source, env)
+    elif ir.expr is not None:
+        vol = infer_volatility(ir.expr, env)
     else:
         vol = STABLE
 
@@ -132,7 +132,9 @@ def __infer_set(
 
     if ir.shape:
         vol = _max_volatility([
-            _common_volatility((el for el, _ in ir.shape), env),
+            _common_volatility(
+                (el.expr for el, _ in ir.shape if el.expr), env
+            ),
             vol,
         ])
     return vol

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -20,6 +20,8 @@
 from __future__ import annotations
 from typing import *
 
+from edb import errors
+
 from edb.edgeql import ast as qlast
 from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import qltypes
@@ -139,6 +141,14 @@ class AliasCommand(
                 in_ddl_context_name='alias definition',
             ),
         )
+
+        if ir.volatility == qltypes.Volatility.Volatile:
+            srcctx = self.get_attribute_source_context('expr')
+            raise errors.SchemaDefinitionError(
+                f'volatile functions are not permitted in schema-defined '
+                f'computables',
+                context=srcctx
+            )
 
         context.cache_value((expr, classname), ir)
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2625,13 +2625,7 @@ class TestExpressions(tb.QueryTestCase):
             [[3, 4.5], [1, 2]],
         )
 
-    @test.xfail("""
-        Error: can not take cross product of volatile operation
-
-        ... but it really shouldn't be a cross product, and a similar case
-        with + below works fine. Sigh.
-    """)
-    async def test_edgeql_expr_implicit_cast_07a(self):
+    async def test_edgeql_expr_implicit_cast_07(self):
         await self.assert_query_result(
             r"""
                 WITH
@@ -2645,22 +2639,6 @@ class TestExpressions(tb.QueryTestCase):
                 SELECT (3 / (A.a + A.b), 3 / (A.a + A.c)) LIMIT 1;
             """,
             [[1.5, 1.5]],
-        )
-
-    async def test_edgeql_expr_implicit_cast_07b(self):
-        await self.assert_query_result(
-            r"""
-                WITH
-                    MODULE schema,
-                    A := (
-                        SELECT ObjectType {
-                            a := 1,
-                            b := 1 + 0 * random(),  # float64
-                            c := 1 + 0 * <int64>random(),
-                        })
-                SELECT (3 / (A.a + A.b) + 3 / (A.a + A.c)) LIMIT 1;
-            """,
-            [3.0],
         )
 
     async def test_edgeql_expr_implicit_cast_08(self):


### PR DESCRIPTION
This required checking shape bodies in volatility inference

Fixes #2467.