### PR TITLE
remove query normalization error consistency check

### DIFF
--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -102,7 +102,8 @@ def _ql_typeexpr_to_type(
         return [_ql_typename_to_type(ql_t, ctx=ctx)]
 
     else:
-        raise errors.InternalServerError(f'unexpected TypeExpr: {ql_t!r}')
+        raise errors.EdgeQLSyntaxError("Unexpected type expression",
+                                       context=ql_t.context)
 
 
 def _ql_typename_to_type(

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1565,11 +1565,7 @@ class Compiler:
                 except errors.EdgeQLSyntaxError as denormalized_err:
                     raise denormalized_err
                 except Exception:
-                    raise AssertionError(
-                        "Normalized and non-normalized query errors differ")
-                else:
-                    raise AssertionError(
-                        "Normalized query is broken while original is valid")
+                    raise original_err
             else:
                 raise original_err
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1566,6 +1566,9 @@ class Compiler:
                     raise denormalized_err
                 except Exception:
                     raise original_err
+                else:
+                    raise AssertionError(
+                        "Normalized query is broken while original is valid")
             else:
                 raise original_err
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4751,3 +4751,9 @@ aa \
             ''',
             [],
         )
+
+    async def test_edgeql_normalization_missmatch_01(self):
+        with self.assertRaisesRegex(
+                edgedb.EdgeQLSyntaxError, "Unexpected '<'"):
+
+            await self.con.query('SELECT <tuple<"">>1;')

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4754,6 +4754,6 @@ aa \
 
     async def test_edgeql_normalization_missmatch_01(self):
         with self.assertRaisesRegex(
-                edgedb.EdgeQLSyntaxError, "Unexpected '<'"):
+                edgedb.EdgeQLSyntaxError, "Unexpected type expression"):
 
             await self.con.query('SELECT <tuple<"">>1;')


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb/issues/2343

The error consistency check is dropped because errors from normalized and non-normalized queries are not guaranteed to be the same.