### PR TITLE
Remove all pgsql backend renaming code

### DIFF
--- a/edb/pgsql/dbops/composites.py
+++ b/edb/pgsql/dbops/composites.py
@@ -147,23 +147,3 @@ class AlterCompositeAlterAttributeType:
     def __repr__(self):
         cls = self.__class__
         return f'<{cls.__name__} {self.attribute_name!r} to {self.new_type}>'
-
-
-class AlterCompositeRenameAttribute:
-    def __init__(
-            self, name, old_attr_name, new_attr_name, *, contained=False,
-            conditions=None, neg_conditions=None, priority=0):
-        super().__init__(
-            name, conditions=conditions, neg_conditions=neg_conditions,
-            priority=priority)
-        self.old_attr_name = old_attr_name
-        self.new_attr_name = new_attr_name
-
-    def code(self, block: base.PLBlock) -> str:
-        code = super().prefix_code()  # type: ignore
-        attrterm = self.get_attribute_term()  # type: ignore
-        old_attr_name = common.quote_ident(str(self.old_attr_name))
-        new_attr_name = common.quote_ident(str(self.new_attr_name))
-        code += ' RENAME {} {} TO {}'.format(
-            attrterm, old_attr_name, new_attr_name)
-        return code

--- a/edb/pgsql/dbops/ddl.py
+++ b/edb/pgsql/dbops/ddl.py
@@ -256,22 +256,6 @@ class CreateObject(SchemaObjectOperation):
             block.add_command(mdata.code(block))
 
 
-class RenameObject(SchemaObjectOperation):
-    def __init__(self, object, *, new_name, **kwargs):
-        super().__init__(name=object.name, **kwargs)
-        self.object = object
-        self.altered_object = object.copy()
-        self.altered_object.rename(new_name)
-        self.new_name = new_name
-
-    def generate_extra(self, block: base.PLBlock) -> None:
-        super().generate_extra(block)
-        if self.object.metadata:
-            mdata = UpdateMetadata(
-                self.altered_object, self.altered_object.metadata)
-            block.add_command(mdata.code(block))
-
-
 class AlterObject(SchemaObjectOperation):
     def __init__(self, object, **kwargs):
         super().__init__(object.get_id(), **kwargs)

--- a/edb/pgsql/dbops/functions.py
+++ b/edb/pgsql/dbops/functions.py
@@ -166,68 +166,6 @@ class CreateOrReplaceFunction(ddl.DDLOperation, FunctionOperation):
         return code.strip()
 
 
-class RenameFunction(base.CommandGroup):
-    def __init__(
-            self, name, args, new_name, *,
-            has_variadic=False,
-            conditions=None,
-            neg_conditions=None, priority=0):
-        super().__init__(
-            conditions=conditions, neg_conditions=neg_conditions,
-            priority=priority)
-
-        if name[0] != new_name[0]:
-            cmd = AlterFunctionSetSchema(
-                name, args, has_variadic, new_name[0])
-            self.add_command(cmd)
-            name = (new_name[0], name[1])
-
-        if name[1] != new_name[1]:
-            cmd = AlterFunctionRenameTo(
-                name, args, has_variadic, new_name[1])
-            self.add_command(cmd)
-
-
-class AlterFunctionSetSchema(ddl.DDLOperation, FunctionOperation):
-    def __init__(
-            self, name, args, has_variadic, new_schema, *,
-            conditions=None,
-            neg_conditions=None, priority=0):
-        super().__init__(
-            conditions=conditions, neg_conditions=neg_conditions,
-            priority=priority)
-        self.name = name
-        self.args = args
-        self.new_schema = new_schema
-        self.has_variadic = has_variadic
-
-    def code(self, block: base.PLBlock) -> str:
-        args = self.format_args(self.args, self.has_variadic,
-                                include_defaults=False)
-        return (f'ALTER FUNCTION {qn(*self.name)}({args}) '
-                f'SET SCHEMA {qi(self.new_schema)}')
-
-
-class AlterFunctionRenameTo(ddl.DDLOperation, FunctionOperation):
-    def __init__(
-            self, name, args, has_variadic, new_name, *,
-            conditions=None,
-            neg_conditions=None, priority=0):
-        super().__init__(
-            conditions=conditions, neg_conditions=neg_conditions,
-            priority=priority)
-        self.name = name
-        self.args = args
-        self.new_name = new_name
-        self.has_variadic = has_variadic
-
-    def code(self, block: base.PLBlock) -> str:
-        args = self.format_args(self.args, self.has_variadic,
-                                include_defaults=False)
-        return (f'ALTER FUNCTION {qn(*self.name)}({args}) '
-                f'RENAME TO {qi(self.new_name)}')
-
-
 class DropFunction(ddl.DDLOperation, FunctionOperation):
     def __init__(
             self, name, args, *,

--- a/edb/pgsql/dbops/schemas.py
+++ b/edb/pgsql/dbops/schemas.py
@@ -60,15 +60,6 @@ class CreateSchema(ddl.DDLOperation):
         return '<edb.sync.%s %s>' % (self.__class__.__name__, self.name)
 
 
-class RenameSchema(ddl.SchemaObjectOperation):
-    def __init__(self, name, new_name):
-        super().__init__(name)
-        self.new_name = new_name
-
-    def code(self, block: base.PLBlock) -> str:
-        return f'ALTER SCHEMA {qi(self.name)} RENAME TO {qi(self.new_name)}'
-
-
 class DropSchema(ddl.DDLOperation):
     def __init__(
             self, name, *, conditions=None, neg_conditions=None, priority=0):

--- a/edb/pgsql/dbops/sequences.py
+++ b/edb/pgsql/dbops/sequences.py
@@ -20,7 +20,6 @@
 from __future__ import annotations
 
 from ..common import qname as qn
-from ..common import quote_ident as qi
 
 from . import base
 from . import ddl
@@ -32,71 +31,6 @@ class CreateSequence(ddl.SchemaObjectOperation):
 
     def code(self, block: base.PLBlock) -> str:
         return f'CREATE SEQUENCE {qn(*self.name)}'
-
-
-class RenameSequence(base.CommandGroup):
-    def __init__(
-            self, name, new_name, *, conditions=None, neg_conditions=None,
-            priority=0):
-        super().__init__(
-            conditions=conditions, neg_conditions=neg_conditions,
-            priority=priority)
-
-        self.name = name
-        self.new_name = new_name
-
-        if name[0] != new_name[0]:
-            cmd = AlterSequenceSetSchema(name, new_name[0])
-            self.add_command(cmd)
-            name = (new_name[0], name[1])
-
-        if name[1] != new_name[1]:
-            cmd = AlterSequenceRenameTo(name, new_name[1])
-            self.add_command(cmd)
-
-    def __repr__(self):
-        return '<%s.%s "%s.%s" to "%s.%s">' % (
-            self.__class__.__module__, self.__class__.__name__, self.name[0],
-            self.name[1], self.new_name[0], self.new_name[1])
-
-
-class AlterSequenceSetSchema(ddl.DDLOperation):
-    def __init__(
-            self, name, new_schema, *, conditions=None, neg_conditions=None,
-            priority=0):
-        super().__init__(
-            conditions=conditions, neg_conditions=neg_conditions,
-            priority=priority)
-        self.name = name
-        self.new_schema = new_schema
-
-    def code(self, block: base.PLBlock) -> str:
-        return (f'ALTER SEQUENCE {qn(*self.name)} '
-                f'SET SCHEMA {qi(self.new_schema)}')
-
-    def __repr__(self):
-        return '<%s.%s "%s.%s" to "%s">' % (
-            self.__class__.__module__, self.__class__.__name__, self.name[0],
-            self.name[1], self.new_schema)
-
-
-class AlterSequenceRenameTo(ddl.DDLOperation):
-    def __init__(
-            self, name, new_name, *, conditions=None, neg_conditions=None,
-            priority=0):
-        super().__init__(
-            conditions=conditions, neg_conditions=neg_conditions,
-            priority=priority)
-        self.name = name
-        self.new_name = new_name
-
-    def code(self, block: base.PLBlock) -> str:
-        return f'ALTER SEQUENCE {qn(*self.name)} RENAME TO {qi(self.new_name)}'
-
-    def __repr__(self):
-        return '<%s.%s "%s.%s" to "%s">' % (
-            self.__class__.__module__, self.__class__.__name__, self.name[0],
-            self.name[1], self.new_name)
 
 
 class DropSequence(ddl.SchemaObjectOperation):

--- a/edb/pgsql/dbops/tables.py
+++ b/edb/pgsql/dbops/tables.py
@@ -507,25 +507,6 @@ class AlterTableAddConstraint(AlterTableFragment, TableConstraintCommand):
             self.constraint)
 
 
-class AlterTableRenameConstraintSimple(AlterTableBase, TableConstraintCommand):
-    def __init__(self, name, *, old_name, new_name, **kwargs):
-        assert name
-        super().__init__(name=name, **kwargs)
-        self.old_name = old_name
-        self.new_name = new_name
-
-    def code(self, block: base.PLBlock) -> str:
-        code = self.prefix_code()
-        code += (f' RENAME CONSTRAINT {qi(self.old_name)} '
-                 f'TO {qi(self.new_name)}')
-        return code
-
-    def __repr__(self):
-        return '<%s.%s %r to %r>' % (
-            self.__class__.__module__, self.__class__.__name__, self.old_name,
-            self.new_name)
-
-
 class AlterTableDropConstraint(AlterTableFragment, TableConstraintCommand):
     def __init__(self, constraint):
         self.constraint = constraint
@@ -537,33 +518,6 @@ class AlterTableDropConstraint(AlterTableFragment, TableConstraintCommand):
         return '<%s.%s %r>' % (
             self.__class__.__module__, self.__class__.__name__,
             self.constraint)
-
-
-class AlterTableSetSchema(AlterTableBase):
-    def __init__(self, name, schema, **kwargs):
-        super().__init__(name, **kwargs)
-        self.schema = schema
-
-    def code(self, block: base.PLBlock) -> str:
-        code = super().prefix_code()
-        code += f' SET SCHEMA {qi(self.schema)} '
-        return code
-
-
-class AlterTableRenameTo(AlterTableBase):
-    def __init__(self, name, new_name, **kwargs):
-        super().__init__(name, **kwargs)
-        self.new_name = new_name
-
-    def code(self, block: base.PLBlock) -> str:
-        code = super().prefix_code()
-        code += f' RENAME TO {qi(self.new_name)} '
-        return code
-
-
-class AlterTableRenameColumn(
-        composites.AlterCompositeRenameAttribute, AlterTableBase):
-    pass
 
 
 class DropTable(ddl.SchemaObjectOperation):

--- a/edb/pgsql/dbops/types.py
+++ b/edb/pgsql/dbops/types.py
@@ -24,7 +24,6 @@ import textwrap
 from edb.common import ordered
 
 from ..common import qname as qn
-from ..common import quote_ident as qi
 from ..common import quote_literal as ql
 
 from . import base
@@ -169,34 +168,6 @@ class AlterCompositeTypeAlterAttributeType(
         composites.AlterCompositeAlterAttributeType,
         AlterCompositeTypeFragment):
     pass
-
-
-class AlterCompositeTypeSetSchema(AlterCompositeTypeBase):
-    def __init__(self, name, schema, **kwargs):
-        super().__init__(name, **kwargs)
-        self.schema = schema
-
-    def code(self, block: base.PLBlock) -> str:
-        code = super().prefix_code()
-        code += f' SET SCHEMA {qi(self.schema)} '
-        return code
-
-
-class AlterCompositeTypeRenameTo(AlterCompositeTypeBase):
-    def __init__(self, name, new_name, **kwargs):
-        super().__init__(name, **kwargs)
-        self.new_name = new_name
-
-    def code(self, block: base.PLBlock) -> str:
-        code = super().prefix_code()
-        code += f' RENAME TO {qi(self.new_name)} '
-        return code
-
-
-class AlterCompositeTypeRenameAttribute(
-        composites.AlterCompositeRenameAttribute, AlterCompositeTypeBase):
-    def get_attribute_term(self):
-        return 'ATTRIBUTE'
 
 
 class DropCompositeType(ddl.SchemaObjectOperation):

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -309,20 +309,6 @@ class SchemaDomainConstraint:
 
         return ops
 
-    def rename_ops(self, orig_constr):
-        ops = dbops.CommandGroup()
-
-        domconstr = self._domain_constraint(self)
-        orig_domconstr = self._domain_constraint(orig_constr)
-
-        add_constr = dbops.AlterDomainRenameConstraint(
-            name=domconstr.get_subject_name(quote=False),
-            constraint=orig_domconstr, new_constraint=domconstr)
-
-        ops.add_command(add_constr)
-
-        return ops
-
     def alter_ops(self, orig_constr):
         ops = dbops.CommandGroup()
         return ops
@@ -375,20 +361,6 @@ class SchemaTableConstraint:
             name=tabconstr.get_subject_name(quote=False), constraint=tabconstr)
 
         ops.add_command(add_constr)
-
-        return ops
-
-    def rename_ops(self, orig_constr):
-        ops = dbops.CommandGroup()
-
-        tabconstr = self._table_constraint(self)
-        orig_tabconstr = self._table_constraint(orig_constr)
-
-        rename_constr = deltadbops.AlterTableRenameConstraint(
-            name=tabconstr.get_subject_name(quote=False),
-            constraint=orig_tabconstr, new_constraint=tabconstr)
-
-        ops.add_command(rename_constr)
 
         return ops
 


### PR DESCRIPTION
Since everything in the backend uses uuids for names and all
user-defined objects live in the same pgsql schema, we don't need any
of our backend renaming code, so rip it all out.

If something changes in the future and we need to generate a pgsql
rename, we can pull the old dbops code out of git.

Fixes #2406.