### PR TITLE
Include catalog version in package version metadata

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -10,14 +10,40 @@ on:
       - nightly
 
 jobs:
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.whichver.outputs.version }}
+      branch: ${{ steps.whichver.outputs.branch }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Determine package version
+      shell: bash
+      run: |
+        branch=${GITHUB_REF#refs/heads/}
+        if [[ $branch != releases/* ]]; then
+          echo ::error::"${branch} is not a release branch."
+          exit 1
+        fi
+        ver=${branch#releases/}
+        ver+=+g$(git rev-parse --verify --quiet "${GITHUB_REF}" | cut -c1-9)
+        ver+=.cv$(sed -n -r 's/EDGEDB_CATALOG_VERSION = ([0-9_]+)/\1/p' \
+                   edb/server/defines.py | sed 's/_//g')
+        echo ::set-output name=version::"${ver}"
+        echo ::set-output name=branch::"${branch}"
+      id: whichver
+
 <% for tgt in targets.linux %>
   build-<< tgt.name >>:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/<< tgt.platform >><< "-{}".format(tgt.platform_version) if tgt.platform_version >>@master
       env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "<< tgt.platform >>"
@@ -32,6 +58,7 @@ jobs:
 <% for tgt in targets.macos %>
   build-<< tgt.name >>:
     runs-on: macos-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v2
@@ -79,6 +106,7 @@ jobs:
 
     - name: Build
       env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "<< tgt.platform >>"

--- a/.github/workflows.src/release.tpl.yml
+++ b/.github/workflows.src/release.tpl.yml
@@ -5,23 +5,41 @@ on:
     inputs: {}
 
 jobs:
-<% for tgt in targets.linux %>
-  build-<< tgt.name >>:
+  prep:
     runs-on: ubuntu-latest
-
+    outputs:
+      version: ${{ steps.whichver.outputs.version }}
+      branch: ${{ steps.whichver.outputs.branch }}
     steps:
+    - uses: actions/checkout@v2
+
     - name: Determine package version
       shell: bash
       run: |
-        echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
-        echo ::set-output name=version::${GITHUB_REF#refs/heads/releases/}
+        branch=${GITHUB_REF#refs/heads/}
+        if [[ $branch != releases/* ]]; then
+          echo ::error::"${branch} is not a release branch."
+          exit 1
+        fi
+        ver=${branch#releases/}
+        ver+=+g$(git rev-parse --verify --quiet "${GITHUB_REF}" | cut -c1-9)
+        ver+=.cv$(sed -n -r 's/EDGEDB_CATALOG_VERSION = ([0-9_]+)/\1/p' \
+                   edb/server/defines.py | sed 's/_//g')
+        echo ::set-output name=version::"${ver}"
+        echo ::set-output name=branch::"${branch}"
       id: whichver
 
+<% for tgt in targets.linux %>
+  build-<< tgt.name >>:
+    runs-on: ubuntu-latest
+    needs: prep
+
+    steps:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/<< tgt.name >>@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "<< tgt.platform >>"
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
@@ -35,15 +53,9 @@ jobs:
 <% for tgt in targets.macos %>
   build-<< tgt.name >>:
     runs-on: macos-latest
+    needs: prep
 
     steps:
-    - name: Determine package version
-      shell: bash
-      run: |
-        echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
-        echo ::set-output name=version::${GITHUB_REF#refs/heads/releases/}
-      id: whichver
-
     - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
@@ -89,8 +101,8 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "<< tgt.platform >>"
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,14 +10,40 @@ on:
       - nightly
 
 jobs:
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.whichver.outputs.version }}
+      branch: ${{ steps.whichver.outputs.branch }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Determine package version
+      shell: bash
+      run: |
+        branch=${GITHUB_REF#refs/heads/}
+        if [[ $branch != releases/* ]]; then
+          echo ::error::"${branch} is not a release branch."
+          exit 1
+        fi
+        ver=${branch#releases/}
+        ver+=+g$(git rev-parse --verify --quiet "${GITHUB_REF}" | cut -c1-9)
+        ver+=.cv$(sed -n -r 's/EDGEDB_CATALOG_VERSION = ([0-9_]+)/\1/p' \
+                   edb/server/defines.py | sed 's/_//g')
+        echo ::set-output name=version::"${ver}"
+        echo ::set-output name=branch::"${branch}"
+      id: whichver
+
 
   build-debian-stretch:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-stretch@master
       env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -31,11 +57,13 @@ jobs:
 
   build-debian-buster:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
       env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "debian"
@@ -49,11 +77,13 @@ jobs:
 
   build-ubuntu-xenial:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-xenial@master
       env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -67,11 +97,13 @@ jobs:
 
   build-ubuntu-bionic:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
       env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -85,11 +117,13 @@ jobs:
 
   build-ubuntu-focal:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
       env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "ubuntu"
@@ -103,11 +137,13 @@ jobs:
 
   build-centos-7:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-7@master
       env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "centos"
@@ -121,11 +157,13 @@ jobs:
 
   build-centos-8:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
       env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "centos"
@@ -140,6 +178,7 @@ jobs:
 
   build-macos-x86_64:
     runs-on: macos-latest
+    needs: prep
 
     steps:
     - uses: actions/checkout@v2
@@ -187,6 +226,7 @@ jobs:
 
     - name: Build
       env:
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
         PKG_REVISION: "<current-date>"
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "macos"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,23 +5,41 @@ on:
     inputs: {}
 
 jobs:
-
-  build-debian-stretch:
+  prep:
     runs-on: ubuntu-latest
-
+    outputs:
+      version: ${{ steps.whichver.outputs.version }}
+      branch: ${{ steps.whichver.outputs.branch }}
     steps:
+    - uses: actions/checkout@v2
+
     - name: Determine package version
       shell: bash
       run: |
-        echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
-        echo ::set-output name=version::${GITHUB_REF#refs/heads/releases/}
+        branch=${GITHUB_REF#refs/heads/}
+        if [[ $branch != releases/* ]]; then
+          echo ::error::"${branch} is not a release branch."
+          exit 1
+        fi
+        ver=${branch#releases/}
+        ver+=+g$(git rev-parse --verify --quiet "${GITHUB_REF}" | cut -c1-9)
+        ver+=.cv$(sed -n -r 's/EDGEDB_CATALOG_VERSION = ([0-9_]+)/\1/p' \
+                   edb/server/defines.py | sed 's/_//g')
+        echo ::set-output name=version::"${ver}"
+        echo ::set-output name=branch::"${branch}"
       id: whichver
 
+
+  build-debian-stretch:
+    runs-on: ubuntu-latest
+    needs: prep
+
+    steps:
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-stretch@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "stretch"
@@ -34,20 +52,14 @@ jobs:
 
   build-debian-buster:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
-    - name: Determine package version
-      shell: bash
-      run: |
-        echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
-        echo ::set-output name=version::${GITHUB_REF#refs/heads/releases/}
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "buster"
@@ -60,20 +72,14 @@ jobs:
 
   build-ubuntu-xenial:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
-    - name: Determine package version
-      shell: bash
-      run: |
-        echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
-        echo ::set-output name=version::${GITHUB_REF#refs/heads/releases/}
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-xenial@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "xenial"
@@ -86,20 +92,14 @@ jobs:
 
   build-ubuntu-bionic:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
-    - name: Determine package version
-      shell: bash
-      run: |
-        echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
-        echo ::set-output name=version::${GITHUB_REF#refs/heads/releases/}
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "bionic"
@@ -112,20 +112,14 @@ jobs:
 
   build-ubuntu-focal:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
-    - name: Determine package version
-      shell: bash
-      run: |
-        echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
-        echo ::set-output name=version::${GITHUB_REF#refs/heads/releases/}
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "focal"
@@ -138,20 +132,14 @@ jobs:
 
   build-centos-7:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
-    - name: Determine package version
-      shell: bash
-      run: |
-        echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
-        echo ::set-output name=version::${GITHUB_REF#refs/heads/releases/}
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-7@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "centos"
         PKG_PLATFORM_VERSION: "7"
@@ -164,20 +152,14 @@ jobs:
 
   build-centos-8:
     runs-on: ubuntu-latest
+    needs: prep
 
     steps:
-    - name: Determine package version
-      shell: bash
-      run: |
-        echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
-        echo ::set-output name=version::${GITHUB_REF#refs/heads/releases/}
-      id: whichver
-
     - name: Build
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "centos"
         PKG_PLATFORM_VERSION: "8"
@@ -191,15 +173,9 @@ jobs:
 
   build-macos-x86_64:
     runs-on: macos-latest
+    needs: prep
 
     steps:
-    - name: Determine package version
-      shell: bash
-      run: |
-        echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
-        echo ::set-output name=version::${GITHUB_REF#refs/heads/releases/}
-      id: whichver
-
     - uses: actions/checkout@v2
       with:
         repository: edgedb/edgedb-pkg
@@ -245,8 +221,8 @@ jobs:
 
     - name: Build
       env:
-        SRC_REF: "${{ steps.whichver.outputs.branch }}"
-        PKG_VERSION: "${{ steps.whichver.outputs.version }}"
+        SRC_REF: "${{ needs.prep.outputs.branch }}"
+        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "macos"
         PKG_PLATFORM_VERSION: "x86_64"

--- a/edb/common/verutils.py
+++ b/edb/common/verutils.py
@@ -89,7 +89,7 @@ def parse_version(ver: str) -> Version:
 
         stage_no = int(v.group('pre_n'))
         if v.group('dev'):
-            local.extend(['dev', v.group('dev_n')])
+            local.extend([f'dev{v.group("dev_n")}'])
     elif v.group('dev'):
         stage = VersionStage.DEV
         stage_no = int(v.group('dev_n'))

--- a/setup.py
+++ b/setup.py
@@ -690,6 +690,9 @@ def custom_scm_version():
         'version_scheme': (
             functools.partial(buildmeta.scm_version_scheme, ROOT_PATH)
         ),
+        'local_scheme': (
+            functools.partial(buildmeta.scm_local_scheme, ROOT_PATH)
+        ),
     }
 
 


### PR DESCRIPTION
This includes `EDGEDB_CATALOG_VERSION` as build metadata in the version
string in the form `cv{version}`.  Also, the build metadata is now used
in release builds also.