### PR TITLE
Pool optimization

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -847,10 +847,12 @@ class Compiler:
 
         create_db = None
         drop_db = None
+        create_db_template = None
         if isinstance(stmt, qlast.DropDatabase):
             drop_db = stmt.name.name
         elif isinstance(stmt, qlast.CreateDatabase):
             create_db = stmt.name.name
+            create_db_template = stmt.template.name if stmt.template else None
 
         if debug.flags.delta_execute:
             debug.header('Delta Script')
@@ -867,6 +869,7 @@ class Compiler:
             ),
             create_db=create_db,
             drop_db=drop_db,
+            create_db_template=create_db_template,
             has_role_ddl=isinstance(stmt, qlast.RoleCommand),
             ddl_stmt_id=ddl_stmt_id,
             user_schema=current_tx.get_user_schema_if_updated(),
@@ -1673,6 +1676,7 @@ class Compiler:
                 unit.sql += comp.sql
                 unit.create_db = comp.create_db
                 unit.drop_db = comp.drop_db
+                unit.create_db_template = comp.create_db_template
                 unit.has_role_ddl = comp.has_role_ddl
                 unit.ddl_stmt_id = comp.ddl_stmt_id
                 if comp.user_schema is not None:

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -126,6 +126,7 @@ class DDLQuery(BaseQuery):
     single_unit: bool = False
     create_db: Optional[str] = None
     drop_db: Optional[str] = None
+    create_db_template: Optional[str] = None
     has_role_ddl: bool = False
     ddl_stmt_id: Optional[str] = None
 
@@ -224,6 +225,11 @@ class QueryUnit:
     # close all inactive unused pooled connections to it.
     create_db: Optional[str] = None
     drop_db: Optional[str] = None
+
+    # If non-None, contains a name of the DB that will be used as
+    # a template database to create the database. The server should
+    # close all inactive unused pooled connections to the template db.
+    create_db_template: Optional[str] = None
 
     # If non-None, the DDL statement will emit data packets marked
     # with the indicated ID.

--- a/edb/server/connpool/pool.py
+++ b/edb/server/connpool/pool.py
@@ -99,6 +99,24 @@ class ConnectionState:
 
 
 class Block(typing.Generic[C]):
+    # A Block holds a number of connections to the same backend database.
+    # A Pool consists of one or more blocks; blocks are the basic unit of
+    # connection pool algorithm, while the pool itself also takes care of
+    # balancing resources between Blocks (because all the blocks share the same
+    # PostgreSQL `max_connections` limit), based on realtime statistics the
+    # block collected and populated.
+    #
+    # Instead of the regular round-robin queue, EdgeDB adopted an LIFO stack
+    # (conn_stack) for the connections - the most recently used connections are
+    # always yielded first. This allows us to run "garbage collection" or
+    # "connection stealing" to recycle the unused connections from the bottom
+    # of the stack (the least recently used ones), so that other blocks could
+    # reuse the spared resource.
+    #
+    # Block is coroutine-safe. Multiple tasks acquiring connections will be put
+    # in a waiters' queue (conn_waiters), if the demand cannot be fulfilled
+    # immediately without blocking/awaiting. When connections are ready in the
+    # stack, the next task in the queue will be woken up to continue.
 
     loop: asyncio.AbstractEventLoop
     dbname: str
@@ -149,18 +167,26 @@ class Block(typing.Generic[C]):
         self._log_events = {}
 
     def count_conns(self) -> int:
+        # The total number of connections in this block, including:
+        #  - Future connections that are still pending in connecting
+        #  - Idle connections in the stack
+        #  - Acquired connections (not in the stack)
         return len(self.conns) + self.pending_conns
 
     def count_waiters(self) -> int:
+        # The number of tasks that are blocked in acquire()
         return self.conn_waiters_num
 
     def count_queued_conns(self) -> int:
+        # Number of connections in the stack/pool
         return len(self.conn_stack)
 
     def count_pending_conns(self) -> int:
+        # Number of future connections that are still pending in connecting
         return self.pending_conns
 
     def count_conns_over_quota(self) -> int:
+        # How many connections over the quota
         return max(self.count_conns() - self.quota, 0)
 
     def count_approx_available_conns(self) -> int:
@@ -183,10 +209,17 @@ class Block(typing.Generic[C]):
     def try_steal(
         self, only_older_than: typing.Optional[float] = None
     ) -> typing.Optional[C]:
+        # Try to take one unused connection from the block without blocking.
+        # If only_older_than is provided, only the connection that was put in
+        # the stack before the given timestamp is returned. None will be
+        # returned if we cannot find such connection in this block.
+
         if not self.conn_stack:
             return None
 
         if only_older_than is not None:
+            # We only need to check the bottom of the stack - higher items in
+            # the stack only have larger timestamps
             oldest_conn = self.conn_stack[0]
             if self.conns[oldest_conn].in_stack_since > only_older_than:
                 return None
@@ -201,6 +234,12 @@ class Block(typing.Generic[C]):
         self.conn_waiters_num += 1
         try:
             attempts = 0
+
+            # Skip the waiters' queue if we can grab a connection from the
+            # stack immediately - this is not completely fair, but it's
+            # extremely hard to always take the shortcut and starve the queue
+            # without blocking the main loop, so we are fine here. (This is
+            # also how asyncio.Queue is implemented.)
             while not self.conn_stack:
                 waiter = self.loop.create_future()
 
@@ -232,16 +271,22 @@ class Block(typing.Generic[C]):
                         self._wakeup_next_waiter()
                     raise
 
+            # Yield the most recently used connection from the top of the stack
             return self.conn_stack.pop()
         finally:
             self.conn_waiters_num -= 1
 
     def release(self, conn: C) -> None:
+        # Put the connection (back) to the top of the stack,
         self.conn_stack.append(conn)
+        # refresh the timestamp,
         self.conns[conn].in_stack_since = time.monotonic()
+        # and call the queue.
         self._wakeup_next_waiter()
 
     def abort_waiters(self, e: Exception) -> None:
+        # Propagate the given exception to all tasks that are waiting in
+        # acquire() - this usually means the underlying connect() is failing
         while self.conn_waiters:
             waiter = self.conn_waiters.popleft()
             if not waiter.done():
@@ -298,15 +343,20 @@ class BasePool(typing.Generic[C]):
     _disconnect_cb: Disconnector[C]
     _stats_cb: typing.Optional[StatsCollector]
 
-    _max_capacity: int
-    _cur_capacity: int
+    _max_capacity: int  # total number of connections allowed in the pool
+    _cur_capacity: int  # counter of all connections (with pending) in the pool
 
     _loop: typing.Optional[asyncio.AbstractEventLoop]
     _current_snapshot: typing.Optional[Snapshot]
 
     _blocks: collections.OrderedDict[str, Block[C]]
+    # Mapping from dbname to the Block instances, also used as a queue in a
+    # starving situation when the blocks are fed with connections in a round-
+    # robin fashion, see also Pool._tick().
 
     _is_starving: bool
+    # Indicates if any block is starving for connections, this usually means
+    # the number of active blocks is greater than the pool max capacity.
 
     _failed_connects: int
     _failed_disconnects: int
@@ -556,6 +606,44 @@ class BasePool(typing.Generic[C]):
 
 
 class Pool(BasePool[C]):
+    # The backend database connection pool implementation in EdgeDB, managing
+    # connections to multiple databases of a single PostgreSQL cluster,
+    # optimized for quality of service (QoS) so that connection acquisitions
+    # and distribution are automatically balanced in a relatively fair way.
+    # Connections to the same database are managed in a Block (see above).
+    #
+    # Conceptually, the Pool has 4 runtime modes (separately optimized):
+    #   Mode A: managing connections to only one database
+    #   Mode B: multiple databases, below max capacity
+    #   Mode C: reached max capacity, some tasks are waiting for connections
+    #   Mode D: some blocks are starving with zero connection
+    #
+    # Mode A is close to a regular connection pool - new connections are only
+    # created when there are not enough spare ones in the pool, and used
+    # connections are released back to the pool, cached for next acquisition
+    # (unless being idle for too long and GC will recycle them). As a
+    # simplified mode, there is usually a shortcut to return early for Mode A
+    # in the same code base shared with other modes.
+    #
+    # Mode B is simply an extension of Mode A for multiple databases. Each
+    # block in Mode B acts just like Mode A, with minimal difference like less
+    # aggressive connection creation. Different blocks could freely create new
+    # connections when needed, racing with each other organically by the demand
+    # for Postgres connections.
+    #
+    # Mode C is when things get complicated. Without being able to create more
+    # connections, pending connection requests can only be satisfied by either
+    # a released connection from the same block, or the pool as the arbiter has
+    # to "transfer" a connection from another block. This is achieved by
+    # rebalancing the pool based on calculated per-block quotas recalibrated
+    # in periodic "ticks" (see _tick()).
+    #
+    # In extreme cases, the number of blocks may go beyond the max capacity.
+    # This is Mode D when even each block takes only at most one connection,
+    # there are still some starved blocks that have no connections at all.
+    # Mode D reuses the framework of Mode C but runs separate logic in a
+    # different if-else branch. In short, the pool reallocates the limited
+    # total number of connections to different blocks in a round-robin fashion.
 
     _new_blocks_waitlist: collections.OrderedDict[Block[C], bool]
     _blocks_over_quota: typing.List[Block[C]]
@@ -597,6 +685,8 @@ class Pool(BasePool[C]):
             self._first_tick = False
             self._capture_snapshot(now=time.monotonic())
 
+        # Only schedule a tick under Mode C/D, and schedule at most one tick
+        # at a time.
         if not self._nacquires or self._htick is not None:
             return
 
@@ -608,6 +698,7 @@ class Pool(BasePool[C]):
     def _tick(self) -> None:
         self._htick = None
         if self._nacquires:
+            # Schedule the next tick if we're still in Mode C/D.
             self._maybe_schedule_tick()
 
         now = time.monotonic()
@@ -615,10 +706,9 @@ class Pool(BasePool[C]):
         self._report_snapshot()
         self._capture_snapshot(now=now)
 
-        # If we're managing connections to only one PostgreSQL DB,
-        # bail out early. Just give the one and only block we have
-        # the max possible quota (which is needed only for logging
-        # purposes.)
+        # If we're managing connections to only one PostgreSQL DB (Mode A),
+        # bail out early. Just give the one and only block we have the max
+        # possible quota (which is needed only for logging purposes.)
         nblocks = len(self._blocks)
         if nblocks <= 1:
             self._is_starving = False
@@ -628,6 +718,12 @@ class Pool(BasePool[C]):
                 first_block.nwaiters_avg.add(first_block.count_waiters())
             return
 
+        # Go over all the blocks and calculate:
+        #  - "nwaiters" - number of connection acquisitions
+        #    (including pending and acquired, per block and total)
+        #  - First round of per-block quota ( := nwaiters )
+        #  - Calibrated demand (per block and total)
+        #  - If any block is starving / Mode D
         need_conns_at_least = 0
         total_nwaiters = 0
         total_calibrated_demand: float = 0
@@ -640,6 +736,9 @@ class Pool(BasePool[C]):
             block.nwaiters_avg.add(nwaiters)
             nwaiters_avg = block.nwaiters_avg.avg()
             if nwaiters_avg:
+                # GOTCHA: this is a counter of blocks that need at least 1
+                # connection. If this number is greater than _max_capacity,
+                # some block will be starving with zero connection.
                 need_conns_at_least += 1
             else:
                 if not block.count_conns():
@@ -647,7 +746,7 @@ class Pool(BasePool[C]):
                     continue
 
             demand = (
-                max(block.nwaiters_avg.avg(), nwaiters) *
+                max(nwaiters_avg, nwaiters) *
                 max(block.querytime_avg.avg(), MIN_QUERY_TIME_THRESHOLD)
             )
             total_calibrated_demand += demand
@@ -661,23 +760,35 @@ class Pool(BasePool[C]):
                 self._drop_block(block)
 
         if not total_nwaiters:
+            # No connection acquisition, nothing to do here.
             return
 
         if total_nwaiters < self._max_capacity:
+            # The total demand for connections is lower than our max capacity,
+            # we could bail out early.
 
             if self._cur_capacity >= self._max_capacity:
+                # GOTCHA: this is still Mode C, because the total_nwaiters
+                # number doesn't include the unused connections in the stacks
+                # if any. Therefore, the rebalance here is necessary to shrink
+                # those blocks and transfer the connection quota to the
+                # starving ones (or they will block). We could simply depend on
+                # the already-set quota based on nwaiters, and skip the regular
+                # Mode C quota calculation below.
                 self._maybe_rebalance()
 
             else:
-                # If we still have space for more connections, don't actively
-                # rebalance the pool just yet - rebalance will kick in when the
-                # max capacity is hit; or we'll depend on the garbage
+                # If we still have space for more connections (Mode B), don't
+                # actively rebalance the pool just yet - rebalance will kick in
+                # when the max capacity is hit; or we'll depend on the garbage
                 # collection to shrink the over-quota blocks.
                 pass
 
             return
 
         if self._is_starving:
+            # Mode D: recalculate the per-block quota.
+
             for block in tuple(self._blocks.values()):
                 nconns = block.count_conns()
                 if nconns == 1:
@@ -707,6 +818,9 @@ class Pool(BasePool[C]):
                         dbname=block.dbname, event='reset-quota')
 
         else:
+            # Mode C: distribute the total connections by calibrated demand
+            # setting the per-block quota, then trigger rebalance.
+
             capacity_left = self._max_capacity
             if min_demand / total_calibrated_demand * self._max_capacity < 1:
                 for block in self._blocks.values():
@@ -755,6 +869,8 @@ class Pool(BasePool[C]):
             if nconns > quota:
                 self._try_shrink_block(block)
                 if block.count_conns() > quota:
+                    # If the block is still over quota, add it to a list so
+                    # that other blocks could steal connections from it
                     self._blocks_over_quota.append(block)
             elif nconns < quota:
                 while (
@@ -1095,9 +1211,6 @@ class _NaivePool(BasePool[C]):
         self._conns = {}
         self._last_tick = 0
 
-    def _maybe_free_conn(self, block: Block[C], conn: C) -> bool:
-        return False
-
     def _maybe_tick(self) -> None:
         now = time.monotonic()
 
@@ -1116,6 +1229,30 @@ class _NaivePool(BasePool[C]):
         self._report_snapshot()
         self._capture_snapshot(now=now)
 
+    async def _steal_conn(self, for_block: Block[C]) -> None:
+        # A simplified connection stealing implementation.
+        # First, tries to steal one from the blocks queue unconditionally.
+        for block in self._blocks.values():
+            if block is for_block:
+                continue
+            if (conn := block.try_steal()) is not None:
+                self._log_to_snapshot(
+                    dbname=block.dbname, event='conn-stolen')
+                self._schedule_transfer(block, conn, for_block)
+                self._blocks.move_to_end(block.dbname, last=True)
+                return
+        # If all the blocks are busy, simply wait in the queue to get one.
+        for block in self._blocks.values():
+            if block is for_block:
+                continue
+            if block.count_conns():
+                conn = await block.acquire()
+                self._log_to_snapshot(
+                    dbname=block.dbname, event='conn-stolen')
+                self._schedule_transfer(block, conn, for_block)
+                self._blocks.move_to_end(block.dbname, last=True)
+                return
+
     async def acquire(self, dbname: str) -> C:
         self._maybe_tick()
 
@@ -1123,6 +1260,11 @@ class _NaivePool(BasePool[C]):
 
         if self._cur_capacity < self._max_capacity:
             self._schedule_new_conn(block)
+        elif not block.count_conns():
+            # As a new block, steal one connection from other blocks if the
+            # max capacity is reached. We cannot depend on the transfer logic
+            # in `release()`, because it would hang if no other block releases.
+            await self._steal_conn(block)
 
         return await block.acquire()
 

--- a/edb/server/connpool/pool.py
+++ b/edb/server/connpool/pool.py
@@ -650,8 +650,17 @@ class Pool(BasePool[C]):
             return
 
         if total_nwaiters < self._max_capacity:
-            # The quota should already be set.
-            self._maybe_rebalance()
+
+            if self._cur_capacity >= self._max_capacity:
+                self._maybe_rebalance()
+
+            else:
+                # If we still have space for more connections, don't actively
+                # rebalance the pool just yet - rebalance will kick in when the
+                # max capacity is hit; or we'll depend on the garbage
+                # collection to shrink the over-quota blocks.
+                pass
+
             return
 
         if self._is_starving:

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -988,6 +988,10 @@ cdef class EdgeConnection:
                 new_types = None
                 self.dbview.start(query_unit)
                 try:
+                    if query_unit.create_db_template:
+                        await self.server._on_before_create_db_from_template(
+                            query_unit.create_db_template, self.dbview.dbname
+                        )
                     if query_unit.drop_db:
                         await self.server._on_before_drop_db(
                             query_unit.drop_db, self.dbview.dbname)
@@ -1449,6 +1453,10 @@ cdef class EdgeConnection:
         conn = await self.get_pgcon()
         try:
             self.dbview.start(query_unit)
+            if query_unit.create_db_template:
+                await self.server._on_before_create_db_from_template(
+                    query_unit.create_db_template, self.dbview.dbname
+                )
             if query_unit.drop_db:
                 await self.server._on_before_drop_db(
                     query_unit.drop_db, self.dbview.dbname)

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -586,11 +586,26 @@ class Server:
         dbname: str,
         current_dbname: str
     ) -> None:
-        assert self._dbindex is not None
-
         if current_dbname == dbname:
             raise errors.ExecutionError(
                 f'cannot drop the currently open database {dbname!r}')
+
+        await self._ensure_database_not_connected(dbname)
+
+    async def _on_before_create_db_from_template(
+        self,
+        dbname: str,
+        current_dbname: str
+    ):
+        if current_dbname == dbname:
+            raise errors.ExecutionError(
+                f'cannot create database using currently open database '
+                f'{dbname!r} as a template database')
+
+        await self._ensure_database_not_connected(dbname)
+
+    async def _ensure_database_not_connected(self, dbname: str):
+        assert self._dbindex is not None
 
         if self._dbindex.count_connections(dbname):
             # If there are open EdgeDB connections to the `dbname` DB


### PR DESCRIPTION
This PR has 5 commits:

## Single block: don't create connection if more than 1 available

Before this PR, the pool will keep adding connections on any `acquire()` when it's managing connections to only one database. That means we'll soon reach the max capacity even if we have only one frontend connection, as far as we keep issuing EdgeQL queries. This wasn't a big issue, just a waste of connections, especially after we add GC in this PR.

This commit checks if the current `acquire()` and the next `acquire()` could return immediately. If yes, don't create a new connection.

## Don't rebalance if `max_capacity` is not reached.

If we still have space for more connections, don't actively rebalance the pool just yet. Because the blocks could just create more connections and don't have to worry about other blocks just yet. Rebalance will kick in when the max
capacity is hit; or we'll depend on the garbage collection (see below) to shrink the over-quota blocks.

## Implement pool "Garbage Collection" (discard unused conns)

This commit makes the per-block connection queue *a stack*, with each connection paired with a monotonic timestamp indicating when it was pushed into the stack. GC is implemented using the same `try_steal` logic to pull connections from the bottom of the stack until a preset timestamp limit is met. GC is now running every 2 minutes after the first idle connection is freed into the pool, and pauses if no idle connection is freed in the last 2 GC cycles. So theoretically an idle connection will be discarded between 2-4 minutes after it's returned to the pool and not otherwise stolen or rebalanced.

## pool: Add comments

Explaining the pool logic. This will be mapped to a blog post later.

This commit also added a simplified `_steal_conn()` to the `NaivePool` so that it doesn't hang if a new block is requested while there's no connection returned in old blocks.

## Prune unused connections when creating from template database

Creating a database from a template database requires the template database have no active connections. With the above changes, now it's possible to have pooled but unused connections to the "template" database while running `CREATE DATABASE xxx FROM yyy`. We simply do the same as we did before dropping a database - prune the unused pooled connections, or raise an error if we know the database has connections.