### PR TITLE
Enable `DESCRIBE SCHEMA AS SDL`.

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -787,8 +787,13 @@ def compile_DescribeStmt(
 
         if ql.object is qlast.DescribeGlobal.Schema:
             if ql.language is qltypes.DescribeLanguage.DDL:
-                # DESCRIBE SCHEMA
+                # DESCRIBE SCHEMA AS DDL
                 text = s_ddl.ddl_text_from_schema(
+                    ctx.env.schema,
+                )
+            elif ql.language is qltypes.DescribeLanguage.SDL:
+                # DESCRIBE SCHEMA AS SDL
+                text = s_ddl.sdl_text_from_schema(
                     ctx.env.schema,
                 )
             else:

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -225,7 +225,7 @@ def delta_schemas(
         excluded_items = set(excluded_items)
 
     if include_module_diff:
-        for added_module in added_modules:
+        for added_module in sorted(added_modules):
             if (
                 guidance is None
                 or (
@@ -349,7 +349,7 @@ def delta_schemas(
             result.add(cmd)
 
     if include_module_diff:
-        for dropped_module in dropped_modules:
+        for dropped_module in sorted(dropped_modules):
             if (
                 guidance is None
                 or (
@@ -715,8 +715,37 @@ def statements_from_delta(
 
     ql_classes = {q for q in ql_classes_src if q is not None}
 
-    text = []
+    # If we're generating SDL and it includes modules, try to nest the
+    # module contents in the actual modules.
+    processed: List[Tuple[qlast.DDLOperation, sd.Command]] = []
+    modules = dict()
     for stmt_ast, cmd in stmts.items():
+        if sdlmode:
+            if isinstance(stmt_ast, qlast.CreateModule):
+                # Record the module stubs.
+                modules[stmt_ast.name.name] = stmt_ast
+                stmt_ast.commands = []
+                processed.append((stmt_ast, cmd))
+
+            elif modules and not isinstance(stmt_ast, qlast.CreateModule):
+                # This SDL included creation of modules, so we will try to
+                # nest the declarations in them.
+                assert isinstance(stmt_ast, qlast.CreateObject)
+                assert stmt_ast.name.module is not None
+                module = modules[stmt_ast.name.module]
+                module.commands.append(stmt_ast)
+                # Strip the module from the object name, since we nest
+                # them in a module already.
+                stmt_ast.name.module = None
+
+            else:
+                processed.append((stmt_ast, cmd))
+
+        else:
+            processed.append((stmt_ast, cmd))
+
+    text = []
+    for stmt_ast, cmd in processed:
         stmt_text = edgeql.generate_source(
             stmt_ast,
             sdlmode=sdlmode,


### PR DESCRIPTION
The DESCRIBE SCHEMA command will produce SDL format. The module
contents are nested inside the respective modules, and the top-level
names are simplified accordingly.