### PR TITLE
Proposal: fix double release refs #2257

### DIFF
--- a/edb/server/protocol/binary.pxd
+++ b/edb/server/protocol/binary.pxd
@@ -114,6 +114,7 @@ cdef class EdgeConnection:
         int _get_pgcon_cc
 
         bint _cancelled
+        bint _pgcon_released
 
     cdef parse_io_format(self, bytes mode)
     cdef parse_cardinality(self, bytes card)

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -214,6 +214,7 @@ cdef class EdgeConnection:
         self.buffer = ReadBuffer()
 
         self._cancelled = False
+        self._pgcon_released = False
 
         self._main_task = None
         self._msg_take_waiter = None
@@ -256,6 +257,7 @@ cdef class EdgeConnection:
             raise RuntimeError('there is already a pinned pgcon')
         conn = await self.server.acquire_pgcon(self.dbview.dbname)
         self._pinned_pgcon = conn
+        self._pgcon_released = False
         return conn
 
     def maybe_release_pgcon(self, pgcon.PGConnection conn):
@@ -273,15 +275,15 @@ cdef class EdgeConnection:
                 # return the connection to the pool (where it would be
                 # discarded and re-opened.)
                 self._pinned_pgcon = None
-                self.server.release_pgcon(
-                    self.dbview.dbname, conn)
+                if not self._pgcon_released:
+                    self.server.release_pgcon(self.dbview.dbname, conn)
             else:
                 self._pinned_pgcon_in_tx = True
         else:
             self._pinned_pgcon_in_tx = False
             self._pinned_pgcon = None
-            self.server.release_pgcon(
-                self.dbview.dbname, conn)
+            if not self._pgcon_released:
+                self.server.release_pgcon(self.dbview.dbname, conn)
 
     def debug_print(self, *args):
         print(
@@ -2106,6 +2108,9 @@ cdef class EdgeConnection:
                             self.dbview.dbname,
                         )
                     )
+                    # Prevent the main task from releasing the same connection
+                    # twice. This flag is for now only used in this case.
+                    self._pgcon_released = True
 
                 # In all other cases, we can just wait until the `main()`
                 # coroutine notices that `self._cancelled` was set.


### PR DESCRIPTION
```
================================================================================
ERROR: test_server_proto_concurrent_global_ddl (test_server_proto.TestServerProtoConcurrentGlobalDDL)
--------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/x86_64-linux-gnu/edgedb-server-1-beta2-dev202103240000/lib/python3.9/site-packages/edb/testbase/server.py", line 919, in tearDown
    self.loop.run_until_complete(
  File "/usr/lib/x86_64-linux-gnu/edgedb-server-1-beta2-dev202103240000/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/usr/lib/x86_64-linux-gnu/edgedb-server-1-beta2-dev202103240000/lib/python3.9/site-packages/edgedb/asyncio_con.py", line 359, in execute
    await self._impl._protocol.simple_query(
  File "edgedb/protocol/protocol.pyx", line 578, in simple_query
edgedb.errors.InternalServerError: cannot release connection <edb.server.pgcon.pgcon.PGConnection object at 0x7fb4635c0510>: the connection does not belong to the pool
```