### PR TITLE
Fix flaky server version test

### DIFF
--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -967,9 +967,9 @@ class TestServerConfig(tb.QueryTestCase, tb.OldCLITestCaseMixin):
 
         self.assertEqual(
             (ver.major, ver.minor, ver.stage.name.lower(),
-             ver.stage_no, ver.local),
+             ver.stage_no,),
             (srv_ver.major, srv_ver.minor, str(srv_ver.stage),
-             srv_ver.stage_no, tuple(srv_ver.local))
+             srv_ver.stage_no,)
         )
 
         srv_ver_string = await self.con.query_one(r"""


### PR DESCRIPTION
The `test_server_version()` test is failing intermittently because we
increased the precision of the date component.  Fix this by trimming the
precision of the comparison.