### PR TITLE
Store compiler pool sockets in a private runstate directory

### DIFF
--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -125,7 +125,7 @@ def _ensure_runstate_dir(
 @contextlib.contextmanager
 def _internal_state_dir(runstate_dir):
     try:
-        with tempfile.TemporaryDirectory(prefix='internal-',
+        with tempfile.TemporaryDirectory(prefix='edgedb-internal-',
                                          dir=runstate_dir) as td:
             yield td
     except PermissionError as ex:

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -251,7 +251,7 @@ class Server:
             self._compiler_pool = await compiler_pool.create_compiler_pool(
                 pool_size=self._compiler_pool_size,
                 dbindex=self._dbindex,
-                runstate_dir=self._runstate_dir,
+                runstate_dir=self._internal_runstate_dir,
                 backend_runtime_params=self.get_backend_runtime_params(),
                 std_schema=self._std_schema,
                 refl_schema=self._refl_schema,


### PR DESCRIPTION
The compiler pool shouldn't store its sockets in a unique subdirectory
in the common runstate-dir to avoid bizzare hangs and/or crashes if
multiple EdgeDB instances are started with the same `--runstate-dir`.