### PR TITLE
Add an option to ignore other tenant in single-tenant mode

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -61,8 +61,8 @@ class ServerConfig(NamedTuple):
     insecure: bool
     data_dir: pathlib.Path
     postgres_dsn: str
-    postgres_tenant_id: Optional[str]
-    ignore_other_postgres_tenant: bool
+    tenant_id: Optional[str]
+    ignore_other_tenants: bool
     log_level: str
     log_to: str
     bootstrap_only: bool
@@ -206,7 +206,7 @@ _server_options = [
         '--postgres-dsn', type=str,
         help='DSN of a remote Postgres cluster, if using one'),
     click.option(
-        '--postgres-tenant-id',
+        '--tenant-id',
         type=str,
         callback=_validate_tenant_id,
         help='Specifies the tenant ID of this server when hosting'
@@ -215,7 +215,7 @@ _server_options = [
              f' {schema_defines.MAX_TENANT_ID_LENGTH} characters long.',
     ),
     click.option(
-        '--ignore-other-postgres-tenant',
+        '--ignore-other-tenants',
         is_flag=True,
         help='If set, the server will ignore the presence of another tenant '
              'in the database instance in single-tenant mode instead of '

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -62,6 +62,7 @@ class ServerConfig(NamedTuple):
     data_dir: pathlib.Path
     postgres_dsn: str
     postgres_tenant_id: Optional[str]
+    ignore_other_postgres_tenant: bool
     log_level: str
     log_to: str
     bootstrap_only: bool
@@ -212,6 +213,13 @@ _server_options = [
              ' multiple EdgeDB instances on one Postgres cluster.'
              ' Must be an alphanumeric ASCII string, maximum'
              f' {schema_defines.MAX_TENANT_ID_LENGTH} characters long.',
+    ),
+    click.option(
+        '--ignore-other-postgres-tenant',
+        is_flag=True,
+        help='If set, the server will ignore the presence of another tenant '
+             'in the database instance in single-tenant mode instead of '
+             'exiting with a catalog incompatibility error.'
     ),
     click.option(
         '-l', '--log-level',

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -219,25 +219,35 @@ async def _is_pristine_cluster(ctx: BootstrapContext) -> bool:
     is_default_tenant = tenant_id == buildmeta.get_default_tenant_id()
 
     if is_default_tenant:
-        result = await ctx.conn.fetchrow('''
+        result = await ctx.conn.fetch('''
             SELECT
-                True
+                r.rolname
             FROM
                 pg_catalog.pg_roles AS r
             WHERE
-                r.rolname LIKE ('%_' || $1)
+                r.rolname LIKE ('%' || $1)
         ''', edbdef.EDGEDB_SUPERGROUP)
     else:
-        result = await ctx.conn.fetchrow('''
+        result = await ctx.conn.fetch('''
             SELECT
-                True
+                r.rolname
             FROM
                 pg_catalog.pg_roles AS r
             WHERE
                 r.rolname = $1
         ''', ctx.cluster.get_role_name(edbdef.EDGEDB_SUPERGROUP))
 
-    return not result
+    if not result:
+        return True
+    elif is_default_tenant and ctx.args.ignore_other_postgres_tenant:
+        for row in result:
+            rolname = row['rolname']
+            other_tenant_id = rolname[: -(len(edbdef.EDGEDB_SUPERGROUP) + 1)]
+            if other_tenant_id == tenant_id:
+                return False
+        return True
+    else:
+        return False
 
 
 async def _create_edgedb_template_database(
@@ -1191,7 +1201,10 @@ async def _check_catalog_compatibility(
         sys_db = await ctx.conn.fetchval(f'''
             SELECT datname
             FROM pg_database
-            WHERE datname LIKE '%_' || $1
+            WHERE datname LIKE '%' || $1
+            ORDER BY
+                datname = $1,
+                datname DESC
             LIMIT 1
         ''', edbdef.EDGEDB_SYSTEM_DB)
     else:

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -239,7 +239,7 @@ async def _is_pristine_cluster(ctx: BootstrapContext) -> bool:
 
     if not result:
         return True
-    elif is_default_tenant and ctx.args.ignore_other_postgres_tenant:
+    elif is_default_tenant and ctx.args.ignore_other_tenants:
         for row in result:
             rolname = row['rolname']
             other_tenant_id = rolname[: -(len(edbdef.EDGEDB_SUPERGROUP) + 1)]

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -247,10 +247,10 @@ def run_server(args: srvargs.ServerConfig, *, do_setproctitle: bool=False):
     pg_cluster_init_by_us = False
     pg_cluster_started_by_us = False
 
-    if args.postgres_tenant_id is None:
+    if args.tenant_id is None:
         tenant_id = buildmeta.get_default_tenant_id()
     else:
-        tenant_id = f'C{args.postgres_tenant_id}'
+        tenant_id = f'C{args.tenant_id}'
 
     cluster: Union[pgcluster.Cluster, pgcluster.RemoteCluster]
     if args.data_dir:

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1547,7 +1547,7 @@ class _EdgeDBServer:
             cmd += ['--runstate-dir', self.runstate_dir]
 
         if self.tenant_id:
-            cmd += ['--postgres-tenant-id', self.tenant_id]
+            cmd += ['--tenant-id', self.tenant_id]
 
         if self.debug:
             print(f'Starting EdgeDB cluster with the following params: {cmd}')

--- a/edb/tools/wipe.py
+++ b/edb/tools/wipe.py
@@ -62,6 +62,7 @@ class AbsPath(click.Path):
 @click.option(
     '--postgres-tenant-id',
     type=str,
+    multiple=True,
     help='The tenant ID of an EdgeDB server to wipe.  May be specified'
          ' multiple times.  If not specified, all tenants are wiped.')
 @click.option(
@@ -73,7 +74,19 @@ class AbsPath(click.Path):
     '--dry-run',
     is_flag=True,
     help='give a summary of wipe operations without performing them')
-def wipe(*, postgres_dsn, data_dir, tenant_id, yes, dry_run):
+@click.option(
+    '--list-tenants',
+    is_flag=True,
+    help='list cluster tenants instead of performing a wipe')
+def wipe(
+    *,
+    postgres_dsn,
+    data_dir,
+    postgres_tenant_id,
+    yes,
+    dry_run,
+    list_tenants,
+):
     if postgres_dsn:
         cluster = pgcluster.get_remote_pg_cluster(
             postgres_dsn,
@@ -95,7 +108,7 @@ def wipe(*, postgres_dsn, data_dir, tenant_id, yes, dry_run):
             'either --postgres-dsn or --data-dir is required'
         )
 
-    if not yes and not click.confirm(
+    if not yes and not dry_run and not list_tenants and not click.confirm(
             'This will DELETE all EdgeDB data from the target '
             'PostgreSQL instance.  ARE YOU SURE?'):
         click.echo('OK. Not proceeding.')
@@ -108,11 +121,13 @@ def wipe(*, postgres_dsn, data_dir, tenant_id, yes, dry_run):
             click.secho(f'Remote cluster is not running', fg='red')
             sys.exit(1)
         else:
-            cluster.start(port=0)
+            cluster.start()
             cluster_started_by_us = True
 
     try:
-        asyncio.run(do_wipe(cluster, tenant_id, dry_run))
+        asyncio.run(
+            do_wipe(cluster, postgres_tenant_id, dry_run, list_tenants),
+        )
     finally:
         if cluster_started_by_us:
             cluster.stop()
@@ -122,6 +137,7 @@ async def do_wipe(
     cluster: pgcluster.BaseCluster,
     tenants: List[str],
     dry_run: bool,
+    list_tenants: bool,
 ) -> None:
 
     conn = await cluster.connect()
@@ -129,11 +145,28 @@ async def do_wipe(
     try:
         if not tenants:
             tenants = await _get_all_tenants(conn)
+            if list_tenants:
+                print('\n'.join(t if t else '(none)' for t in tenants))
+                return
 
         for tenant in tenants:
             await wipe_tenant(cluster, conn, tenant, dry_run)
     finally:
         await conn.close()
+
+
+def get_database_backend_name(name: str, tenant_id: str) -> str:
+    if not tenant_id:
+        return name
+    else:
+        return pgcommon.get_database_backend_name(name, tenant_id=tenant_id)
+
+
+def get_role_backend_name(name: str, tenant_id: str) -> str:
+    if not tenant_id:
+        return name
+    else:
+        return pgcommon.get_role_backend_name(name, tenant_id=tenant_id)
 
 
 async def wipe_tenant(
@@ -143,12 +176,12 @@ async def wipe_tenant(
     dry_run: bool,
 ) -> None:
 
-    tpl_db = pgcommon.get_database_backend_name(
+    tpl_db = get_database_backend_name(
         edbdef.EDGEDB_TEMPLATE_DB,
         tenant_id=tenant,
     )
 
-    sup_role = pgcommon.get_role_backend_name(
+    sup_role = get_role_backend_name(
         edbdef.EDGEDB_SUPERUSER,
         tenant_id=tenant,
     )
@@ -172,7 +205,7 @@ async def wipe_tenant(
     ]
 
     for db in databases:
-        pg_db = pgcommon.get_database_backend_name(db, tenant_id=tenant)
+        pg_db = get_database_backend_name(db, tenant_id=tenant)
         owner = await pgconn.fetchval("""
             SELECT
                 rolname
@@ -195,7 +228,7 @@ async def wipe_tenant(
     stmts.append('RESET ROLE;')
 
     for role in roles:
-        pg_role = pgcommon.get_role_backend_name(role, tenant_id=tenant)
+        pg_role = get_role_backend_name(role, tenant_id=tenant)
 
         members = await pgconn.fetchval("""
             SELECT
@@ -210,6 +243,10 @@ async def wipe_tenant(
             stmts.append(f'REVOKE {qi(pg_role)} FROM {qi(member)}')
 
         stmts.append(f'DROP ROLE {qi(pg_role)}')
+
+    super_group = get_role_backend_name(
+        edbdef.EDGEDB_SUPERGROUP, tenant_id=tenant)
+    stmts.append(f'DROP ROLE {qi(super_group)}')
 
     for stmt in stmts:
         click.echo(stmt + (';' if not stmt.endswith(';') else ''))
@@ -226,12 +263,15 @@ async def _get_all_tenants(
             FROM pg_database
             WHERE datname LIKE $1
         """,
-        f"%_{edbdef.EDGEDB_TEMPLATE_DB}",
+        f"%{edbdef.EDGEDB_TEMPLATE_DB}",
     )
 
     tenants = []
     for db in dbs:
-        t, _, _ = db['datname'].partition('_')
+        if db['datname'] == edbdef.EDGEDB_TEMPLATE_DB:
+            t = ""
+        else:
+            t, _, _ = db['datname'].partition('_')
         tenants.append(t)
 
     return tenants

--- a/edb/tools/wipe.py
+++ b/edb/tools/wipe.py
@@ -60,7 +60,7 @@ class AbsPath(click.Path):
     type=AbsPath(),
     help='database cluster directory')
 @click.option(
-    '--postgres-tenant-id',
+    '--tenant-id',
     type=str,
     multiple=True,
     help='The tenant ID of an EdgeDB server to wipe.  May be specified'
@@ -82,7 +82,7 @@ def wipe(
     *,
     postgres_dsn,
     data_dir,
-    postgres_tenant_id,
+    tenant_id,
     yes,
     dry_run,
     list_tenants,
@@ -126,7 +126,7 @@ def wipe(
 
     try:
         asyncio.run(
-            do_wipe(cluster, postgres_tenant_id, dry_run, list_tenants),
+            do_wipe(cluster, tenant_id, dry_run, list_tenants),
         )
     finally:
         if cluster_started_by_us:


### PR DESCRIPTION
To allow in-place upgrades, add the new `--ignore-other-postgres-tenant`
server flag, which will ask the server to ignore the existing tenant
with a different catalog version in single-tenant mode.