### PR TITLE
Add `IF NOT EXISTS` clause to ROLE creations DDL.

### DIFF
--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -877,10 +877,10 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             else:
                 self.write(ident_to_str(node.name.module), '::',
                            ident_to_str(node.name.name))
-        if node.create_if_not_exists and not self.sdlmode:
-            self.write(' IF NOT EXISTS')
         if after_name:
             after_name()
+        if node.create_if_not_exists and not self.sdlmode:
+            self.write(' IF NOT EXISTS')
 
         commands = node.commands
         if commands and render_commands:

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -219,6 +219,14 @@ class UnqualifiedPointerName(Nonterm):
         self.val = kids[0].val
 
 
+class OptIfNotExists(Nonterm):
+    def reduce_IF_NOT_EXISTS(self, *kids):
+        self.val = True
+
+    def reduce_empty(self, *kids):
+        self.val = False
+
+
 class ProductionTpl:
     def _passthrough(self, cmd):
         self.val = cmd.val
@@ -848,12 +856,13 @@ class OptSuperuser(Nonterm):
 class CreateRoleStmt(Nonterm):
     def reduce_CreateRoleStmt(self, *kids):
         r"""%reduce CREATE OptSuperuser ROLE ShortNodeName
-                    OptShortExtending OptCreateRoleCommandsBlock
+                    OptShortExtending OptIfNotExists OptCreateRoleCommandsBlock
         """
         self.val = qlast.CreateRole(
             name=kids[3].val,
             bases=kids[4].val,
-            commands=kids[5].val,
+            create_if_not_exists=kids[5].val,
+            commands=kids[6].val,
             superuser=kids[1].val,
         )
 
@@ -1934,19 +1943,12 @@ class DropAliasStmt(Nonterm):
 # CREATE MODULE
 #
 class CreateModuleStmt(Nonterm):
-    def reduce_CREATE_MODULE_ModuleName_OptCreateCommandsBlock(
+    def reduce_CREATE_MODULE_ModuleName_OptIfNotExists_OptCreateCommandsBlock(
             self, *kids):
         self.val = qlast.CreateModule(
             name=qlast.ObjectRef(module=None, name='.'.join(kids[2].val)),
-            commands=kids[3].val
-        )
-
-    def reduce_CREATE_MODULE_ModuleName_IF_NOT_EXISTS_OptCreateCommandsBlock(
-            self, *kids):
-        self.val = qlast.CreateModule(
-            name=qlast.ObjectRef(module=None, name='.'.join(kids[2].val)),
-            create_if_not_exists=True,
-            commands=kids[6].val
+            create_if_not_exists=kids[3].val,
+            commands=kids[4].val
         )
 
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3666,6 +3666,16 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_role_08(self):
+        """
+        CREATE ROLE username IF NOT EXISTS;
+        CREATE SUPERUSER ROLE username IF NOT EXISTS;
+        CREATE ROLE username EXTENDING generic IF NOT EXISTS;
+        CREATE ROLE username EXTENDING generic IF NOT EXISTS {
+            SET password := 'secret';
+        };
+        """
+
     def test_edgeql_syntax_ddl_delta_02(self):
         """
         START MIGRATION TO {type test::Foo;};
@@ -4737,6 +4747,11 @@ aa';
     def test_edgeql_syntax_ddl_module_05(self):
         """
         CREATE MODULE `__std__`;
+        """
+
+    def test_edgeql_syntax_ddl_module_06(self):
+        """
+        CREATE MODULE foo IF NOT EXISTS;
         """
 
     def test_edgeql_syntax_ddl_type_01(self):


### PR DESCRIPTION
`CREATE ROLE` command benefits from the same `IF NOT EXISTS` clause
as `CREATE MODULE`.

Issue #1385