### PR TITLE
Properly escape underscores in a LIKE filter in _get_cached_reflection()

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -2918,7 +2918,7 @@ class GetCachedReflection(dbops.Function):
             pg_proc
             INNER JOIN pg_namespace ON (pronamespace = pg_namespace.oid)
         WHERE
-            proname LIKE '__rh_%'
+            proname LIKE '\\_\\_rh\\_%'
     '''
 
     def __init__(self) -> None:


### PR DESCRIPTION
Underscore has a special meaning of "any character" in LIKE patterns, so
the `WHERE` clause in `_get_cached_reflection()` is currently picking up
functions that aren't actual reflection helpers resulting in a server
crash in `introspect_db`.