### PR TITLE
Server shutdown optimization

### DIFF
--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -215,6 +215,7 @@ def _run_server(
             )
 
         loop.add_signal_handler(signal.SIGTERM, terminate_server, ss, loop)
+        loop.add_signal_handler(signal.SIGINT, terminate_server, ss, loop)
 
         # Notify systemd that we've started up.
         _sd_notify('READY=1')
@@ -222,11 +223,9 @@ def _run_server(
         try:
             loop.run_forever()
         finally:
-            try:
-                logger.info('Shutting down.')
-                loop.run_until_complete(ss.stop())
-            finally:
-                _sd_notify('STOPPING=1')
+            _sd_notify('STOPPING=1')
+            logger.info('Shutting down.')
+            loop.run_until_complete(ss.stop())
 
 
 def run_server(args: srvargs.ServerConfig, *, do_setproctitle: bool=False):


### PR DESCRIPTION
In case of:

1. The EdgeDB process group received SIGINT (regular CTRL + C in terminal)
2. ~Compiler main process exited~
3. ~Compiler subprocess exited~ <- we'll restart the compiler worker process
4. ~Postgres exited~ <- we'll put the server in an error state in a different PR. For now, just mute the error.

This PR will make sure of the same exclusive execution path to stop the server.

* ~SIGINT/SIGTERM can be sent twice - first to initialize the shutdown,
  second (or more) will lead to sys.exit(1)~
* ~In the first 1000ms after the shutdown is initialized, SIGINT/SIGTERM
  will be ignored to protect the shutdown process from e.g. double kill~ <- doesn't make sense any more

Also fixed a wrong indication of server shutting down for systemd.