### PR TITLE
Add `schema::Object.name_parts` property

### DIFF
--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -44,6 +44,7 @@ CREATE SCALAR TYPE schema::TypeModifier
 # Base type for all schema entities.
 CREATE ABSTRACT TYPE schema::Object EXTENDING std::BaseObject {
     CREATE REQUIRED PROPERTY name -> std::str;
+    CREATE REQUIRED PROPERTY name_parts -> array<std::str>;
     CREATE REQUIRED PROPERTY internal -> std::bool {
         SET default := false;
     };

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3193,6 +3193,8 @@ def _generate_database_views(schema: s_schema.Schema) -> List[dbops.View]:
                 AS {qi(ptr_col_name(schema, Database, 'name'))},
             (d.description)->>'name'
                 AS {qi(ptr_col_name(schema, Database, 'name__internal'))},
+            ARRAY[(d.description)->>'name']
+                AS {qi(ptr_col_name(schema, Database, 'name_parts'))},
             ARRAY[]::text[]
                 AS {qi(ptr_col_name(schema, Database, 'computed_fields'))},
             ((d.description)->>'builtin')::bool
@@ -3296,6 +3298,8 @@ def _generate_extension_views(schema: s_schema.Schema) -> List[dbops.View]:
                 AS {qi(ptr_col_name(schema, ExtPkg, 'name'))},
             (e.value->>'name__internal')
                 AS {qi(ptr_col_name(schema, ExtPkg, 'name__internal'))},
+            ARRAY[e.value->>'name']
+                AS {qi(ptr_col_name(schema, ExtPkg, 'name_parts'))},
             (
                 (e.value->'version'->>'major')::int,
                 (e.value->'version'->>'minor')::int,
@@ -3421,6 +3425,8 @@ def _generate_role_views(schema: s_schema.Schema) -> List[dbops.View]:
                 AS {qi(ptr_col_name(schema, Role, 'name'))},
             (d.description)->>'name'
                 AS {qi(ptr_col_name(schema, Role, 'name__internal'))},
+            ARRAY[(d.description)->>'name']
+                AS {qi(ptr_col_name(schema, Role, 'name_parts'))},
             {superuser}
                 AS {qi(ptr_col_name(schema, Role, 'superuser'))},
             False
@@ -3602,6 +3608,8 @@ def _generate_schema_ver_views(schema: s_schema.Schema) -> List[dbops.View]:
                 AS {qi(ptr_col_name(schema, Ver, 'name'))},
             (v.value->>'name')
                 AS {qi(ptr_col_name(schema, Ver, 'name__internal'))},
+            ARRAY[v.value->>'name']
+                AS {qi(ptr_col_name(schema, Ver, 'name_parts'))},
             (v.value->>'version')::uuid
                 AS {qi(ptr_col_name(schema, Ver, 'version'))},
             (v.value->>'builtin')::bool

--- a/edb/schema/name.py
+++ b/edb/schema/name.py
@@ -50,6 +50,9 @@ if TYPE_CHECKING:
         def get_local_name(self) -> UnqualName:
             ...
 
+        def as_tuple(self) -> Tuple[str, ...]:
+            ...
+
         def __lt__(self, other: Any) -> bool:
             ...
 
@@ -147,6 +150,9 @@ else:
         def get_module_name(self) -> Name:
             return UnqualName(self.module)
 
+        def as_tuple(self) -> Tuple[str, ...]:
+            return (self.module, self.name)
+
         def __str__(self) -> str:
             return f'{self.module}::{self.name}'
 
@@ -166,6 +172,9 @@ else:
 
         def get_local_name(self) -> UnqualName:
             return self
+
+        def as_tuple(self) -> Tuple[str, ...]:
+            return (self.name,)
 
         def __str__(self) -> str:
             return self.name

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -282,6 +282,9 @@ def _build_object_mutation_shape(
             else:
                 target_value = None
                 variables[f'{var_n}__internal'] = json.dumps(None)
+            if v is not None:
+                assignments.append(f'{n}_parts := <array<str>>${var_n}_parts')
+                variables[f'{var_n}_parts'] = json.dumps(v.as_tuple())
 
         elif isinstance(target, s_objtypes.ObjectType):
             if cardinality is qltypes.SchemaCardinality.Many:

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,7 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_04_27_00_00
+EDGEDB_CATALOG_VERSION = 2021_04_27_00_01
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs


### PR DESCRIPTION
Currently there is no convenient way to get structured object name in
the introspection schema, because `schema::Object.name` is a string.
Fix this by adding `Object.name_parts` which is an array of strings
representing the parts of the name: module and unqualified name.