### PR TITLE
Support filling a newly created required field

### DIFF
--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1315,10 +1315,22 @@ class DropPropertyStmt(Nonterm):
 # CREATE LINK ... { CREATE PROPERTY
 #
 
+class SetRequiredInCreateStmt(Nonterm):
+
+    def reduce_SET_REQUIRED_OptAlterUsingClause(self, *kids):
+        self.val = qlast.SetPointerOptionality(
+            name='required',
+            value=qlast.BooleanConstant.from_python(True),
+            special_syntax=True,
+            fill_expr=kids[2].val,
+        )
+
+
 commands_block(
     'CreateConcreteProperty',
     UsingStmt,
     SetFieldStmt,
+    SetRequiredInCreateStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     CreateConcreteConstraintStmt
@@ -1616,6 +1628,7 @@ commands_block(
     'CreateConcreteLink',
     UsingStmt,
     SetFieldStmt,
+    SetRequiredInCreateStmt,
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     CreateConcreteConstraintStmt,

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3649,6 +3649,24 @@ def get_special_field_alter_handler(
     return field_handlers.get(schema_cls)
 
 
+def get_special_field_create_handler(
+    field: str,
+    schema_cls: Type[so.Object],
+) -> Optional[Type[AlterSpecialObjectField[so.Object]]]:
+    """Return a custom handler for the field value transition, if any.
+
+    Returns a subclass of AlterSpecialObjectField, when in the context
+    of an CreateObject operation, and a special handler has been declared.
+
+    For now this is just a hacky special case:
+      the 'required' field of Pointers. If that changes, we should generalize
+      the mechanism.
+    """
+    if field != 'required':
+        return None
+    return get_special_field_alter_handler(field, schema_cls)
+
+
 def get_special_field_alter_handler_for_context(
     field: str,
     context: CommandContext,
@@ -3665,6 +3683,9 @@ def get_special_field_alter_handler_for_context(
     ):
         mcls = this_op.get_schema_metaclass()
         return get_special_field_alter_handler(field, mcls)
+    elif isinstance(this_op, CreateObject):
+        mcls = this_op.get_schema_metaclass()
+        return get_special_field_create_handler(field, mcls)
     else:
         return None
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1388,8 +1388,8 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
             diff = s_ddl.delta_schemas(multi_migration, cur_state)
 
-            note = ('' if i + 1 < len(migration)
-                    else '( migrating to empty schema)')
+            note = ('' if i + 1 < len(migrations)
+                    else ' (migrating to empty schema)')
 
             if list(diff.get_subcommands()):
                 self.fail(


### PR DESCRIPTION
This involves adding syntactic support for using SET REQUIRED USING in
CREATE PROPERTY/LINK and making schema diffing able to understand it.

Partially fixes #2486. Unfortunately it doesn't actually fix the issue
that the bug was filed originally as, which is prompting to populate a
required field that is being added by a new parent type.