### PR TITLE
Avoid losing parameter ordering in schema introspection

### DIFF
--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -175,7 +175,7 @@ CREATE TYPE schema::Parameter EXTENDING schema::Object {
 CREATE ABSTRACT TYPE schema::CallableObject
     EXTENDING schema::AnnotationSubject
 {
-    CREATE MULTI LINK params -> schema::Parameter {
+    CREATE MULTI LINK params EXTENDING schema::ordered -> schema::Parameter {
         ON TARGET DELETE ALLOW;
     };
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,7 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_04_18_00_00
+EDGEDB_CATALOG_VERSION = 2021_04_27_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs


### PR DESCRIPTION
The order of parameters in callables obviously matters, so make sure
they're reflected and introspected correctly.