### PR TITLE
Add functions to manipulate sequence state and preserve sequence state in dumps

### DIFF
--- a/docs/edgeql/funcops/index.rst
+++ b/docs/edgeql/funcops/index.rst
@@ -65,6 +65,7 @@ singletons. Examples of aggregate functions include built-ins such as
     json
     bytes
     math
+    sequence
     sys
     uuid
     deprecated

--- a/docs/edgeql/funcops/sequence.rst
+++ b/docs/edgeql/funcops/sequence.rst
@@ -1,0 +1,103 @@
+.. _ref_eql_funcops_sequence:
+
+========
+Sequence
+========
+
+:edb-alt-title: Sequence Manipulation Functions
+
+
+.. list-table::
+    :class: funcoptable
+
+    * - :eql:func:`sequence_next`
+      - :eql:func-desc:`sequence_next`
+
+    * - :eql:func:`sequence_reset`
+      - :eql:func-desc:`sequence_reset`
+
+
+---------
+
+
+.. eql:function:: std::sequence_next(seq: schema::ScalarType) -> int64
+
+    Advance the sequence to its next value and return that value.
+
+    Sequence advancement is done atomically, each concurrent session and
+    transaction will receive a distinct sequence value.
+
+    .. code-block:: edgeql-repl
+
+       db> SELECT sequence_next(INTROSPECT MySequence);
+       {11}
+
+
+---------
+
+
+.. eql:function:: std::sequence_reset(seq: schema::ScalarType) -> int64
+                  std::sequence_reset( \
+                    seq: schema::ScalarType, val: int64) -> int64
+
+    Reset the sequence to its initial state or the specified value.
+
+    The single-parameter form resets the sequence to its initial state, where
+    the next :eql:func:`sequence_next` call will return the first value in
+    sequence.  The two-parameters form allows changing the last returned
+    value of the sequence.
+
+    .. code-block:: edgeql-repl
+
+       db> SELECT sequence_reset(INTROSPECT MySequence);
+       {1}
+       db> SELECT sequence_next(INTROSPECT MySequence);
+       {1}
+       db> SELECT sequence_reset(INTROSPECT MySequence, 22);
+       {22}
+       db> SELECT sequence_next(INTROSPECT MySequence);
+       {23}
+
+
+---------
+
+.. note::
+
+   The sequence to be operated on by the functions above is specified
+   by a ``schema::ScalarType`` object.  If the sequence argument is
+   known ahead of time and does not change, the recommended way to pass
+   it is to use the :eql:op:`INTROSPECT` operator:
+
+   .. code-block:: edgeql
+
+      SELECT sequence_next(INTROSPECT MySequenceType);
+      # or
+      SELECT sequence_next(INTROSPECT TYPEOF MyObj.seq_prop);
+
+   This style will ensure that a reference to a sequence type from an
+   expression is tracked properly to ensure schema referential integrity.
+
+   If, on the other hand, the operated sequence type is determined at run time
+   via a query argument, it must be queried from the ``schema::ScalarType``
+   set directly like so:
+
+   .. code-block:: edgeql
+
+      WITH
+        SeqType := (
+          SELECT schema::ScalarType
+          FILTER .name = <str>$seq_type_name
+        )
+      SELECT
+        sequence_next(SeqType);
+
+
+.. warning::
+
+   **Caution**
+
+   To work efficiently in high concurrency without lock contention, a
+   :eql:func:`sequence_next` operation is never rolled back even if
+   the containing transaction is aborted.  This may result in gaps
+   in the generated sequence.  Likewise, :eql:func:`sequence_reset`
+   is not undone if the transaction is rolled back.

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -276,6 +276,70 @@ CREATE TYPE schema::ScalarType
 };
 
 
+CREATE FUNCTION std::sequence_reset(
+    seq: schema::ScalarType,
+    value: std::int64,
+) -> std::int64
+{
+    SET volatility := 'Volatile';
+    USING SQL $$
+        SELECT
+            pg_catalog.setval(
+                pg_catalog.quote_ident(sn.schema)
+                    || '.' || pg_catalog.quote_ident(sn.name),
+                "value",
+                true
+            )
+        FROM
+            ROWS FROM (edgedb.get_user_sequence_backend_name("seq"))
+                AS sn(schema text, name text)
+    $$;
+};
+
+
+CREATE FUNCTION std::sequence_reset(
+    seq: schema::ScalarType,
+) -> std::int64
+{
+    SET volatility := 'Volatile';
+    USING SQL $$
+        SELECT
+            pg_catalog.setval(
+                pg_catalog.quote_ident(sn.schema)
+                    || '.' || pg_catalog.quote_ident(sn.name),
+                s.start_value,
+                false
+            )
+        FROM
+            ROWS FROM (edgedb.get_user_sequence_backend_name("seq"))
+                AS sn(schema text, name text),
+            LATERAL (
+                SELECT start_value
+                FROM pg_catalog.pg_sequences
+                WHERE schemaname = sn.schema AND sequencename = sn.name
+            ) AS s
+    $$;
+};
+
+
+CREATE FUNCTION std::sequence_next(
+    seq: schema::ScalarType,
+) -> std::int64
+{
+    SET volatility := 'Volatile';
+    USING SQL $$
+        SELECT
+            pg_catalog.nextval(
+                pg_catalog.quote_ident(sn.schema)
+                    || '.' || pg_catalog.quote_ident(sn.name)
+            )
+        FROM
+            ROWS FROM (edgedb.get_user_sequence_backend_name("seq"))
+                AS sn(schema text, name text)
+    $$;
+};
+
+
 CREATE TYPE schema::ObjectType
     EXTENDING
         schema::InheritingObject, schema::ConsistencySubject,

--- a/edb/lib/std/30-sequencefuncs.edgeql
+++ b/edb/lib/std/30-sequencefuncs.edgeql
@@ -1,0 +1,22 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+## std::sequence functions and operators.
+
+# See schema.edgeql for definitions of sequence_next() and friends.

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -543,6 +543,25 @@ class GetRoleBackendNameFunction(dbops.Function):
         )
 
 
+class GetUserSequenceBackendNameFunction(dbops.Function):
+
+    text = f"""
+        SELECT
+            'edgedbpub',
+            "sequence_type_id"::text || '_sequence'
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', 'get_user_sequence_backend_name'),
+            args=[('sequence_type_id', ('uuid',))],
+            returns=('record',),
+            language='sql',
+            volatility='stable',
+            text=self.text,
+        )
+
+
 class GetObjectMetadata(dbops.Function):
     """Return EdgeDB metadata associated with a backend object."""
     text = '''
@@ -3043,6 +3062,7 @@ async def bootstrap(conn: asyncpg.Connection) -> None:
         dbops.CreateFunction(GetBackendTenantIDFunction()),
         dbops.CreateFunction(GetDatabaseBackendNameFunction()),
         dbops.CreateFunction(GetRoleBackendNameFunction()),
+        dbops.CreateFunction(GetUserSequenceBackendNameFunction()),
         dbops.CreateFunction(GetObjectMetadata()),
         dbops.CreateFunction(GetColumnMetadata()),
         dbops.CreateFunction(GetSharedObjectMetadata()),

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -69,6 +69,10 @@ class ScalarType(
     def is_enum(self, schema: s_schema.Schema) -> bool:
         return bool(self.get_enum_values(schema))
 
+    def is_sequence(self, schema: s_schema.Schema) -> bool:
+        seq = schema.get('std::sequence', type=ScalarType)
+        return self.issubclass(schema, seq)
+
     def is_polymorphic(self, schema: s_schema.Schema) -> bool:
         return self.get_abstract(schema)
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -232,6 +232,9 @@ class Type(
     def is_enum(self, schema: s_schema.Schema) -> bool:
         return False
 
+    def is_sequence(self, schema: s_schema.Schema) -> bool:
+        return False
+
     def test_polymorphic(self, schema: s_schema.Schema, poly: Type) -> bool:
         """Check if this type can be matched by a polymorphic type.
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2046,6 +2046,7 @@ class Compiler:
             exclude_global=True,
         )
         ids = []
+        sequences = []
         for obj in all_objects:
             if isinstance(obj, s_obj.QualifiedObject):
                 ql_class = ''
@@ -2058,6 +2059,9 @@ class Compiler:
                 obj.id.bytes,
             ))
 
+            if isinstance(obj, s_types.Type) and obj.is_sequence(schema):
+                sequences.append(obj.id)
+
         objtypes = schema.get_objects(
             type=s_objtypes.ObjectType,
             exclude_stdlib=True,
@@ -2069,8 +2073,19 @@ class Compiler:
                 continue
             descriptors.extend(self._describe_object(schema, objtype))
 
+        dynamic_ddl = []
+        if sequences:
+            seq_ids = ', '.join(
+                pg_common.quote_literal(str(seq_id))
+                for seq_id in sequences
+            )
+            dynamic_ddl.append(
+                f'SELECT edgedb._dump_sequences(ARRAY[{seq_ids}]::uuid[])'
+            )
+
         return DumpDescriptor(
             schema_ddl=config_ddl + '\n' + schema_ddl,
+            schema_dynamic_ddl=tuple(dynamic_ddl),
             schema_ids=ids,
             blocks=descriptors,
         )
@@ -2489,6 +2504,7 @@ class Compiler:
 class DumpDescriptor(NamedTuple):
 
     schema_ddl: str
+    schema_dynamic_ddl: Tuple[str]
     schema_ids: List[Tuple[str, str, bytes]]
     blocks: Sequence[DumpBlockDescriptor]
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,7 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_04_27_00_02
+EDGEDB_CATALOG_VERSION = 2021_04_27_00_03
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,7 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_04_27_00_00
+EDGEDB_CATALOG_VERSION = 2021_04_27_00_02
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/schemas/dump03_default.esdl
+++ b/tests/schemas/dump03_default.esdl
@@ -18,6 +18,8 @@
 
 
 scalar type MyStr extending str;
+scalar type MySeq extending sequence;
+scalar type MyPristineSeq extending sequence;
 
 type Test {
     required property name -> str {
@@ -30,4 +32,5 @@ type Test {
             array<MyStr>,
             tuple<int64, int64, array<MyStr>>,
         >;
+    property seq -> MySeq;
 };

--- a/tests/test_dump03.py
+++ b/tests/test_dump03.py
@@ -38,6 +38,7 @@ class DumpTestCaseMixin:
                 SELECT Test {
                     array_of_tuples,
                     tuple_of_arrays,
+                    seq,
                 } FILTER .name = 'test01'
             ''',
             [
@@ -51,9 +52,20 @@ class DumpTestCaseMixin:
                         ['2', '3'],
                         [4, 5, ['6']],
                     ],
+                    'seq': 1,
                 },
             ]
         )
+
+        result = await self.con.query_one(
+            "SELECT sequence_next(INTROSPECT TYPEOF Test.seq)"
+        )
+        self.assertEqual(result, 2)
+
+        result = await self.con.query_one(
+            "SELECT sequence_next(INTROSPECT MyPristineSeq)"
+        )
+        self.assertEqual(result, 1)
 
 
 class TestDump03(tb.StableDumpTestCase, DumpTestCaseMixin):

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -4642,3 +4642,40 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             ''',
             [1, 3, 5, 7, 9]
         )
+
+    async def test_edgeql_functions_sequence_next_reset(self):
+        await self.con.execute('''
+            CREATE SCALAR TYPE test::my_seq_01 EXTENDING std::sequence;
+        ''')
+
+        result = await self.con.query_one('''
+            SELECT sequence_next(INTROSPECT test::my_seq_01)
+        ''')
+
+        self.assertEqual(result, 1)
+
+        result = await self.con.query_one('''
+            SELECT sequence_next(INTROSPECT test::my_seq_01)
+        ''')
+
+        self.assertEqual(result, 2)
+
+        await self.con.execute('''
+            SELECT sequence_reset(INTROSPECT test::my_seq_01)
+        ''')
+
+        result = await self.con.query_one('''
+            SELECT sequence_next(INTROSPECT test::my_seq_01)
+        ''')
+
+        self.assertEqual(result, 1)
+
+        await self.con.execute('''
+            SELECT sequence_reset(INTROSPECT test::my_seq_01, 20)
+        ''')
+
+        result = await self.con.query_one('''
+            SELECT sequence_next(INTROSPECT test::my_seq_01)
+        ''')
+
+        self.assertEqual(result, 21)


### PR DESCRIPTION
### Implement functions to explicitly advance or reset a sequence value

The new `std::sequence_next(schema::ScalarType)` function
returns the next value for the specified sequence type.

The new `std::sequence_reset(schema::ScalarType, std::int64)`
function sets the _current_ value of the specified sequence, the
next call to `sequence_next` will return the next value in sequence.

The new `std::sequence_reset(schema::ScalarType)`
function resets the specified sequence to its initial state, so
the next call to `sequence_next` will return the start value of the
sequence.

### Make sure sequence state gets included in dumps

The current value of a sequence type is a piece of data that must be
preserved in the database dump.

Fixes: #2441