### PR TITLE
Fix migration prompting while adding required pointers via parent types

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2163,6 +2163,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                         # and that have their value actually changed.
                         not fop.new_inherited
                         or context.descriptive_mode
+                        or self.ast_ignore_ownership()
                     )
                     and (
                         fop.old_value != new_value
@@ -2604,6 +2605,10 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         if self.annotations is None:
             self.annotations = {}
         self.annotations[name] = value
+
+    def ast_ignore_ownership(self) -> bool:
+        """Whether to force something into the AST even though it is owned"""
+        return False
 
 
 class ObjectCommandContext(CommandContextToken[ObjectCommand[so.Object_T]]):

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2607,7 +2607,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         self.annotations[name] = value
 
     def ast_ignore_ownership(self) -> bool:
-        """Whether to force something into the AST even though it is owned"""
+        """Whether to force generating an AST even though it isn't owned"""
         return False
 
 

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -770,7 +770,11 @@ def _trace_op(
                     referrer_name = renames_r[referrer_name]
                 ref_name_str = str(referrer_name)
                 deps.add(('create', ref_name_str))
-                deps.add(('rebase', ref_name_str))
+                if op.ast_ignore_ownership():
+                    ref_item = get_deps(('rebase', ref_name_str))
+                    ref_item.deps.add((tag, this_name_str))
+                else:
+                    deps.add(('rebase', ref_name_str))
 
                 if isinstance(obj, referencing.ReferencedInheritingObject):
                     implicit_ancestors = [

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1589,6 +1589,13 @@ class CreatePointer(
     PointerCommand[Pointer_T],
 ):
 
+    def ast_ignore_ownership(self) -> bool:
+        # If we have a SET REQUIRED with a fill_expr, we need to force
+        # this operation to appear in the AST in a useful position,
+        # even if it normally would be skipped.
+        subs = list(self.get_subcommands(type=AlterPointerLowerCardinality))
+        return len(subs) == 1 and bool(subs[0].fill_expr)
+
     @classmethod
     def as_inherited_ref_cmd(
         cls,
@@ -2272,7 +2279,6 @@ class AlterPointerLowerCardinality(
         return (
             not old_required and new_required
             and not self.is_attribute_computed('required')
-            and not self.is_attribute_inherited('required')
             and not ptr_op.maybe_get_object_aux_data('from_alias')
             and self.fill_expr is None
             and not (

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -587,7 +587,11 @@ class CreateReferencedObject(
         scls = self.get_object(schema, context)
         assert isinstance(scls, ReferencedInheritingObject)
         implicit_bases = scls.get_implicit_bases(schema)
-        if implicit_bases and not context.declarative:
+        if (
+            implicit_bases
+            and not context.declarative
+            and not self.ast_ignore_ownership()
+        ):
             alter = scls.init_delta_command(schema, sd.AlterObject)
             return alter._get_ast_node(schema, context)
         else:
@@ -993,7 +997,10 @@ class CreateReferencedInheritingObject(
             if self.get_attribute_value('from_alias'):
                 return None
 
-            elif not self.get_attribute_value('owned'):
+            elif (
+                not self.get_attribute_value('owned')
+                and not self.ast_ignore_ownership()
+            ):
                 if context.descriptive_mode:
                     astnode = super()._get_ast(
                         schema,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -764,9 +764,14 @@ class Compiler:
             schema = delta.apply(schema, context=context)
 
             if mstate.last_proposed:
-                if mstate.last_proposed[0].required_user_input:
+                if (
+                    mstate.last_proposed[0].required_user_input
+                    or mstate.last_proposed[0].prompt_id.startswith("Rename")
+                ):
                     # Cannot auto-apply the proposed DDL
                     # if user input is required.
+                    # Also skip auto-applying for renames, since
+                    # renames often force a bunch of rethinking.
                     mstate = mstate._replace(last_proposed=tuple())
                 else:
                     proposed_stmts = mstate.last_proposed[0].statements


### PR DESCRIPTION
The key idea is that we force a `CREATE PROPERTY ... { SET REQUIRED  ... }`
to be generated when appropriate even if we would normally elide it.

Forcing this to happen exposed a funny corner case in which the
diffing mechanism sometimes generates DELETE/CREATE pairs for the
__type__ link when a type is renamed. This might be worth dealing with
more robustly, but I worked around this for now by having the compiler
regenerate the proposed plan after applying DDL that does a rename.
This turns out to have been a good idea in general, since it fixed
issues where we would generate prompts that referred to old names
instead of new ones.

Fixes #2486.