### PR TITLE
Make DROP MODULE actually drop module contents

### DIFF
--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -88,7 +88,7 @@ class DeleteModule(ModuleCommand, sd.DeleteObject[Module]):
         # Modules aren't actually stored with any direct linkage
         # to the objects in them, so explicitly search for objects
         # in the module (excluding the module itself).
-        has_objects = bool(any(schema.get_objects(
+        has_objects = bool(list(schema.get_objects(
             included_modules=[self.classname],
             excluded_items=[self.classname],
         )))

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -88,7 +88,7 @@ class DeleteModule(ModuleCommand, sd.DeleteObject[Module]):
         # Modules aren't actually stored with any direct linkage
         # to the objects in them, so explicitly search for objects
         # in the module (excluding the module itself).
-        has_objects = bool(list(schema.get_objects(
+        has_objects = bool(any(schema.get_objects(
             included_modules=[self.classname],
             excluded_items=[self.classname],
         )))

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6298,6 +6298,47 @@ type test::Foo {
                 DROP MODULE test_other;
             """)
 
+    async def test_edgeql_ddl_modules_04(self):
+        await self.con.execute(r"""
+            CREATE MODULE test_other;
+
+            CREATE ABSTRACT TYPE test_other::Named {
+                CREATE REQUIRED PROPERTY name -> str;
+            };
+
+            CREATE ABSTRACT TYPE test_other::UniquelyNamed
+                EXTENDING test_other::Named
+            {
+                ALTER PROPERTY name {
+                    CREATE DELEGATED CONSTRAINT exclusive;
+                }
+            };
+
+            CREATE ABSTRACT ANNOTATION whatever;
+
+            CREATE TYPE test_other::Foo;
+            CREATE TYPE test_other::Bar {
+                CREATE LINK foo -> test_other::Foo;
+                CREATE ANNOTATION whatever := "huh";
+            };
+            ALTER TYPE test_other::Foo {
+                CREATE LINK bar -> test_other::Bar;
+            };
+        """)
+
+        await self.con.execute(r"""
+            DROP MODULE test_other;
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT count((
+                    SELECT schema::Object FILTER .name LIKE 'test_other::%'
+                ))
+            """,
+            [0],
+        )
+
     async def test_edgeql_ddl_extension_package_01(self):
         await self.con.execute(r"""
             CREATE EXTENSION PACKAGE foo_01 VERSION '1.0' {

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6326,18 +6326,13 @@ type test::Foo {
             };
         """)
 
-        await self.con.execute(r"""
-            DROP MODULE test_other;
-        """)
-
-        await self.assert_query_result(
-            r"""
-                SELECT count((
-                    SELECT schema::Object FILTER .name LIKE 'test_other::%'
-                ))
-            """,
-            [0],
-        )
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaError,
+            "cannot drop module 'test_other' because it is not empty",
+        ):
+            await self.con.execute(r"""
+                DROP MODULE test_other;
+            """)
 
     async def test_edgeql_ddl_extension_package_01(self):
         await self.con.execute(r"""


### PR DESCRIPTION
This is done in the most heavy handed way possible: by emulating
schema migrations. Deleting lots of things at once in our sytem is
kind of hard, and we've put a lot of effort into making it work with
schema migrations.

Fixes #1989.