### PR TITLE
Support switching to binary protocol with HTTP upgrade

### DIFF
--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -196,6 +196,7 @@ def _run_server(
         echo_runtime_info=args.echo_runtime_info,
         status_sink=args.status_sink,
         startup_script=args.startup_script,
+        testmode=args.testmode,
     )
 
     loop.run_until_complete(ss.init())

--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -26,6 +26,8 @@ cdef class HttpRequest:
         public bytes content_type
         public bytes method
         public bytes body
+        public bytes upgrade
+        public bint should_upgrade
 
 
 cdef class HttpResponse:
@@ -49,6 +51,7 @@ cdef class HttpProtocol:
         bint in_response
         bint first_data_call
         bint external_auth
+        bytes upgrade_remaining_data
 
         HttpRequest current_request
 
@@ -60,3 +63,4 @@ cdef class HttpProtocol:
     cdef unhandled_exception(self, ex)
     cdef resume(self)
     cdef close(self)
+    cdef handle_upgrade(self, HttpRequest request)

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -22,6 +22,7 @@ include "./consts.pxi"
 
 import collections
 import http
+import os
 import urllib.parse
 
 import httptools
@@ -208,9 +209,12 @@ cdef class HttpProtocol:
         if self.transport is None:
             return
 
-        if request.should_upgrade and request.upgrade == b'edgedb-binary':
-            self.handle_upgrade(request)
-            return
+        if not self.server.in_test_mode() or not os.environ.get(
+            'EDGEDB_DISABLE_HTTP_UPGRADE'
+        ):
+            if request.should_upgrade and request.upgrade == b'edgedb-binary':
+                self.handle_upgrade(request)
+                return
 
         try:
             await self.handle_request(request, response)

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -101,6 +101,7 @@ class Server:
         echo_runtime_info: bool = False,
         status_sink: Optional[Callable[[str], None]] = None,
         startup_script: Optional[srvargs.StartupScript] = None,
+        testmode: bool = False,
     ):
 
         self._loop = loop
@@ -155,6 +156,7 @@ class Server:
         self._sys_queries = immutables.Map()
 
         self._devmode = devmode.is_in_dev_mode()
+        self._testmode = testmode
 
         self._binary_proto_id_counter = 0
         self._binary_proto_num_connections = 0
@@ -189,6 +191,9 @@ class Server:
 
     def in_dev_mode(self):
         return self._devmode
+
+    def in_test_mode(self):
+        return self._testmode
 
     def get_pg_dbname(self, dbname: str) -> str:
         return self._cluster.get_db_name(dbname)

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -58,8 +58,10 @@ class BaseHttpTest:
         cls.http_addr = f'http://{cls.http_host}:{cls.http_port}{api_path}'
 
     @contextlib.contextmanager
-    def http_con(self):
-        con = StubbornHttpConnection(self.http_host, self.http_port)
+    def http_con(self, **http_connection_kwargs):
+        con = StubbornHttpConnection(
+            self.http_host, self.http_port, **http_connection_kwargs
+        )
         con.connect()
         try:
             yield con

--- a/edb/testbase/protocol/protocol.pxd
+++ b/edb/testbase/protocol/protocol.pxd
@@ -17,7 +17,7 @@
 #
 
 
-from edgedb.protocol.asyncio_proto cimport AsyncIOProtocol
+from edgedb.protocol.protocol cimport SansIOProtocol
 
 
 cdef class Connection:
@@ -25,4 +25,4 @@ cdef class Connection:
     cdef:
         object _transport
         readonly list inbox
-        AsyncIOProtocol _protocol
+        SansIOProtocol _protocol

--- a/tests/test_http_protocol_upgrade.py
+++ b/tests/test_http_protocol_upgrade.py
@@ -1,0 +1,159 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2021-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import io
+
+from edb.common import binwrapper
+from edb.testbase import http as tb
+from edb.testbase import protocol
+from edb.testbase import server as tb_server
+from edb.testbase.protocol import protocol as tb_protocol  # type: ignore
+
+
+class TestHttpProtocolUpgrade(tb.BaseHttpTest, tb_server.ConnectedTestCase):
+    @classmethod
+    def get_api_path(cls) -> str:
+        return "/"
+
+    def test_http_upgrade_success(self):
+        with self.http_con() as con:
+            con.request(
+                "GET",
+                "/server/status/ready",
+                headers={"Connection": "upgrade", "Upgrade": "edgedb-binary"},
+            )
+            data, headers, status = self.http_con_read_response(con)
+            self.assertEqual(data, b"")
+            self.assertEqual(headers["connection"], "upgrade")
+            self.assertEqual(headers["upgrade"], "edgedb-binary")
+            self.assertEqual(status, 101)
+
+            con = tb_protocol.new_sync_connection(
+                con.sock, **self.get_connect_args()
+            )
+            con.sync_connect()
+            con.sync_send(
+                protocol.ExecuteScript(
+                    headers=[],
+                    script="SELECT 1",
+                )
+            )
+            con.sync_recv_match(protocol.CommandComplete, status="SELECT")
+            con.sync_recv_match(
+                protocol.ReadyForCommand,
+                transaction_state=protocol.TransactionState.NOT_IN_TRANSACTION,
+            )
+
+    def test_http_upgrade_success_mix_pipelining(self):
+        with self.http_con(timeout=5) as con:
+            conn_args = self.get_connect_args()
+            con.sock.send(
+                b"GET /server/status/ready HTTP/1.1\r\n"
+                b"\r\n"
+                b"GET /server/status/ready HTTP/1.1\r\n"
+                b"Connection: upgrade\r\n"
+                b"Upgrade: edgedb-binary\r\n"
+                b"\r\n"
+                + protocol.ClientHandshake(
+                    major_ver=0,
+                    minor_ver=10,
+                    params=[
+                        protocol.ConnectionParam(
+                            name="user",
+                            value=conn_args["user"],
+                        ),
+                        protocol.ConnectionParam(
+                            name="database",
+                            value=conn_args["database"],
+                        ),
+                    ],
+                    extensions=[],
+                ).dump()
+            )
+
+            resp = con.response_class(con.sock, method="GET")
+            resp.begin()
+            self.assertFalse(resp.will_close)
+            self.assertEqual(resp.status, 200)
+            self.assertIn(b"OK", resp.read())
+
+            resp = con.response_class(con.sock, method="GET")
+            resp.begin()
+            self.assertFalse(resp.will_close)
+            headers = {k.lower(): v.lower() for k, v in resp.getheaders()}
+            self.assertEqual(headers["connection"], "upgrade")
+            self.assertEqual(headers["upgrade"], "edgedb-binary")
+            self.assertEqual(resp.status, 101)
+
+            data = resp.fp.read1()  # data might've been buffered in the fp
+            buffer = binwrapper.BinWrapper(io.BytesIO(data))
+            mtype = buffer.read_ui8()
+            data = buffer.read_bytes(buffer.read_i32() - 4)
+            buffer = binwrapper.BinWrapper(io.BytesIO(data))
+
+            msg_type = protocol.AuthenticationRequiredSASLMessage
+            self.assertEqual(mtype, msg_type.mtype.default)
+            kwargs = {}
+            for fieldname, field in msg_type._fields.items():
+                if fieldname in {"mtype", "message_length"}:
+                    continue
+                kwargs[fieldname] = field.parse(buffer)
+            msg = msg_type(**kwargs)
+            self.assertEqual(msg.auth_status, msg_type.auth_status.default)
+            self.assertIn("SCRAM-SHA-256", msg.methods)
+
+    def test_http_upgrade_wrong_protocol(self):
+        with self.http_con() as con:
+            con.request(
+                "GET",
+                "/server/status/ready",
+                headers={"Connection": "upgrade", "Upgrade": "binary"},
+            )
+            data, headers, status = self.http_con_read_response(con)
+            self.assertEqual(status, 200)
+            self.assertIn(b"OK", data)
+
+            con.request(
+                "GET",
+                "/server/status/ready",
+            )
+            data, headers, status = self.http_con_read_response(con)
+            self.assertEqual(status, 200)
+            self.assertIn(b"OK", data)
+
+    def test_http_upgrade_wrong_protocol_with_pipelining(self):
+        with self.http_con(timeout=5) as con:
+            con.sock.send(
+                b"GET /server/status/ready HTTP/1.1\r\n"
+                b"Connection: upgrade\r\n"
+                b"Upgrade: binary\r\n"
+                b"\r\n"
+                b"GET /server/status/ready HTTP/1.1\r\n"
+                b"\r\n"
+            )
+            resp = con.response_class(con.sock, method="GET")
+            resp.begin()
+            self.assertFalse(resp.will_close)
+            self.assertEqual(resp.status, 200)
+            self.assertIn(b"OK", resp.read())
+
+            resp = con.response_class(con.sock, method="GET")
+            resp.begin()
+            self.assertFalse(resp.will_close)
+            self.assertEqual(resp.status, 200)
+            self.assertIn(b"OK", resp.read())


### PR DESCRIPTION
The server now follows HTTP/1.1 upgrade protocol to promote a single
frontend connection from HTTP-based protocol to EdgeDB binary protocol.
The protocol is named `edgedb-binary` and it has to be exactly the same
in the Upgrade header, e.g. `Upgrade: edgedb-binary`.

Previous mechanism to detect if a new connection is HTTP or binary by
looking at the first byte still remains, so old clients are still
supported. But new clients are suggested to use HTTP upgrade on
connect in order to switch to the binary protocol (or remain in HTTP).