### PR TITLE
Add the _datetime_range_buckets function

### DIFF
--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,7 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_04_27_00_03
+EDGEDB_CATALOG_VERSION = 2021_04_29_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -4679,3 +4679,41 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         ''')
 
         self.assertEqual(result, 21)
+
+    async def test_edgeql_functions__datetime_range_buckets(self):
+        await self.assert_query_result(
+            '''
+            SELECT <tuple<str, str>>std::_datetime_range_buckets(
+                <datetime>'2021-01-01T00:00:00Z',
+                <datetime>'2021-04-01T00:00:00Z',
+                '1 month');
+            ''',
+            [
+                ('2021-01-01T00:00:00+00:00', '2021-02-01T00:00:00+00:00'),
+                ('2021-02-01T00:00:00+00:00', '2021-03-01T00:00:00+00:00'),
+                ('2021-03-01T00:00:00+00:00', '2021-04-01T00:00:00+00:00'),
+            ],
+        )
+
+        await self.assert_query_result(
+            '''
+            SELECT <tuple<str, str>>std::_datetime_range_buckets(
+                <datetime>'2021-04-01T00:00:00Z',
+                <datetime>'2021-04-01T00:00:00Z',
+                '1 month');
+            ''',
+            [],
+        )
+
+        await self.assert_query_result(
+            '''
+            SELECT <tuple<str, str>>std::_datetime_range_buckets(
+                <datetime>'2021-01-01T00:00:00Z',
+                <datetime>'2021-04-01T00:00:00Z',
+                '1.5 months');
+            ''',
+            [
+                ('2021-01-01T00:00:00+00:00', '2021-02-16T00:00:00+00:00'),
+                ('2021-02-16T00:00:00+00:00', '2021-03-31T00:00:00+00:00'),
+            ],
+        )


### PR DESCRIPTION
`_datetime_range_buckets` generates a set of datetime pairs representing
buckets within a given datetime range.  The function isn't public,
because a proper public implementation will need range types and
`cal::relativedelta`, neither of which are implemented.