### PR TITLE
Fix DESCRIBE SCHEMA AS SDL in presence of unqualified objects

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -753,7 +753,12 @@ class DropMigration(DropObject, MigrationCommand):
     pass
 
 
-class GlobalObjectCommand(ObjectDDL):
+class UnqualifiedObjectCommand(ObjectDDL):
+
+    __abstract_node__ = True
+
+
+class GlobalObjectCommand(UnqualifiedObjectCommand):
 
     __abstract_node__ = True
 
@@ -798,7 +803,8 @@ class DropExtensionPackage(DropObject, ExtensionPackageCommand):
     pass
 
 
-class ExtensionCommand(ObjectDDL):
+class ExtensionCommand(UnqualifiedObjectCommand):
+
     __abstract_node__ = True
     object_class: qltypes.SchemaObjectClass = (
         qltypes.SchemaObjectClass.EXTENSION)
@@ -813,7 +819,7 @@ class DropExtension(DropObject, ExtensionCommand):
     pass
 
 
-class ModuleCommand(ObjectDDL):
+class ModuleCommand(UnqualifiedObjectCommand):
 
     __abstract_node__ = True
     object_class: qltypes.SchemaObjectClass = (

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1032,7 +1032,10 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self.write(' ')
         self.write(ident_to_str(node.name.name))
         if node.version is not None:
-            self.write(' VERSION ')
+            if self.sdlmode or self.descmode:
+                self.write(' version ')
+            else:
+                self.write(' VERSION ')
             self.visit(node.version)
         if node.commands:
             self._ddl_visit_body(node.commands)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7040,6 +7040,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
     def test_schema_describe_schema_02(self):
         self._assert_describe(
             """
+            using extension notebook version '1.0';
             module default {
                 type Foo {
                     link bar -> test::Bar;
@@ -7057,6 +7058,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             """
             CREATE MODULE default IF NOT EXISTS;
             CREATE MODULE test IF NOT EXISTS;
+            CREATE EXTENSION NOTEBOOK VERSION '1.0';
             CREATE TYPE default::Foo;
             CREATE TYPE test::Bar {
                 CREATE LINK foo -> default::Foo;
@@ -7069,6 +7071,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             'DESCRIBE SCHEMA AS SDL',
 
             r"""
+            using extension notebook version '1.0';
             module default {
                 type Foo {
                     link bar -> test::Bar;


### PR DESCRIPTION
Modules aren't the only unqualified objects in the schema, there are
also extensions.

Fixes: #2522