### PR TITLE
Prevent illegal UPDATEs to covariantly overloaded link types

### DIFF
--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -75,7 +75,7 @@ def get_tuple_indirection_path_id(
         # typeref_cache=ctx.env.type_ref_cache,
     )
 
-    return tuple_path_id.extend(schema=ctx.env.schema, ptrref=ptrref)
+    return tuple_path_id.extend(ptrref=ptrref)
 
 
 def get_expression_path_id(
@@ -160,8 +160,7 @@ def extend_path_id(
         typeref_cache=ctx.env.type_ref_cache,
     )
 
-    return path_id.extend(ptrref=ptrref, direction=direction,
-                          ns=ns, schema=ctx.env.schema)
+    return path_id.extend(ptrref=ptrref, direction=direction, ns=ns)
 
 
 def ban_path(

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -881,8 +881,7 @@ def type_intersection_set(
         typeref_cache=ctx.env.type_ref_cache,
     )
 
-    poly_set.path_id = source_set.path_id.extend(
-        schema=ctx.env.schema, ptrref=ptrref,)
+    poly_set.path_id = source_set.path_id.extend(ptrref=ptrref)
 
     ptr = irast.TypeIntersectionPointer(
         source=source_set,

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -606,6 +606,16 @@ def compile_InsertQuery(
     return result
 
 
+def _get_dunder_type_ptrref(ctx: context.ContextLevel) -> irast.PointerRef:
+    return typeutils.lookup_obj_ptrref(
+        ctx.env.schema,
+        s_name.QualName('std', 'BaseObject'),
+        s_name.UnqualName('__type__'),
+        cache=ctx.env.ptr_ref_cache,
+        typeref_cache=ctx.env.type_ref_cache,
+    )
+
+
 @dispatch.compile.register(qlast.UpdateQuery)
 def compile_UpdateQuery(
         expr: qlast.UpdateQuery, *, ctx: context.ContextLevel) -> irast.Set:
@@ -622,6 +632,8 @@ def compile_UpdateQuery(
     with ctx.subquery() as ictx:
         stmt = irast.UpdateStmt(context=expr.context)
         init_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
+
+        stmt.dunder_type_ptrref = _get_dunder_type_ptrref(ctx)
 
         subject = dispatch.compile(expr.subject, ctx=ictx)
         assert isinstance(subject, irast.Set)

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -772,7 +772,12 @@ class InsertStmt(MutatingStmt):
 
 
 class UpdateStmt(MutatingStmt, FilteredStmt):
-    pass
+    # The pgsql DML compilation needs to be able to access __type__
+    # fields on link fields for doing covariant assignment checking.
+    # To enable this, we just make sure that update has access to
+    # BaseObject's __type__, from which we can derive whatever we need.
+    # This is at least a bit of a hack.
+    dunder_type_ptrref: BasePointerRef
 
 
 class DeleteStmt(MutatingStmt, FilteredStmt):

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -210,7 +210,7 @@ class PathId:
             raise AssertionError(f'unexpected pointer source: {source!r}')
 
         ptrref = typeutils.ptrref_from_ptrcls(schema=schema, ptrcls=pointer)
-        return prefix.extend(ptrref=ptrref, schema=schema)
+        return prefix.extend(ptrref=ptrref)
 
     @classmethod
     def from_typeref(
@@ -286,7 +286,6 @@ class PathId:
         direction: s_pointers.PointerDirection = (
             s_pointers.PointerDirection.Outbound),
         ns: AbstractSet[AnyNamespace] = frozenset(),
-        schema: s_schema.Schema,
     ) -> PathId:
         """Return a new ``PathId`` that is a *path step* from this ``PathId``.
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1110,8 +1110,8 @@ def check_update_type(
     # have the infrastructure here.
     if (
         not irtyputils.is_object(ir_set.typeref)
-        or base_ptrref.out_target == actual_ptrref.out_target
-        or shape_ptrref.out_target == actual_ptrref.out_target
+        or base_ptrref.out_target.id == actual_ptrref.out_target.id
+        or shape_ptrref.out_target.id == actual_ptrref.out_target.id
     ):
         return val
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2894,18 +2894,18 @@ class PointerMetaCommand(MetaCommand, sd.ObjectCommand,
         is_required = pointer.get_required(schema)
         changing_col_type = not is_link
 
+        source_ctx = self.get_referrer_context_or_die(context)
         if is_multi:
             if isinstance(self, sd.AlterObjectFragment):
                 source_op = self.get_parent_op(context)
             else:
                 source_op = self
         else:
-            source_ctx = self.get_referrer_context_or_die(context)
             source_op = source_ctx.op
 
         # Ignore type narrowing resulting from a creation of a subtype
         # as there isn't any data in the link yet.
-        if is_link and isinstance(source_op, sd.CreateObject):
+        if is_link and isinstance(source_ctx.op, sd.CreateObject):
             return
 
         new_target = pointer.get_target(schema)

--- a/tests/schemas/updates.edgeql
+++ b/tests/schemas/updates.edgeql
@@ -25,6 +25,14 @@ INSERT test::Status {
     name := 'Closed'
 };
 
+INSERT test::MajorLifeEvent {
+    name := 'Broke a Type System'
+};
+
+INSERT test::MajorLifeEvent {
+    name := 'Downloaded a Car'
+};
+
 INSERT test::Tag {
     name := 'fun'
 };

--- a/tests/schemas/updates.esdl
+++ b/tests/schemas/updates.esdl
@@ -22,6 +22,7 @@ type Status {
         constraint exclusive;
     }
 }
+type MajorLifeEvent extending Status;
 
 type Tag {
     required property name -> str {
@@ -50,6 +51,7 @@ type UpdateTest {
             readonly := true;
         }
     }
+    multi link statuses -> Status;
 
     # for testing links to sets of the same type as originator
     multi link related -> UpdateTest;
@@ -70,7 +72,10 @@ type UpdateTest {
 
 type UpdateTestSubType extending UpdateTest;
 
-type UpdateTestSubSubType extending UpdateTestSubType;
+type UpdateTestSubSubType extending UpdateTestSubType {
+    overloaded link status -> MajorLifeEvent;
+    overloaded multi link statuses -> MajorLifeEvent;
+};
 
 type CollectionTest {
     required property name -> str;

--- a/tests/test_edgeql_ir_pathid.py
+++ b/tests/test_edgeql_ir_pathid.py
@@ -54,7 +54,7 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
             schema=self.schema,
             ptrcls=deck_ptr,
         )
-        pid_2 = pid_1.extend(ptrref=deck_ptr_ref, schema=self.schema)
+        pid_2 = pid_1.extend(ptrref=deck_ptr_ref)
         self.assertEqual(
             str(pid_2),
             '(test::User).>deck[IS test::Card]')
@@ -80,7 +80,7 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
             schema=self.schema,
             ptrcls=count_prop,
         )
-        prop_pid = ptr_pid.extend(ptrref=count_prop_ref, schema=self.schema)
+        prop_pid = ptr_pid.extend(ptrref=count_prop_ref)
         self.assertEqual(
             str(prop_pid),
             '(test::User).>deck[IS test::Card]@count[IS std::int64]')
@@ -105,9 +105,9 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
         )
 
         pid_1 = pathid.PathId.from_type(self.schema, User)
-        pid_2 = pid_1.extend(ptrref=deck_ptr_ref, schema=self.schema)
+        pid_2 = pid_1.extend(ptrref=deck_ptr_ref)
         ptr_pid = pid_2.ptr_path()
-        prop_pid = ptr_pid.extend(ptrref=count_prop_ref, schema=self.schema)
+        prop_pid = ptr_pid.extend(ptrref=count_prop_ref)
 
         self.assertTrue(pid_2.startswith(pid_1))
         self.assertFalse(pid_1.startswith(pid_2))
@@ -135,9 +135,9 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
 
         ns = frozenset(('foo',))
         pid_1 = pathid.PathId.from_type(self.schema, User, namespace=ns)
-        pid_2 = pid_1.extend(ptrref=deck_ptr_ref, schema=self.schema)
+        pid_2 = pid_1.extend(ptrref=deck_ptr_ref)
         ptr_pid = pid_2.ptr_path()
-        prop_pid = ptr_pid.extend(ptrref=count_prop_ref, schema=self.schema)
+        prop_pid = ptr_pid.extend(ptrref=count_prop_ref)
 
         self.assertEqual(pid_1.namespace, ns)
         self.assertEqual(pid_2.namespace, ns)
@@ -172,16 +172,15 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
         ns_2 = frozenset(('bar',))
 
         pid_1 = pathid.PathId.from_type(self.schema, Card)
-        pid_2 = pid_1.extend(ptrref=owners_ptr_ref, ns=ns_1,
-                             schema=self.schema)
-        pid_2_no_ns = pid_1.extend(ptrref=owners_ptr_ref, schema=self.schema)
+        pid_2 = pid_1.extend(ptrref=owners_ptr_ref, ns=ns_1)
+        pid_2_no_ns = pid_1.extend(ptrref=owners_ptr_ref)
 
         self.assertNotEqual(pid_2, pid_2_no_ns)
         self.assertEqual(pid_2.src_path(), pid_1)
 
-        pid_3 = pid_2.extend(ptrref=deck_ptr_ref, ns=ns_2, schema=self.schema)
+        pid_3 = pid_2.extend(ptrref=deck_ptr_ref, ns=ns_2)
         ptr_pid = pid_3.ptr_path()
-        prop_pid = ptr_pid.extend(ptrref=count_prop_ref, schema=self.schema)
+        prop_pid = ptr_pid.extend(ptrref=count_prop_ref)
 
         self.assertEqual(prop_pid.src_path().namespace, ns_1 | ns_2)
         self.assertEqual(prop_pid.src_path().src_path().namespace, ns_1)


### PR DESCRIPTION
Insert dynamic type checks in situations where it can occur.

One slightly fiddly part is making sure that we can extract the
`__type__` from the places we need it (since doing this check can
require `__type__` in places where it otherwise wouldn't appear anywhere
in the AST). This is solved with a bit of a hack: UpdateStmt is
augmented with a PointerRef to `BaseObject.__type__`, from which we can
extract whatever we need.

Also fixes creation of covariantly overloaded multi links.

Fixes #2324.