### PR TITLE
Fix interactive tutorial links

### DIFF
--- a/docs/cheatsheet/index.rst
+++ b/docs/cheatsheet/index.rst
@@ -9,7 +9,7 @@ Cheatsheets
 Just getting started? Keep an eye on this collection of cheatsheets with
 handy examples for what you'll need to get started with EdgeDB.
 After familiarizing yourself with them, feel free to dive into more EdgeDB
-via our longer `interactive tutorial <https://tutorial.edgedb.com>`_ and
+via our longer `interactive tutorial <https://www.edgedb.com/tutorial>`_ and
 **much** longer `Easy EdgeDB textbook </easy-edgedb>`_.
 
 CLI/Admin:

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -15,7 +15,7 @@ it. This is a good starting point if you're new to EdgeDB.
 4. Make your data accessible via :ref:`GraphQL <ref_tutorial_graphql>`.
 
 For more examples check out our `interactive tutorial
-<https://tutorial.edgedb.com/>`_.
+<https://www.edgedb.com/tutorial>`_.
 
 .. toctree::
     :maxdepth: 3


### PR DESCRIPTION
tutorial.edgedb.com moved to edgedb.com/tutorial