### PR TITLE
add domain for std::duration

### DIFF
--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -559,7 +559,7 @@ CREATE INFIX OPERATOR
 std::`+` (l: cal::local_time, r: std::duration) -> cal::local_time {
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
-    USING SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+(time, interval)';
 };
 
 
@@ -567,14 +567,14 @@ CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: cal::local_time) -> cal::local_time {
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
-    USING SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+(interval, time)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: cal::local_time, r: std::duration) -> cal::local_time {
     SET volatility := 'Immutable';
-    USING SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-(time, interval)';
 };
 
 

--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -129,10 +129,10 @@ std::duration_truncate(dt: std::duration, unit: std::str) -> std::duration
     USING SQL $$
     SELECT CASE WHEN "unit" in ('microseconds', 'milliseconds',
                                 'seconds', 'minutes', 'hours')
-        THEN date_trunc("unit", "dt")::edgedb.interval_t
+        THEN date_trunc("unit", "dt")::edgedb.duration_t
         ELSE
             edgedb.raise(
-                NULL::edgedb.interval_t,
+                NULL::edgedb.duration_t,
                 'invalid_datetime_format',
                 msg => (
                     'invalid unit for std::duration_truncate: '
@@ -270,7 +270,7 @@ CREATE INFIX OPERATOR
 std::`-` (l: std::datetime, r: std::datetime) -> std::duration {
     SET volatility := 'Immutable';
     USING SQL $$
-        SELECT EXTRACT(epoch FROM "l" - "r")::text::edgedb.interval_t
+        SELECT EXTRACT(epoch FROM "l" - "r")::text::edgedb.duration_t
     $$
 };
 

--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -129,10 +129,10 @@ std::duration_truncate(dt: std::duration, unit: std::str) -> std::duration
     USING SQL $$
     SELECT CASE WHEN "unit" in ('microseconds', 'milliseconds',
                                 'seconds', 'minutes', 'hours')
-        THEN date_trunc("unit", "dt")
+        THEN date_trunc("unit", "dt")::edgedb.interval_t
         ELSE
             edgedb.raise(
-                NULL::interval,
+                NULL::edgedb.interval_t,
                 'invalid_datetime_format',
                 msg => (
                     'invalid unit for std::duration_truncate: '
@@ -270,7 +270,7 @@ CREATE INFIX OPERATOR
 std::`-` (l: std::datetime, r: std::datetime) -> std::duration {
     SET volatility := 'Immutable';
     USING SQL $$
-        SELECT EXTRACT(epoch FROM "l" - "r")::text::interval
+        SELECT EXTRACT(epoch FROM "l" - "r")::text::edgedb.interval_t
     $$
 };
 
@@ -282,7 +282,7 @@ std::`=` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'Immutable';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
-    USING SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=(interval,interval)';
 };
 
 
@@ -298,7 +298,7 @@ std::`!=` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'Immutable';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
-    USING SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>(interval,interval)';
 };
 
 
@@ -317,7 +317,7 @@ std::`>` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'Immutable';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
-    USING SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>(interval,interval)';
 };
 
 
@@ -326,7 +326,7 @@ std::`>=` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'Immutable';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
-    USING SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=(interval,interval)';
 };
 
 
@@ -335,7 +335,7 @@ std::`<` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'Immutable';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
-    USING SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<(interval,interval)';
 };
 
 
@@ -344,7 +344,7 @@ std::`<=` (l: std::duration, r: std::duration) -> std::bool {
     SET volatility := 'Immutable';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
-    USING SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=(interval,interval)';
 };
 
 
@@ -352,21 +352,21 @@ CREATE INFIX OPERATOR
 std::`+` (l: std::duration, r: std::duration) -> std::duration {
     SET volatility := 'Immutable';
     SET commutator := 'std::+';
-    USING SQL OPERATOR r'+';
+    USING SQL OPERATOR r'+(interval,interval)';
 };
 
 
 CREATE INFIX OPERATOR
 std::`-` (l: std::duration, r: std::duration) -> std::duration {
     SET volatility := 'Immutable';
-    USING SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-(interval,interval)';
 };
 
 
 CREATE PREFIX OPERATOR
 std::`-` (v: std::duration) -> std::duration {
     SET volatility := 'Immutable';
-    USING SQL OPERATOR r'-';
+    USING SQL OPERATOR r'-(NONE, interval)';
 };
 
 

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -362,15 +362,18 @@ std::to_duration(
     CREATE ANNOTATION std::description := 'Create a `duration` value.';
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT make_interval(
-        0,
-        0,
-        0,
-        0,
-        "hours"::int,
-        "minutes"::int,
-        "seconds"
-    ) + (microseconds::text || ' microseconds')::interval
+    SELECT (
+        make_interval(
+            0,
+            0,
+            0,
+            0,
+            "hours"::int,
+            "minutes"::int,
+            "seconds"
+        ) +
+        (microseconds::text || ' microseconds')::interval
+    )::edgedb.interval_t
     $$;
 };
 

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -373,7 +373,7 @@ std::to_duration(
             "seconds"
         ) +
         (microseconds::text || ' microseconds')::interval
-    )::edgedb.interval_t
+    )::edgedb.duration_t
     $$;
 };
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -182,11 +182,11 @@ class DateDomain(dbops.Domain):
 class IntervalDomain(dbops.Domain):
     def __init__(self) -> None:
         super().__init__(
-            name=('edgedb', 'interval_t'),
+            name=('edgedb', 'duration_t'),
             base='interval',
             constraints=(
                 dbops.DomainCheckConstraint(
-                    domain_name=('edgedb', 'interval_t'),
+                    domain_name=('edgedb', 'duration_t'),
                     expr=r'''
                         EXTRACT(months from VALUE) = 0 AND
                         EXTRACT(years from VALUE) = 0 AND
@@ -1934,7 +1934,7 @@ class DurationInFunction(dbops.Function):
                 EXTRACT(DAY FROM v.column1) != 0
             THEN
                 edgedb.raise(
-                    NULL::edgedb.interval_t,
+                    NULL::edgedb.duration_t,
                     'invalid_datetime_format',
                     msg => (
                         'invalid input syntax for type std::duration: '
@@ -1945,7 +1945,7 @@ class DurationInFunction(dbops.Function):
                         || 'for std::duration."}'
                     )
                 )
-            ELSE v.column1::edgedb.interval_t
+            ELSE v.column1::edgedb.duration_t
             END
         FROM
             (VALUES (
@@ -1957,7 +1957,7 @@ class DurationInFunction(dbops.Function):
         super().__init__(
             name=('edgedb', 'duration_in'),
             args=[('val', ('text',))],
-            returns=('edgedb', 'interval_t'),
+            returns=('edgedb', 'duration_t'),
             # Same volatility as raise() (stable)
             volatility='stable',
             text=self.text,

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -179,6 +179,24 @@ class DateDomain(dbops.Domain):
         )
 
 
+class IntervalDomain(dbops.Domain):
+    def __init__(self) -> None:
+        super().__init__(
+            name=('edgedb', 'interval_t'),
+            base='interval',
+            constraints=(
+                dbops.DomainCheckConstraint(
+                    domain_name=('edgedb', 'interval_t'),
+                    expr=r'''
+                        EXTRACT(months from VALUE) = 0 AND
+                        EXTRACT(years from VALUE) = 0 AND
+                        EXTRACT(days from VALUE) = 0
+                    ''',
+                ),
+            ),
+        )
+
+
 class AlterCurrentDatabaseSetString(dbops.Function):
     """Alter a PostgreSQL configuration parameter of the current database."""
     text = '''
@@ -1916,7 +1934,7 @@ class DurationInFunction(dbops.Function):
                 EXTRACT(DAY FROM v.column1) != 0
             THEN
                 edgedb.raise(
-                    NULL::interval,
+                    NULL::edgedb.interval_t,
                     'invalid_datetime_format',
                     msg => (
                         'invalid input syntax for type std::duration: '
@@ -1927,7 +1945,7 @@ class DurationInFunction(dbops.Function):
                         || 'for std::duration."}'
                     )
                 )
-            ELSE v.column1
+            ELSE v.column1::edgedb.interval_t
             END
         FROM
             (VALUES (
@@ -1939,7 +1957,7 @@ class DurationInFunction(dbops.Function):
         super().__init__(
             name=('edgedb', 'duration_in'),
             args=[('val', ('text',))],
-            returns=('interval',),
+            returns=('edgedb', 'interval_t'),
             # Same volatility as raise() (stable)
             volatility='stable',
             text=self.text,
@@ -3215,6 +3233,7 @@ async def bootstrap(conn: asyncpg.Connection) -> None:
         dbops.CreateDomain(TimestampTzDomain()),
         dbops.CreateDomain(TimestampDomain()),
         dbops.CreateDomain(DateDomain()),
+        dbops.CreateDomain(IntervalDomain()),
         dbops.CreateFunction(StrToBigint()),
         dbops.CreateFunction(StrToDecimal()),
         dbops.CreateFunction(StrToInt64NoInline()),

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -49,7 +49,7 @@ base_type_name_map = {
     s_obj.get_known_type_id('std::float32'): ('float4',),
     s_obj.get_known_type_id('std::uuid'): ('uuid',),
     s_obj.get_known_type_id('std::datetime'): ('edgedb', 'timestamptz_t'),
-    s_obj.get_known_type_id('std::duration'): ('interval',),
+    s_obj.get_known_type_id('std::duration'): ('edgedb', 'interval_t',),
     s_obj.get_known_type_id('std::bytes'): ('bytea',),
     s_obj.get_known_type_id('std::json'): ('jsonb',),
 
@@ -82,7 +82,7 @@ base_type_name_map_r = {
     'edgedb.timestamptz_t': sn.QualName('std', 'datetime'),
     'timestamptz_t': sn.QualName('std', 'datetime'),
     'timestamptz': sn.QualName('std', 'datetime'),
-    'interval': sn.QualName('std', 'duration'),
+    'edgedb.interval_t': sn.QualName('std', 'duration'),
     'bytea': sn.QualName('std', 'bytes'),
     'jsonb': sn.QualName('std', 'json'),
 

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -83,6 +83,7 @@ base_type_name_map_r = {
     'timestamptz_t': sn.QualName('std', 'datetime'),
     'timestamptz': sn.QualName('std', 'datetime'),
     'edgedb.duration_t': sn.QualName('std', 'duration'),
+    'interval': sn.QualName('std', 'duration'),
     'bytea': sn.QualName('std', 'bytes'),
     'jsonb': sn.QualName('std', 'json'),
 

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -49,7 +49,7 @@ base_type_name_map = {
     s_obj.get_known_type_id('std::float32'): ('float4',),
     s_obj.get_known_type_id('std::uuid'): ('uuid',),
     s_obj.get_known_type_id('std::datetime'): ('edgedb', 'timestamptz_t'),
-    s_obj.get_known_type_id('std::duration'): ('edgedb', 'interval_t',),
+    s_obj.get_known_type_id('std::duration'): ('edgedb', 'duration_t',),
     s_obj.get_known_type_id('std::bytes'): ('bytea',),
     s_obj.get_known_type_id('std::json'): ('jsonb',),
 
@@ -82,7 +82,7 @@ base_type_name_map_r = {
     'edgedb.timestamptz_t': sn.QualName('std', 'datetime'),
     'timestamptz_t': sn.QualName('std', 'datetime'),
     'timestamptz': sn.QualName('std', 'datetime'),
-    'edgedb.interval_t': sn.QualName('std', 'duration'),
+    'edgedb.duration_t': sn.QualName('std', 'duration'),
     'bytea': sn.QualName('std', 'bytes'),
     'jsonb': sn.QualName('std', 'json'),
 


### PR DESCRIPTION
Enforces duration constraints in SQL types instead of only in casting logic.