### PR TITLE
Inject volatility_ref on object types also

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1168,10 +1168,7 @@ def process_set_as_subquery(
             pathctx.put_path_id_map(ctx.rel, outer_id, inner_id)
 
         if ir_source is not None:
-            if (
-                not is_objtype_path
-                and ir_source.path_id != ctx.current_insert_path_id
-            ):
+            if ir_source.path_id != ctx.current_insert_path_id:
                 # This is a computable pointer.  In order to ensure that
                 # the volatile functions in the pointer expression are called
                 # the necessary number of times, we must inject a
@@ -1186,7 +1183,8 @@ def process_set_as_subquery(
                     lambda: relctx.maybe_get_path_var(
                         stmt, path_id=path_id, aspect='identity',
                         ctx=ctx),)
-            elif is_objtype_path and not source_is_visible:
+
+            if is_objtype_path and not source_is_visible:
                 path_scope = relctx.get_scope(ir_set, ctx=newctx)
                 if (path_scope is None or
                         path_scope.find_descendant(ir_source.path_id) is None):

--- a/tests/schemas/volatility.esdl
+++ b/tests/schemas/volatility.esdl
@@ -20,3 +20,7 @@
 type Obj {
     required property n -> int64;
 }
+
+type Tgt {
+    required property n -> int64;
+}

--- a/tests/schemas/volatility_setup.edgeql
+++ b/tests/schemas/volatility_setup.edgeql
@@ -59,7 +59,15 @@ CREATE FUNCTION test::err_volatile() -> float64 {
     $$;
 };
 
+CREATE FUNCTION test::rand_int(top: int64) -> int64 {
+    USING (<int64>(random() * top))
+};
+
 
 INSERT test::Obj { n := 1 };
 INSERT test::Obj { n := 2 };
 INSERT test::Obj { n := 3 };
+INSERT test::Tgt { n := 1 };
+INSERT test::Tgt { n := 2 };
+INSERT test::Tgt { n := 3 };
+INSERT test::Tgt { n := 4 };

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -468,6 +468,20 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             [True],
         )
 
+    async def test_edgeql_volatility_nested_link_01(self):
+        # random() should get called once for each Obj/Tgt pair
+        result = await self.con.query(
+            r"""
+                WITH MODULE test
+                SELECT Obj {
+                    l := (SELECT Tgt { m := random() }),
+                };
+            """
+        )
+
+        nums = [t.m for o in result for t in o.l]
+        self.assertEqual(len(nums), len(set(nums)))
+
     async def test_edgeql_volatility_errors_01(self):
         async with self._run_and_rollback():
             with self.assertRaisesRegex(


### PR DESCRIPTION
This ensures that nested volatile computables get executed the right
number of times. Since the calls to get_path_var are only done when
there is actually a volatile, it shouldn't degrade code quality in
other cases.