### PR TITLE
Compiler pool: restart dead workers

### DIFF
--- a/edb/server/compiler_pool/amsg.py
+++ b/edb/server/compiler_pool/amsg.py
@@ -20,32 +20,32 @@
 from __future__ import annotations
 
 import asyncio
+import functools
+import logging
 import os
+import socket
 import struct
+import typing
 
 
+logger = logging.getLogger("edb.server")
 _uint64_unpacker = struct.Struct('!Q').unpack
 _uint64_packer = struct.Struct('!Q').pack
 
 
-class PoolClosedError(Exception):
-    pass
+def _wakeup_waiter(waiter, fut):
+    if not waiter.done():
+        waiter.set_result(fut.result())
 
 
-class BaseFramedProtocol(asyncio.Protocol):
+class MessageStream:
+    """Data stream that yields messages."""
 
-    def __init__(self, *, loop, con_waiter=None):
-        self._loop = loop
+    def __init__(self):
         self._buffer = b''
-        self._transport = None
-        self._con_waiter = con_waiter
         self._curmsg_len = -1
-        self._closed = False
 
-    def process_message(self, msg):
-        raise NotImplementedError
-
-    def data_received(self, data):
+    def feed_data(self, data):
         # TODO: rewrite to avoid buffer copies.
         self._buffer += data
         while self._buffer:
@@ -60,36 +60,27 @@ class BaseFramedProtocol(asyncio.Protocol):
                 msg = self._buffer[:self._curmsg_len]
                 self._buffer = self._buffer[self._curmsg_len:]
                 self._curmsg_len = -1
-                self.process_message(msg)
+                yield msg
             else:
                 return
 
-    def connection_made(self, tr):
-        self._transport = tr
-        if self._con_waiter is not None:
-            self._con_waiter.set_result(True)
-            self._con_waiter = None
 
-    def connection_lost(self, exc):
-        self._closed = True
+class HiveProtocol(asyncio.Protocol):
+    """The Protocol used by the Hive per connection to the Queen or Worker."""
 
-        if self._con_waiter is not None:
-            if exc is None:
-                # The connection is aborted on our end
-                self._con_waiter.set_result(None)
-            else:
-                self._con_waiter.set_exception(exc)
-            self._con_waiter = None
-
-
-class HubProtocol(BaseFramedProtocol):
-
-    def __init__(self, *, loop, on_pid):
-        super().__init__(loop=loop)
+    def __init__(self, *, loop, on_pid, on_connection_lost):
+        self._loop = loop
+        self._transport = None
+        self._closed = False
+        self._stream = MessageStream()
         self._resp_waiter = None
         self._resp_expected_id = -1
         self._on_pid = on_pid
+        self._on_connection_lost = on_connection_lost
         self._pid = None
+
+    def connection_made(self, tr):
+        self._transport = tr
 
     def send(self, req_id: int, waiter: asyncio.Future, payload: bytes):
         if self._resp_waiter is not None and not self._resp_waiter.done():
@@ -113,17 +104,18 @@ class HubProtocol(BaseFramedProtocol):
 
     def data_received(self, data):
         if self._pid is None:
-            pid_data = data[:8]
-            data = data[8:]
+            worker_type = data[:1]
+            pid_data = data[1:9]
+            data = data[9:]
             self._pid = _uint64_unpacker(pid_data)[0]
-            self._on_pid(self, self._transport, self._pid)
-            if data:
-                super().data_received(data)
-        else:
-            super().data_received(data)
+            self._on_pid(self, self._transport, self._pid, worker_type)
+            if not data:
+                return
+        for msg in self._stream.feed_data(data):
+            self.process_message(msg)
 
     def connection_lost(self, exc):
-        super().connection_lost(exc)
+        self._closed = True
 
         if self._resp_waiter is not None:
             if exc is not None:
@@ -133,38 +125,18 @@ class HubProtocol(BaseFramedProtocol):
                     'lost connection to the worker during a call'))
             self._resp_waiter = None
 
-
-class WorkerProtocol(BaseFramedProtocol):
-
-    def __init__(self, loop, con_waiter, con):
-        self._est = False
-        self._con = con
-        super().__init__(loop=loop, con_waiter=con_waiter)
-
-    def reply(self, req_id: int, payload: bytes):
-        self._transport.writelines(
-            (_uint64_packer(len(payload) + 8), _uint64_packer(req_id), payload)
-        )
-
-    def process_message(self, msg):
-        self._con._on_message(msg)
-
-    def connection_made(self, tr):
-        super().connection_made(tr)
-        tr.write(_uint64_packer(os.getpid()))
-
-    def connection_lost(self, exc):
-        super().connection_lost(exc)
-        self._con._on_connection_lost(exc)
+        self._on_connection_lost(self._pid)
 
 
-class HubConnection:
+class HiveConnection:
+    """An abstraction of the Hive's connections to the Queen and Workers."""
 
-    def __init__(self, transport, protocol, loop):
+    def __init__(self, transport, protocol, loop, pid):
         self._transport = transport
         self._protocol = protocol
         self._loop = loop
         self._req_id_cnt = 0
+        self.pid = pid
 
     def is_closed(self):
         return self._protocol._closed
@@ -181,94 +153,123 @@ class HubConnection:
         self._transport.abort()
 
 
-class WorkerConnection:
+class QueenConnection:
+    """Connection object used by the Queen's process."""
 
-    def __init__(self, loop):
-        self._loop = loop
-        self._msgs = asyncio.Queue(loop=loop)
-        self._protocol = None
-        self._transport = None
-        self._con_lost_fut = loop.create_future()
+    WORKER_TYPE = b'Q'
 
-    def is_closed(self):
-        return self._protocol._closed
+    def __init__(self, sockname):
+        self._sock = socket.socket(socket.AF_UNIX)
+        self._sock.connect(sockname)
+        self._sock.sendall(self.WORKER_TYPE + _uint64_packer(os.getpid()))
+        self._stream = MessageStream()
 
     def _on_message(self, msg: bytes):
         msgview = memoryview(msg)
         req_id = _uint64_unpacker(msgview[:8])[0]
-        self._msgs.put_nowait((req_id, msgview[8:]))
+        return req_id, msgview[8:]
 
-    def _on_connection_lost(self, exc):
-        self._con_lost_fut.set_exception(
-            PoolClosedError('connection to the pool is closed'))
-        self._con_lost_fut._log_traceback = False
+    def reply(self, req_id, payload):
+        self._sock.sendall(
+            b"".join(
+                (
+                    _uint64_packer(len(payload) + 8),
+                    _uint64_packer(req_id),
+                    payload,
+                )
+            )
+        )
 
-    async def reply(self, req_id, data):
-        self._protocol.reply(req_id, data)
-
-    async def next_request(self) -> bytes:
-        getter = self._loop.create_task(self._msgs.get())
-        await asyncio.wait(
-            [getter, self._con_lost_fut],
-            return_when=asyncio.FIRST_COMPLETED)
-
-        if self._con_lost_fut.done():
-            getter.cancel()
-            return self._con_lost_fut.result()
-
-        return getter.result()
+    def iter_request(self):
+        while True:
+            if self._sock is not None:
+                data = self._sock.recv(4096)
+            else:
+                data = None
+            if not data:
+                self.abort()
+                return
+            yield from map(self._on_message, self._stream.feed_data(data))
 
     def abort(self):
-        self._transport.abort()
+        if self._sock is not None:
+            self._sock.close()
+            self._sock = None
 
 
-async def worker_connect(sockname):
-    loop = asyncio.get_running_loop()
-    waiter = loop.create_future()
-    con = WorkerConnection(loop)
-    tr, pr = await loop.create_unix_connection(
-        lambda: WorkerProtocol(loop=loop, con_waiter=waiter, con=con),
-        path=sockname)
-    con._protocol = pr
-    con._transport = tr
-    await waiter
-    return con
+class WorkerConnection(QueenConnection):
+    """Connection object used by the the Worker's process."""
+
+    WORKER_TYPE = b'W'
 
 
-class Server:
+class HiveControlProtocol:
+    def queen_connected(self, conn: HiveConnection):
+        pass
 
-    def __init__(self, sockname, pool_size, loop):
+    def queen_disconnected(self):
+        pass
+
+    def worker_connected(self, pid):
+        pass
+
+    def worker_disconnected(self, pid):
+        pass
+
+
+class Hive:
+
+    _proto: HiveControlProtocol
+    _queen: asyncio.Future[HiveConnection]
+    _pids: typing.Dict[int, HiveConnection]
+
+    def __init__(self, sockname, loop, control_protocol):
         self._sockname = sockname
         self._loop = loop
         self._srv = None
         self._pids = {}
-        self._pid_waiters = {}
-        self._pool_size = pool_size
-        self._ready_fut = loop.create_future()
+        self._queen = loop.create_future()
+        self._proto = control_protocol
 
-    def _on_pid_connected(self, proto, tr, pid):
+    def _on_pid_connected(self, proto, tr, pid, worker_type):
         assert pid not in self._pids
-        self._pids[pid] = HubConnection(tr, proto, self._loop)
-        if len(self._pids) == self._pool_size:
-            self._ready_fut.set_result(True)
+        conn = HiveConnection(tr, proto, self._loop, pid)
+        if worker_type == QueenConnection.WORKER_TYPE:
+            if self._queen.done():
+                raise RuntimeError(
+                    "More than one Queen found in the same Hive!"
+                )
+            logger.info("The compiler Queen is ready.")
+            self._proto.queen_connected(conn)
+            self._queen.set_result(conn)
+        else:
+            self._pids[pid] = conn
+            self._proto.worker_connected(pid)
+
+    def _on_pid_disconnected(self, pid: typing.Optional[int]):
+        if not pid:
+            return
+        if pid in self._pids:
+            self._pids.pop(pid)
+            self._proto.worker_disconnected(pid)
+        elif self._queen.done():
+            queen = self._queen.result()
+            if pid == queen.pid:
+                logger.error(
+                    "We lost the compiler Queen - we won't be able to spawn "
+                    "more compiler Workers until the Queen is back."
+                )
+                self._queen = self._loop.create_future()
+                self._proto.queen_disconnected()
 
     def _proto_factory(self):
-        return HubProtocol(loop=self._loop, on_pid=self._on_pid_connected)
-
-    async def wait_until_ready(self):
-        await self._ready_fut
-
-    def iter_pids(self):
-        return iter(self._pids)
+        return HiveProtocol(
+            loop=self._loop,
+            on_pid=self._on_pid_connected,
+            on_connection_lost=self._on_pid_disconnected,
+        )
 
     async def get_by_pid(self, pid):
-        if not self._ready_fut.done():
-            raise RuntimeError(
-                'the message server does not yet have all workers connected')
-
-        # Will raise if it was cancelled of there was an error.
-        self._ready_fut.result()
-
         return self._pids[pid]
 
     async def start(self):
@@ -281,3 +282,21 @@ class Server:
         await self._srv.wait_closed()
         for con in self._pids.values():
             con.abort()
+        if self._queen.done():
+            self._queen.result().abort()
+
+    async def spawn_worker(self):
+        if self._queen.done():
+            queen = self._queen.result()
+        else:
+            waiter = self._loop.create_future()
+            cb = functools.partial(_wakeup_waiter, waiter)
+            self._queen.add_done_callback(cb)
+            try:
+                queen = await waiter
+            except asyncio.CancelledError:
+                try:
+                    self._queen.remove_done_callback(cb)
+                finally:
+                    raise
+        return await queen.request(b'')


### PR DESCRIPTION
* Promoted the first worker into a Queen (talking to the "Hive" in the same protocol for requests to spawn workers)
* Also removed async code from workers
* Fixed zombie worker issue by daemonizing
* The current design avoids using waitpid() on worker processes

(Before this PR, we were expecting the worker processes to exit on a broken UNIX socket. But in cases like OOM the worker process would die in a zombie because we didn't (want to?) `waitpid()` on it. This PR simply used two forks to avoid the zombie issue, and keep `waitpid()` away.)

The current design has 2 issues:
* It doesn't survive edgedb/edgedb-cli#349 because even though the (user) systemd process took over the daemonized worker processes, they are still considered a part of the service and lingered longer than the main process, thus triggering the CentOS bug [0017461](https://bugs.centos.org/view.php?id=17461#c38441).
* The double-fork breaks the EdgeDB server process tree hierarchy - it's kinda weird.

I'm now leaning towards a different design: the Queen just wait on all its subprocesses, and immediately fork a new one if any worker exited with non-zero code, until all workers exit with zero. And we don't need the Queen-Hive communication any more, as well as the double-forking. Theoretically, edgedb/edgedb-cli#349 won't be an issue.