### PR TITLE
Compiler pool worker restart and mgmt

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -884,6 +884,9 @@ class Server:
             await self._stop_servers(self._servers)
             self._servers = []
 
+            await self._compiler_pool.stop()
+            self._compiler_pool = None
+
         finally:
             if self.__sys_pgcon is not None:
                 self.__sys_pgcon.terminate()

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -16,9 +16,20 @@
 # limitations under the License.
 #
 
+import asyncio
+import contextlib
+import os
+import pickle
+import signal
+import subprocess
+import sys
+import tempfile
 
 from edb.testbase import lang as tb
+from edb.testbase import server as tbs
 from edb.server import compiler as edbcompiler
+from edb.server.compiler_pool import amsg
+from edb.server.compiler_pool import pool
 
 
 class TestServerCompiler(tb.BaseSchemaLoadTest):
@@ -50,3 +61,172 @@ class TestServerCompiler(tb.BaseSchemaLoadTest):
                 }
             ''',
         )
+
+
+class ServerProtocol(amsg.ServerProtocol):
+    def __init__(self):
+        self.connected = asyncio.Queue()
+        self.disconnected = asyncio.Queue()
+        self.pids = set()
+
+    def worker_connected(self, pid):
+        self.connected.put_nowait(pid)
+        self.pids.add(pid)
+
+    def worker_disconnected(self, pid):
+        self.disconnected.put_nowait(pid)
+        self.pids.remove(pid)
+
+
+class TestCompilerPool(tbs.TestCase):
+    @contextlib.asynccontextmanager
+    async def compiler_pool(self, num_proc):
+        proto = ServerProtocol()
+
+        with tempfile.TemporaryDirectory() as td:
+            sock_name = f'{td}/compiler.sock'
+            server = amsg.Server(sock_name, self.loop, proto)
+            await server.start()
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    sys.executable, "-m", pool.WORKER_MOD,
+                    "--sockname", sock_name,
+                    "--numproc", str(num_proc),
+                    env=pool._ENV,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                try:
+                    yield server, proto, proc, sock_name
+                finally:
+                    try:
+                        proc.terminate()
+                        await proc.wait()
+                    except ProcessLookupError:
+                        pass
+            finally:
+                await server.stop()
+                self.assertEqual(len(proto.pids), 0)
+
+    async def check_pid(self, pid, server):
+        conn = server.get_by_pid(pid)
+        resp = await conn.request(pickle.dumps(('not_exist', ())))
+        status, *data = pickle.loads(resp)
+        self.assertEqual(status, 1)
+        self.assertIsInstance(data[0], RuntimeError)
+
+    async def test_server_compiler_pool_restart(self):
+        pids = []
+        async with self.compiler_pool(2) as (server, proto, proc, sn):
+            # Make sure both compiler workers are up and ready
+            pid1 = await asyncio.wait_for(proto.connected.get(), 10)
+            pid2 = await asyncio.wait_for(proto.connected.get(), 1)
+            await self.check_pid(pid1, server)
+            await self.check_pid(pid2, server)
+
+            # Worker killed with SIGTERM shall be restarted
+            os.kill(pid1, signal.SIGTERM)
+            pid = await asyncio.wait_for(proto.disconnected.get(), 1)
+            pids.append(pid)
+            self.assertEqual(pid, pid1)
+            pid3 = await asyncio.wait_for(proto.connected.get(), 1)
+            self.assertNotIn(pid3, (pid1, pid2))
+            await self.check_pid(pid3, server)
+
+            # Worker killed with SIGKILL shall be restarted
+            os.kill(pid2, signal.SIGKILL)
+            pid = await asyncio.wait_for(proto.disconnected.get(), 1)
+            pids.append(pid)
+            self.assertEqual(pid, pid2)
+            pid4 = await asyncio.wait_for(proto.connected.get(), 1)
+            self.assertNotIn(pid4, (pid1, pid2, pid3))
+            await self.check_pid(pid4, server)
+
+            # Worker killed with SIGINT shall NOT be restarted
+            os.kill(pid3, signal.SIGINT)
+            pid = await asyncio.wait_for(proto.disconnected.get(), 1)
+            pids.append(pid)
+            self.assertEqual(pid, pid3)
+            with self.assertRaises(asyncio.TimeoutError):
+                await asyncio.wait_for(proto.connected.get(), 1)
+
+        # The only remaining worker should be terminated on exit
+        pid = await asyncio.wait_for(proto.disconnected.get(), 1)
+        pids.append(pid)
+
+        # Make sure all the workers are gone
+        for pid in pids:
+            with self.assertRaises(OSError):
+                os.kill(pid, 0)
+
+    async def test_server_compiler_pool_template_proc_exit(self):
+        async with self.compiler_pool(2) as (server, proto, proc, sn):
+            # Make sure both compiler workers are up and ready
+            pid1 = await asyncio.wait_for(proto.connected.get(), 10)
+            pid2 = await asyncio.wait_for(proto.connected.get(), 1)
+            await self.check_pid(pid1, server)
+            await self.check_pid(pid2, server)
+
+            proc.terminate()
+            await proc.wait()
+
+            pids = []
+            for _ in range(2):
+                pid = await asyncio.wait_for(proto.disconnected.get(), 1)
+                pids.append(pid)
+
+            self.assertIn(pid1, pids)
+            self.assertIn(pid2, pids)
+
+            # Make sure all the workers are gone
+            for pid in pids:
+                with self.assertRaises(OSError):
+                    os.kill(pid, 0)
+
+    async def test_server_compiler_pool_server_exit(self):
+        async with self.compiler_pool(2) as (server, proto, proc, sn):
+            # Make sure both compiler workers are up and ready
+            pid1 = await asyncio.wait_for(proto.connected.get(), 10)
+            pid2 = await asyncio.wait_for(proto.connected.get(), 1)
+            await self.check_pid(pid1, server)
+            await self.check_pid(pid2, server)
+
+            await server.stop()
+
+            await asyncio.wait_for(proc.wait(), 1)
+
+            pids = []
+            for _ in range(2):
+                pid = await asyncio.wait_for(proto.disconnected.get(), 1)
+                pids.append(pid)
+
+            self.assertIn(pid1, pids)
+            self.assertIn(pid2, pids)
+
+            # Make sure all the workers are gone
+            for pid in pids:
+                with self.assertRaises(OSError):
+                    os.kill(pid, 0)
+
+    async def test_server_compiler_pool_no_socket(self):
+        async with self.compiler_pool(2) as (server, proto, proc, sn):
+            # Make sure both compiler workers are up and ready
+            pid1 = await asyncio.wait_for(proto.connected.get(), 10)
+            pid2 = await asyncio.wait_for(proto.connected.get(), 1)
+            await self.check_pid(pid1, server)
+            await self.check_pid(pid2, server)
+
+            os.unlink(sn)
+            os.kill(pid1, signal.SIGTERM)
+
+            await asyncio.wait_for(proc.wait(), 1)
+
+            pids = []
+            while not proto.disconnected.empty():
+                pids.append(proto.disconnected.get_nowait())
+
+            # Make sure all the workers are gone
+            for pid in pids:
+                with self.assertRaises(OSError):
+                    os.kill(pid, 0)


### PR DESCRIPTION
### Background

1. The compiler worker processes may exit due to 1) out of memory 2) future timeout kills 3) other unexpected issues.
2. We want the EdgeDB server to keep running if a worker exits like that, and start a new worker to maintain the pool size.
3. Starting a compiler worker is time-consuming. Therefore in the existing design, we only loaded the necessary parser spec and everything in the first worker, and used the low-level `os.fork()` to create other workers to 1) save time reloading those preset, and 2) leverage shared memory.
4. We didn't get involved into the unreliable `SIGCHLD` solution (thus no `waitpid()`) before, so we reused the same UNIX socket for IPC between the server and the workers to also maintain the worker's lifetime: the worker will organically exit if the connection is broken because of e.g. the server is killed, or on the other hand the server will know if the worker dies and disconnects.
5. We'd like to keep the design similarly simple in this PR too.
6. However, the exisiting design will leave zombie processes behind in the scenario described in (1) and (2) because we never waited on the subprocesses. (except for the first worker - the parent of all reamining workers. asyncio will automatically wait on it in `SIGCHLD` handler, but all the remaining workers will be re-parented to a supervisor daemon - PID=1 or systemd user daemon.)

### Solution A

This is implemented in #2548 and abandoned due to complexity. The idea was to keep avoiding `SIGCHLD` and `waitpid()`, and make use of the IPC socket to restart the dead workers. Therefore, we altered the role of the first worker into a "template process" (queen in #2548), that will accept requests from the IPC socket and spawn workers. In order to avoid zombie processes without `waitpid()`, we had to introdue double-forking to daemonize the workers. However, that gets into the same issue of edgedb/edgedb-cli#349.

### Solution B

Implemented in this PR. Similar to solution A, we have a preloaded idle "template process", which keeps waiting on its child processes to exit. If a child exits with an error or gets killed (return code > 0 or killing signal is not SIGINT), the template process will simply fork a new child, until all child processes exits normally. In this case, we won't have zombies (memory is happy), or daemonized processes (CentOS is happy), and the design is simple (no additional IPCs).

On the server side, we keep attaching newly-connected workers to the pool, and exit if the template process dies.

In addition, this PR also made workers asyncio-free.

Closes #2548
Fixes edgedb/edgedb-cli#349