### PR TITLE
Test: adding a timeout to debug a hanging test for query cancellation

### DIFF
--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -177,6 +177,12 @@ class TestProtocol(ProtocolTestCase):
         )
 
     async def test_proto_connection_lost_cancel_query(self):
+        # This test is occasionally hanging - adding a timeout to find out why
+        await asyncio.wait_for(
+            self._test_proto_connection_lost_cancel_query(), 30
+        )
+
+    async def _test_proto_connection_lost_cancel_query(self):
         # Prepare the test data
         con2 = await edgedb.async_connect(**self.get_connect_args())
         try:


### PR DESCRIPTION
This is occasionally seen in nightly builds on different Linux:

https://github.com/edgedb/edgedb/runs/2635273420?check_suite_focus=true