### PR TITLE
Increase the confidence of simple create pointer migrations

### DIFF
--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -699,7 +699,7 @@ def statements_from_delta(
     sdlmode: bool = False,
     descriptive_mode: bool = False,
     limit_ref_classes: Iterable[so.ObjectMeta] = tuple(),
-) -> Tuple[Tuple[str, sd.Command], ...]:
+) -> Tuple[Tuple[str, qlast.DDLOperation, sd.Command], ...]:
 
     stmts = ddlast_from_delta(
         schema_a,
@@ -759,7 +759,7 @@ def statements_from_delta(
             descmode=descriptive_mode,
             limit_ref_classes=ql_classes,
         )
-        text.append((stmt_text + ';', cmd))
+        text.append((stmt_text + ';', stmt_ast, cmd))
 
     return tuple(text)
 
@@ -781,7 +781,7 @@ def text_from_delta(
         descriptive_mode=descriptive_mode,
         limit_ref_classes=limit_ref_classes,
     )
-    return '\n'.join(text for text, _ in stmts)
+    return '\n'.join(text for text, _, _ in stmts)
 
 
 def ddl_text_from_delta(

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -195,6 +195,8 @@ def delta_objects(
             s, y = comparison_map[x]
             x_name = x.get_name(new_schema)
             y_name = y.get_name(old_schema)
+
+            already_has = x_name == y_name and x_name not in renames_x
             if (
                 0.6 < s < 1.0
                 or (
@@ -204,7 +206,8 @@ def delta_objects(
                 or x_name in renames_x
             ):
                 if (
-                    (x_alter_variants[x] > 1 or can_create(x_name))
+                    (x_alter_variants[x] > 1 or (
+                        not already_has and can_create(x_name)))
                     and parent_confidence != 1.0
                 ):
                     confidence = s
@@ -1638,9 +1641,11 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                 )
             )
         ):
+            from . import referencing as s_referencing
+
             subcommands = self.get_subcommands(
                 type=ObjectCommand,
-                exclude=AlterObjectProperty,
+                exclude=(AlterObjectProperty, s_referencing.AlterOwned),
             )
             if len(subcommands) == 1:
                 subcommand = subcommands[0]

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -1123,10 +1123,14 @@ class RebaseInheritingObject(
                 continue
 
             if isinstance(pos, tuple):
+                typ = utils.typeref_to_ast(schema, pos[1])
+                assert isinstance(typ, qlast.TypeName)
+
                 pos_node = qlast.Position(
                     position=pos[0],
-                    ref=utils.typeref_to_ast(schema, pos[1]),
+                    ref=typ.maintype,
                 )
+
             else:
                 pos_node = qlast.Position(position=pos)
 


### PR DESCRIPTION
The slight churn in the produced deltas caused us to produce worse
migration prompts in some cases (a "did you alter <parent>?") instead
of a useful prompt about what was really done, so I hacked the code
for DESCRIBE MIGRATION AS JSON to generate better prompts by
rebuilding the delta from the AST. Sorry. This improves our prompts in
some existing cases too.

Fixes #2547.