### PR TITLE
Compile view shapes inside of operator calls

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -509,11 +509,12 @@ def compile_operator(
 
     matched_params = oper.get_params(env.schema)
     rtype = matched_call.return_type
+    matched_rtype = oper.get_return_type(env.schema)
 
     is_polymorphic = (
         any(p.get_type(env.schema).is_polymorphic(env.schema)
             for p in matched_params.objects(env.schema)) and
-        rtype.is_polymorphic(env.schema)
+        matched_rtype.is_polymorphic(env.schema)
     )
 
     final_args, params_typemods = finalize_args(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1308,9 +1308,9 @@ def _compile_view_shapes_in_select(
         stmt.result, rptr=rptr, parent_view_type=parent_view_type, ctx=ctx)
 
 
-@compile_view_shapes.register(irast.FunctionCall)
-def _compile_view_shapes_in_fcall(
-        expr: irast.FunctionCall, *,
+@compile_view_shapes.register(irast.Call)
+def _compile_view_shapes_in_call(
+        expr: irast.Call, *,
         rptr: Optional[irast.Pointer]=None,
         parent_view_type: Optional[s_types.ExprType]=None,
         ctx: context.ContextLevel) -> None:

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -6317,6 +6317,30 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_select_expr_objects_08(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE test,
+            SELECT DISTINCT
+                [(SELECT Issue {number, name} FILTER .number = "1")];
+            ''',
+            [
+                [{'number': '1', 'name': 'Release EdgeDB'}],
+            ]
+        )
+
+        await self.assert_query_result(
+            r'''
+            WITH MODULE test,
+            SELECT DISTINCT
+                ((SELECT Issue {number, name} FILTER .number = "1"),
+                 Issue.status.name);
+            ''',
+            [
+                [{'number': '1', 'name': 'Release EdgeDB'}, "Open"],
+            ]
+        )
+
     @test.xfail("We produce results that don't decode properly")
     async def test_edgeql_select_array_common_type_01(self):
         res = await self.con._fetchall("""


### PR DESCRIPTION
This fixes DISTINCT over collections of shapes.
Closes #2540.