### PR TITLE
Implement removal/reordering of enum elements

### DIFF
--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -555,17 +555,6 @@ class RebaseScalarType(
             raise errors.SchemaError(
                 f'enums cannot contain duplicate values')
 
-        cur_set = set(cur_labels)
-        if cur_set - new_set:
-            raise errors.SchemaError(
-                f'cannot remove labels from an enumeration type')
-
-        for cur_label, new_label in zip(cur_labels, new_labels):
-            if cur_label != new_label:
-                raise errors.SchemaError(
-                    f'cannot change the existing labels in an enumeration '
-                    f'type, only appending new labels is allowed')
-
         self.set_attribute_value('enum_values', new_labels)
         schema = stype.set_field_value(schema, 'enum_values', new_labels)
         return schema

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -8544,6 +8544,7 @@ type test::Foo {
         await self.con.execute('''
             DROP SCALAR TYPE test::Color;
         ''')
+        await self.con.query("COMMIT")
 
     async def test_edgeql_ddl_enum_05(self):
         await self.con.execute('''

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -8551,19 +8551,22 @@ type test::Foo {
             CREATE SCALAR TYPE test::Color
                 EXTENDING enum<Red, Green, Blue>;
 
-             CREATE TYPE test::Entry {
-                 CREATE PROPERTY num -> int64;
-                 CREATE PROPERTY color -> test::Color;
-                 CREATE PROPERTY colors -> array<test::Color>;
-             };
-             INSERT test::Entry { num := 1, color := "Red" };
-             INSERT test::Entry {
-                 num := 2, color := "Green", colors := ["Red", "Green"] };
-
              CREATE FUNCTION test::asdf(x: test::Color) -> str USING (
                  <str>(x));
              CREATE FUNCTION test::asdf2() -> str USING (
                  test::asdf(<test::Color>'Red'));
+
+             CREATE TYPE test::Entry {
+                 CREATE PROPERTY num -> int64;
+                 CREATE PROPERTY color -> test::Color;
+                 CREATE PROPERTY colors -> array<test::Color>;
+                 CREATE CONSTRAINT expression ON (
+                     <str>.num != test::asdf2()
+                 );
+             };
+             INSERT test::Entry { num := 1, color := "Red" };
+             INSERT test::Entry {
+                 num := 2, color := "Green", colors := ["Red", "Green"] };
         ''')
 
         await self.con.execute('''

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -8563,6 +8563,10 @@ type test::Foo {
                  CREATE CONSTRAINT expression ON (
                      <str>.num != test::asdf2()
                  );
+                 CREATE INDEX ON (test::asdf(.color));
+                 CREATE PROPERTY lol -> str {
+                     SET default := test::asdf2();
+                 }
              };
              INSERT test::Entry { num := 1, color := "Red" };
              INSERT test::Entry {
@@ -10332,9 +10336,11 @@ type test::Foo {
         await self.con.execute(r"""
             SET MODULE test;
 
+            CREATE FUNCTION foo() -> str USING ("test");
+
             CREATE TYPE Foo {
                 CREATE REQUIRED PROPERTY a -> str {
-                    SET default := "test";
+                    SET default := foo();
                 }
             };
         """)
@@ -10359,6 +10365,10 @@ type test::Foo {
             await self.con.execute(r"""
                 INSERT Foo;
             """)
+
+        await self.con.execute(r"""
+            DROP FUNCTION foo();
+        """)
 
     async def test_edgeql_ddl_drop_field_02(self):
         await self.con.execute(r"""


### PR DESCRIPTION
Mostly this is able to leverage the machinery built in #2407 to
handle adding constraints to scalar types that are contained in
composite types.

Fixes #2564.