### PR TITLE
Fix deduplication of computable link paths

### DIFF
--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -91,7 +91,6 @@ def register_set_in_scope(
         ir_set: irast.Set, *,
         path_scope: Optional[irast.ScopeTreeNode]=None,
         optional: bool=False,
-        fence_points: FrozenSet[irast.PathId]=frozenset(),
         ctx: context.ContextLevel) -> List[irast.ScopeTreeNode]:
     if path_scope is None:
         path_scope = ctx.path_scope
@@ -102,7 +101,6 @@ def register_set_in_scope(
     return path_scope.attach_path(
         ir_set.path_id,
         optional=optional,
-        fence_points=fence_points,
         context=ir_set.context,
     )
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -507,12 +507,12 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
     # }
     #
     # Note that we use an unfenced BRANCH node to isolate the path head,
-    # to make sure it is still properly factorable.  We temporarily flip
-    # the branch to be a full fence for the compilation of the computable.
-    fence_points = frozenset(c.path_id for c in computables)
+    # to make sure it is still properly factorable.
+    # The branch insertion is handled automatically by attach_path, and
+    # we temporarily flip the branch to be a full fence for the compilation
+    # of the computable.
     fences = pathctx.register_set_in_scope(
         path_tip,
-        fence_points=fence_points,
         ctx=ctx,
     )
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1199,7 +1199,8 @@ def process_set_as_subquery(
                 # path inside the computable.
                 # (See test_edgeql_scope_computables_09 for an example.)
                 with newctx.subrel() as _, _.newscope() as subctx:
-                    subrvar = get_set_rvar(ir_source, ctx=subctx)
+                    get_set_rvar(ir_source, ctx=subctx)
+                    subrvar = relctx.rvar_for_rel(subctx.rel, ctx=subctx)
 
                 relctx.include_rvar(
                     stmt, subrvar, ir_source.path_id, ctx=ctx)

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -968,7 +968,12 @@ def process_set_as_path(
     semi_join = (
         not source_is_visible and
         ir_set.path_id not in ctx.disable_semi_join and
-        not (is_linkprop or is_primitive_ref)
+        not (is_linkprop or is_primitive_ref) and
+        # This is an optimization for when we are inside of a semi-join on
+        # a computable: process_set_as_subquery will have included an
+        # rvar for the computable source, and we want to join on it
+        # instead of semi-joining.
+        not relctx.find_rvar(stmt, path_id=ir_source.path_id, ctx=ctx)
     )
 
     source_rptr = ir_source.rptr
@@ -1185,18 +1190,19 @@ def process_set_as_subquery(
                         ctx=xctx),)
 
             if is_objtype_path and not source_is_visible:
-                path_scope = relctx.get_scope(ir_set, ctx=newctx)
-                if (path_scope is None or
-                        path_scope.find_descendant(ir_source.path_id) is None):
-                    # Non-scalar computable semi-join.
-                    semi_join = True
+                # Non-scalar computable semi-join.
+                semi_join = True
 
-                    with newctx.subrel() as _, _.newscope() as subctx:
-                        get_set_rvar(ir_source, ctx=subctx)
-                        subrel = subctx.rel
+                # We need to compile the source and include it in,
+                # since we need to do the semi-join deduplication here
+                # on the outside, and not when the source is used in a
+                # path inside the computable.
+                # (See test_edgeql_scope_computables_09 for an example.)
+                with newctx.subrel() as _, _.newscope() as subctx:
+                    subrvar = get_set_rvar(ir_source, ctx=subctx)
 
-                    pathctx.get_path_identity_output(
-                        subrel, path_id=ir_source.path_id, env=ctx.env)
+                relctx.include_rvar(
+                    stmt, subrvar, ir_source.path_id, ctx=ctx)
 
         if (isinstance(ir_set.expr, irast.MutatingStmt)
                 and ir_set.expr in ctx.dml_stmts):
@@ -1211,21 +1217,18 @@ def process_set_as_subquery(
             dispatch.visit(ir_set.expr, ctx=newctx)
 
         if semi_join:
-            assert ir_source is not None
-            src_ref = pathctx.maybe_get_path_identity_var(
-                stmt, path_id=ir_source.path_id, env=ctx.env)
+            set_rvar = relctx.new_root_rvar(ir_set, ctx=newctx)
+            tgt_ref = pathctx.get_rvar_path_identity_var(
+                set_rvar, ir_set.path_id, env=ctx.env)
 
-            cond_expr: pgast.BaseExpr
-            if src_ref is not None:
-                cond_expr = astutils.new_binop(src_ref, subrel, 'IN')
-            else:
-                # The link expression does not refer to the source,
-                # so simply check it's not empty.
-                cond_expr = pgast.SubLink(
-                    type=pgast.SubLinkType.EXISTS,
-                    expr=subrel
-                )
+            pathctx.get_path_identity_output(
+                stmt, ir_set.path_id, env=ctx.env)
+            cond_expr = astutils.new_binop(tgt_ref, stmt, 'IN')
 
+            # Make a new stmt, join in the new root, and semi join on
+            # the original statement.
+            stmt = pgast.SelectStmt()
+            relctx.include_rvar(stmt, set_rvar, ir_set.path_id, ctx=ctx)
             stmt.where_clause = astutils.extend_binop(
                 stmt.where_clause, cond_expr)
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -527,14 +527,19 @@ class ConnectedTestCaseMixin:
                                   exp_result_json,
                                   exp_result_binary=...,
                                   *,
-                                  msg=None, sort=None, variables=None):
+                                  msg=None, sort=None, implicit_limit=0,
+                                  variables=None):
         fetch_args = variables if isinstance(variables, tuple) else ()
         fetch_kw = variables if isinstance(variables, dict) else {}
         try:
             tx = self.con.transaction()
             await tx.start()
             try:
-                res = await self.con.query_json(query, *fetch_args, **fetch_kw)
+                res = await self.con._fetchall_json(
+                    query,
+                    *fetch_args,
+                    __limit__=implicit_limit,
+                    **fetch_kw)
             finally:
                 await tx.rollback()
 
@@ -559,6 +564,7 @@ class ConnectedTestCaseMixin:
                 *fetch_args,
                 __typenames__=typenames,
                 __typeids__=typeids,
+                __limit__=implicit_limit,
                 **fetch_kw
             )
             res = serutils.serialize(res)

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -55,6 +55,8 @@ type Card extending Named {
     multi link owners := __source__.<deck[IS User];
     # computable property
     property elemental_cost := <str>.cost ++ ' ' ++ .element;
+    multi link awards -> Award;
+    multi link good_awards := (SELECT .awards FILTER .name != '3rd');
 }
 
 type SpecialCard extending Card;

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -55,7 +55,9 @@ type Card extending Named {
     multi link owners := __source__.<deck[IS User];
     # computable property
     property elemental_cost := <str>.cost ++ ' ' ++ .element;
-    multi link awards -> Award;
+    multi link awards -> Award {
+        constraint exclusive;
+    }
     multi link good_awards := (SELECT .awards FILTER .name != '3rd');
 }
 

--- a/tests/schemas/cards_setup.edgeql
+++ b/tests/schemas/cards_setup.edgeql
@@ -16,19 +16,25 @@
 # limitations under the License.
 #
 
+WITH MODULE test
+FOR award in {'1st', '2nd', '3rd'} UNION (
+    INSERT Award { name := award }
+);
 
 WITH MODULE test
 INSERT Card {
     name := 'Imp',
     element := 'Fire',
-    cost := 1
+    cost := 1,
+    awards := (SELECT Award FILTER .name = '2nd'),
 };
 
 WITH MODULE test
 INSERT Card {
     name := 'Dragon',
     element := 'Fire',
-    cost := 5
+    cost := 5,
+    awards := (SELECT Award FILTER .name = '1st'),
 };
 
 WITH MODULE test
@@ -77,19 +83,8 @@ WITH MODULE test
 INSERT SpecialCard {
     name := 'Djinn',
     element := 'Air',
-    cost := 4
-};
-
-
-WITH MODULE test
-INSERT Award {
-    name := '1st'
-};
-
-
-WITH MODULE test
-INSERT Award {
-    name := '2nd'
+    cost := 4,
+    awards := (SELECT Award FILTER .name = '3rd'),
 };
 
 
@@ -101,7 +96,7 @@ INSERT User {
         SELECT Card {@count := len(Card.element) - 2}
         FILTER .element IN {'Fire', 'Water'}
     ),
-    awards := Award,
+    awards := (SELECT Award FILTER .name IN {'1st', '2nd'}),
     avatar := (
         SELECT Card {@text := 'Best'} FILTER .name = 'Dragon'
     ),
@@ -113,9 +108,7 @@ INSERT User {
     deck := (
         SELECT Card {@count := 3} FILTER .element IN {'Earth', 'Water'}
     ),
-    awards := (INSERT Award {
-        name := '3rd'
-    })
+    awards := (SELECT Award FILTER .name = '3rd'),
 };
 
 WITH MODULE test

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -104,7 +104,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(test::Card)",
             "(test::Card).<deck[IS __derived__::(opaque: test:User)]\
 .>indirection[IS test::User]": {
-                "(test::Card).<deck[IS __derived__::(opaque: test:User)]"
+                "(test::Card).<deck[IS __derived__::(opaque: test:User)]",
+                "[ns~1]@[ns~2]@@(test::Card).<deck[IS __derived__::\
+(opaque: test:User)]"
             },
             "FENCE": {
                 "(test::Card).>owner[IS test::User]"
@@ -126,7 +128,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(test::Card).<deck[IS __derived__::(opaque: test:User)]\
 .>indirection[IS test::User]": {
-                "(test::Card).<deck[IS __derived__::(opaque: test:User)]"
+                "(test::Card).<deck[IS __derived__::(opaque: test:User)]",
+                "[ns~1]@[ns~2]@@(test::Card).<deck[IS __derived__::\
+(opaque: test:User)]"
             },
             "(test::Card)",
             "FENCE": {

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2260,6 +2260,142 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_scope_computables_07a(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test,
+                     U := User { cards := .deck },
+                SELECT count((U.cards.name, U.cards.cost));
+            """,
+            [9],
+        )
+
+    async def test_edgeql_scope_computables_07b(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test,
+                     U := User { cards := Card },
+                SELECT count((U.cards.name, U.cards.cost));
+            """,
+            [9],
+        )
+
+    async def test_edgeql_scope_computables_07c(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test,
+                     U := (SELECT User { cards := Card }
+                           FILTER .name = "Phil"),
+                SELECT count((U.cards.name, U.cards.cost));
+            """,
+            [0],
+        )
+
+    async def test_edgeql_scope_computables_08(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test,
+                SELECT count((Card.owners.name, Card.owners.deck_cost));
+            """,
+            [4],
+        )
+
+    async def test_edgeql_scope_computables_09a(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test,
+                    U := User {
+                        unowned := (SELECT Card FILTER Card NOT IN User.deck)
+                    },
+                SELECT _ := U.unowned.name ORDER BY _;
+            """,
+            [
+                'Djinn', 'Dragon', 'Dwarf', 'Giant eagle',
+                'Golem', 'Imp', 'Sprite',
+            ],
+        )
+
+    async def test_edgeql_scope_computables_09b(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test,
+                    U := (SELECT User {
+                        unowned := (SELECT Card FILTER Card NOT IN User.deck)
+                    } FILTER .name IN {'Carol', 'Dave'}),
+                SELECT _ := U.unowned.name ORDER BY _;
+            """,
+            [
+                'Dragon', 'Dwarf', 'Imp',
+            ],
+        )
+
+    async def test_edgeql_scope_computables_09c(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test,
+                    U := (SELECT User {
+                        unowned := (SELECT Card FILTER Card NOT IN User.deck)
+                    } FILTER .name IN {'Carol', 'Dave'}),
+                SELECT _ := (U.unowned.name, U.unowned.cost) ORDER BY _;
+            """,
+            [
+                ['Dragon', 5], ['Dwarf', 1], ['Imp', 1],
+            ],
+        )
+
+    async def test_edgeql_scope_computables_10(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test,
+                     U := User { cards := (.deck UNION .deck) },
+                SELECT count(U.cards);
+            """,
+            [9],
+        )
+
+    async def test_edgeql_scope_computables_11a(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test,
+                    U := (SELECT User {
+                        deck: {name, a := Award},
+                    }),
+                SELECT count((U.deck.a.name, U.deck.a.id, U.deck.name));
+            """,
+            [27],
+            implicit_limit=100,
+        )
+
+    async def test_edgeql_scope_computables_11b(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test,
+                    U := (SELECT User {
+                        cards := .deck {name, a := Award},
+                    }),
+                SELECT count((U.cards.a.name, U.cards.a.id, U.cards.name));
+            """,
+            [27],
+        )
+
+    @test.xfail('''
+        We fail to generate a proper shape output
+    ''')
+    async def test_edgeql_scope_computables_11c(self):
+        # ... make sure we output legit objects in this case
+        await self.assert_query_result(
+            r"""
+                WITH MODULE test,
+                    U := (SELECT User {
+                        cards := .deck {name, a := Award},
+                    }),
+                SELECT (U.cards.a.name, U.cards.a.id, U.cards) LIMIT 1;
+            """,
+            [
+                [{}, {}, {"id": {}}],
+            ],
+        )
+
     async def test_edgeql_scope_with_01(self):
         # Test that same symbol can be re-used in WITH block.
         await self.assert_query_result(


### PR DESCRIPTION
There are two components to the fix:
 * The scope tree didn't properly do longest-prefix detection
   for computable paths, because of how the head of a computable
   gets wrapped in a branch to protect it from the compiled body
   of the computable.

   The fix to this part is a bit involved:
     * Have attach_subtree detect the BRANCH-covered case and
       be able to merge BRANCH-covered nodes.
     * Track which nodes are merged into which other nodes,
       so that the list of fences that compile_path sets as
       full fences temporarily is correct.
     * Generate the fence_points in attach_path directly, so that
       computable paths *always* use them, not just when actually
       compiling the computable. (Which keeps the merging from
       breaking when the path is registered in another place.)
     * When merging a visible node, use fuse_subtree to fuse its
       children recursively instead of just picking them up from
       the tree traversal. This allows our detection to work when
       there are multiple computables in a path.

 * Fixing the scope tree makes a lot of simple cases work (because
   relying on the semi-joins that get done when the underlying
   paths are referenced work), but handling tricky cases like
   a negative filter requires reworking computable semi-joins
   in the pgsql compiler.

   We need to compile the source and evaluate the body of the
   computable with the source joined in and visible, and *then*
   do a semi-join on the final result.

At one point, things were broken when there was an implicit limit but
not when there wasn't, so I tweaked assert_query_result to make it
easy to insert an implicit limit.