### PR TITLE
allow empty blocks

### DIFF
--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -273,6 +273,9 @@ class WithDeclList(ListNonterm, element=WithDecl,
 
 
 class Shape(Nonterm):
+    def reduce_LBRACE_RBRACE(self, *kids):
+        self.val = None
+
     def reduce_LBRACE_ShapeElementList_RBRACE(self, *kids):
         self.val = kids[1].val
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1689,6 +1689,15 @@ aa';
         SELECT [Foo{id} bar];
         """
 
+    def test_edgeql_syntax_shape_64(self):
+        """
+        SELECT sys::Database{};
+
+% OK %
+
+        SELECT sys::Database;
+        """
+
     def test_edgeql_syntax_struct_01(self):
         """
         SELECT (


### PR DESCRIPTION
This change enables use cases where shape field lists are built
pragmatically and it is possible for the field list to be empty.

fixes https://github.com/edgedb/edgedb/issues/2485