### PR TITLE
Fix handling of reverse link cardinality when there are multiple pointers

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -642,6 +642,18 @@ def _infer_set_inner(
                     rptr_spec_card = _union_cardinality(
                         s.dir_cardinality for s in rptr_spec)
 
+                    # If the intersection has an rptr_specialization,
+                    # then we take a step back and start with
+                    # the source of *that*, which lets us take
+                    # advantage of std::exclusive on links when using
+                    # reverse pointers with multiple possibilities.
+                    if rptr_spec:
+                        # Already inferred, should just be hitting cache.
+                        source_card = infer_cardinality(
+                            ind_prefix.rptr.source,
+                            scope_tree=new_scope, ctx=ctx,
+                        )
+
                     # The resulting cardinality is the cartesian
                     # product of the base to which the type
                     # intersection is applied and the cardinality due

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -55,9 +55,7 @@ type Card extending Named {
     multi link owners := __source__.<deck[IS User];
     # computable property
     property elemental_cost := <str>.cost ++ ' ' ++ .element;
-    multi link awards -> Award {
-        constraint exclusive;
-    }
+    multi link awards -> Award;
     multi link good_awards := (SELECT .awards FILTER .name != '3rd');
 }
 

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2534,3 +2534,20 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 {'name': 'Dave'},
             ],
         )
+
+    async def test_edgeql_scope_link_narrow_card_01(self):
+        await self.assert_query_result(
+            """
+                WITH MODULE test
+                SELECT User {
+                    name,
+                    specials := .deck[IS SpecialCard].name
+                } ORDER BY .name;
+            """,
+            [
+                {"name": "Alice", "specials": []},
+                {"name": "Bob", "specials": []},
+                {"name": "Carol", "specials": ["Djinn"]},
+                {"name": "Dave", "specials": ["Djinn"]}
+            ],
+        )


### PR DESCRIPTION
This was revealed by the addition of an "awards" link to Card
in the cards test schema.