### PR TITLE
Drop the reverse_map_path_id in _maybe_get_path_rvar

### DIFF
--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -251,8 +251,10 @@ def gen_dml_cte(
         dml_stmt, target_path_id, dml_stmt.relation, env=ctx.env)
     pathctx.put_path_source_rvar(
         dml_stmt, target_path_id, dml_stmt.relation, env=ctx.env)
-    pathctx.put_path_bond(
-        dml_stmt, target_path_id)
+    # Skip the path bond for inserts, since it doesn't help and
+    # interferes when inserting in an UNLESS CONFLICT ELSE
+    if not isinstance(ir_stmt, irast.InsertStmt):
+        pathctx.put_path_bond(dml_stmt, target_path_id)
 
     dml_cte = pgast.CommonTableExpr(
         query=dml_stmt,

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -288,9 +288,6 @@ def _maybe_get_path_rvar(
                 pathctx.put_path_rvar(stmt, path_id, rvar, aspect=aspect,
                                       env=ctx.env)
             return rvar, path_id
-        if qry.view_path_id_map:
-            path_id = pathctx.reverse_map_path_id(
-                path_id, qry.view_path_id_map)
         qry = ctx.rel_hierarchy.get(qry)
 
     return None


### PR DESCRIPTION
The map reversing there I think doesn't make any sense; if it finds
something, there's no guarentee that the thing it finds will have the
right outputs, since /it/ doesn't know about the mapping.

The one impact it had on our test suite was that it was *preventing*
us from finding something in an UNLESS CONFLICT case where we do an
INSERT in the ELSE, but that was just an accident.