### PR TITLE
Some cleanup of NodeVisitor

### DIFF
--- a/edb/common/ast/visitor.py
+++ b/edb/common/ast/visitor.py
@@ -136,7 +136,7 @@ class NodeVisitor:
                 result.append(self.visit(elem))
             else:
                 result.append(elem)
-        return node.__class__(result)
+        return result
 
     def repeated_node_visit(self, node):
         result = self.memo[node]
@@ -165,7 +165,7 @@ class NodeVisitor:
     def visit(self, node):
         if typeutils.is_container(node):
             return self.container_visit(node)
-        else:
+        elif base.is_ast_node(node):
             return self.node_visit(node)
 
     def generic_visit(self, node, *, combine_results=None):
@@ -176,16 +176,9 @@ class NodeVisitor:
             if self.skip_hidden and field_spec.hidden:
                 continue
 
-            if typeutils.is_container(value):
-                for item in value:
-                    if base.is_ast_node(item) or typeutils.is_container(item):
-                        res = self.visit(item)
-                        if res is not None:
-                            field_results.append(res)
-            elif base.is_ast_node(value):
-                res = self.visit(value)
-                if res is not None:
-                    field_results.append(res)
+            res = self.visit(value)
+            if res is not None:
+                field_results.append(res)
 
         if combine_results is not None:
             return combine_results(field_results)

--- a/edb/common/typeutils.py
+++ b/edb/common/typeutils.py
@@ -26,8 +26,10 @@ import functools
 @functools.lru_cache(1024)
 def _is_container_type(cls):
     return (
-        issubclass(cls, (collections.abc.Container)) and
-        not issubclass(cls, (str, bytes, bytearray, memoryview))
+        issubclass(cls, (collections.abc.Container))
+        and not issubclass(cls, (str, bytes, bytearray, memoryview))
+        # not namedtuple, either
+        and not (issubclass(cls, tuple) and hasattr(cls, '_fields'))
     )
 
 

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -297,7 +297,11 @@ class ContainsDMLVisitor(ast.NodeVisitor):
         self.skip_bindings = skip_bindings
 
     def combine_field_results(self, xs: List[Optional[bool]]) -> bool:
-        return any(x is True for x in xs)
+        return any(
+            x is True
+            or (isinstance(x, list) and self.combine_field_results(x))
+            for x in xs
+        )
 
     def visit_MutatingStmt(self, stmt: irast.MutatingStmt) -> bool:
         return True


### PR DESCRIPTION
Make the handling of fields in generic_visitor equivalent to calling
visit on each of them.