### PR TITLE
Make most tests use the `default` module instead of `test`

### DIFF
--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -441,7 +441,8 @@ class BaseSchemaTest(BaseDocTest):
         return current_schema
 
     @classmethod
-    def load_schema(cls, source: str, modname: str='test') -> s_schema.Schema:
+    def load_schema(
+            cls, source: str, modname: str='default') -> s_schema.Schema:
         sdl_schema = qlparser.parse_sdl(f'module {modname} {{ {source} }}')
         schema = _load_std_schema()
         return s_ddl.apply_sdl(
@@ -459,7 +460,8 @@ class BaseSchemaTest(BaseDocTest):
         for name, val in cls.__dict__.items():
             m = re.match(r'^SCHEMA(?:_(\w+))?', name)
             if m:
-                module_name = (m.group(1) or 'test').lower().replace('__', '.')
+                module_name = (m.group(1)
+                               or 'default').lower().replace('__', '.')
 
                 if '\n' in val:
                     # Inline schema source

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -304,6 +304,7 @@ def new_compiler():
 
 
 class BaseSchemaTest(BaseDocTest):
+    DEFAULT_MODULE = 'default'
     SCHEMA: Optional[str] = None
 
     schema: s_schema.Schema
@@ -442,7 +443,9 @@ class BaseSchemaTest(BaseDocTest):
 
     @classmethod
     def load_schema(
-            cls, source: str, modname: str='default') -> s_schema.Schema:
+            cls, source: str, modname: Optional[str]=None) -> s_schema.Schema:
+        if not modname:
+            modname = cls.DEFAULT_MODULE
         sdl_schema = qlparser.parse_sdl(f'module {modname} {{ {source} }}')
         schema = _load_std_schema()
         return s_ddl.apply_sdl(

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -826,7 +826,7 @@ class DatabaseTestCase(ClusterTestCase, ConnectedTestCaseMixin):
     SETUP: Optional[Union[str, List[str]]] = None
     TEARDOWN: Optional[str] = None
     SCHEMA: Optional[Union[str, pathlib.Path]] = None
-    DEFAULT_MODULE: str = 'test'
+    DEFAULT_MODULE: str = 'default'
 
     SETUP_METHOD: Optional[str] = None
     TEARDOWN_METHOD: Optional[str] = None
@@ -1131,7 +1131,7 @@ class DatabaseTestCase(ClusterTestCase, ConnectedTestCaseMixin):
             finally:
                 await tx.rollback()
 
-    async def migrate(self, migration, *, module: str = 'test'):
+    async def migrate(self, migration, *, module: str = 'default'):
         async with self.con.transaction():
             await self.con.execute(f"""
                 START MIGRATION TO {{

--- a/tests/schemas/cards_aliases_setup.edgeql
+++ b/tests/schemas/cards_aliases_setup.edgeql
@@ -17,72 +17,63 @@
 #
 
 
-CREATE ALIAS test::AirCard := (
-    WITH MODULE test
+CREATE ALIAS AirCard := (
     SELECT Card
     FILTER Card.element = 'Air'
 );
 
 
-CREATE ALIAS test::WaterCard := (
-    WITH MODULE test
+CREATE ALIAS WaterCard := (
     SELECT Card
     FILTER Card.element = 'Water'
 );
 
 
-CREATE ALIAS test::EarthCard := (
-    WITH MODULE test
+CREATE ALIAS EarthCard := (
     SELECT Card
     FILTER Card.element = 'Earth'
 );
 
 
-CREATE ALIAS test::FireCard := (
-    WITH MODULE test
+CREATE ALIAS FireCard := (
     SELECT Card
     FILTER Card.element = 'Fire'
 );
 
 
-CREATE ALIAS test::AliceCard := (
-    WITH MODULE test
+CREATE ALIAS AliceCard := (
     SELECT Card
     FILTER Card.<deck[IS User].name = 'Alice'
 );
 
 
-CREATE ALIAS test::BobCard := (
-    WITH MODULE test
+CREATE ALIAS BobCard := (
     SELECT Card
     FILTER Card.<deck[IS User].name = 'Bob'
 );
 
 
-CREATE ALIAS test::CarolCard := (
-    WITH MODULE test
+CREATE ALIAS CarolCard := (
     SELECT Card
     FILTER Card.<deck[IS User].name = 'Carol'
 );
 
 
-CREATE ALIAS test::DaveCard := (
-    WITH MODULE test
+CREATE ALIAS DaveCard := (
     SELECT Card
     FILTER Card.<deck[IS User].name = 'Dave'
 );
 
 
-CREATE ALIAS test::AliasedFriends := (
-    WITH MODULE test
+CREATE ALIAS AliasedFriends := (
     SELECT User { my_friends := User.friends, my_name := User.name }
 );
 
 
-CREATE ALIAS test::AwardAlias := (
-    test::Award {
+CREATE ALIAS AwardAlias := (
+    Award {
         # this should be a single link, because awards are exclusive
-        winner := test::Award.<awards[IS test::User] {
+        winner := Award.<awards[IS User] {
             name_upper := str_upper(.name)
         }
     }
@@ -90,10 +81,9 @@ CREATE ALIAS test::AwardAlias := (
 
 # This expression is unnecessarily deep, but that shouldn't have
 # any impact as compared to AwardAlias.
-CREATE ALIAS test::AwardAlias2 := (
-    WITH MODULE test
+CREATE ALIAS AwardAlias2 := (
     SELECT Award {
-        winner := Award.<awards[IS test::User] {
+        winner := Award.<awards[IS User] {
             deck: {
                 id
             }
@@ -102,8 +92,7 @@ CREATE ALIAS test::AwardAlias2 := (
 );
 
 # This alias includes ordering
-CREATE ALIAS test::UserAlias := (
-    WITH MODULE test
+CREATE ALIAS UserAlias := (
     SELECT User {
         deck: {
             id

--- a/tests/schemas/cards_setup.edgeql
+++ b/tests/schemas/cards_setup.edgeql
@@ -16,12 +16,10 @@
 # limitations under the License.
 #
 
-WITH MODULE test
 FOR award in {'1st', '2nd', '3rd'} UNION (
     INSERT Award { name := award }
 );
 
-WITH MODULE test
 INSERT Card {
     name := 'Imp',
     element := 'Fire',
@@ -29,7 +27,6 @@ INSERT Card {
     awards := (SELECT Award FILTER .name = '2nd'),
 };
 
-WITH MODULE test
 INSERT Card {
     name := 'Dragon',
     element := 'Fire',
@@ -37,49 +34,42 @@ INSERT Card {
     awards := (SELECT Award FILTER .name = '1st'),
 };
 
-WITH MODULE test
 INSERT Card {
     name := 'Bog monster',
     element := 'Water',
     cost := 2
 };
 
-WITH MODULE test
 INSERT Card {
     name := 'Giant turtle',
     element := 'Water',
     cost := 3
 };
 
-WITH MODULE test
 INSERT Card {
     name := 'Dwarf',
     element := 'Earth',
     cost := 1
 };
 
-WITH MODULE test
 INSERT Card {
     name := 'Golem',
     element := 'Earth',
     cost := 3
 };
 
-WITH MODULE test
 INSERT Card {
     name := 'Sprite',
     element := 'Air',
     cost := 1
 };
 
-WITH MODULE test
 INSERT Card {
     name := 'Giant eagle',
     element := 'Air',
     cost := 2
 };
 
-WITH MODULE test
 INSERT SpecialCard {
     name := 'Djinn',
     element := 'Air',
@@ -89,7 +79,6 @@ INSERT SpecialCard {
 
 
 # create players & decks
-WITH MODULE test
 INSERT User {
     name := 'Alice',
     deck := (
@@ -102,7 +91,6 @@ INSERT User {
     ),
 };
 
-WITH MODULE test
 INSERT User {
     name := 'Bob',
     deck := (
@@ -111,7 +99,6 @@ INSERT User {
     awards := (SELECT Award FILTER .name = '3rd'),
 };
 
-WITH MODULE test
 INSERT User {
     name := 'Carol',
     deck := (
@@ -119,7 +106,6 @@ INSERT User {
     )
 };
 
-WITH MODULE test
 INSERT User {
     name := 'Dave',
     deck := (
@@ -130,7 +116,6 @@ INSERT User {
 
 # update friends list
 WITH
-    MODULE test,
     U2 := DETACHED User
 UPDATE User
 FILTER User.name = 'Alice'
@@ -146,7 +131,6 @@ SET {
 };
 
 WITH
-    MODULE test,
     U2 := DETACHED User
 UPDATE User
 FILTER User.name = 'Dave'

--- a/tests/schemas/casts_setup.edgeql
+++ b/tests/schemas/casts_setup.edgeql
@@ -17,7 +17,6 @@
 #
 
 
-WITH MODULE test
 INSERT Test {
     p_bool := True,
     p_str := 'Hello',
@@ -36,7 +35,6 @@ INSERT Test {
 };
 
 
-WITH MODULE test
 INSERT JSONTest {
     j_bool := <json>True,
     j_str := <json>'Hello',

--- a/tests/schemas/groups_setup.edgeql
+++ b/tests/schemas/groups_setup.edgeql
@@ -17,56 +17,46 @@
 #
 
 
-WITH MODULE test
 INSERT Priority {
     name := 'High'
 };
 
-WITH MODULE test
 INSERT Priority {
     name := 'Low'
 };
 
-WITH MODULE test
 INSERT Status {
     name := 'Open'
 };
 
-WITH MODULE test
 INSERT Status {
     name := 'Closed'
 };
 
 
-WITH MODULE test
 INSERT User {
     name := 'Elvis'
 };
 
-WITH MODULE test
 INSERT User {
     name := 'Yury'
 };
 
-WITH MODULE test
 INSERT URL {
     name := 'edgedb.com',
     address := 'https://edgedb.com'
 };
 
-WITH MODULE test
 INSERT File {
     name := 'screenshot.png'
 };
 
-WITH MODULE test
 INSERT LogEntry {
     owner := (SELECT User FILTER User.name = 'Elvis'),
     spent_time := 50000,
     body := 'Rewriting everything.'
 };
 
-WITH MODULE test
 INSERT Issue {
     number := '1',
     name := 'Release EdgeDB',
@@ -78,7 +68,6 @@ INSERT Issue {
     time_estimate := 3000
 };
 
-WITH MODULE test
 INSERT Comment {
     body := 'EdgeDB needs to happen soon.',
     owner := (SELECT User FILTER User.name = 'Elvis'),
@@ -86,7 +75,6 @@ INSERT Comment {
 };
 
 
-WITH MODULE test
 INSERT Issue {
     number := '2',
     name := 'Improve EdgeDB repl output rendering.',
@@ -102,7 +90,6 @@ INSERT Issue {
 };
 
 WITH
-    MODULE test,
     I := DETACHED Issue
 INSERT Issue {
     number := '3',
@@ -118,7 +105,6 @@ INSERT Issue {
 };
 
 WITH
-    MODULE test,
     I := DETACHED Issue
 INSERT Issue {
     number := '4',
@@ -133,14 +119,12 @@ INSERT Issue {
 
 # NOTE: UPDATE Users for testing the link properties
 #
-WITH MODULE test
 UPDATE User
 FILTER User.name = 'Elvis'
 SET {
     todo := (SELECT Issue FILTER Issue.number IN {'1', '2'})
 };
 
-WITH MODULE test
 UPDATE User
 FILTER User.name = 'Yury'
 SET {

--- a/tests/schemas/inventory_setup.edgeql
+++ b/tests/schemas/inventory_setup.edgeql
@@ -17,7 +17,6 @@
 #
 
 
-WITH MODULE test
 INSERT Item {
     name := 'table',
 
@@ -26,7 +25,6 @@ INSERT Item {
     tag_array := ['wood', 'rectangle'],
 };
 
-WITH MODULE test
 INSERT Item {
     name := 'floor lamp',
 
@@ -36,7 +34,6 @@ INSERT Item {
 };
 
 # some items with incomplete data
-WITH MODULE test
 INSERT Item {
     name := 'chair',
 
@@ -45,7 +42,6 @@ INSERT Item {
 };
 
 
-WITH MODULE test
 INSERT Item {
     name := 'tv',
 
@@ -54,7 +50,6 @@ INSERT Item {
 };
 
 
-WITH MODULE test
 INSERT Item {
     name := 'ball',
 
@@ -63,20 +58,17 @@ INSERT Item {
 };
 
 
-WITH MODULE test
 INSERT Item {
     name := 'teapot',
 
     tag_array := ['ceramic', 'round'],
 };
 
-WITH MODULE test
 INSERT Item {
     name := 'mystery toy',
 };
 
 # no known properties
-WITH MODULE test
 INSERT Item {
     name := 'ectoplasm',
 };

--- a/tests/schemas/issues_coalesce_setup.edgeql
+++ b/tests/schemas/issues_coalesce_setup.edgeql
@@ -17,79 +17,66 @@
 #
 
 
-WITH MODULE test
 INSERT Priority {
     name := 'High'
 };
 
-WITH MODULE test
 INSERT Priority {
     name := 'Low'
 };
 
-WITH MODULE test
 INSERT Status {
     name := 'Open'
 };
 
-WITH MODULE test
 INSERT Status {
     name := 'Closed'
 };
 
 
-WITH MODULE test
 INSERT User {
     name := 'Elvis'
 };
 
-WITH MODULE test
 INSERT URL {
     name := 'edgedb.com',
     address := 'https://edgedb.com'
 };
 
-WITH MODULE test
 INSERT File {
     name := 'screenshot.png'
 };
 
-WITH MODULE test
 INSERT LogEntry {
     owner := (SELECT User FILTER User.name = 'Elvis'),
     spent_time := -1,
     body := 'Dummy'
 };
 
-WITH MODULE test
 INSERT LogEntry {
     owner := (SELECT User FILTER User.name = 'Elvis'),
     spent_time := 60,
     body := 'Log1'
 };
 
-WITH MODULE test
 INSERT LogEntry {
     owner := (SELECT User FILTER User.name = 'Elvis'),
     spent_time := 90,
     body := 'Log2'
 };
 
-WITH MODULE test
 INSERT LogEntry {
     owner := (SELECT User FILTER User.name = 'Elvis'),
     spent_time := 60,
     body := 'Log3'
 };
 
-WITH MODULE test
 INSERT LogEntry {
     owner := (SELECT User FILTER User.name = 'Elvis'),
     spent_time := 30,
     body := 'Log4'
 };
 
-WITH MODULE test
 INSERT Issue {
     number := '1',
     name := 'Issue 1',
@@ -100,7 +87,6 @@ INSERT Issue {
     time_spent_log := (SELECT LogEntry FILTER LogEntry.body = 'Log1'),
 };
 
-WITH MODULE test
 INSERT Issue {
     number := '2',
     name := 'Issue 2',
@@ -111,7 +97,6 @@ INSERT Issue {
     time_spent_log := (SELECT LogEntry FILTER LogEntry.body = 'Log2'),
 };
 
-WITH MODULE test
 INSERT Issue {
     number := '3',
     name := 'Issue 3',
@@ -123,7 +108,6 @@ INSERT Issue {
         SELECT LogEntry FILTER LogEntry.body IN {'Log3','Log4'}),
 };
 
-WITH MODULE test
 INSERT Issue {
     number := '4',
     name := 'Issue 4',
@@ -133,7 +117,6 @@ INSERT Issue {
 };
 
 WITH
-    MODULE test,
     I := DETACHED Issue
 INSERT Issue {
     number := '5',
@@ -145,7 +128,6 @@ INSERT Issue {
 };
 
 WITH
-    MODULE test,
     I := DETACHED Issue
 INSERT Issue {
     number := '6',

--- a/tests/schemas/issues_filter_setup.edgeql
+++ b/tests/schemas/issues_filter_setup.edgeql
@@ -17,34 +17,28 @@
 #
 
 
-WITH MODULE test
 INSERT Status {
     name := 'Open'
 };
 
-WITH MODULE test
 INSERT Status {
     name := 'Closed'
 };
 
 
-WITH MODULE test
 INSERT User {
     name := 'Elvis'
 };
 
-WITH MODULE test
 INSERT User {
     name := 'Yury'
 };
 
-WITH MODULE test
 INSERT User {
     name := 'Victor'
 };
 
 
-WITH MODULE test
 INSERT Issue {
     number := '1',
     name := 'Implicit path existence',
@@ -54,7 +48,6 @@ INSERT Issue {
     time_estimate := 9001,
 };
 
-WITH MODULE test
 INSERT Issue {
     number := '2',
     name := 'NOT EXISTS problem',
@@ -64,7 +57,6 @@ INSERT Issue {
     due_date := <datetime>'2020-01-15T00:00:00+00:00',
 };
 
-WITH MODULE test
 INSERT Issue {
     number := '3',
     name := 'EdgeQL to SQL translator',
@@ -75,7 +67,6 @@ INSERT Issue {
     due_date := <datetime>'2020-01-15T00:00:00+00:00',
 };
 
-WITH MODULE test
 INSERT Issue {
     number := '4',
     name := 'Translator optimization',

--- a/tests/schemas/issues_setup.edgeql
+++ b/tests/schemas/issues_setup.edgeql
@@ -17,49 +17,40 @@
 #
 
 
-WITH MODULE test
 INSERT Priority {
     name := 'High'
 };
 
-WITH MODULE test
 INSERT Priority {
     name := 'Low'
 };
 
-WITH MODULE test
 INSERT Status {
     name := 'Open'
 };
 
-WITH MODULE test
 INSERT Status {
     name := 'Closed'
 };
 
 
-WITH MODULE test
 INSERT User {
     name := 'Elvis'
 };
 
-WITH MODULE test
 INSERT User {
     name := 'Yury'
 };
 
-WITH MODULE test
 INSERT URL {
     name := 'edgedb.com',
     address := 'https://edgedb.com'
 };
 
-WITH MODULE test
 INSERT File {
     name := 'screenshot.png'
 };
 
-WITH MODULE test
 INSERT LogEntry {
     owner := (
         SELECT
@@ -73,7 +64,6 @@ INSERT LogEntry {
     body := 'Rewriting everything.'
 };
 
-WITH MODULE test
 INSERT Issue {
     number := '1',
     name := 'Release EdgeDB',
@@ -89,7 +79,6 @@ INSERT Issue {
     time_estimate := 3000
 };
 
-WITH MODULE test
 INSERT Comment {
     body := 'EdgeDB needs to happen soon.',
     owner := (SELECT User FILTER User.name = 'Elvis'),
@@ -97,7 +86,6 @@ INSERT Comment {
 };
 
 
-WITH MODULE test
 INSERT Issue {
     number := '2',
     name := 'Improve EdgeDB repl output rendering.',
@@ -113,7 +101,6 @@ INSERT Issue {
 };
 
 WITH
-    MODULE test,
     I := DETACHED Issue
 INSERT Issue {
     number := '3',
@@ -129,7 +116,6 @@ INSERT Issue {
 };
 
 WITH
-    MODULE test,
     I := DETACHED Issue
 INSERT Issue {
     number := '4',
@@ -145,14 +131,12 @@ INSERT Issue {
 
 # NOTE: UPDATE Users for testing the link properties
 #
-WITH MODULE test
 UPDATE User
 FILTER User.name = 'Elvis'
 SET {
     todo := (SELECT Issue FILTER Issue.number IN {'1', '2'})
 };
 
-WITH MODULE test
 UPDATE User
 FILTER User.name = 'Yury'
 SET {

--- a/tests/schemas/json_setup.edgeql
+++ b/tests/schemas/json_setup.edgeql
@@ -17,7 +17,6 @@
 #
 
 
-SET MODULE test;
 
 INSERT JSONTest {
     number := 0,

--- a/tests/schemas/tree_setup.edgeql
+++ b/tests/schemas/tree_setup.edgeql
@@ -17,7 +17,6 @@
 #
 
 
-SET MODULE test;
 
 INSERT Tree {val := '0'};
 INSERT Tree {

--- a/tests/schemas/updates.edgeql
+++ b/tests/schemas/updates.edgeql
@@ -17,35 +17,34 @@
 #
 
 
-INSERT test::Status {
+INSERT Status {
     name := 'Open'
 };
 
-INSERT test::Status {
+INSERT Status {
     name := 'Closed'
 };
 
-INSERT test::MajorLifeEvent {
+INSERT MajorLifeEvent {
     name := 'Broke a Type System'
 };
 
-INSERT test::MajorLifeEvent {
+INSERT MajorLifeEvent {
     name := 'Downloaded a Car'
 };
 
-INSERT test::Tag {
+INSERT Tag {
     name := 'fun'
 };
 
-INSERT test::Tag {
+INSERT Tag {
     name := 'boring'
 };
 
-INSERT test::Tag {
+INSERT Tag {
     name := 'wow'
 };
 
-WITH MODULE test
 INSERT UpdateTest {
     name := 'update-test1',
     status := (SELECT Status FILTER Status.name = 'Open'),
@@ -53,21 +52,18 @@ INSERT UpdateTest {
     readonly_note := 'this is read-only',
 };
 
-WITH MODULE test
 INSERT UpdateTest {
     name := 'update-test2',
     comment := 'second',
     status := (SELECT Status FILTER Status.name = 'Open')
 };
 
-WITH MODULE test
 INSERT UpdateTest {
     name := 'update-test3',
     comment := 'third',
     status := (SELECT Status FILTER Status.name = 'Closed')
 };
 
-WITH MODULE test
 INSERT CollectionTest {
     name := 'collection-test1'
 };

--- a/tests/schemas/volatility_setup.edgeql
+++ b/tests/schemas/volatility_setup.edgeql
@@ -17,57 +17,57 @@
 #
 
 
-CREATE FUNCTION test::vol_immutable() -> float64 {
+CREATE FUNCTION vol_immutable() -> float64 {
     SET volatility := 'Immutable';
     USING SQL $$
         SELECT random();
     $$;
 };
 
-CREATE FUNCTION test::vol_stable() -> float64 {
+CREATE FUNCTION vol_stable() -> float64 {
     SET volatility := 'Stable';
     USING SQL $$
         SELECT random();
     $$;
 };
 
-CREATE FUNCTION test::vol_volatile() -> float64 {
+CREATE FUNCTION vol_volatile() -> float64 {
     SET volatility := 'Volatile';
     USING SQL $$
         SELECT random();
     $$;
 };
 
-CREATE FUNCTION test::err_immutable() -> float64 {
+CREATE FUNCTION err_immutable() -> float64 {
     SET volatility := 'Immutable';
     USING SQL $$
         SELECT random()/0;
     $$;
 };
 
-CREATE FUNCTION test::err_stable() -> float64 {
+CREATE FUNCTION err_stable() -> float64 {
     SET volatility := 'Stable';
     USING SQL $$
         SELECT random()/0;
     $$;
 };
 
-CREATE FUNCTION test::err_volatile() -> float64 {
+CREATE FUNCTION err_volatile() -> float64 {
     SET volatility := 'Volatile';
     USING SQL $$
         SELECT random()/0;
     $$;
 };
 
-CREATE FUNCTION test::rand_int(top: int64) -> int64 {
+CREATE FUNCTION rand_int(top: int64) -> int64 {
     USING (<int64>(random() * top))
 };
 
 
-INSERT test::Obj { n := 1 };
-INSERT test::Obj { n := 2 };
-INSERT test::Obj { n := 3 };
-INSERT test::Tgt { n := 1 };
-INSERT test::Tgt { n := 2 };
-INSERT test::Tgt { n := 3 };
-INSERT test::Tgt { n := 4 };
+INSERT Obj { n := 1 };
+INSERT Obj { n := 2 };
+INSERT Obj { n := 3 };
+INSERT Tgt { n := 1 };
+INSERT Tgt { n := 2 };
+INSERT Tgt { n := 3 };
+INSERT Tgt { n := 4 };

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -63,7 +63,7 @@ class TestConstraintsSchema(tb.QueryTestCase):
             (10 ** 7, 'good'),
         }
 
-        await self._run_link_tests(data, 'test::Object', 'c_length')
+        await self._run_link_tests(data, 'default::Object', 'c_length')
 
         data = {
             (10 ** 10,
@@ -75,7 +75,7 @@ class TestConstraintsSchema(tb.QueryTestCase):
             (10 ** 8, 'good'),
         }
 
-        await self._run_link_tests(data, 'test::Object', 'c_length_2')
+        await self._run_link_tests(data, 'default::Object', 'c_length_2')
 
         data = {
             (10 ** 10,
@@ -84,7 +84,7 @@ class TestConstraintsSchema(tb.QueryTestCase):
             (10 ** 9 - 1, 'c_length_3 must be no shorter than 10 characters'),
         }
 
-        await self._run_link_tests(data, 'test::Object', 'c_length_3')
+        await self._run_link_tests(data, 'default::Object', 'c_length_3')
 
     async def test_constraints_scalar_minmax(self):
         data = {
@@ -98,7 +98,7 @@ class TestConstraintsSchema(tb.QueryTestCase):
             (10 ** 8 - 21, 'good'),
         }
 
-        await self._run_link_tests(data, 'test::Object', 'c_minmax')
+        await self._run_link_tests(data, 'default::Object', 'c_minmax')
 
     async def test_constraints_scalar_strvalue(self):
         data = {
@@ -116,7 +116,7 @@ class TestConstraintsSchema(tb.QueryTestCase):
             ('9999000009', 'good'),
         }
 
-        await self._run_link_tests(data, 'test::Object', 'c_strvalue')
+        await self._run_link_tests(data, 'default::Object', 'c_strvalue')
 
     async def test_constraints_scalar_enum_01(self):
         data = {
@@ -125,7 +125,7 @@ class TestConstraintsSchema(tb.QueryTestCase):
             ('foo', 'good'),
         }
 
-        await self._run_link_tests(data, 'test::Object', 'c_enum')
+        await self._run_link_tests(data, 'default::Object', 'c_enum')
 
     async def test_constraints_scalar_enum_02(self):
         data = {
@@ -134,7 +134,7 @@ class TestConstraintsSchema(tb.QueryTestCase):
             ('buz', 'good'),
         }
 
-        await self._run_link_tests(data, 'test::Object', 'c_my_enum')
+        await self._run_link_tests(data, 'default::Object', 'c_my_enum')
 
     async def test_constraints_exclusive_simple(self):
         async with self._run_and_rollback():
@@ -142,11 +142,11 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     edgedb.ConstraintViolationError,
                     'name violates exclusivity constraint'):
                 await self.con.execute("""
-                    INSERT test::UniqueName {
+                    INSERT UniqueName {
                         name := 'Test'
                     };
 
-                    INSERT test::UniqueName {
+                    INSERT UniqueName {
                         name := 'Test'
                     };
                 """)
@@ -157,11 +157,11 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     edgedb.ConstraintViolationError,
                     'name violates exclusivity constraint'):
                 await self.con.execute("""
-                    INSERT test::UniqueNameInherited {
+                    INSERT UniqueNameInherited {
                         name := 'Test'
                     };
 
-                    INSERT test::UniqueNameInherited {
+                    INSERT UniqueNameInherited {
                         name := 'Test'
                     };
                 """)
@@ -173,11 +173,11 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     'name violates exclusivity constraint'):
 
                 await self.con.execute("""
-                    INSERT test::UniqueName {
+                    INSERT UniqueName {
                         name := 'exclusive_name_across'
                     };
 
-                    INSERT test::UniqueNameInherited {
+                    INSERT UniqueNameInherited {
                         name := 'exclusive_name_across'
                     };
                 """)
@@ -188,22 +188,22 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     'name violates exclusivity constraint'):
 
                 await self.con.execute("""
-                    INSERT test::UniqueNameInherited {
+                    INSERT UniqueNameInherited {
                         name := 'exclusive_name_across'
                     };
 
-                    INSERT test::UniqueName {
+                    INSERT UniqueName {
                         name := 'exclusive_name_across'
                     };
                 """)
 
         async with self._run_and_rollback():
             await self.con.execute("""
-                INSERT test::UniqueName {
+                INSERT UniqueName {
                     name := 'exclusive_name_ok'
                 };
 
-                INSERT test::UniqueNameInherited {
+                INSERT UniqueNameInherited {
                     name := 'exclusive_name_inherited_ok'
                 };
             """)
@@ -213,9 +213,9 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     'name violates exclusivity constraint'):
                 await self.con.execute("""
                     UPDATE
-                        test::UniqueNameInherited
+                        UniqueNameInherited
                     FILTER
-                        test::UniqueNameInherited.name =
+                        UniqueNameInherited.name =
                             'exclusive_name_inherited_ok'
                     SET {
                         name := 'exclusive_name_ok'
@@ -228,11 +228,11 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     edgedb.ConstraintViolationError,
                     'name violates exclusivity constraint'):
                 await self.con.execute("""
-                    INSERT test::UniqueName_3 {
+                    INSERT UniqueName_3 {
                         name := 'TeSt'
                     };
 
-                    INSERT test::UniqueName_3 {
+                    INSERT UniqueName_3 {
                         name := 'tEsT'
                     };
                 """)
@@ -241,22 +241,22 @@ class TestConstraintsSchema(tb.QueryTestCase):
         async with self._run_and_rollback():
             # This is OK, the name exclusivity constraint is delegating
             await self.con.execute("""
-                INSERT test::AbstractConstraintParent {
+                INSERT AbstractConstraintParent {
                     name := 'exclusive_name_ap'
                 };
 
-                INSERT test::AbstractConstraintParent {
+                INSERT AbstractConstraintParent {
                     name := 'exclusive_name_ap'
                 };
             """)
 
             # This is OK too
             await self.con.execute("""
-                INSERT test::AbstractConstraintParent {
+                INSERT AbstractConstraintParent {
                     name := 'exclusive_name_ap1'
                 };
 
-                INSERT test::AbstractConstraintPureChild {
+                INSERT AbstractConstraintPureChild {
                     name := 'exclusive_name_ap1'
                 };
             """)
@@ -267,11 +267,11 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     'name violates exclusivity constraint'):
                 # Not OK, abstract constraint materializes into a real one
                 await self.con.execute("""
-                    INSERT test::AbstractConstraintPureChild {
+                    INSERT AbstractConstraintPureChild {
                         name := 'exclusive_name_ap2'
                     };
 
-                    INSERT test::AbstractConstraintPureChild {
+                    INSERT AbstractConstraintPureChild {
                         name := 'exclusive_name_ap2'
                     };
                 """)
@@ -282,11 +282,11 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     'name violates exclusivity constraint'):
                 # Not OK, abstract constraint materializes into a real one
                 await self.con.execute("""
-                    INSERT test::AbstractConstraintMixedChild {
+                    INSERT AbstractConstraintMixedChild {
                         name := 'exclusive_name_ap2'
                     };
 
-                    INSERT test::AbstractConstraintMixedChild {
+                    INSERT AbstractConstraintMixedChild {
                         name := 'exclusive_name_AP2'
                     };
                 """)
@@ -294,22 +294,22 @@ class TestConstraintsSchema(tb.QueryTestCase):
         async with self._run_and_rollback():
             # This is OK, duplication is in different children
             await self.con.execute("""
-                INSERT test::AbstractConstraintPureChild {
+                INSERT AbstractConstraintPureChild {
                     name := 'exclusive_name_ap3'
                 };
 
-                INSERT test::AbstractConstraintMixedChild {
+                INSERT AbstractConstraintMixedChild {
                     name := 'exclusive_name_ap3'
                 };
             """)
 
             # This is OK, the name exclusivity constraint is abstract again
             await self.con.execute("""
-                INSERT test::AbstractConstraintPropagated {
+                INSERT AbstractConstraintPropagated {
                     name := 'exclusive_name_ap4'
                 };
 
-                INSERT test::AbstractConstraintPropagated {
+                INSERT AbstractConstraintPropagated {
                     name := 'exclusive_name_ap4'
                 };
             """)
@@ -320,22 +320,22 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     'name violates exclusivity constraint'):
                 # Not OK, yet
                 await self.con.execute("""
-                    INSERT test::BecomingAbstractConstraint {
+                    INSERT BecomingAbstractConstraint {
                         name := 'exclusive_name_ap5'
                     };
 
-                    INSERT test::BecomingAbstractConstraintChild {
+                    INSERT BecomingAbstractConstraintChild {
                         name := 'exclusive_name_ap5'
                     };
                 """)
 
         async with self._run_and_rollback():
             await self.con.execute("""
-                INSERT test::BecomingConcreteConstraint {
+                INSERT BecomingConcreteConstraint {
                     name := 'exclusive_name_ap6'
                 };
 
-                INSERT test::BecomingConcreteConstraintChild {
+                INSERT BecomingConcreteConstraintChild {
                     name := 'exclusive_name_ap6'
                 };
             """)
@@ -345,11 +345,11 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     edgedb.ConstraintViolationError,
                     'name violates exclusivity constraint'):
                 await self.con.execute("""
-                    INSERT test::LosingAbstractConstraintParent {
+                    INSERT LosingAbstractConstraintParent {
                         name := 'exclusive_name_ap7'
                     };
 
-                    INSERT test::LosingAbstractConstraintParent {
+                    INSERT LosingAbstractConstraintParent {
                         name := 'exclusive_name_ap7'
                     };
                 """)
@@ -359,11 +359,11 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     edgedb.ConstraintViolationError,
                     'name violates exclusivity constraint'):
                 await self.con.execute("""
-                    INSERT test::AbstractConstraintMultipleParentsFlattening{
+                    INSERT AbstractConstraintMultipleParentsFlattening{
                         name := 'exclusive_name_ap8'
                     };
 
-                    INSERT test::AbstractConstraintMultipleParentsFlattening{
+                    INSERT AbstractConstraintMultipleParentsFlattening{
                         name := 'exclusive_name_ap8'
                     };
                 """)
@@ -374,18 +374,18 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     edgedb.ConstraintViolationError,
                     "ObjCnstr violates exclusivity constraint"):
                 await self.con.execute("""
-                    INSERT test::ObjCnstr {
+                    INSERT ObjCnstr {
                         first_name := "foo", last_name := "bar" };
 
-                    INSERT test::ObjCnstr {
+                    INSERT ObjCnstr {
                         first_name := "foo", last_name := "baz" }
             """)
 
         async with self._run_and_rollback():
             await self.con.execute("""
-                INSERT test::ObjCnstr {
+                INSERT ObjCnstr {
                     first_name := "foo", last_name := "bar",
-                    label := (INSERT test::Label {text := "obj_test" })
+                    label := (INSERT Label {text := "obj_test" })
                 };
             """)
 
@@ -393,9 +393,9 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     edgedb.ConstraintViolationError,
                     "ObjCnstr violates exclusivity constraint"):
                 await self.con.execute("""
-                    INSERT test::ObjCnstr {
+                    INSERT ObjCnstr {
                         first_name := "emarg", last_name := "hatch",
-                        label := (SELECT test::Label
+                        label := (SELECT Label
                                   FILTER .text = "obj_test" LIMIT 1) };
                 """)
 
@@ -419,22 +419,22 @@ class TestConstraintsSchemaMigration(tb.QueryTestCase):
         async with self._run_and_rollback():
             # This is OK, the name exclusivity constraint is abstract
             await self.con.execute("""
-                INSERT test::AbstractConstraintParent {
+                INSERT AbstractConstraintParent {
                     name := 'exclusive_name_ap'
                 };
 
-                INSERT test::AbstractConstraintParent {
+                INSERT AbstractConstraintParent {
                     name := 'exclusive_name_ap'
                 };
             """)
 
             # This is OK too
             await self.con.execute("""
-                INSERT test::AbstractConstraintParent {
+                INSERT AbstractConstraintParent {
                     name := 'exclusive_name_ap1'
                 };
 
-                INSERT test::AbstractConstraintPureChild {
+                INSERT AbstractConstraintPureChild {
                     name := 'exclusive_name_ap1'
                 };
             """)
@@ -445,11 +445,11 @@ class TestConstraintsSchemaMigration(tb.QueryTestCase):
                     'name violates exclusivity constraint'):
                 # Not OK, abstract constraint materializes into a real one
                 await self.con.execute("""
-                    INSERT test::AbstractConstraintPureChild {
+                    INSERT AbstractConstraintPureChild {
                         name := 'exclusive_name_ap2'
                     };
 
-                    INSERT test::AbstractConstraintPureChild {
+                    INSERT AbstractConstraintPureChild {
                         name := 'exclusive_name_ap2'
                     };
                 """)
@@ -460,11 +460,11 @@ class TestConstraintsSchemaMigration(tb.QueryTestCase):
                     'name violates exclusivity constraint'):
                 # Not OK, abstract constraint materializes into a real one
                 await self.con.execute("""
-                    INSERT test::AbstractConstraintMixedChild {
+                    INSERT AbstractConstraintMixedChild {
                         name := 'exclusive_name_ap2'
                     };
 
-                    INSERT test::AbstractConstraintMixedChild {
+                    INSERT AbstractConstraintMixedChild {
                         name := 'exclusive_name_AP2'
                     };
                 """)
@@ -472,11 +472,11 @@ class TestConstraintsSchemaMigration(tb.QueryTestCase):
         async with self._run_and_rollback():
             # This is OK, duplication is in different children
             await self.con.execute("""
-                INSERT test::AbstractConstraintMixedChild {
+                INSERT AbstractConstraintMixedChild {
                     name := 'exclusive_name_ap3'
                 };
 
-                INSERT test::AbstractConstraintPureChild {
+                INSERT AbstractConstraintPureChild {
                     name := 'exclusive_name_ap3'
                 };
             """)
@@ -484,11 +484,11 @@ class TestConstraintsSchemaMigration(tb.QueryTestCase):
         async with self._run_and_rollback():
             # This is OK, the name exclusivity constraint is abstract again
             await self.con.execute("""
-                INSERT test::AbstractConstraintPropagated {
+                INSERT AbstractConstraintPropagated {
                     name := 'exclusive_name_ap4'
                 };
 
-                INSERT test::AbstractConstraintPropagated {
+                INSERT AbstractConstraintPropagated {
                     name := 'exclusive_name_ap4'
                 };
             """)
@@ -496,11 +496,11 @@ class TestConstraintsSchemaMigration(tb.QueryTestCase):
         async with self._run_and_rollback():
             # OK, former constraint was turned into an abstract constraint
             await self.con.execute("""
-                INSERT test::BecomingAbstractConstraint {
+                INSERT BecomingAbstractConstraint {
                     name := 'exclusive_name_ap5'
                 };
 
-                INSERT test::BecomingAbstractConstraintChild {
+                INSERT BecomingAbstractConstraintChild {
                     name := 'exclusive_name_ap5'
                 };
             """)
@@ -511,11 +511,11 @@ class TestConstraintsSchemaMigration(tb.QueryTestCase):
                     'name violates exclusivity constraint'):
                 # Constraint is no longer abstract
                 await self.con.execute("""
-                    INSERT test::BecomingConcreteConstraint {
+                    INSERT BecomingConcreteConstraint {
                         name := 'exclusive_name_ap6'
                     };
 
-                    INSERT test::BecomingConcreteConstraintChild {
+                    INSERT BecomingConcreteConstraintChild {
                         name := 'exclusive_name_ap6'
                     };
                 """)
@@ -526,22 +526,22 @@ class TestConstraintsSchemaMigration(tb.QueryTestCase):
                     'name violates exclusivity constraint'):
                 # Constraint is no longer abstract
                 await self.con.execute("""
-                    INSERT test::LosingAbstractConstraintParent {
+                    INSERT LosingAbstractConstraintParent {
                         name := 'exclusive_name_ap6'
                     };
 
-                    INSERT test::LosingAbstractConstraintParent {
+                    INSERT LosingAbstractConstraintParent {
                         name := 'exclusive_name_ap6'
                     };
                 """)
 
         async with self._run_and_rollback():
             await self.con.execute("""
-                INSERT test::LosingAbstractConstraintParent2 {
+                INSERT LosingAbstractConstraintParent2 {
                     name := 'exclusive_name_ap7'
                 };
 
-                INSERT test::LosingAbstractConstraintParent2 {
+                INSERT LosingAbstractConstraintParent2 {
                     name := 'exclusive_name_ap7'
                 };
             """)
@@ -552,11 +552,11 @@ class TestConstraintsSchemaMigration(tb.QueryTestCase):
                     'name violates exclusivity constraint'):
                 # Constraint is no longer abstract
                 await self.con.execute("""
-                    INSERT test::AbstractConstraintMultipleParentsFlattening{
+                    INSERT AbstractConstraintMultipleParentsFlattening{
                         name := 'exclusive_name_ap8'
                     };
 
-                    INSERT test::AbstractConstraintMultipleParentsFlattening{
+                    INSERT AbstractConstraintMultipleParentsFlattening{
                         name := 'exclusive_name_AP8'
                     };
                 """)
@@ -566,10 +566,10 @@ class TestConstraintsSchemaMigration(tb.QueryTestCase):
                     edgedb.ConstraintViolationError,
                     "nope!"):
                 await self.con.execute("""
-                    INSERT test::ObjCnstr {
+                    INSERT ObjCnstr {
                         first_name := "foo", last_name := "bar" };
 
-                    INSERT test::ObjCnstr {
+                    INSERT ObjCnstr {
                         first_name := "foo", last_name := "baz" }
             """)
 
@@ -578,21 +578,21 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
     async def test_constraints_ddl_01(self):
         qry = """
-            CREATE ABSTRACT LINK test::translated_label {
+            CREATE ABSTRACT LINK translated_label {
                 CREATE PROPERTY lang -> std::str;
                 CREATE PROPERTY prop1 -> std::str;
             };
 
-            CREATE ABSTRACT LINK test::link_with_exclusive_property {
+            CREATE ABSTRACT LINK link_with_exclusive_property {
                 CREATE PROPERTY exclusive_property -> std::str {
                     CREATE CONSTRAINT std::exclusive;
                 };
             };
 
-            CREATE ABSTRACT LINK test::link_with_exclusive_property_inherited
-                EXTENDING test::link_with_exclusive_property;
+            CREATE ABSTRACT LINK link_with_exclusive_property_inherited
+                EXTENDING link_with_exclusive_property;
 
-            CREATE TYPE test::UniqueName {
+            CREATE TYPE UniqueName {
                 CREATE PROPERTY name -> std::str {
                     CREATE CONSTRAINT std::exclusive;
                 };
@@ -609,46 +609,46 @@ class TestConstraintsDDL(tb.DDLTestCase):
             'name violates exclusivity constraint',
         ):
             await self.con.execute("""
-                INSERT test::UniqueName {
+                INSERT UniqueName {
                     name := 'Test'
                 };
 
-                INSERT test::UniqueName {
+                INSERT UniqueName {
                     name := 'Test'
                 };
             """)
 
         qry = """
-            CREATE TYPE test::AbstractConstraintParent {
+            CREATE TYPE AbstractConstraintParent {
                 CREATE PROPERTY name -> std::str {
                     CREATE DELEGATED CONSTRAINT std::exclusive;
                 };
             };
 
-            CREATE TYPE test::AbstractConstraintPureChild
-                EXTENDING test::AbstractConstraintParent;
+            CREATE TYPE AbstractConstraintPureChild
+                EXTENDING AbstractConstraintParent;
         """
 
         await self.con.execute(qry)
 
         # This is OK, the name exclusivity constraint is abstract
         await self.con.execute("""
-            INSERT test::AbstractConstraintParent {
+            INSERT AbstractConstraintParent {
                 name := 'exclusive_name_ap'
             };
 
-            INSERT test::AbstractConstraintParent {
+            INSERT AbstractConstraintParent {
                 name := 'exclusive_name_ap'
             };
         """)
 
         # This is OK too
         await self.con.execute("""
-            INSERT test::AbstractConstraintParent {
+            INSERT AbstractConstraintParent {
                 name := 'exclusive_name_ap1'
             };
 
-            INSERT test::AbstractConstraintPureChild {
+            INSERT AbstractConstraintPureChild {
                 name := 'exclusive_name_ap1'
             };
         """)
@@ -656,7 +656,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
     async def test_constraints_ddl_02(self):
         # testing the generalized constraint with 'ON (...)' clause
         qry = r"""
-            CREATE ABSTRACT CONSTRAINT test::mymax1(max: std::int64)
+            CREATE ABSTRACT CONSTRAINT mymax1(max: std::int64)
                     ON (len(__subject__))
             {
                 SET errmessage :=
@@ -664,20 +664,20 @@ class TestConstraintsDDL(tb.DDLTestCase):
                 USING (__subject__ <= max);
             };
 
-            CREATE ABSTRACT CONSTRAINT test::mymax_ext1(max: std::int64)
+            CREATE ABSTRACT CONSTRAINT mymax_ext1(max: std::int64)
                     ON (len(__subject__)) EXTENDING std::max_value
             {
                 SET errmessage :=
                     '{__subject__} must be no longer than {max} characters.';
             };
 
-            CREATE TYPE test::ConstraintOnTest1 {
+            CREATE TYPE ConstraintOnTest1 {
                 CREATE PROPERTY foo -> std::str {
-                    CREATE CONSTRAINT test::mymax1(3);
+                    CREATE CONSTRAINT mymax1(3);
                 };
 
                 CREATE PROPERTY bar -> std::str {
-                    CREATE CONSTRAINT test::mymax_ext1(3);
+                    CREATE CONSTRAINT mymax_ext1(3);
                 };
             };
         """
@@ -701,12 +701,12 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     FILTER .num > 0
                     ORDER BY .num ASC
                 } FILTER
-                    .name = 'test::mymax_ext1'
+                    .name = 'default::mymax_ext1'
                     AND exists(.subject);
             ''',
             [
                 {
-                    "name": 'test::mymax_ext1',
+                    "name": 'default::mymax_ext1',
                     "params": [
                         {
                             "num": 1,
@@ -737,12 +737,12 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     FILTER .num > 0
                     ORDER BY .num ASC
                 } FILTER
-                    .name = 'test::mymax_ext1'
+                    .name = 'default::mymax_ext1'
                     AND NOT exists(.subject);
             ''',
             [
                 {
-                    "name": 'test::mymax_ext1',
+                    "name": 'default::mymax_ext1',
                     "params": [
                         {
                             "num": 1,
@@ -762,7 +762,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             'foo must be no longer than 3 characters.',
         ):
             await self.con.execute("""
-                INSERT test::ConstraintOnTest1 {
+                INSERT ConstraintOnTest1 {
                     foo := 'Test'
                 };
             """)
@@ -772,35 +772,35 @@ class TestConstraintsDDL(tb.DDLTestCase):
             'bar must be no longer than 3 characters.',
         ):
             await self.con.execute("""
-                INSERT test::ConstraintOnTest1 {
+                INSERT ConstraintOnTest1 {
                     bar := 'Test'
                 };
             """)
 
         # constraint should not fail
         await self.con.execute("""
-            INSERT test::ConstraintOnTest1 {
+            INSERT ConstraintOnTest1 {
                 foo := '',
                 bar := ''
             };
 
-            INSERT test::ConstraintOnTest1 {
+            INSERT ConstraintOnTest1 {
                 foo := 'a',
                 bar := 'q'
             };
 
-            INSERT test::ConstraintOnTest1 {
+            INSERT ConstraintOnTest1 {
                 foo := 'ab',
                 bar := 'qw'
             };
 
-            INSERT test::ConstraintOnTest1 {
+            INSERT ConstraintOnTest1 {
                 foo := 'abc',
                 bar := 'qwe'
             };
 
             # a duplicate 'foo' and 'bar' just for good measure
-            INSERT test::ConstraintOnTest1 {
+            INSERT ConstraintOnTest1 {
                 foo := 'ab',
                 bar := 'qw'
             };
@@ -809,15 +809,15 @@ class TestConstraintsDDL(tb.DDLTestCase):
     async def test_constraints_ddl_03(self):
         # testing the specialized constraint with 'ON (...)' clause
         qry = r"""
-            CREATE ABSTRACT CONSTRAINT test::mymax2(max: std::int64) {
+            CREATE ABSTRACT CONSTRAINT mymax2(max: std::int64) {
                 SET errmessage :=
                     '{__subject__} must be no longer than {max} characters.';
                 USING (__subject__ <= max);
             };
 
-            CREATE TYPE test::ConstraintOnTest2 {
+            CREATE TYPE ConstraintOnTest2 {
                 CREATE PROPERTY foo -> std::str {
-                    CREATE CONSTRAINT test::mymax2(3) ON (len(__subject__));
+                    CREATE CONSTRAINT mymax2(3) ON (len(__subject__));
                 };
 
                 CREATE PROPERTY bar -> std::str {
@@ -839,7 +839,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             'foo must be no longer than 3 characters.',
         ):
             await self.con.execute("""
-                INSERT test::ConstraintOnTest2 {
+                INSERT ConstraintOnTest2 {
                     foo := 'Test'
                 };
             """)
@@ -849,35 +849,35 @@ class TestConstraintsDDL(tb.DDLTestCase):
             'bar must be no longer than 3 characters.',
         ):
             await self.con.execute("""
-                INSERT test::ConstraintOnTest2 {
+                INSERT ConstraintOnTest2 {
                     bar := 'Test'
                 };
             """)
 
         # constraint should not fail
         await self.con.execute("""
-            INSERT test::ConstraintOnTest2 {
+            INSERT ConstraintOnTest2 {
                 foo := '',
                 bar := ''
             };
 
-            INSERT test::ConstraintOnTest2 {
+            INSERT ConstraintOnTest2 {
                 foo := 'a',
                 bar := 'q'
             };
 
-            INSERT test::ConstraintOnTest2 {
+            INSERT ConstraintOnTest2 {
                 foo := 'ab',
                 bar := 'qw'
             };
 
-            INSERT test::ConstraintOnTest2 {
+            INSERT ConstraintOnTest2 {
                 foo := 'abc',
                 bar := 'qwe'
             };
 
             # a duplicate 'foo' and 'bar' just for good measure
-            INSERT test::ConstraintOnTest2 {
+            INSERT ConstraintOnTest2 {
                 foo := 'ab',
                 bar := 'qw'
             };
@@ -886,16 +886,16 @@ class TestConstraintsDDL(tb.DDLTestCase):
     async def test_constraints_ddl_04(self):
         # testing an issue with expressions used for 'errmessage'
         qry = r"""
-            CREATE ABSTRACT CONSTRAINT test::mymax3(max: std::int64) {
+            CREATE ABSTRACT CONSTRAINT mymax3(max: std::int64) {
                 SET errmessage :=
                     '{__subject__} must be no longer ' ++
                     'than {max} characters.';
                 USING (__subject__ <= max);
             };
 
-            CREATE TYPE test::ConstraintOnTest3 {
+            CREATE TYPE ConstraintOnTest3 {
                 CREATE PROPERTY foo -> std::str {
-                    CREATE CONSTRAINT test::mymax3(3) ON (len(__subject__));
+                    CREATE CONSTRAINT mymax3(3) ON (len(__subject__));
                 };
             };
         """
@@ -908,7 +908,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             'foo must be no longer than 3 characters.',
         ):
             await self.con.execute("""
-                INSERT test::ConstraintOnTest3 {
+                INSERT ConstraintOnTest3 {
                     foo := 'Test'
                 };
             """)
@@ -925,7 +925,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         # create a type with a constraint
         await self.con.execute(r"""
-            CREATE TYPE test::ConstraintOnTest5 {
+            CREATE TYPE ConstraintOnTest5 {
                 CREATE REQUIRED PROPERTY foo -> int64 {
                     # Use the function in a constraint expression,
                     # s.t. it will effectively fail for any int
@@ -941,14 +941,14 @@ class TestConstraintsDDL(tb.DDLTestCase):
             r'invalid foo',
         ):
             await self.con.execute("""
-                INSERT test::ConstraintOnTest5 {
+                INSERT ConstraintOnTest5 {
                     foo := 42
                 };
             """)
 
         # constraint should not fail
         await self.con.execute("""
-            INSERT test::ConstraintOnTest5 {
+            INSERT ConstraintOnTest5 {
                 foo := 2
             };
         """)
@@ -965,7 +965,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         # create a type with a constraint
         await self.con.execute(r"""
-            CREATE TYPE test::ConstraintOnTest6 {
+            CREATE TYPE ConstraintOnTest6 {
                 CREATE REQUIRED PROPERTY foo -> int64 {
                     # Use the function in a constraint expression,
                     # s.t. it will never fail.
@@ -977,20 +977,20 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         # constraint should not fail
         await self.con.execute("""
-            INSERT test::ConstraintOnTest6 {
+            INSERT ConstraintOnTest6 {
                 foo := 42
             };
         """)
 
         await self.con.execute("""
-            INSERT test::ConstraintOnTest6 {
+            INSERT ConstraintOnTest6 {
                 foo := 2
             };
         """)
 
     async def test_constraints_ddl_07(self):
         await self.con.execute("""
-            CREATE TYPE test::ObjCnstr {
+            CREATE TYPE ObjCnstr {
                 CREATE PROPERTY first_name -> str;
                 CREATE PROPERTY last_name -> str;
                 CREATE CONSTRAINT exclusive on (__subject__.first_name);
@@ -998,7 +998,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
         """)
 
         await self.con.execute("""
-            INSERT test::ObjCnstr { first_name := "foo", last_name := "bar" }
+            INSERT ObjCnstr { first_name := "foo", last_name := "bar" }
         """)
 
         async with self.assertRaisesRegexTx(
@@ -1006,25 +1006,25 @@ class TestConstraintsDDL(tb.DDLTestCase):
             "ObjCnstr violates exclusivity constraint",
         ):
             await self.con.execute("""
-                INSERT test::ObjCnstr {
+                INSERT ObjCnstr {
                     first_name := "foo", last_name := "baz" }
             """)
 
         await self.con.execute("""
-            ALTER TYPE test::ObjCnstr {
+            ALTER TYPE ObjCnstr {
                 DROP CONSTRAINT exclusive on (__subject__.first_name);
             }
         """)
 
         await self.con.execute("""
-            ALTER TYPE test::ObjCnstr {
+            ALTER TYPE ObjCnstr {
                 CREATE CONSTRAINT exclusive
                 on ((__subject__.first_name, __subject__.last_name));
             }
         """)
 
         await self.con.execute("""
-            ALTER TYPE test::ObjCnstr {
+            ALTER TYPE ObjCnstr {
                 ALTER CONSTRAINT exclusive
                 on ((__subject__.first_name, __subject__.last_name)) {
                     SET errmessage := "nope!";
@@ -1034,7 +1034,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
         # This one should work now
         await self.con.execute("""
-            INSERT test::ObjCnstr { first_name := "foo", last_name := "baz" }
+            INSERT ObjCnstr { first_name := "foo", last_name := "baz" }
         """)
 
         async with self.assertRaisesRegexTx(
@@ -1042,13 +1042,13 @@ class TestConstraintsDDL(tb.DDLTestCase):
             "nope!",
         ):
             await self.con.execute("""
-                INSERT test::ObjCnstr {
+                INSERT ObjCnstr {
                     first_name := "foo", last_name := "bar" }
             """)
 
     async def test_constraints_ddl_08(self):
         await self.con.execute("""
-            CREATE TYPE test::ObjCnstr2 {
+            CREATE TYPE ObjCnstr2 {
                 CREATE MULTI PROPERTY first_name -> str;
                 CREATE MULTI PROPERTY last_name -> str;
                 CREATE LINK foo -> Object {
@@ -1064,7 +1064,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             "constraint where at least one link or property is MULTI",
         ):
             await self.con.execute("""
-                ALTER TYPE test::ObjCnstr2 {
+                ALTER TYPE ObjCnstr2 {
                     CREATE CONSTRAINT exclusive
                     on ((__subject__.first_name, __subject__.last_name));
                 };
@@ -1076,7 +1076,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             "non-aggregating constraint",
         ):
             await self.con.execute("""
-                ALTER TYPE test::ObjCnstr2 {
+                ALTER TYPE ObjCnstr2 {
                     CREATE CONSTRAINT expression on (EXISTS .first_name);
                 };
             """)
@@ -1087,7 +1087,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             "non-aggregating constraint",
         ):
             await self.con.execute("""
-                ALTER TYPE test::ObjCnstr2 {
+                ALTER TYPE ObjCnstr2 {
                     ALTER PROPERTY first_name {
                         CREATE CONSTRAINT expression on (EXISTS __subject__);
                     }
@@ -1099,7 +1099,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             "constraints cannot contain paths with more than one hop",
         ):
             await self.con.execute("""
-                ALTER TYPE test::ObjCnstr2 {
+                ALTER TYPE ObjCnstr2 {
                     CREATE CONSTRAINT expression on (<str>.foo.id != 'lol');
                 };
             """)
@@ -1109,7 +1109,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             "constraints cannot contain paths with more than one hop",
         ):
             await self.con.execute("""
-                ALTER TYPE test::ObjCnstr2 {
+                ALTER TYPE ObjCnstr2 {
                     ALTER LINK foo {
                         CREATE CONSTRAINT expression on (
                             <str>__subject__.id != 'lol');
@@ -1122,22 +1122,22 @@ class TestConstraintsDDL(tb.DDLTestCase):
             "not supported because it would depend on multiple objects",
         ):
             await self.con.execute("""
-                ALTER TYPE test::ObjCnstr2 {
+                ALTER TYPE ObjCnstr2 {
                     CREATE CONSTRAINT expression on (<str>.id != .foo@p);
                 };
             """)
 
     async def test_constraints_ddl_09(self):
         await self.con.execute("""
-            CREATE TYPE test::Label {
+            CREATE TYPE Label {
                 CREATE PROPERTY text -> str;
             };
-            CREATE TYPE test::ObjCnstr3 {
-                CREATE LINK label -> test::Label;
+            CREATE TYPE ObjCnstr3 {
+                CREATE LINK label -> Label;
                 CREATE CONSTRAINT exclusive on (__subject__.label);
             };
-            INSERT test::ObjCnstr3 {
-                label := (INSERT test::Label {text := "obj_test" })
+            INSERT ObjCnstr3 {
+                label := (INSERT Label {text := "obj_test" })
             };
         """)
 
@@ -1146,43 +1146,43 @@ class TestConstraintsDDL(tb.DDLTestCase):
             "ObjCnstr3 violates exclusivity constraint",
         ):
             await self.con.execute("""
-                INSERT test::ObjCnstr3 {
-                    label := (SELECT test::Label
+                INSERT ObjCnstr3 {
+                    label := (SELECT Label
                                 FILTER .text = "obj_test" LIMIT 1) };
             """)
 
     async def test_constraints_ddl_10(self):
         await self.con.execute(r"""
-            CREATE ABSTRACT CONSTRAINT test::mymax5(max: std::int64) {
+            CREATE ABSTRACT CONSTRAINT mymax5(max: std::int64) {
                 USING (__subject__ <= max);
             };
 
-            CREATE TYPE test::ConstraintTest10 {
+            CREATE TYPE ConstraintTest10 {
                 CREATE PROPERTY foo -> std::int64 {
-                    CREATE CONSTRAINT test::mymax5(3);
+                    CREATE CONSTRAINT mymax5(3);
                 };
             };
         """)
 
         await self.con.execute(r"""
-            ALTER ABSTRACT CONSTRAINT test::mymax5
-            RENAME TO test::mymax6;
+            ALTER ABSTRACT CONSTRAINT mymax5
+            RENAME TO mymax6;
         """)
 
         async with self._run_and_rollback():
             with self.assertRaises(edgedb.ConstraintViolationError):
                 await self.con.execute(r"""
-                    INSERT test::ConstraintTest10 { foo := 4 }
+                    INSERT ConstraintTest10 { foo := 4 }
                 """)
 
         await self.con.execute(r"""
             CREATE MODULE foo IF NOT EXISTS;
-            ALTER ABSTRACT CONSTRAINT test::mymax6
+            ALTER ABSTRACT CONSTRAINT mymax6
             RENAME TO foo::mymax2;
         """)
 
         await self.con.execute(r"""
-            ALTER TYPE test::ConstraintTest10 {
+            ALTER TYPE ConstraintTest10 {
                 ALTER PROPERTY foo {
                     DROP CONSTRAINT foo::mymax2(3);
                 }
@@ -1194,7 +1194,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
 
     async def test_constraints_ddl_11(self):
         qry = r"""
-            CREATE ABSTRACT CONSTRAINT test::mymax7(max: std::int64) {
+            CREATE ABSTRACT CONSTRAINT mymax7(max: std::int64) {
                 USING (__subject__ <= max);
             };
         """
@@ -1202,13 +1202,13 @@ class TestConstraintsDDL(tb.DDLTestCase):
         # Check that renaming and then recreating works
         await self.con.execute(qry)
         await self.con.execute("""
-            ALTER ABSTRACT CONSTRAINT test::mymax7 RENAME TO test::mymax8;
+            ALTER ABSTRACT CONSTRAINT mymax7 RENAME TO mymax8;
         """)
         await self.con.execute(qry)
 
     async def test_constraints_ddl_12(self):
         qry = r"""
-            CREATE ABSTRACT CONSTRAINT test::mymax9(max: std::int64) {
+            CREATE ABSTRACT CONSTRAINT mymax9(max: std::int64) {
                 USING (__subject__ <= max);
             };
         """
@@ -1216,78 +1216,78 @@ class TestConstraintsDDL(tb.DDLTestCase):
         # Check that deleting and then recreating works
         await self.con.execute(qry)
         await self.con.execute("""
-            DROP ABSTRACT CONSTRAINT test::mymax9;
+            DROP ABSTRACT CONSTRAINT mymax9;
         """)
         await self.con.execute(qry)
 
     async def test_constraints_ddl_13(self):
         await self.con.execute(r"""
-            CREATE ABSTRACT CONSTRAINT test::mymax13(max: std::int64) {
+            CREATE ABSTRACT CONSTRAINT mymax13(max: std::int64) {
                 USING (__subject__ <= max);
             };
 
-            CREATE TYPE test::ConstraintTest13 {
+            CREATE TYPE ConstraintTest13 {
                 CREATE PROPERTY foo -> std::int64 {
-                    CREATE CONSTRAINT test::mymax13(3);
+                    CREATE CONSTRAINT mymax13(3);
                 };
             };
         """)
 
         await self.con.execute(r"""
-            ALTER ABSTRACT CONSTRAINT test::mymax13
-            RENAME TO test::mymax13b;
+            ALTER ABSTRACT CONSTRAINT mymax13
+            RENAME TO mymax13b;
         """)
 
         res = await self.con.query_one("""
-            DESCRIBE MODULE test
+            DESCRIBE MODULE default
         """)
 
         self.assertEqual(res.count("mymax13b"), 2)
 
     async def test_constraints_ddl_14(self):
         await self.con.execute(r"""
-            CREATE ABSTRACT CONSTRAINT test::mymax14(max: std::int64) {
+            CREATE ABSTRACT CONSTRAINT mymax14(max: std::int64) {
                 USING (__subject__ <= max);
             };
 
-            CREATE TYPE test::ConstraintTest14 {
+            CREATE TYPE ConstraintTest14 {
                 CREATE PROPERTY foo -> std::int64 {
-                    CREATE CONSTRAINT test::mymax14(3);
+                    CREATE CONSTRAINT mymax14(3);
                 };
             };
         """)
 
         await self.con.execute(r"""
-            ALTER TYPE test::ConstraintTest14 {
+            ALTER TYPE ConstraintTest14 {
                 ALTER PROPERTY foo {
-                    DROP CONSTRAINT test::mymax14(3);
+                    DROP CONSTRAINT mymax14(3);
                 }
             }
         """)
 
         await self.con.execute(r"""
-            ALTER TYPE test::ConstraintTest14 {
+            ALTER TYPE ConstraintTest14 {
                 ALTER PROPERTY foo {
-                    CREATE CONSTRAINT test::mymax14(5);
+                    CREATE CONSTRAINT mymax14(5);
                 }
             }
         """)
 
     async def test_constraints_ddl_function(self):
         await self.con.execute('''\
-            CREATE FUNCTION test::comp_func(s: str) -> str {
+            CREATE FUNCTION comp_func(s: str) -> str {
                 USING (
                     SELECT str_lower(s)
                 );
                 SET volatility := 'Immutable';
             };
 
-            CREATE TYPE test::CompPropFunction {
+            CREATE TYPE CompPropFunction {
                 CREATE PROPERTY title -> str {
                     CREATE CONSTRAINT exclusive ON
-                        (test::comp_func(__subject__));
+                        (comp_func(__subject__));
                 };
-                CREATE PROPERTY comp_prop := test::comp_func(.title);
+                CREATE PROPERTY comp_prop := comp_func(.title);
             };
         ''')
 
@@ -1299,7 +1299,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             r"subjectexpr is already defined for .+max_int",
         ):
             await self.con.execute(r"""
-                CREATE ABSTRACT CONSTRAINT test::max_int(m: std::int64)
+                CREATE ABSTRACT CONSTRAINT max_int(m: std::int64)
                     ON (<int64>__subject__)
                 {
                     SET errmessage :=
@@ -1309,9 +1309,9 @@ class TestConstraintsDDL(tb.DDLTestCase):
                     USING (__subject__ <= m);
                 };
 
-                CREATE TYPE test::InvalidConstraintTest2 {
+                CREATE TYPE InvalidConstraintTest2 {
                     CREATE PROPERTY foo -> std::str {
-                        CREATE CONSTRAINT test::max_int(3)
+                        CREATE CONSTRAINT max_int(3)
                             ON (len(__subject__));
                     };
                 };
@@ -1388,14 +1388,14 @@ class TestConstraintsDDL(tb.DDLTestCase):
         ):
             await self.con.execute(r"""
                 CREATE ABSTRACT CONSTRAINT
-                test::mymax_er_06(max: std::int64) ON (len(__subject__))
+                mymax_er_06(max: std::int64) ON (len(__subject__))
                 {
                     USING (__subject__ <= $max);
                 };
 
-                CREATE TYPE test::ConstraintOnTest_err_06 {
+                CREATE TYPE ConstraintOnTest_err_06 {
                     CREATE PROPERTY foo -> std::str {
-                        CREATE CONSTRAINT test::mymax_er_06(3);
+                        CREATE CONSTRAINT mymax_er_06(3);
                     };
                 };
             """)

--- a/tests/test_dump01.py
+++ b/tests/test_dump01.py
@@ -1876,8 +1876,8 @@ class DumpTestCaseMixin:
 
 class TestDump01(tb.StableDumpTestCase, DumpTestCaseMixin):
 
-    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
-                          'dump01_test.esdl')
+    SCHEMA_TEST = os.path.join(os.path.dirname(__file__), 'schemas',
+                               'dump01_test.esdl')
     SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
                                   'dump01_default.esdl')
 

--- a/tests/test_dump02.py
+++ b/tests/test_dump02.py
@@ -226,6 +226,7 @@ class DumpTestCaseMixin:
 
 
 class TestDump02(tb.StableDumpTestCase, DumpTestCaseMixin):
+    DEFAULT_MODULE = 'test'
 
     SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
                                   'dump02_default.esdl')

--- a/tests/test_dump03.py
+++ b/tests/test_dump03.py
@@ -69,6 +69,7 @@ class DumpTestCaseMixin:
 
 
 class TestDump03(tb.StableDumpTestCase, DumpTestCaseMixin):
+    DEFAULT_MODULE = 'test'
 
     SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
                                   'dump03_default.esdl')

--- a/tests/test_dump_basic.py
+++ b/tests/test_dump_basic.py
@@ -25,6 +25,7 @@ from edb.testbase import server as tb
 
 
 class TestDumpBasics(tb.DatabaseTestCase, tb.CLITestCaseMixin):
+    DEFAULT_MODULE = 'test'
 
     TRANSACTION_ISOLATION = False
 

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -28,7 +28,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
 
     async def test_edgeql_calls_01(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call1(
+            CREATE FUNCTION call1(
                 s: str,
                 VARIADIC a: int64,
                 NAMED ONLY suffix: str = '-suf',
@@ -40,58 +40,58 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call1('-');''',
+            r'''SELECT call1('-');''',
             ['pref--0-suf'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call1('-', suffix := 's1');''',
+            r'''SELECT call1('-', suffix := 's1');''',
             ['pref--0s1'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call1('-', prefix := 'p1');''',
+            r'''SELECT call1('-', prefix := 'p1');''',
             ['p1-0-suf'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call1('-', suffix := 's1', prefix := 'p1');''',
+            r'''SELECT call1('-', suffix := 's1', prefix := 'p1');''',
             ['p1-0s1'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call1('-', 1);''',
+            r'''SELECT call1('-', 1);''',
             ['pref--1-suf'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call1('-', 1, suffix := 's1');''',
+            r'''SELECT call1('-', 1, suffix := 's1');''',
             ['pref--1s1'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call1('-', 1, prefix := 'p1');''',
+            r'''SELECT call1('-', 1, prefix := 'p1');''',
             ['p1-1-suf'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call1('-', 1, 2, 3, 4, 5);''',
+            r'''SELECT call1('-', 1, 2, 3, 4, 5);''',
             ['pref--15-suf'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call1('-', 1, 2, 3, 4, 5, suffix := 's1');''',
+            r'''SELECT call1('-', 1, 2, 3, 4, 5, suffix := 's1');''',
             ['pref--15s1'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call1('-', 1, 2, 3, 4, 5, prefix := 'p1');''',
+            r'''SELECT call1('-', 1, 2, 3, 4, 5, prefix := 'p1');''',
             ['p1-15-suf'],
         )
 
         await self.assert_query_result(
             r'''
-                SELECT test::call1('-', 1, 2, 3, 4, 5, prefix := 'p1',
+                SELECT call1('-', 1, 2, 3, 4, 5, prefix := 'p1',
                                    suffix := 'aaa');
             ''',
             ['p1-15aaa'],
@@ -99,7 +99,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
 
     async def test_edgeql_calls_02(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call2(
+            CREATE FUNCTION call2(
                 VARIADIC a: anytype
             ) -> std::str {
                 USING (
@@ -109,17 +109,17 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call2('a', 'b');''',
+            r'''SELECT call2('a', 'b');''',
             ['=2='],
         )
         await self.assert_query_result(
-            r'''SELECT test::call2(4, 2, 0);''',
+            r'''SELECT call2(4, 2, 0);''',
             ['=3='],
         )
 
     async def test_edgeql_calls_03(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call3(
+            CREATE FUNCTION call3(
                 a: int32,
                 NAMED ONLY b: int32
             ) -> int32
@@ -129,11 +129,11 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         cases = [
-            'SELECT test::call3(1);',
-            'SELECT test::call3(1, 2);',
-            'SELECT test::call3(1, 2, 3);',
-            'SELECT test::call3(b := 1);',
-            'SELECT test::call3(1, 2, b := 1);',
+            'SELECT call3(1);',
+            'SELECT call3(1, 2);',
+            'SELECT call3(1, 2, 3);',
+            'SELECT call3(b := 1);',
+            'SELECT call3(1, 2, b := 1);',
         ]
 
         for c in cases:
@@ -147,7 +147,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         'type of the "[]" default cannot be determined for array<anytype>')
     async def test_edgeql_calls_04(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call4(
+            CREATE FUNCTION call4(
                 a: int32,
                 NAMED ONLY b: array<anytype> = []
             ) -> int32
@@ -157,27 +157,27 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call4(100);''',
+            r'''SELECT call4(100);''',
             [100],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call4(100, b := <int32>[]);''',
+            r'''SELECT call4(100, b := <int32>[]);''',
             [100],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call4(100, b := [1, 2]);''',
+            r'''SELECT call4(100, b := [1, 2]);''',
             [102],
         )
         await self.assert_query_result(
-            r'''SELECT test::call4(100, b := ['a', 'b']);''',
+            r'''SELECT call4(100, b := ['a', 'b']);''',
             [102],
         )
 
     async def test_edgeql_calls_05(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call5(
+            CREATE FUNCTION call5(
                 a: int64,
                 NAMED ONLY b: OPTIONAL int64 = <int64>{}
             ) -> int64
@@ -187,55 +187,55 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call5(1);''',
+            r'''SELECT call5(1);''',
             [-99],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call5(<int32>2);''',
+            r'''SELECT call5(<int32>2);''',
             [-98],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call5(1, b := 20);''',
+            r'''SELECT call5(1, b := 20);''',
             [21],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call5(1, b := <int16>10);''',
+            r'''SELECT call5(1, b := <int16>10);''',
             [11],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call5(<int32>{});''',
+            r'''SELECT call5(<int32>{});''',
             [],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call5(<int32>{}, b := <int32>{});''',
+            r'''SELECT call5(<int32>{}, b := <int32>{});''',
             [],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call5(<int32>{}, b := 50);''',
+            r'''SELECT call5(<int32>{}, b := 50);''',
             [],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call5(1, b := <int32>{});''',
+            r'''SELECT call5(1, b := <int32>{});''',
             [-99],
         )
 
         await self.assert_query_result(
             r'''
             WITH X := (SELECT _:={1,2,3} FILTER _ < 0)
-            SELECT test::call5(1, b := X);''',
+            SELECT call5(1, b := X);''',
             [-99],
         )
 
     async def test_edgeql_calls_06(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call6(
+            CREATE FUNCTION call6(
                 VARIADIC a: int64
             ) -> int64
                 USING EdgeQL $$
@@ -244,23 +244,23 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call6();''',
+            r'''SELECT call6();''',
             [0],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call6(1, 2, 3);''',
+            r'''SELECT call6(1, 2, 3);''',
             [6],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call6(<int16>1, <int32>2, 3);''',
+            r'''SELECT call6(<int16>1, <int32>2, 3);''',
             [6],
         )
 
     async def test_edgeql_calls_07(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call7(
+            CREATE FUNCTION call7(
                 a: int64 = 1,
                 b: int64 = 2,
                 c: int64 = 3,
@@ -273,43 +273,43 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call7();''',
+            r'''SELECT call7();''',
             [[1, 2, 3, 4, 5]],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call7(e := 100);''',
+            r'''SELECT call7(e := 100);''',
             [[1, 2, 3, 4, 100]],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call7(d := 200);''',
+            r'''SELECT call7(d := 200);''',
             [[1, 2, 3, 200, 5]],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call7(20, 30, d := 200);''',
+            r'''SELECT call7(20, 30, d := 200);''',
             [[20, 30, 3, 200, 5]],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call7(20, 30, e := 42, d := 200);''',
+            r'''SELECT call7(20, 30, e := 42, d := 200);''',
             [[20, 30, 3, 200, 42]],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call7(20, 30, 1, d := 200, e := 42);''',
+            r'''SELECT call7(20, 30, 1, d := 200, e := 42);''',
             [[20, 30, 1, 200, 42]],
         )
 
         cases = [
-            'SELECT test::call7(1, 2, 3, 4, 5);'
-            'SELECT test::call7(1, 2, 3, 4);'
-            'SELECT test::call7(1, z := 1);'
-            'SELECT test::call7(1, 2, 3, z := 1);'
-            'SELECT test::call7(1, 2, 3, 4, z := 1);'
-            'SELECT test::call7(1, 2, 3, d := 1, z := 10);'
-            'SELECT test::call7(1, 2, 3, d := 1, e := 2, z := 10);'
+            'SELECT call7(1, 2, 3, 4, 5);'
+            'SELECT call7(1, 2, 3, 4);'
+            'SELECT call7(1, z := 1);'
+            'SELECT call7(1, 2, 3, z := 1);'
+            'SELECT call7(1, 2, 3, 4, z := 1);'
+            'SELECT call7(1, 2, 3, d := 1, z := 10);'
+            'SELECT call7(1, 2, 3, d := 1, e := 2, z := 10);'
         ]
 
         for c in cases:
@@ -321,7 +321,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
 
     async def test_edgeql_calls_08(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call8(
+            CREATE FUNCTION call8(
                 a: int64 = 1,
                 NAMED ONLY b: int64 = 2
             ) -> int64
@@ -329,7 +329,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
                     SELECT a + b
                 $$;
 
-            CREATE FUNCTION test::call8(
+            CREATE FUNCTION call8(
                 a: float64 = 1.0,
                 NAMED ONLY b: int64 = 2
             ) -> int64
@@ -339,30 +339,30 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call8(1);''',
+            r'''SELECT call8(1);''',
             [3],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call8(1.0);''',
+            r'''SELECT call8(1.0);''',
             [1003],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call8(1, b := 10);''',
+            r'''SELECT call8(1, b := 10);''',
             [11],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call8(1.0, b := 10);''',
+            r'''SELECT call8(1.0, b := 10);''',
             [1011],
         )
 
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'function test::call8 is not unique'):
+                r'function call8 is not unique'):
             async with self.con.transaction():
-                await self.con.execute('SELECT test::call8();')
+                await self.con.execute('SELECT call8();')
 
     async def test_edgeql_calls_09(self):
         await self.assert_query_result(
@@ -475,7 +475,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
 
     async def test_edgeql_calls_11(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call11(
+            CREATE FUNCTION call11(
                 a: array<int32>
             ) -> int64
                 USING EdgeQL $$
@@ -484,24 +484,24 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call11([<int16>1, <int16>22]);''',
+            r'''SELECT call11([<int16>1, <int16>22]);''',
             [23],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call11([<int16>1, <int32>23]);''',
+            r'''SELECT call11([<int16>1, <int32>23]);''',
             [24],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call11([<int32>1, <int32>24]);''',
+            r'''SELECT call11([<int32>1, <int32>24]);''',
             [25],
         )
 
         cases = [
-            'SELECT test::call11([<int32>1, 1.1]);',
-            'SELECT test::call11([<int32>1, <float32>1]);',
-            'SELECT test::call11([1, 2]);',
+            'SELECT call11([<int32>1, 1.1]);',
+            'SELECT call11([<int32>1, <float32>1]);',
+            'SELECT call11([1, 2]);',
         ]
 
         for c in cases:
@@ -517,14 +517,14 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         "at the call site")
     async def test_edgeql_calls_12(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call12(
+            CREATE FUNCTION call12(
                 a: anyint
             ) -> int64
                 USING EdgeQL $$
                     SELECT <int64>a + 100
                 $$;
 
-            CREATE FUNCTION test::call12(
+            CREATE FUNCTION call12(
                 a: int64
             ) -> int64
                 USING EdgeQL $$
@@ -533,91 +533,91 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call12(<int32>1);''',
+            r'''SELECT call12(<int32>1);''',
             [101],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call12(1);''',
+            r'''SELECT call12(1);''',
             [2],
         )
 
     async def test_edgeql_calls_13(self):
         await self.con.execute('''
-            CREATE FUNCTION test::inner(
+            CREATE FUNCTION inner(
                 a: anytype
             ) -> int64
                 USING (
                     SELECT 1
                 );
 
-            CREATE FUNCTION test::call13(
+            CREATE FUNCTION call13(
                 a: anytype
             ) -> int64
                 USING (
-                    SELECT test::inner(a)
+                    SELECT inner(a)
                 );
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call13('aaa');''',
+            r'''SELECT call13('aaa');''',
             [{}],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call13(b'aaaa');''',
+            r'''SELECT call13(b'aaaa');''',
             [{}],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call13([1, 2, 3, 4, 5]);''',
+            r'''SELECT call13([1, 2, 3, 4, 5]);''',
             [{}],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call13(['a', 'b']);''',
+            r'''SELECT call13(['a', 'b']);''',
             [{}],
         )
 
         await self.con.execute('''
-            CREATE FUNCTION test::inner(
+            CREATE FUNCTION inner(
                 a: str
             ) -> int64
                 USING EdgeQL $$
                     SELECT 2
                 $$;
 
-            CREATE FUNCTION test::call13_2(
+            CREATE FUNCTION call13_2(
                 a: anytype
             ) -> int64
                 USING EdgeQL $$
-                    SELECT test::inner(a)
+                    SELECT inner(a)
                 $$;
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call13_2('aaa');''',
+            r'''SELECT call13_2('aaa');''',
             [2],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call13_2(b'aaaa');''',
+            r'''SELECT call13_2(b'aaaa');''',
             [{}],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call13_2([1, 2, 3, 4, 5]);''',
+            r'''SELECT call13_2([1, 2, 3, 4, 5]);''',
             [{}],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call13_2(['a', 'b']);''',
+            r'''SELECT call13_2(['a', 'b']);''',
             [{}],
         )
 
     async def test_edgeql_calls_14(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call14(
+            CREATE FUNCTION call14(
                 a: anytype
             ) -> array<anytype>
                 USING EdgeQL $$
@@ -626,23 +626,23 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call14('aaa');''',
+            r'''SELECT call14('aaa');''',
             [['aaa']],
         )
 
         self.assertEqual(
-            await self.con.query(r'''SELECT test::call14(b'aaaa');'''),
+            await self.con.query(r'''SELECT call14(b'aaaa');'''),
             [[b'aaaa']]
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call14(1);''',
+            r'''SELECT call14(1);''',
             [[1]],
         )
 
     async def test_edgeql_calls_15(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call15(
+            CREATE FUNCTION call15(
                 a: anytype
             ) -> array<anytype>
                 USING EdgeQL $$
@@ -651,18 +651,18 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call15('aaa');''',
+            r'''SELECT call15('aaa');''',
             [['aaa', 'aaa', 'aaa']],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call15(1);''',
+            r'''SELECT call15(1);''',
             [[1, 1, 1]],
         )
 
     async def test_edgeql_calls_16(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call16(
+            CREATE FUNCTION call16(
                 a: array<anytype>,
                 idx: int64
             ) -> anytype
@@ -670,7 +670,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
                     SELECT a[idx]
                 $$;
 
-            CREATE FUNCTION test::call16(
+            CREATE FUNCTION call16(
                 a: array<anytype>,
                 idx: str
             ) -> anytype
@@ -678,7 +678,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
                     SELECT a[<int64>idx + 1]
                 $$;
 
-            CREATE FUNCTION test::call16(
+            CREATE FUNCTION call16(
                 a: anyscalar,
                 idx: int64
             ) -> anytype
@@ -688,40 +688,40 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call16([1, 2, 3], 1);''',
+            r'''SELECT call16([1, 2, 3], 1);''',
             [2],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call16(['a', 'b', 'c'], 1);''',
+            r'''SELECT call16(['a', 'b', 'c'], 1);''',
             ['b'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call16([1, 2, 3], '1');''',
+            r'''SELECT call16([1, 2, 3], '1');''',
             [3],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call16(['a', 'b', 'c'], '1');''',
+            r'''SELECT call16(['a', 'b', 'c'], '1');''',
             ['c'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call16('xyz', 1);''',
+            r'''SELECT call16('xyz', 1);''',
             ['y'],
         )
 
     async def test_edgeql_calls_17(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call17(
+            CREATE FUNCTION call17(
                 a: anytype
             ) -> array<anytype>
                 USING EdgeQL $$
                     SELECT [a, a, a]
                 $$;
 
-            CREATE FUNCTION test::call17(
+            CREATE FUNCTION call17(
                 a: str
             ) -> array<str>
                 USING EdgeQL $$
@@ -730,18 +730,18 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call17(2);''',
+            r'''SELECT call17(2);''',
             [[2, 2, 2]],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call17('aaa');''',
+            r'''SELECT call17('aaa');''',
             [['!!!!', 'aaa', '!!!!']],
         )
 
     async def test_edgeql_calls_18(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call18(
+            CREATE FUNCTION call18(
                 VARIADIC a: anytype
             ) -> int64
                 USING EdgeQL $$
@@ -750,17 +750,17 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call18(2);''',
+            r'''SELECT call18(2);''',
             [{}],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call18(1, 2, 3);''',
+            r'''SELECT call18(1, 2, 3);''',
             [3],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call18('a', 'b');''',
+            r'''SELECT call18('a', 'b');''',
             [2],
         )
 
@@ -769,7 +769,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
                 r'function .+ does not exist'):
 
             async with self.con.transaction():
-                await self.con.execute('SELECT test::call18(1, 2, "a");')
+                await self.con.execute('SELECT call18(1, 2, "a");')
 
     @test.not_implemented(
         "PG fails with 'return type record[] is not supported'")
@@ -778,7 +778,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         #    return type record[] is not supported for SQL functions
 
         await self.con.execute('''
-            CREATE FUNCTION test::call19(
+            CREATE FUNCTION call19(
                 a: anytype
             ) -> array<anytype>
                 USING EdgeQL $$
@@ -786,7 +786,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
                 $$;
         ''')
 
-        await self.con.execute('SELECT test::call19((1,2));')
+        await self.con.execute('SELECT call19((1,2));')
 
     @test.xfail(
         "Polymorphic callable matching is currently too dumb to realize "
@@ -794,14 +794,14 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         "actual forms defined.")
     async def test_edgeql_calls_20(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call20_1(
+            CREATE FUNCTION call20_1(
                 a: anyreal, b: anyreal
             ) -> anyreal
                 USING EdgeQL $$
                     SELECT a + b
                 $$;
 
-            CREATE FUNCTION test::call20_2(
+            CREATE FUNCTION call20_2(
                 a: anyscalar, b: anyscalar
             ) -> bool
                 USING EdgeQL $$
@@ -810,17 +810,17 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call20_1(10, 20);''',
+            r'''SELECT call20_1(10, 20);''',
             [30],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call20_2(1, 2);''',
+            r'''SELECT call20_2(1, 2);''',
             [True],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call20_2('b', 'a');''',
+            r'''SELECT call20_2('b', 'a');''',
             [False],
         )
 
@@ -828,11 +828,11 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
                 edgedb.QueryError,
                 r'function .+ does not exist'):
             async with self.con.transaction():
-                await self.con.execute('SELECT test::call20_1(1, "1");')
+                await self.con.execute('SELECT call20_1(1, "1");')
 
     async def test_edgeql_calls_21(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call21(
+            CREATE FUNCTION call21(
                 a: array<anytype>
             ) -> int64
                 USING EdgeQL $$
@@ -841,35 +841,35 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call21(<array<str>>[]);''',
+            r'''SELECT call21(<array<str>>[]);''',
             [0],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call21([1,2]);''',
+            r'''SELECT call21([1,2]);''',
             [2],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call21(['a', 'b', 'c']);''',
+            r'''SELECT call21(['a', 'b', 'c']);''',
             [3],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call21([(1, 2), (2, 3), (3, 4), (4, 5)]);''',
+            r'''SELECT call21([(1, 2), (2, 3), (3, 4), (4, 5)]);''',
             [4],
         )
 
     async def test_edgeql_calls_22(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call22(
+            CREATE FUNCTION call22(
                 a: str, b: str
             ) -> str
                 USING EdgeQL $$
                     SELECT a ++ b
                 $$;
 
-            CREATE FUNCTION test::call22(
+            CREATE FUNCTION call22(
                 a: array<anytype>, b: array<anytype>
             ) -> array<anytype>
                 USING EdgeQL $$
@@ -878,12 +878,12 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call22('a', 'b');''',
+            r'''SELECT call22('a', 'b');''',
             ['ab'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call22(['a'], ['b']);''',
+            r'''SELECT call22(['a'], ['b']);''',
             [
                 ['a', 'b'],
             ]
@@ -891,7 +891,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
 
     async def test_edgeql_calls_23(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call23(
+            CREATE FUNCTION call23(
                 a: anytype,
                 idx: int64
             ) -> anytype
@@ -899,7 +899,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
                     SELECT a[idx]
                 $$;
 
-            CREATE FUNCTION test::call23(
+            CREATE FUNCTION call23(
                 a: anytype,
                 idx: int32
             ) -> anytype
@@ -909,32 +909,32 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call23('abcde', 2);''',
+            r'''SELECT call23('abcde', 2);''',
             ['c'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call23('abcde', <int32>2);''',
+            r'''SELECT call23('abcde', <int32>2);''',
             ['de'],
         )
 
         self.assertEqual(
             await self.con.query_one(
-                r'''SELECT test::call23(to_json('[{"a":"b"}]'), 0);'''),
+                r'''SELECT call23(to_json('[{"a":"b"}]'), 0);'''),
             '{"a": "b"}')
         self.assertEqual(
             await self.con.query_json(
-                r'''SELECT test::call23(to_json('[{"a":"b"}]'), 0);'''),
+                r'''SELECT call23(to_json('[{"a":"b"}]'), 0);'''),
             '[{"a": "b"}]')
 
     async def test_edgeql_calls_24(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call24() -> str
+            CREATE FUNCTION call24() -> str
                 USING EdgeQL $$
                     SELECT 'ab' ++ 'cd'
                 $$;
 
-            CREATE FUNCTION test::call24(
+            CREATE FUNCTION call24(
                 a: str
             ) -> str
                 USING EdgeQL $$
@@ -943,18 +943,18 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''select test::call24();''',
+            r'''select call24();''',
             ['abcd'],
         )
 
         await self.assert_query_result(
-            r'''select test::call24('aaa');''',
+            r'''select call24('aaa');''',
             ['aaa!'],
         )
 
     async def test_edgeql_calls_26(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call26(
+            CREATE FUNCTION call26(
                 a: array<anyscalar>
             ) -> int64
                 USING EdgeQL $$
@@ -963,12 +963,12 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call26(['aaa']);''',
+            r'''SELECT call26(['aaa']);''',
             [{}],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call26([b'', b'aa']);''',
+            r'''SELECT call26([b'', b'aa']);''',
             [2],
         )
 
@@ -976,11 +976,11 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
                 edgedb.QueryError,
                 r'function .+ does not exist'):
             async with self.con.transaction():
-                await self.con.execute('SELECT test::call26([(1, 2)]);')
+                await self.con.execute('SELECT call26([(1, 2)]);')
 
     async def test_edgeql_calls_27(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call27(
+            CREATE FUNCTION call27(
                 a: array<anyint>
             ) -> int64
                 USING EdgeQL $$
@@ -989,20 +989,20 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call27([<int32>1, <int32>2]);''',
+            r'''SELECT call27([<int32>1, <int32>2]);''',
             [2],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call27([1, 2, 3]);''',
+            r'''SELECT call27([1, 2, 3]);''',
             [3],
         )
 
         cases = [
-            "SELECT test::call27(['aaa']);",
-            "SELECT test::call27([b'', b'aa']);",
-            "SELECT test::call27([1.0, 2.1]);",
-            "SELECT test::call27([('a',), ('b',)]);",
+            "SELECT call27(['aaa']);",
+            "SELECT call27([b'', b'aa']);",
+            "SELECT call27([1.0, 2.1]);",
+            "SELECT call27([('a',), ('b',)]);",
         ]
 
         for c in cases:
@@ -1016,14 +1016,14 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         "we get two `(anynonarray)->bigint` PG functions which is ambiguous")
     async def test_edgeql_calls_28(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call28(
+            CREATE FUNCTION call28(
                 a: array<anyint>
             ) -> int64
                 USING EdgeQL $$
                     SELECT len(a)
                 $$;
 
-            CREATE FUNCTION test::call28(
+            CREATE FUNCTION call28(
                 a: array<anyscalar>
             ) -> int64
                 USING EdgeQL $$
@@ -1032,23 +1032,23 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call28([<int32>1, <int32>2]);''',
+            r'''SELECT call28([<int32>1, <int32>2]);''',
             [2],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call28([1, 2, 3]);''',
+            r'''SELECT call28([1, 2, 3]);''',
             [3],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call28(['a', 'b']);''',
+            r'''SELECT call28(['a', 'b']);''',
             [1002],
         )
 
     async def test_edgeql_calls_29(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call29(
+            CREATE FUNCTION call29(
                 a: anyint
             ) -> anyint
                 USING EdgeQL $$
@@ -1057,13 +1057,13 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call29(10);''',
+            r'''SELECT call29(10);''',
             [11],
         )
 
     async def test_edgeql_calls_30(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call30(
+            CREATE FUNCTION call30(
                 a: anyint
             ) -> int64
                 USING EdgeQL $$
@@ -1072,18 +1072,18 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call30(10);''',
+            r'''SELECT call30(10);''',
             [110],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call30(<int32>20);''',
+            r'''SELECT call30(<int32>20);''',
             [120],
         )
 
     async def test_edgeql_calls_31(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call31(
+            CREATE FUNCTION call31(
                 a: anytype
             ) -> anytype
                 USING EdgeQL $$
@@ -1092,67 +1092,67 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call31(10);''',
+            r'''SELECT call31(10);''',
             [10],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call31('aa');''',
+            r'''SELECT call31('aa');''',
             ['aa'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call31([1, 2]);''',
+            r'''SELECT call31([1, 2]);''',
             [[1, 2]],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call31([1, 2])[0];''',
+            r'''SELECT call31([1, 2])[0];''',
             [{}],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call31((a:=1001, b:=1002)).a;''',
+            r'''SELECT call31((a:=1001, b:=1002)).a;''',
             [1001],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call31((a:=1001, b:=1002)).1;''',
+            r'''SELECT call31((a:=1001, b:=1002)).1;''',
             [1002],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call31((a:=['a', 'b'], b:=['x', 'y'])).1;''',
+            r'''SELECT call31((a:=['a', 'b'], b:=['x', 'y'])).1;''',
             [['x', 'y']],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call31((a:=['a', 'b'], b:=['x', 'y'])).a[1];''',
+            r'''SELECT call31((a:=['a', 'b'], b:=['x', 'y'])).a[1];''',
             ['b'],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call31((a:=1001, b:=1002));''',
+            r'''SELECT call31((a:=1001, b:=1002));''',
             [{"a": 1001, "b": 1002}],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call31((a:=[(x:=1)])).a[0].x;''',
+            r'''SELECT call31((a:=[(x:=1)])).a[0].x;''',
             [{}],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call31((a:=[(x:=1)])).0[0].x;''',
+            r'''SELECT call31((a:=[(x:=1)])).0[0].x;''',
             [{}],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call31((a:=[(x:=1)])).0[0].0;''',
+            r'''SELECT call31((a:=[(x:=1)])).0[0].0;''',
             [{}],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call31((a:=[(x:=1)])).a[0];''',
+            r'''SELECT call31((a:=[(x:=1)])).a[0];''',
             [{"x": 1}],
         )
 
@@ -1163,7 +1163,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         "before calling.")
     async def test_edgeql_calls_32(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call32(
+            CREATE FUNCTION call32(
                 a: anytype, b: anytype
             ) -> anytype
                 USING EdgeQL $$
@@ -1172,7 +1172,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call32([1], [<int16>2]);''',
+            r'''SELECT call32([1], [<int16>2]);''',
             [
                 [1, 2],
             ]
@@ -1182,7 +1182,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         # Tuple argument
 
         await self.con.execute('''
-            CREATE FUNCTION test::call33(
+            CREATE FUNCTION call33(
                 a: tuple<int64, tuple<int64>>,
                 b: tuple<foo: int64, bar: str>
             ) -> int64
@@ -1192,7 +1192,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call33((1, (2,)), (foo := 10, bar := 'bar'));''',
+            r'''SELECT call33((1, (2,)), (foo := 10, bar := 'bar'));''',
             [
                 11,
             ]
@@ -1202,7 +1202,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         # Tuple argument
 
         await self.con.execute('''
-            CREATE FUNCTION test::call34(
+            CREATE FUNCTION call34(
                 a: array<tuple<int64, int64>>
             ) -> int64
                 USING EdgeQL $$
@@ -1211,7 +1211,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call34([(1, 2), (3, 4)]);''',
+            r'''SELECT call34([(1, 2), (3, 4)]);''',
             [
                 1,
             ]
@@ -1221,7 +1221,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         # Tuple return
 
         await self.con.execute('''
-            CREATE FUNCTION test::call35(
+            CREATE FUNCTION call35(
                 a: int64
             ) -> tuple<int64, tuple<foo: int64>>
                 USING EdgeQL $$
@@ -1230,14 +1230,14 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call35(1);''',
+            r'''SELECT call35(1);''',
             [
                 [1, {'foo': 2}]
             ]
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call35(1).1.foo;''',
+            r'''SELECT call35(1).1.foo;''',
             [
                 2
             ]
@@ -1247,7 +1247,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         # Tuple return with a deep and unavoidable implicit cast
 
         await self.con.execute('''
-            CREATE FUNCTION test::call35(
+            CREATE FUNCTION call35(
                 a: tuple<int64, array<tuple<int64>>>
             ) -> tuple<int64, array<tuple<foo: int64>>>
                 USING EdgeQL $$
@@ -1256,14 +1256,14 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call35((1, [(2,)]));''',
+            r'''SELECT call35((1, [(2,)]));''',
             [
                 [1, [{'foo': 2}]]
             ]
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call35((1, [(2,)])).1[0].foo;''',
+            r'''SELECT call35((1, [(2,)])).1[0].foo;''',
             [
                 2
             ]
@@ -1271,7 +1271,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
 
     async def test_edgeql_calls_36(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call36(
+            CREATE FUNCTION call36(
                 a: int64
             ) -> array<tuple<int64>>
                 USING EdgeQL $$
@@ -1280,7 +1280,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call36(1);''',
+            r'''SELECT call36(1);''',
             [
                 [[1]]
             ]
@@ -1289,7 +1289,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
     async def test_edgeql_calls_37(self):
         # define a function with positional arguments with defaults
         await self.con.execute('''
-            CREATE FUNCTION test::call37(
+            CREATE FUNCTION call37(
                 a: int64 = 1,
                 b: int64 = 2
             ) -> int64
@@ -1299,17 +1299,17 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call37();''',
+            r'''SELECT call37();''',
             [3],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call37(2);''',
+            r'''SELECT call37(2);''',
             [4],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call37(2, 3);''',
+            r'''SELECT call37(2, 3);''',
             [5],
         )
 
@@ -1318,7 +1318,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         await self.con.execute('''
             CREATE TYPE C38 { CREATE PROPERTY name -> str };
             INSERT C38 { name := 'yay' };
-            CREATE FUNCTION test::call38(
+            CREATE FUNCTION call38(
                 a: C38
             ) -> str
                 USING (
@@ -1327,20 +1327,20 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call38(C38);''',
+            r'''SELECT call38(C38);''',
             ['yay'],
         )
 
     async def test_edgeql_calls_39(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call39(
+            CREATE FUNCTION call39(
                 foo: str
             ) -> str
                 USING (foo);
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call39("identity");''',
+            r'''SELECT call39("identity");''',
             ['identity'],
         )
 
@@ -1353,44 +1353,44 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
 
             INSERT Rectangle { width := 2, height := 3 };
 
-            CREATE FUNCTION test::call40(
+            CREATE FUNCTION call40(
                 r: Rectangle
             ) -> int64
                 USING (r.width * r.height);
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call40(Rectangle);''',
+            r'''SELECT call40(Rectangle);''',
             [6],
         )
 
     async def test_edgeql_calls_41(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call41(
+            CREATE FUNCTION call41(
                 a: int64, b: int64
             ) -> SET OF int64
                 USING ({a, b});
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call41(1, 2);''',
+            r'''SELECT call41(1, 2);''',
             [1, 2],
         )
 
     async def test_edgeql_calls_42(self):
         await self.con.execute('''
-            CREATE FUNCTION test::call42(
+            CREATE FUNCTION call42(
                 a: int64, b: int64
             ) -> SET OF tuple<int64, str>
                 USING ({(a, '1'), (b, '2')});
         ''')
 
         await self.assert_query_result(
-            r'''SELECT test::call42(1, 2);''',
+            r'''SELECT call42(1, 2);''',
             [[1, '1'], [2, '2']],
         )
 
         await self.assert_query_result(
-            r'''SELECT test::call42(1, 2).0;''',
+            r'''SELECT call42(1, 2).0;''',
             [1, 2],
         )

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -1008,7 +1008,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # of the json values.
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <uuid><str>T.id = T.id;
             ''',
             [True],
@@ -1016,7 +1016,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <bool><str>T.p_bool = T.p_bool;
             ''',
             [True],
@@ -1024,7 +1024,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <str><str>T.p_str = T.p_str;
             ''',
             [True],
@@ -1032,7 +1032,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <datetime><str>T.p_datetime = T.p_datetime;
             ''',
             [True],
@@ -1040,7 +1040,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <cal::local_datetime><str>T.p_local_datetime =
                     T.p_local_datetime;
             ''',
@@ -1049,7 +1049,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <cal::local_date><str>T.p_local_date = T.p_local_date;
             ''',
             [True],
@@ -1057,7 +1057,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <cal::local_time><str>T.p_local_time = T.p_local_time;
             ''',
             [True],
@@ -1065,7 +1065,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <duration><str>T.p_duration = T.p_duration;
             ''',
             [True],
@@ -1073,7 +1073,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <int16><str>T.p_int16 = T.p_int16;
             ''',
             [True],
@@ -1081,7 +1081,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <int32><str>T.p_int32 = T.p_int32;
             ''',
             [True],
@@ -1089,7 +1089,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <int64><str>T.p_int64 = T.p_int64;
             ''',
             [True],
@@ -1097,7 +1097,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <float32><str>T.p_float32 = T.p_float32;
             ''',
             [True],
@@ -1105,7 +1105,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <float64><str>T.p_float64 = T.p_float64;
             ''',
             [True],
@@ -1113,7 +1113,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <bigint><str>T.p_bigint = T.p_bigint;
             ''',
             [True],
@@ -1121,7 +1121,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <decimal><str>T.p_decimal = T.p_decimal;
             ''',
             [True],
@@ -1611,7 +1611,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
     async def test_edgeql_casts_json_02(self):
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <bool><json>T.p_bool = T.p_bool;
             ''',
             [True],
@@ -1619,7 +1619,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <str><json>T.p_str = T.p_str;
             ''',
             [True],
@@ -1627,7 +1627,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <datetime><json>T.p_datetime = T.p_datetime;
             ''',
             [True],
@@ -1635,7 +1635,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <cal::local_datetime><json>T.p_local_datetime =
                     T.p_local_datetime;
             ''',
@@ -1644,7 +1644,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <cal::local_date><json>T.p_local_date = T.p_local_date;
             ''',
             [True],
@@ -1652,7 +1652,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <cal::local_time><json>T.p_local_time = T.p_local_time;
             ''',
             [True],
@@ -1660,7 +1660,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <duration><json>T.p_duration = T.p_duration;
             ''',
             [True],
@@ -1668,7 +1668,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <int16><json>T.p_int16 = T.p_int16;
             ''',
             [True],
@@ -1676,7 +1676,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <int32><json>T.p_int32 = T.p_int32;
             ''',
             [True],
@@ -1684,7 +1684,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <int64><json>T.p_int64 = T.p_int64;
             ''',
             [True],
@@ -1692,7 +1692,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <float32><json>T.p_float32 = T.p_float32;
             ''',
             [True],
@@ -1700,7 +1700,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <float64><json>T.p_float64 = T.p_float64;
             ''',
             [True],
@@ -1708,7 +1708,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <bigint><json>T.p_bigint = T.p_bigint;
             ''',
             [True],
@@ -1716,7 +1716,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH T := (SELECT test::Test FILTER .p_str = 'Hello')
+                WITH T := (SELECT Test FILTER .p_str = 'Hello')
                 SELECT <decimal><json>T.p_decimal = T.p_decimal;
             ''',
             [True],
@@ -1726,7 +1726,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <bool>J.j_bool = T.p_bool;
@@ -1737,7 +1736,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <str>J.j_str = T.p_str;
@@ -1748,7 +1746,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <datetime>J.j_datetime = T.p_datetime;
@@ -1759,7 +1756,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <cal::local_datetime>J.j_local_datetime =
@@ -1771,7 +1767,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <cal::local_date>J.j_local_date = T.p_local_date;
@@ -1782,7 +1777,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <cal::local_time>J.j_local_time = T.p_local_time;
@@ -1793,7 +1787,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <duration>J.j_duration = T.p_duration;
@@ -1804,7 +1797,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <int16>J.j_int16 = T.p_int16;
@@ -1815,7 +1807,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <int32>J.j_int32 = T.p_int32;
@@ -1826,7 +1817,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <int64>J.j_int64 = T.p_int64;
@@ -1837,7 +1827,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <float32>J.j_float32 = T.p_float32;
@@ -1848,7 +1837,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <float64>J.j_float64 = T.p_float64;
@@ -1859,7 +1847,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <bigint>J.j_bigint = T.p_bigint;
@@ -1870,7 +1857,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     T := (SELECT Test FILTER .p_str = 'Hello'),
                     J := (SELECT JSONTest FILTER .j_str = <json>'Hello')
                 SELECT <decimal>J.j_decimal = T.p_decimal;
@@ -2333,7 +2319,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
     async def test_edgeql_casts_assignment_01(self):
         async with self._run_and_rollback():
             await self.con.execute(r"""
-                SET MODULE test;
 
                 # int64 is assignment castable or implicitly castable
                 # into any other numeric type
@@ -2374,7 +2359,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
     async def test_edgeql_casts_assignment_02(self):
         async with self._run_and_rollback():
             await self.con.execute(r"""
-                SET MODULE test;
 
                 # float64 is assignment castable to float32
                 INSERT ScalarTest {
@@ -2406,7 +2390,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 for numtype in {'bigint', 'decimal'}:
 
                     query = f'''
-                        INSERT test::ScalarTest {{
+                        INSERT ScalarTest {{
                             p_{typename} := <{numtype}>3,
                             p_{numtype} := 1001,
                         }};
@@ -2418,7 +2402,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                         await self.con.execute(query + f'''
                             # clean up, so other tests can proceed
                             DELETE (
-                                SELECT test::ScalarTest
+                                SELECT ScalarTest
                                 FILTER .p_{numtype} = 1001
                             );
                         ''')
@@ -2426,7 +2410,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
     async def test_edgeql_casts_custom_scalar_01(self):
         await self.assert_query_result(
             '''
-                SELECT <test::custom_str_t>'ABC'
+                SELECT <custom_str_t>'ABC'
             ''',
             ['ABC']
         )
@@ -2435,7 +2419,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 edgedb.ConstraintViolationError,
                 'invalid custom_str_t'):
             await self.con.query(
-                "SELECT <test::custom_str_t>'123'")
+                "SELECT <custom_str_t>'123'")
 
     async def test_edgeql_casts_prohibit_tuple_query_params_01(self):
         async with self.assertRaisesRegexTx(
@@ -2444,7 +2428,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         ):
             await self.con.query(
                 r'''
-                WITH MODULE test
                 SELECT Test {
                     id,
                     num := (<tuple<int64, float64, str, bytes>>$tup).0,

--- a/tests/test_edgeql_coalesce.py
+++ b/tests/test_edgeql_coalesce.py
@@ -36,7 +36,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_scalar_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Issue {
                     time_estimate := Issue.time_estimate ?? -1
                 };
@@ -55,7 +54,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_scalar_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (Issue.number, Issue.time_estimate ?? -1)
                 ORDER BY Issue.number;
             ''',
@@ -72,7 +70,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_scalar_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # Only values present in the graph will be selected.
                 # There is at least one value there.
                 # Therefore, the second argument to ?? will not be returned.
@@ -89,7 +86,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_scalar_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # No open issue has a time_estimate, so the first argument
                 # to ?? is an empty set.
                 # Therefore, the second argument to ?? will be returned.
@@ -107,7 +103,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     I := (SELECT Issue
                           FILTER Issue.status.name = 'Open')
                 # No open issue has a time_estimate, so the first argument
@@ -126,7 +121,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         # Our database contains one estimate.
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Issue.time_estimate ?? -1
                 FILTER NOT EXISTS Issue.time_estimate;
             """,
@@ -136,7 +130,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_scalar_07(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Issue {
                     number,
                     has_estimate := Issue.time_estimate ?!= <int64>{}
@@ -156,7 +149,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_scalar_08(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (Issue.number, Issue.time_estimate ?= 60)
                 ORDER BY Issue.number;
             ''',
@@ -174,7 +166,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # Only values present in the graph will be selected.
-                WITH MODULE test
                 SELECT Issue.time_estimate ?= 60;
             ''',
             [
@@ -185,7 +176,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Issue.time_estimate ?= <int64>{};
             ''',
             [
@@ -199,7 +189,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             r'''
                 # No open issue has a time_estimate, so the first argument
                 # to ?= is an empty set.
-                WITH MODULE test
                 SELECT (
                     SELECT Issue
                     FILTER Issue.status.name = 'Open'
@@ -216,7 +205,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
                 # No open issue has a time_estimate, so the first argument
                 # to ?!= is an empty set.
                 WITH
-                    MODULE test,
                     I := (SELECT Issue
                           FILTER Issue.status.name = 'Open')
                 SELECT I.time_estimate ?!= <int64>{};
@@ -229,7 +217,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     I := (SELECT Issue
                           FILTER Issue.status.name = 'Open')
                 SELECT I.time_estimate ?!= 60;
@@ -242,7 +229,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_scalar_12(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Issue {
                     number,
                     time_estimate,
@@ -271,7 +257,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # now test a combination of several coalescing operators
-                WITH MODULE test
                 SELECT
                     Issue.time_estimate ??
                     Issue.related_to.time_estimate ?=
@@ -286,7 +271,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Issue {
                     comp_time_estimate := Issue.time_estimate ?? {-1, -2}
                 };
@@ -305,7 +289,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Issue {
                     multi te := (
                         SELECT Issue.time_estimate ?? {-1, -2}
@@ -326,7 +309,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT _ := (Issue.number, Issue.time_estimate ?? {-1, -2})
                 ORDER BY _;
             ''',
@@ -346,7 +328,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # Only values present in the graph will be selected.
                 # There is at least one value there.
                 # Therefore, the second argument to ?? will not be returned.
@@ -363,7 +344,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_05(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # No open issue has a time_estimate, so the first argument
                 # to ?? is an empty set.
                 # Therefore, the second argument to ?? will be returned.
@@ -381,7 +361,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     I := (SELECT Issue
                           FILTER Issue.status.name = 'Open')
                 # No open issue has a time_estimate, so the first argument
@@ -397,7 +376,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_07(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Issue {
                     number,
                     te := Issue.time_estimate ?= {60, 30}
@@ -417,7 +395,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_08(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT _ := (Issue.number, Issue.time_estimate ?= {60, 90})
                 ORDER BY _;
             ''',
@@ -441,7 +418,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # Only values present in the graph will be selected.
-                WITH MODULE test
                 SELECT Issue.time_estimate ?= {60, 30};
             ''',
             [
@@ -460,7 +436,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             r'''
                 # No open issue has a time_estimate, so the first argument
                 # to ?!= is an empty set.
-                WITH MODULE test
                 SELECT (
                     SELECT Issue
                     FILTER Issue.status.name = 'Open'
@@ -477,7 +452,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
                 # No open issue has a time_estimate, so the first argument
                 # to ?= is an empty set.
                 WITH
-                    MODULE test,
                     I := (SELECT Issue
                           FILTER Issue.status.name = 'Open')
                 SELECT I.time_estimate ?= {-1, -2};
@@ -490,7 +464,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_dependent_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Issue {
                     # for every issue, there's a unique derived "default"
                     # to use  with ??
@@ -511,7 +484,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_dependent_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # for every issue, there's a unique derived "default" to use
                 # with ??
                 SELECT (Issue.number,
@@ -531,7 +503,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_dependent_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # ?? is OPTIONAL w.r.t. first argument, so it behaves like
                 # an element-wise function. Therefore, the longest common
                 # prefix `Issue` is factored out and the expression is
@@ -547,7 +518,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_dependent_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # Since ?? is OPTIONAL over it's first argument,
                 # the expression is evaluated for all six issues.
                 SELECT (
@@ -569,7 +539,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
                 # sides of ??, so the result set contains
                 # only three elements.
                 WITH
-                    MODULE test,
                     I := (SELECT Issue
                           FILTER Issue.status.name = 'Open')
                 SELECT I.time_estimate ?? -<int64>I.number;
@@ -584,7 +553,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     I2 := Issue
                 # ?? is OPTIONAL w.r.t. first argument, so it behaves like
                 # an element-wise function. However, since there is no
@@ -601,8 +569,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_dependent_07(self):
         await self.assert_query_result(
             r'''
-                WITH
-                    MODULE test
                 SELECT (
                     SELECT Issue
                     FILTER Issue.status.name = 'Open'
@@ -617,7 +583,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_dependent_08(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # On one hand the right operand of ?? is not independent
                 # of the left. On the other hand, it is constructed in
                 # such a way as to be equivalent to literal `-1` for the
@@ -637,7 +602,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_dependent_09(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # `Issue` on both sides is behind a fence, so the left-hand
                 # expression is an empty set, and the result is a union
                 # of all existing time estimates and -1.
@@ -656,7 +620,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     I := (
                         SELECT Issue
                         FILTER Issue.status.name = 'Open'
@@ -672,7 +635,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_dependent_11(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Issue {
                     number,
                     foo := Issue.time_estimate ?= <int64>Issue.number * 30
@@ -691,7 +653,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_dependent_12(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (
                     Issue.number,
                     Issue.time_estimate ?!= <int64>Issue.number * 30
@@ -711,7 +672,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_dependent_13(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # ?= is OPTIONAL w.r.t. both arguments, so it behaves like
                 # an element-wise function. Therefore, the longest common
                 # prefix `Issue` is factored out and the expression is
@@ -732,7 +692,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_dependent_14(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (
                     SELECT Issue
                     FILTER Issue.status.name = 'Open'
@@ -748,7 +707,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     I := (SELECT Issue
                           FILTER Issue.status.name = 'Open')
                 # Same as dependent_13, but only 'Open' issues
@@ -765,7 +723,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     I2 := Issue
                 # ?= is OPTIONAL w.r.t. both arguments, so it behaves like
                 # an element-wise function. However, since there is no
@@ -789,7 +746,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     I2 := Issue
                 # ?!= is OPTIONAL w.r.t. both arguments, so it behaves like
                 # an element-wise function. However, since there is no
@@ -813,7 +769,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_dependent_18(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # LCP is `Issue.time_estimate`, so this should not
                 # actually be evaluated for every `Issue`, but for every
                 # `Issue.time_estimate`.
@@ -828,7 +783,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_dependent_19(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # `Issue` is now a LCP and the overall expression will be
                 # evaluated for every `Issue`.
                 SELECT (
@@ -846,7 +800,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     I := (
                         SELECT Issue
                         FILTER Issue.status.name = 'Open'
@@ -863,7 +816,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     X := {Priority, Status}
                 SELECT X[IS Priority].name ?? X[IS Status].name;
             ''',
@@ -874,7 +826,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     X := {Priority, Status}
                 SELECT X[IS Priority].name[0] ?? X[IS Status].name;
             ''',
@@ -884,7 +835,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     X := {Priority, Status}
                 SELECT X[IS Priority].name ?? X[IS Status].name[0];
             ''',
@@ -894,7 +844,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     X := {Priority, Status}
                 SELECT X[IS Priority].name[0] ?? X[IS Status].name[0];
             ''',
@@ -905,7 +854,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     X := {Priority, Status}
                 SELECT X {
                     foo := X[IS Priority].name ?? X[IS Status].name
@@ -923,7 +871,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     X := {Priority, Status}
                 SELECT X {
                     foo := X[IS Priority].name[0] ?? X[IS Status].name
@@ -941,7 +888,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     X := {Priority, Status}
                 SELECT X {
                     foo := X[IS Priority].name ?? X[IS Status].name[0]
@@ -959,7 +905,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     X := {Priority, Status}
                 SELECT X {
                     foo := X[IS Priority].name[0] ?? X[IS Status].name[0]
@@ -978,7 +923,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     DUMMY := (SELECT LogEntry FILTER LogEntry.body = 'Dummy')
                 SELECT Issue {
                     number,
@@ -1032,7 +976,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     DUMMY := (SELECT LogEntry FILTER LogEntry.body = 'Dummy')
                 SELECT x := (
                     Issue.number,
@@ -1054,7 +997,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     DUMMY := (SELECT LogEntry FILTER LogEntry.body = 'Dummy')
                 SELECT x := (Issue.time_spent_log ?? DUMMY) {
                     spent_time
@@ -1074,7 +1016,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     DUMMY := (SELECT LogEntry FILTER LogEntry.body = 'Dummy')
                 SELECT (
                     (SELECT Issue
@@ -1095,7 +1036,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     DUMMY := (SELECT LogEntry FILTER LogEntry.body = 'Dummy'),
                     I := (
                         SELECT Issue
@@ -1115,7 +1055,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     LOG1 := (SELECT LogEntry FILTER LogEntry.body = 'Log1')
                 SELECT Issue {
                     number,
@@ -1149,7 +1088,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     LOG1 := (SELECT LogEntry FILTER LogEntry.body = 'Log1')
                 SELECT (
                     Issue.number, Issue.time_spent_log ?= LOG1
@@ -1170,7 +1108,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     LOG1 := (SELECT LogEntry FILTER LogEntry.body = 'Log1')
                 SELECT Issue.time_spent_log ?!= LOG1;
             ''',
@@ -1187,7 +1124,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     DUMMY := (SELECT LogEntry FILTER LogEntry.body = 'Dummy')
                 SELECT (
                     SELECT Issue
@@ -1203,7 +1139,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     DUMMY := (SELECT LogEntry FILTER LogEntry.body = 'Dummy'),
                     I := (
                         SELECT Issue
@@ -1219,7 +1154,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_object_11(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT
                     (
                         (SELECT Issue FILTER .number = '1')
@@ -1237,7 +1171,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_object_12(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT
                     (
                         (SELECT Issue FILTER .number = '100')
@@ -1255,7 +1188,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_wrapping_optional(self):
         await self.con.execute(
             r'''
-                CREATE FUNCTION test::optfunc(
+                CREATE FUNCTION optfunc(
                         a: std::str, b: OPTIONAL std::str) -> std::str
                     USING EdgeQL $$
                         SELECT b IF a = 'foo' ELSE a
@@ -1265,19 +1198,19 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                SELECT test::optfunc('foo', <str>{}) ?? 'N/A';
+                SELECT optfunc('foo', <str>{}) ?? 'N/A';
             ''',
             ['N/A'],
         )
         await self.assert_query_result(
             r'''
-                SELECT test::optfunc('foo', 'b') ?? 'N/A';
+                SELECT optfunc('foo', 'b') ?? 'N/A';
             ''',
             ['b'],
         )
         await self.assert_query_result(
             r'''
-                SELECT test::optfunc('a', <str>{}) ?? 'N/A';
+                SELECT optfunc('a', <str>{}) ?? 'N/A';
             ''',
             ['a'],
         )
@@ -1285,7 +1218,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_of_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT <str>Publication.id ?? <str>count(Publication)
             ''',
             ['0'],
@@ -1294,7 +1226,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_of_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Publication.title ?? <str>count(Publication)
             ''',
             ['0'],
@@ -1303,7 +1234,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_of_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT <str>Publication.id ?= <str>count(Publication)
             ''',
             [False],
@@ -1312,7 +1242,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_of_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Publication.title ?= <str>count(Publication)
             ''',
             [False],
@@ -1321,7 +1250,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_of_05(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (Publication.title ?? <str>count(Publication))
                        ?? Publication.title
             ''',
@@ -1331,7 +1259,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_of_06(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (Publication.title ?= <str>count(Publication),
                         Publication)
             ''',
@@ -1341,7 +1268,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_of_07(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (Publication.title ?= '0',
                         (Publication.title ?? <str>count(Publication)));
             ''',
@@ -1351,7 +1277,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_of_08(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT ("1" if Publication.title ?= "foo" else "2") ++
                        (Publication.title ?? <str>count(Publication))
             ''',
@@ -1361,7 +1286,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_of_09(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (Publication.title ?= "Foo", Publication.title ?= "bar")
             ''',
             [[False, False]],
@@ -1370,7 +1294,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_of_10(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (Publication.title++Publication.title ?= "Foo",
                         Publication.title ?= "bar")
             ''',
@@ -1380,7 +1303,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_of_11(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (Publication.title ?= "", count(Publication))
             ''',
             [[False, 0]],
@@ -1389,7 +1311,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_of_12(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (
                     Publication ?= Publication,
                     (Publication.title++Publication.title
@@ -1403,7 +1324,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_set_of_13(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (Publication ?= Publication, Publication)
             ''',
             [],
@@ -1411,13 +1331,12 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
 
     async def test_edgeql_coalesce_set_of_nonempty_01(self):
         await self.con.execute(
-            '''INSERT test::Publication { title := "1" }''')
+            '''INSERT Publication { title := "1" }''')
         await self.con.execute(
-            '''INSERT test::Publication { title := "asdf" }''')
+            '''INSERT Publication { title := "asdf" }''')
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Publication.title ?= <str>count(Publication)
             ''',
             [True, False],
@@ -1433,7 +1352,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         # This is busted!
         await self.assert_query_result(
             r'''
-                SELECT test::Publication ?? test::Publication
+                SELECT Publication ?? Publication
             ''',
             [],
         )

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -42,6 +42,8 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
     should match for easy reference, even if it means skipping some.
     """
 
+    DEFAULT_MODULE = 'test'
+
     def normalize_statement(self, s: str) -> str:
         re_filter = re.compile(r'[\s]+|(#.*?(\n|$))|(,(?=\s*[})]))')
         stripped = textwrap.dedent(s.lstrip('\n')).rstrip('\n')

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -8953,8 +8953,6 @@ class TestEdgeQLDataMigrationNonisolated(tb.DDLTestCase):
         """)
 
     async def test_edgeql_ddl_collection_cleanup_06(self):
-        await self.con.execute("SET MODULE test;")
-
         for _ in range(2):
             await self.con.execute(r"""
                 CREATE FUNCTION cleanup_06(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1956,8 +1956,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaError,
-                "cannot RESET TYPE of property 'b' of object type 'default::Foo' "
-                "because it is not inherited"):
+                "cannot RESET TYPE of property 'b' of object type "
+                "'default::Foo' because it is not inherited"):
             await self.con.execute('''
                 ALTER TYPE Foo ALTER PROPERTY b RESET TYPE;
             ''')
@@ -2013,7 +2013,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 WITH
                     C := (SELECT schema::ObjectType
-                          FILTER .name IN {'default::Child', 'default::Parent01'})
+                          FILTER .name IN
+                          {'default::Child', 'default::Parent01'})
                 SELECT
                     C.pointers { target: { name } }
                 FILTER
@@ -7325,8 +7326,8 @@ type default::Foo {
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidLinkTargetError,
-            "invalid link type: 'default::CreateAlias09' is an expression alias,"
-            " not a proper object type",
+            "invalid link type: 'default::CreateAlias09' is an"
+            " expression alias, not a proper object type",
         ):
             await self.con.execute(r"""
                 CREATE TYPE AliasType09 {
@@ -9375,7 +9376,8 @@ type default::Foo {
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                 edgedb.errors.InvalidReferenceError,
-                r"index on \(.zz\) does not exist on object type 'default::Err1'",
+                r"index on \(.zz\) does not exist on object type "
+                r"'default::Err1'",
             ):
                 await self.con.execute('''
                     ALTER TYPE Err1
@@ -9385,7 +9387,8 @@ type default::Foo {
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                     edgedb.errors.InvalidReferenceError,
-                    "object type 'default::Err1' has no link or property 'zz'"):
+                    "object type 'default::Err1' has no link or "
+                    "property 'zz'"):
                 await self.con.execute('''
                     ALTER TYPE Err1
                     CREATE INDEX ON (.zz)
@@ -9394,7 +9397,8 @@ type default::Foo {
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                     edgedb.errors.InvalidReferenceError,
-                    "object type 'default::Err1' has no link or property 'zz'"):
+                    "object type 'default::Err1' has no link or "
+                    "property 'zz'"):
                 await self.con.execute('''
                     ALTER TYPE Err1
                     CREATE INDEX ON ((.foo, .zz))

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -31,26 +31,26 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_04(self):
         await self.con.execute("""
-            CREATE TYPE test::A;
-            CREATE TYPE test::B EXTENDING test::A;
+            CREATE TYPE A;
+            CREATE TYPE B EXTENDING A;
 
-            CREATE TYPE test::Object1 {
-                CREATE REQUIRED LINK a -> test::A;
+            CREATE TYPE Object1 {
+                CREATE REQUIRED LINK a -> A;
             };
 
-            CREATE TYPE test::Object2 {
-                CREATE LINK a -> test::B;
+            CREATE TYPE Object2 {
+                CREATE LINK a -> B;
             };
 
-            CREATE TYPE test::Object_12
-                EXTENDING test::Object1, test::Object2;
+            CREATE TYPE Object_12
+                EXTENDING Object1, Object2;
         """)
 
     async def test_edgeql_ddl_type_05(self):
         await self.con.execute("""
-            CREATE TYPE test::A5;
-            CREATE TYPE test::Object5 {
-                CREATE REQUIRED LINK a -> test::A5;
+            CREATE TYPE A5;
+            CREATE TYPE Object5 {
+                CREATE REQUIRED LINK a -> A5;
                 CREATE REQUIRED PROPERTY b -> str;
             };
         """)
@@ -72,7 +72,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     FILTER .name = 'b'
                     ORDER BY .name
                 }
-                FILTER .name = 'test::Object5';
+                FILTER .name = 'default::Object5';
             """,
             [{
                 'links': [{
@@ -88,11 +88,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute("""
-            ALTER TYPE test::Object5 {
+            ALTER TYPE Object5 {
                 ALTER LINK a SET OPTIONAL;
             };
 
-            ALTER TYPE test::Object5 {
+            ALTER TYPE Object5 {
                 ALTER PROPERTY b SET OPTIONAL;
             };
         """)
@@ -114,7 +114,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     FILTER .name = 'b'
                     ORDER BY .name
                 }
-                FILTER .name = 'test::Object5';
+                FILTER .name = 'default::Object5';
             """,
             [{
                 'links': [{
@@ -131,18 +131,18 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_type_06(self):
         await self.con.execute("""
-            CREATE TYPE test::A6 {
+            CREATE TYPE A6 {
                 CREATE PROPERTY name -> str;
             };
 
-            CREATE TYPE test::Object6 {
-                CREATE SINGLE LINK a -> test::A6;
+            CREATE TYPE Object6 {
+                CREATE SINGLE LINK a -> A6;
                 CREATE SINGLE PROPERTY b -> str;
             };
 
-            INSERT test::A6 { name := 'a6' };
-            INSERT test::Object6 {
-                a := (SELECT test::A6 LIMIT 1),
+            INSERT A6 { name := 'a6' };
+            INSERT Object6 {
+                a := (SELECT A6 LIMIT 1),
                 b := 'foo'
             };
         """)
@@ -164,7 +164,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     FILTER .name = 'b'
                     ORDER BY .name
                 }
-                FILTER .name = 'test::Object6';
+                FILTER .name = 'default::Object6';
             """,
             [{
                 'links': [{
@@ -181,7 +181,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r"""
-            SELECT test::Object6 {
+            SELECT Object6 {
                 a: {name},
                 b,
             }
@@ -193,11 +193,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute("""
-            ALTER TYPE test::Object6 {
+            ALTER TYPE Object6 {
                 ALTER LINK a SET MULTI;
             };
 
-            ALTER TYPE test::Object6 {
+            ALTER TYPE Object6 {
                 ALTER PROPERTY b SET MULTI;
             };
         """)
@@ -219,7 +219,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     FILTER .name = 'b'
                     ORDER BY .name
                 }
-                FILTER .name = 'test::Object6';
+                FILTER .name = 'default::Object6';
             """,
             [{
                 'links': [{
@@ -237,7 +237,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Check that the data has been migrated correctly.
         await self.assert_query_result(
             r"""
-            SELECT test::Object6 {
+            SELECT Object6 {
                 a: {name},
                 b,
             }
@@ -250,11 +250,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         # Change it back.
         await self.con.execute("""
-            ALTER TYPE test::Object6 {
+            ALTER TYPE Object6 {
                 ALTER LINK a SET SINGLE USING (SELECT .a LIMIT 1);
             };
 
-            ALTER TYPE test::Object6 {
+            ALTER TYPE Object6 {
                 ALTER PROPERTY b SET SINGLE USING (SELECT .b LIMIT 1);
             };
         """)
@@ -276,7 +276,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     FILTER .name = 'b'
                     ORDER BY .name
                 }
-                FILTER .name = 'test::Object6';
+                FILTER .name = 'default::Object6';
             """,
             [{
                 'links': [{
@@ -294,7 +294,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Check that the data has been migrated correctly.
         await self.assert_query_result(
             r"""
-            SELECT test::Object6 {
+            SELECT Object6 {
                 a: {name},
                 b,
             }
@@ -307,7 +307,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_rename_type_and_add_01(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE TYPE Foo {
                 CREATE PROPERTY x -> str;
@@ -333,7 +332,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 constraints: {name},
                 annotations: {name}
             }
-            FILTER .name = 'test::Bar';
+            FILTER .name = 'default::Bar';
             """,
             [
                 {
@@ -356,7 +355,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_rename_type_and_add_02(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE TYPE Foo;
         """)
@@ -379,7 +377,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 constraints: {name},
                 annotations: {name}
             }
-            FILTER .name = 'test::Bar';
+            FILTER .name = 'default::Bar';
             """,
             [
                 {
@@ -402,7 +400,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_rename_type_and_drop_01(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE TYPE Foo {
                 CREATE PROPERTY a -> str;
@@ -430,7 +427,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 constraints: {name},
                 annotations: {name}
             }
-            FILTER .name = 'test::Bar';
+            FILTER .name = 'default::Bar';
             """,
             [
                 {
@@ -448,7 +445,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_rename_type_and_drop_02(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE TYPE Foo {
                 CREATE PROPERTY a -> str;
@@ -476,7 +472,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 constraints: {name},
                 annotations: {name}
             }
-            FILTER .name = 'test::Bar';
+            FILTER .name = 'default::Bar';
             """,
             [
                 {
@@ -493,7 +489,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_rename_type_and_prop_01(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Note {
                 CREATE PROPERTY note -> str;
@@ -518,7 +513,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_11(self):
         await self.con.execute(r"""
-            CREATE TYPE test::TestContainerLinkObjectType {
+            CREATE TYPE TestContainerLinkObjectType {
                 CREATE PROPERTY test_array_link -> array<std::str>;
                 # FIXME: for now dimension specs on the array are
                 # disabled pending a syntax change
@@ -533,7 +528,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r"backtick-quoted names surrounded by double underscores "
                 r"are forbidden"):
             await self.con.execute(r"""
-                CREATE TYPE test::TestBadContainerLinkObjectType {
+                CREATE TYPE TestBadContainerLinkObjectType {
                     CREATE PROPERTY foo -> std::str {
                         CREATE CONSTRAINT expression
                             ON (`__subject__` = 'foo');
@@ -546,7 +541,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.InvalidReferenceError,
                 "object type or alias 'default::self' does not exist"):
             await self.con.execute(r"""
-                CREATE TYPE test::TestBadContainerLinkObjectType {
+                CREATE TYPE TestBadContainerLinkObjectType {
                     CREATE PROPERTY foo -> std::str {
                         CREATE CONSTRAINT expression ON (`self` = 'foo');
                     };
@@ -558,7 +553,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.QueryError,
                 f'__source__ cannot be used in this expression'):
             await self.con.execute("""
-                CREATE TYPE test::TestSelfLink1 {
+                CREATE TYPE TestSelfLink1 {
                     CREATE PROPERTY foo1 -> std::str;
                     CREATE PROPERTY bar1 -> std::str {
                         SET default := __source__.foo1;
@@ -568,28 +563,27 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_15(self):
         await self.con.execute(r"""
-            CREATE TYPE test::TestSelfLink2 {
+            CREATE TYPE TestSelfLink2 {
                 CREATE PROPERTY foo2 -> std::str;
                 CREATE MULTI PROPERTY bar2 -> std::str {
                     # NOTE: this is a set of all TestSelfLink2.foo2
-                    SET default := test::TestSelfLink2.foo2;
+                    SET default := TestSelfLink2.foo2;
                 };
             };
 
-            INSERT test::TestSelfLink2 {
+            INSERT TestSelfLink2 {
                 foo2 := 'Alice'
             };
-            INSERT test::TestSelfLink2 {
+            INSERT TestSelfLink2 {
                 foo2 := 'Bob'
             };
-            INSERT test::TestSelfLink2 {
+            INSERT TestSelfLink2 {
                 foo2 := 'Carol'
             };
         """)
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT TestSelfLink2 {
                     foo2,
                     bar2,
@@ -607,11 +601,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.SchemaDefinitionError,
                 'possibly more than one element'):
             await self.con.execute(r"""
-                CREATE TYPE test::TestSelfLink3 {
+                CREATE TYPE TestSelfLink3 {
                     CREATE PROPERTY foo3 -> std::str;
                     CREATE PROPERTY bar3 -> std::str {
                         # NOTE: this is a set of all TestSelfLink3.foo3
-                        SET default := test::TestSelfLink3.foo3;
+                        SET default := TestSelfLink3.foo3;
                     };
                 };
             """)
@@ -682,7 +676,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_19(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE TYPE ActualType {
                 CREATE REQUIRED PROPERTY foo -> str;
@@ -696,7 +689,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 connected := (SELECT Alias1 ORDER BY Alias1.foo)
             };
 
-            SET MODULE test;
 
             INSERT ActualType {
                 foo := 'obj1'
@@ -743,7 +735,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_20(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE TYPE A20 {
                 CREATE REQUIRED PROPERTY foo -> str;
@@ -765,7 +756,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         }
                     } FILTER .name = 'l'
                 }
-                FILTER .name = 'test::B20'
+                FILTER .name = 'default::B20'
             """,
             [
                 {
@@ -780,7 +771,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE ABSTRACT LINK l20;
 
@@ -800,14 +790,14 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         }
                     } FILTER .name = 'l'
                 }
-                FILTER .name = 'test::B20'
+                FILTER .name = 'default::B20'
             """,
             [
                 {
                     'links': [{
                         'name': 'l',
                         'bases': [{
-                            'name': 'test::l20',
+                            'name': 'default::l20',
                         }],
                     }],
                 },
@@ -815,7 +805,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute("""
-            SET MODULE test;
 
             ALTER TYPE B20 {
                 ALTER LINK l DROP EXTENDING l20;
@@ -833,7 +822,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         }
                     } FILTER .name = 'l'
                 }
-                FILTER .name = 'test::B20'
+                FILTER .name = 'default::B20'
             """,
             [
                 {
@@ -852,7 +841,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # as an alias pointer target is handled correctly and
         # manifests as std::BaseObject.
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE TYPE User;
             CREATE TYPE Award {
@@ -868,7 +856,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 WITH
                     C := (SELECT schema::ObjectType
-                          FILTER .name = 'test::Alias1')
+                          FILTER .name = 'default::Alias1')
                 SELECT
                     C.pointers { target: { name } }
                 FILTER
@@ -886,7 +874,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_24(self):
         # Test transition of property from inherited to owned.
         await self.con.execute("""
-            SET MODULE test;
             CREATE TYPE Desc;
             CREATE TYPE Named {
                 CREATE PROPERTY name -> str;
@@ -899,7 +886,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 WITH
                     C := (SELECT schema::ObjectType
-                          FILTER .name = 'test::User')
+                          FILTER .name = 'default::User')
                 SELECT
                     C {
                         pointers: { @owned }
@@ -928,7 +915,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 WITH
                     C := (SELECT schema::ObjectType
-                          FILTER .name = 'test::User')
+                          FILTER .name = 'default::User')
                 SELECT
                     C {
                         pointers: { @owned }
@@ -964,7 +951,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 WITH
                     C := (SELECT schema::ObjectType
-                          FILTER .name = 'test::User')
+                          FILTER .name = 'default::User')
                 SELECT
                     C {
                         pointers: {
@@ -1008,7 +995,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 WITH
                     C := (SELECT schema::ObjectType
-                          FILTER .name = 'test::User')
+                          FILTER .name = 'default::User')
                 SELECT
                     C {
                         pointers: {
@@ -1042,7 +1029,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             "cannot drop owned property 'name'.*not inherited",
         ):
             await self.con.execute("""
-                SET MODULE test;
                 CREATE TYPE Named {
                     CREATE PROPERTY name -> str;
                 };
@@ -1051,7 +1037,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_26(self):
         await self.con.execute("""
-            SET MODULE test;
             CREATE TYPE Target;
             CREATE TYPE Source {
                 CREATE LINK target -> Source;
@@ -1072,7 +1057,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         """)
 
         await self.con.execute("""
-            SET MODULE test;
             ALTER TYPE Child ALTER LINK target DROP OWNED;
         """)
 
@@ -1080,7 +1064,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 WITH
                     C := (SELECT schema::ObjectType
-                          FILTER .name = 'test::Child')
+                          FILTER .name = 'default::Child')
                 SELECT
                     C {
                         links: {
@@ -1108,7 +1092,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 WITH
                     C := (SELECT schema::ObjectType
-                          FILTER .name = 'test::Grandchild')
+                          FILTER .name = 'default::Grandchild')
                 SELECT
                     C {
                         links: {
@@ -1144,7 +1128,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_27(self):
         await self.con.execute("""
-            SET MODULE test;
             CREATE TYPE Base {
                 CREATE PROPERTY foo -> str;
             };
@@ -1157,7 +1140,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 WITH
                     C := (SELECT schema::ObjectType
-                          FILTER .name = 'test::Derived')
+                          FILTER .name = 'default::Derived')
                 SELECT
                     C {
                         properties: {
@@ -1184,7 +1167,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute("""
-            SET MODULE test;
             ALTER TYPE Base DROP PROPERTY foo;
         """)
 
@@ -1192,7 +1174,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 WITH
                     C := (SELECT schema::ObjectType
-                          FILTER .name = 'test::Derived')
+                          FILTER .name = 'default::Derived')
                 SELECT
                     C {
                         properties: {
@@ -1218,7 +1200,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test that identifiers that are SQL keywords get quoted.
         # Issue 1667
         await self.con.execute("""
-            CREATE TYPE test::Foo {
+            CREATE TYPE Foo {
                 CREATE PROPERTY left -> str;
                 CREATE PROPERTY smallint -> str;
                 CREATE PROPERTY natural -> str;
@@ -1231,7 +1213,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_sequence_01(self):
         await self.con.execute("""
-            SET MODULE test;
             CREATE TYPE Foo {
                 CREATE REQUIRED PROPERTY index -> std::int64;
             };
@@ -1252,16 +1233,16 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_abstract_link_01(self):
         await self.con.execute("""
-            CREATE ABSTRACT LINK test::test_link;
+            CREATE ABSTRACT LINK test_link;
         """)
 
     async def test_edgeql_ddl_abstract_link_02(self):
         await self.con.execute("""
-            CREATE ABSTRACT LINK test::test_object_link {
+            CREATE ABSTRACT LINK test_object_link {
                 CREATE PROPERTY test_link_prop -> std::int64;
             };
 
-            CREATE TYPE test::TestObjectType {
+            CREATE TYPE TestObjectType {
                 CREATE LINK test_object_link -> std::Object {
                     CREATE PROPERTY test_link_prop -> std::int64 {
                         CREATE ANNOTATION title := 'Test Property';
@@ -1272,14 +1253,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_abstract_link_03(self):
         await self.con.execute("""
-            CREATE ABSTRACT LINK test::test_object_link_prop {
+            CREATE ABSTRACT LINK test_object_link_prop {
                 CREATE PROPERTY link_prop1 -> std::str;
             };
         """)
 
     async def test_edgeql_ddl_abstract_link_04(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE ABSTRACT LINK test_object_link {
                 CREATE PROPERTY test_link_prop -> int64;
@@ -1309,7 +1289,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_drop_extending_01(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE TYPE Parent {
                 CREATE PROPERTY name -> str {
@@ -1325,7 +1304,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.QueryError,
-            "object type 'test::Child' has no link or property 'name'",
+            "object type 'default::Child' has no link or property 'name'",
         ):
             await self.con.execute("""
                 SELECT Child.name
@@ -1338,7 +1317,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_drop_extending_02(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE TYPE Parent {
                 CREATE PROPERTY name -> str {
@@ -1390,7 +1368,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_drop_extending_03(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE TYPE Parent {
                 CREATE PROPERTY name -> str {
@@ -1417,7 +1394,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_drop_extending_04(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE TYPE Parent {
                 CREATE PROPERTY name -> str {
@@ -1459,7 +1435,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_drop_extending_05(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE TYPE Parent {
                 CREATE PROPERTY name -> str {
@@ -1485,7 +1460,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_drop_extending_06(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE ABSTRACT TYPE Named {
                 CREATE OPTIONAL SINGLE PROPERTY name -> str;
@@ -1516,7 +1490,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_drop_extending_07(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE ABSTRACT TYPE Named {
                 CREATE PROPERTY name -> str;
@@ -1570,7 +1543,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_drop_extending_08(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE ABSTRACT TYPE Named {
                 CREATE OPTIONAL SINGLE PROPERTY name -> str;
@@ -1603,7 +1575,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_add_extending_01(self):
         await self.con.execute("""
-            SET MODULE test;
 
             CREATE TYPE Thing;
 
@@ -1649,7 +1620,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 'default expression is of invalid type: std::int64, '
                 'expected std::str'):
             await self.con.execute(r"""
-                CREATE TYPE test::TestDefault01 {
+                CREATE TYPE TestDefault01 {
                     CREATE PROPERTY def01 -> str {
                         # int64 doesn't have an assignment cast into str
                         SET default := 42;
@@ -1663,13 +1634,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 'default expression is of invalid type: std::int64, '
                 'expected std::str'):
             await self.con.execute(r"""
-                CREATE TYPE test::TestDefault02 {
+                CREATE TYPE TestDefault02 {
                     CREATE PROPERTY def02 -> str {
                         SET default := '42';
                     };
                 };
 
-                ALTER TYPE test::TestDefault02 {
+                ALTER TYPE TestDefault02 {
                     ALTER PROPERTY def02 SET default := 42;
                 };
             """)
@@ -1677,11 +1648,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_default_03(self):
         # Test INSERT as default link expression
         await self.con.execute(r"""
-            CREATE TYPE test::TestDefaultInsert03;
+            CREATE TYPE TestDefaultInsert03;
 
-            CREATE TYPE test::TestDefault03 {
-                CREATE LINK def03 -> test::TestDefaultInsert03 {
-                    SET default := (INSERT test::TestDefaultInsert03);
+            CREATE TYPE TestDefault03 {
+                CREATE LINK def03 -> TestDefaultInsert03 {
+                    SET default := (INSERT TestDefaultInsert03);
                 };
             };
         """)
@@ -1689,8 +1660,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.assert_query_result(
             r"""
                 SELECT (
-                    count(test::TestDefault03),
-                    count(test::TestDefaultInsert03)
+                    count(TestDefault03),
+                    count(TestDefaultInsert03)
                 );
             """,
             [[0, 0]],
@@ -1698,7 +1669,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r"""
-                SELECT test::TestDefault03 {
+                SELECT TestDefault03 {
                     def03
                 };
             """,
@@ -1708,15 +1679,15 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # `assert_query_result` is used instead of `execute` to
         # highlight the issue #1721
         await self.assert_query_result(
-            r"""INSERT test::TestDefault03;""",
+            r"""INSERT TestDefault03;""",
             [{'id': uuid.UUID}]
         )
 
         await self.assert_query_result(
             r"""
                 SELECT (
-                    count(test::TestDefault03),
-                    count(test::TestDefaultInsert03)
+                    count(TestDefault03),
+                    count(TestDefaultInsert03)
                 );
             """,
             [[1, 1]],
@@ -1724,7 +1695,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r"""
-                SELECT test::TestDefault03 {
+                SELECT TestDefault03 {
                     def03
                 };
             """,
@@ -1738,16 +1709,16 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_default_04(self):
         # Test UPDATE as default link expression
         await self.con.execute(r"""
-            CREATE TYPE test::TestDefaultUpdate04 {
+            CREATE TYPE TestDefaultUpdate04 {
                 CREATE PROPERTY val -> str {
                     CREATE CONSTRAINT exclusive;
                 };
             };
 
-            CREATE TYPE test::TestDefault04 {
-                CREATE LINK def04 -> test::TestDefaultUpdate04 {
+            CREATE TYPE TestDefault04 {
+                CREATE LINK def04 -> TestDefaultUpdate04 {
                     SET default := (
-                        UPDATE test::TestDefaultUpdate04
+                        UPDATE TestDefaultUpdate04
                         FILTER .val = 'def04'
                         SET {
                             val := .val ++ '!'
@@ -1756,38 +1727,38 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             };
 
-            INSERT test::TestDefaultUpdate04 {
+            INSERT TestDefaultUpdate04 {
                 val := 'notdef04'
             };
-            INSERT test::TestDefaultUpdate04 {
+            INSERT TestDefaultUpdate04 {
                 val := 'def04'
             };
         """)
 
         await self.assert_query_result(
             r"""
-                SELECT test::TestDefaultUpdate04.val;
+                SELECT TestDefaultUpdate04.val;
             """,
             {'def04', 'notdef04'},
         )
 
         await self.assert_query_result(r"""
             SELECT {
-                (INSERT test::TestDefault04),
-                (INSERT test::TestDefault04)
+                (INSERT TestDefault04),
+                (INSERT TestDefault04)
             };
         """, [{'id': uuid.UUID}, {'id': uuid.UUID}])
 
         await self.assert_query_result(
             r"""
-                SELECT test::TestDefaultUpdate04.val;
+                SELECT TestDefaultUpdate04.val;
             """,
             {'def04!', 'notdef04'},
         )
 
         await self.assert_query_result(
             r"""
-                SELECT test::TestDefault04 {
+                SELECT TestDefault04 {
                     def04: {
                         val
                     }
@@ -1805,50 +1776,50 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_default_05(self):
         # Test DELETE as default property expression
         await self.con.execute(r"""
-            CREATE TYPE test::TestDefaultDelete05 {
+            CREATE TYPE TestDefaultDelete05 {
                 CREATE PROPERTY val -> str;
             };
 
-            CREATE TYPE test::TestDefault05 {
+            CREATE TYPE TestDefault05 {
                 CREATE PROPERTY def05 -> str {
                     SET default := (SELECT (
-                        DELETE test::TestDefaultDelete05
+                        DELETE TestDefaultDelete05
                         FILTER .val = 'def05'
                         LIMIT 1
                     ).val);
                 };
             };
 
-            INSERT test::TestDefaultDelete05 {
+            INSERT TestDefaultDelete05 {
                 val := 'notdef05'
             };
-            INSERT test::TestDefaultDelete05 {
+            INSERT TestDefaultDelete05 {
                 val := 'def05'
             };
         """)
 
         await self.assert_query_result(
             r"""
-                SELECT test::TestDefaultDelete05.val;
+                SELECT TestDefaultDelete05.val;
             """,
             {'def05', 'notdef05'},
         )
 
         await self.con.execute(r"""
-            INSERT test::TestDefault05;
-            INSERT test::TestDefault05;
+            INSERT TestDefault05;
+            INSERT TestDefault05;
         """)
 
         await self.assert_query_result(
             r"""
-                SELECT test::TestDefaultDelete05.val;
+                SELECT TestDefaultDelete05.val;
             """,
             {'notdef05'},
         )
 
         await self.assert_query_result(
             r"""
-                SELECT test::TestDefault05 {
+                SELECT TestDefault05 {
                     def05
                 } ORDER BY .def05 EMPTY FIRST;
             """,
@@ -1862,28 +1833,28 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_default_06(self):
         # Test DELETE as default link expression
         await self.con.execute(r"""
-            CREATE TYPE test::TestDefaultDelete06 {
+            CREATE TYPE TestDefaultDelete06 {
                 CREATE PROPERTY val -> str;
             };
 
-            CREATE TYPE test::TestDefault06 {
-                CREATE REQUIRED LINK def06 -> test::TestDefaultDelete06 {
+            CREATE TYPE TestDefault06 {
+                CREATE REQUIRED LINK def06 -> TestDefaultDelete06 {
                     SET default := (
-                        DELETE test::TestDefaultDelete06
+                        DELETE TestDefaultDelete06
                         FILTER .val = 'def06'
                         LIMIT 1
                     );
                 };
             };
 
-            INSERT test::TestDefaultDelete06 {
+            INSERT TestDefaultDelete06 {
                 val := 'notdef06'
             };
         """)
 
         await self.assert_query_result(
             r"""
-                SELECT test::TestDefaultDelete06.val;
+                SELECT TestDefaultDelete06.val;
             """,
             {'notdef06'},
         )
@@ -1892,36 +1863,35 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.MissingRequiredError,
                 r"missing value for required link 'def06'"):
             await self.con.execute(r"""
-                INSERT test::TestDefault06;
+                INSERT TestDefault06;
             """)
 
     async def test_edgeql_ddl_default_circular(self):
         await self.con.execute(r"""
-            CREATE TYPE test::TestDefaultCircular {
+            CREATE TYPE TestDefaultCircular {
                 CREATE PROPERTY def01 -> int64 {
-                    SET default := (SELECT count(test::TestDefaultCircular));
+                    SET default := (SELECT count(TestDefaultCircular));
                 };
             };
         """)
 
     async def test_edgeql_ddl_property_alter_01(self):
         await self.con.execute(r"""
-            CREATE TYPE test::Foo {
+            CREATE TYPE Foo {
                 CREATE PROPERTY bar -> float32;
             };
         """)
 
         await self.con.execute(r"""
-            CREATE TYPE test::TestDefaultCircular {
+            CREATE TYPE TestDefaultCircular {
                 CREATE PROPERTY def01 -> int64 {
-                    SET default := (SELECT count(test::TestDefaultCircular));
+                    SET default := (SELECT count(TestDefaultCircular));
                 };
             };
         """)
 
     async def test_edgeql_ddl_link_target_bad_01(self):
         await self.con.execute('''
-            SET MODULE test;
 
             CREATE TYPE A;
             CREATE TYPE B;
@@ -1936,7 +1906,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         with self.assertRaisesRegex(
             edgedb.SchemaError,
-            "inherited link 'foo' of object type 'test::Derived' has a "
+            "inherited link 'foo' of object type 'default::Derived' has a "
             "type conflict"
         ):
             await self.con.execute('''
@@ -1945,7 +1915,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_link_target_bad_02(self):
         await self.con.execute('''
-            SET MODULE test;
 
             CREATE TYPE A;
             CREATE TYPE B;
@@ -1961,7 +1930,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         with self.assertRaisesRegex(
             edgedb.SchemaError,
-            "inherited link 'foo' of object type 'test::Derived' "
+            "inherited link 'foo' of object type 'default::Derived' "
             "has a type conflict"
         ):
             await self.con.execute('''
@@ -1970,7 +1939,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_link_target_bad_03(self):
         await self.con.execute('''
-            SET MODULE test;
             CREATE TYPE A;
             CREATE TYPE Foo {
                 CREATE LINK a -> A;
@@ -1980,7 +1948,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaError,
-                "cannot RESET TYPE of link 'a' of object type 'test::Foo' "
+                "cannot RESET TYPE of link 'a' of object type 'default::Foo' "
                 "because it is not inherited"):
             await self.con.execute('''
                 ALTER TYPE Foo ALTER LINK a RESET TYPE;
@@ -1988,7 +1956,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaError,
-                "cannot RESET TYPE of property 'b' of object type 'test::Foo' "
+                "cannot RESET TYPE of property 'b' of object type 'default::Foo' "
                 "because it is not inherited"):
             await self.con.execute('''
                 ALTER TYPE Foo ALTER PROPERTY b RESET TYPE;
@@ -1996,7 +1964,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_link_target_merge_01(self):
         await self.con.execute('''
-            SET MODULE test;
 
             CREATE TYPE A;
             CREATE TYPE B EXTENDING A;
@@ -2012,7 +1979,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_link_target_merge_02(self):
         await self.con.execute('''
-            SET MODULE test;
 
             CREATE TYPE A;
             CREATE TYPE B;
@@ -2029,16 +1995,16 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_link_target_alter_01(self):
         await self.con.execute(r"""
-            CREATE TYPE test::GrandParent01 {
+            CREATE TYPE GrandParent01 {
                 CREATE PROPERTY foo -> int64;
             };
 
-            CREATE TYPE test::Parent01 EXTENDING test::GrandParent01;
-            CREATE TYPE test::Parent02 EXTENDING test::GrandParent01;
+            CREATE TYPE Parent01 EXTENDING GrandParent01;
+            CREATE TYPE Parent02 EXTENDING GrandParent01;
 
-            CREATE TYPE test::Child EXTENDING test::Parent01, test::Parent02;
+            CREATE TYPE Child EXTENDING Parent01, Parent02;
 
-            ALTER TYPE test::GrandParent01 {
+            ALTER TYPE GrandParent01 {
                 ALTER PROPERTY foo SET TYPE int16;
             };
         """)
@@ -2047,7 +2013,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 WITH
                     C := (SELECT schema::ObjectType
-                          FILTER .name IN {'test::Child', 'test::Parent01'})
+                          FILTER .name IN {'default::Child', 'default::Parent01'})
                 SELECT
                     C.pointers { target: { name } }
                 FILTER
@@ -2070,44 +2036,43 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_link_target_alter_02(self):
         with self.assertRaisesRegex(
             edgedb.SchemaError,
-            "inherited property 'foo' of object type 'test::Child'"
+            "inherited property 'foo' of object type 'default::Child'"
             " has a type conflict",
         ):
             await self.con.execute("""
-                CREATE TYPE test::Parent01 {
+                CREATE TYPE Parent01 {
                     CREATE PROPERTY foo -> int64;
                 };
 
-                CREATE TYPE test::Parent02 {
+                CREATE TYPE Parent02 {
                     CREATE PROPERTY foo -> int64;
                 };
 
-                CREATE TYPE test::Child
-                    EXTENDING test::Parent01, test::Parent02;
+                CREATE TYPE Child
+                    EXTENDING Parent01, Parent02;
 
-                ALTER TYPE test::Parent02 {
+                ALTER TYPE Parent02 {
                     ALTER PROPERTY foo SET TYPE int16;
                 };
             """)
 
     async def test_edgeql_ddl_link_target_alter_03(self):
         await self.con.execute("""
-            CREATE TYPE test::Foo {
+            CREATE TYPE Foo {
                 CREATE PROPERTY bar -> int64;
             };
 
-            CREATE TYPE test::Bar {
+            CREATE TYPE Bar {
                 CREATE MULTI PROPERTY foo -> int64 {
-                    SET default := (SELECT test::Foo.bar);
+                    SET default := (SELECT Foo.bar);
                 }
             };
 
-            ALTER TYPE test::Foo ALTER PROPERTY bar SET TYPE int32;
+            ALTER TYPE Foo ALTER PROPERTY bar SET TYPE int32;
         """)
 
     async def test_edgeql_ddl_link_target_alter_04(self):
         await self.con.execute('''
-            SET MODULE test;
 
             CREATE TYPE A;
             CREATE TYPE B;
@@ -2123,7 +2088,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_link_target_alter_05(self):
         await self.con.execute('''
-            SET MODULE test;
 
             CREATE TYPE A;
             CREATE TYPE B EXTENDING A;
@@ -2141,14 +2105,14 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_link_target_alter_06(self):
         await self.con.execute(r"""
-            CREATE TYPE test::Foo {
+            CREATE TYPE Foo {
                 CREATE PROPERTY foo -> int64;
                 CREATE PROPERTY bar := .foo + .foo;
             };
         """)
 
         await self.con.execute(r"""
-            ALTER TYPE test::Foo {
+            ALTER TYPE Foo {
                 ALTER PROPERTY foo SET TYPE int16;
             };
         """)
@@ -2157,7 +2121,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 WITH
                     C := (SELECT schema::ObjectType
-                          FILTER .name = 'test::Foo')
+                          FILTER .name = 'default::Foo')
                 SELECT
                     C.pointers { target: { name } }
                 FILTER
@@ -2174,15 +2138,15 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_prop_target_alter_array_01(self):
         await self.con.execute(r"""
-            CREATE TYPE test::Foo {
+            CREATE TYPE Foo {
                 CREATE PROPERTY foo -> array<int32>;
             };
 
-            ALTER TYPE test::Foo {
+            ALTER TYPE Foo {
                 ALTER PROPERTY foo SET TYPE array<float64>;
             };
 
-            ALTER TYPE test::Foo {
+            ALTER TYPE Foo {
                 ALTER PROPERTY foo {
                     SET TYPE array<int32> USING (<array<int32>>.foo);
                 };
@@ -2191,36 +2155,35 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_prop_target_subtype_01(self):
         await self.con.execute(r"""
-            CREATE SCALAR TYPE test::mystr EXTENDING std::str {
+            CREATE SCALAR TYPE mystr EXTENDING std::str {
                 CREATE CONSTRAINT std::max_len_value(5)
             };
 
-            CREATE TYPE test::Foo {
+            CREATE TYPE Foo {
                 CREATE PROPERTY a -> std::str;
             };
 
-            CREATE TYPE test::Bar EXTENDING test::Foo {
-                ALTER PROPERTY a SET TYPE test::mystr;
+            CREATE TYPE Bar EXTENDING Foo {
+                ALTER PROPERTY a SET TYPE mystr;
             };
         """)
 
-        await self.con.execute('INSERT test::Foo { a := "123456" }')
+        await self.con.execute('INSERT Foo { a := "123456" }')
 
         async with self.assertRaisesRegexTx(
             edgedb.ConstraintViolationError,
             'must be no longer than 5 characters'
         ):
-            await self.con.execute('INSERT test::Bar { a := "123456" }')
+            await self.con.execute('INSERT Bar { a := "123456" }')
 
         await self.con.execute("""
-            ALTER TYPE test::Bar ALTER PROPERTY a RESET TYPE;
+            ALTER TYPE Bar ALTER PROPERTY a RESET TYPE;
         """)
 
-        await self.con.execute('INSERT test::Bar { a := "123456" }')
+        await self.con.execute('INSERT Bar { a := "123456" }')
 
     async def test_edgeql_ddl_ptr_set_type_using_01(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE SCALAR TYPE mystr EXTENDING str;
 
@@ -2302,7 +2265,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # A normal cast of a property.
         async with self._run_and_rollback():
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY p {
                     SET TYPE int64 USING (<int64>.p)
                 }
@@ -2317,7 +2279,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             )
 
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY m_p {
                     SET TYPE int64 USING (<int64>.m_p)
                 }
@@ -2334,7 +2295,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Cast to an already-compatible type, but with an explicit expression.
         async with self._run_and_rollback():
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY p {
                     SET TYPE mystr USING (.p ++ '!')
                 }
@@ -2351,7 +2311,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Cast to the _same_ type, but with an explicit expression.
         async with self._run_and_rollback():
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY p {
                     SET TYPE str USING (.p ++ '!')
                 }
@@ -2368,7 +2327,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # A reference to another property of the same host type.
         async with self._run_and_rollback():
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY p {
                     SET TYPE int64 USING (<int64>.r_p)
                 }
@@ -2383,7 +2341,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             )
 
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY m_p {
                     SET TYPE int64 USING (<int64>.m_p + <int64>.r_p)
                 }
@@ -2400,7 +2357,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Conversion expression that reduces cardinality...
         async with self._run_and_rollback():
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY p {
                     SET TYPE int64 USING (<int64>{})
                 }
@@ -2415,7 +2371,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             )
 
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY m_p {
                     SET TYPE int64 USING (
                         <int64>{} IF <int64>.m_p % 2 = 0 ELSE <int64>.m_p
@@ -2435,10 +2390,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             r"missing value for required property 'r_p'"
-            r" of object type 'test::Foo'"
+            r" of object type 'default::Foo'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY r_p {
                     SET TYPE int64 USING (<int64>{})
                 }
@@ -2447,10 +2401,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             r"missing value for required property 'rm_p'"
-            r" of object type 'test::Foo'"
+            r" of object type 'default::Foo'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY rm_p {
                     SET TYPE int64 USING (
                         <int64>{} IF True ELSE <int64>.rm_p
@@ -2461,7 +2414,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Straightforward link cast.
         async with self._run_and_rollback():
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK l {
                     SET TYPE SubBar USING (.l[IS SubBar])
                 }
@@ -2476,7 +2428,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             )
 
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK m_l {
                     SET TYPE SubBar USING (.m_l[IS SubBar])
                 }
@@ -2493,7 +2444,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Use a more elaborate expression for the tranform.
         async with self._run_and_rollback():
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK l {
                     SET TYPE SubBar USING (SELECT .m_l[IS SubBar] LIMIT 1)
                 }
@@ -2511,10 +2461,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             r"missing value for required link 'r_l'"
-            r" of object type 'test::Foo'"
+            r" of object type 'default::Foo'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK r_l {
                     SET TYPE SubBar USING (.r_l[IS SubBar])
                 }
@@ -2523,10 +2472,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             r"missing value for required link 'rm_l'"
-            r" of object type 'test::Foo'"
+            r" of object type 'default::Foo'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK rm_l {
                     SET TYPE SubBar USING (SELECT SubBar FILTER False LIMIT 1)
                 }
@@ -2535,7 +2483,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Test link property transforms now.
         async with self._run_and_rollback():
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK l ALTER PROPERTY lp {
                     SET TYPE int64 USING (<int64>@lp)
                 }
@@ -2551,7 +2498,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_ptr_set_type_using_02(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE ABSTRACT TYPE Parent {
                 CREATE PROPERTY name -> str;
@@ -2577,7 +2523,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_ptr_set_type_validation(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Bar;
             CREATE TYPE Spam;
@@ -2592,24 +2537,22 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
-            r"property 'p' of object type 'test::Foo' cannot be cast"
+            r"property 'p' of object type 'default::Foo' cannot be cast"
             r" automatically from scalar type 'std::str' to scalar"
             r" type 'std::int64'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY p SET TYPE int64;
             """)
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
             r"result of USING clause for the alteration of"
-            r" property 'p' of object type 'test::Foo' cannot be cast"
+            r" property 'p' of object type 'default::Foo' cannot be cast"
             r" automatically from scalar type 'std::float64' to scalar"
             r" type 'std::int64'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY p
                     SET TYPE int64 USING (<float64>.p)
             """)
@@ -2617,51 +2560,46 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
             r"possibly more than one element returned by the USING clause for"
-            r" the alteration of property 'p' of object type 'test::Foo',"
+            r" the alteration of property 'p' of object type 'default::Foo',"
             r" while a singleton is expected"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY p SET TYPE int64 USING ({1, 2})
             """)
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
-            r"link 'l' of object type 'test::Foo' cannot be cast"
-            r" automatically from object type 'test::Bar' to object"
-            r" type 'test::Spam'"
+            r"link 'l' of object type 'default::Foo' cannot be cast"
+            r" automatically from object type 'default::Bar' to object"
+            r" type 'default::Spam'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK l SET TYPE Spam;
             """)
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
             r"result of USING clause for the alteration of"
-            r" link 'l' of object type 'test::Foo' cannot be cast"
-            r" automatically from object type 'test::Bar & test::Egg'"
-            r" to object type 'test::Spam'"
+            r" link 'l' of object type 'default::Foo' cannot be cast"
+            r" automatically from object type 'default::Bar & default::Egg'"
+            r" to object type 'default::Spam'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK l SET TYPE Spam USING (.l[IS Egg])
             """)
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
             r"possibly more than one element returned by the USING clause for"
-            r" the alteration of link 'l' of object type 'test::Foo', while"
+            r" the alteration of link 'l' of object type 'default::Foo', while"
             r" a singleton is expected"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK l SET TYPE Spam USING (SELECT Spam)
             """)
 
     async def test_edgeql_ddl_ptr_set_cardinality_validation(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Bar;
             CREATE TYPE Egg;
             CREATE TYPE Foo {
@@ -2675,22 +2613,20 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
             r"cannot automatically convert property 'p' of object type"
-            r" 'test::Foo' to 'single' cardinality"
+            r" 'default::Foo' to 'single' cardinality"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY p SET SINGLE;
             """)
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
             r"result of USING clause for the alteration of"
-            r" property 'p' of object type 'test::Foo' cannot be cast"
+            r" property 'p' of object type 'default::Foo' cannot be cast"
             r" automatically from scalar type 'std::float64' to scalar"
             r" type 'std::int64'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY p
                     SET TYPE int64 USING (<float64>.p)
             """)
@@ -2698,33 +2634,30 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
             r"possibly more than one element returned by the USING clause for"
-            r" the alteration of property 'p' of object type 'test::Foo',"
+            r" the alteration of property 'p' of object type 'default::Foo',"
             r" while a singleton is expected"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY p SET SINGLE USING ({1, 2})
             """)
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
             r"cannot automatically convert link 'l' of object type"
-            r" 'test::Foo' to 'single' cardinality"
+            r" 'default::Foo' to 'single' cardinality"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK l SET SINGLE;
             """)
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
             r"result of USING clause for the alteration of"
-            r" link 'l' of object type 'test::Foo' cannot be cast"
-            r" automatically from object type 'test::Egg'"
-            r" to object type 'test::Bar'"
+            r" link 'l' of object type 'default::Foo' cannot be cast"
+            r" automatically from object type 'default::Egg'"
+            r" to object type 'default::Bar'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK l
                     SET SINGLE USING (SELECT Egg LIMIT 1);
             """)
@@ -2732,17 +2665,15 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
             r"possibly more than one element returned by the USING clause for"
-            r" the alteration of link 'l' of object type 'test::Foo', while"
+            r" the alteration of link 'l' of object type 'default::Foo', while"
             r" a singleton is expected"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK l SET SINGLE USING (SELECT Bar)
             """)
 
     async def test_edgeql_ddl_ptr_set_required_01(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Bar {
                 CREATE PROPERTY name -> str {
@@ -2802,7 +2733,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             )
 
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY m_p {
                     SET REQUIRED USING ('3')
                 }
@@ -2819,7 +2749,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # A reference to another property of the same host type.
         async with self._run_and_rollback():
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY p {
                     SET REQUIRED USING (.p2)
                 }
@@ -2834,7 +2763,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             )
 
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY m_p {
                     SET REQUIRED USING (.p2)
                 }
@@ -2852,10 +2780,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             r"missing value for required property 'p'"
-            r" of object type 'test::Foo'"
+            r" of object type 'default::Foo'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY p {
                     SET REQUIRED USING (<str>{})
                 }
@@ -2864,10 +2791,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             r"missing value for required property 'm_p'"
-            r" of object type 'test::Foo'"
+            r" of object type 'default::Foo'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER PROPERTY m_p {
                     SET REQUIRED USING (
                         <str>{} IF True ELSE .p2
@@ -2878,7 +2804,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # And now see about the links.
         async with self._run_and_rollback():
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK l {
                     SET REQUIRED USING (SELECT Bar FILTER .name = 'bar2')
                 }
@@ -2893,7 +2818,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             )
 
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK m_l {
                     SET REQUIRED USING (SELECT Bar FILTER .name = 'bar2')
                 }
@@ -2914,10 +2838,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             r"missing value for required link 'l'"
-            r" of object type 'test::Foo'"
+            r" of object type 'default::Foo'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK l {
                     SET REQUIRED USING (SELECT Bar FILTER false LIMIT 1)
                 }
@@ -2926,10 +2849,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             r"missing value for required link 'm_l'"
-            r" of object type 'test::Foo'"
+            r" of object type 'default::Foo'"
         ):
             await self.con.execute("""
-                WITH MODULE test
                 ALTER TYPE Foo ALTER LINK m_l {
                     SET REQUIRED USING (SELECT Bar FILTER false LIMIT 1)
                 }
@@ -2940,7 +2862,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.InvalidPropertyDefinitionError,
                 r"link properties cannot be required"):
             await self.con.execute("""
-                CREATE TYPE test::TestLinkPropType_01 {
+                CREATE TYPE TestLinkPropType_01 {
                     CREATE LINK test_linkprop_link_01 -> std::Object {
                         CREATE REQUIRED PROPERTY test_link_prop_01
                             -> std::int64;
@@ -2953,7 +2875,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.InvalidPropertyDefinitionError,
                 r"multi properties aren't supported for links"):
             await self.con.execute("""
-                CREATE TYPE test::TestLinkPropType_02 {
+                CREATE TYPE TestLinkPropType_02 {
                     CREATE LINK test_linkprop_link_02 -> std::Object {
                         CREATE MULTI PROPERTY test_link_prop_02 -> std::int64;
                     };
@@ -2965,11 +2887,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.InvalidPropertyDefinitionError,
                 r"link properties cannot be required"):
             await self.con.execute("""
-                CREATE TYPE test::TestLinkPropType_03 {
+                CREATE TYPE TestLinkPropType_03 {
                     CREATE LINK test_linkprop_link_03 -> std::Object;
                 };
 
-                ALTER TYPE test::TestLinkPropType_03 {
+                ALTER TYPE TestLinkPropType_03 {
                     ALTER LINK test_linkprop_link_03 {
                         CREATE REQUIRED PROPERTY test_link_prop_03
                             -> std::int64;
@@ -2982,11 +2904,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.InvalidPropertyDefinitionError,
                 r"multi properties aren't supported for links"):
             await self.con.execute("""
-                CREATE TYPE test::TestLinkPropType_04 {
+                CREATE TYPE TestLinkPropType_04 {
                     CREATE LINK test_linkprop_link_04 -> std::Object;
                 };
 
-                ALTER TYPE test::TestLinkPropType_04 {
+                ALTER TYPE TestLinkPropType_04 {
                     ALTER LINK test_linkprop_link_04 {
                         CREATE MULTI PROPERTY test_link_prop_04 -> std::int64;
                     };
@@ -2998,13 +2920,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.InvalidPropertyDefinitionError,
                 r"link properties cannot be required"):
             await self.con.execute("""
-                CREATE TYPE test::TestLinkPropType_05 {
+                CREATE TYPE TestLinkPropType_05 {
                     CREATE LINK test_linkprop_link_05 -> std::Object {
                         CREATE PROPERTY test_link_prop_05 -> std::int64;
                     };
                 };
 
-                ALTER TYPE test::TestLinkPropType_05 {
+                ALTER TYPE TestLinkPropType_05 {
                     ALTER LINK test_linkprop_link_05 {
                         ALTER PROPERTY test_link_prop_05 {
                             SET REQUIRED;
@@ -3018,13 +2940,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.InvalidPropertyDefinitionError,
                 r"multi properties aren't supported for links"):
             await self.con.execute("""
-                CREATE TYPE test::TestLinkPropType_06 {
+                CREATE TYPE TestLinkPropType_06 {
                     CREATE LINK test_linkprop_link_06 -> std::Object {
                         CREATE MULTI PROPERTY test_link_prop_06 -> std::int64;
                     };
                 };
 
-                ALTER TYPE test::TestLinkPropType_06 {
+                ALTER TYPE TestLinkPropType_06 {
                     ALTER LINK test_linkprop_link_06 {
                         ALTER PROPERTY test_link_prop_06 {
                             SET MULTI;
@@ -3038,7 +2960,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.InvalidReferenceError,
                 r"type 'default::array' does not exist"):
             await self.con.execute(r"""
-                CREATE TYPE test::Foo {
+                CREATE TYPE Foo {
                     CREATE PROPERTY bar -> array;
                 };
             """)
@@ -3048,7 +2970,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.InvalidReferenceError,
                 r"type 'default::tuple' does not exist"):
             await self.con.execute(r"""
-                CREATE TYPE test::Foo {
+                CREATE TYPE Foo {
                     CREATE PROPERTY bar -> tuple;
                 };
             """)
@@ -3058,7 +2980,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.SchemaError,
                 r'unexpected number of subtypes, expecting 1'):
             await self.con.execute(r"""
-                CREATE TYPE test::Foo {
+                CREATE TYPE Foo {
                     CREATE PROPERTY bar -> array<int64, int64, int64>;
                 };
             """)
@@ -3068,7 +2990,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.UnsupportedFeatureError,
                 r'nested arrays are not supported'):
             await self.con.execute(r"""
-                CREATE TYPE test::Foo {
+                CREATE TYPE Foo {
                     CREATE PROPERTY bar -> array<array<int64>>;
                 };
             """)
@@ -3079,7 +3001,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r'mixing named and unnamed subtype declarations is not '
                 r'supported'):
             await self.con.execute(r"""
-                CREATE TYPE test::Foo {
+                CREATE TYPE Foo {
                     CREATE PROPERTY bar -> tuple<int64, foo:int64>;
                 };
             """)
@@ -3090,10 +3012,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r"mutations are invalid in computable link 'foo'"):
             async with self.con.transaction():
                 await self.con.execute(r"""
-                    CREATE TYPE test::Foo;
+                    CREATE TYPE Foo;
 
-                    CREATE TYPE test::Bar {
-                        CREATE LINK foo := (INSERT test::Foo);
+                    CREATE TYPE Bar {
+                        CREATE LINK foo := (INSERT Foo);
                     };
                 """)
 
@@ -3103,11 +3025,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r"mutations are invalid in computable link 'foo'"):
             async with self.con.transaction():
                 await self.con.execute(r"""
-                    CREATE TYPE test::Foo;
+                    CREATE TYPE Foo;
 
-                    CREATE TYPE test::Bar {
+                    CREATE TYPE Bar {
                         CREATE LINK foo := (
-                            WITH x := (INSERT test::Foo)
+                            WITH x := (INSERT Foo)
                             SELECT x
                         );
                     };
@@ -3119,10 +3041,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r"mutations are invalid in computable property 'foo'"):
             async with self.con.transaction():
                 await self.con.execute(r"""
-                    CREATE TYPE test::Foo;
+                    CREATE TYPE Foo;
 
-                    CREATE TYPE test::Bar {
-                        CREATE PROPERTY foo := (INSERT test::Foo).id;
+                    CREATE TYPE Bar {
+                        CREATE PROPERTY foo := (INSERT Foo).id;
                     };
                 """)
 
@@ -3132,11 +3054,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r"mutations are invalid in alias definition"):
             async with self.con.transaction():
                 await self.con.execute(r"""
-                    CREATE TYPE test::Foo;
-                    CREATE TYPE test::Bar;
+                    CREATE TYPE Foo;
+                    CREATE TYPE Bar;
 
-                    CREATE ALIAS test::Baz := test::Bar {
-                        foo := (INSERT test::Foo)
+                    CREATE ALIAS Baz := Bar {
+                        foo := (INSERT Foo)
                     };
                 """)
 
@@ -3146,11 +3068,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r"mutations are invalid in alias definition"):
             async with self.con.transaction():
                 await self.con.execute(r"""
-                    CREATE TYPE test::Foo;
-                    CREATE TYPE test::Bar;
+                    CREATE TYPE Foo;
+                    CREATE TYPE Bar;
 
-                    CREATE ALIAS test::Baz := test::Bar {
-                        foo := (INSERT test::Foo).id
+                    CREATE ALIAS Baz := Bar {
+                        foo := (INSERT Foo).id
                     };
                 """)
 
@@ -3160,14 +3082,14 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r"mutations are invalid in alias definition"):
             async with self.con.transaction():
                 await self.con.execute(r"""
-                    CREATE TYPE test::Foo;
-                    CREATE TYPE test::Bar {
-                        CREATE LINK foo -> test::Foo;
+                    CREATE TYPE Foo;
+                    CREATE TYPE Bar {
+                        CREATE LINK foo -> Foo;
                     };
 
-                    CREATE ALIAS test::Baz := test::Bar {
+                    CREATE ALIAS Baz := Bar {
                         foo: {
-                            fuz := (INSERT test::Foo)
+                            fuz := (INSERT Foo)
                         }
                     };
                 """)
@@ -3178,14 +3100,14 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r"mutations are invalid in alias definition"):
             async with self.con.transaction():
                 await self.con.execute(r"""
-                    CREATE TYPE test::Foo;
-                    CREATE TYPE test::Bar {
-                        CREATE LINK foo -> test::Foo;
+                    CREATE TYPE Foo;
+                    CREATE TYPE Bar {
+                        CREATE LINK foo -> Foo;
                     };
 
-                    CREATE ALIAS test::Baz := (
-                        WITH x := (INSERT test::Foo)
-                        SELECT test::Bar {
+                    CREATE ALIAS Baz := (
+                        WITH x := (INSERT Foo)
+                        SELECT Bar {
                             foo: {
                                 fuz := x
                             }
@@ -3199,16 +3121,16 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             '_123456789_123456789_123456789_123456789'
         )
         await self.con.execute(f"""
-            CREATE ABSTRACT LINK test::{link_name};
+            CREATE ABSTRACT LINK {link_name};
         """)
 
         await self.con.execute(f"""
-            CREATE TYPE test::Foo {{
-                CREATE LINK {link_name} -> test::Foo;
+            CREATE TYPE Foo {{
+                CREATE LINK {link_name} -> Foo;
             }};
         """)
 
-        await self.con.query(f"SELECT test::Foo.{link_name}")
+        await self.con.query(f"SELECT Foo.{link_name}")
 
     async def test_edgeql_ddl_link_bad_02(self):
         with self.assertRaisesRegex(
@@ -3216,8 +3138,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 f'unexpected fully-qualified name'):
             async with self.con.transaction():
                 await self.con.execute("""
-                    CREATE TYPE test::Foo {
-                        CREATE LINK foo::bar -> test::Foo;
+                    CREATE TYPE Foo {
+                        CREATE LINK foo::bar -> Foo;
                     };
                 """)
 
@@ -3227,7 +3149,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 f"'default' is not a valid field for an abstract link"):
             async with self.con.transaction():
                 await self.con.execute("""
-                    CREATE ABSTRACT LINK test::bar {
+                    CREATE ABSTRACT LINK bar {
                         SET default := Object;
                     };
                 """)
@@ -3238,16 +3160,16 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             '_123456789_123456789_123456789_123456789'
         )
         await self.con.execute(f"""
-            CREATE ABSTRACT PROPERTY test::{prop_name}
+            CREATE ABSTRACT PROPERTY {prop_name}
         """)
 
         await self.con.execute(f"""
-            CREATE TYPE test::Foo {{
+            CREATE TYPE Foo {{
                 CREATE PROPERTY {prop_name} -> std::str;
             }};
         """)
 
-        await self.con.query(f"SELECT test::Foo.{prop_name}")
+        await self.con.query(f"SELECT Foo.{prop_name}")
 
     async def test_edgeql_ddl_property_bad_02(self):
         with self.assertRaisesRegex(
@@ -3255,8 +3177,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 f'unexpected fully-qualified name'):
             async with self.con.transaction():
                 await self.con.execute("""
-                    CREATE TYPE test::Foo {
-                        CREATE PROPERTY foo::bar -> test::Foo;
+                    CREATE TYPE Foo {
+                        CREATE PROPERTY foo::bar -> Foo;
                     };
                 """)
 
@@ -3266,23 +3188,23 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 f"'default' is not a valid field for an abstract property"):
             async with self.con.transaction():
                 await self.con.execute("""
-                    CREATE ABSTRACT PROPERTY test::bar {
+                    CREATE ABSTRACT PROPERTY bar {
                         SET default := 'bad';
                     };
                 """)
 
     async def test_edgeql_ddl_function_01(self):
         await self.con.execute("""
-            CREATE FUNCTION test::my_lower(s: std::str) -> std::str
+            CREATE FUNCTION my_lower(s: std::str) -> std::str
                 USING SQL FUNCTION 'lower';
         """)
 
         with self.assertRaisesRegex(edgedb.DuplicateFunctionDefinitionError,
-                                    r'cannot create.*test::my_lower.*func'):
+                                    r'cannot create.*my_lower.*func'):
 
             async with self.con.transaction():
                 await self.con.execute("""
-                    CREATE FUNCTION test::my_lower(s: SET OF std::str)
+                    CREATE FUNCTION my_lower(s: SET OF std::str)
                         -> std::str {
                         SET initial_value := '';
                         USING SQL FUNCTION 'count';
@@ -3290,11 +3212,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 """)
 
         await self.con.execute("""
-            DROP FUNCTION test::my_lower(s: std::str);
+            DROP FUNCTION my_lower(s: std::str);
         """)
 
         await self.con.execute("""
-            CREATE FUNCTION test::my_lower(s: SET OF anytype)
+            CREATE FUNCTION my_lower(s: SET OF anytype)
                 -> std::str {
                 USING SQL FUNCTION 'count';
                 SET initial_value := '';
@@ -3302,53 +3224,53 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         """)
 
         with self.assertRaisesRegex(edgedb.DuplicateFunctionDefinitionError,
-                                    r'cannot create.*test::my_lower.*func'):
+                                    r'cannot create.*my_lower.*func'):
 
             async with self.con.transaction():
                 await self.con.execute("""
-                    CREATE FUNCTION test::my_lower(s: anytype) -> std::str
+                    CREATE FUNCTION my_lower(s: anytype) -> std::str
                         USING SQL FUNCTION 'lower';
                 """)
 
         await self.con.execute("""
-            DROP FUNCTION test::my_lower(s: anytype);
+            DROP FUNCTION my_lower(s: anytype);
         """)
 
     async def test_edgeql_ddl_function_02(self):
         long_func_name = 'my_sql_func5_' + 'abc' * 50
 
         await self.con.execute(f"""
-            CREATE FUNCTION test::my_sql_func1()
+            CREATE FUNCTION my_sql_func1()
                 -> std::str
                 USING SQL $$
                     SELECT 'spam'::text
                 $$;
 
-            CREATE FUNCTION test::my_sql_func2(foo: std::str)
+            CREATE FUNCTION my_sql_func2(foo: std::str)
                 -> std::str
                 USING SQL $$
                     SELECT "foo"::text
                 $$;
 
-            CREATE FUNCTION test::my_sql_func4(VARIADIC s: std::str)
+            CREATE FUNCTION my_sql_func4(VARIADIC s: std::str)
                 -> std::str
                 USING SQL $$
                     SELECT array_to_string(s, '-')
                 $$;
 
-            CREATE FUNCTION test::{long_func_name}()
+            CREATE FUNCTION {long_func_name}()
                 -> std::str
                 USING SQL $$
                     SELECT '{long_func_name}'::text
                 $$;
 
-            CREATE FUNCTION test::my_sql_func6(a: std::str='a' ++ 'b')
+            CREATE FUNCTION my_sql_func6(a: std::str='a' ++ 'b')
                 -> std::str
                 USING SQL $$
                     SELECT $1 || 'c'
                 $$;
 
-            CREATE FUNCTION test::my_sql_func7(s: array<std::int64>)
+            CREATE FUNCTION my_sql_func7(s: array<std::int64>)
                 -> std::int64
                 USING SQL $$
                     SELECT sum(s)::bigint FROM UNNEST($1) AS s
@@ -3357,61 +3279,61 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r"""
-                SELECT test::my_sql_func1();
+                SELECT my_sql_func1();
             """,
             ['spam'],
         )
         await self.assert_query_result(
             r"""
-                SELECT test::my_sql_func2('foo');
+                SELECT my_sql_func2('foo');
             """,
             ['foo'],
         )
         await self.assert_query_result(
             r"""
-                SELECT test::my_sql_func4('fizz', 'buzz');
+                SELECT my_sql_func4('fizz', 'buzz');
             """,
             ['fizz-buzz'],
         )
         await self.assert_query_result(
             fr"""
-                SELECT test::{long_func_name}();
+                SELECT {long_func_name}();
             """,
             [long_func_name],
         )
         await self.assert_query_result(
             r"""
-                SELECT test::my_sql_func6();
+                SELECT my_sql_func6();
             """,
             ['abc'],
         )
         await self.assert_query_result(
             r"""
-                SELECT test::my_sql_func6('xy');
+                SELECT my_sql_func6('xy');
             """,
             ['xyc'],
         )
         await self.assert_query_result(
             r"""
-                SELECT test::my_sql_func7([1, 2, 3, 10]);
+                SELECT my_sql_func7([1, 2, 3, 10]);
             """,
             [16],
         )
 
         await self.con.execute(f"""
-            DROP FUNCTION test::my_sql_func1();
-            DROP FUNCTION test::my_sql_func2(foo: std::str);
-            DROP FUNCTION test::my_sql_func4(VARIADIC s: std::str);
-            DROP FUNCTION test::{long_func_name}();
-            DROP FUNCTION test::my_sql_func6(a: std::str='a' ++ 'b');
-            DROP FUNCTION test::my_sql_func7(s: array<std::int64>);
+            DROP FUNCTION my_sql_func1();
+            DROP FUNCTION my_sql_func2(foo: std::str);
+            DROP FUNCTION my_sql_func4(VARIADIC s: std::str);
+            DROP FUNCTION {long_func_name}();
+            DROP FUNCTION my_sql_func6(a: std::str='a' ++ 'b');
+            DROP FUNCTION my_sql_func7(s: array<std::int64>);
         """)
 
     async def test_edgeql_ddl_function_03(self):
         with self.assertRaisesRegex(edgedb.InvalidFunctionDefinitionError,
                                     r'invalid default value'):
             await self.con.execute(f"""
-                CREATE FUNCTION test::broken_sql_func1(
+                CREATE FUNCTION broken_sql_func1(
                     a: std::int64=(SELECT schema::ObjectType))
                 -> std::str
                 USING SQL $$
@@ -3421,13 +3343,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_function_04(self):
         await self.con.execute(f"""
-            CREATE FUNCTION test::my_edgeql_func1()
+            CREATE FUNCTION my_edgeql_func1()
                 -> std::str
                 USING EdgeQL $$
                     SELECT 'sp' ++ 'am'
                 $$;
 
-            CREATE FUNCTION test::my_edgeql_func2(s: std::str)
+            CREATE FUNCTION my_edgeql_func2(s: std::str)
                 -> schema::ObjectType
                 USING EdgeQL $$
                     SELECT
@@ -3436,13 +3358,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     LIMIT 1
                 $$;
 
-            CREATE FUNCTION test::my_edgeql_func3(s: std::int64)
+            CREATE FUNCTION my_edgeql_func3(s: std::int64)
                 -> std::int64
                 USING EdgeQL $$
                     SELECT s + 10
                 $$;
 
-            CREATE FUNCTION test::my_edgeql_func4(i: std::int64)
+            CREATE FUNCTION my_edgeql_func4(i: std::int64)
                 -> array<std::int64>
                 USING EdgeQL $$
                     SELECT [i, 1, 2, 3]
@@ -3451,45 +3373,45 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r"""
-                SELECT test::my_edgeql_func1();
+                SELECT my_edgeql_func1();
             """,
             ['spam'],
         )
         await self.assert_query_result(
             r"""
-                SELECT test::my_edgeql_func2('schema::Object').name;
+                SELECT my_edgeql_func2('schema::Object').name;
             """,
             ['schema::Object'],
         )
         await self.assert_query_result(
             r"""
-                SELECT (SELECT test::my_edgeql_func2('schema::Object')).name;
+                SELECT (SELECT my_edgeql_func2('schema::Object')).name;
             """,
             ['schema::Object'],
         )
         await self.assert_query_result(
             r"""
-                SELECT test::my_edgeql_func3(1);
+                SELECT my_edgeql_func3(1);
             """,
             [11],
         )
         await self.assert_query_result(
             r"""
-                SELECT test::my_edgeql_func4(42);
+                SELECT my_edgeql_func4(42);
             """,
             [[42, 1, 2, 3]]
         )
 
         await self.con.execute(f"""
-            DROP FUNCTION test::my_edgeql_func1();
-            DROP FUNCTION test::my_edgeql_func2(s: std::str);
-            DROP FUNCTION test::my_edgeql_func3(s: std::int64);
-            DROP FUNCTION test::my_edgeql_func4(i: std::int64);
+            DROP FUNCTION my_edgeql_func1();
+            DROP FUNCTION my_edgeql_func2(s: std::str);
+            DROP FUNCTION my_edgeql_func3(s: std::int64);
+            DROP FUNCTION my_edgeql_func4(i: std::int64);
         """)
 
     async def test_edgeql_ddl_function_05(self):
         await self.con.execute("""
-            CREATE FUNCTION test::attr_func_1() -> std::str {
+            CREATE FUNCTION attr_func_1() -> std::str {
                 CREATE ANNOTATION description := 'hello';
                 USING EdgeQL "SELECT '1'";
             };
@@ -3501,7 +3423,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     annotations: {
                         @value
                     } FILTER .name = 'std::description'
-                } FILTER .name = 'test::attr_func_1';
+                } FILTER .name = 'default::attr_func_1';
             """,
             [{
                 'annotations': [{
@@ -3511,19 +3433,19 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute("""
-            DROP FUNCTION test::attr_func_1();
+            DROP FUNCTION attr_func_1();
         """)
 
     async def test_edgeql_ddl_function_06(self):
         await self.con.execute("""
-            CREATE FUNCTION test::int_func_1() -> std::int64 {
+            CREATE FUNCTION int_func_1() -> std::int64 {
                 USING EdgeQL "SELECT 1";
             };
         """)
 
         await self.assert_query_result(
             r"""
-                SELECT test::int_func_1();
+                SELECT int_func_1();
             """,
             [{}],
         )
@@ -3531,10 +3453,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_function_07(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
-                r'cannot create.*test::my_agg.*function:.+anytype.+cannot '
+                r'cannot create.*my_agg.*function:.+anytype.+cannot '
                 r'have a non-empty default'):
             await self.con.execute(r"""
-                CREATE FUNCTION test::my_agg(
+                CREATE FUNCTION my_agg(
                         s: anytype = [1]) -> array<anytype>
                     USING SQL FUNCTION "my_agg";
             """)
@@ -3545,13 +3467,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r'invalid declaration.*unexpected type of the default'):
 
             await self.con.execute("""
-                CREATE FUNCTION test::ddlf_08(s: std::str = 1) -> std::str
+                CREATE FUNCTION ddlf_08(s: std::str = 1) -> std::str
                     USING EdgeQL $$ SELECT "1" $$;
             """)
 
     async def test_edgeql_ddl_function_09(self):
         await self.con.execute("""
-            CREATE FUNCTION test::ddlf_09(
+            CREATE FUNCTION ddlf_09(
                 NAMED ONLY a: int64,
                 NAMED ONLY b: int64
             ) -> std::str
@@ -3564,7 +3486,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             async with self.con.transaction():
                 await self.con.execute("""
-                    CREATE FUNCTION test::ddlf_09(
+                    CREATE FUNCTION ddlf_09(
                         NAMED ONLY b: int64,
                         NAMED ONLY a: int64 = 1
                     ) -> std::str
@@ -3572,7 +3494,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 """)
 
         await self.con.execute("""
-            CREATE FUNCTION test::ddlf_09(
+            CREATE FUNCTION ddlf_09(
                 NAMED ONLY b: str,
                 NAMED ONLY a: int64
             ) -> std::str
@@ -3581,13 +3503,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''
-                SELECT test::ddlf_09(a:=1, b:=1);
+                SELECT ddlf_09(a:=1, b:=1);
             ''',
             ['1'],
         )
         await self.assert_query_result(
             r'''
-                SELECT test::ddlf_09(a:=1, b:='a');
+                SELECT ddlf_09(a:=1, b:='a');
             ''',
             ['2'],
         )
@@ -3599,7 +3521,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 _line=6, _col=39):
 
             await self.con.execute('''
-                CREATE FUNCTION test::ddlf_10(
+                CREATE FUNCTION ddlf_10(
                     sum: int64
                 ) -> int64
                     USING (
@@ -3609,17 +3531,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_function_11(self):
         await self.con.execute(r'''
-            CREATE FUNCTION test::ddlf_11_1() -> str
+            CREATE FUNCTION ddlf_11_1() -> str
                 USING EdgeQL $$
                     SELECT '\u0062'
                 $$;
 
-            CREATE FUNCTION test::ddlf_11_2() -> str
+            CREATE FUNCTION ddlf_11_2() -> str
                 USING EdgeQL $$
                     SELECT r'\u0062'
                 $$;
 
-            CREATE FUNCTION test::ddlf_11_3() -> str
+            CREATE FUNCTION ddlf_11_3() -> str
                 USING EdgeQL $$
                     SELECT $a$\u0062$a$
                 $$;
@@ -3628,68 +3550,68 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         try:
             await self.assert_query_result(
                 r'''
-                    SELECT test::ddlf_11_1();
+                    SELECT ddlf_11_1();
                 ''',
                 ['b'],
             )
             await self.assert_query_result(
                 r'''
-                    SELECT test::ddlf_11_2();
+                    SELECT ddlf_11_2();
                 ''',
                 [r'\u0062'],
             )
             await self.assert_query_result(
                 r'''
-                    SELECT test::ddlf_11_3();
+                    SELECT ddlf_11_3();
                 ''',
                 [r'\u0062'],
             )
         finally:
             await self.con.execute("""
-                DROP FUNCTION test::ddlf_11_1();
-                DROP FUNCTION test::ddlf_11_2();
-                DROP FUNCTION test::ddlf_11_3();
+                DROP FUNCTION ddlf_11_1();
+                DROP FUNCTION ddlf_11_2();
+                DROP FUNCTION ddlf_11_3();
             """)
 
     async def test_edgeql_ddl_function_12(self):
         with self.assertRaisesRegex(
                 edgedb.DuplicateFunctionDefinitionError,
-                r'cannot create.*test::ddlf_12\(a: std::int64\).*'
+                r'cannot create.*ddlf_12\(a: std::int64\).*'
                 r'function with the same signature is already defined'):
 
             await self.con.execute(r'''
-                CREATE FUNCTION test::ddlf_12(a: int64) -> int64
+                CREATE FUNCTION ddlf_12(a: int64) -> int64
                     USING EdgeQL $$ SELECT 11 $$;
 
-                CREATE FUNCTION test::ddlf_12(a: int64) -> float64
+                CREATE FUNCTION ddlf_12(a: int64) -> float64
                     USING EdgeQL $$ SELECT 11 $$;
             ''')
 
     async def test_edgeql_ddl_function_13(self):
         with self.assertRaisesRegex(
                 edgedb.UnsupportedFeatureError,
-                r'cannot create.*test::ddlf_13\(a: SET OF std::int64\).*'
+                r'cannot create.*ddlf_13\(a: SET OF std::int64\).*'
                 r'SET OF parameters in user-defined EdgeQL functions are '
                 r'not supported'):
 
             async with self.con.transaction():
                 await self.con.execute(r'''
-                    CREATE FUNCTION test::ddlf_13(a: SET OF int64) -> int64
+                    CREATE FUNCTION ddlf_13(a: SET OF int64) -> int64
                         USING EdgeQL $$ SELECT 11 $$;
                 ''')
 
         with self.assertRaises(edgedb.InvalidReferenceError):
             await self.con.execute("""
-                DROP FUNCTION test::ddlf_13(a: SET OF int64);
+                DROP FUNCTION ddlf_13(a: SET OF int64);
             """)
 
     async def test_edgeql_ddl_function_14(self):
         await self.con.execute(r'''
-            CREATE FUNCTION test::ddlf_14(
+            CREATE FUNCTION ddlf_14(
                     a: int64, NAMED ONLY f: int64) -> int64
                 USING EdgeQL $$ SELECT 11 $$;
 
-            CREATE FUNCTION test::ddlf_14(
+            CREATE FUNCTION ddlf_14(
                     a: int32, NAMED ONLY f: str) -> int64
                 USING EdgeQL $$ SELECT 12 $$;
         ''')
@@ -3697,34 +3619,34 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         try:
             await self.assert_query_result(
                 r'''
-                    SELECT test::ddlf_14(<int64>10, f := 11);
+                    SELECT ddlf_14(<int64>10, f := 11);
                 ''',
                 [11],
             )
             await self.assert_query_result(
                 r'''
-                    SELECT test::ddlf_14(<int32>10, f := '11');
+                    SELECT ddlf_14(<int32>10, f := '11');
                 ''',
                 [12],
             )
         finally:
             await self.con.execute("""
-                DROP FUNCTION test::ddlf_14(a: int64, NAMED ONLY f: int64);
-                DROP FUNCTION test::ddlf_14(a: int32, NAMED ONLY f: str);
+                DROP FUNCTION ddlf_14(a: int64, NAMED ONLY f: int64);
+                DROP FUNCTION ddlf_14(a: int32, NAMED ONLY f: str);
             """)
 
     async def test_edgeql_ddl_function_15(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
-                r'cannot create.*test::ddlf_15.*NAMED ONLY h:.*'
+                r'cannot create.*ddlf_15.*NAMED ONLY h:.*'
                 r'different named only parameters'):
 
             await self.con.execute(r'''
-                CREATE FUNCTION test::ddlf_15(
+                CREATE FUNCTION ddlf_15(
                         a: int64, NAMED ONLY f: int64) -> int64
                     USING EdgeQL $$ SELECT 11 $$;
 
-                CREATE FUNCTION test::ddlf_15(
+                CREATE FUNCTION ddlf_15(
                         a: int32, NAMED ONLY h: str) -> int64
                     USING EdgeQL $$ SELECT 12 $$;
             ''')
@@ -3732,48 +3654,48 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_function_16(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
-                r'cannot create the polymorphic.*test::ddlf_16.*'
+                r'cannot create the polymorphic.*ddlf_16.*'
                 r'function with different return type'):
 
             await self.con.execute(r'''
-                CREATE FUNCTION test::ddlf_16(
+                CREATE FUNCTION ddlf_16(
                         a: anytype, b: int64) -> OPTIONAL int64
                     USING EdgeQL $$ SELECT 11 $$;
 
-                CREATE FUNCTION test::ddlf_16(a: anytype, b: float64) -> str
+                CREATE FUNCTION ddlf_16(a: anytype, b: float64) -> str
                     USING EdgeQL $$ SELECT '12' $$;
             ''')
 
     async def test_edgeql_ddl_function_17(self):
         await self.con.execute(r'''
-            CREATE FUNCTION test::ddlf_17(str: std::str) -> int64
+            CREATE FUNCTION ddlf_17(str: std::str) -> int64
                 USING SQL FUNCTION 'whatever';
         ''')
 
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
-                r'cannot create.*test::ddlf_17.*'
+                r'cannot create.*ddlf_17.*'
                 r'overloading "USING SQL FUNCTION"'):
 
             async with self.con.transaction():
                 await self.con.execute(r'''
-                    CREATE FUNCTION test::ddlf_17(str: std::int64) -> int64
+                    CREATE FUNCTION ddlf_17(str: std::int64) -> int64
                         USING SQL FUNCTION 'whatever2';
                 ''')
 
         await self.con.execute("""
-            DROP FUNCTION test::ddlf_17(str: std::str);
+            DROP FUNCTION ddlf_17(str: std::str);
         """)
 
     async def test_edgeql_ddl_function_18(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
-                r'cannot create.*test::ddlf_18.*'
+                r'cannot create.*ddlf_18.*'
                 r'function returns a generic type but has no '
                 r'generic parameters'):
 
             await self.con.execute(r'''
-                CREATE FUNCTION test::ddlf_18(str: std::str) -> anytype
+                CREATE FUNCTION ddlf_18(str: std::str) -> anytype
                     USING EdgeQL $$ SELECT 1 $$;
             ''')
 
@@ -3783,7 +3705,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r"type 'std::anytype' does not exist"):
 
             await self.con.execute(r'''
-                CREATE FUNCTION test::ddlf_19(f: std::anytype) -> int64
+                CREATE FUNCTION ddlf_19(f: std::anytype) -> int64
                     USING EdgeQL $$ SELECT 1 $$;
             ''')
 
@@ -3793,7 +3715,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r"Unexpected ';'"):
 
             await self.con.execute(r'''
-                CREATE FUNCTION test::ddlf_20(f: int64) -> int64
+                CREATE FUNCTION ddlf_20(f: int64) -> int64
                     USING EdgeQL $$ SELECT 1; SELECT f; $$;
             ''')
 
@@ -3803,7 +3725,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"return type mismatch.*scalar type 'std::int64'"
         ):
             await self.con.execute(r"""
-                CREATE FUNCTION test::broken_edgeql_func22(
+                CREATE FUNCTION broken_edgeql_func22(
                     a: std::str) -> std::int64
                 USING EdgeQL $$
                     SELECT a
@@ -3816,7 +3738,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"return type mismatch.*scalar type 'std::int64'"
         ):
             await self.con.execute(r"""
-                CREATE FUNCTION test::broken_edgeql_func23(
+                CREATE FUNCTION broken_edgeql_func23(
                     a: std::str) -> std::int64
                 USING EdgeQL $$
                     SELECT [a]
@@ -3829,7 +3751,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"return type mismatch.*scalar type 'std::str'"
         ):
             await self.con.execute(r"""
-                CREATE FUNCTION test::broken_edgeql_func24(
+                CREATE FUNCTION broken_edgeql_func24(
                     a: std::str) -> std::str
                 USING EdgeQL $$
                     SELECT [a]
@@ -3842,7 +3764,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"return cardinality mismatch"
         ):
             await self.con.execute(r"""
-                CREATE FUNCTION test::broken_edgeql_func25(
+                CREATE FUNCTION broken_edgeql_func25(
                     a: std::str) -> std::str
                 USING EdgeQL $$
                     SELECT {a, a}
@@ -3853,7 +3775,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.con.execute(r"""
             CREATE ABSTRACT ANNOTATION foo26;
 
-            CREATE FUNCTION test::edgeql_func26(a: std::str) -> std::str {
+            CREATE FUNCTION edgeql_func26(a: std::str) -> std::str {
                 USING EdgeQL $$
                     SELECT a ++ 'aaa'
                 $$;
@@ -3861,11 +3783,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 SET volatility := 'Volatile';
             };
 
-            ALTER FUNCTION test::edgeql_func26(a: std::str) {
+            ALTER FUNCTION edgeql_func26(a: std::str) {
                 CREATE ANNOTATION foo26 := 'aaaa';
             };
 
-            ALTER FUNCTION test::edgeql_func26(a: std::str) {
+            ALTER FUNCTION edgeql_func26(a: std::str) {
                 # volatility must be case insensitive
                 SET volatility := 'immutable';
             };
@@ -3873,7 +3795,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''
-                SELECT test::edgeql_func26('b')
+                SELECT edgeql_func26('b')
             ''',
             [
                 'baaa'
@@ -3892,11 +3814,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     vol := <str>.volatility,
                 }
                 FILTER
-                    .name = 'test::edgeql_func26';
+                    .name = 'default::edgeql_func26';
             ''',
             [
                 {
-                    'name': 'test::edgeql_func26',
+                    'name': 'default::edgeql_func26',
                     'annotations': [
                         {
                             'name': 'default::foo26',
@@ -3909,7 +3831,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute(r"""
-            ALTER FUNCTION test::edgeql_func26(a: std::str) {
+            ALTER FUNCTION edgeql_func26(a: std::str) {
                 DROP ANNOTATION foo26;
             };
         """)
@@ -3925,18 +3847,18 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     },
                 }
                 FILTER
-                    .name = 'test::edgeql_func26';
+                    .name = 'default::edgeql_func26';
             ''',
             [
                 {
-                    'name': 'test::edgeql_func26',
+                    'name': 'default::edgeql_func26',
                     'annotations': [],
                 },
             ]
         )
 
         await self.con.execute(r"""
-            ALTER FUNCTION test::edgeql_func26(a: std::str) {
+            ALTER FUNCTION edgeql_func26(a: std::str) {
                 USING (
                     SELECT a ++ 'bbb'
                 )
@@ -3945,7 +3867,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''
-                SELECT test::edgeql_func26('b')
+                SELECT edgeql_func26('b')
             ''',
             [
                 'bbbb'
@@ -3953,7 +3875,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute(r"""
-            ALTER FUNCTION test::edgeql_func26(a: std::str) {
+            ALTER FUNCTION edgeql_func26(a: std::str) {
                 USING EdgeQL $$
                     SELECT a ++ 'zzz'
                 $$
@@ -3962,7 +3884,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''
-                SELECT test::edgeql_func26('b')
+                SELECT edgeql_func26('b')
             ''',
             [
                 'bzzz'
@@ -3973,16 +3895,16 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # This test checks constants, but we have to do DDLs to test them
         # with constant extraction disabled
         await self.con.execute('''
-            CREATE FUNCTION test::constant_int() -> std::int64 {
+            CREATE FUNCTION constant_int() -> std::int64 {
                 USING (SELECT 1_024);
             };
-            CREATE FUNCTION test::constant_bigint() -> std::bigint {
+            CREATE FUNCTION constant_bigint() -> std::bigint {
                 USING (SELECT 1_024n);
             };
-            CREATE FUNCTION test::constant_float() -> std::float64 {
+            CREATE FUNCTION constant_float() -> std::float64 {
                 USING (SELECT 1_024.1_250);
             };
-            CREATE FUNCTION test::constant_decimal() -> std::decimal {
+            CREATE FUNCTION constant_decimal() -> std::decimal {
                 USING (SELECT 1_024.1_024n);
             };
         ''')
@@ -3990,10 +3912,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.assert_query_result(
                 r'''
                     SELECT (
-                        int := test::constant_int(),
-                        bigint := test::constant_bigint(),
-                        float := test::constant_float(),
-                        decimal := test::constant_decimal(),
+                        int := constant_int(),
+                        bigint := constant_bigint(),
+                        float := constant_float(),
+                        decimal := constant_decimal(),
                     )
                 ''',
                 [{
@@ -4011,85 +3933,85 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             )
         finally:
             await self.con.execute("""
-                DROP FUNCTION test::constant_int();
-                DROP FUNCTION test::constant_float();
-                DROP FUNCTION test::constant_bigint();
-                DROP FUNCTION test::constant_decimal();
+                DROP FUNCTION constant_int();
+                DROP FUNCTION constant_float();
+                DROP FUNCTION constant_bigint();
+                DROP FUNCTION constant_decimal();
             """)
 
     async def test_edgeql_ddl_function_28(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r"'test::foo' is already present in the schema"):
+                r"'default::foo' is already present in the schema"):
 
             await self.con.execute('''\
-                CREATE TYPE test::foo;
-                CREATE FUNCTION test::foo() -> str USING ('a');
+                CREATE TYPE foo;
+                CREATE FUNCTION foo() -> str USING ('a');
             ''')
 
     async def test_edgeql_ddl_function_29(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r"'test::foo\(\)' is already present in the schema"):
+                r"'default::foo\(\)' is already present in the schema"):
 
             await self.con.execute('''\
-                CREATE FUNCTION test::foo() -> str USING ('a');
-                CREATE TYPE test::foo;
+                CREATE FUNCTION foo() -> str USING ('a');
+                CREATE TYPE foo;
             ''')
 
     async def test_edgeql_ddl_function_rename_01(self):
         await self.con.execute("""
-            CREATE FUNCTION test::foo(s: str) -> str {
+            CREATE FUNCTION foo(s: str) -> str {
                 USING (SELECT s)
             }
         """)
 
         await self.assert_query_result(
-            """SELECT test::foo("a")""",
+            """SELECT foo("a")""",
             ["a"],
         )
 
         await self.con.execute("""
-            ALTER FUNCTION test::foo(s: str)
-            RENAME TO test::bar;
+            ALTER FUNCTION foo(s: str)
+            RENAME TO bar;
         """)
 
         await self.assert_query_result(
-            """SELECT test::bar("a")""",
+            """SELECT bar("a")""",
             ["a"],
         )
 
         await self.con.execute("""
-            DROP FUNCTION test::bar(s: str)
+            DROP FUNCTION bar(s: str)
         """)
 
     async def test_edgeql_ddl_function_rename_02(self):
         await self.con.execute("""
-            CREATE FUNCTION test::foo(s: str) -> str {
+            CREATE FUNCTION foo(s: str) -> str {
                 USING (SELECT s)
             };
 
-            CREATE FUNCTION test::bar(s: int64) -> str {
+            CREATE FUNCTION bar(s: int64) -> str {
                 USING (SELECT <str>s)
             };
         """)
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r"can not rename function to 'test::foo' because "
+                r"can not rename function to 'default::foo' because "
                 r"a function with the same name already exists"):
             await self.con.execute("""
-                ALTER FUNCTION test::bar(s: int64)
-                RENAME TO test::foo;
+                ALTER FUNCTION bar(s: int64)
+                RENAME TO foo;
             """)
 
     async def test_edgeql_ddl_function_rename_03(self):
         await self.con.execute("""
-            CREATE FUNCTION test::foo(s: str) -> str {
+            CREATE FUNCTION foo(s: str) -> str {
                 USING (SELECT s)
             };
 
-            CREATE FUNCTION test::foo(s: int64) -> str {
+            CREATE FUNCTION foo(s: int64) -> str {
                 USING (SELECT <str>s)
             };
         """)
@@ -4098,25 +4020,25 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.SchemaError,
                 r"renaming an overloaded function is not allowed"):
             await self.con.execute("""
-                ALTER FUNCTION test::foo(s: int64)
-                RENAME TO test::bar;
+                ALTER FUNCTION foo(s: int64)
+                RENAME TO bar;
             """)
 
     async def test_edgeql_ddl_function_rename_04(self):
         await self.con.execute("""
-            CREATE FUNCTION test::foo(s: str) -> str {
+            CREATE FUNCTION foo(s: str) -> str {
                 USING (SELECT s)
             };
             CREATE MODULE foo;
         """)
 
         await self.assert_query_result(
-            """SELECT test::foo("a")""",
+            """SELECT foo("a")""",
             ["a"],
         )
 
         await self.con.execute("""
-            ALTER FUNCTION test::foo(s: str)
+            ALTER FUNCTION foo(s: str)
             RENAME TO foo::bar;
         """)
 
@@ -4131,46 +4053,46 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_function_rename_05(self):
         await self.con.execute("""
-            CREATE FUNCTION test::foo(s: str) -> str {
+            CREATE FUNCTION foo(s: str) -> str {
                 USING (SELECT s)
             };
-            CREATE FUNCTION test::call(s: str) -> str {
-                USING (SELECT test::foo(s))
+            CREATE FUNCTION call(s: str) -> str {
+                USING (SELECT foo(s))
             };
         """)
 
         await self.con.execute("""
-            ALTER FUNCTION test::foo(s: str) RENAME TO test::bar;
+            ALTER FUNCTION foo(s: str) RENAME TO bar;
         """)
 
         await self.assert_query_result(
-            """SELECT test::call("a")""",
+            """SELECT call("a")""",
             ["a"],
         )
 
     async def test_edgeql_ddl_function_rename_06(self):
         await self.con.execute("""
-            CREATE FUNCTION test::foo(s: str) -> str {
+            CREATE FUNCTION foo(s: str) -> str {
                 USING (SELECT s)
             };
-            CREATE FUNCTION test::call(s: str) -> str {
-                USING (SELECT test::foo(s))
+            CREATE FUNCTION call(s: str) -> str {
+                USING (SELECT foo(s))
             };
         """)
 
         await self.con.execute("""
             CREATE MODULE foo;
-            ALTER FUNCTION test::foo(s: str) RENAME TO foo::foo;
+            ALTER FUNCTION foo(s: str) RENAME TO foo::foo;
         """)
 
         await self.assert_query_result(
-            """SELECT test::call("a")""",
+            """SELECT call("a")""",
             ["a"],
         )
 
     async def test_edgeql_ddl_function_volatility_01(self):
         await self.con.execute('''
-            CREATE FUNCTION test::foo() -> int64 {
+            CREATE FUNCTION foo() -> int64 {
                 USING (SELECT 1)
             }
         ''')
@@ -4178,7 +4100,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.assert_query_result(
             r'''
             SELECT schema::Function { volatility }
-            FILTER .name = 'test::foo';
+            FILTER .name = 'default::foo';
             ''',
             [{
                 "volatility": "Immutable",
@@ -4186,13 +4108,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.assert_query_result(
-            '''SELECT (test::foo(), {1,2})''',
+            '''SELECT (foo(), {1,2})''',
             [[1, 1], [1, 2]]
         )
 
     async def test_edgeql_ddl_function_volatility_02(self):
         await self.con.execute('''
-            CREATE FUNCTION test::foo() -> int64 {
+            CREATE FUNCTION foo() -> int64 {
                 USING (SELECT <int64>random())
             }
         ''')
@@ -4200,7 +4122,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.assert_query_result(
             r'''
             SELECT schema::Function {volatility}
-            FILTER .name = 'test::foo';
+            FILTER .name = 'default::foo';
             ''',
             [{
                 "volatility": "Volatile",
@@ -4211,12 +4133,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.QueryError,
                 r"can not take cross product of volatile operation"):
             await self.con.query(
-                '''SELECT (test::foo(), {1,2})'''
+                '''SELECT (foo(), {1,2})'''
             )
 
     async def test_edgeql_ddl_function_volatility_03(self):
         await self.con.execute('''
-            CREATE FUNCTION test::foo() -> int64 {
+            CREATE FUNCTION foo() -> int64 {
                 USING (SELECT 1);
                 SET volatility := "volatile";
             }
@@ -4225,7 +4147,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.assert_query_result(
             r'''
             SELECT schema::Function {volatility}
-            FILTER .name = 'test::foo';
+            FILTER .name = 'default::foo';
             ''',
             [{
                 "volatility": "Volatile",
@@ -4236,7 +4158,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.QueryError,
                 r"can not take cross product of volatile operation"):
             await self.con.query(
-                '''SELECT (test::foo(), {1,2})'''
+                '''SELECT (foo(), {1,2})'''
             )
 
     async def test_edgeql_ddl_function_volatility_04(self):
@@ -4244,7 +4166,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.InvalidFunctionDefinitionError,
                 r"(?s)volatility mismatch in function declared as stable"):
             await self.con.execute('''
-                CREATE FUNCTION test::foo() -> int64 {
+                CREATE FUNCTION foo() -> int64 {
                     USING (SELECT <int64>random());
                     SET volatility := "stable";
                 }
@@ -4255,7 +4177,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.InvalidFunctionDefinitionError,
                 r"(?s)volatility mismatch in function declared as immutable"):
             await self.con.execute('''
-                CREATE FUNCTION test::foo() -> int64 {
+                CREATE FUNCTION foo() -> int64 {
                     USING (SELECT count(Object));
                     SET volatility := "immutable";
                 }
@@ -4263,46 +4185,46 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_function_volatility_06(self):
         await self.con.execute('''
-            CREATE FUNCTION test::foo() -> float64 {
+            CREATE FUNCTION foo() -> float64 {
                 USING (1);
             };
-            CREATE FUNCTION test::bar() -> float64 {
-                USING (test::foo());
+            CREATE FUNCTION bar() -> float64 {
+                USING (foo());
             };
         ''')
 
         await self.assert_query_result(
             r'''
             SELECT schema::Function {name, volatility}
-            FILTER .name LIKE 'test::%'
+            FILTER .name LIKE 'default::%'
             ORDER BY .name;
             ''',
             [
-                {"name": "test::bar", "volatility": "Immutable"},
-                {"name": "test::foo", "volatility": "Immutable"},
+                {"name": "default::bar", "volatility": "Immutable"},
+                {"name": "default::foo", "volatility": "Immutable"},
             ]
         )
 
         await self.con.execute('''
-            ALTER FUNCTION test::foo() SET volatility := "stable";
+            ALTER FUNCTION foo() SET volatility := "stable";
         ''')
 
         await self.assert_query_result(
             r'''
             SELECT schema::Function {name, volatility, computed_fields}
-            FILTER .name LIKE 'test::%'
+            FILTER .name LIKE 'default::%'
             ORDER BY .name;
             ''',
             [
-                {"name": "test::bar", "volatility": "Stable",
+                {"name": "default::bar", "volatility": "Stable",
                  "computed_fields": ["volatility"]},
-                {"name": "test::foo", "volatility": "Stable",
+                {"name": "default::foo", "volatility": "Stable",
                  "computed_fields": []},
             ]
         )
 
         await self.con.execute('''
-            ALTER FUNCTION test::foo() {
+            ALTER FUNCTION foo() {
                 RESET volatility;
             }
         ''')
@@ -4310,19 +4232,19 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.assert_query_result(
             r'''
             SELECT schema::Function {name, volatility, computed_fields}
-            FILTER .name LIKE 'test::%'
+            FILTER .name LIKE 'default::%'
             ORDER BY .name;
             ''',
             [
-                {"name": "test::bar", "volatility": "Immutable",
+                {"name": "default::bar", "volatility": "Immutable",
                  "computed_fields": ["volatility"]},
-                {"name": "test::foo", "volatility": "Immutable",
+                {"name": "default::foo", "volatility": "Immutable",
                  "computed_fields": ["volatility"]},
             ]
         )
 
         await self.con.execute('''
-            ALTER FUNCTION test::foo() {
+            ALTER FUNCTION foo() {
                 RESET volatility;
                 USING (random());
             }
@@ -4331,85 +4253,85 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.assert_query_result(
             r'''
             SELECT schema::Function {name, volatility}
-            FILTER .name LIKE 'test::%'
+            FILTER .name LIKE 'default::%'
             ORDER BY .name;
             ''',
             [
-                {"name": "test::bar", "volatility": "Volatile"},
-                {"name": "test::foo", "volatility": "Volatile"},
+                {"name": "default::bar", "volatility": "Volatile"},
+                {"name": "default::foo", "volatility": "Volatile"},
             ]
         )
 
     async def test_edgeql_ddl_function_volatility_07(self):
         await self.con.execute('''
-            CREATE FUNCTION test::foo() -> float64 {
+            CREATE FUNCTION foo() -> float64 {
                 USING (1);
             };
-            CREATE FUNCTION test::bar() -> float64 {
-                USING (test::foo());
+            CREATE FUNCTION bar() -> float64 {
+                USING (foo());
             };
-            CREATE FUNCTION test::baz() -> float64 {
-                USING (test::bar());
+            CREATE FUNCTION baz() -> float64 {
+                USING (bar());
             };
         ''')
 
         # Test that the alter propagates multiple times
         await self.con.execute('''
-            ALTER FUNCTION test::foo() SET volatility := "stable";
+            ALTER FUNCTION foo() SET volatility := "stable";
         ''')
 
         await self.assert_query_result(
             r'''
             SELECT schema::Function {name, volatility}
-            FILTER .name LIKE 'test::%'
+            FILTER .name LIKE 'default::%'
             ORDER BY .name;
             ''',
             [
-                {"name": "test::bar", "volatility": "Stable"},
-                {"name": "test::baz", "volatility": "Stable"},
-                {"name": "test::foo", "volatility": "Stable"},
+                {"name": "default::bar", "volatility": "Stable"},
+                {"name": "default::baz", "volatility": "Stable"},
+                {"name": "default::foo", "volatility": "Stable"},
             ]
         )
 
     async def test_edgeql_ddl_function_volatility_08(self):
         await self.con.execute('''
-            CREATE FUNCTION test::foo() -> float64 {
+            CREATE FUNCTION foo() -> float64 {
                 USING (1);
             };
-            CREATE FUNCTION test::bar() -> float64 {
+            CREATE FUNCTION bar() -> float64 {
                 SET volatility := "stable";
-                USING (test::foo());
+                USING (foo());
             };
         ''')
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaDefinitionError,
-            r"cannot alter function 'test::foo\(\)' because this affects "
-            r".*function 'test::bar\(\)'",
+            r"cannot alter function 'default::foo\(\)' because this affects "
+            r".*function 'default::bar\(\)'",
 
         ):
             await self.con.execute('''
-                ALTER FUNCTION test::foo() SET volatility := "volatile";
+                ALTER FUNCTION foo() SET volatility := "volatile";
             ''')
 
     async def test_edgeql_ddl_function_fallback_01(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
-                r'cannot create.*test::foo\(a: anytype\).*'
+                r'cannot create.*foo\(a: anytype\).*'
                 r'only one generic fallback per polymorphic function '
                 r'is allowed'):
             await self.con.execute(r'''
-                CREATE FUNCTION test::foo(a: int64) -> str {
+                CREATE FUNCTION foo(a: int64) -> str {
                     USING (SELECT 'foo' ++ <str>(a + 1));
                 };
-                CREATE FUNCTION test::foo(a: bytes) -> str {
+                CREATE FUNCTION foo(a: bytes) -> str {
                     USING (SELECT 'foobytes' ++ <str>len(a));
                 };
-                CREATE FUNCTION test::foo(a: array<anytype>) -> str {
+                CREATE FUNCTION foo(a: array<anytype>) -> str {
                     SET fallback := True;
                     USING (SELECT 'fooarray' ++ <str>len(a));
                 };
-                CREATE FUNCTION test::foo(a: anytype) -> str {
+                CREATE FUNCTION foo(a: anytype) -> str {
                     SET fallback := True;
                     USING (SELECT 'foo' ++ <str>a);
                 };
@@ -4417,32 +4339,32 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_function_fallback_02(self):
         await self.con.execute(r'''
-            CREATE FUNCTION test::foo(a: int64) -> str {
+            CREATE FUNCTION foo(a: int64) -> str {
                 USING (SELECT 'foo' ++ <str>(a + 1));
             };
-            CREATE FUNCTION test::foo(a: bytes) -> str {
+            CREATE FUNCTION foo(a: bytes) -> str {
                 USING (SELECT 'foobytes' ++ <str>len(a));
             };
-            CREATE FUNCTION test::foo(a: array<anytype>) -> str {
+            CREATE FUNCTION foo(a: array<anytype>) -> str {
                 USING (SELECT 'fooarray' ++ <str>len(a));
             };
-            CREATE FUNCTION test::foo(a: anytype) -> str {
+            CREATE FUNCTION foo(a: anytype) -> str {
                 USING (SELECT 'foo' ++ <str>a);
             };
         ''')
         await self.con.execute(r'''
-            ALTER FUNCTION test::foo(a: array<anytype>) {
+            ALTER FUNCTION foo(a: array<anytype>) {
                 SET fallback := true;
             };
         ''')
 
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
-                r'cannot alter.*test::foo\(a: anytype\).*'
+                r'cannot alter.*foo\(a: anytype\).*'
                 r'only one generic fallback per polymorphic function '
                 r'is allowed'):
             await self.con.execute(r'''
-                ALTER FUNCTION test::foo(a: anytype) {
+                ALTER FUNCTION foo(a: anytype) {
                     SET fallback := true;
                 };
             ''')
@@ -4469,10 +4391,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_operator_01(self):
         await self.con.execute('''
-            CREATE INFIX OPERATOR test::`+++`
+            CREATE INFIX OPERATOR `+++`
                 (left: int64, right: int64) -> int64
             {
-                SET commutator := 'test::+++';
+                SET commutator := 'default::+++';
                 USING SQL OPERATOR r'+';
             };
         ''')
@@ -4493,10 +4415,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     return_typemod
                 }
                 FILTER
-                    .name = 'test::+++';
+                    .name = 'default::+++';
             ''',
             [{
-                'name': 'test::+++',
+                'name': 'default::+++',
                 'params': [
                     {
                         'name': 'left',
@@ -4518,7 +4440,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute('''
-            ALTER INFIX OPERATOR test::`+++`
+            ALTER INFIX OPERATOR `+++`
                 (left: int64, right: int64)
                 CREATE ANNOTATION description := 'my plus';
         ''')
@@ -4530,17 +4452,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     name,
                 }
                 FILTER
-                    .name = 'test::+++'
+                    .name = 'default::+++'
                     AND .annotations.name = 'std::description'
                     AND .annotations@value = 'my plus';
             ''',
             [{
-                'name': 'test::+++',
+                'name': 'default::+++',
             }]
         )
 
         await self.con.execute("""
-            DROP INFIX OPERATOR test::`+++` (left: int64, right: int64);
+            DROP INFIX OPERATOR `+++` (left: int64, right: int64);
         """)
 
         await self.assert_query_result(
@@ -4559,7 +4481,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     return_typemod
                 }
                 FILTER
-                    .name = 'test::+++';
+                    .name = 'default::+++';
             ''',
             []
         )
@@ -4567,11 +4489,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_operator_02(self):
         try:
             await self.con.execute('''
-                CREATE POSTFIX OPERATOR test::`!`
+                CREATE POSTFIX OPERATOR `!`
                     (operand: int64) -> int64
                     USING SQL OPERATOR r'!';
 
-                CREATE PREFIX OPERATOR test::`!`
+                CREATE PREFIX OPERATOR `!`
                     (operand: int64) -> int64
                     USING SQL OPERATOR r'!!';
             ''')
@@ -4584,17 +4506,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         operator_kind,
                     }
                     FILTER
-                        .name = 'test::!'
+                        .name = 'default::!'
                     ORDER BY
                         .operator_kind;
                 ''',
                 [
                     {
-                        'name': 'test::!',
+                        'name': 'default::!',
                         'operator_kind': 'Postfix',
                     },
                     {
-                        'name': 'test::!',
+                        'name': 'default::!',
                         'operator_kind': 'Prefix',
                     }
                 ]
@@ -4602,20 +4524,20 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         finally:
             await self.con.execute('''
-                DROP POSTFIX OPERATOR test::`!`
+                DROP POSTFIX OPERATOR `!`
                     (operand: int64);
 
-                DROP PREFIX OPERATOR test::`!`
+                DROP PREFIX OPERATOR `!`
                     (operand: int64);
             ''')
 
     async def test_edgeql_ddl_operator_03(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidOperatorDefinitionError,
-                r'cannot create the `test::NOT\(\)` operator: '
+                r'cannot create the `default::NOT\(\)` operator: '
                 r'an operator must have operands'):
             await self.con.execute('''
-                CREATE PREFIX OPERATOR test::`NOT`() -> bool
+                CREATE PREFIX OPERATOR `NOT`() -> bool
                     USING SQL EXPRESSION;
             ''')
 
@@ -4623,12 +4545,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.InvalidOperatorDefinitionError,
                 r'cannot create the '
-                r'`test::=\(l: array<anytype>, r: std::str\)` operator: '
+                r'`default::=\(l: array<anytype>, r: std::str\)` operator: '
                 r'operands of a recursive operator must either be '
                 r'all arrays or all tuples'):
             await self.con.execute('''
                 CREATE INFIX OPERATOR
-                test::`=` (l: array<anytype>, r: str) -> std::bool {
+                `=` (l: array<anytype>, r: str) -> std::bool {
                     USING SQL EXPRESSION;
                     SET recursive := true;
                 };
@@ -4638,12 +4560,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.InvalidOperatorDefinitionError,
                 r'cannot create the '
-                r'`test::=\(l: array<anytype>, r: anytuple\)` operator: '
+                r'`default::=\(l: array<anytype>, r: anytuple\)` operator: '
                 r'operands of a recursive operator must either be '
                 r'all arrays or all tuples'):
             await self.con.execute('''
                 CREATE INFIX OPERATOR
-                test::`=` (l: array<anytype>, r: anytuple) -> std::bool {
+                `=` (l: array<anytype>, r: anytuple) -> std::bool {
                     USING SQL EXPRESSION;
                     SET recursive := true;
                 };
@@ -4653,7 +4575,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.InvalidOperatorDefinitionError,
                 r'cannot create the non-recursive '
-                r'`test::=\(l: array<std::int64>, '
+                r'`default::=\(l: array<std::int64>, '
                 r'r: array<std::int64>\)` operator: '
                 r'overloading a recursive operator '
                 r'`array<anytype> = array<anytype>` with a non-recursive one '
@@ -4662,13 +4584,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             # non-recursive version
             await self.con.execute('''
                 CREATE INFIX OPERATOR
-                test::`=` (l: array<anytype>, r: array<anytype>) -> std::bool {
+                `=` (l: array<anytype>, r: array<anytype>) -> std::bool {
                     SET recursive := true;
                     USING SQL EXPRESSION;
                 };
 
                 CREATE INFIX OPERATOR
-                test::`=` (l: array<int64>, r: array<int64>) -> std::bool {
+                `=` (l: array<int64>, r: array<int64>) -> std::bool {
                     USING SQL EXPRESSION;
                 };
             ''')
@@ -4677,7 +4599,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.InvalidOperatorDefinitionError,
                 r'cannot create the recursive '
-                r'`test::=\(l: array<std::int64>, '
+                r'`default::=\(l: array<std::int64>, '
                 r'r: array<std::int64>\)` operator: '
                 r'overloading a non-recursive operator '
                 r'`array<anytype> = array<anytype>` with a recursive one '
@@ -4686,12 +4608,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             # recursive one
             await self.con.execute('''
                 CREATE INFIX OPERATOR
-                test::`=` (l: array<anytype>, r: array<anytype>) -> std::bool {
+                `=` (l: array<anytype>, r: array<anytype>)
+                    -> std::bool {
                     USING SQL EXPRESSION;
                 };
 
                 CREATE INFIX OPERATOR
-                test::`=` (l: array<int64>, r: array<int64>) -> std::bool {
+                `=` (l: array<int64>, r: array<int64>) -> std::bool {
                     USING SQL EXPRESSION;
                     SET recursive := true;
                 };
@@ -4700,7 +4623,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_operator_08(self):
         try:
             await self.con.execute('''
-                CREATE ABSTRACT INFIX OPERATOR test::`>`
+                CREATE ABSTRACT INFIX OPERATOR `>`
                     (left: anytype, right: anytype) -> bool;
             ''')
 
@@ -4712,11 +4635,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         abstract,
                     }
                     FILTER
-                        .name = 'test::>'
+                        .name = 'default::>'
                 ''',
                 [
                     {
-                        'name': 'test::>',
+                        'name': 'default::>',
                         'abstract': True,
                     },
                 ]
@@ -4724,7 +4647,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         finally:
             await self.con.execute('''
-                DROP INFIX OPERATOR test::`>`
+                DROP INFIX OPERATOR `>`
                     (left: anytype, right: anytype);
             ''')
 
@@ -4734,7 +4657,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r'unexpected USING clause in abstract operator definition'):
             await self.con.execute('''
                 CREATE ABSTRACT INFIX OPERATOR
-                test::`=` (l: array<anytype>, r: array<anytype>) -> std::bool {
+                `=` (l: array<anytype>, r: array<anytype>) -> std::bool {
                     USING SQL EXPRESSION;
                 };
             ''')
@@ -4743,19 +4666,19 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.DuplicateOperatorDefinitionError,
                 r'cannot create the '
-                r'`test::IN\(l: std::int64, r: std::int64\)` operator: '
+                r'`default::IN\(l: std::int64, r: std::int64\)` operator: '
                 r'there exists a derivative operator of the same name'):
             # create 2 operators in test: derivative first, then a
             # non-derivative one
             await self.con.execute('''
                 CREATE INFIX OPERATOR
-                test::`IN` (l: std::float64, r: std::float64) -> std::bool {
+                `IN` (l: std::float64, r: std::float64) -> std::bool {
                     USING SQL EXPRESSION;
                     SET derivative_of := 'std::=';
                 };
 
                 CREATE INFIX OPERATOR
-                test::`IN` (l: std::int64, r: std::int64) -> std::bool {
+                `IN` (l: std::int64, r: std::int64) -> std::bool {
                     USING SQL EXPRESSION;
                 };
             ''')
@@ -4764,19 +4687,19 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
                 edgedb.DuplicateOperatorDefinitionError,
                 r'cannot create '
-                r'`test::IN\(l: std::int64, r: std::int64\)` as a '
+                r'`default::IN\(l: std::int64, r: std::int64\)` as a '
                 r'derivative operator: there already exists an operator '
                 r'of the same name'):
             # create 2 operators in test: non-derivative first, then a
             # derivative one
             await self.con.execute('''
                 CREATE INFIX OPERATOR
-                test::`IN` (l: std::float64, r: std::float64) -> std::bool {
+                `IN` (l: std::float64, r: std::float64) -> std::bool {
                     USING SQL EXPRESSION;
                 };
 
                 CREATE INFIX OPERATOR
-                test::`IN` (l: std::int64, r: std::int64) -> std::bool {
+                `IN` (l: std::int64, r: std::int64) -> std::bool {
                     USING SQL EXPRESSION;
                     SET derivative_of := 'std::=';
                 };
@@ -4787,66 +4710,66 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.SchemaError,
                 r'may not have more than one concrete base type'):
             await self.con.execute('''
-                CREATE SCALAR TYPE test::myint EXTENDING std::int64, std::str;
+                CREATE SCALAR TYPE myint EXTENDING std::int64, std::str;
             ''')
 
     async def test_edgeql_ddl_scalar_02(self):
         await self.con.execute('''
-            CREATE ABSTRACT SCALAR TYPE test::a EXTENDING std::int64;
-            CREATE ABSTRACT SCALAR TYPE test::b EXTENDING std::str;
+            CREATE ABSTRACT SCALAR TYPE a EXTENDING std::int64;
+            CREATE ABSTRACT SCALAR TYPE b EXTENDING std::str;
         ''')
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
                 r'may not have more than one concrete base type'):
             await self.con.execute('''
-                CREATE SCALAR TYPE test::myint EXTENDING test::a, test::b;
+                CREATE SCALAR TYPE myint EXTENDING a, b;
             ''')
 
     async def test_edgeql_ddl_scalar_03(self):
         await self.con.execute('''
-            CREATE ABSTRACT SCALAR TYPE test::a EXTENDING std::int64;
-            CREATE ABSTRACT SCALAR TYPE test::b EXTENDING std::str;
-            CREATE SCALAR TYPE test::myint EXTENDING test::a;
+            CREATE ABSTRACT SCALAR TYPE a EXTENDING std::int64;
+            CREATE ABSTRACT SCALAR TYPE b EXTENDING std::str;
+            CREATE SCALAR TYPE myint EXTENDING a;
         ''')
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
                 r'may not have more than one concrete base type'):
             await self.con.execute('''
-                ALTER SCALAR TYPE test::myint EXTENDING test::b;
+                ALTER SCALAR TYPE myint EXTENDING b;
             ''')
 
     async def test_edgeql_ddl_scalar_04(self):
         await self.con.execute('''
-            CREATE ABSTRACT SCALAR TYPE test::a;
-            CREATE SCALAR TYPE test::myint EXTENDING int64, test::a;
+            CREATE ABSTRACT SCALAR TYPE a;
+            CREATE SCALAR TYPE myint EXTENDING int64, a;
         ''')
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
                 r'may not have more than one concrete base type'):
             await self.con.execute('''
-                ALTER SCALAR TYPE test::a EXTENDING str;
+                ALTER SCALAR TYPE a EXTENDING str;
             ''')
 
     async def test_edgeql_ddl_scalar_05(self):
         await self.con.execute('''
-            CREATE ABSTRACT SCALAR TYPE test::a EXTENDING std::int64;
-            CREATE ABSTRACT SCALAR TYPE test::b EXTENDING std::int64;
-            CREATE SCALAR TYPE test::myint EXTENDING test::a, test::b;
+            CREATE ABSTRACT SCALAR TYPE a EXTENDING std::int64;
+            CREATE ABSTRACT SCALAR TYPE b EXTENDING std::int64;
+            CREATE SCALAR TYPE myint EXTENDING a, b;
         ''')
 
     async def test_edgeql_ddl_scalar_06(self):
         await self.con.execute('''
-            CREATE SCALAR TYPE test::myint EXTENDING int64;
-            CREATE SCALAR TYPE test::myint2 EXTENDING test::myint;
+            CREATE SCALAR TYPE myint EXTENDING int64;
+            CREATE SCALAR TYPE myint2 EXTENDING myint;
         ''')
 
     async def test_edgeql_ddl_scalar_07(self):
         await self.con.execute('''
-            CREATE SCALAR TYPE test::a EXTENDING std::str;
-            CREATE SCALAR TYPE test::b EXTENDING std::str;
+            CREATE SCALAR TYPE a EXTENDING std::str;
+            CREATE SCALAR TYPE b EXTENDING std::str;
         ''')
 
         # I think we want to prohibit this kind of diamond pattern
@@ -4854,12 +4777,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.SchemaError,
                 r'may not have more than one concrete base type'):
             await self.con.execute('''
-                CREATE SCALAR TYPE test::myint EXTENDING test::a, test::b;
+                CREATE SCALAR TYPE myint EXTENDING a, b;
             ''')
 
     async def test_edgeql_ddl_scalar_08(self):
         await self.con.execute('''
-            SET MODULE test;
 
             CREATE SCALAR TYPE myint EXTENDING int64;
             CREATE TYPE Bar {
@@ -4912,16 +4834,16 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_cast_01(self):
         await self.con.execute('''
-            CREATE SCALAR TYPE test::type_a EXTENDING std::str;
-            CREATE SCALAR TYPE test::type_b EXTENDING std::int64;
-            CREATE SCALAR TYPE test::type_c EXTENDING std::datetime;
+            CREATE SCALAR TYPE type_a EXTENDING std::str;
+            CREATE SCALAR TYPE type_b EXTENDING std::int64;
+            CREATE SCALAR TYPE type_c EXTENDING std::datetime;
 
-            CREATE CAST FROM test::type_a TO test::type_b {
+            CREATE CAST FROM type_a TO type_b {
                 USING SQL CAST;
                 ALLOW IMPLICIT;
             };
 
-            CREATE CAST FROM test::type_a TO test::type_c {
+            CREATE CAST FROM type_a TO type_c {
                 USING SQL CAST;
                 ALLOW ASSIGNMENT;
             };
@@ -4937,20 +4859,20 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     allow_assignment,
                 }
                 FILTER
-                    .from_type.name LIKE 'test::%'
+                    .from_type.name LIKE 'default::%'
                 ORDER BY
                     .allow_implicit;
             ''',
             [
                 {
-                    'from_type': {'name': 'test::type_a'},
-                    'to_type': {'name': 'test::type_c'},
+                    'from_type': {'name': 'default::type_a'},
+                    'to_type': {'name': 'default::type_c'},
                     'allow_implicit': False,
                     'allow_assignment': True,
                 },
                 {
-                    'from_type': {'name': 'test::type_a'},
-                    'to_type': {'name': 'test::type_b'},
+                    'from_type': {'name': 'default::type_a'},
+                    'to_type': {'name': 'default::type_b'},
                     'allow_implicit': True,
                     'allow_assignment': False,
                 }
@@ -4958,8 +4880,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute("""
-            DROP CAST FROM test::type_a TO test::type_b;
-            DROP CAST FROM test::type_a TO test::type_c;
+            DROP CAST FROM type_a TO type_b;
+            DROP CAST FROM type_a TO type_c;
         """)
 
         await self.assert_query_result(
@@ -4972,7 +4894,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     allow_assignment,
                 }
                 FILTER
-                    .from_type.name LIKE 'test::%'
+                    .from_type.name LIKE 'default::%'
                 ORDER BY
                     .allow_implicit;
             ''',
@@ -4981,16 +4903,16 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_property_computable_01(self):
         await self.con.execute('''\
-            CREATE TYPE test::CompProp;
-            ALTER TYPE test::CompProp {
+            CREATE TYPE CompProp;
+            ALTER TYPE CompProp {
                 CREATE PROPERTY prop := 'I am a computable';
             };
-            INSERT test::CompProp;
+            INSERT CompProp;
         ''')
 
         await self.assert_query_result(
             r'''
-                SELECT test::CompProp {
+                SELECT CompProp {
                     prop
                 };
             ''',
@@ -5011,7 +4933,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     } FILTER .name = 'prop'
                 }
                 FILTER
-                    .name = 'test::CompProp';
+                    .name = 'default::CompProp';
             ''',
             [{
                 'properties': [{
@@ -5025,15 +4947,15 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_property_computable_02(self):
         await self.con.execute('''\
-            CREATE TYPE test::CompProp {
+            CREATE TYPE CompProp {
                 CREATE PROPERTY prop := 'I am a computable';
             };
-            INSERT test::CompProp;
+            INSERT CompProp;
         ''')
 
         await self.assert_query_result(
             r'''
-                SELECT test::CompProp {
+                SELECT CompProp {
                     prop
                 };
             ''',
@@ -5043,7 +4965,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute('''\
-            ALTER TYPE test::CompProp {
+            ALTER TYPE CompProp {
                 ALTER PROPERTY prop {
                     RESET EXPRESSION;
                 };
@@ -5052,7 +4974,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''
-                SELECT test::CompProp {
+                SELECT CompProp {
                     prop
                 };
             ''',
@@ -5063,8 +4985,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_property_computable_circular(self):
         await self.con.execute('''\
-            CREATE TYPE test::CompPropCircular {
-                CREATE PROPERTY prop := (SELECT count(test::CompPropCircular))
+            CREATE TYPE CompPropCircular {
+                CREATE PROPERTY prop := (SELECT count(CompPropCircular))
             };
         ''')
 
@@ -5073,25 +4995,25 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 edgedb.InvalidPropertyTargetError,
                 r"invalid property type: expected.* got .* 'std::Object'"):
             await self.con.execute('''\
-                CREATE TYPE test::CompPropBad;
-                ALTER TYPE test::CompPropBad {
+                CREATE TYPE CompPropBad;
+                ALTER TYPE CompPropBad {
                     CREATE PROPERTY prop := (SELECT std::Object LIMIT 1);
                 };
             ''')
 
     async def test_edgeql_ddl_link_computable_01(self):
         await self.con.execute('''\
-            CREATE TYPE test::LinkTarget;
-            CREATE TYPE test::CompLink {
-                CREATE MULTI LINK l := test::LinkTarget;
+            CREATE TYPE LinkTarget;
+            CREATE TYPE CompLink {
+                CREATE MULTI LINK l := LinkTarget;
             };
 
-            INSERT test::LinkTarget;
-            INSERT test::CompLink;
+            INSERT LinkTarget;
+            INSERT CompLink;
         ''')
         await self.assert_query_result(
             r'''
-                SELECT test::CompLink {
+                SELECT CompLink {
                     l: {
                         id
                     }
@@ -5105,7 +5027,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute('''\
-            ALTER TYPE test::CompLink {
+            ALTER TYPE CompLink {
                 ALTER LINK l {
                     RESET EXPRESSION;
                 };
@@ -5113,7 +5035,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         ''')
         await self.assert_query_result(
             r'''
-                SELECT test::CompLink {
+                SELECT CompLink {
                     l: {
                         id
                     }
@@ -5126,27 +5048,27 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_link_computable_circular_01(self):
         await self.con.execute('''\
-            CREATE TYPE test::CompLinkCircular {
-                CREATE LINK l := (SELECT test::CompLinkCircular LIMIT 1)
+            CREATE TYPE CompLinkCircular {
+                CREATE LINK l := (SELECT CompLinkCircular LIMIT 1)
             };
         ''')
 
     async def test_edgeql_ddl_link_target_circular_01(self):
         # Circular target as part of a union.
         await self.con.execute('''\
-            CREATE TYPE test::LinkCircularA;
-            CREATE TYPE test::LinkCircularB {
-                CREATE LINK l -> test::LinkCircularA
-                                 | test::LinkCircularB;
+            CREATE TYPE LinkCircularA;
+            CREATE TYPE LinkCircularB {
+                CREATE LINK l -> LinkCircularA
+                                 | LinkCircularB;
             };
         ''')
 
     async def test_edgeql_ddl_annotation_01(self):
         await self.con.execute("""
-            CREATE ABSTRACT ANNOTATION test::attr1;
+            CREATE ABSTRACT ANNOTATION attr1;
 
-            CREATE SCALAR TYPE test::TestAttrType1 EXTENDING std::str {
-                CREATE ANNOTATION test::attr1 := 'aaaa';
+            CREATE SCALAR TYPE TestAttrType1 EXTENDING std::str {
+                CREATE ANNOTATION attr1 := 'aaaa';
             };
         """)
 
@@ -5160,9 +5082,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     }
                 }
                 FILTER
-                    .name = 'test::TestAttrType1';
+                    .name = 'default::TestAttrType1';
             ''',
-            [{"annotations": [{"name": "test::attr1", "@value": "aaaa"}]}]
+            [{"annotations": [{"name": "default::attr1", "@value": "aaaa"}]}]
         )
 
         await self.migrate("""
@@ -5183,17 +5105,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     }
                 }
                 FILTER
-                    .name = 'test::TestAttrType1';
+                    .name = 'default::TestAttrType1';
             ''',
-            [{"annotations": [{"name": "test::attr2", "@value": "aaaa"}]}]
+            [{"annotations": [{"name": "default::attr2", "@value": "aaaa"}]}]
         )
 
     async def test_edgeql_ddl_annotation_02(self):
         await self.con.execute("""
-            CREATE ABSTRACT ANNOTATION test::attr1;
+            CREATE ABSTRACT ANNOTATION attr1;
 
-            CREATE TYPE test::TestAttrType2 {
-                CREATE ANNOTATION test::attr1 := 'aaaa';
+            CREATE TYPE TestAttrType2 {
+                CREATE ANNOTATION attr1 := 'aaaa';
             };
         """)
 
@@ -5212,25 +5134,25 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     annotations: {
                         name,
                         @value,
-                    } FILTER .name = 'test::attr2'
+                    } FILTER .name = 'default::attr2'
                 }
                 FILTER
-                    .name = 'test::TestAttrType2';
+                    .name = 'default::TestAttrType2';
             ''',
-            [{"annotations": [{"name": "test::attr2", "@value": "aaaa"}]}]
+            [{"annotations": [{"name": "default::attr2", "@value": "aaaa"}]}]
         )
 
     async def test_edgeql_ddl_annotation_03(self):
         await self.con.execute("""
-            CREATE ABSTRACT ANNOTATION test::noninh;
-            CREATE ABSTRACT INHERITABLE ANNOTATION test::inh;
+            CREATE ABSTRACT ANNOTATION noninh;
+            CREATE ABSTRACT INHERITABLE ANNOTATION inh;
 
-            CREATE TYPE test::TestAttr1 {
-                CREATE ANNOTATION test::noninh := 'no inherit';
-                CREATE ANNOTATION test::inh := 'inherit me';
+            CREATE TYPE TestAttr1 {
+                CREATE ANNOTATION noninh := 'no inherit';
+                CREATE ANNOTATION inh := 'inherit me';
             };
 
-            CREATE TYPE test::TestAttr2 EXTENDING test::TestAttr1;
+            CREATE TYPE TestAttr2 EXTENDING TestAttr1;
         """)
 
         await self.assert_query_result(
@@ -5242,26 +5164,26 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         inheritable,
                         @value,
                     }
-                    FILTER .name LIKE 'test::%'
+                    FILTER .name LIKE 'default::%'
                     ORDER BY .name
                 }
                 FILTER
-                    .name LIKE 'test::TestAttr%'
+                    .name LIKE 'default::TestAttr%'
                 ORDER BY
                     .name;
             ''',
             [{
                 "annotations": [{
-                    "name": "test::inh",
+                    "name": "default::inh",
                     "inheritable": True,
                     "@value": "inherit me",
                 }, {
-                    "name": "test::noninh",
+                    "name": "default::noninh",
                     "@value": "no inherit",
                 }]
             }, {
                 "annotations": [{
-                    "name": "test::inh",
+                    "name": "default::inh",
                     "inheritable": True,
                     "@value": "inherit me",
                 }]
@@ -5270,14 +5192,14 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_annotation_04(self):
         await self.con.execute('''
-            CREATE TYPE test::BaseAnno4;
-            CREATE TYPE test::DerivedAnno4 EXTENDING test::BaseAnno4;
-            CREATE ABSTRACT ANNOTATION test::noninh_anno;
-            CREATE ABSTRACT INHERITABLE ANNOTATION test::inh_anno;
-            ALTER TYPE test::BaseAnno4
-                CREATE ANNOTATION test::noninh_anno := '1';
-            ALTER TYPE test::BaseAnno4
-                CREATE ANNOTATION test::inh_anno := '2';
+            CREATE TYPE BaseAnno4;
+            CREATE TYPE DerivedAnno4 EXTENDING BaseAnno4;
+            CREATE ABSTRACT ANNOTATION noninh_anno;
+            CREATE ABSTRACT INHERITABLE ANNOTATION inh_anno;
+            ALTER TYPE BaseAnno4
+                CREATE ANNOTATION noninh_anno := '1';
+            ALTER TYPE BaseAnno4
+                CREATE ANNOTATION inh_anno := '2';
         ''')
 
         await self.assert_query_result(
@@ -5289,17 +5211,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         inheritable,
                         @value,
                     }
-                    FILTER .name LIKE 'test::%_anno'
+                    FILTER .name LIKE 'default::%_anno'
                     ORDER BY .name
                 }
                 FILTER
-                    .name = 'test::DerivedAnno4'
+                    .name = 'default::DerivedAnno4'
                 ORDER BY
                     .name;
             ''',
             [{
                 "annotations": [{
-                    "name": "test::inh_anno",
+                    "name": "default::inh_anno",
                     "inheritable": True,
                     "@value": "2",
                 }]
@@ -5308,7 +5230,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_annotation_05(self):
         await self.con.execute(r'''
-            CREATE TYPE test::BaseAnno05 {
+            CREATE TYPE BaseAnno05 {
                 CREATE PROPERTY name -> str;
                 CREATE INDEX ON (.name) {
                     CREATE ANNOTATION title := 'name index'
@@ -5329,7 +5251,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     }
                 }
                 FILTER
-                    .name = 'test::BaseAnno05';
+                    .name = 'default::BaseAnno05';
             ''',
             [{
                 "indexes": [{
@@ -5344,14 +5266,14 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_annotation_06(self):
         await self.con.execute(r'''
-            CREATE TYPE test::BaseAnno06 {
+            CREATE TYPE BaseAnno06 {
                 CREATE PROPERTY name -> str;
                 CREATE INDEX ON (.name);
             };
         ''')
 
         await self.con.execute(r'''
-            ALTER TYPE test::BaseAnno06 {
+            ALTER TYPE BaseAnno06 {
                 ALTER INDEX ON (.name) {
                     CREATE ANNOTATION title := 'name index'
                 }
@@ -5371,7 +5293,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     }
                 }
                 FILTER
-                    .name = 'test::BaseAnno06';
+                    .name = 'default::BaseAnno06';
             ''',
             [{
                 "indexes": [{
@@ -5385,7 +5307,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
 
         await self.con.execute(r'''
-            ALTER TYPE test::BaseAnno06 {
+            ALTER TYPE BaseAnno06 {
                 ALTER INDEX ON (.name) {
                     DROP ANNOTATION title;
                 }
@@ -5405,7 +5327,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     }
                 }
                 FILTER
-                    .name = 'test::BaseAnno06';
+                    .name = 'default::BaseAnno06';
             ''',
             [{
                 "indexes": [{
@@ -5418,7 +5340,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_annotation_07(self):
         # Create index annotation using DDL, then drop annotation using SDL.
         await self.con.execute(r'''
-            CREATE TYPE test::BaseAnno07 {
+            CREATE TYPE BaseAnno07 {
                 CREATE PROPERTY name -> str;
                 CREATE INDEX ON (.name) {
                     CREATE ANNOTATION title := 'name index'
@@ -5439,7 +5361,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     }
                 }
                 FILTER
-                    .name = 'test::BaseAnno07';
+                    .name = 'default::BaseAnno07';
             ''',
             [{
                 "indexes": [{
@@ -5472,7 +5394,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     }
                 }
                 FILTER
-                    .name = 'test::BaseAnno07';
+                    .name = 'default::BaseAnno07';
             ''',
             [{
                 "indexes": [{
@@ -5485,7 +5407,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_annotation_08(self):
         # Create index using DDL, then add annotation to it using SDL.
         await self.con.execute(r'''
-            CREATE TYPE test::BaseAnno08 {
+            CREATE TYPE BaseAnno08 {
                 CREATE PROPERTY name -> str;
                 CREATE INDEX ON (.name);
             };
@@ -5504,7 +5426,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     }
                 }
                 FILTER
-                    .name = 'test::BaseAnno08';
+                    .name = 'default::BaseAnno08';
             ''',
             [{
                 "indexes": [{
@@ -5536,7 +5458,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     }
                 }
                 FILTER
-                    .name = 'test::BaseAnno08';
+                    .name = 'default::BaseAnno08';
             ''',
             [{
                 "indexes": [{
@@ -5551,10 +5473,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_annotation_09(self):
         await self.con.execute("""
-            CREATE ABSTRACT ANNOTATION test::anno09;
+            CREATE ABSTRACT ANNOTATION anno09;
 
-            CREATE TYPE test::TestTypeAnno09 {
-                CREATE ANNOTATION test::anno09 := 'A';
+            CREATE TYPE TestTypeAnno09 {
+                CREATE ANNOTATION anno09 := 'A';
             };
         """)
 
@@ -5565,18 +5487,18 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     annotations: {
                         name,
                         @value,
-                    } FILTER .name = 'test::anno09'
+                    } FILTER .name = 'default::anno09'
                 }
                 FILTER
-                    .name = 'test::TestTypeAnno09';
+                    .name = 'default::TestTypeAnno09';
             ''',
-            [{"annotations": [{"name": "test::anno09", "@value": "A"}]}]
+            [{"annotations": [{"name": "default::anno09", "@value": "A"}]}]
         )
 
         # Alter the annotation.
         await self.con.execute("""
-            ALTER TYPE test::TestTypeAnno09 {
-                ALTER ANNOTATION test::anno09 := 'B';
+            ALTER TYPE TestTypeAnno09 {
+                ALTER ANNOTATION anno09 := 'B';
             };
         """)
 
@@ -5587,30 +5509,30 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     annotations: {
                         name,
                         @value,
-                    } FILTER .name = 'test::anno09'
+                    } FILTER .name = 'default::anno09'
                 }
                 FILTER
-                    .name = 'test::TestTypeAnno09';
+                    .name = 'default::TestTypeAnno09';
             ''',
-            [{"annotations": [{"name": "test::anno09", "@value": "B"}]}]
+            [{"annotations": [{"name": "default::anno09", "@value": "B"}]}]
         )
 
     async def test_edgeql_ddl_annotation_10(self):
         await self.con.execute("""
-            CREATE ABSTRACT ANNOTATION test::anno10;
-            CREATE ABSTRACT INHERITABLE ANNOTATION test::anno10_inh;
+            CREATE ABSTRACT ANNOTATION anno10;
+            CREATE ABSTRACT INHERITABLE ANNOTATION anno10_inh;
 
-            CREATE TYPE test::TestTypeAnno10
+            CREATE TYPE TestTypeAnno10
             {
-                CREATE ANNOTATION test::anno10 := 'A';
-                CREATE ANNOTATION test::anno10_inh := 'A';
+                CREATE ANNOTATION anno10 := 'A';
+                CREATE ANNOTATION anno10_inh := 'A';
             };
 
-            CREATE TYPE test::TestSubTypeAnno10
-                    EXTENDING test::TestTypeAnno10
+            CREATE TYPE TestSubTypeAnno10
+                    EXTENDING TestTypeAnno10
             {
-                CREATE ANNOTATION test::anno10 := 'B';
-                ALTER ANNOTATION test::anno10_inh := 'B';
+                CREATE ANNOTATION anno10 := 'B';
+                ALTER ANNOTATION anno10_inh := 'B';
             }
         """)
 
@@ -5622,25 +5544,25 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         name,
                         @value,
                     }
-                    FILTER .name LIKE 'test::anno10%'
+                    FILTER .name LIKE 'default::anno10%'
                     ORDER BY .name
                 }
                 FILTER
-                    .name LIKE 'test::%Anno10'
+                    .name LIKE 'default::%Anno10'
                 ORDER BY
                     .name
             ''',
             [
                 {
                     "annotations": [
-                        {"name": "test::anno10", "@value": "B"},
-                        {"name": "test::anno10_inh", "@value": "B"},
+                        {"name": "default::anno10", "@value": "B"},
+                        {"name": "default::anno10_inh", "@value": "B"},
                     ]
                 },
                 {
                     "annotations": [
-                        {"name": "test::anno10", "@value": "A"},
-                        {"name": "test::anno10_inh", "@value": "A"},
+                        {"name": "default::anno10", "@value": "A"},
+                        {"name": "default::anno10_inh", "@value": "A"},
                     ]
                 },
             ]
@@ -5648,8 +5570,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         # Drop the non-inherited annotation from subtype.
         await self.con.execute("""
-            ALTER TYPE test::TestSubTypeAnno10 {
-                DROP ANNOTATION test::anno10;
+            ALTER TYPE TestSubTypeAnno10 {
+                DROP ANNOTATION anno10;
             };
         """)
 
@@ -5660,27 +5582,27 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     annotations: {
                         name,
                         @value,
-                    } FILTER .name LIKE 'test::anno10%'
+                    } FILTER .name LIKE 'default::anno10%'
                 }
                 FILTER
-                    .name = 'test::TestSubTypeAnno10';
+                    .name = 'default::TestSubTypeAnno10';
             ''',
-            [{"annotations": [{"name": "test::anno10_inh", "@value": "B"}]}]
+            [{"annotations": [{"name": "default::anno10_inh", "@value": "B"}]}]
         )
 
         with self.assertRaisesRegex(
             edgedb.SchemaError,
-            "cannot drop inherited annotation 'test::anno10_inh'",
+            "cannot drop inherited annotation 'default::anno10_inh'",
         ):
             await self.con.execute("""
-                ALTER TYPE test::TestSubTypeAnno10 {
-                    DROP ANNOTATION test::anno10_inh;
+                ALTER TYPE TestSubTypeAnno10 {
+                    DROP ANNOTATION anno10_inh;
                 };
             """)
 
     async def test_edgeql_ddl_annotation_11(self):
         await self.con.execute("""
-            CREATE ABSTRACT ANNOTATION test::anno11;
+            CREATE ABSTRACT ANNOTATION anno11;
         """)
 
         await self.assert_query_result(
@@ -5690,14 +5612,14 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     name,
                 }
                 FILTER
-                    .name LIKE 'test::anno11%';
+                    .name LIKE 'default::anno11%';
             ''',
-            [{"name": "test::anno11"}]
+            [{"name": "default::anno11"}]
         )
 
         await self.con.execute("""
-            ALTER ABSTRACT ANNOTATION test::anno11
-                RENAME TO test::anno11_new_name;
+            ALTER ABSTRACT ANNOTATION anno11
+                RENAME TO anno11_new_name;
         """)
 
         await self.assert_query_result(
@@ -5707,15 +5629,15 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     name,
                 }
                 FILTER
-                    .name LIKE 'test::anno11%';
+                    .name LIKE 'default::anno11%';
             ''',
-            [{"name": "test::anno11_new_name"}]
+            [{"name": "default::anno11_new_name"}]
         )
 
         await self.con.execute("""
             CREATE MODULE foo;
 
-            ALTER ABSTRACT ANNOTATION test::anno11_new_name
+            ALTER ABSTRACT ANNOTATION anno11_new_name
                 RENAME TO foo::anno11_new_name;
         """)
 
@@ -5758,7 +5680,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_annotation_13(self):
         await self.con.execute("""
-            CREATE ABSTRACT ANNOTATION test::anno13;
+            CREATE ABSTRACT ANNOTATION anno13;
         """)
 
         with self.assertRaisesRegex(
@@ -5766,47 +5688,47 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             "module 'bogus' is not in this schema",
         ):
             await self.con.execute("""
-                ALTER ABSTRACT ANNOTATION test::anno13 RENAME TO bogus::anno13;
+                ALTER ABSTRACT ANNOTATION anno13 RENAME TO bogus::anno13;
             """)
 
     async def test_edgeql_ddl_annotation_14(self):
         await self.con.execute("""
-            CREATE ABSTRACT ANNOTATION test::anno;
-            CREATE TYPE test::Foo {
-                CREATE ANNOTATION test::anno := "test";
+            CREATE ABSTRACT ANNOTATION anno;
+            CREATE TYPE Foo {
+                CREATE ANNOTATION anno := "test";
             };
         """)
 
         await self.con.execute("""
-            ALTER ABSTRACT ANNOTATION test::anno
-                RENAME TO test::anno_new_name;
+            ALTER ABSTRACT ANNOTATION anno
+                RENAME TO anno_new_name;
         """)
 
         await self.assert_query_result(
-            "DESCRIBE MODULE test as sdl",
+            "DESCRIBE MODULE default as sdl",
             ["""
-abstract annotation test::anno_new_name;
-type test::Foo {
-    annotation test::anno_new_name := 'test';
+abstract annotation default::anno_new_name;
+type default::Foo {
+    annotation default::anno_new_name := 'test';
 };
             """.strip()]
         )
 
         await self.con.execute("""
-            DROP TYPE test::Foo;
+            DROP TYPE Foo;
         """)
 
     async def test_edgeql_ddl_annotation_15(self):
         await self.con.execute("""
-            CREATE ABSTRACT INHERITABLE ANNOTATION test::anno;
-            CREATE TYPE test::Foo {
+            CREATE ABSTRACT INHERITABLE ANNOTATION anno;
+            CREATE TYPE Foo {
                 CREATE PROPERTY prop -> str {
-                    CREATE ANNOTATION test::anno := "parent";
+                    CREATE ANNOTATION anno := "parent";
                 };
             };
-            CREATE TYPE test::Bar EXTENDING test::Foo {
+            CREATE TYPE Bar EXTENDING Foo {
                 ALTER PROPERTY prop {
-                    ALTER ANNOTATION test::anno := "child";
+                    ALTER ANNOTATION anno := "child";
                 }
             };
         """)
@@ -5830,24 +5752,24 @@ type test::Foo {
                 {
                     "annotations": [
                         {"@value": "child", "@owned": True,
-                         "name": "test::anno"}
+                         "name": "default::anno"}
                     ],
-                    "obj": "test::Bar"
+                    "obj": "default::Bar"
                 },
                 {
                     "annotations": [
                         {"@value": "parent", "@owned": True,
-                         "name": "test::anno"}
+                         "name": "default::anno"}
                     ],
-                    "obj": "test::Foo"
+                    "obj": "default::Foo"
                 }
             ]
         )
 
         await self.con.execute("""
-            ALTER TYPE test::Bar {
+            ALTER TYPE Bar {
                 ALTER PROPERTY prop {
-                    ALTER ANNOTATION test::anno DROP OWNED;
+                    ALTER ANNOTATION anno DROP OWNED;
                 }
             };
         """)
@@ -5858,16 +5780,16 @@ type test::Foo {
                 {
                     "annotations": [
                         {"@value": "parent", "@owned": False,
-                         "name": "test::anno"}
+                         "name": "default::anno"}
                     ],
-                    "obj": "test::Bar"
+                    "obj": "default::Bar"
                 },
                 {
                     "annotations": [
                         {"@value": "parent", "@owned": True,
-                         "name": "test::anno"}
+                         "name": "default::anno"}
                     ],
-                    "obj": "test::Foo"
+                    "obj": "default::Foo"
                 }
             ]
         )
@@ -5878,7 +5800,7 @@ type test::Foo {
                 r"invalid property type"):
 
             await self.con.execute("""
-                CREATE ABSTRACT LINK test::test_object_link_prop {
+                CREATE ABSTRACT LINK test_object_link_prop {
                     CREATE PROPERTY link_prop1 -> anytype;
                 };
             """)
@@ -5889,7 +5811,7 @@ type test::Foo {
                 r"invalid link target"):
 
             await self.con.execute("""
-                CREATE TYPE test::AnyObject2 {
+                CREATE TYPE AnyObject2 {
                     CREATE LINK a -> anytype;
                 };
             """)
@@ -5900,7 +5822,7 @@ type test::Foo {
                 r"invalid property type"):
 
             await self.con.execute("""
-                CREATE TYPE test::AnyObject3 {
+                CREATE TYPE AnyObject3 {
                     CREATE PROPERTY a -> anytype;
                 };
             """)
@@ -5911,7 +5833,7 @@ type test::Foo {
                 r"invalid property type"):
 
             await self.con.execute("""
-                CREATE TYPE test::AnyObject4 {
+                CREATE TYPE AnyObject4 {
                     CREATE PROPERTY a -> anyscalar;
                 };
             """)
@@ -5922,7 +5844,7 @@ type test::Foo {
                 r"invalid property type"):
 
             await self.con.execute("""
-                CREATE TYPE test::AnyObject5 {
+                CREATE TYPE AnyObject5 {
                     CREATE PROPERTY a -> anyint;
                 };
             """)
@@ -5933,8 +5855,8 @@ type test::Foo {
                 r"'anytype' cannot be a parent type"):
 
             await self.con.execute("""
-                CREATE TYPE test::AnyObject6 EXTENDING anytype {
-                    CREATE REQUIRED LINK a -> test::AnyObject6;
+                CREATE TYPE AnyObject6 EXTENDING anytype {
+                    CREATE REQUIRED LINK a -> AnyObject6;
                     CREATE REQUIRED PROPERTY b -> str;
                 };
             """)
@@ -5943,37 +5865,37 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
                 r"Could not find consistent ancestor order for "
-                r"object type 'test::Merged1'"):
+                r"object type 'default::Merged1'"):
 
             await self.con.execute(r"""
-                CREATE TYPE test::ExtA1;
-                CREATE TYPE test::ExtB1;
+                CREATE TYPE ExtA1;
+                CREATE TYPE ExtB1;
                 # create two types with incompatible linearized bases
-                CREATE TYPE test::ExtC1 EXTENDING test::ExtA1, test::ExtB1;
-                CREATE TYPE test::ExtD1 EXTENDING test::ExtB1, test::ExtA1;
+                CREATE TYPE ExtC1 EXTENDING ExtA1, ExtB1;
+                CREATE TYPE ExtD1 EXTENDING ExtB1, ExtA1;
                 # extending from both of these incompatible types
-                CREATE TYPE test::Merged1 EXTENDING test::ExtC1, test::ExtD1;
+                CREATE TYPE Merged1 EXTENDING ExtC1, ExtD1;
             """)
 
     async def test_edgeql_ddl_extending_02(self):
         await self.con.execute(r"""
-            CREATE TYPE test::ExtA2;
+            CREATE TYPE ExtA2;
             # Create two types with a different position of Object
             # in the bases. This doesn't impact the linearized
             # bases because Object is already implicitly included
             # as the first element of the base types.
-            CREATE TYPE test::ExtC2 EXTENDING test::ExtA2, Object;
-            CREATE TYPE test::ExtD2 EXTENDING Object, test::ExtA2;
+            CREATE TYPE ExtC2 EXTENDING ExtA2, Object;
+            CREATE TYPE ExtD2 EXTENDING Object, ExtA2;
             # extending from both of these types
-            CREATE TYPE test::Merged2 EXTENDING test::ExtC2, test::ExtD2;
+            CREATE TYPE Merged2 EXTENDING ExtC2, ExtD2;
         """)
 
     async def test_edgeql_ddl_extending_03(self):
         # Check that ancestors are recomputed properly on rebase.
         await self.con.execute(r"""
-            CREATE TYPE test::ExtA3;
-            CREATE TYPE test::ExtB3 EXTENDING test::ExtA3;
-            CREATE TYPE test::ExtC3 EXTENDING test::ExtB3;
+            CREATE TYPE ExtA3;
+            CREATE TYPE ExtB3 EXTENDING ExtA3;
+            CREATE TYPE ExtC3 EXTENDING ExtB3;
         """)
 
         await self.assert_query_result(
@@ -5983,13 +5905,13 @@ type test::Foo {
                         name
                     } ORDER BY @index
                 }
-                FILTER .name = 'test::ExtC3'
+                FILTER .name = 'default::ExtC3'
             """,
             [{
                 'ancestors': [{
-                    'name': 'test::ExtB3',
+                    'name': 'default::ExtB3',
                 }, {
-                    'name': 'test::ExtA3',
+                    'name': 'default::ExtA3',
                 }, {
                     'name': 'std::Object',
                 }, {
@@ -5999,7 +5921,7 @@ type test::Foo {
         )
 
         await self.con.execute(r"""
-            ALTER TYPE test::ExtB3 DROP EXTENDING test::ExtA3;
+            ALTER TYPE ExtB3 DROP EXTENDING ExtA3;
         """)
 
         await self.assert_query_result(
@@ -6009,11 +5931,11 @@ type test::Foo {
                         name
                     } ORDER BY @index
                 }
-                FILTER .name = 'test::ExtC3'
+                FILTER .name = 'default::ExtC3'
             """,
             [{
                 'ancestors': [{
-                    'name': 'test::ExtB3',
+                    'name': 'default::ExtB3',
                 }, {
                     'name': 'std::Object',
                 }, {
@@ -6025,13 +5947,13 @@ type test::Foo {
     async def test_edgeql_ddl_extending_04(self):
         # Check that descendants are recomputed properly on rebase.
         await self.con.execute(r"""
-            CREATE TYPE test::ExtA4 {
+            CREATE TYPE ExtA4 {
                 CREATE PROPERTY a -> int64;
             };
 
             CREATE ABSTRACT INHERITABLE ANNOTATION a_anno;
 
-            CREATE TYPE test::ExtB4 {
+            CREATE TYPE ExtB4 {
                 CREATE PROPERTY a -> int64 {
                     CREATE ANNOTATION a_anno := 'anno';
                 };
@@ -6039,24 +5961,24 @@ type test::Foo {
                 CREATE PROPERTY b -> str;
             };
 
-            CREATE TYPE test::Ext4Child EXTENDING test::ExtA4;
-            CREATE TYPE test::Ext4GrandChild EXTENDING test::Ext4Child;
-            CREATE TYPE test::Ext4GrandGrandChild
-                EXTENDING test::Ext4GrandChild;
+            CREATE TYPE Ext4Child EXTENDING ExtA4;
+            CREATE TYPE Ext4GrandChild EXTENDING Ext4Child;
+            CREATE TYPE Ext4GrandGrandChild
+                EXTENDING Ext4GrandChild;
         """)
 
         await self.assert_query_result(
             r"""
                 SELECT (
                     SELECT schema::ObjectType
-                    FILTER .name = 'test::Ext4Child'
+                    FILTER .name = 'default::Ext4Child'
                 ).properties.name;
             """,
             {'id', 'a'}
         )
 
         await self.con.execute(r"""
-            ALTER TYPE test::Ext4Child EXTENDING test::ExtB4;
+            ALTER TYPE Ext4Child EXTENDING ExtB4;
         """)
 
         for name in {'Ext4Child', 'Ext4GrandChild', 'Ext4GrandGrandChild'}:
@@ -6064,7 +5986,7 @@ type test::Foo {
                 f"""
                     SELECT (
                         SELECT schema::ObjectType
-                        FILTER .name = 'test::{name}'
+                        FILTER .name = 'default::{name}'
                     ).properties.name;
                 """,
                 {'id', 'a', 'b'}
@@ -6075,7 +5997,7 @@ type test::Foo {
                 WITH
                     ggc := (
                         SELECT schema::ObjectType
-                        FILTER .name = 'test::Ext4GrandGrandChild'
+                        FILTER .name = 'default::Ext4GrandGrandChild'
                     )
                 SELECT
                     (SELECT ggc.properties FILTER .name = 'a')
@@ -6085,7 +6007,7 @@ type test::Foo {
         )
 
         await self.con.execute(r"""
-            ALTER TYPE test::Ext4Child DROP EXTENDING test::ExtB4;
+            ALTER TYPE Ext4Child DROP EXTENDING ExtB4;
         """)
 
         for name in {'Ext4Child', 'Ext4GrandChild', 'Ext4GrandGrandChild'}:
@@ -6093,7 +6015,7 @@ type test::Foo {
                 f"""
                     SELECT (
                         SELECT schema::ObjectType
-                        FILTER .name = 'test::{name}'
+                        FILTER .name = 'default::{name}'
                     ).properties.name;
                 """,
                 {'id', 'a'}
@@ -6104,7 +6026,7 @@ type test::Foo {
                 WITH
                     ggc := (
                         SELECT schema::ObjectType
-                        FILTER .name = 'test::Ext4GrandGrandChild'
+                        FILTER .name = 'default::Ext4GrandGrandChild'
                     )
                 SELECT
                     (SELECT ggc.properties FILTER .name = 'a')
@@ -6116,19 +6038,19 @@ type test::Foo {
     async def test_edgeql_ddl_extending_05(self):
         # Check that field alters are propagated.
         await self.con.execute(r"""
-            CREATE TYPE test::ExtA5 {
+            CREATE TYPE ExtA5 {
                 CREATE PROPERTY a -> int64 {
                     SET default := 1;
                 };
             };
 
-            CREATE TYPE test::ExtB5 {
+            CREATE TYPE ExtB5 {
                 CREATE PROPERTY a -> int64 {
                     SET default := 2;
                 };
             };
 
-            CREATE TYPE test::ExtC5 EXTENDING test::ExtB5;
+            CREATE TYPE ExtC5 EXTENDING ExtB5;
         """)
 
         await self.assert_query_result(
@@ -6136,7 +6058,7 @@ type test::Foo {
                 WITH
                     C5 := (
                         SELECT schema::ObjectType
-                        FILTER .name = 'test::ExtC5'
+                        FILTER .name = 'default::ExtC5'
                     )
                 SELECT
                     (SELECT C5.properties FILTER .name = 'a')
@@ -6146,7 +6068,7 @@ type test::Foo {
         )
 
         await self.con.execute(r"""
-            ALTER TYPE test::ExtC5 EXTENDING test::ExtA5 FIRST;
+            ALTER TYPE ExtC5 EXTENDING ExtA5 FIRST;
         """)
 
         await self.assert_query_result(
@@ -6154,7 +6076,7 @@ type test::Foo {
                 WITH
                     C5 := (
                         SELECT schema::ObjectType
-                        FILTER .name = 'test::ExtC5'
+                        FILTER .name = 'default::ExtC5'
                     )
                 SELECT
                     (SELECT C5.properties FILTER .name = 'a')
@@ -6164,7 +6086,7 @@ type test::Foo {
         )
 
         await self.con.execute(r"""
-            ALTER TYPE test::ExtC5 DROP EXTENDING test::ExtA5;
+            ALTER TYPE ExtC5 DROP EXTENDING ExtA5;
         """)
 
         await self.assert_query_result(
@@ -6172,7 +6094,7 @@ type test::Foo {
                 WITH
                     C5 := (
                         SELECT schema::ObjectType
-                        FILTER .name = 'test::ExtC5'
+                        FILTER .name = 'default::ExtC5'
                     )
                 SELECT
                     (SELECT C5.properties FILTER .name = 'a')
@@ -6182,8 +6104,8 @@ type test::Foo {
         )
 
         await self.con.execute(r"""
-            ALTER TYPE test::ExtC5 ALTER PROPERTY a SET REQUIRED;
-            ALTER TYPE test::ExtC5 DROP EXTENDING test::ExtA5;
+            ALTER TYPE ExtC5 ALTER PROPERTY a SET REQUIRED;
+            ALTER TYPE ExtC5 DROP EXTENDING ExtA5;
         """)
 
         await self.assert_query_result(
@@ -6191,7 +6113,7 @@ type test::Foo {
                 WITH
                     C5 := (
                         SELECT schema::ObjectType
-                        FILTER .name = 'test::ExtC5'
+                        FILTER .name = 'default::ExtC5'
                     )
                 SELECT
                     (SELECT C5.properties FILTER .name = 'a')
@@ -6205,7 +6127,7 @@ type test::Foo {
             await self.con.execute(r"""
                 CREATE MODULE test_other;
 
-                CREATE TYPE test::ModuleTest01 {
+                CREATE TYPE ModuleTest01 {
                     CREATE PROPERTY clash -> str;
                 };
 
@@ -6241,15 +6163,15 @@ type test::Foo {
                 }
             };
 
-            CREATE TYPE test::Priority EXTENDING test_other::Named;
+            CREATE TYPE Priority EXTENDING test_other::Named;
 
-            CREATE TYPE test::Status
+            CREATE TYPE Status
                 EXTENDING test_other::UniquelyNamed;
 
-            INSERT test::Priority {name := 'one'};
-            INSERT test::Priority {name := 'two'};
-            INSERT test::Status {name := 'open'};
-            INSERT test::Status {name := 'closed'};
+            INSERT Priority {name := 'one'};
+            INSERT Priority {name := 'two'};
+            INSERT Status {name := 'open'};
+            INSERT Status {name := 'closed'};
         """)
 
         await self.assert_query_result(
@@ -6273,8 +6195,8 @@ type test::Foo {
         )
 
         await self.con.execute("""
-            DROP TYPE test::Status;
-            DROP TYPE test::Priority;
+            DROP TYPE Status;
+            DROP TYPE Priority;
             DROP TYPE test_other::UniquelyNamed;
             DROP TYPE test_other::Named;
             DROP MODULE test_other;
@@ -6308,14 +6230,14 @@ type test::Foo {
             async with self.con.transaction():
                 await self.con.execute(r"""
                     START MIGRATION TO {
-                        type test::Status extending test_other::UniquelyNamed;
+                        type Status extending test_other::UniquelyNamed;
                     };
                     POPULATE MIGRATION;
                     COMMIT MIGRATION;
                 """)
 
             await self.con.execute("""
-                DROP TYPE test::Status;
+                DROP TYPE Status;
             """)
         finally:
             await self.con.execute("""
@@ -6774,33 +6696,33 @@ type test::Foo {
 
     async def test_edgeql_ddl_rename_01(self):
         await self.con.execute(r"""
-            CREATE TYPE test::RenameObj01 {
+            CREATE TYPE RenameObj01 {
                 CREATE PROPERTY name -> str;
             };
 
-            INSERT test::RenameObj01 {name := 'rename 01'};
+            INSERT RenameObj01 {name := 'rename 01'};
 
-            ALTER TYPE test::RenameObj01 {
-                RENAME TO test::NewNameObj01;
+            ALTER TYPE RenameObj01 {
+                RENAME TO NewNameObj01;
             };
         """)
 
         await self.assert_query_result(
             r'''
-                SELECT test::NewNameObj01.name;
+                SELECT NewNameObj01.name;
             ''',
             ['rename 01']
         )
 
     async def test_edgeql_ddl_rename_02(self):
         await self.con.execute(r"""
-            CREATE TYPE test::RenameObj02 {
+            CREATE TYPE RenameObj02 {
                 CREATE PROPERTY name -> str;
             };
 
-            INSERT test::RenameObj02 {name := 'rename 02'};
+            INSERT RenameObj02 {name := 'rename 02'};
 
-            ALTER TYPE test::RenameObj02 {
+            ALTER TYPE RenameObj02 {
                 ALTER PROPERTY name {
                     RENAME TO new_name_02;
                 };
@@ -6809,16 +6731,15 @@ type test::Foo {
 
         await self.assert_query_result(
             r'''
-                SELECT test::RenameObj02.new_name_02;
+                SELECT RenameObj02.new_name_02;
             ''',
             ['rename 02']
         )
 
     async def test_edgeql_ddl_rename_03(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
-            CREATE TYPE test::RenameObj03 {
+            CREATE TYPE RenameObj03 {
                 CREATE PROPERTY name -> str;
             };
 
@@ -6835,29 +6756,29 @@ type test::Foo {
 
         await self.assert_query_result(
             r'''
-                SELECT test::RenameObj03.new_name_03;
+                SELECT RenameObj03.new_name_03;
             ''',
             ['rename 03']
         )
 
     async def test_edgeql_ddl_rename_04(self):
         await self.con.execute("""
-            CREATE ABSTRACT LINK test::rename_link_04 {
+            CREATE ABSTRACT LINK rename_link_04 {
                 CREATE PROPERTY rename_prop_04 -> std::int64;
             };
 
-            CREATE TYPE test::LinkedObj04;
-            CREATE TYPE test::RenameObj04 {
-                CREATE MULTI LINK rename_link_04 EXTENDING test::rename_link_04
-                    -> test::LinkedObj04;
+            CREATE TYPE LinkedObj04;
+            CREATE TYPE RenameObj04 {
+                CREATE MULTI LINK rename_link_04 EXTENDING rename_link_04
+                    -> LinkedObj04;
             };
 
-            INSERT test::LinkedObj04;
-            INSERT test::RenameObj04 {
-                rename_link_04 := test::LinkedObj04 {@rename_prop_04 := 123}
+            INSERT LinkedObj04;
+            INSERT RenameObj04 {
+                rename_link_04 := LinkedObj04 {@rename_prop_04 := 123}
             };
 
-            ALTER ABSTRACT LINK test::rename_link_04 {
+            ALTER ABSTRACT LINK rename_link_04 {
                 ALTER PROPERTY rename_prop_04 {
                     RENAME TO new_prop_04;
                 };
@@ -6866,30 +6787,30 @@ type test::Foo {
 
         await self.assert_query_result(
             r'''
-                SELECT test::RenameObj04.rename_link_04@new_prop_04;
+                SELECT RenameObj04.rename_link_04@new_prop_04;
             ''',
             [123]
         )
 
     async def test_edgeql_ddl_rename_05(self):
         await self.con.execute("""
-            CREATE TYPE test::GrandParent01 {
+            CREATE TYPE GrandParent01 {
                 CREATE PROPERTY foo -> int64;
             };
 
-            CREATE TYPE test::Parent01 EXTENDING test::GrandParent01;
-            CREATE TYPE test::Parent02 EXTENDING test::GrandParent01;
+            CREATE TYPE Parent01 EXTENDING GrandParent01;
+            CREATE TYPE Parent02 EXTENDING GrandParent01;
 
-            CREATE TYPE test::Child EXTENDING test::Parent01, test::Parent02;
+            CREATE TYPE Child EXTENDING Parent01, Parent02;
 
-            ALTER TYPE test::GrandParent01 {
+            ALTER TYPE GrandParent01 {
                 ALTER PROPERTY foo RENAME TO renamed;
             };
         """)
 
         await self.assert_query_result(
             r'''
-                SELECT test::Child.renamed;
+                SELECT Child.renamed;
             ''',
             []
         )
@@ -6899,76 +6820,76 @@ type test::Foo {
                 edgedb.SchemaDefinitionError,
                 "cannot rename inherited property 'foo'"):
             await self.con.execute("""
-                CREATE TYPE test::Parent01 {
+                CREATE TYPE Parent01 {
                     CREATE PROPERTY foo -> int64;
                 };
 
-                CREATE TYPE test::Parent02 {
+                CREATE TYPE Parent02 {
                     CREATE PROPERTY foo -> int64;
                 };
 
-                CREATE TYPE test::Child
-                    EXTENDING test::Parent01, test::Parent02;
+                CREATE TYPE Child
+                    EXTENDING Parent01, Parent02;
 
-                ALTER TYPE test::Parent02 {
+                ALTER TYPE Parent02 {
                     ALTER PROPERTY foo RENAME TO renamed;
                 };
             """)
 
     async def test_edgeql_ddl_rename_07(self):
         await self.con.execute("""
-            CREATE TYPE test::Foo;
+            CREATE TYPE Foo;
 
-            CREATE TYPE test::Bar {
-                CREATE MULTI LINK foo -> test::Foo {
-                    SET default := (SELECT test::Foo);
+            CREATE TYPE Bar {
+                CREATE MULTI LINK foo -> Foo {
+                    SET default := (SELECT Foo);
                 }
             };
 
-            ALTER TYPE test::Foo RENAME TO test::FooRenamed;
+            ALTER TYPE Foo RENAME TO FooRenamed;
         """)
 
     async def test_edgeql_ddl_rename_abs_ptr_01(self):
         await self.con.execute("""
-            CREATE ABSTRACT LINK test::abs_link {
+            CREATE ABSTRACT LINK abs_link {
                 CREATE PROPERTY prop -> std::int64;
             };
 
-            CREATE TYPE test::LinkedObj;
-            CREATE TYPE test::RenameObj {
-                CREATE MULTI LINK link EXTENDING test::abs_link
-                    -> test::LinkedObj;
+            CREATE TYPE LinkedObj;
+            CREATE TYPE RenameObj {
+                CREATE MULTI LINK link EXTENDING abs_link
+                    -> LinkedObj;
             };
 
-            INSERT test::LinkedObj;
-            INSERT test::RenameObj {
-                link := test::LinkedObj {@prop := 123}
+            INSERT LinkedObj;
+            INSERT RenameObj {
+                link := LinkedObj {@prop := 123}
             };
         """)
 
         await self.con.execute("""
-            ALTER ABSTRACT LINK test::abs_link
-            RENAME TO test::new_abs_link;
+            ALTER ABSTRACT LINK abs_link
+            RENAME TO new_abs_link;
         """)
 
         await self.assert_query_result(
             r'''
-                SELECT test::RenameObj.link@prop;
+                SELECT RenameObj.link@prop;
             ''',
             [123]
         )
 
         # Check we can create a new type that uses it
         await self.con.execute("""
-            CREATE TYPE test::RenameObj2 {
-                CREATE MULTI LINK link EXTENDING test::new_abs_link
-                    -> test::LinkedObj;
+            CREATE TYPE RenameObj2 {
+                CREATE MULTI LINK link EXTENDING new_abs_link
+                    -> LinkedObj;
             };
         """)
 
         # Check we can create a new link with the same name
         await self.con.execute("""
-            CREATE ABSTRACT LINK test::abs_link {
+            CREATE ABSTRACT LINK abs_link {
                 CREATE PROPERTY prop -> std::int64;
             };
         """)
@@ -6976,42 +6897,42 @@ type test::Foo {
         await self.con.execute("""
             CREATE MODULE foo;
 
-            ALTER ABSTRACT LINK test::new_abs_link
+            ALTER ABSTRACT LINK new_abs_link
             RENAME TO foo::new_abs_link2;
         """)
 
         await self.con.execute("""
-            ALTER TYPE test::RenameObj DROP LINK link;
-            ALTER TYPE test::RenameObj2 DROP LINK link;
+            ALTER TYPE RenameObj DROP LINK link;
+            ALTER TYPE RenameObj2 DROP LINK link;
             DROP ABSTRACT LINK foo::new_abs_link2;
         """)
 
     async def test_edgeql_ddl_rename_abs_ptr_02(self):
         await self.con.execute("""
-            CREATE ABSTRACT PROPERTY test::abs_prop {
+            CREATE ABSTRACT PROPERTY abs_prop {
                 CREATE ANNOTATION title := "lol";
             };
 
-            CREATE TYPE test::RenameObj {
-                CREATE PROPERTY prop EXTENDING test::abs_prop -> str;
+            CREATE TYPE RenameObj {
+                CREATE PROPERTY prop EXTENDING abs_prop -> str;
             };
         """)
 
         await self.con.execute("""
-            ALTER ABSTRACT PROPERTY test::abs_prop
-            RENAME TO test::new_abs_prop;
+            ALTER ABSTRACT PROPERTY abs_prop
+            RENAME TO new_abs_prop;
         """)
 
         # Check we can create a new type that uses it
         await self.con.execute("""
-            CREATE TYPE test::RenameObj2 {
-                CREATE PROPERTY prop EXTENDING test::new_abs_prop -> str;
+            CREATE TYPE RenameObj2 {
+                CREATE PROPERTY prop EXTENDING new_abs_prop -> str;
             };
         """)
 
         # Check we can create a new prop with the same name
         await self.con.execute("""
-            CREATE ABSTRACT PROPERTY test::abs_prop {
+            CREATE ABSTRACT PROPERTY abs_prop {
                 CREATE ANNOTATION title := "lol";
             };
         """)
@@ -7019,19 +6940,19 @@ type test::Foo {
         await self.con.execute("""
             CREATE MODULE foo;
 
-            ALTER ABSTRACT PROPERTY test::new_abs_prop
+            ALTER ABSTRACT PROPERTY new_abs_prop
             RENAME TO foo::new_abs_prop2;
         """)
 
         await self.con.execute("""
-            ALTER TYPE test::RenameObj DROP PROPERTY prop;
-            ALTER TYPE test::RenameObj2 DROP PROPERTY prop;
+            ALTER TYPE RenameObj DROP PROPERTY prop;
+            ALTER TYPE RenameObj2 DROP PROPERTY prop;
             DROP ABSTRACT PROPERTY foo::new_abs_prop2;
         """)
 
     async def test_edgeql_ddl_rename_annotated_01(self):
         await self.con.execute("""
-            CREATE TYPE test::RenameObj {
+            CREATE TYPE RenameObj {
                 CREATE PROPERTY prop -> str {
                    CREATE ANNOTATION title := "lol";
                 }
@@ -7039,7 +6960,7 @@ type test::Foo {
         """)
 
         await self.con.execute("""
-            ALTER TYPE test::RenameObj {
+            ALTER TYPE RenameObj {
                 ALTER PROPERTY prop RENAME TO prop2;
             };
         """)
@@ -7047,17 +6968,16 @@ type test::Foo {
     async def test_edgeql_ddl_delete_abs_link_01(self):
         # test deleting a trivial abstract link
         await self.con.execute("""
-            CREATE ABSTRACT LINK test::abs_link;
+            CREATE ABSTRACT LINK abs_link;
         """)
 
         await self.con.execute("""
-            DROP ABSTRACT LINK test::abs_link;
+            DROP ABSTRACT LINK abs_link;
         """)
 
     async def test_edgeql_ddl_alias_01(self):
         # Issue #1184
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE User {
                 CREATE REQUIRED PROPERTY name -> str;
@@ -7109,7 +7029,6 @@ type test::Foo {
     async def test_edgeql_ddl_alias_02(self):
         # Issue #1184
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE User {
                 CREATE REQUIRED PROPERTY name -> str;
@@ -7161,20 +7080,20 @@ type test::Foo {
 
     async def test_edgeql_ddl_alias_03(self):
         await self.con.execute(r"""
-            CREATE ALIAS test::RenameAlias03 := (
+            CREATE ALIAS RenameAlias03 := (
                 SELECT BaseObject {
                     alias_computable := 'rename alias 03'
                 }
             );
 
-            ALTER ALIAS test::RenameAlias03 {
-                RENAME TO test::NewAlias03;
+            ALTER ALIAS RenameAlias03 {
+                RENAME TO NewAlias03;
             };
         """)
 
         await self.assert_query_result(
             r'''
-                SELECT test::NewAlias03.alias_computable LIMIT 1;
+                SELECT NewAlias03.alias_computable LIMIT 1;
             ''',
             ['rename alias 03']
         )
@@ -7182,7 +7101,7 @@ type test::Foo {
         await self.con.execute(r"""
             CREATE MODULE foo;
 
-            ALTER ALIAS test::NewAlias03 {
+            ALTER ALIAS NewAlias03 {
                 RENAME TO foo::NewAlias03;
             };
         """)
@@ -7200,33 +7119,32 @@ type test::Foo {
 
     async def test_edgeql_ddl_alias_04(self):
         await self.con.execute(r"""
-            CREATE ALIAS test::DupAlias04_1 := BaseObject {
+            CREATE ALIAS DupAlias04_1 := BaseObject {
                 foo := 'hello world 04'
             };
 
             # create an identical alias with a different name
-            CREATE ALIAS test::DupAlias04_2 := BaseObject {
+            CREATE ALIAS DupAlias04_2 := BaseObject {
                 foo := 'hello world 04'
             };
         """)
 
         await self.assert_query_result(
             r'''
-                SELECT test::DupAlias04_1.foo LIMIT 1;
+                SELECT DupAlias04_1.foo LIMIT 1;
             ''',
             ['hello world 04']
         )
 
         await self.assert_query_result(
             r'''
-                SELECT test::DupAlias04_2.foo LIMIT 1;
+                SELECT DupAlias04_2.foo LIMIT 1;
             ''',
             ['hello world 04']
         )
 
     async def test_edgeql_ddl_alias_05(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE BaseType05 {
                 CREATE PROPERTY name -> str;
@@ -7268,7 +7186,6 @@ type test::Foo {
     async def test_edgeql_ddl_alias_06(self):
         # Issue #1184
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE BaseType06 {
                 CREATE PROPERTY name -> str;
@@ -7341,17 +7258,15 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "illegal self-reference in definition of "
-                "'test::IllegalAlias07'"):
+                "'default::IllegalAlias07'"):
 
             await self.con.execute(r"""
-                WITH MODULE test
                 CREATE ALIAS IllegalAlias07 := Object {a := IllegalAlias07};
             """)
 
     async def test_edgeql_ddl_alias_08(self):
         # Issue #1184
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE BaseType08 {
                 CREATE PROPERTY name -> str;
@@ -7401,7 +7316,7 @@ type test::Foo {
 
     async def test_edgeql_ddl_alias_09(self):
         await self.con.execute(r"""
-            CREATE ALIAS test::CreateAlias09 := (
+            CREATE ALIAS CreateAlias09 := (
                 SELECT BaseObject {
                     alias_computable := 'rename alias 03'
                 }
@@ -7410,37 +7325,37 @@ type test::Foo {
 
         async with self.assertRaisesRegexTx(
             edgedb.InvalidLinkTargetError,
-            "invalid link type: 'test::CreateAlias09' is an expression alias,"
+            "invalid link type: 'default::CreateAlias09' is an expression alias,"
             " not a proper object type",
         ):
             await self.con.execute(r"""
-                CREATE TYPE test::AliasType09 {
-                    CREATE OPTIONAL SINGLE LINK a -> test::CreateAlias09;
+                CREATE TYPE AliasType09 {
+                    CREATE OPTIONAL SINGLE LINK a -> CreateAlias09;
                 }
             """)
 
     async def test_edgeql_ddl_inheritance_alter_01(self):
         await self.con.execute(r"""
-            CREATE TYPE test::InhTest01 {
+            CREATE TYPE InhTest01 {
                 CREATE PROPERTY testp -> int64;
             };
 
-            CREATE TYPE test::InhTest01_child EXTENDING test::InhTest01;
+            CREATE TYPE InhTest01_child EXTENDING InhTest01;
         """)
 
         await self.con.execute("""
-            ALTER TYPE test::InhTest01 {
+            ALTER TYPE InhTest01 {
                 DROP PROPERTY testp;
             }
         """)
 
     async def test_edgeql_ddl_inheritance_alter_02(self):
         await self.con.execute(r"""
-            CREATE TYPE test::InhTest01 {
+            CREATE TYPE InhTest01 {
                 CREATE PROPERTY testp -> int64;
             };
 
-            CREATE TYPE test::InhTest01_child EXTENDING test::InhTest01;
+            CREATE TYPE InhTest01_child EXTENDING InhTest01;
         """)
 
         with self.assertRaisesRegex(
@@ -7448,41 +7363,41 @@ type test::Foo {
                 "cannot drop inherited property 'testp'"):
 
             await self.con.execute("""
-                ALTER TYPE test::InhTest01_child {
+                ALTER TYPE InhTest01_child {
                     DROP PROPERTY testp;
                 }
             """)
 
     async def test_edgeql_ddl_inheritance_alter_03(self):
         await self.con.execute(r"""
-            CREATE TYPE test::Owner;
+            CREATE TYPE Owner;
 
-            CREATE TYPE test::Stuff1 {
+            CREATE TYPE Stuff1 {
                 # same link name, but NOT related via explicit inheritance
-                CREATE LINK owner -> test::Owner
+                CREATE LINK owner -> Owner
             };
 
-            CREATE TYPE test::Stuff2 {
+            CREATE TYPE Stuff2 {
                 # same link name, but NOT related via explicit inheritance
-                CREATE LINK owner -> test::Owner
+                CREATE LINK owner -> Owner
             };
         """)
 
         await self.assert_query_result("""
-            SELECT test::Owner.<owner;
+            SELECT Owner.<owner;
         """, [])
 
     async def test_edgeql_ddl_inheritance_alter_04(self):
         await self.con.execute(r"""
-            CREATE TYPE test::InhTest04 {
+            CREATE TYPE InhTest04 {
                 CREATE PROPERTY testp -> int64;
             };
 
-            CREATE TYPE test::InhTest04_child EXTENDING test::InhTest04;
+            CREATE TYPE InhTest04_child EXTENDING InhTest04;
         """)
 
         await self.con.execute(r"""
-            ALTER TYPE test::InhTest04_child {
+            ALTER TYPE InhTest04_child {
                 ALTER PROPERTY testp {
                     SET default := 42;
                 };
@@ -7498,7 +7413,7 @@ type test::Foo {
                     }
                     FILTER .name = 'testp',
                 }
-                FILTER .name = 'test::InhTest04_child';
+                FILTER .name = 'default::InhTest04_child';
             """,
             [{
                 'properties': [{
@@ -7512,13 +7427,13 @@ type test::Foo {
         # Test that the inherited constraint doesn't end up with some
         # bad name like 'default::std::exclusive'.
         await self.con.execute(r"""
-            CREATE ABSTRACT TYPE test::BaseTypeCon01;
-            CREATE TYPE test::TypeCon01 EXTENDING test::BaseTypeCon01;
-            ALTER TYPE test::BaseTypeCon01
+            CREATE ABSTRACT TYPE BaseTypeCon01;
+            CREATE TYPE TypeCon01 EXTENDING BaseTypeCon01;
+            ALTER TYPE BaseTypeCon01
                 CREATE SINGLE PROPERTY name -> std::str;
             # make sure that we can create a constraint in the base
             # type now
-            ALTER TYPE test::BaseTypeCon01
+            ALTER TYPE BaseTypeCon01
                 ALTER PROPERTY name
                     CREATE DELEGATED CONSTRAINT exclusive;
         """)
@@ -7535,11 +7450,11 @@ type test::Foo {
                     }
                 } FILTER .name = 'name'
             }
-            FILTER .name LIKE 'test::%TypeCon01'
+            FILTER .name LIKE 'default::%TypeCon01'
             ORDER BY .name;
         """, [
             {
-                'name': 'test::BaseTypeCon01',
+                'name': 'default::BaseTypeCon01',
                 'properties': [{
                     'name': 'name',
                     'constraints': [{
@@ -7549,7 +7464,7 @@ type test::Foo {
                 }]
             },
             {
-                'name': 'test::TypeCon01',
+                'name': 'default::TypeCon01',
                 'properties': [{
                     'name': 'name',
                     'constraints': [{
@@ -7578,7 +7493,7 @@ type test::Foo {
     async def test_edgeql_ddl_constraint_03(self):
         # Test for #1727. Usage of EXISTS in constraints.
         await self.con.execute(r"""
-            CREATE TYPE test::TypeCon03 {
+            CREATE TYPE TypeCon03 {
                 CREATE PROPERTY name -> str {
                     # emulating "required"
                     CREATE CONSTRAINT expression ON (EXISTS __subject__)
@@ -7587,7 +7502,7 @@ type test::Foo {
         """)
 
         await self.con.execute("""
-            INSERT test::TypeCon03 {name := 'OK'};
+            INSERT TypeCon03 {name := 'OK'};
         """)
 
         with self.assertRaisesRegex(
@@ -7595,7 +7510,7 @@ type test::Foo {
                 r'invalid name'):
             async with self.con.transaction():
                 await self.con.execute("""
-                    INSERT test::TypeCon03;
+                    INSERT TypeCon03;
                 """)
 
     @test.xfail('''
@@ -7604,7 +7519,7 @@ type test::Foo {
     async def test_edgeql_ddl_constraint_04(self):
         # Test for #1727. Usage of EXISTS in constraints.
         await self.con.execute(r"""
-            CREATE TYPE test::TypeCon04 {
+            CREATE TYPE TypeCon04 {
                 CREATE MULTI PROPERTY name -> str {
                     # emulating "required"
                     CREATE CONSTRAINT expression ON (EXISTS __subject__)
@@ -7613,7 +7528,7 @@ type test::Foo {
         """)
 
         await self.con.execute("""
-            INSERT test::TypeCon04 {name := 'OK'};
+            INSERT TypeCon04 {name := 'OK'};
         """)
 
         with self.assertRaisesRegex(
@@ -7621,7 +7536,7 @@ type test::Foo {
                 r'invalid name'):
             async with self.con.transaction():
                 await self.con.execute("""
-                    INSERT test::TypeCon04 {name := {}};
+                    INSERT TypeCon04 {name := {}};
                 """)
 
         with self.assertRaisesRegex(
@@ -7629,15 +7544,15 @@ type test::Foo {
                 r'invalid name'):
             async with self.con.transaction():
                 await self.con.execute("""
-                    INSERT test::TypeCon04;
+                    INSERT TypeCon04;
                 """)
 
     async def test_edgeql_ddl_constraint_05(self):
         # Test for #1727. Usage of EXISTS in constraints.
         await self.con.execute(r"""
-            CREATE TYPE test::Child05;
-            CREATE TYPE test::TypeCon05 {
-                CREATE LINK child -> test::Child05 {
+            CREATE TYPE Child05;
+            CREATE TYPE TypeCon05 {
+                CREATE LINK child -> Child05 {
                     # emulating "required"
                     CREATE CONSTRAINT expression ON (EXISTS __subject__)
                 }
@@ -7645,8 +7560,8 @@ type test::Foo {
         """)
 
         await self.con.execute("""
-            INSERT test::Child05;
-            INSERT test::TypeCon05 {child := (SELECT test::Child05 LIMIT 1)};
+            INSERT Child05;
+            INSERT TypeCon05 {child := (SELECT Child05 LIMIT 1)};
         """)
 
         with self.assertRaisesRegex(
@@ -7654,7 +7569,7 @@ type test::Foo {
                 r'invalid child'):
             async with self.con.transaction():
                 await self.con.execute("""
-                    INSERT test::TypeCon05;
+                    INSERT TypeCon05;
                 """)
 
     @test.xfail('''
@@ -7663,9 +7578,9 @@ type test::Foo {
     async def test_edgeql_ddl_constraint_06(self):
         # Test for #1727. Usage of EXISTS in constraints.
         await self.con.execute(r"""
-            CREATE TYPE test::Child06;
-            CREATE TYPE test::TypeCon06 {
-                CREATE MULTI LINK children -> test::Child06 {
+            CREATE TYPE Child06;
+            CREATE TYPE TypeCon06 {
+                CREATE MULTI LINK children -> Child06 {
                     # emulating "required"
                     CREATE CONSTRAINT expression ON (EXISTS __subject__)
                 }
@@ -7673,8 +7588,8 @@ type test::Foo {
         """)
 
         await self.con.execute("""
-            INSERT test::Child06;
-            INSERT test::TypeCon06 {children := test::Child06};
+            INSERT Child06;
+            INSERT TypeCon06 {children := Child06};
         """)
 
         with self.assertRaisesRegex(
@@ -7682,15 +7597,15 @@ type test::Foo {
                 r'invalid children'):
             async with self.con.transaction():
                 await self.con.execute("""
-                    INSERT test::TypeCon06;
+                    INSERT TypeCon06;
                 """)
 
     async def test_edgeql_ddl_constraint_07(self):
         # Test for #1727. Usage of EXISTS in constraints.
         await self.con.execute(r"""
-            CREATE TYPE test::Child07;
-            CREATE TYPE test::TypeCon07 {
-                CREATE LINK child -> test::Child07 {
+            CREATE TYPE Child07;
+            CREATE TYPE TypeCon07 {
+                CREATE LINK child -> Child07 {
                     CREATE PROPERTY index -> int64;
                     # emulating "required"
                     CREATE CONSTRAINT expression ON (EXISTS __subject__@index)
@@ -7699,9 +7614,9 @@ type test::Foo {
         """)
 
         await self.con.execute("""
-            INSERT test::Child07;
-            INSERT test::TypeCon07 {
-                child := (SELECT test::Child07 LIMIT 1){@index := 0}
+            INSERT Child07;
+            INSERT TypeCon07 {
+                child := (SELECT Child07 LIMIT 1){@index := 0}
             };
         """)
 
@@ -7710,35 +7625,34 @@ type test::Foo {
                 r'invalid child'):
             async with self.con.transaction():
                 await self.con.execute("""
-                    INSERT test::TypeCon07 {
-                        child := (SELECT test::Child07 LIMIT 1)
+                    INSERT TypeCon07 {
+                        child := (SELECT Child07 LIMIT 1)
                     };
                 """)
 
     async def test_edgeql_ddl_constraint_08(self):
         # Test non-delegated object constraints on abstract types
         await self.con.execute(r"""
-            CREATE TYPE test::Base {
+            CREATE TYPE Base {
                 CREATE PROPERTY x -> str {
                     CREATE CONSTRAINT exclusive;
                 }
             };
-            CREATE TYPE test::Foo EXTENDING test::Base;
-            CREATE TYPE test::Bar EXTENDING test::Base;
+            CREATE TYPE Foo EXTENDING Base;
+            CREATE TYPE Bar EXTENDING Base;
 
-            INSERT test::Foo { x := "a" };
+            INSERT Foo { x := "a" };
         """)
 
         with self.assertRaisesRegex(
                 edgedb.ConstraintViolationError,
                 r'violates exclusivity constraint'):
             await self.con.execute(r"""
-                INSERT test::Foo { x := "a" };
+                INSERT Foo { x := "a" };
             """)
 
     async def test_edgeql_ddl_constraint_09(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE ABSTRACT TYPE Text {
                 CREATE REQUIRED SINGLE PROPERTY body -> str {
@@ -7756,7 +7670,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_constraint_10(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE ABSTRACT TYPE Text {
                 CREATE REQUIRED SINGLE PROPERTY body -> str {
@@ -7773,7 +7686,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_constraint_11(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE ABSTRACT TYPE Text {
                 CREATE REQUIRED SINGLE PROPERTY body -> str {
@@ -7828,17 +7740,17 @@ type test::Foo {
 
     async def test_edgeql_ddl_constraint_alter_01(self):
         await self.con.execute(r"""
-            CREATE TYPE test::ConTest01 {
+            CREATE TYPE ConTest01 {
                 CREATE PROPERTY con_test -> int64;
             };
 
-            ALTER TYPE test::ConTest01
+            ALTER TYPE ConTest01
                 ALTER PROPERTY con_test
                     CREATE CONSTRAINT min_value(0);
         """)
 
         await self.con.execute("""
-            ALTER TYPE test::ConTest01
+            ALTER TYPE ConTest01
                 ALTER PROPERTY con_test
                     DROP CONSTRAINT min_value(0);
         """)
@@ -7852,10 +7764,10 @@ type test::Foo {
                     constraints: { name }
                 } FILTER .name = 'con_test'
             }
-            FILTER .name = 'test::ConTest01';
+            FILTER .name = 'default::ConTest01';
         """, [
             {
-                'name': 'test::ConTest01',
+                'name': 'default::ConTest01',
                 'properties': [{
                     'name': 'con_test',
                     'constraints': {},
@@ -7867,13 +7779,13 @@ type test::Foo {
         # Create constraint, then add and drop annotation for it. This
         # is similar to `test_edgeql_ddl_annotation_06`.
         await self.con.execute(r'''
-            CREATE SCALAR TYPE test::contest2_t EXTENDING int64 {
+            CREATE SCALAR TYPE contest2_t EXTENDING int64 {
                 CREATE CONSTRAINT expression ON (__subject__ > 0);
             };
         ''')
 
         await self.con.execute(r'''
-            ALTER SCALAR TYPE test::contest2_t {
+            ALTER SCALAR TYPE contest2_t {
                 ALTER CONSTRAINT expression ON (__subject__ > 0) {
                     CREATE ANNOTATION title := 'my constraint 2'
                 }
@@ -7893,7 +7805,7 @@ type test::Foo {
                     }
                 }
                 FILTER
-                    .name = 'test::contest2_t';
+                    .name = 'default::contest2_t';
             ''',
             [{
                 "constraints": [{
@@ -7907,7 +7819,7 @@ type test::Foo {
         )
 
         await self.con.execute(r'''
-            ALTER SCALAR TYPE test::contest2_t {
+            ALTER SCALAR TYPE contest2_t {
                 ALTER CONSTRAINT expression ON (__subject__ > 0) {
                     DROP ANNOTATION title;
                 }
@@ -7927,7 +7839,7 @@ type test::Foo {
                     }
                 }
                 FILTER
-                    .name = 'test::contest2_t';
+                    .name = 'default::contest2_t';
             ''',
             [{
                 "constraints": [{
@@ -7941,7 +7853,7 @@ type test::Foo {
         # Create constraint annotation using DDL, then drop annotation
         # using SDL. This is similar to `test_edgeql_ddl_annotation_07`.
         await self.con.execute(r'''
-            CREATE SCALAR TYPE test::contest3_t EXTENDING int64 {
+            CREATE SCALAR TYPE contest3_t EXTENDING int64 {
                 CREATE CONSTRAINT expression ON (__subject__ > 0) {
                     CREATE ANNOTATION title := 'my constraint 3';
                 }
@@ -7961,7 +7873,7 @@ type test::Foo {
                     }
                 }
                 FILTER
-                    .name = 'test::contest3_t';
+                    .name = 'default::contest3_t';
             ''',
             [{
                 "constraints": [{
@@ -7993,7 +7905,7 @@ type test::Foo {
                     }
                 }
                 FILTER
-                    .name = 'test::contest3_t';
+                    .name = 'default::contest3_t';
             ''',
             [{
                 "constraints": [{
@@ -8008,7 +7920,7 @@ type test::Foo {
         # using SDL. This tests how "on expr" is handled. This is
         # similar to `test_edgeql_ddl_annotation_08`.
         await self.con.execute(r'''
-            CREATE SCALAR TYPE test::contest4_t EXTENDING int64 {
+            CREATE SCALAR TYPE contest4_t EXTENDING int64 {
                 CREATE CONSTRAINT expression ON (__subject__ > 0);
             };
         ''')
@@ -8026,7 +7938,7 @@ type test::Foo {
                     }
                 }
                 FILTER
-                    .name = 'test::contest4_t';
+                    .name = 'default::contest4_t';
             ''',
             [{
                 "constraints": [{
@@ -8057,7 +7969,7 @@ type test::Foo {
                     }
                 }
                 FILTER
-                    .name = 'test::contest4_t';
+                    .name = 'default::contest4_t';
             ''',
             [{
                 "constraints": [{
@@ -8092,26 +8004,26 @@ type test::Foo {
 
     async def test_edgeql_ddl_drop_inherited_link(self):
         await self.con.execute(r"""
-            CREATE TYPE test::Target;
-            CREATE TYPE test::Parent {
-                CREATE LINK dil_foo -> test::Target;
+            CREATE TYPE Target;
+            CREATE TYPE Parent {
+                CREATE LINK dil_foo -> Target;
             };
 
-            CREATE TYPE test::Child EXTENDING test::Parent;
-            CREATE TYPE test::GrandChild EXTENDING test::Child;
+            CREATE TYPE Child EXTENDING Parent;
+            CREATE TYPE GrandChild EXTENDING Child;
        """)
 
         await self.con.execute("""
-            ALTER TYPE test::Parent DROP LINK dil_foo;
+            ALTER TYPE Parent DROP LINK dil_foo;
         """)
 
     async def test_edgeql_ddl_drop_01(self):
         # Check that constraints defined on scalars being dropped are
         # dropped.
         await self.con.execute("""
-            CREATE SCALAR TYPE test::a1 EXTENDING std::str;
+            CREATE SCALAR TYPE a1 EXTENDING std::str;
 
-            ALTER SCALAR TYPE test::a1 {
+            ALTER SCALAR TYPE a1 {
                 CREATE CONSTRAINT std::one_of('a', 'b') {
                     CREATE ANNOTATION description :=
                         'test_delta_drop_01_constraint';
@@ -8135,7 +8047,7 @@ type test::Foo {
         )
 
         await self.con.execute("""
-            DROP SCALAR TYPE test::a1;
+            DROP SCALAR TYPE a1;
         """)
 
         await self.assert_query_result(
@@ -8153,7 +8065,7 @@ type test::Foo {
         # Check that links defined on types being dropped are
         # dropped.
         await self.con.execute("""
-            CREATE TYPE test::C1 {
+            CREATE TYPE C1 {
                 CREATE PROPERTY l1 -> std::str {
                     CREATE ANNOTATION description := 'test_delta_drop_02_link';
                 };
@@ -8176,7 +8088,7 @@ type test::Foo {
         )
 
         await self.con.execute("""
-            DROP TYPE test::C1;
+            DROP TYPE C1;
         """)
 
         await self.assert_query_result(
@@ -8192,63 +8104,63 @@ type test::Foo {
 
     async def test_edgeql_ddl_drop_03(self):
         await self.con.execute("""
-            CREATE TYPE test::Foo {
+            CREATE TYPE Foo {
                 CREATE REQUIRED SINGLE PROPERTY name -> std::str;
             };
         """)
         await self.con.execute("""
-            CREATE TYPE test::Bar {
-                CREATE OPTIONAL SINGLE LINK lol -> test::Foo {
+            CREATE TYPE Bar {
+                CREATE OPTIONAL SINGLE LINK lol -> Foo {
                     CREATE PROPERTY note -> str;
                 };
             };
         """)
 
         await self.con.execute("""
-            DROP TYPE test::Bar;
+            DROP TYPE Bar;
         """)
 
     async def test_edgeql_ddl_drop_refuse_01(self):
         # Check that the schema refuses to drop objects with live references
         await self.con.execute("""
-            CREATE TYPE test::DropA;
-            CREATE ABSTRACT ANNOTATION test::dropattr;
-            CREATE ABSTRACT LINK test::l1_parent;
-            CREATE TYPE test::DropB {
-                CREATE LINK l1 EXTENDING test::l1_parent -> test::DropA {
-                    CREATE ANNOTATION test::dropattr := 'foo';
+            CREATE TYPE DropA;
+            CREATE ABSTRACT ANNOTATION dropattr;
+            CREATE ABSTRACT LINK l1_parent;
+            CREATE TYPE DropB {
+                CREATE LINK l1 EXTENDING l1_parent -> DropA {
+                    CREATE ANNOTATION dropattr := 'foo';
                 };
             };
-            CREATE SCALAR TYPE test::dropint EXTENDING int64;
-            CREATE FUNCTION test::dropfunc(a: test::dropint) -> int64
+            CREATE SCALAR TYPE dropint EXTENDING int64;
+            CREATE FUNCTION dropfunc(a: dropint) -> int64
                 USING EdgeQL $$ SELECT a $$;
         """)
 
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaError,
-                'cannot drop object type.*test::DropA.*other objects'):
-            await self.con.execute('DROP TYPE test::DropA')
+                'cannot drop object type.*DropA.*other objects'):
+            await self.con.execute('DROP TYPE DropA')
 
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaError,
-                'cannot drop abstract anno.*test::dropattr.*other objects'):
-            await self.con.execute('DROP ABSTRACT ANNOTATION test::dropattr')
+                'cannot drop abstract anno.*dropattr.*other objects'):
+            await self.con.execute('DROP ABSTRACT ANNOTATION dropattr')
 
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaError,
-                'cannot drop abstract link.*test::l1_parent.*other objects'):
-            await self.con.execute('DROP ABSTRACT LINK test::l1_parent')
+                'cannot drop abstract link.*l1_parent.*other objects'):
+            await self.con.execute('DROP ABSTRACT LINK l1_parent')
 
         async with self.assertRaisesRegexTx(
                 edgedb.SchemaError,
                 'cannot drop.*dropint.*other objects'):
-            await self.con.execute('DROP SCALAR TYPE test::dropint')
+            await self.con.execute('DROP SCALAR TYPE dropint')
 
     async def test_edgeql_ddl_unicode_01(self):
         await self.con.execute(r"""
             # setup delta
             START MIGRATION TO {
-                module test {
+                module default {
                     type Пример {
                         required property номер -> int16;
                     };
@@ -8256,7 +8168,6 @@ type test::Foo {
             };
             POPULATE MIGRATION;
             COMMIT MIGRATION;
-            SET MODULE test;
 
             INSERT Пример {
                 номер := 987
@@ -8280,14 +8191,14 @@ type test::Foo {
 
     async def test_edgeql_ddl_tuple_properties(self):
         await self.con.execute(r"""
-            CREATE TYPE test::TupProp01 {
+            CREATE TYPE TupProp01 {
                 CREATE PROPERTY p1 -> tuple<int64, str>;
                 CREATE PROPERTY p2 -> tuple<foo: int64, bar: str>;
                 CREATE PROPERTY p3 -> tuple<foo: int64,
                                             bar: tuple<json, json>>;
             };
 
-            CREATE TYPE test::TupProp02 {
+            CREATE TYPE TupProp02 {
                 CREATE PROPERTY p1 -> tuple<int64, str>;
                 CREATE PROPERTY p2 -> tuple<json, json>;
             };
@@ -8296,13 +8207,13 @@ type test::Foo {
         # Drop identical p1 properties from both objects,
         # to check positive refcount.
         await self.con.execute(r"""
-            ALTER TYPE test::TupProp01 {
+            ALTER TYPE TupProp01 {
                 DROP PROPERTY p1;
             };
         """)
 
         await self.con.execute(r"""
-            ALTER TYPE test::TupProp02 {
+            ALTER TYPE TupProp02 {
                 DROP PROPERTY p1;
             };
         """)
@@ -8310,7 +8221,7 @@ type test::Foo {
         # Re-create the property to check that the associated
         # composite type was actually removed.
         await self.con.execute(r"""
-            ALTER TYPE test::TupProp02 {
+            ALTER TYPE TupProp02 {
                 CREATE PROPERTY p1 -> tuple<int64, str>;
             };
         """)
@@ -8318,28 +8229,28 @@ type test::Foo {
         # Now, drop the property that has a nested tuple that
         # is referred to directly by another property.
         await self.con.execute(r"""
-            ALTER TYPE test::TupProp01 {
+            ALTER TYPE TupProp01 {
                 DROP PROPERTY p3;
             };
         """)
 
         # Drop the last user.
         await self.con.execute(r"""
-            ALTER TYPE test::TupProp02 {
+            ALTER TYPE TupProp02 {
                 DROP PROPERTY p2;
             };
         """)
 
         # Re-create to assure cleanup.
         await self.con.execute(r"""
-            ALTER TYPE test::TupProp02 {
+            ALTER TYPE TupProp02 {
                 CREATE PROPERTY p3 -> tuple<json, json>;
                 CREATE PROPERTY p4 -> tuple<a: json, b: json>;
             };
         """)
 
         await self.con.execute(r"""
-            ALTER TYPE test::TupProp02 {
+            ALTER TYPE TupProp02 {
                 CREATE PROPERTY p5 -> array<tuple<int64>>;
             };
         """)
@@ -8351,8 +8262,8 @@ type test::Foo {
                 'expected a scalar type, or a scalar collection'):
 
             await self.con.execute(r"""
-                ALTER TYPE test::TupProp02 {
-                    CREATE PROPERTY p6 -> tuple<test::TupProp02>;
+                ALTER TYPE TupProp02 {
+                    CREATE PROPERTY p6 -> tuple<TupProp02>;
                 };
             """)
 
@@ -8361,7 +8272,7 @@ type test::Foo {
 
     async def test_edgeql_ddl_enum_01(self):
         await self.con.execute('''
-            CREATE SCALAR TYPE test::my_enum EXTENDING enum<'foo', 'bar'>;
+            CREATE SCALAR TYPE my_enum EXTENDING enum<'foo', 'bar'>;
         ''')
 
         await self.assert_query_result(
@@ -8369,7 +8280,7 @@ type test::Foo {
                 SELECT schema::ScalarType {
                     enum_values,
                 }
-                FILTER .name = 'test::my_enum';
+                FILTER .name = 'default::my_enum';
             """,
             [{
                 'enum_values': ['foo', 'bar'],
@@ -8377,8 +8288,8 @@ type test::Foo {
         )
 
         await self.con.execute('''
-            CREATE TYPE test::EnumHost {
-                CREATE PROPERTY foo -> test::my_enum;
+            CREATE TYPE EnumHost {
+                CREATE PROPERTY foo -> my_enum;
             }
         ''')
 
@@ -8388,7 +8299,7 @@ type test::Foo {
                 edgedb.SchemaError,
                 'enumeration must be the only supertype specified'):
             await self.con.execute('''
-                CREATE SCALAR TYPE test::my_enum_2
+                CREATE SCALAR TYPE my_enum_2
                     EXTENDING enum<'foo', 'bar'>,
                     std::int32;
             ''')
@@ -8396,7 +8307,7 @@ type test::Foo {
         await self.con.query('ROLLBACK TO SAVEPOINT t0;')
 
         await self.con.execute('''
-            CREATE SCALAR TYPE test::my_enum_2
+            CREATE SCALAR TYPE my_enum_2
                 EXTENDING enum<'foo', 'bar'>;
         ''')
 
@@ -8406,7 +8317,7 @@ type test::Foo {
                 edgedb.UnsupportedFeatureError,
                 'constraints cannot be defined on enumerated type.*'):
             await self.con.execute('''
-                CREATE SCALAR TYPE test::my_enum_3
+                CREATE SCALAR TYPE my_enum_3
                     EXTENDING enum<'foo', 'bar', 'baz'> {
                     CREATE CONSTRAINT expression ON (EXISTS(__subject__))
                 };
@@ -8416,13 +8327,13 @@ type test::Foo {
         await self.con.query('ROLLBACK TO SAVEPOINT t1;')
 
         await self.con.execute('''
-            ALTER SCALAR TYPE test::my_enum_2
-                RENAME TO test::my_enum_3;
+            ALTER SCALAR TYPE my_enum_2
+                RENAME TO my_enum_3;
         ''')
 
         await self.con.execute('''
             CREATE MODULE foo;
-            ALTER SCALAR TYPE test::my_enum_3
+            ALTER SCALAR TYPE my_enum_3
                 RENAME TO foo::my_enum_4;
         ''')
 
@@ -8432,25 +8343,25 @@ type test::Foo {
 
     async def test_edgeql_ddl_enum_02(self):
         await self.con.execute('''
-            CREATE SCALAR TYPE test::my_enum EXTENDING enum<'foo', 'bar'>;
+            CREATE SCALAR TYPE my_enum EXTENDING enum<'foo', 'bar'>;
         ''')
 
         await self.con.execute('''
-            CREATE TYPE test::Obj {
-                CREATE PROPERTY e -> test::my_enum {
-                    SET default := <test::my_enum>'foo';
+            CREATE TYPE Obj {
+                CREATE PROPERTY e -> my_enum {
+                    SET default := <my_enum>'foo';
                 }
             }
         ''')
 
         await self.con.execute('''
             CREATE MODULE foo;
-            ALTER SCALAR TYPE test::my_enum
+            ALTER SCALAR TYPE my_enum
                 RENAME TO foo::my_enum_2;
         ''')
 
         await self.con.execute('''
-            DROP TYPE test::Obj;
+            DROP TYPE Obj;
             DROP SCALAR TYPE foo::my_enum_2;
         ''')
 
@@ -8459,13 +8370,13 @@ type test::Foo {
                 edgedb.SchemaDefinitionError,
                 'enums cannot contain duplicate values'):
             await self.con.execute('''
-                CREATE SCALAR TYPE test::Color
+                CREATE SCALAR TYPE Color
                     EXTENDING enum<Red, Green, Blue, Red>;
             ''')
 
     async def test_edgeql_ddl_enum_04(self):
         await self.con.execute('''
-            CREATE SCALAR TYPE test::Color
+            CREATE SCALAR TYPE Color
                 EXTENDING enum<Red, Green, Blue>;
         ''')
 
@@ -8475,7 +8386,7 @@ type test::Foo {
                 edgedb.SchemaError,
                 'cannot DROP EXTENDING enum'):
             await self.con.execute('''
-                ALTER SCALAR TYPE test::Color
+                ALTER SCALAR TYPE Color
                     DROP EXTENDING enum<Red, Green, Blue>;
             ''')
 
@@ -8486,7 +8397,7 @@ type test::Foo {
                 edgedb.SchemaError,
                 'enumeration must be the only supertype specified'):
             await self.con.execute('''
-                ALTER SCALAR TYPE test::Color EXTENDING str FIRST;
+                ALTER SCALAR TYPE Color EXTENDING str FIRST;
             ''')
 
         # Recover.
@@ -8497,7 +8408,7 @@ type test::Foo {
                 'cannot add another enum as supertype, '
                 'use EXTENDING without position qualification'):
             await self.con.execute('''
-                ALTER SCALAR TYPE test::Color
+                ALTER SCALAR TYPE Color
                     EXTENDING enum<Bad> LAST;
             ''')
 
@@ -8508,7 +8419,7 @@ type test::Foo {
                 edgedb.SchemaError,
                 'cannot set more than one enum as supertype'):
             await self.con.execute('''
-                ALTER SCALAR TYPE test::Color
+                ALTER SCALAR TYPE Color
                     EXTENDING enum<Bad>, enum<AlsoBad>;
             ''')
 
@@ -8519,7 +8430,7 @@ type test::Foo {
                 edgedb.SchemaError,
                 'enums cannot contain duplicate values'):
             await self.con.execute('''
-                ALTER SCALAR TYPE test::Color
+                ALTER SCALAR TYPE Color
                     EXTENDING enum<Red, Green, Blue, Red>;
             ''')
 
@@ -8527,7 +8438,7 @@ type test::Foo {
         await self.con.query('ROLLBACK TO SAVEPOINT t0;')
 
         await self.con.execute(r'''
-            ALTER SCALAR TYPE test::Color
+            ALTER SCALAR TYPE Color
                 EXTENDING enum<Red, Green, Blue, Magic>;
         ''')
         # Commit the changes and start a new transaction for more testing.
@@ -8535,57 +8446,57 @@ type test::Foo {
         await self.con.query("START TRANSACTION")
         await self.assert_query_result(
             r"""
-                SELECT <test::Color>'Magic' >
-                    <test::Color>'Red';
+                SELECT <Color>'Magic' >
+                    <Color>'Red';
             """,
             [True],
         )
 
         await self.con.execute('''
-            DROP SCALAR TYPE test::Color;
+            DROP SCALAR TYPE Color;
         ''')
         await self.con.query("COMMIT")
 
     async def test_edgeql_ddl_enum_05(self):
         await self.con.execute('''
-            CREATE SCALAR TYPE test::Color
+            CREATE SCALAR TYPE Color
                 EXTENDING enum<Red, Green, Blue>;
 
-             CREATE FUNCTION test::asdf(x: test::Color) -> str USING (
+             CREATE FUNCTION asdf(x: Color) -> str USING (
                  <str>(x));
-             CREATE FUNCTION test::asdf2() -> str USING (
-                 test::asdf(<test::Color>'Red'));
+             CREATE FUNCTION asdf2() -> str USING (
+                 asdf(<Color>'Red'));
 
-             CREATE TYPE test::Entry {
+             CREATE TYPE Entry {
                  CREATE PROPERTY num -> int64;
-                 CREATE PROPERTY color -> test::Color;
-                 CREATE PROPERTY colors -> array<test::Color>;
+                 CREATE PROPERTY color -> Color;
+                 CREATE PROPERTY colors -> array<Color>;
                  CREATE CONSTRAINT expression ON (
-                     <str>.num != test::asdf2()
+                     <str>.num != asdf2()
                  );
-                 CREATE INDEX ON (test::asdf(.color));
+                 CREATE INDEX ON (asdf(.color));
                  CREATE PROPERTY lol -> str {
-                     SET default := test::asdf2();
+                     SET default := asdf2();
                  }
              };
-             INSERT test::Entry { num := 1, color := "Red" };
-             INSERT test::Entry {
+             INSERT Entry { num := 1, color := "Red" };
+             INSERT Entry {
                  num := 2, color := "Green", colors := ["Red", "Green"] };
         ''')
 
         await self.con.execute('''
-            ALTER SCALAR TYPE test::Color
+            ALTER SCALAR TYPE Color
                 EXTENDING enum<Red, Green>;
         ''')
 
         await self.con.execute('''
-            ALTER SCALAR TYPE test::Color
+            ALTER SCALAR TYPE Color
                 EXTENDING enum<Green, Red>;
         ''')
 
         await self.assert_query_result(
             r"""
-                SELECT test::Entry { num, color } ORDER BY .color;
+                SELECT Entry { num, color } ORDER BY .color;
             """,
             [
                 {'num': 2, 'color': 'Green'},
@@ -8597,13 +8508,13 @@ type test::Foo {
                 edgedb.InvalidValueError,
                 'invalid input value for enum'):
             await self.con.execute('''
-                ALTER SCALAR TYPE test::Color
+                ALTER SCALAR TYPE Color
                     EXTENDING enum<Green>;
             ''')
 
     async def test_edgeql_ddl_explicit_id(self):
         await self.con.execute('''
-            CREATE TYPE test::ExID {
+            CREATE TYPE ExID {
                 SET id := <uuid>'00000000-0000-0000-0000-0000feedbeef'
             };
         ''')
@@ -8613,7 +8524,7 @@ type test::Foo {
                 SELECT schema::ObjectType {
                     id
                 }
-                FILTER .name = 'test::ExID';
+                FILTER .name = 'default::ExID';
             """,
             [{
                 'id': '00000000-0000-0000-0000-0000feedbeef',
@@ -8624,27 +8535,27 @@ type test::Foo {
                 edgedb.SchemaDefinitionError,
                 'cannot alter object id'):
             await self.con.execute('''
-                ALTER TYPE test::ExID {
+                ALTER TYPE ExID {
                     SET id := <uuid>'00000000-0000-0000-0000-0000feedbeef'
                 }
             ''')
 
     async def test_edgeql_ddl_quoting_01(self):
         await self.con.execute("""
-            CREATE TYPE test::`U S``E R` {
+            CREATE TYPE `U S``E R` {
                 CREATE PROPERTY `n ame` -> str;
             };
         """)
 
         await self.con.execute("""
-            INSERT test::`U S``E R` {
+            INSERT `U S``E R` {
                 `n ame` := 'quoting_01'
             };
         """)
 
         await self.assert_query_result(
             r"""
-                SELECT test::`U S``E R` {
+                SELECT `U S``E R` {
                     __type__: {
                         name
                     },
@@ -8652,13 +8563,13 @@ type test::Foo {
                 };
             """,
             [{
-                '__type__': {'name': 'test::U S`E R'},
+                '__type__': {'name': 'default::U S`E R'},
                 'n ame': 'quoting_01'
             }],
         )
 
         await self.con.execute("""
-            DROP TYPE test::`U S``E R`;
+            DROP TYPE `U S``E R`;
         """)
 
     async def test_edgeql_ddl_link_overload_01(self):
@@ -8691,11 +8602,10 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'foo' of "
-                "object type 'test::Derived': it is defined as True in "
-                "property 'foo' of object type 'test::Derived' and as "
-                "False in property 'foo' of object type 'test::Base'."):
+                "object type 'default::Derived': it is defined as True in "
+                "property 'foo' of object type 'default::Derived' and as "
+                "False in property 'foo' of object type 'default::Base'."):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base {
                     CREATE PROPERTY foo -> str;
@@ -8713,11 +8623,10 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'foo' of "
-                "object type 'test::Derived': it is defined as False in "
-                "property 'foo' of object type 'test::Derived' and as "
-                "True in property 'foo' of object type 'test::Base'."):
+                "object type 'default::Derived': it is defined as False in "
+                "property 'foo' of object type 'default::Derived' and as "
+                "True in property 'foo' of object type 'default::Base'."):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base {
                     CREATE PROPERTY foo -> str {
@@ -8737,11 +8646,10 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'foo' of "
-                "object type 'test::Derived': it is defined as False in "
-                "property 'foo' of object type 'test::Base0' and as "
-                "True in property 'foo' of object type 'test::Base1'."):
+                "object type 'default::Derived': it is defined as False in "
+                "property 'foo' of object type 'default::Base0' and as "
+                "True in property 'foo' of object type 'default::Base1'."):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base0 {
                     CREATE PROPERTY foo -> str;
@@ -8758,7 +8666,6 @@ type test::Foo {
         # Test that read-only flag must be consistent in the
         # inheritance hierarchy.
         await self.con.execute('''
-            SET MODULE test;
 
             CREATE TYPE Base0 {
                 CREATE PROPERTY foo -> str;
@@ -8772,9 +8679,9 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'foo' of "
-                "object type 'test::Derived': it is defined as False in "
-                "property 'foo' of object type 'test::Base0' and as "
-                "True in property 'foo' of object type 'test::Base1'."):
+                "object type 'default::Derived': it is defined as False in "
+                "property 'foo' of object type 'default::Base0' and as "
+                "True in property 'foo' of object type 'default::Base1'."):
             await self.con.execute('''
                 ALTER TYPE Base1 {
                     ALTER PROPERTY foo {
@@ -8789,11 +8696,10 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of link 'foo' of "
-                "object type 'test::Derived': it is defined as True in "
-                "link 'foo' of object type 'test::Derived' and as "
-                "False in link 'foo' of object type 'test::Base'."):
+                "object type 'default::Derived': it is defined as True in "
+                "link 'foo' of object type 'default::Derived' and as "
+                "False in link 'foo' of object type 'default::Base'."):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base {
                     CREATE LINK foo -> Object;
@@ -8811,11 +8717,10 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of link 'foo' of "
-                "object type 'test::Derived': it is defined as False in "
-                "link 'foo' of object type 'test::Derived' and as "
-                "True in link 'foo' of object type 'test::Base'."):
+                "object type 'default::Derived': it is defined as False in "
+                "link 'foo' of object type 'default::Derived' and as "
+                "True in link 'foo' of object type 'default::Base'."):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base {
                     CREATE LINK foo -> Object {
@@ -8835,11 +8740,10 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of link 'foo' of "
-                "object type 'test::Derived': it is defined as False in "
-                "link 'foo' of object type 'test::Base0' and as "
-                "True in link 'foo' of object type 'test::Base1'."):
+                "object type 'default::Derived': it is defined as False in "
+                "link 'foo' of object type 'default::Base0' and as "
+                "True in link 'foo' of object type 'default::Base1'."):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base0 {
                     CREATE LINK foo -> Object;
@@ -8856,7 +8760,6 @@ type test::Foo {
         # Test that read-only flag must be consistent in the
         # inheritance hierarchy.
         await self.con.execute('''
-            SET MODULE test;
 
             CREATE TYPE Base0 {
                 CREATE LINK foo -> Object;
@@ -8870,9 +8773,9 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of link 'foo' of "
-                "object type 'test::Derived': it is defined as False in "
-                "link 'foo' of object type 'test::Base0' and as "
-                "True in link 'foo' of object type 'test::Base1'."):
+                "object type 'default::Derived': it is defined as False in "
+                "link 'foo' of object type 'default::Base0' and as "
+                "True in link 'foo' of object type 'default::Base1'."):
             await self.con.execute('''
                 ALTER TYPE Base1 {
                     ALTER LINK foo {
@@ -8887,12 +8790,11 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'bar' of "
-                "link 'foo' of object type 'test::Derived': it is defined "
+                "link 'foo' of object type 'default::Derived': it is defined "
                 "as True in property 'bar' of link 'foo' of object type "
-                "'test::Derived' and as False in property 'bar' of link "
-                "'foo' of object type 'test::Base'."):
+                "'default::Derived' and as False in property 'bar' of link "
+                "'foo' of object type 'default::Base'."):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base {
                     CREATE LINK foo -> Object {
@@ -8914,12 +8816,11 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'bar' of "
-                "link 'foo' of object type 'test::Derived': it is defined "
+                "link 'foo' of object type 'default::Derived': it is defined "
                 "as False in property 'bar' of link 'foo' of object type "
-                "'test::Derived' and as True in property 'bar' of link "
-                "'foo' of object type 'test::Base'."):
+                "'default::Derived' and as True in property 'bar' of link "
+                "'foo' of object type 'default::Base'."):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base {
                     CREATE LINK foo -> Object {
@@ -8943,12 +8844,11 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'bar' of "
-                "link 'foo' of object type 'test::Derived': it is defined "
+                "link 'foo' of object type 'default::Derived': it is defined "
                 "as False in property 'bar' of link 'foo' of object type "
-                "'test::Base0' and as True in property 'bar' of link "
-                "'foo' of object type 'test::Base1'."):
+                "'default::Base0' and as True in property 'bar' of link "
+                "'foo' of object type 'default::Base1'."):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base0 {
                     CREATE LINK foo -> Object {
@@ -8969,7 +8869,6 @@ type test::Foo {
         # Test that read-only flag must be consistent in the
         # inheritance hierarchy.
         await self.con.execute('''
-            SET MODULE test;
 
             CREATE TYPE Base0 {
                 CREATE LINK foo -> Object {
@@ -8987,10 +8886,10 @@ type test::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "cannot redefine the readonly flag of property 'bar' of "
-                "link 'foo' of object type 'test::Derived': it is defined "
+                "link 'foo' of object type 'default::Derived': it is defined "
                 "as False in property 'bar' of link 'foo' of object type "
-                "'test::Base0' and as True in property 'bar' of link "
-                "'foo' of object type 'test::Base1'."):
+                "'default::Base0' and as True in property 'bar' of link "
+                "'foo' of object type 'default::Base1'."):
             await self.con.execute('''
                 ALTER TYPE Base1 {
                     ALTER LINK foo {
@@ -9009,7 +8908,6 @@ type test::Foo {
             "cannot make.*optional",
         ):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base {
                     CREATE REQUIRED PROPERTY foo -> str;
@@ -9030,7 +8928,6 @@ type test::Foo {
             "cannot make.*optional",
         ):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base {
                     CREATE REQUIRED PROPERTY foo -> str;
@@ -9050,7 +8947,6 @@ type test::Foo {
             "cannot make.*optional",
         ):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base {
                     CREATE REQUIRED LINK foo -> Object;
@@ -9071,7 +8967,6 @@ type test::Foo {
             "cannot make.*optional",
         ):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base {
                     CREATE REQUIRED LINK foo -> Object;
@@ -9091,7 +8986,6 @@ type test::Foo {
             "cannot make.*optional",
         ):
             await self.con.execute('''
-                SET MODULE test;
 
                 CREATE TYPE Base {
                     CREATE OPTIONAL LINK foo -> Object;
@@ -9110,7 +9004,6 @@ type test::Foo {
         # Test normal that required qualifier behavior.
 
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Base {
                 CREATE REQUIRED PROPERTY foo -> str;
@@ -9127,7 +9020,7 @@ type test::Foo {
         with self.assertRaisesRegex(
             edgedb.MissingRequiredError,
             f"missing value for required property"
-            r" 'foo' of object type 'test::Base'",
+            r" 'foo' of object type 'default::Base'",
         ):
             async with self.con.transaction():
                 await self.con.execute("""
@@ -9137,7 +9030,7 @@ type test::Foo {
         with self.assertRaisesRegex(
             edgedb.MissingRequiredError,
             f"missing value for required property"
-            r" 'foo' of object type 'test::Derived'",
+            r" 'foo' of object type 'default::Derived'",
         ):
             async with self.con.transaction():
                 await self.con.execute("""
@@ -9165,7 +9058,7 @@ type test::Foo {
         with self.assertRaisesRegex(
             edgedb.MissingRequiredError,
             f"missing value for required property"
-            r" 'foo' of object type 'test::Derived'",
+            r" 'foo' of object type 'default::Derived'",
         ):
             async with self.con.transaction():
                 await self.con.execute("""
@@ -9194,7 +9087,6 @@ type test::Foo {
         # Test normal that required qualifier behavior.
 
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Base {
                 CREATE OPTIONAL PROPERTY foo -> str;
@@ -9211,7 +9103,7 @@ type test::Foo {
         with self.assertRaisesRegex(
             edgedb.MissingRequiredError,
             f"missing value for required property"
-            r" 'foo' of object type 'test::Derived'",
+            r" 'foo' of object type 'default::Derived'",
         ):
             async with self.con.transaction():
                 await self.con.execute("""
@@ -9231,7 +9123,7 @@ type test::Foo {
         with self.assertRaisesRegex(
             edgedb.MissingRequiredError,
             f"missing value for required property"
-            r" 'foo' of object type 'test::Derived'",
+            r" 'foo' of object type 'default::Derived'",
         ):
             async with self.con.transaction():
                 await self.con.execute("""
@@ -9260,7 +9152,7 @@ type test::Foo {
         # Test normal that required qualifier behavior.
 
         await self.con.execute(r"""
-            CREATE TYPE test::Base {
+            CREATE TYPE Base {
                 CREATE REQUIRED MULTI PROPERTY name -> str;
             };
         """)
@@ -9268,32 +9160,32 @@ type test::Foo {
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             r"missing value for required property 'name'"
-            r" of object type 'test::Base'",
+            r" of object type 'default::Base'",
         ):
             async with self.con.transaction():
                 await self.con.execute("""
-                    INSERT test::Base;
+                    INSERT Base;
                 """)
 
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             r"missing value for required property 'name'"
-            r" of object type 'test::Base'",
+            r" of object type 'default::Base'",
         ):
             async with self.con.transaction():
                 await self.con.execute("""
-                    INSERT test::Base {name := {}};
+                    INSERT Base {name := {}};
                 """)
 
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             r"missing value for required property 'name'"
-            r" of object type 'test::Base'",
+            r" of object type 'default::Base'",
         ):
             async with self.con.transaction():
                 await self.con.execute("""
                     WITH names := {'A', 'B'}
-                    INSERT test::Base {
+                    INSERT Base {
                         name := (SELECT names FILTER names = 'C'),
                     };
                 """)
@@ -9302,41 +9194,41 @@ type test::Foo {
         # Test normal that required qualifier behavior.
 
         await self.con.execute(r"""
-            CREATE TYPE test::Child;
-            CREATE TYPE test::Base {
-                CREATE REQUIRED MULTI LINK children -> test::Child;
+            CREATE TYPE Child;
+            CREATE TYPE Base {
+                CREATE REQUIRED MULTI LINK children -> Child;
             };
         """)
 
         with self.assertRaisesRegex(
             edgedb.MissingRequiredError,
             r"missing value for required link 'children'"
-            r" of object type 'test::Base'"
+            r" of object type 'default::Base'"
         ):
             async with self.con.transaction():
                 await self.con.execute("""
-                    INSERT test::Base;
+                    INSERT Base;
                 """)
 
         with self.assertRaisesRegex(
             edgedb.MissingRequiredError,
             r"missing value for required link 'children'"
-            r" of object type 'test::Base'"
+            r" of object type 'default::Base'"
         ):
             async with self.con.transaction():
                 await self.con.execute("""
-                    INSERT test::Base {children := {}};
+                    INSERT Base {children := {}};
                 """)
 
         with self.assertRaisesRegex(
             edgedb.MissingRequiredError,
             r"missing value for required link 'children'"
-            r" of object type 'test::Base'"
+            r" of object type 'default::Base'"
         ):
             async with self.con.transaction():
                 await self.con.execute("""
-                    INSERT test::Base {
-                        children := (SELECT test::Child FILTER false)
+                    INSERT Base {
+                        children := (SELECT Child FILTER false)
                     };
                 """)
 
@@ -9388,12 +9280,10 @@ type test::Foo {
 
     async def test_edgeql_ddl_errors_01(self):
         await self.con.execute('''
-            WITH MODULE test
             CREATE TYPE Err1 {
                 CREATE REQUIRED PROPERTY foo -> str;
             };
 
-            WITH MODULE test
             ALTER TYPE Err1
             CREATE REQUIRED LINK bar -> Err1;
         ''')
@@ -9403,7 +9293,6 @@ type test::Foo {
                     edgedb.errors.InvalidReferenceError,
                     "property 'b' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1 ALTER PROPERTY b
                     CREATE CONSTRAINT std::regexp(r'b');
                 ''')
@@ -9413,16 +9302,14 @@ type test::Foo {
                     edgedb.errors.InvalidReferenceError,
                     "property 'b' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1 DROP PROPERTY b
                 ''')
 
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                     edgedb.errors.InvalidReferenceError,
-                    "constraint 'test::a' does not exist"):
+                    "constraint 'default::a' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1 ALTER PROPERTY foo
                     DROP CONSTRAINT a;
                 ''')
@@ -9430,9 +9317,8 @@ type test::Foo {
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                     edgedb.errors.InvalidReferenceError,
-                    "constraint 'test::a' does not exist"):
+                    "constraint 'default::a' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1 ALTER PROPERTY foo
                     ALTER CONSTRAINT a ON (foo > 0) {
                         CREATE ANNOTATION title := 'test'
@@ -9444,7 +9330,6 @@ type test::Foo {
                     edgedb.errors.InvalidReferenceError,
                     "annotation 'std::title' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1 ALTER PROPERTY foo
                     ALTER ANNOTATION title := 'aaa'
                 ''')
@@ -9454,7 +9339,6 @@ type test::Foo {
                     edgedb.errors.InvalidReferenceError,
                     "annotation 'std::title' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1 ALTER PROPERTY foo
                     DROP ANNOTATION title;
                 ''')
@@ -9464,7 +9348,6 @@ type test::Foo {
                     edgedb.errors.InvalidReferenceError,
                     "annotation 'std::title' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1
                     ALTER ANNOTATION title := 'aaa'
                 ''')
@@ -9474,7 +9357,6 @@ type test::Foo {
                     edgedb.errors.InvalidReferenceError,
                     "annotation 'std::title' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1
                     DROP ANNOTATION title
                 ''')
@@ -9483,10 +9365,9 @@ type test::Foo {
             with self.assertRaisesRegex(
                 edgedb.errors.InvalidReferenceError,
                 r"index on \(.foo\) does not exist on"
-                r" object type 'test::Err1'",
+                r" object type 'default::Err1'",
             ):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1
                     DROP INDEX ON (.foo)
                 ''')
@@ -9494,10 +9375,9 @@ type test::Foo {
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                 edgedb.errors.InvalidReferenceError,
-                r"index on \(.zz\) does not exist on object type 'test::Err1'",
+                r"index on \(.zz\) does not exist on object type 'default::Err1'",
             ):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1
                     DROP INDEX ON (.zz)
                 ''')
@@ -9505,9 +9385,8 @@ type test::Foo {
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                     edgedb.errors.InvalidReferenceError,
-                    "object type 'test::Err1' has no link or property 'zz'"):
+                    "object type 'default::Err1' has no link or property 'zz'"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1
                     CREATE INDEX ON (.zz)
                 ''')
@@ -9515,9 +9394,8 @@ type test::Foo {
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                     edgedb.errors.InvalidReferenceError,
-                    "object type 'test::Err1' has no link or property 'zz'"):
+                    "object type 'default::Err1' has no link or property 'zz'"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1
                     CREATE INDEX ON ((.foo, .zz))
                 ''')
@@ -9525,9 +9403,8 @@ type test::Foo {
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                     edgedb.errors.InvalidReferenceError,
-                    "object type 'test::blah' does not exist"):
+                    "object type 'default::blah' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     CREATE TYPE Err1 EXTENDING blah {
                         CREATE PROPERTY foo -> str;
                     };
@@ -9536,10 +9413,9 @@ type test::Foo {
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                     edgedb.errors.InvalidReferenceError,
-                    "object type 'test::blah' does not exist"):
+                    "object type 'default::blah' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
-                    CREATE TYPE Err2 EXTENDING test::blah {
+                    CREATE TYPE Err2 EXTENDING blah {
                         CREATE PROPERTY foo -> str;
                     };
                 ''')
@@ -9549,7 +9425,6 @@ type test::Foo {
                     edgedb.errors.InvalidReferenceError,
                     "link 'b' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1 ALTER LINK b
                     CREATE CONSTRAINT std::regexp(r'b');
                 ''')
@@ -9559,7 +9434,6 @@ type test::Foo {
                     edgedb.errors.InvalidReferenceError,
                     "link 'b' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1 DROP LINK b;
                 ''')
 
@@ -9568,7 +9442,6 @@ type test::Foo {
                     edgedb.errors.InvalidReferenceError,
                     "annotation 'std::title' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1 ALTER LINK bar
                     DROP ANNOTATION title;
                 ''')
@@ -9578,7 +9451,6 @@ type test::Foo {
                     edgedb.errors.InvalidReferenceError,
                     "constraint 'std::min_value' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1 ALTER LINK bar
                     DROP CONSTRAINT min_value(0);
                 ''')
@@ -9588,7 +9460,6 @@ type test::Foo {
                     edgedb.errors.InvalidReferenceError,
                     "property 'spam' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err1
                     ALTER LINK bar
                     DROP PROPERTY spam;
@@ -9601,12 +9472,10 @@ type test::Foo {
     ''')
     async def test_edgeql_ddl_errors_02(self):
         await self.con.execute('''
-            WITH MODULE test
             CREATE TYPE Err2 {
                 CREATE REQUIRED PROPERTY foo -> str;
             };
 
-            WITH MODULE test
             ALTER TYPE Err2
             CREATE REQUIRED LINK bar -> Err2;
         ''')
@@ -9616,7 +9485,6 @@ type test::Foo {
                     edgedb.errors.InvalidReferenceError,
                     "link 'foo' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER TYPE Err2
                     ALTER LINK foo
                     DROP PROPERTY spam;
@@ -9626,9 +9494,8 @@ type test::Foo {
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                     edgedb.errors.InvalidReferenceError,
-                    "function 'test::foo___1' does not exist"):
+                    "function 'default::foo___1' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     ALTER FUNCTION foo___1(a: int64)
                     SET volatility := 'Stable';
                 ''')
@@ -9636,9 +9503,8 @@ type test::Foo {
         async with self._run_and_rollback():
             with self.assertRaisesRegex(
                     edgedb.errors.InvalidReferenceError,
-                    "function 'test::foo___1' does not exist"):
+                    "function 'default::foo___1' does not exist"):
                 await self.con.execute('''
-                    WITH MODULE test
                     DROP FUNCTION foo___1(a: int64);
                 ''')
 
@@ -9665,7 +9531,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_naked_backlink_in_computable(self):
         await self.con.execute('''
-            SET MODULE test;
             CREATE TYPE User {
                 CREATE PROPERTY name -> str {
                     CREATE CONSTRAINT exclusive;
@@ -9688,7 +9553,8 @@ type test::Foo {
         await self.assert_query_result(
             '''
             WITH
-                User := (SELECT schema::ObjectType FILTER .name = 'test::User')
+                User := (SELECT schema::ObjectType
+                         FILTER .name = 'default::User')
             SELECT
                 User.pointers {
                     target: {
@@ -9707,21 +9573,20 @@ type test::Foo {
 
         await self.assert_query_result(
             '''
-            WITH MODULE test
             SELECT _ := User.authored.__type__.name
             ORDER BY _
             ''',
-            ['test::Post', 'test::Video']
+            ['default::Post', 'default::Video']
         )
 
     async def test_edgeql_ddl_change_module_01(self):
         await self.con.execute("""
             CREATE MODULE foo;
 
-            CREATE TYPE test::Note {
+            CREATE TYPE Note {
                 CREATE PROPERTY note -> str;
             };
-            ALTER TYPE test::Note RENAME TO foo::Note;
+            ALTER TYPE Note RENAME TO foo::Note;
             DROP TYPE foo::Note;
         """)
 
@@ -9729,12 +9594,12 @@ type test::Foo {
         await self.con.execute("""
             CREATE MODULE foo;
 
-            CREATE TYPE test::Parent {
+            CREATE TYPE Parent {
                 CREATE PROPERTY note -> str;
             };
-            CREATE TYPE test::Sub EXTENDING test::Parent;
-            ALTER TYPE test::Parent RENAME TO foo::Parent;
-            DROP TYPE test::Sub;
+            CREATE TYPE Sub EXTENDING Parent;
+            ALTER TYPE Parent RENAME TO foo::Parent;
+            DROP TYPE Sub;
             DROP TYPE foo::Parent;
         """)
 
@@ -9742,12 +9607,12 @@ type test::Foo {
         await self.con.execute("""
             CREATE MODULE foo;
 
-            CREATE TYPE test::Note {
+            CREATE TYPE Note {
                 CREATE PROPERTY note -> str {
                     CREATE CONSTRAINT exclusive;
                 }
             };
-            ALTER TYPE test::Note RENAME TO foo::Note;
+            ALTER TYPE Note RENAME TO foo::Note;
             DROP TYPE foo::Note;
         """)
 
@@ -9755,29 +9620,29 @@ type test::Foo {
         await self.con.execute("""
             CREATE MODULE foo;
 
-            CREATE TYPE test::Tag;
+            CREATE TYPE Tag;
 
-            CREATE TYPE test::Note {
-                CREATE SINGLE LINK tags -> test::Tag {
+            CREATE TYPE Note {
+                CREATE SINGLE LINK tags -> Tag {
                     ON TARGET DELETE DELETE SOURCE;
                 }
             };
 
-            INSERT test::Note { tags := (INSERT test::Tag) };
+            INSERT Note { tags := (INSERT Tag) };
         """)
 
         await self.con.execute("""
-            ALTER TYPE test::Tag RENAME TO foo::Tag;
+            ALTER TYPE Tag RENAME TO foo::Tag;
             DELETE foo::Tag FILTER true;
         """)
 
         await self.assert_query_result(
-            """SELECT test::Note;""",
+            """SELECT Note;""",
             [],
         )
 
         await self.con.execute("""
-            ALTER TYPE test::Note RENAME TO foo::Note;
+            ALTER TYPE Note RENAME TO foo::Note;
             DROP TYPE foo::Note;
             DROP TYPE foo::Tag;
         """)
@@ -9802,12 +9667,10 @@ type test::Foo {
 
         """
         await self.con.execute(f"""
-            WITH MODULE test
             CREATE TYPE Note {{
                 CREATE PROPERTY note -> str;
             }};
 
-            WITH MODULE test
             {ddl.lstrip()}
         """)
 
@@ -9816,7 +9679,6 @@ type test::Foo {
             "ALTER PROPERTY note RENAME TO remark;" if rename_prop else "")
 
         await self.con.execute(f"""
-            WITH MODULE test
             ALTER TYPE Note {{
                 {type_rename.lstrip()}
                 {prop_rename.lstrip()}
@@ -9825,12 +9687,12 @@ type test::Foo {
         if rename_module:
             await self.con.execute(f"""
             CREATE MODULE foo;
-            ALTER TYPE test::Note RENAME TO foo::Note;
+            ALTER TYPE Note RENAME TO foo::Note;
             """)
 
         else:
             res = await self.con.query_one("""
-                DESCRIBE MODULE test
+                DESCRIBE MODULE default
             """)
 
             total_type = 1 + type_refs
@@ -9848,9 +9710,8 @@ type test::Foo {
             if rename_type:
                 cleanup = cleanup.replace("Note", "Remark")
             if rename_module:
-                cleanup = cleanup.replace("test", "foo")
+                cleanup = cleanup.replace("default", "foo")
             await self.con.execute(f"""
-                WITH MODULE test
                 {cleanup.lstrip()}
             """)
 
@@ -9885,7 +9746,7 @@ type test::Foo {
                                (SELECT Note.note LIMIT 1)))
             }
             """,
-            """DROP FUNCTION foo(x: test::Note);""",
+            """DROP FUNCTION foo(x: default::Note);""",
             type_extra=1,
             prop_extra=1,
             type_refs=2,
@@ -9896,40 +9757,35 @@ type test::Foo {
         # Test renaming two types that appear as function arguments at
         # the same time.
         await self.con.execute("""
-            WITH MODULE test
             CREATE TYPE Note {
                 CREATE PROPERTY note -> str;
             };
 
-            WITH MODULE test
             CREATE TYPE Name {
                 CREATE PROPERTY name -> str;
             };
 
-            WITH MODULE test
             CREATE FUNCTION foo(x: Note, y: Name) -> str {
                 USING (SELECT (x.note ++ " " ++ y.name))
             };
         """)
 
         await self.con.execute("""
-            WITH MODULE test
             INSERT Note { note := "hello" }
         """)
         await self.con.execute("""
-            WITH MODULE test
             INSERT Name { name := "world" }
         """)
 
         await self.con.execute("""
             CREATE MIGRATION {
-                ALTER TYPE test::Note RENAME TO test::Remark;
-                ALTER TYPE test::Name RENAME TO test::Handle;
+                ALTER TYPE Note RENAME TO Remark;
+                ALTER TYPE Name RENAME TO Handle;
             }
             """)
 
         res = await self.con.query_one("""
-            DESCRIBE MODULE test
+            DESCRIBE MODULE default
         """)
 
         self.assertEqual(res.count("Note"), 0)
@@ -9939,14 +9795,12 @@ type test::Foo {
 
         await self.assert_query_result(
             '''
-                WITH MODULE test
                 SELECT foo(Remark, Handle);
             ''',
             ['hello world'],
         )
 
         await self.con.execute("""
-            WITH MODULE test
             DROP FUNCTION foo(x: Remark, y: Handle);
         """)
 
@@ -9986,7 +9840,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_rename_ref_constraint_01(self):
         await self.con.execute("""
-            WITH MODULE test
             CREATE TYPE Note {
                 CREATE PROPERTY name -> str;
                 CREATE PROPERTY note -> str;
@@ -9996,7 +9849,6 @@ type test::Foo {
         """)
 
         await self.con.execute("""
-            WITH MODULE test
             ALTER TYPE Note {
                 ALTER PROPERTY note {
                     RENAME TO remark;
@@ -10008,7 +9860,7 @@ type test::Foo {
         """)
 
         res = await self.con.query_one("""
-            DESCRIBE MODULE test
+            DESCRIBE MODULE default
         """)
 
         self.assertEqual(res.count("note"), 0)
@@ -10017,7 +9869,7 @@ type test::Foo {
         self.assertEqual(res.count("callsign"), 2)
 
         await self.con.execute("""
-            ALTER TYPE test::Note
+            ALTER TYPE Note
             DROP CONSTRAINT exclusive ON ((
                 (__subject__.callsign, __subject__.remark)));
         """)
@@ -10025,7 +9877,7 @@ type test::Foo {
     async def test_edgeql_ddl_rename_ref_index_01(self):
         await self._simple_rename_ref_tests(
             """ALTER TYPE Note CREATE INDEX ON (.note);""",
-            """ALTER TYPE test::Note DROP INDEX ON (.note);""",
+            """ALTER TYPE default::Note DROP INDEX ON (.note);""",
             type_refs=0,
         )
 
@@ -10037,7 +9889,6 @@ type test::Foo {
                 }
             };
 
-            WITH MODULE test
             CREATE TYPE Uses2 {
                 CREATE REQUIRED PROPERTY x -> str {
                     SET default := (SELECT Note.note LIMIT 1)
@@ -10052,7 +9903,7 @@ type test::Foo {
                 CREATE PROPERTY x := .note ++ "!";
             };
             """,
-            """ALTER TYPE test::Note DROP PROPERTY x;""",
+            """ALTER TYPE default::Note DROP PROPERTY x;""",
             type_refs=0,
         )
 
@@ -10090,7 +9941,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_drop_multi_prop_01(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Test {
                 CREATE MULTI PROPERTY x -> str;
@@ -10111,7 +9961,6 @@ type test::Foo {
         orig_count = await self.con.query_one(count_query)
 
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE SCALAR TYPE a extending str;
             CREATE SCALAR TYPE b extending str;
@@ -10154,7 +10003,6 @@ type test::Foo {
         orig_count = await self.con.query_one(count_query)
 
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE SCALAR TYPE a extending str;
             CREATE SCALAR TYPE b extending str;
@@ -10198,7 +10046,6 @@ type test::Foo {
         orig_count = await self.con.query_one(count_query)
 
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE SCALAR TYPE a extending str;
             CREATE SCALAR TYPE b extending str;
@@ -10224,7 +10071,6 @@ type test::Foo {
         orig_elem_count = await self.con.query_one(elem_count_query)
 
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE SCALAR TYPE a extending str;
             CREATE SCALAR TYPE b extending str;
@@ -10251,7 +10097,6 @@ type test::Foo {
         orig_count = await self.con.query_one(count_query)
 
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE SCALAR TYPE a extending str;
             CREATE SCALAR TYPE b extending str;
@@ -10310,7 +10155,6 @@ type test::Foo {
         orig_count = await self.con.query_one(count_query)
 
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE SCALAR TYPE a extending str;
             CREATE SCALAR TYPE b extending str;
@@ -10334,7 +10178,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_drop_field_01(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE FUNCTION foo() -> str USING ("test");
 
@@ -10360,7 +10203,7 @@ type test::Foo {
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             r"missing value for required property"
-            r" 'a' of object type 'test::Foo'",
+            r" 'a' of object type 'default::Foo'",
         ):
             await self.con.execute(r"""
                 INSERT Foo;
@@ -10372,7 +10215,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_drop_field_02(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Foo {
                 CREATE REQUIRED PROPERTY a -> str {
@@ -10415,7 +10257,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_drop_field_03(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE ABSTRACT CONSTRAINT bogus {
                 USING (false);
@@ -10454,7 +10295,7 @@ type test::Foo {
             "'ha' is not a valid field",
         ):
             await self.con.execute(r"""
-                CREATE TYPE test::Lol {SET ha := "crash"};
+                CREATE TYPE Lol {SET ha := "crash"};
             """)
 
     async def test_edgeql_ddl_bad_field_02(self):
@@ -10464,7 +10305,7 @@ type test::Foo {
         ):
             await self.con.execute(r"""
                 START MIGRATION TO {
-                    type test::Lol {
+                    type default::Lol {
                         ha := "crash"
                     }
                 }
@@ -10472,7 +10313,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_adjust_computed_01(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Foo {
                 CREATE PROPERTY foo := {1, 2, 3};
@@ -10493,7 +10333,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_adjust_computed_02(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Foo {
                 CREATE PROPERTY foo := 1;
@@ -10533,7 +10372,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_adjust_computed_03(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Foo {
                 CREATE PROPERTY foo := 1;
@@ -10601,7 +10439,7 @@ type test::Foo {
     async def test_edgeql_ddl_captured_as_migration_01(self):
 
         await self.con.execute(r"""
-            CREATE TYPE test::Foo {
+            CREATE TYPE Foo {
                 CREATE PROPERTY foo := 1;
             };
         """)
@@ -10621,7 +10459,7 @@ type test::Foo {
             [{
                 'script': textwrap.dedent(
                     '''\
-                    CREATE TYPE test::Foo {
+                    CREATE TYPE Foo {
                         CREATE PROPERTY foo := (1);
                     };'''
                 )
@@ -10630,7 +10468,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_link_policy_01(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Tgt;
             CREATE TYPE Foo { CREATE MULTI LINK tgt -> Tgt; };
@@ -10651,7 +10488,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_link_policy_02(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Tgt;
             CREATE TYPE Base { CREATE MULTI LINK tgt -> Tgt; };
@@ -10673,7 +10509,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_link_policy_03(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Tgt;
             CREATE TYPE Base;
@@ -10703,7 +10538,6 @@ type test::Foo {
         # Make sure that a newly created subtype gets the appropriate
         # target link policies
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Tgt;
             CREATE TYPE Foo { CREATE MULTI LINK tgt -> Tgt; };
@@ -10726,7 +10560,6 @@ type test::Foo {
         # Make sure that a subtype with newly added bases gets the appropriate
         # target link policies
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Tgt;
             CREATE TYPE Foo { CREATE MULTI LINK tgt -> Tgt; };
@@ -10761,7 +10594,6 @@ type test::Foo {
         # Make sure that links coming into base types don't
         # interfere with link policies
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Tgt;
             CREATE TYPE Tgt2 EXTENDING Tgt;
@@ -10784,7 +10616,6 @@ type test::Foo {
     async def test_edgeql_ddl_link_policy_07(self):
         # Make sure that swapping between deferred and not works
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Tgt;
             CREATE TYPE Foo {
@@ -10808,7 +10639,6 @@ type test::Foo {
     async def test_edgeql_ddl_link_policy_08(self):
         # Make sure that swapping between deferred and not works
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Tgt;
             CREATE TYPE Foo {
@@ -10837,7 +10667,6 @@ type test::Foo {
     async def test_edgeql_ddl_link_policy_09(self):
         # Make sure that it still works after we rebase a link
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Tgt;
             CREATE TYPE Foo {
@@ -10870,7 +10699,6 @@ type test::Foo {
         # Make sure we NULL out the pointer on the delete, which will
         # trigger the constraint
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Tgt;
             CREATE TYPE Foo {
@@ -10902,7 +10730,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_link_policy_11(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Tgt { CREATE PROPERTY name -> str };
             CREATE TYPE Foo {
@@ -10935,7 +10762,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_dupe_link_storage_01(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             CREATE TYPE Foo {
                 CREATE PROPERTY name -> str;
@@ -10990,7 +10816,7 @@ type test::Foo {
             "computables",
         ):
             await self.con.execute("""
-                CREATE TYPE test::Foo {
+                CREATE TYPE Foo {
                     CREATE PROPERTY foo := random();
                 }
             """)
@@ -11001,7 +10827,7 @@ type test::Foo {
             "computables",
         ):
             await self.con.execute("""
-                CREATE TYPE test::Foo {
+                CREATE TYPE Foo {
                     CREATE PROPERTY foo := (SELECT stdgraphql::Query {
                         asdf := random()
                     }).asdf
@@ -11014,8 +10840,8 @@ type test::Foo {
             "computables",
         ):
             await self.con.execute("""
-                CREATE TYPE test::Noob {
-                    CREATE MULTI LINK friends -> test::Noob;
+                CREATE TYPE Noob {
+                    CREATE MULTI LINK friends -> Noob;
                     CREATE LINK best_friends := (
                         SELECT .friends FILTER random() > 0.5
                     );
@@ -11028,8 +10854,8 @@ type test::Foo {
             "computables",
         ):
             await self.con.execute("""
-                CREATE TYPE test::Noob {
-                    CREATE LINK noob -> test::Noob {
+                CREATE TYPE Noob {
+                    CREATE LINK noob -> Noob {
                         CREATE PROPERTY foo := random();
                     }
                 }
@@ -11046,7 +10872,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_new_required_pointer_01(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Foo;
             INSERT Foo;
         """)
@@ -11054,7 +10879,7 @@ type test::Foo {
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             "missing value for required property 'name' of object type "
-            "'test::Foo'"
+            "'default::Foo'"
         ):
             await self.con.execute("""
                 ALTER TYPE Foo CREATE REQUIRED PROPERTY name -> str;
@@ -11062,7 +10887,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_new_required_pointer_02(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Foo {
                 CREATE PROPERTY num -> int64;
             };
@@ -11084,7 +10908,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_new_required_pointer_03(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Foo {
                 CREATE PROPERTY num -> int64;
             };
@@ -11106,7 +10929,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_new_required_pointer_04(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Foo {
                 CREATE PROPERTY num -> int64;
             };
@@ -11139,7 +10961,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_new_required_pointer_05(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Foo {
                 CREATE PROPERTY num -> int64;
             };
@@ -11172,7 +10993,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_new_required_pointer_06(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE ABSTRACT TYPE Bar  {
                 CREATE PROPERTY num -> int64;
             };
@@ -11195,7 +11015,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_new_required_pointer_07(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE ABSTRACT TYPE Bar  {
                 CREATE PROPERTY num -> int64;
                 CREATE PROPERTY name -> str;
@@ -11219,7 +11038,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_new_required_pointer_08(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Bar  {
                 CREATE PROPERTY num -> int64;
                 CREATE PROPERTY name -> str;
@@ -11247,7 +11065,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_new_required_multi_pointer_01(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Foo;
             INSERT Foo;
         """)
@@ -11255,7 +11072,7 @@ type test::Foo {
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             "missing value for required property 'name' of object type "
-            "'test::Foo'"
+            "'default::Foo'"
         ):
             await self.con.execute("""
                 ALTER TYPE Foo CREATE REQUIRED MULTI PROPERTY name -> str;
@@ -11263,7 +11080,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_new_required_multi_pointer_02(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Foo;
             INSERT Foo;
         """)
@@ -11271,7 +11087,7 @@ type test::Foo {
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             "missing value for required link 'link' of object type "
-            "'test::Foo'"
+            "'default::Foo'"
         ):
             await self.con.execute("""
                 ALTER TYPE Foo CREATE REQUIRED MULTI LINK link -> Object;
@@ -11279,7 +11095,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_new_required_multi_pointer_03(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Foo {
                 CREATE MULTI PROPERTY name -> str;
             };
@@ -11289,7 +11104,7 @@ type test::Foo {
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             "missing value for required property 'name' of object type "
-            "'test::Foo'"
+            "'default::Foo'"
         ):
             await self.con.execute("""
                 ALTER TYPE Foo ALTER PROPERTY name SET REQUIRED;
@@ -11297,7 +11112,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_new_required_multi_pointer_04(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Foo {
                 CREATE MULTI LINK link -> Object;
             };
@@ -11307,7 +11121,7 @@ type test::Foo {
         async with self.assertRaisesRegexTx(
             edgedb.MissingRequiredError,
             "missing value for required link 'link' of object type "
-            "'test::Foo'"
+            "'default::Foo'"
         ):
             await self.con.execute("""
                 ALTER TYPE Foo ALTER LINK link SET REQUIRED;
@@ -11315,7 +11129,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_alter_union_01(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Foo;
             CREATE TYPE Bar;
         """)
@@ -11338,7 +11151,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_alter_union_02(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Foo { CREATE PROPERTY x -> str; };
             CREATE TYPE Bar { CREATE PROPERTY x -> str; };
             CREATE TYPE Baz { CREATE PROPERTY x -> str; };
@@ -11372,7 +11184,6 @@ type test::Foo {
 
     async def test_edgeql_ddl_alter_union_03(self):
         await self.con.execute(r"""
-            SET MODULE test;
             CREATE TYPE Parent;
             CREATE TYPE Child EXTENDING Parent {
                 CREATE PROPERTY prop -> str;
@@ -11393,7 +11204,7 @@ type test::Foo {
 
         async with self.assertRaisesRegexTx(
             edgedb.QueryError,
-            "object type 'test::Parent' has no link or property 'prop'",
+            "object type 'default::Parent' has no link or property 'prop'",
         ):
             await self.assert_query_result(
                 r'''SELECT Ref.fubar.y.prop''',
@@ -11407,15 +11218,15 @@ class TestConsecutiveMigrations(tb.DDLTestCase):
     async def test_edgeql_ddl_consecutive_create_migration_01(self):
         # A regression test for https://github.com/edgedb/edgedb/issues/2085.
         await self.con.execute('''
-        CREATE MIGRATION m1arqp5cg4dqgdqx7tb4vv2lui6wlksysbplyc5kqrdkpcvcv4em6q
-            ONTO m1a2l6lbzimqokzygdzbkyjrhbmjh3iljg7i2m6r2ias2z2de4x4cq
+        CREATE MIGRATION m1dpxyvsejl6b2tqe5nzpy6wpk5zzjhm7gwky7jn5vmnqrqoujxn6q
+            ONTO initial
         {
             CREATE TYPE default::A;
         };
         ''')
         await self.con.query('''
-        CREATE MIGRATION m1jd2aedby6pksanlucebgb6tfkcs4si2zdcyoisupckq46dteorpq
-            ONTO m1arqp5cg4dqgdqx7tb4vv2lui6wlksysbplyc5kqrdkpcvcv4em6q
+        CREATE MIGRATION m1xuduby4e6u2sraygw352y553ltcj4cyz4dijuwlbqqq34ap43yca
+            ONTO m1dpxyvsejl6b2tqe5nzpy6wpk5zzjhm7gwky7jn5vmnqrqoujxn6q
         {
             CREATE TYPE default::B;
         };

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -25,7 +25,7 @@ from edb.testbase import server as tb
 class TestDelete(tb.QueryTestCase):
     SETUP = """
         START MIGRATION TO {
-            module test {
+            module default {
                 type LinkingType {
                     multi link objs -> AbstractDeleteTest;
                 };
@@ -55,49 +55,48 @@ class TestDelete(tb.QueryTestCase):
     async def test_edgeql_delete_simple_01(self):
         # ensure a clean slate, not part of functionality testing
         await self.con.execute(r"""
-            DELETE test::DeleteTest;
+            DELETE DeleteTest;
         """)
 
         await self.con.execute(r"""
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'delete-test'
             };
         """)
 
         await self.assert_query_result(
             r"""
-                SELECT test::DeleteTest;
+                SELECT DeleteTest;
             """,
             [{}],
         )
 
         await self.con.execute(r"""
-            DELETE test::DeleteTest;
+            DELETE DeleteTest;
         """)
 
         await self.assert_query_result(
             r"""
-                SELECT test::DeleteTest;
+                SELECT DeleteTest;
             """,
             [],
         )
 
     async def test_edgeql_delete_simple_02(self):
         id1 = str((await self.con.query_one(r"""
-            SELECT(INSERT test::DeleteTest {
+            SELECT(INSERT DeleteTest {
                 name := 'delete-test1'
             }) LIMIT 1;
         """)).id)
 
         id2 = str((await self.con.query_one(r"""
-            SELECT(INSERT test::DeleteTest {
+            SELECT(INSERT DeleteTest {
                 name := 'delete-test2'
             }) LIMIT 1;
         """)).id)
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 DELETE (SELECT DeleteTest
                         FILTER DeleteTest.name = 'bad name');
             """,
@@ -106,7 +105,6 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT DeleteTest ORDER BY DeleteTest.name;
             """,
             [{'id': id1}, {'id': id2}],
@@ -114,7 +112,6 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (DELETE (SELECT DeleteTest
                         FILTER DeleteTest.name = 'delete-test1'));
             """,
@@ -123,7 +120,6 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT DeleteTest ORDER BY DeleteTest.name;
             """,
             [{'id': id2}],
@@ -131,7 +127,6 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (DELETE (SELECT DeleteTest
                         FILTER DeleteTest.name = 'delete-test2'));
             """,
@@ -140,7 +135,6 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT DeleteTest ORDER BY DeleteTest.name;
             """,
             [],
@@ -148,23 +142,22 @@ class TestDelete(tb.QueryTestCase):
 
     async def test_edgeql_delete_returning_01(self):
         id1 = str((await self.con.query_one(r"""
-            SELECT (INSERT test::DeleteTest {
+            SELECT (INSERT DeleteTest {
                 name := 'delete-test1'
             }) LIMIT 1;
         """)).id)
 
         await self.con.execute(r"""
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'delete-test2'
             };
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'delete-test3'
             };
         """)
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (DELETE DeleteTest
                         FILTER DeleteTest.name = 'delete-test1');
             """,
@@ -174,7 +167,6 @@ class TestDelete(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     D := (DELETE DeleteTest
                           FILTER DeleteTest.name = 'delete-test2')
                 SELECT D {name};
@@ -184,7 +176,6 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
                     (DELETE DeleteTest
                      FILTER DeleteTest.name = 'delete-test3'
@@ -195,20 +186,20 @@ class TestDelete(tb.QueryTestCase):
 
     async def test_edgeql_delete_returning_02(self):
         await self.con.execute(r"""
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'delete-test1'
             };
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'delete-test2'
             };
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'delete-test3'
             };
         """)
 
         await self.assert_query_result(
             r"""
-                WITH D := (DELETE test::DeleteTest)
+                WITH D := (DELETE DeleteTest)
                 SELECT count(D);
             """,
             [3],
@@ -216,21 +207,21 @@ class TestDelete(tb.QueryTestCase):
 
     async def test_edgeql_delete_returning_03(self):
         await self.con.execute(r"""
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'dt1.1'
             };
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'dt1.2'
             };
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'dt1.3'
             };
             # create a different object
-            INSERT test::DeleteTest2 {
+            INSERT DeleteTest2 {
                 name := 'dt2.1'
             };
 
-            INSERT test::DeleteTest2 {
+            INSERT DeleteTest2 {
                 name := 'delete test2.2'
             };
         """)
@@ -238,7 +229,6 @@ class TestDelete(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     D := (DELETE DeleteTest)
                 SELECT DeleteTest2 {
                     name,
@@ -253,7 +243,6 @@ class TestDelete(tb.QueryTestCase):
 
         deleted = await self.con._fetchall(
             r"""
-                WITH MODULE test
                 DELETE DeleteTest2;
             """,
             __typeids__=True,
@@ -261,21 +250,21 @@ class TestDelete(tb.QueryTestCase):
         )
 
         self.assertTrue(hasattr(deleted[0], '__tid__'))
-        self.assertEqual(deleted[0].__tname__, 'test::DeleteTest2')
+        self.assertEqual(deleted[0].__tname__, 'default::DeleteTest2')
 
     async def test_edgeql_delete_returning_04(self):
         await self.con.execute(r"""
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'dt1.1'
             };
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'dt1.2'
             };
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'dt1.3'
             };
             # create a different object
-            INSERT test::DeleteTest2 {
+            INSERT DeleteTest2 {
                 name := 'dt2.1'
             };
         """)
@@ -283,7 +272,6 @@ class TestDelete(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     # make sure that aliased deletion works as an expression
                     #
                     Q := (DELETE DeleteTest)
@@ -300,7 +288,6 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (DELETE DeleteTest2) {name};
             """,
             [{
@@ -310,17 +297,17 @@ class TestDelete(tb.QueryTestCase):
 
     async def test_edgeql_delete_returning_05(self):
         await self.con.execute(r"""
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'dt1.1'
             };
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'dt1.2'
             };
-            INSERT test::DeleteTest {
+            INSERT DeleteTest {
                 name := 'dt1.3'
             };
             # create a different object
-            INSERT test::DeleteTest2 {
+            INSERT DeleteTest2 {
                 name := 'dt2.1'
             };
         """)
@@ -328,7 +315,6 @@ class TestDelete(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     D := (DELETE DeleteTest)
                 # the returning clause is actually trying to simulate
                 # returning "stats" of deleted objects
@@ -346,7 +332,6 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (DELETE DeleteTest2) {name};
             """,
             [{
@@ -356,7 +341,6 @@ class TestDelete(tb.QueryTestCase):
 
     async def test_edgeql_delete_sugar_01(self):
         await self.con.execute(r"""
-            WITH MODULE test
             FOR x IN {'1', '2', '3', '4', '5', '6'}
             UNION (INSERT DeleteTest {
                 name := 'sugar delete ' ++ x
@@ -364,7 +348,6 @@ class TestDelete(tb.QueryTestCase):
         """)
 
         await self.con.execute(r"""
-            WITH MODULE test
             DELETE
                 DeleteTest
             FILTER
@@ -376,7 +359,7 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                SELECT test::DeleteTest.name;
+                SELECT DeleteTest.name;
             """,
             {
                 'sugar delete 1',
@@ -388,28 +371,23 @@ class TestDelete(tb.QueryTestCase):
 
     async def test_edgeql_delete_union(self):
         await self.con.execute(r"""
-            WITH MODULE test
             FOR x IN {'1', '2', '3', '4', '5', '6'}
             UNION (INSERT DeleteTest {
                 name := 'delete union ' ++ x
             });
 
-            WITH MODULE test
             FOR x IN {'7', '8', '9'}
             UNION (INSERT DeleteTest2 {
                 name := 'delete union ' ++ x
             });
 
-            WITH MODULE test
             INSERT DeleteTest { name := 'not delete union 1' };
 
-            WITH MODULE test
             INSERT DeleteTest2 { name := 'not delete union 2' };
         """)
 
         await self.con.execute(r"""
             WITH
-                MODULE test,
                 ToDelete := (
                     (SELECT DeleteTest FILTER .name ILIKE 'delete union%')
                     UNION
@@ -420,9 +398,8 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
-                    test::DeleteTest
+                    DeleteTest
                 FILTER
                     .name ILIKE 'delete union%';
 
@@ -432,9 +409,8 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
-                    test::DeleteTest {name}
+                    DeleteTest {name}
                 FILTER
                     .name ILIKE 'not delete union%';
 
@@ -446,9 +422,8 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
-                    test::DeleteTest2
+                    DeleteTest2
                 FILTER
                     .name ILIKE 'delete union%';
 
@@ -458,9 +433,8 @@ class TestDelete(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
-                    test::DeleteTest2 {name}
+                    DeleteTest2 {name}
                 FILTER
                     .name ILIKE 'not delete union%';
 
@@ -475,7 +449,6 @@ class TestDelete(tb.QueryTestCase):
                 edgedb.QueryError,
                 'DELETE statements cannot be used'):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT
                     (SELECT DeleteTest2)
                     ??
@@ -487,7 +460,6 @@ class TestDelete(tb.QueryTestCase):
                 edgedb.QueryError,
                 'DELETE statements cannot be used'):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT
                     (SELECT DeleteTest FILTER .name = 'foo')
                     IF EXISTS DeleteTest
@@ -500,7 +472,6 @@ class TestDelete(tb.QueryTestCase):
 
     async def test_edgeql_delete_abstract_01(self):
         await self.con.execute(r"""
-            SET MODULE test;
 
             INSERT DeleteTest { name := 'child of abstract 1' };
             INSERT DeleteTest2 { name := 'child of abstract 2' };
@@ -509,7 +480,6 @@ class TestDelete(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     D := (
                         DELETE
                             AbstractDeleteTest

--- a/tests/test_edgeql_enums.py
+++ b/tests/test_edgeql_enums.py
@@ -31,7 +31,6 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
     async def test_edgeql_enums_cast_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT <color_enum_t>{'RED', 'GREEN', 'BLUE'};
             ''',
             {'RED', 'GREEN', 'BLUE'},
@@ -42,7 +41,6 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
                 edgedb.InvalidValueError,
                 r'invalid input value for enum .+color_enum_t.+YELLOW'):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT <color_enum_t>'YELLOW';
             ''')
 
@@ -51,7 +49,6 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
                 edgedb.InvalidValueError,
                 r'invalid input value for enum .+color_enum_t.+red'):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT <color_enum_t>'red';
             ''')
 
@@ -59,21 +56,18 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r"operator '\+\+' cannot be applied to operands of type "
-                r"'std::str' and 'test::color_enum_t'"):
+                r"'std::str' and 'default::color_enum_t'"):
             await self.con.execute(r'''
-                WITH MODULE test
                 INSERT Foo {
                     color := 'BLUE'
                 };
 
-                WITH MODULE test
                 SELECT 'The test color is: ' ++ Foo.color;
             ''')
 
     async def test_edgeql_enums_cast_05(self):
         await self.con.execute(
             r'''
-                WITH MODULE test
                 INSERT Foo {
                     color := 'BLUE'
                 };
@@ -81,7 +75,6 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT 'The test color is: ' ++ <str>Foo.color;
             ''',
             ['The test color is: BLUE'],
@@ -91,7 +84,6 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
         # testing the INSERT assignment cast
         await self.con.execute(
             r'''
-                WITH MODULE test
                 INSERT Foo {
                     color := 'RED'
                 };
@@ -99,7 +91,6 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Foo {
                     color
                 };
@@ -112,7 +103,6 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
     async def test_edgeql_enums_assignment_02(self):
         await self.con.execute(
             r'''
-                WITH MODULE test
                 INSERT Foo {
                     color := 'RED'
                 };
@@ -121,7 +111,6 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
         # testing the UPDATE assignment cast
         await self.con.execute(
             r'''
-                WITH MODULE test
                 UPDATE Foo
                 SET {
                     color := 'GREEN'
@@ -130,7 +119,6 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Foo {
                     color
                 };
@@ -144,13 +132,11 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
         # testing the INSERT assignment cast
         await self.con.execute(
             r'''
-                WITH MODULE test
                 INSERT Bar;
             ''')
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Bar {
                     color
                 };
@@ -163,14 +149,12 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
     async def test_edgeql_enums_assignment_04(self):
         await self.con.execute(
             r'''
-                WITH MODULE test
                 INSERT Bar;
             ''')
 
         # testing the UPDATE assignment cast
         await self.con.execute(
             r'''
-                WITH MODULE test
                 UPDATE Bar
                 SET {
                     color := 'GREEN'
@@ -179,7 +163,6 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Bar {
                     color
                 };
@@ -192,26 +175,26 @@ class TestEdgeQLEnuma(tb.QueryTestCase):
     async def test_edgeql_enums_json_cast_01(self):
         self.assertEqual(
             await self.con.query(
-                "SELECT <json><test::color_enum_t>'RED'"
+                "SELECT <json><color_enum_t>'RED'"
             ),
             ['"RED"'])
 
         await self.assert_query_result(
-            "SELECT <test::color_enum_t><json>'RED'",
+            "SELECT <color_enum_t><json>'RED'",
             ['RED'])
 
         await self.assert_query_result(
-            "SELECT <test::color_enum_t>'RED'",
+            "SELECT <color_enum_t>'RED'",
             ['RED'])
 
     async def test_edgeql_enums_json_cast_02(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidValueError,
                 r'invalid input value for enum .+color_enum_t.+: "BANANA"'):
-            await self.con.execute("SELECT <test::color_enum_t><json>'BANANA'")
+            await self.con.execute("SELECT <color_enum_t><json>'BANANA'")
 
     async def test_edgeql_enums_json_cast_03(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidValueError,
                 r'expected json string or null; got json number'):
-            await self.con.execute("SELECT <test::color_enum_t><json>12")
+            await self.con.execute("SELECT <color_enum_t><json>12")

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2948,7 +2948,8 @@ class TestExpressions(tb.QueryTestCase):
             '''
                 WITH
                     MODULE schema,
-                    A := (SELECT ScalarType FILTER .name = 'default::issue_num_t')
+                    A := (SELECT ScalarType
+                          FILTER .name = 'default::issue_num_t')
                 SELECT [A.name, A.default];
             ''',
             [],

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2233,7 +2233,6 @@ class TestExpressions(tb.QueryTestCase):
 
         for case in cases:
             await self.con.execute('''
-                WITH MODULE test
                 SELECT
                     Issue {
                         number
@@ -2269,7 +2268,6 @@ class TestExpressions(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"'Issue.number' changes the interpretation of 'Issue'"):
             await self.con.execute(r"""
-                WITH MODULE test
                 SELECT Issue.owner
                 FILTER Issue.number > '2';
             """)
@@ -2282,7 +2280,6 @@ class TestExpressions(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"'Issue.number' changes the interpretation of 'Issue'"):
             await self.con.execute(r"""
-                WITH MODULE test
                 SELECT Issue.id
                 FILTER Issue.number > '2';
             """)
@@ -2295,7 +2292,6 @@ class TestExpressions(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"'Issue.number' changes the interpretation of 'Issue'"):
             await self.con.execute(r"""
-                WITH MODULE test
                 SELECT Issue.owner {
                     foo := Issue.number
                 };
@@ -2309,7 +2305,6 @@ class TestExpressions(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"'Issue.number' changes the interpretation of 'Issue'"):
             await self.con.execute(r"""
-                WITH MODULE test
                 UPDATE Issue.owner
                 FILTER Issue.number > '2'
                 SET {
@@ -2324,7 +2319,6 @@ class TestExpressions(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"'Issue' changes the interpretation of 'Issue'"):
             await self.con.execute(r"""
-                WITH MODULE test
                 UPDATE Issue.related_to
                 SET {
                     related_to := Issue
@@ -2333,19 +2327,17 @@ class TestExpressions(tb.QueryTestCase):
 
     async def test_edgeql_expr_polymorphic_01(self):
         await self.con.execute(r"""
-            WITH MODULE test
             SELECT Text {
                 [IS Issue].number,
                 [IS Issue].related_to,
                 [IS Issue].`priority`,
-                [IS test::Comment].owner: {
+                [IS Comment].owner: {
                     name
                 }
             };
         """)
 
         await self.con.execute(r"""
-            WITH MODULE test
             SELECT Owned {
                 [IS Named].name
             };
@@ -2956,7 +2948,7 @@ class TestExpressions(tb.QueryTestCase):
             '''
                 WITH
                     MODULE schema,
-                    A := (SELECT ScalarType FILTER .name = 'test::issue_num_t')
+                    A := (SELECT ScalarType FILTER .name = 'default::issue_num_t')
                 SELECT [A.name, A.default];
             ''',
             [],
@@ -3816,9 +3808,9 @@ aa \
         with self.assertRaisesRegex(
                 edgedb.QueryError, r'cannot assign to __type__'):
             await self.con.query(r"""
-                SELECT test::Text {
+                SELECT Text {
                     __type__ := (SELECT schema::ObjectType
-                                 FILTER .name = 'test::Named')
+                                 FILTER .name = 'default::Named')
                 };
             """)
 
@@ -3826,7 +3818,7 @@ aa \
         with self.assertRaisesRegex(
                 edgedb.QueryError, r'cannot assign to id'):
             await self.con.execute(r"""
-                SELECT test::Text {
+                SELECT Text {
                     id := <uuid>'77841036-8e35-49ce-b509-2cafa0c25c4f'
                 };
             """)
@@ -4256,10 +4248,9 @@ aa \
                 edgedb.QueryError,
                 r'possibly more than one element returned by an expression '
                 r'where only singletons are allowed',
-                _position=71):
+                _position=38):
 
             await self.con.execute('''\
-                WITH MODULE test
                 SELECT Issue ORDER BY Issue.watchers.name;
             ''')
 
@@ -4268,10 +4259,9 @@ aa \
                 edgedb.QueryError,
                 r'possibly more than one element returned by an expression '
                 r'where only singletons are allowed',
-                _position=62):
+                _position=29):
 
             await self.con.execute('''\
-                WITH MODULE test
                 SELECT Issue LIMIT LogEntry.spent_time;
             ''')
 
@@ -4280,10 +4270,9 @@ aa \
                 edgedb.QueryError,
                 r'possibly more than one element returned by an expression '
                 r'where only singletons are allowed',
-                _position=62):
+                _position=29):
 
             await self.con.execute('''\
-                WITH MODULE test
                 SELECT Issue OFFSET LogEntry.spent_time;
             ''')
 
@@ -4292,10 +4281,9 @@ aa \
                 edgedb.QueryError,
                 r'possibly more than one element returned by an expression '
                 r'where only singletons are allowed',
-                _position=78):
+                _position=45):
 
             await self.con.execute('''\
-                WITH MODULE test
                 SELECT EXISTS Issue ORDER BY Issue.name;
             ''')
 
@@ -4304,10 +4292,9 @@ aa \
                 edgedb.QueryError,
                 r'possibly more than one element returned by an expression '
                 r'where only singletons are allowed',
-                _position=85):
+                _position=52):
 
             await self.con.execute('''\
-                WITH MODULE test
                 SELECT 'foo' IN Issue.name ORDER BY Issue.name;
             ''')
 
@@ -4316,10 +4303,9 @@ aa \
                 edgedb.QueryError,
                 r'possibly more than one element returned by an expression '
                 r'where only singletons are allowed',
-                _position=82):
+                _position=49):
 
             await self.con.execute('''\
-                WITH MODULE test
                 SELECT Issue UNION Text ORDER BY Issue.name;
             ''')
 
@@ -4328,10 +4314,9 @@ aa \
                 edgedb.QueryError,
                 r'possibly more than one element returned by an expression '
                 r'where only singletons are allowed',
-                _position=80):
+                _position=47):
 
             await self.con.execute('''\
-                WITH MODULE test
                 SELECT DISTINCT Issue ORDER BY Issue.name;
             ''')
 

--- a/tests/test_edgeql_filter.py
+++ b/tests/test_edgeql_filter.py
@@ -37,7 +37,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
             r'''
                 # Find Users who own at least one Issue with simultaneously
                 # time_estimate > 9000 and due_date on 2020/01/15.
-                WITH MODULE test
                 SELECT User{name}
                 FILTER
                     User.<owner[IS Issue].time_estimate > 9000
@@ -56,7 +55,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                 # NOTE: semantically same as and01, but using OR
                 # Find Users who own at least one Issue with simultaneously
                 # time_estimate > 9000 and due_date on 2020/01/15.
-                WITH MODULE test
                 SELECT User{name}
                 FILTER
                     EXISTS (
@@ -87,7 +85,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                 # NOTE: same as above, but more human-like
                 # Find Users who own at least one Issue with simultaneously
                 # time_estimate > 9000 and due_date on 2020/01/15.
-                WITH MODULE test
                 SELECT User{name}
                 FILTER
                     EXISTS (
@@ -117,7 +114,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                 # Find Users who own at least one Issue with simultaneously
                 # time_estimate > 9000 and due_date on 2020/01/15.
                 WITH
-                    MODULE test,
                     U2 := User
                 SELECT User{name}
                 FILTER
@@ -140,7 +136,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # Find Users who do not have any Issues with time_estimate
-                WITH MODULE test
                 SELECT User{name}
                 FILTER
                     NOT EXISTS User.<owner[IS Issue].time_estimate
@@ -154,7 +149,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # Find Users who have at least one Issue without time_estimates
-                WITH MODULE test
                 SELECT (
                     SELECT Issue
                     FILTER
@@ -172,7 +166,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                 # NOTE: same as above, but starting with User
                 #
                 # Find Users who have at least one Issue without time_estimates
-                WITH MODULE test
                 SELECT User{name}
                 FILTER
                     EXISTS (
@@ -193,7 +186,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                 #
                 # Find Users who have at least one Issue without time_estimates
                 WITH
-                    MODULE test,
                     U2 := User
                 SELECT User{name}
                 FILTER
@@ -216,7 +208,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                 #
                 # Find Users who own at least one Issue with simultaneously
                 # having a time_estimate and a due_date.
-                WITH MODULE test
                 SELECT User{name}
                 FILTER
                     EXISTS (
@@ -238,7 +229,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                 #
                 # Find Users who own at least one Issue with simultaneously
                 # time_estimate > 9000 and due_date on 2020/01/15.
-                WITH MODULE test
                 SELECT User{name}
                 FILTER
                     EXISTS (
@@ -265,7 +255,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                 # Find Users who own at least one Issue with simultaneously
                 # time_estimate > 9000 and due_date on 2020/01/15.
                 WITH
-                    MODULE test,
                     U2 := User
                 SELECT User{name}
                 FILTER
@@ -292,7 +281,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                 # Find Users who own at least one Issue with simultaneously
                 # time_estimate > 9000 and due_date on 2020/01/15.
                 WITH
-                    MODULE test,
                     U2 := User
                 SELECT User{name}
                 FILTER
@@ -317,7 +305,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
     async def test_edgeql_filter_short_form01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Status{name}
                 FILTER .name = 'Open';
             ''',
@@ -329,7 +316,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
             r'''
                 # test that shape spec is not necessary to use short form
                 # in the filter
-                WITH MODULE test
                 SELECT Status
                 FILTER .name = 'Open';
             ''',
@@ -339,7 +325,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
     async def test_edgeql_filter_flow01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Issue.number
                 FILTER TRUE
                 ORDER BY Issue.number;
@@ -349,7 +334,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Issue.number
                 # obviously irrelevant filter, simply equivalent to TRUE
                 FILTER Status.name = 'Closed'
@@ -361,7 +345,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
     async def test_edgeql_filter_flow02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Issue.number
                 FILTER FALSE
                 ORDER BY Issue.number;
@@ -371,7 +354,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Issue.number
                 # obviously irrelevant filter, simply equivalent to FALSE
                 FILTER Status.name = 'XXX'
@@ -384,7 +366,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # base line for a cross product
-                WITH MODULE test
                 SELECT _ := Issue.number ++ Status.name
                 ORDER BY _;
             ''',
@@ -399,7 +380,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # interaction of filter and cross product
-                WITH MODULE test
                 SELECT _ := (
                         SELECT Issue
                         FILTER Issue.owner.name = 'Elvis'
@@ -411,7 +391,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT _ := (
                         SELECT Issue
                         FILTER Issue.owner.name = 'Elvis'
@@ -430,7 +409,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 # the FILTER clause is always empty, so it can never be true
-                WITH MODULE test
                 SELECT Issue{number}
                 FILTER {};
             """,
@@ -441,7 +419,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 # the FILTER clause evaluates to empty, so it can never be true
-                WITH MODULE test
                 SELECT Issue{number}
                 FILTER Issue.number = <str>{};
             """,
@@ -450,7 +427,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Issue{number}
                 FILTER Issue.priority = <Object>{};
             """,
@@ -459,7 +435,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Issue{number}
                 FILTER Issue.priority.name = <str>{};
             """,
@@ -469,7 +444,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
     async def test_edgeql_filter_aggregate01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT count(Issue);
             ''',
             [4],
@@ -478,7 +452,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
     async def test_edgeql_filter_aggregate04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT count(Issue)
                 # this filter is not related to the aggregate and is allowed
                 #
@@ -489,7 +462,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT count(Issue)
                 # this filter is conceptually equivalent to the above
                 FILTER TRUE;
@@ -501,7 +473,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     I := (SELECT Issue FILTER Issue.status.name = 'Open')
                 SELECT count(I);
             ''',
@@ -513,7 +484,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
             r'''
                 # regardless of what count evaluates to, FILTER clause is
                 # impossible to fulfill, so the result is empty
-                WITH MODULE test
                 SELECT count(Issue)
                 FILTER FALSE;
             ''',
@@ -522,7 +492,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT count(Issue)
                 FILTER {};
             ''',

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -39,7 +39,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
                  'Giant turtle', 'Golem', 'Imp', 'Sprite']
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 FOR C IN {Card}
                 # C and Card are not related here
                 UNION (C.name, Card.name);
@@ -51,7 +50,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_cross_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 FOR C IN {Card}
                 # C and Card are not related here, so count(Card) should be 9
                 UNION (C.name, count(Card));
@@ -73,7 +71,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_cross_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 FOR Card IN {Card}
                 # Card is shadowed here
                 UNION (Card.name, count(Card));
@@ -95,7 +92,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_cross_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 FOR C IN {Card}
                 # C and Card are not related here, so count(Card) should be 9
                 UNION (count(C), count(Card));
@@ -108,7 +104,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_mix_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 FOR X IN {Card.name, User.name}
                 UNION X;
             ''',
@@ -132,7 +127,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_mix_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 FOR X IN {Card.name, User.name}
                 # both Card and User should be independent of X
                 UNION (X, count(Card), count(User));
@@ -159,7 +153,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # should be the same result as above
-                WITH MODULE test
                 FOR X IN {Card.name, User.name}
                 UNION (X, count(Card FILTER TRUE), count(User FILTER TRUE));
             ''',
@@ -184,7 +177,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_mix_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 FOR X IN {Card.name, User.name}
                 # this should be just [3] for each name (9 + 4 of names)
                 UNION count(User.friends);
@@ -195,7 +187,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_limit_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT X := (
                     FOR X IN {User.name}
                     UNION X
@@ -212,7 +203,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_filter_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT X := (
                     FOR X IN {Card.name}
                     UNION X
@@ -236,7 +226,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_filter_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (
                     # get a combination of names from different object types
                     FOR X IN {Card.name, User.name}
@@ -265,7 +254,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_in_computable_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     select_deck := (
                         FOR letter IN {'I', 'B'}
@@ -296,7 +284,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_in_computable_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     select_deck := (
                         SELECT _ := (
@@ -332,7 +319,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_in_computable_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     select_deck := (
                         SELECT _ := (
@@ -387,7 +373,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
         # SELECT tup.1 {<shape>};
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     select_deck := (
                         WITH
@@ -423,7 +408,7 @@ class TestEdgeQLFor(tb.QueryTestCase):
 
     @test.xfail('''
         The second query fails with
-            cannot redefine link 'select_deck' of object type 'test::User'
+            cannot redefine link 'select_deck' of object type 'User'
             as scalar type 'std::str'
 
         I think because viewgen is too eager to decide that the first
@@ -432,7 +417,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_in_computable_05(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     select_deck := (
                         FOR letter IN {'X'}
@@ -452,7 +436,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
         # This one caused a totally nonsense type error.
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     select_deck := (
                         FOR letter IN {'X'}
@@ -472,7 +455,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_in_computable_06(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT User {
                 select_deck := (
                     WITH ps := (FOR x IN {"!", "?"} UNION (x)),
@@ -503,7 +485,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_in_computable_07(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT User {
                 select_deck := (
                     WITH ps := (FOR x IN {"!", "?"} UNION (
@@ -535,7 +516,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_in_computable_08(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT User {
                 select_deck := (
                     WITH ps := (FOR x in {"!", "?"} UNION (x++""))
@@ -577,14 +557,13 @@ class TestEdgeQLFor(tb.QueryTestCase):
             }
         )
 
-    @test.xfail("'test::letter' does not exist")
+    @test.xfail("'letter' does not exist")
     async def test_edgeql_for_in_computable_09(self):
         # This is basically test_edgeql_for_in_computable_01 but with
         # a WITH binding in front of the whole shape
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     U := (
                         SELECT User {
                             select_deck := (
@@ -623,12 +602,11 @@ class TestEdgeQLFor(tb.QueryTestCase):
         # a WITH binding inside the computable and no link prop
 
         # If we just drop the WITH Z binding, we get
-        # `test::letter does not exist`.
+        # `letter does not exist`.
         # If we replace the WITH Z part with an extra SELECT,
         # we get the same buggy behavior.
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT (SELECT User {
                 select_deck := (
                     WITH Z := (
@@ -683,7 +661,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_correlated_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT count((Card.name,
                               (FOR x in {Card} UNION (SELECT x.name)),
                 ));
@@ -694,7 +671,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
     async def test_edgeql_for_correlated_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT count(((FOR x in {Card} UNION (SELECT x.name)),
                                Card.name,
                 ));

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -37,7 +37,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     x := (
                         # User is simply employed as an object to be augmented
                         SELECT User {
@@ -54,7 +53,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     x := (
                         # User is simply employed as an object to be augmented
                         SELECT User {
@@ -71,7 +69,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     x := (
                         # User is simply employed as an object to be augmented
                         SELECT User {
@@ -253,7 +250,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                 edgedb.UnsupportedFeatureError,
                 r"nested arrays are not supported"):
             await self.con.query(r"""
-                WITH MODULE test
                 SELECT array_agg(
                     [<str>Issue.number, Issue.status.name]
                     ORDER BY Issue.number);
@@ -262,7 +258,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_array_agg_11(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT array_agg(
                     (<str>Issue.number, Issue.status.name)
                     ORDER BY Issue.number
@@ -274,8 +269,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_array_agg_12(self):
         await self.assert_query_result(
             r'''
-                WITH
-                    MODULE test
                 SELECT
                     array_agg(User{name} ORDER BY User.name);
             ''',
@@ -283,8 +276,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         )
 
         result = await self.con.query(r'''
-            WITH
-                MODULE test
             SELECT
                 array_agg(User{name} ORDER BY User.name);
         ''')
@@ -295,8 +286,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_array_agg_13(self):
         await self.assert_query_result(
             r'''
-                WITH
-                    MODULE test
                 SELECT
                     Issue {
                         number,
@@ -319,14 +308,12 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                 edgedb.UnsupportedFeatureError,
                 r"nested arrays are not supported"):
             await self.con.query(r'''
-                WITH MODULE test
                 SELECT array_agg(array_agg(User.name));
             ''')
 
     async def test_edgeql_functions_array_agg_15(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT array_agg(
                     ([([User.name],)],) ORDER BY User.name
                 );
@@ -341,7 +328,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_array_agg_16(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT array_agg(   # outer array
                     (               # tuple
                         array_agg(  # array
@@ -424,7 +410,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # array_agg and array_unpack are inverses of each other
-                WITH MODULE test
                 SELECT array_unpack(array_agg(Issue.number));
             ''',
             {'1', '2', '3', '4'},
@@ -434,7 +419,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # array_agg and array_unpack are inverses of each other
-                WITH MODULE test
                 SELECT array_unpack(array_agg(Issue)){number};
             ''',
             [
@@ -549,8 +533,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         )
 
     async def test_edgeql_functions_enumerate_03(self):
-        await self.con.execute('SET MODULE test')
-
         await self.assert_query_result(
             r'''SELECT enumerate((SELECT User.name ORDER BY User.name));''',
             [[0, 'Elvis'], [1, 'Yury']],
@@ -584,13 +566,13 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
     async def test_edgeql_functions_enumerate_05(self):
         await self.assert_query_result(
-            r'''SELECT enumerate(test::User { name } ORDER BY .name);''',
+            r'''SELECT enumerate(User { name } ORDER BY .name);''',
             [[0, {"name": "Elvis"}],
              [1, {"name": "Yury"}]],
         )
 
         await self.assert_query_result(
-            r'''SELECT enumerate(test::User ORDER BY .name).1.name;''',
+            r'''SELECT enumerate(User ORDER BY .name).1.name;''',
             ["Elvis", "Yury"],
         )
 
@@ -622,8 +604,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         )
 
     async def test_edgeql_functions_array_get_02(self):
-        await self.con.execute('SET MODULE test')
-
         await self.assert_query_result(
             r'''
                 SELECT array_get(array_agg(
@@ -956,13 +936,13 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
     async def test_edgeql_functions_re_replace_02(self):
         await self.assert_query_result(
-            r'''SELECT re_replace('[aeiou]', '~', test::User.name);''',
+            r'''SELECT re_replace('[aeiou]', '~', User.name);''',
             {'Elv~s', 'Y~ry'},
         )
 
         await self.assert_query_result(
             r'''
-                SELECT re_replace('[aeiou]', '~', test::User.name,
+                SELECT re_replace('[aeiou]', '~', User.name,
                                   flags := 'g');
             ''',
             {'Elv~s', 'Y~ry'},
@@ -970,7 +950,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                SELECT re_replace('[aeiou]', '~', test::User.name,
+                SELECT re_replace('[aeiou]', '~', User.name,
                                   flags := 'i');
             ''',
             {'~lvis', 'Y~ry'},
@@ -978,7 +958,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                SELECT re_replace('[aeiou]', '~', test::User.name,
+                SELECT re_replace('[aeiou]', '~', User.name,
                                   flags := 'gi');
             ''',
             {'~lv~s', 'Y~ry'},
@@ -2837,7 +2817,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_min_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT min(User.name);
             ''',
             ['Elvis'],
@@ -2845,7 +2824,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT min(Issue.time_estimate);
             ''',
             [3000],
@@ -2853,7 +2831,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT min(<int64>Issue.number);
             ''',
             [{}],
@@ -2863,7 +2840,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         # Objects are valid inputs to "min" and are ordered by their .id.
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT min(User).id = min(User.id);
             ''',
             [True],
@@ -2983,7 +2959,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_max_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT max(User.name);
             ''',
             ['Yury'],
@@ -2991,7 +2966,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT max(Issue.time_estimate);
             ''',
             [3000],
@@ -2999,7 +2973,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT max(<int64>Issue.number);
             ''',
             [4],
@@ -3009,7 +2982,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         # Objects are valid inputs to "max" and are ordered by their .id.
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT max(User).id = max(User.id);
             ''',
             [True],
@@ -3074,7 +3046,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_all_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT all(len(User.name) = 4);
             ''',
             [False],
@@ -3082,7 +3053,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT all(
                     (
                         FOR I IN {Issue}
@@ -3095,7 +3065,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT all(Issue.number != '');
                 ''',
             [True],
@@ -3160,7 +3129,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_any_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT any(len(User.name) = 4);
             ''',
             [True],
@@ -3168,7 +3136,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT any(
                     (
                         FOR I IN {Issue}
@@ -3181,7 +3148,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT any(Issue.number != '');
             ''',
             [True],
@@ -3190,7 +3156,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_any_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT any(len(User.name) = 4) =
                     NOT all(NOT (len(User.name) = 4));
             ''',
@@ -3199,7 +3164,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT any(
                     (
                         FOR I IN {Issue}
@@ -3217,7 +3181,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT any(Issue.number != '') = NOT all(Issue.number = '');
             ''',
             [True],
@@ -3401,7 +3364,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_round_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT _ := round(<int64>Issue.number / 2)
                 ORDER BY _;
             ''',
@@ -3410,7 +3372,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT _ := round(<decimal>Issue.number / 2)
                 ORDER BY _;
             ''',
@@ -4196,7 +4157,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             r'''
                 WITH
                     MODULE math,
-                    A := len(test::Named.name)
+                    A := len(default::Named.name)
                 # the difference between sum and mean * count is due to
                 # rounding errors, but it should be small
                 SELECT abs(sum(A) - count(A) * mean(A)) < 1e-10;
@@ -4209,7 +4170,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             r'''
                 WITH
                     MODULE math,
-                    A := <float64>len(test::Named.name)
+                    A := <float64>len(default::Named.name)
                 # the difference between sum and mean * count is due to
                 # rounding errors, but it should be small
                 SELECT abs(sum(A) - count(A) * mean(A)) < 1e-10;
@@ -4645,37 +4606,37 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
     async def test_edgeql_functions_sequence_next_reset(self):
         await self.con.execute('''
-            CREATE SCALAR TYPE test::my_seq_01 EXTENDING std::sequence;
+            CREATE SCALAR TYPE my_seq_01 EXTENDING std::sequence;
         ''')
 
         result = await self.con.query_one('''
-            SELECT sequence_next(INTROSPECT test::my_seq_01)
+            SELECT sequence_next(INTROSPECT my_seq_01)
         ''')
 
         self.assertEqual(result, 1)
 
         result = await self.con.query_one('''
-            SELECT sequence_next(INTROSPECT test::my_seq_01)
+            SELECT sequence_next(INTROSPECT my_seq_01)
         ''')
 
         self.assertEqual(result, 2)
 
         await self.con.execute('''
-            SELECT sequence_reset(INTROSPECT test::my_seq_01)
+            SELECT sequence_reset(INTROSPECT my_seq_01)
         ''')
 
         result = await self.con.query_one('''
-            SELECT sequence_next(INTROSPECT test::my_seq_01)
+            SELECT sequence_next(INTROSPECT my_seq_01)
         ''')
 
         self.assertEqual(result, 1)
 
         await self.con.execute('''
-            SELECT sequence_reset(INTROSPECT test::my_seq_01, 20)
+            SELECT sequence_reset(INTROSPECT my_seq_01, 20)
         ''')
 
         result = await self.con.query_one('''
-            SELECT sequence_next(INTROSPECT test::my_seq_01)
+            SELECT sequence_next(INTROSPECT my_seq_01)
         ''')
 
         self.assertEqual(result, 21)

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -39,7 +39,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_simple_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 GROUP User
                 USING _ := User.name
                 BY _
@@ -52,7 +51,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_simple_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 GROUP Issue := Issue
                 # time_estimate is {} on some Issues,
                 # but that's a valid grouping
@@ -68,7 +66,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_simple_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 GROUP Issue
                 USING _ := Issue.time_estimate
                 BY _
@@ -82,7 +79,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_simple_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 GROUP Issue
                 USING _ := Issue.time_estimate
                 BY _
@@ -97,7 +93,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_simple_05(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 GROUP Issue
                 USING _ := Issue.time_estimate
                 BY _
@@ -112,7 +107,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_simple_06(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 GROUP Issue
                 USING _ := Issue.time_estimate
                 BY _
@@ -127,7 +121,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_by_01(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 GROUP Issue
                 USING B :=  Issue.status.name
                 BY B
@@ -152,7 +145,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_by_02(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 GROUP Issue
                 USING B :=  Issue.status.name
                 BY B
@@ -176,7 +168,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # re-use the same "_" alias in nested scope
-                WITH MODULE test
                 GROUP Issue
                 USING _ :=  Issue.time_estimate
                 BY _
@@ -192,7 +183,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 GROUP Issue
                 USING _ :=  Issue.time_estimate
                 BY _
@@ -210,7 +200,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # re-use the same "_" alias in nested scope
-                WITH MODULE test
                 GROUP Issue
                 USING _ :=  Issue.time_estimate
                 BY _
@@ -229,7 +218,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_nested_01(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
                     R := (
                         name := User.name,
@@ -277,7 +265,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_returning_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 GROUP Issue
                 USING _ :=  Issue.time_estimate
                 BY _
@@ -293,7 +280,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_returning_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 GROUP Issue
                 USING B := Issue.time_estimate
                 BY B
@@ -309,7 +295,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_returning_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 GROUP Issue
                 USING B := Issue.status
                 BY B
@@ -338,7 +323,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_returning_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 GROUP Issue
                 USING _ := Issue.status
                 BY _
@@ -685,7 +669,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_by_tuple_01(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 GROUP Issue
                 USING B := (Issue.status.name, Issue.time_estimate)
                 # This tuple will be {} for Issues lacking
@@ -716,7 +699,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_by_multiple_01(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 GROUP Issue
                 USING
                     Stat := Issue.status.name,
@@ -752,7 +734,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_by_multiple_02(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 GROUP Issue
                 USING
                     Stat := Issue.status.name,
@@ -784,7 +765,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_by_multiple_03(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 GROUP Issue
                 USING
                     Stat := Issue.status.name,
@@ -821,7 +801,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_by_multiple_04(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 GROUP Issue
                 USING
                     Stat := Issue.status.name,
@@ -863,7 +842,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_by_multiple_05(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 GROUP
                     # define a computable in the GROUP expr
                     Issue := Issue {
@@ -906,7 +884,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
     async def test_edgeql_group_by_multiple_06(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 GROUP Issue
                 USING
                     Stat := Issue.status.name,
@@ -1205,7 +1182,6 @@ class TestEdgeQLGroup(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     I := <int64>Issue.number
                 GROUP I
                 USING _ :=  I % 2 = 0

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -36,32 +36,32 @@ class TestInsert(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.MissingRequiredError,
             r"missing value for required property"
-            r" 'l2' of object type 'test::InsertTest'",
+            r" 'l2' of object type 'default::InsertTest'",
         ):
             await self.con.execute('''
-                INSERT test::InsertTest;
+                INSERT InsertTest;
             ''')
 
     async def test_edgeql_insert_simple_01(self):
         await self.con.execute(r"""
-            INSERT test::InsertTest {
+            INSERT InsertTest {
                 name := 'insert simple 01',
                 l2 := 0,
             };
 
-            INSERT test::InsertTest {
+            INSERT InsertTest {
                 name := 'insert simple 01',
                 l3 := "Test\"1\"",
                 l2 := 1
             };
 
-            INSERT test::InsertTest {
+            INSERT InsertTest {
                 name := 'insert simple 01',
                 l3 := 'Test\'2\'',
                 l2 := 2
             };
 
-            INSERT test::InsertTest {
+            INSERT InsertTest {
                 name := 'insert simple 01',
                 l3 := '\"Test\'3\'\"',
                 l2 := 3
@@ -71,13 +71,13 @@ class TestInsert(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 SELECT
-                    test::InsertTest {
+                    InsertTest {
                         l2, l3
                     }
                 FILTER
-                    test::InsertTest.name = 'insert simple 01'
+                    InsertTest.name = 'insert simple 01'
                 ORDER BY
-                    test::InsertTest.l2;
+                    InsertTest.l2;
             """,
             [
                 {
@@ -101,17 +101,15 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_simple_02(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT DefaultTest1 { foo := '02' };
 
-            INSERT test::DefaultTest1 { foo := '02' };
+            INSERT DefaultTest1 { foo := '02' };
 
-            INSERT test::DefaultTest1 { foo := '02' };
+            INSERT DefaultTest1 { foo := '02' };
         ''')
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT DefaultTest1 { num } FILTER DefaultTest1.foo = '02';
             ''',
             [{'num': 42}, {'num': 42}, {'num': 42}],
@@ -119,23 +117,21 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_simple_03(self):
         await self.con.execute('''
-            INSERT test::DefaultTest1 { num := 100 };
+            INSERT DefaultTest1 { num := 100 };
 
-            WITH MODULE test
             INSERT DefaultTest2;
 
-            INSERT test::DefaultTest1 { num := 101 };
+            INSERT DefaultTest1 { num := 101 };
 
-            INSERT test::DefaultTest2;
+            INSERT DefaultTest2;
 
-            INSERT test::DefaultTest1 { num := 102 };
+            INSERT DefaultTest1 { num := 102 };
 
-            INSERT test::DefaultTest2;
+            INSERT DefaultTest2;
         ''')
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT DefaultTest2 { num }
                 ORDER BY DefaultTest2.num;
             ''',
@@ -144,34 +140,34 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_nested_01(self):
         await self.con.execute('''
-            INSERT test::Subordinate {
+            INSERT Subordinate {
                 name := 'subtest 1'
             };
 
-            INSERT test::Subordinate {
+            INSERT Subordinate {
                 name := 'subtest 2'
             };
 
-            INSERT test::InsertTest {
+            INSERT InsertTest {
                 name := 'insert nested',
                 l2 := 0,
                 subordinates := (
-                    SELECT test::Subordinate
-                    FILTER test::Subordinate.name LIKE 'subtest%'
+                    SELECT Subordinate
+                    FILTER Subordinate.name LIKE 'subtest%'
                 )
             };
         ''')
 
         await self.assert_query_result(
             r'''
-                SELECT test::InsertTest {
+                SELECT InsertTest {
                     subordinates: {
                         name,
                         @comment,
-                    } ORDER BY test::InsertTest.subordinates.name
+                    } ORDER BY InsertTest.subordinates.name
                 }
                 FILTER
-                    test::InsertTest.name = 'insert nested';
+                    InsertTest.name = 'insert nested';
             ''',
             [{
                 'subordinates': [{
@@ -186,17 +182,14 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_nested_02(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT Subordinate {
                 name := 'subtest 3'
             };
 
-            WITH MODULE test
             INSERT Subordinate {
                 name := 'subtest 4'
             };
 
-            WITH MODULE test
             INSERT InsertTest {
                 name := 'insert nested 2',
                 l2 := 0,
@@ -211,7 +204,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT InsertTest {
                     subordinates: {
                         name,
@@ -234,7 +226,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_nested_03(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT InsertTest {
                 name := 'insert nested 3',
                 l2 := 0,
@@ -246,7 +237,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT InsertTest {
                     subordinates: {
                         name
@@ -264,7 +254,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_nested_04(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT InsertTest {
                 name := 'insert nested 4',
                 l2 := 0,
@@ -277,7 +266,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT InsertTest {
                     subordinates: {
                         name,
@@ -297,15 +285,14 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_nested_05(self):
         await self.con.execute('''
-            INSERT test::Subordinate {
+            INSERT Subordinate {
                 name := 'only subordinate'
             };
 
-            INSERT test::Subordinate {
+            INSERT Subordinate {
                 name := 'never subordinate'
             };
 
-            WITH MODULE test
             INSERT InsertTest {
                 name := 'insert nested 5',
                 l2 := 0,
@@ -318,7 +305,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT InsertTest {
                     name,
                     l2,
@@ -344,12 +330,10 @@ class TestInsert(tb.QueryTestCase):
     ''')
     async def test_edgeql_insert_nested_06(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT Subordinate {
                 name := 'linkprop test target 6'
             };
 
-            WITH MODULE test
             INSERT InsertTest {
                 name := 'insert nested 6',
                 l2 := 0,
@@ -364,7 +348,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT InsertTest {
                     subordinates: {
                         name,
@@ -387,7 +370,6 @@ class TestInsert(tb.QueryTestCase):
                 edgedb.EdgeQLSyntaxError,
                 "Unexpected 'Subordinate'"):
             await self.con.execute('''
-                WITH MODULE test
                 INSERT InsertTest {
                     subordinates: Subordinate {
                         name := 'nested sub 7.1',
@@ -399,7 +381,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_nested_08(self):
         await self.assert_query_result(r'''
             WITH
-                MODULE test,
                 x1 := (
                     INSERT InsertTest {
                         name := 'insert nested 8',
@@ -425,7 +406,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_nested_09(self):
         # test a single link with a link property
         await self.con.execute(r'''
-            WITH MODULE test
             INSERT InsertTest {
                 name := 'insert nested 9',
                 l2 := 0,
@@ -439,7 +419,6 @@ class TestInsert(tb.QueryTestCase):
         ''')
 
         await self.assert_query_result(r'''
-            WITH MODULE test
             SELECT InsertTest {
                 name,
                 sub: {
@@ -463,7 +442,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_nested_10(self):
         # test a single link with a link property
         await self.con.execute(r'''
-            SET MODULE test;
 
             INSERT Subordinate {
                 name := 'nested sub 10',
@@ -483,7 +461,6 @@ class TestInsert(tb.QueryTestCase):
         ''')
 
         await self.assert_query_result(r'''
-            WITH MODULE test
             SELECT InsertTest {
                 name,
                 sub: {
@@ -502,7 +479,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_nested_11(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT Subordinate {
                 name := 'linkprop test target 6'
             };
@@ -510,7 +486,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             '''
-                WITH MODULE test
                 SELECT (
                     INSERT InsertTest {
                         name := 'insert nested 6',
@@ -535,7 +510,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_returning_01(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT DefaultTest1 {
                 foo := 'ret1',
                 num := 1,
@@ -544,7 +518,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (INSERT DefaultTest1 {
                     foo := 'ret2',
                     num := 2,
@@ -557,7 +530,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (INSERT DefaultTest1 {
                     foo := 'ret3',
                     num := 3,
@@ -569,7 +541,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_returning_02(self):
         await self.assert_query_result(
             '''
-                WITH MODULE test
                 INSERT DefaultTest1 {
                     foo := 'ret1',
                     num := 1,
@@ -582,7 +553,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             '''
-                WITH MODULE test
                 SELECT (INSERT DefaultTest1 {
                     foo := 'ret2',
                     num := 2,
@@ -595,7 +565,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             '''
-                WITH MODULE test
                 SELECT (INSERT DefaultTest1 {
                     foo := 'ret3',
                     num := 3,
@@ -606,7 +575,6 @@ class TestInsert(tb.QueryTestCase):
 
         obj = await self.con._fetchall(
             '''
-                WITH MODULE test
                 INSERT DefaultTest1 {
                     foo := 'ret1',
                     num := 1,
@@ -618,11 +586,11 @@ class TestInsert(tb.QueryTestCase):
 
         self.assertTrue(hasattr(obj[0], 'id'))
         self.assertTrue(hasattr(obj[0], '__tid__'))
-        self.assertEqual(obj[0].__tname__, 'test::DefaultTest1')
+        self.assertEqual(obj[0].__tname__, 'default::DefaultTest1')
 
     async def test_edgeql_insert_returning_03(self):
         await self.con.execute('''
-            INSERT test::Subordinate {
+            INSERT Subordinate {
                 name := 'sub returning 3'
             };
         ''')
@@ -630,7 +598,6 @@ class TestInsert(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     I := (INSERT InsertTest {
                         name := 'insert nested returning 3',
                         l2 := 0,
@@ -659,7 +626,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_returning_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (INSERT DefaultTest1 {
                     foo := 'DT returning 4',
                     num := 33,
@@ -674,7 +640,6 @@ class TestInsert(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     I := (INSERT _ := InsertTest {
                         name := 'IT returning 4',
                         l2 := 9999,
@@ -689,7 +654,6 @@ class TestInsert(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     I := (INSERT _ := InsertTest {
                         name := 'IT returning 4',
                         l2 := 9,
@@ -707,7 +671,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_returning_05(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (INSERT DefaultTest1 {
                     foo := 'DT returning 5',
                 }) {
@@ -724,14 +687,13 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_returning_06(self):
         await self.con.execute('''
-            INSERT test::Subordinate {
+            INSERT Subordinate {
                 name := 'DefaultTest5/Sub'
             };
         ''')
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (INSERT DefaultTest5 {
                     name := 'ret6/DT5',
                 }) {
@@ -752,14 +714,13 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_returning_07(self):
         await self.con.execute('''
-            INSERT test::Subordinate {
+            INSERT Subordinate {
                 name := 'DefaultTest5/Sub'
             };
         ''')
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (INSERT DefaultTest6 {
                     name := 'ret7/DT6',
                 }) {
@@ -786,14 +747,13 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_returning_08(self):
         await self.con.execute('''
-            INSERT test::Subordinate {
+            INSERT Subordinate {
                 name := 'DefaultTest5/Sub'
             };
         ''')
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (INSERT DefaultTest7 {
                     name := 'ret8/DT7',
                 }) {
@@ -828,8 +788,7 @@ class TestInsert(tb.QueryTestCase):
         # make sure a WITH bound insert makes it into the returned data
         await self.assert_query_result(
             r'''
-                WITH MODULE test,
-                     N := (INSERT Note {name := "!" }),
+                WITH N := (INSERT Note {name := "!" }),
                 SELECT ((
                     INSERT Person {
                         name := "Phil Emarg",
@@ -847,8 +806,7 @@ class TestInsert(tb.QueryTestCase):
         # make sure it works when *doubly* nested!
         await self.assert_query_result(
             r'''
-                WITH MODULE test,
-                     S := (INSERT Subordinate { name := "sub" }),
+                WITH S := (INSERT Subordinate { name := "sub" }),
                      N := (INSERT Note {name := "!", subject := S }),
                 SELECT ((
                     INSERT Person {
@@ -867,8 +825,7 @@ class TestInsert(tb.QueryTestCase):
         # ... *doubly* nested, but the inner insert is a multi link
         await self.assert_query_result(
             r'''
-            WITH MODULE test,
-                 N := (INSERT Note {name := "!" }),
+            WITH N := (INSERT Note {name := "!" }),
                  P := (INSERT Person {
                     name := "Emmanuel Villip",
                     notes := N,
@@ -889,7 +846,6 @@ class TestInsert(tb.QueryTestCase):
         # test that subtypes get returned by a nested insert
         await self.assert_query_result(
             r'''
-                WITH MODULE test,
                 SELECT
                 (INSERT Note {
                      name := "test",
@@ -904,14 +860,12 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_returning_11(self):
         await self.con.execute(r'''
-            WITH MODULE test
             INSERT Note { name := "note", note := "a" };
         ''')
 
         # test that subtypes get returned by a nested update
         await self.assert_query_result(
             r'''
-                WITH MODULE test,
                 SELECT
                 (INSERT Person {
                      name := "test",
@@ -930,14 +884,12 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_returning_12(self):
         await self.con.execute(r'''
-            WITH MODULE test
             INSERT DerivedNote { name := "note", note := "a" };
         ''')
 
         # test that subtypes get returned by a nested update
         await self.assert_query_result(
             r'''
-                WITH MODULE test,
                 SELECT
                 (INSERT Person {
                      name := "test",
@@ -956,19 +908,16 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_returning_13(self):
         await self.con.execute(r'''
-            WITH MODULE test
             INSERT DerivedNote { name := "dnote", note := "a" };
         ''')
 
         await self.con.execute(r'''
-            WITH MODULE test
             INSERT DerivedNote { name := "anote", note := "some note" };
         ''')
 
         # test that subtypes get returned by a nested update
         await self.assert_query_result(
             r'''
-            WITH MODULE test,
             SELECT
             (INSERT Person {
                 name := "test",
@@ -994,14 +943,12 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_for_01(self):
         await self.con.execute(r'''
-            WITH MODULE test
             FOR x IN {3, 5, 7, 2}
             UNION (INSERT InsertTest {
                 name := 'insert for 1',
                 l2 := x,
             });
 
-            WITH MODULE test
             FOR Q IN {(SELECT InsertTest{foo := 'foo' ++ <str> InsertTest.l2}
                        FILTER .name = 'insert for 1')}
             UNION (INSERT InsertTest {
@@ -1013,7 +960,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT InsertTest{name, l2, l3}
                 FILTER .name = 'insert for 1'
                 ORDER BY .l2 THEN .l3;
@@ -1068,7 +1014,6 @@ class TestInsert(tb.QueryTestCase):
         await self.con.execute(r'''
             # create 10 DefaultTest3 objects, each object is defined
             # as having a randomly generated value for 'foo'
-            WITH MODULE test
             FOR x IN {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
             UNION (INSERT DefaultTest3);
         ''')
@@ -1078,7 +1023,6 @@ class TestInsert(tb.QueryTestCase):
                 # statistically, randomly generated value for 'foo'
                 # should not be identical for all 10 records
                 WITH
-                    MODULE test,
                     DT3 := DefaultTest3
                 SELECT count(
                     DefaultTest3 FILTER DefaultTest3.foo != DT3.foo) > 0;
@@ -1092,14 +1036,12 @@ class TestInsert(tb.QueryTestCase):
             # 'bar' is technically evaluated for each object, but
             # because it is deterministic it will be same for all 5
             # new objects.
-            WITH MODULE test
             FOR x IN {1, 2, 3, 4, 5}
             UNION (INSERT DefaultTest4);
         ''')
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT DefaultTest4.bar
                 ORDER BY DefaultTest4.bar;
             ''',
@@ -1108,7 +1050,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_for_04(self):
         await self.con.execute(r'''
-            WITH MODULE test
             INSERT InsertTest {
                 name := 'nested-insert-for',
                 l2 := 999,
@@ -1126,7 +1067,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT InsertTest {
                     subordinates: {
                         name,
@@ -1148,7 +1088,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_for_06(self):
         res = await self.con.query(r'''
-            WITH MODULE test
             FOR a in {"a", "b"} UNION (
                 FOR b in {"c", "d"} UNION (
                     INSERT Note {name := b}));
@@ -1157,7 +1096,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Note.name
                 ORDER BY Note.name;
             ''',
@@ -1166,7 +1104,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_for_07(self):
         res = await self.con.query(r'''
-            WITH MODULE test
             FOR a in {"a", "b"} UNION (
                 FOR b in {a++"c", a++"d"} UNION (
                     INSERT Note {name := b}));
@@ -1175,7 +1112,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Note.name
                 ORDER BY Note.name;
             ''',
@@ -1184,7 +1120,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_for_08(self):
         res = await self.con.query(r'''
-            WITH MODULE test
             FOR a in {"a", "b"} UNION (
                 FOR b in {"a", "b"} UNION (
                     FOR c in {a++b++"a", a++b++"b"} UNION (
@@ -1194,7 +1129,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Note.name
                 ORDER BY Note.name;
             ''',
@@ -1203,7 +1137,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_for_09(self):
         res = await self.con.query(r'''
-            WITH MODULE test
             FOR a in {"a", "b"} UNION (
                 FOR b in {"a", "b"} UNION (
                     FOR c in {"a", "b"} UNION (
@@ -1213,7 +1146,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Note.name
                 ORDER BY Note.name;
             ''',
@@ -1223,7 +1155,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_for_10(self):
         # Nested FOR where the inner-most one isn't referenced
         res = await self.con.query(r'''
-            WITH MODULE test
             FOR a in {"a", "b"} UNION (
                 FOR b in {"a", "b"} UNION (
                     FOR c in {"a", "b"} UNION (
@@ -1233,7 +1164,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Note.name
                 ORDER BY Note.name;
             ''',
@@ -1243,7 +1173,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_for_11(self):
         # Nested FOR where the inner-most two aren't referenced
         res = await self.con.query(r'''
-            WITH MODULE test
             FOR a in {"a", "b"} UNION (
                 FOR b in {"a", "b"} UNION (
                     FOR c in {"a", "b"} UNION (
@@ -1253,7 +1182,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Note.name
                 ORDER BY Note.name;
             ''',
@@ -1264,7 +1192,6 @@ class TestInsert(tb.QueryTestCase):
         # FOR that has a correlated SELECT and INSERT
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 FOR a in {"foo", "bar"} UNION (
                     (a,(INSERT Note {name:=a}))
                 )
@@ -1275,7 +1202,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Note.name
                 ORDER BY Note.name;
             ''',
@@ -1285,7 +1211,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_for_13(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 FOR a in {"foo", "bar"} UNION (
                     SELECT (INSERT Note {name:=a}) {name}
                 )
@@ -1296,7 +1221,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Note.name
                 ORDER BY Note.name;
             ''',
@@ -1307,7 +1231,6 @@ class TestInsert(tb.QueryTestCase):
         # Nested FOR that has a correlated SELECT and INSERT
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 FOR a in {"a", "b"} UNION (
                     FOR b in {"c", "d"} UNION (
                         (a, b, (INSERT Note {name:=a++b}).name)
@@ -1325,7 +1248,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Note.name
                 ORDER BY Note.name;
             ''',
@@ -1334,7 +1256,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_for_15(self):
         await self.con.execute(r"""
-            WITH MODULE test
             FOR noob in {"Phil Emarg", "Madeline Hatch"}
             UNION (
                 INSERT Person {name := noob ++ "!",
@@ -1342,7 +1263,7 @@ class TestInsert(tb.QueryTestCase):
         """)
 
         await self.assert_query_result(
-            "SELECT test::Person { name, notes: {name} } ORDER BY .name DESC",
+            "SELECT Person { name, notes: {name} } ORDER BY .name DESC",
             [{"name": "Phil Emarg!",
               "notes": [{"name": "Phil Emarg"}]},
              {"name": "Madeline Hatch!",
@@ -1351,7 +1272,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_for_16(self):
         await self.con.execute(r"""
-            WITH MODULE test
             FOR noob in {"Phil Emarg", "Madeline Hatch"}
             UNION (
                 INSERT Person {name := noob,
@@ -1361,7 +1281,7 @@ class TestInsert(tb.QueryTestCase):
         """)
 
         await self.assert_query_result(
-            """SELECT test::Person {
+            """SELECT Person {
                name, notes: {name} ORDER BY .name DESC} ORDER BY .name DESC""",
             [
                 {"name": "Phil Emarg",
@@ -1377,7 +1297,6 @@ class TestInsert(tb.QueryTestCase):
         # same as above, but with a SELECT wrapping the inner FOR,
         # which exposed some issues
         await self.con.execute(r"""
-            WITH MODULE test
             FOR noob in {"Phil Emarg", "Madeline Hatch"}
             UNION (
                 INSERT Person {name := noob,
@@ -1387,7 +1306,7 @@ class TestInsert(tb.QueryTestCase):
         """)
 
         await self.assert_query_result(
-            """SELECT test::Person {
+            """SELECT Person {
                name, notes: {name} ORDER BY .name DESC} ORDER BY .name DESC""",
             [
                 {"name": "Phil Emarg",
@@ -1401,7 +1320,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_for_18(self):
         await self.con.execute(r"""
-            WITH MODULE test
             FOR noob in {"Phil Emarg", "Madeline Hatch"}
             UNION (
                 INSERT Person {name := noob ++ "!",
@@ -1409,7 +1327,7 @@ class TestInsert(tb.QueryTestCase):
         """)
 
         await self.assert_query_result(
-            "SELECT test::Person { name, note: {name} } ORDER BY .name DESC",
+            "SELECT Person { name, note: {name} } ORDER BY .name DESC",
             [{"name": "Phil Emarg!",
               "note": {"name": "Phil Emarg"}},
              {"name": "Madeline Hatch!",
@@ -1422,7 +1340,6 @@ class TestInsert(tb.QueryTestCase):
             "cannot reference correlated set",
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT (Person,
                         (FOR x in {Person} UNION (
                              INSERT Note {name := x.name})));
@@ -1434,7 +1351,6 @@ class TestInsert(tb.QueryTestCase):
             "cannot reference correlated set",
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT (Person,
                         (FOR x in {Person} UNION (
                              SELECT (INSERT Note {name := x.name}))));
@@ -1446,7 +1362,6 @@ class TestInsert(tb.QueryTestCase):
             "cannot reference correlated set",
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT ((FOR x in {Person} UNION (
                              INSERT Note {name := x.name})),
                         Person);
@@ -1458,7 +1373,6 @@ class TestInsert(tb.QueryTestCase):
             "cannot reference correlated set",
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT (Person,
                         (FOR x in {Person} UNION (
                              SELECT (
@@ -1471,17 +1385,17 @@ class TestInsert(tb.QueryTestCase):
         await self.con.execute(r'''
             # create 10 DefaultTest3 objects, each object is defined
             # as having a randomly generated value for 'foo'
-            INSERT test::DefaultTest3;
-            INSERT test::DefaultTest3;
-            INSERT test::DefaultTest3;
-            INSERT test::DefaultTest3;
-            INSERT test::DefaultTest3;
+            INSERT DefaultTest3;
+            INSERT DefaultTest3;
+            INSERT DefaultTest3;
+            INSERT DefaultTest3;
+            INSERT DefaultTest3;
 
-            INSERT test::DefaultTest3;
-            INSERT test::DefaultTest3;
-            INSERT test::DefaultTest3;
-            INSERT test::DefaultTest3;
-            INSERT test::DefaultTest3;
+            INSERT DefaultTest3;
+            INSERT DefaultTest3;
+            INSERT DefaultTest3;
+            INSERT DefaultTest3;
+            INSERT DefaultTest3;
         ''')
 
         await self.assert_query_result(
@@ -1489,7 +1403,6 @@ class TestInsert(tb.QueryTestCase):
                 # statistically, randomly generated value for 'foo'
                 # should not be identical for all 10 records
                 WITH
-                    MODULE test,
                     DT3 := DefaultTest3
                 SELECT count(
                     DefaultTest3 FILTER DefaultTest3.foo != DT3.foo) > 0;
@@ -1501,16 +1414,15 @@ class TestInsert(tb.QueryTestCase):
         await self.con.execute(r'''
             # by default the 'bar' value is simply going to be "indexing" the
             # created objects
-            INSERT test::DefaultTest4;
-            INSERT test::DefaultTest4;
-            INSERT test::DefaultTest4;
-            INSERT test::DefaultTest4;
-            INSERT test::DefaultTest4;
+            INSERT DefaultTest4;
+            INSERT DefaultTest4;
+            INSERT DefaultTest4;
+            INSERT DefaultTest4;
+            INSERT DefaultTest4;
         ''')
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT DefaultTest4 { bar }
                 ORDER BY DefaultTest4.bar;
             ''',
@@ -1537,14 +1449,13 @@ class TestInsert(tb.QueryTestCase):
         await self.con.execute(r'''
             # by default the 'bar' value is simply going to be "indexing" the
             # created objects
-            INSERT test::DefaultTest4 { bar:= 10 };
-            INSERT test::DefaultTest4;
-            INSERT test::DefaultTest4;
+            INSERT DefaultTest4 { bar:= 10 };
+            INSERT DefaultTest4;
+            INSERT DefaultTest4;
         ''')
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT DefaultTest4 { bar }
                 ORDER BY DefaultTest4.bar;
             ''',
@@ -1565,16 +1476,15 @@ class TestInsert(tb.QueryTestCase):
         await self.con.execute(r'''
             # by default the 'bar' value is simply going to be "indexing" the
             # created objects
-            INSERT test::DefaultTest4;
-            INSERT test::DefaultTest4;
-            INSERT test::DefaultTest4 { bar:= 0 };
-            INSERT test::DefaultTest4;
-            INSERT test::DefaultTest4;
+            INSERT DefaultTest4;
+            INSERT DefaultTest4;
+            INSERT DefaultTest4 { bar:= 0 };
+            INSERT DefaultTest4;
+            INSERT DefaultTest4;
         ''')
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT DefaultTest4 { bar }
                 ORDER BY DefaultTest4.bar;
             ''',
@@ -1602,14 +1512,13 @@ class TestInsert(tb.QueryTestCase):
         await self.con.execute(r'''
             # The 'number' property is supposed to be
             # self-incrementing and read-only.
-            INSERT test::DefaultTest8;
-            INSERT test::DefaultTest8;
-            INSERT test::DefaultTest8;
+            INSERT DefaultTest8;
+            INSERT DefaultTest8;
+            INSERT DefaultTest8;
         ''')
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT DefaultTest8.number;
             ''',
             {1, 2, 3}
@@ -1617,7 +1526,7 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_default_06(self):
         res = await self.con.query(r'''
-            INSERT test::DefaultTest1;
+            INSERT DefaultTest1;
         ''')
         assert len(res) == 1
         obj = res[0]
@@ -1627,7 +1536,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_as_expr_01(self):
         await self.con.execute(r'''
             # insert several objects, then annotate one of the inserted batch
-            WITH MODULE test
             FOR x IN {(
                     SELECT _i := (
                         FOR y IN {3, 5, 7, 2}
@@ -1646,7 +1554,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT
                     InsertTest {
                         name,
@@ -1694,7 +1601,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_polymorphic_01(self):
         await self.con.execute(r'''
-            WITH MODULE test
             INSERT Directive {
                 args := (INSERT InputValue {
                     val := "something"
@@ -1704,7 +1610,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Callable {
                     args: {
                         val
@@ -1718,7 +1623,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Field {
                     args: {
                         val
@@ -1730,7 +1634,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Directive {
                     args: {
                         val
@@ -1744,7 +1647,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT InputValue {
                     val
                 };
@@ -1756,14 +1658,12 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_linkprops_with_for_01(self):
         await self.con.execute(r"""
-            WITH MODULE test
             FOR i IN {'1', '2', '3'} UNION (
                 INSERT Subordinate {
                     name := 'linkproptest ' ++ i
                 }
             );
 
-            WITH MODULE test
             INSERT InsertTest {
                 l2 := 99,
                 subordinates := (
@@ -1777,7 +1677,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT InsertTest {
                     l2,
                     subordinates: {
@@ -1807,7 +1706,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_empty_01(self):
         await self.con.execute(r"""
-            WITH MODULE test
             INSERT InsertTest {
                 l1 := {},
                 l2 := 99,
@@ -1818,7 +1716,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT InsertTest {
                     l1,
                     l2,
@@ -1837,7 +1734,6 @@ class TestInsert(tb.QueryTestCase):
                 edgedb.InvalidPropertyTargetError,
                 r"invalid target.*std::datetime.*expecting 'std::int64'"):
             await self.con.execute(r"""
-                WITH MODULE test
                 INSERT InsertTest {
                     l1 := <datetime>{},
                     l2 := 99,
@@ -1850,7 +1746,6 @@ class TestInsert(tb.QueryTestCase):
                 r"missing value for required property"):
             await self.con.execute(
                 r"""
-                    WITH MODULE test
                     INSERT InsertTest {
                         l2 := {},
                     };
@@ -1859,7 +1754,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_empty_04(self):
         await self.con.execute(r"""
-            WITH MODULE test
             INSERT InsertTest {
                 l2 := 99,
                 subordinates := {}
@@ -1868,7 +1762,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT InsertTest {
                     l2,
                     subordinates
@@ -1884,9 +1777,8 @@ class TestInsert(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.InvalidLinkTargetError,
                 r"invalid target for link.*std::Object.*"
-                r"expecting 'test::Subordinate'"):
+                r"expecting 'default::Subordinate'"):
             await self.con.execute(r"""
-                WITH MODULE test
                 INSERT InsertTest {
                     l2 := 99,
                     subordinates := <Object>{}
@@ -1904,15 +1796,15 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_alias(self):
         await self.con.execute('''
-            CREATE ALIAS test::Foo := (SELECT test::InsertTest);
+            CREATE ALIAS Foo := (SELECT InsertTest);
         ''')
 
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r"cannot insert into expression alias 'test::Foo'",
+                r"cannot insert into expression alias 'default::Foo'",
                 _position=23):
             await self.con.execute("""\
-                INSERT test::Foo;
+                INSERT Foo;
             """)
 
     async def test_edgeql_insert_selfref_01(self):
@@ -1920,7 +1812,6 @@ class TestInsert(tb.QueryTestCase):
                 edgedb.QueryError,
                 'self-referencing INSERTs are not allowed'):
             await self.con.execute(r"""
-                WITH MODULE test
                 INSERT SelfRef {
                     name := 'myself',
                     ref := SelfRef
@@ -1932,12 +1823,10 @@ class TestInsert(tb.QueryTestCase):
                 edgedb.QueryError,
                 'self-referencing INSERTs are not allowed'):
             await self.con.execute(r"""
-                WITH MODULE test
                 INSERT SelfRef {
                     name := 'other'
                 };
 
-                WITH MODULE test
                 INSERT SelfRef {
                     name := 'myself',
                     ref := (
@@ -1952,12 +1841,10 @@ class TestInsert(tb.QueryTestCase):
                 edgedb.QueryError,
                 'self-referencing INSERTs are not allowed'):
             await self.con.execute(r"""
-                WITH MODULE test
                 INSERT SelfRef {
                     name := 'other'
                 };
 
-                WITH MODULE test
                 INSERT SelfRef {
                     name := 'myself',
                     ref := (
@@ -1970,12 +1857,10 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_selfref_04(self):
         await self.con.execute(r"""
-            WITH MODULE test
             INSERT SelfRef {
                 name := 'ok other'
             };
 
-            WITH MODULE test
             INSERT SelfRef {
                 name := 'ok myself',
                 ref := (
@@ -1987,7 +1872,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT SelfRef {
                     name,
                     ref: {
@@ -2009,7 +1893,6 @@ class TestInsert(tb.QueryTestCase):
                 edgedb.QueryError,
                 'single'):
             await self.con.execute(r'''
-                SET MODULE test;
 
                 INSERT Subordinate { name := 'sub1_cardinality_01'};
                 INSERT Subordinate { name := 'sub2_cardinality_01'};
@@ -2024,24 +1907,24 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_derived_01(self):
         await self.con.execute(r"""
-            INSERT test::DerivedTest {
+            INSERT DerivedTest {
                 name := 'insert derived 01',
                 l2 := 0,
             };
 
-            INSERT test::DerivedTest {
+            INSERT DerivedTest {
                 name := 'insert derived 01',
                 l3 := "Test\"1\"",
                 l2 := 1
             };
 
-            INSERT test::DerivedTest {
+            INSERT DerivedTest {
                 name := 'insert derived 01',
                 l3 := 'Test\'2\'',
                 l2 := 2
             };
 
-            INSERT test::DerivedTest {
+            INSERT DerivedTest {
                 name := 'insert derived 01',
                 l3 := '\"Test\'3\'\"',
                 l2 := 3
@@ -2051,13 +1934,13 @@ class TestInsert(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 SELECT
-                    test::DerivedTest {
+                    DerivedTest {
                         l2, l3
                     }
                 FILTER
-                    test::DerivedTest.name = 'insert derived 01'
+                    DerivedTest.name = 'insert derived 01'
                 ORDER BY
-                    test::DerivedTest.l2;
+                    DerivedTest.l2;
             """,
             [
                 {
@@ -2081,7 +1964,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_derived_02(self):
         await self.con.execute(r"""
-            WITH MODULE test
             INSERT DerivedTest {
                 name := 'insert derived 02',
                 l2 := 0,
@@ -2095,7 +1977,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
                     DerivedTest {
                         name,
@@ -2122,14 +2003,13 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_collection_01(self):
         await self.con.execute(r"""
-            INSERT test::CollectionTest {
+            INSERT CollectionTest {
                 some_tuple := ('collection_01', 99),
             };
         """)
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
                     CollectionTest {
                         some_tuple
@@ -2146,14 +2026,13 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_collection_02(self):
         await self.con.execute(r"""
-            INSERT test::CollectionTest {
+            INSERT CollectionTest {
                 str_array := ['collection_02', '99'],
             };
         """)
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
                     CollectionTest {
                         str_array
@@ -2170,14 +2049,13 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_collection_03(self):
         await self.con.execute(r"""
-            INSERT test::CollectionTest {
+            INSERT CollectionTest {
                 float_array := [3, 1234.5],
             };
         """)
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
                     CollectionTest {
                         float_array
@@ -2194,12 +2072,12 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_collection_04(self):
         await self.con.execute(r"""
-            INSERT test::CollectionTest {
+            INSERT CollectionTest {
                 some_tuple := ('huh', -1),
                 some_multi_tuple := ('foo', 0),
             };
 
-            INSERT test::CollectionTest {
+            INSERT CollectionTest {
                 some_tuple := ('foo', 0),
                 some_multi_tuple := {('foo', 0), ('bar', 1)},
             };
@@ -2207,7 +2085,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT count(
                     CollectionTest FILTER ('bar', 1) IN .some_multi_tuple
                 );
@@ -2217,7 +2094,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT count(
                     CollectionTest FILTER .some_tuple IN .some_multi_tuple
                 );
@@ -2227,7 +2103,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT count(
                     CollectionTest FILTER ('foo', '0') IN
                     <tuple<str, str>>.some_multi_tuple
@@ -2242,7 +2117,6 @@ class TestInsert(tb.QueryTestCase):
                 'INSERT statements cannot be used inside '
                 'conditional expressions'):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT
                     (SELECT Subordinate FILTER .name = 'foo')
                     ??
@@ -2255,7 +2129,6 @@ class TestInsert(tb.QueryTestCase):
                 'INSERT statements cannot be used inside '
                 'conditional expressions'):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT
                     (SELECT Subordinate FILTER .name = 'foo')
                     IF EXISTS Subordinate
@@ -2271,7 +2144,6 @@ class TestInsert(tb.QueryTestCase):
                 edgedb.QueryError,
                 "cannot reference correlated set 'Subordinate' here"):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT (
                     Subordinate,
                     (INSERT InsertTest {
@@ -2287,7 +2159,6 @@ class TestInsert(tb.QueryTestCase):
                 edgedb.QueryError,
                 "cannot reference correlated set 'Subordinate' here"):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT (
                     (INSERT InsertTest {
                         name := 'insert bad',
@@ -2303,7 +2174,6 @@ class TestInsert(tb.QueryTestCase):
                 edgedb.QueryError,
                 "cannot reference correlated set 'Person' here"):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT (
                     Person,
                     (INSERT Person {name := 'insert bad'}),
@@ -2313,8 +2183,8 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_unless_conflict_01(self):
         query = r'''
             SELECT
-             ((INSERT test::Person {name := "test"} UNLESS CONFLICT)
-              ?? (SELECT test::Person FILTER .name = "test")) {name};
+             ((INSERT Person {name := "test"} UNLESS CONFLICT)
+              ?? (SELECT Person FILTER .name = "test")) {name};
         '''
 
         await self.assert_query_result(
@@ -2329,8 +2199,8 @@ class TestInsert(tb.QueryTestCase):
 
         query2 = r'''
             SELECT
-             ((INSERT test::Person {name := <str>$0} UNLESS CONFLICT ON .name)
-              ?? (SELECT test::Person FILTER .name = <str>$0));
+             ((INSERT Person {name := <str>$0} UNLESS CONFLICT ON .name)
+              ?? (SELECT Person FILTER .name = <str>$0));
         '''
 
         res = await self.con.query(query2, "test2")
@@ -2345,7 +2215,7 @@ class TestInsert(tb.QueryTestCase):
                 edgedb.QueryError,
                 "UNLESS CONFLICT argument must be a property"):
             await self.con.query(r'''
-                INSERT test::Person {name := "hello"}
+                INSERT Person {name := "hello"}
                 UNLESS CONFLICT ON 20;
             ''')
 
@@ -2354,8 +2224,8 @@ class TestInsert(tb.QueryTestCase):
                 "UNLESS CONFLICT argument must be a property of "
                 "the type being inserted"):
             await self.con.query(r'''
-                INSERT test::Person {name := "hello"}
-                UNLESS CONFLICT ON test::Note.name;
+                INSERT Person {name := "hello"}
+                UNLESS CONFLICT ON Note.name;
             ''')
 
         async with self.assertRaisesRegexTx(
@@ -2363,7 +2233,7 @@ class TestInsert(tb.QueryTestCase):
                 "UNLESS CONFLICT property must have a "
                 "single exclusive constraint"):
             await self.con.query(r'''
-                INSERT test::Note {name := "hello"}
+                INSERT Note {name := "hello"}
                 UNLESS CONFLICT ON .name;
             ''')
 
@@ -2371,7 +2241,7 @@ class TestInsert(tb.QueryTestCase):
                 edgedb.QueryError,
                 "UNLESS CONFLICT property must be a SINGLE property"):
             await self.con.query(r'''
-                INSERT test::Person {name := "hello", multi_prop := "lol"}
+                INSERT Person {name := "hello", multi_prop := "lol"}
                 UNLESS CONFLICT ON .multi_prop;
             ''')
 
@@ -2380,9 +2250,9 @@ class TestInsert(tb.QueryTestCase):
                 "object type 'std::Object' has no link or property 'name'"):
             await self.con.query(r'''
                 SELECT (
-                    INSERT test::Person {name := "hello"}
+                    INSERT Person {name := "hello"}
                     UNLESS CONFLICT ON .name
-                    ELSE test::DefaultTest1
+                    ELSE DefaultTest1
                 ) {name};
             ''')
 
@@ -2391,8 +2261,7 @@ class TestInsert(tb.QueryTestCase):
                 "possibly more than one element returned by an expression "
                 "for a computable link 'foo' declared as 'single'"):
             await self.con.query(r'''
-                WITH MODULE test,
-                     X := (
+                WITH X := (
                         INSERT Person {name := "hello"}
                         UNLESS CONFLICT ON .name
                         ELSE (DETACHED Person)
@@ -2407,8 +2276,7 @@ class TestInsert(tb.QueryTestCase):
                 "possibly more than one element returned by an expression "
                 "for a computable link 'foo' declared as 'single'"):
             await self.con.query(r'''
-                WITH MODULE test,
-                     X := (
+                WITH X := (
                         INSERT Person {name := "hello"}
                         UNLESS CONFLICT ON .name
                         ELSE Note
@@ -2423,8 +2291,7 @@ class TestInsert(tb.QueryTestCase):
                 "possibly an empty set returned by an expression for a "
                 "computable link 'foo' declared as 'required'"):
             await self.con.query(r'''
-                WITH MODULE test,
-                     X := (
+                WITH X := (
                         INSERT Person {name := "hello"}
                         UNLESS CONFLICT ON .name
                     )
@@ -2436,7 +2303,7 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_unless_conflict_03(self):
         query = r'''
             SELECT (
-                INSERT test::Person {name := "test"} UNLESS CONFLICT) {name};
+                INSERT Person {name := "test"} UNLESS CONFLICT) {name};
         '''
 
         await self.assert_query_result(
@@ -2451,7 +2318,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_unless_conflict_04(self):
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person {name := "test"} UNLESS CONFLICT
                 ON .name ELSE (SELECT Person)
@@ -2469,12 +2335,11 @@ class TestInsert(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
-            r'''SELECT test::Person {name}''',
+            r'''SELECT Person {name}''',
             [{"name": "test"}],
         )
 
         query2 = r'''
-            WITH MODULE test
             INSERT Person {name := <str>$0} UNLESS CONFLICT
             ON .name ELSE (SELECT Person)
         '''
@@ -2488,11 +2353,10 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_unless_conflict_05(self):
         await self.con.execute(r'''
-            INSERT test::Person { name := "Phil Emarg" }
+            INSERT Person { name := "Phil Emarg" }
         ''')
 
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person {name := "Emmanuel Villip"} UNLESS CONFLICT
                 ON .name ELSE (UPDATE Person SET { tag := "redo" })
@@ -2505,7 +2369,7 @@ class TestInsert(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
-            "SELECT test::Person {name, tag} ORDER BY .name",
+            "SELECT Person {name, tag} ORDER BY .name",
             [{"name": "Emmanuel Villip", "tag": None},
              {"name": "Phil Emarg", "tag": None}],
         )
@@ -2517,7 +2381,7 @@ class TestInsert(tb.QueryTestCase):
 
         # Only the correct record should be updated
         await self.assert_query_result(
-            "SELECT test::Person {name, tag} ORDER BY .name",
+            "SELECT Person {name, tag} ORDER BY .name",
             [{"name": "Emmanuel Villip", "tag": "redo"},
              {"name": "Phil Emarg", "tag": None}],
             sort=lambda x: x['name']
@@ -2525,12 +2389,11 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_unless_conflict_06(self):
         await self.con.execute(r'''
-            INSERT test::Person { name := "Phil Emarg" };
-            INSERT test::Person { name := "Madeline Hatch" };
+            INSERT Person { name := "Phil Emarg" };
+            INSERT Person { name := "Madeline Hatch" };
         ''')
 
         query = r'''
-            WITH MODULE test
             SELECT (
                 FOR noob in {"Emmanuel Villip", "Madeline Hatch"} UNION (
                     INSERT Person {name := noob} UNLESS CONFLICT
@@ -2546,7 +2409,7 @@ class TestInsert(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
-            "SELECT test::Person {name, tag} ORDER BY .name",
+            "SELECT Person {name, tag} ORDER BY .name",
             [
                 {"name": "Emmanuel Villip", "tag": None},
                 {"name": "Madeline Hatch", "tag": "redo"},
@@ -2561,7 +2424,7 @@ class TestInsert(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
-            "SELECT test::Person {name, tag} ORDER BY .name",
+            "SELECT Person {name, tag} ORDER BY .name",
             [
                 {"name": "Emmanuel Villip", "tag": "redo"},
                 {"name": "Madeline Hatch", "tag": "redo"},
@@ -2572,7 +2435,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_unless_conflict_07(self):
         # Test it using default values
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person UNLESS CONFLICT
                 ON .name ELSE (UPDATE Person SET { tag := "redo" })
@@ -2585,7 +2447,7 @@ class TestInsert(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
-            "SELECT test::Person {name, tag}",
+            "SELECT Person {name, tag}",
             [{"name": "Nemo", "tag": None}]
         )
 
@@ -2595,19 +2457,18 @@ class TestInsert(tb.QueryTestCase):
         )
 
         await self.con.execute(r'''
-            INSERT test::Person { name := "Phil Emarg" }
+            INSERT Person { name := "Phil Emarg" }
         ''')
 
         # Only the correct record should be updated
         await self.assert_query_result(
-            "SELECT test::Person {name, tag} ORDER BY .name",
+            "SELECT Person {name, tag} ORDER BY .name",
             [{"name": "Nemo", "tag": "redo"},
              {"name": "Phil Emarg", "tag": None}],
         )
 
     async def test_edgeql_insert_unless_conflict_08(self):
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT PersonWrapper {
                     person := (
@@ -2626,7 +2487,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_unless_conflict_09(self):
         query = r'''
-            WITH MODULE test
             INSERT Person {
                 name := 'Cap',
                 tag := 'hero',
@@ -2640,7 +2500,7 @@ class TestInsert(tb.QueryTestCase):
         await self.con.execute(query)
 
         await self.assert_query_result(
-            "SELECT test::Person { tag } FILTER .name = 'Cap'",
+            "SELECT Person { tag } FILTER .name = 'Cap'",
             [{
                 'tag': 'hero'
             }]
@@ -2649,7 +2509,7 @@ class TestInsert(tb.QueryTestCase):
         await self.con.execute(query)
 
         await self.assert_query_result(
-            "SELECT test::Person { tag } FILTER .name = 'Cap'",
+            "SELECT Person { tag } FILTER .name = 'Cap'",
             [{
                 'tag': 'super hero'
             }]
@@ -2658,7 +2518,7 @@ class TestInsert(tb.QueryTestCase):
         await self.con.execute(query)
 
         await self.assert_query_result(
-            "SELECT test::Person { tag } FILTER .name = 'Cap'",
+            "SELECT Person { tag } FILTER .name = 'Cap'",
             [{
                 'tag': 'super super hero'
             }]
@@ -2666,7 +2526,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_unless_conflict_10(self):
         await self.con.execute(r'''
-            WITH MODULE test
             INSERT Person {
                 name := "Foo",
                 case_name := "Foo",
@@ -2675,7 +2534,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person {
                     name := "Bar",
@@ -2693,7 +2551,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_unless_conflict_11(self):
         # ELSE without ON, using object constraint
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person {name := "Madz"}
                 UNLESS CONFLICT ON (.name)
@@ -2714,7 +2571,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_unless_conflict_12(self):
         # An upsert where we don't wrap it in another shape
         query = r'''
-            WITH MODULE test
             INSERT Person {name := "Emmanuel Villip"} UNLESS CONFLICT
             ON .name ELSE (UPDATE Person SET { tag := "redo" })
         '''
@@ -2731,7 +2587,6 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_unless_conflict_13(self):
         # An insert-or-select where we don't wrap it in another shape
         query = r'''
-            WITH MODULE test
             INSERT Person {name := "Emmanuel Villip"} UNLESS CONFLICT
             ON .name ELSE (SELECT Person)
         '''
@@ -2747,7 +2602,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_unless_conflict_14(self):
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person2a {first := "Phil", last := "Emarg"}
                 UNLESS CONFLICT ON (.first, .last) ELSE (SELECT Person2a)
@@ -2765,26 +2619,23 @@ class TestInsert(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
-            r'''SELECT test::Person2a {first, last}''',
+            r'''SELECT Person2a {first, last}''',
             [{"first": "Phil", "last": "Emarg"}],
         )
 
     async def test_edgeql_insert_unless_conflict_15(self):
         # test using a tuple object constraint with a link in it
         await self.con.execute(r'''
-            WITH MODULE test
             INSERT Person {
                 name := "Phil Emarg",
             };
 
-            WITH MODULE test
             INSERT Person {
                 name := "Madeline Hatch",
             };
         ''')
 
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person2a {
                     first := "Emmanuel",
@@ -2811,7 +2662,7 @@ class TestInsert(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
-            r'''SELECT test::Person2a {first, last, friend := .bff.name}''',
+            r'''SELECT Person2a {first, last, friend := .bff.name}''',
             [{"first": "Emmanuel", "last": "Villip", "friend": "Phil Emarg"}],
         )
 
@@ -2823,7 +2674,7 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                SELECT test::Person2a {first, last, friend := .bff.name}
+                SELECT Person2a {first, last, friend := .bff.name}
                 ORDER BY .last
             ''',
             [
@@ -2836,7 +2687,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_dependent_01(self):
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person {
                     name :=  "Test",
@@ -2857,13 +2707,12 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure only 1 insert into Note happened
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [1],
         )
 
     async def test_edgeql_insert_dependent_02(self):
         await self.con.execute(r"""
-            WITH MODULE test
             FOR noob in {"Phil Emarg", "Madeline Hatch"}
             UNION (
                 INSERT Person {name := noob,
@@ -2871,20 +2720,19 @@ class TestInsert(tb.QueryTestCase):
         """)
 
         await self.assert_query_result(
-            "SELECT test::Person { name, notes: {name} } ORDER BY .name",
+            "SELECT Person { name, notes: {name} } ORDER BY .name",
             [{"name": "Madeline Hatch", "notes": [{"name": "tag"}]},
              {"name": "Phil Emarg", "notes": [{"name": "tag"}]}]
         )
 
         # Make sure the notes are distinct
         await self.assert_query_result(
-            r'''SELECT count(DISTINCT test::Person.notes)''',
+            r'''SELECT count(DISTINCT Person.notes)''',
             [2],
         )
 
     async def test_edgeql_insert_dependent_03(self):
         await self.con.execute(r"""
-            WITH MODULE test
             FOR noob in {"Phil Emarg", "Madeline Hatch"}
             UNION (
                 INSERT Person {
@@ -2894,7 +2742,7 @@ class TestInsert(tb.QueryTestCase):
         """)
 
         await self.assert_query_result(
-            "SELECT test::Person { name, notes: {name} } ORDER BY .name",
+            "SELECT Person { name, notes: {name} } ORDER BY .name",
             [{"name": "Madeline Hatch",
               "notes": [{"name": "hello"}, {"name": "world"}]},
              {"name": "Phil Emarg",
@@ -2903,13 +2751,12 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure the notes are distinct
         await self.assert_query_result(
-            r'''SELECT count(DISTINCT test::Person.notes)''',
+            r'''SELECT count(DISTINCT Person.notes)''',
             [4],
         )
 
     async def test_edgeql_insert_dependent_04(self):
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person {
                     name :=  "Zendaya",
@@ -2933,13 +2780,12 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure only the 2 inserts into Note happened
         await self.assert_query_result(
-            r'''SELECT DISTINCT count(test::Person.notes)''',
+            r'''SELECT DISTINCT count(Person.notes)''',
             [2],
         )
 
     async def test_edgeql_insert_dependent_05(self):
         await self.con.execute(r"""
-            WITH MODULE test
             FOR noob in {"Phil Emarg", "Madeline Hatch"}
             UNION (
                 INSERT Person {name := noob}
@@ -2947,7 +2793,6 @@ class TestInsert(tb.QueryTestCase):
         """)
 
         await self.con.execute(r"""
-            WITH MODULE test
             FOR noob in {"Phil Emarg", "Madeline Hatch"}
             UNION (
                 UPDATE Person FILTER .name = noob
@@ -2956,20 +2801,19 @@ class TestInsert(tb.QueryTestCase):
         """)
 
         await self.assert_query_result(
-            "SELECT test::Person { name, notes: {name} } ORDER BY .name DESC",
+            "SELECT Person { name, notes: {name} } ORDER BY .name DESC",
             [{"name": "Phil Emarg", "notes": [{"name": "tag"}]},
              {"name": "Madeline Hatch", "notes": [{"name": "tag"}]}],
         )
 
         # Make sure the notes are distinct
         await self.assert_query_result(
-            r'''SELECT count(DISTINCT test::Person.notes)''',
+            r'''SELECT count(DISTINCT Person.notes)''',
             [2],
         )
 
     async def test_edgeql_insert_dependent_06(self):
         await self.con.execute(r"""
-            WITH MODULE test
             FOR noob in {"Phil Emarg", "Madeline Hatch"}
             UNION (
                 INSERT Person {name := noob}
@@ -2977,7 +2821,6 @@ class TestInsert(tb.QueryTestCase):
         """)
 
         await self.con.execute(r"""
-            WITH MODULE test
             FOR noob in {"Phil Emarg", "Madeline Hatch"}
             UNION (
                 UPDATE Person FILTER .name = noob
@@ -2989,7 +2832,7 @@ class TestInsert(tb.QueryTestCase):
         """)
 
         await self.assert_query_result(
-            "SELECT test::Person { name, notes: {name} } ORDER BY .name DESC",
+            "SELECT Person { name, notes: {name} } ORDER BY .name DESC",
             [{"name": "Phil Emarg",
               "notes": [{"name": "hello"}, {"name": "world"}]},
              {"name": "Madeline Hatch",
@@ -2998,7 +2841,7 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure the notes are distinct
         await self.assert_query_result(
-            r'''SELECT count(DISTINCT test::Person.notes)''',
+            r'''SELECT count(DISTINCT Person.notes)''',
             [4],
         )
 
@@ -3008,7 +2851,6 @@ class TestInsert(tb.QueryTestCase):
                 "mutations are invalid in a shape computable"):
             await self.con.execute(
                 r"""
-                    WITH MODULE test
                     SELECT Person {
                         name,
                         foo := (
@@ -3022,7 +2864,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_dependent_08(self):
         await self.con.execute(r"""
-            WITH MODULE test
             INSERT Person {
                 name := 'PersonDep08'
             };
@@ -3031,7 +2872,6 @@ class TestInsert(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     foo := (
                         INSERT Note {name := 'NoteDep08'}
                     )
@@ -3054,7 +2894,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Person {
                     name,
                     notes: {
@@ -3072,7 +2911,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Note {
                     name,
                 };
@@ -3086,7 +2924,6 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_dependent_09(self):
         await self.con.execute(r"""
-            WITH MODULE test
             INSERT Person {
                 name := 'PersonDep09'
             };
@@ -3095,7 +2932,6 @@ class TestInsert(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     foo := (
                         INSERT Note {name := 'NoteDep09'}
                     )
@@ -3119,7 +2955,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Person {
                     name,
                     notes: {
@@ -3137,7 +2972,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Note {
                     name,
                 };
@@ -3150,10 +2984,9 @@ class TestInsert(tb.QueryTestCase):
         )
 
     async def test_edgeql_insert_dependent_10(self):
-        await self.con.execute(r"""INSERT test::Note { name := "foo" };""")
+        await self.con.execute(r"""INSERT Note { name := "foo" };""")
 
         query = r"""
-            WITH MODULE test
             FOR noob in {"foo", "bar"} UNION (
                 INSERT Person { name := noob,
                                 notes := (UPDATE Note FILTER .name = noob
@@ -3166,19 +2999,19 @@ class TestInsert(tb.QueryTestCase):
         await self.con.execute(query)
 
         await self.assert_query_result(
-            "SELECT test::Person { name, notes: {name} } ORDER BY .name DESC",
+            "SELECT Person { name, notes: {name} } ORDER BY .name DESC",
             [{"name": "foo",
               "notes": [{"name": "foo!"}]},
              {"name": "bar",
               "notes": []}],
         )
 
-        await self.con.execute(r"""INSERT test::Note { name := "bar" };""")
+        await self.con.execute(r"""INSERT Note { name := "bar" };""")
 
         await self.con.execute(query)
 
         await self.assert_query_result(
-            "SELECT test::Person { name, notes: {name} } ORDER BY .name",
+            "SELECT Person { name, notes: {name} } ORDER BY .name",
             [{"name": "bar",
               "notes": []},
              {"name": "foo",
@@ -3186,7 +3019,7 @@ class TestInsert(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
-            "SELECT test::Note.name",
+            "SELECT Note.name",
             ["foo!", "bar"]
         )
 
@@ -3194,8 +3027,7 @@ class TestInsert(tb.QueryTestCase):
         # A with-bound insert used in a FOR should only execute once
         await self.con.execute(
             r'''
-                WITH MODULE test,
-                     N := (INSERT Note {name := "tag!" }),
+                WITH N := (INSERT Note {name := "tag!" }),
                 FOR name in {"Phil", "Madz"} UNION (
                     INSERT Person {
                         name := name,
@@ -3207,7 +3039,7 @@ class TestInsert(tb.QueryTestCase):
 
         # Should only be one note
         await self.assert_query_result(
-            r'''SELECT test::Note { name }''',
+            r'''SELECT Note { name }''',
             [{"name": "tag!"}],
         )
 
@@ -3216,8 +3048,7 @@ class TestInsert(tb.QueryTestCase):
         # Same as above, but using a single link
         await self.con.execute(
             r'''
-                WITH MODULE test,
-                     N := (INSERT Note {name := "tag!" }),
+                WITH N := (INSERT Note {name := "tag!" }),
                 FOR name in {"Phil", "Madz"} UNION (
                     INSERT Person {
                         name := name,
@@ -3229,7 +3060,7 @@ class TestInsert(tb.QueryTestCase):
 
         # Should only be one note
         await self.assert_query_result(
-            r'''SELECT test::Note { name }''',
+            r'''SELECT Note { name }''',
             [{"name": "tag!"}],
         )
 
@@ -3237,8 +3068,7 @@ class TestInsert(tb.QueryTestCase):
         # A WITH bound INSERT used in an INSERT UNLESS CONFLICT
         # should execute unconditionally
         query = r'''
-        WITH MODULE test,
-             N := (INSERT Note {name := "tag!" }),
+        WITH N := (INSERT Note {name := "tag!" }),
         SELECT (
             INSERT Person {
                 name := "Test",
@@ -3259,7 +3089,7 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure that two inserts happened
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [2],
         )
 
@@ -3268,8 +3098,7 @@ class TestInsert(tb.QueryTestCase):
         # FOR loop, and a shape query that references both
         await self.assert_query_result(
             r'''
-                WITH MODULE test,
-                    N := (INSERT Note {name := "tag!" }),
+                WITH N := (INSERT Note {name := "tag!" }),
                     X := (FOR name in {"Phil", "Madz"} UNION (
                         INSERT Person {
                             name := name,
@@ -3288,13 +3117,12 @@ class TestInsert(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [1],
         )
 
     async def test_edgeql_insert_dependent_15(self):
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person {
                     name := "Test",
@@ -3315,14 +3143,13 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure only 1 insert into Note happened
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [1],
         )
 
     async def test_edgeql_insert_dependent_16(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (
                     INSERT Person {
                         name := "Test",
@@ -3335,7 +3162,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (
                     INSERT Person {
                         name := "Test",
@@ -3350,13 +3176,12 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure the update did not happen
         await self.assert_query_result(
-            r'''SELECT test::Note { name }''',
+            r'''SELECT Note { name }''',
             [{"name": "tag!"}],
         )
 
     async def test_edgeql_insert_dependent_17(self):
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person {
                     name := "Test",
@@ -3377,18 +3202,16 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure only 1 insert into Note happened
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [1],
         )
 
     async def test_edgeql_insert_dependent_18(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT Person { name := "foo" }
         ''')
 
         query = r'''
-            WITH MODULE test
             SELECT (
             FOR name in {"foo", "bar"} UNION (
                 SELECT (
@@ -3408,19 +3231,17 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure only 1 insert into Note happened
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [1],
         )
 
     async def test_edgeql_insert_dependent_19(self):
         # same as above but without ELSE
         await self.con.execute('''
-            WITH MODULE test
             INSERT Person { name := "foo" }
         ''')
 
         query = r'''
-            WITH MODULE test
             SELECT (
             FOR name in {"foo", "bar"} UNION (
                 SELECT (
@@ -3439,7 +3260,7 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure only 1 insert into Note happened
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [1],
         )
 
@@ -3448,12 +3269,10 @@ class TestInsert(tb.QueryTestCase):
         # nested in a dumb way instead of directly being put in a
         # pointer
         await self.con.execute('''
-            WITH MODULE test
             INSERT Person { name := "foo" }
         ''')
 
         query = r'''
-            WITH MODULE test
             SELECT (
             FOR name in {"foo", "bar"} UNION (
                 SELECT (
@@ -3472,14 +3291,13 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure only 1 insert into Note happened
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [1],
         )
 
     async def test_edgeql_insert_dependent_21(self):
         # test with an empty set as one of the values
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person {
                     name := "Test",
@@ -3501,7 +3319,7 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure only 1 insert into Note happened
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [1],
         )
 
@@ -3509,7 +3327,6 @@ class TestInsert(tb.QueryTestCase):
         # test with a constraint that has a nontrivial subjectexpr
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person {
                     name := "Test",
@@ -3523,7 +3340,6 @@ class TestInsert(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person {
                     name := "Test2",
@@ -3537,13 +3353,12 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure only 1 insert into Note happened
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [1],
         )
 
     async def test_edgeql_insert_dependent_23(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT Person2a {
                 first := "Madeline",
                 last := "Hatch1",
@@ -3552,7 +3367,6 @@ class TestInsert(tb.QueryTestCase):
 
         # test with something that has an object constraint
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person2a {
                     first := "Phil",
@@ -3574,14 +3388,13 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure only 1 insert into Note happened
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [1],
         )
 
     async def test_edgeql_insert_dependent_24(self):
         # test with something that has a computed constraint
         await self.con.execute('''
-            WITH MODULE test
             INSERT Person2b {
                 first := "Madeline",
                 last := "Hatch2",
@@ -3589,7 +3402,6 @@ class TestInsert(tb.QueryTestCase):
         ''')
 
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person2b {
                     first := "Phil",
@@ -3611,13 +3423,12 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure only 1 insert into Note happened
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [1],
         )
 
     async def test_edgeql_insert_dependent_25(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT Person2b {
                 first := "Madeline",
                 last := "Hatch3",
@@ -3625,7 +3436,6 @@ class TestInsert(tb.QueryTestCase):
         ''')
         # test with something that has a computed constraint using ON
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person2b {
                     first := "Phil",
@@ -3649,14 +3459,13 @@ class TestInsert(tb.QueryTestCase):
 
         # Make sure only 1 insert into Note happened
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [1],
         )
 
     async def test_edgeql_insert_dependent_26(self):
         # test that it works with an empty value in a computed prop
         await self.con.execute('''
-            WITH MODULE test
             INSERT Person2b {
                 first := "Madeline",
                 last := "Hatch4",
@@ -3664,7 +3473,6 @@ class TestInsert(tb.QueryTestCase):
         ''')
 
         query = r'''
-            WITH MODULE test
             SELECT (
                 INSERT Person2b {
                     first := "Phil",
@@ -3685,14 +3493,13 @@ class TestInsert(tb.QueryTestCase):
 
         # No conflict (because last was empty), so two inserts
         await self.assert_query_result(
-            r'''SELECT count(test::Note)''',
+            r'''SELECT count(Note)''',
             [2],
         )
 
     async def test_edgeql_insert_dependent_27(self):
         # test with two nested single links
         await self.con.execute('''
-            SET MODULE test;
             CREATE ABSTRACT TYPE Named {
                 CREATE REQUIRED PROPERTY name -> str {
                     CREATE DELEGATED CONSTRAINT exclusive;
@@ -3727,7 +3534,7 @@ class TestInsert(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
-            "SELECT test::Obj {name, foo: {name}, bar: {name}}",
+            "SELECT Obj {name, foo: {name}, bar: {name}}",
             [{"name": "obj", "foo": {"name": "foo"}, "bar": {"name": "bar"}}],
         )
 
@@ -3735,7 +3542,6 @@ class TestInsert(tb.QueryTestCase):
         # It would also be a reasonable semantics for this test to
         # return two objects
         query = r'''
-            WITH MODULE test
             SELECT (
               FOR x in {"Phil Emarg", "Phil Emarg"} UNION (
                 INSERT Person {name := x}
@@ -3754,7 +3560,6 @@ class TestInsert(tb.QueryTestCase):
         # It would also be a reasonable semantics for this test to
         # not fail
         query = r'''
-            WITH MODULE test
             SELECT (
               (INSERT Person {name := "Emmanuel Villip"} UNLESS CONFLICT),
               (INSERT Person {name := "Emmanuel Villip"} UNLESS CONFLICT),
@@ -3769,7 +3574,6 @@ class TestInsert(tb.QueryTestCase):
         # It would also be a reasonable semantics for this test to
         # not fail
         query = r'''
-            WITH MODULE test
             INSERT Person {
                 name := "Madeline Hatch",
                 note := (
@@ -3791,19 +3595,19 @@ class TestInsert(tb.QueryTestCase):
 
     async def test_edgeql_insert_nested_volatile_01(self):
         await self.con.execute('''
-            INSERT test::Subordinate {
+            INSERT Subordinate {
                 name := 'subtest 1'
             };
 
-            INSERT test::Subordinate {
+            INSERT Subordinate {
                 name := 'subtest 2'
             };
 
-            INSERT test::InsertTest {
+            INSERT InsertTest {
                 name := 'insert nested',
                 l2 := 0,
                 subordinates := (
-                    SELECT test::Subordinate {
+                    SELECT Subordinate {
                         @comment := <str>uuid_generate_v1mc()
                     }
                 )
@@ -3813,7 +3617,7 @@ class TestInsert(tb.QueryTestCase):
         # Each object should get a distinct @comment
         await self.assert_query_result(
             r'''
-                SELECT count(DISTINCT test::InsertTest.subordinates@comment);
+                SELECT count(DISTINCT InsertTest.subordinates@comment);
             ''',
             [2]
         )
@@ -3822,16 +3626,16 @@ class TestInsert(tb.QueryTestCase):
         # INSERTing something that would violate a constraint while
         # fixing the violation is still supposed to be an error.
         await self.con.execute('''
-            INSERT test::Person { name := 'foo' };
+            INSERT Person { name := 'foo' };
         ''')
 
         with self.assertRaisesRegex(edgedb.ConstraintViolationError,
                                     "violates exclusivity constraint"):
             await self.con.execute('''
                 SELECT (
-                    (UPDATE test::Person FILTER .name = 'foo'
+                    (UPDATE Person FILTER .name = 'foo'
                         SET { name := 'foo' }),
-                    (INSERT test::Person { name := 'foo' })
+                    (INSERT Person { name := 'foo' })
                 )
             ''')
 
@@ -3839,14 +3643,14 @@ class TestInsert(tb.QueryTestCase):
         # INSERTing something that would violate a constraint while
         # fixing the violation is still supposed to be an error.
         await self.con.execute('''
-            INSERT test::Person { name := 'foo' };
+            INSERT Person { name := 'foo' };
         ''')
 
         with self.assertRaisesRegex(edgedb.ConstraintViolationError,
                                     "violates exclusivity constraint"):
             await self.con.execute('''
                 SELECT (
-                    (DELETE test::Person FILTER .name = 'foo'),
-                    (INSERT test::Person { name := 'foo' })
+                    (DELETE Person FILTER .name = 'foo'),
+                    (INSERT Person { name := 'foo' })
                 )
             ''')

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -52,25 +52,25 @@ class TestIntrospection(tb.QueryTestCase):
                     name
                 }
                 FILTER
-                    .name LIKE 'test::%'
+                    .name LIKE 'default::%'
                     AND NOT .compound_type
                 ORDER BY
                     .name;
             """,
             [
-                {'name': 'test::Comment'},
-                {'name': 'test::Dictionary'},
-                {'name': 'test::File'},
-                {'name': 'test::Issue'},
-                {'name': 'test::LogEntry'},
-                {'name': 'test::Named'},
-                {'name': 'test::Owned'},
-                {'name': 'test::Priority'},
-                {'name': 'test::Publication'},
-                {'name': 'test::Status'},
-                {'name': 'test::Text'},
-                {'name': 'test::URL'},
-                {'name': 'test::User'}
+                {'name': 'default::Comment'},
+                {'name': 'default::Dictionary'},
+                {'name': 'default::File'},
+                {'name': 'default::Issue'},
+                {'name': 'default::LogEntry'},
+                {'name': 'default::Named'},
+                {'name': 'default::Owned'},
+                {'name': 'default::Priority'},
+                {'name': 'default::Publication'},
+                {'name': 'default::Status'},
+                {'name': 'default::Text'},
+                {'name': 'default::URL'},
+                {'name': 'default::User'}
             ]
         )
 
@@ -85,10 +85,10 @@ class TestIntrospection(tb.QueryTestCase):
                         name,
                     } ORDER BY .name
                 }
-                FILTER ObjectType.name = 'test::User';
+                FILTER ObjectType.name = 'default::User';
             """,
             [{
-                'name': 'test::User',
+                'name': 'default::User',
                 'abstract': False,
                 'pointers': [{
                     'name': '__type__',
@@ -113,10 +113,10 @@ class TestIntrospection(tb.QueryTestCase):
                         name,
                     } ORDER BY .name
                 }
-                FILTER ObjectType.name = 'test::Owned';
+                FILTER ObjectType.name = 'default::Owned';
             """,
             [{
-                'name': 'test::Owned',
+                'name': 'default::Owned',
                 'abstract': True,
                 'pointers': [{
                     'name': '__type__',
@@ -139,10 +139,10 @@ class TestIntrospection(tb.QueryTestCase):
                         name
                     } ORDER BY .name
                 }
-                FILTER ObjectType.name = 'test::User';
+                FILTER ObjectType.name = 'default::User';
             """,
             [{
-                'name': 'test::User',
+                'name': 'default::User',
                 'abstract': False,
                 'pointers': [{
                     'name': '__type__',
@@ -169,10 +169,10 @@ class TestIntrospection(tb.QueryTestCase):
                     } FILTER @owned
                       ORDER BY .name
                 }
-                FILTER ObjectType.name = 'test::User';
+                FILTER ObjectType.name = 'default::User';
             """,
             [{
-                'name': 'test::User',
+                'name': 'default::User',
                 'abstract': False,
                 'pointers': [{
                     'name': 'todo',
@@ -199,22 +199,22 @@ class TestIntrospection(tb.QueryTestCase):
                 FILTER .name LIKE '%Comment';
             """,
             [{
-                'name': 'test::Comment',
+                'name': 'default::Comment',
                 'links': [{
                     'name': '__type__',
                     'target': {'name': 'schema::Type'},
                     'cardinality': 'One',
                 }, {
                     'name': 'issue',
-                    'target': {'name': 'test::Issue'},
+                    'target': {'name': 'default::Issue'},
                     'cardinality': 'One',
                 }, {
                     'name': 'owner',
-                    'target': {'name': 'test::User'},
+                    'target': {'name': 'default::User'},
                     'cardinality': 'One',
                 }, {
                     'name': 'parent',
-                    'target': {'name': 'test::Comment'},
+                    'target': {'name': 'default::Comment'},
                     'cardinality': 'One',
                 }]
             }]
@@ -229,20 +229,20 @@ class TestIntrospection(tb.QueryTestCase):
                     name,
                 }
                 FILTER
-                    ObjectType.name LIKE 'test::%'
+                    ObjectType.name LIKE 'default::%'
                     AND
                     ObjectType.links.cardinality = <Cardinality>'Many'
                 ORDER BY ObjectType.name;
             """,
             [
                 {
-                    'name': 'test::Issue',
+                    'name': 'default::Issue',
                 },
                 {
-                    'name': 'test::Publication',
+                    'name': 'default::Publication',
                 },
                 {
-                    'name': 'test::User',
+                    'name': 'default::User',
                 }
             ]
         )
@@ -257,20 +257,20 @@ class TestIntrospection(tb.QueryTestCase):
                     name,
                 }
                 FILTER
-                    `ObjectType`.name LIKE 'test::%'
+                    `ObjectType`.name LIKE 'default::%'
                     AND
                     ObjectType.links.cardinality = <Cardinality>'Many'
                 ORDER BY `ObjectType`.name;
             """,
             [
                 {
-                    'name': 'test::Issue',
+                    'name': 'default::Issue',
                 },
                 {
-                    'name': 'test::Publication',
+                    'name': 'default::Publication',
                 },
                 {
-                    'name': 'test::User',
+                    'name': 'default::User',
                 }
             ]
         )
@@ -291,7 +291,7 @@ class TestIntrospection(tb.QueryTestCase):
                     } FILTER .name = 'tags'
                 }
                 FILTER
-                    .name = 'test::Issue';
+                    .name = 'default::Issue';
             """,
             [{
                 'properties': [
@@ -319,23 +319,23 @@ class TestIntrospection(tb.QueryTestCase):
                     } ORDER BY @index
                 }
                 FILTER
-                    .name = 'test::Issue';
+                    .name = 'default::Issue';
             """,
             [{
                 'bases': [{
-                    'name': 'test::Named',
+                    'name': 'default::Named',
                 }, {
-                    'name': 'test::Owned',
+                    'name': 'default::Owned',
                 }, {
-                    'name': 'test::Text',
+                    'name': 'default::Text',
                 }],
 
                 'ancestors': [{
-                    'name': 'test::Named',
+                    'name': 'default::Named',
                 }, {
-                    'name': 'test::Owned',
+                    'name': 'default::Owned',
                 }, {
-                    'name': 'test::Text',
+                    'name': 'default::Text',
                 }, {
                     'name': 'std::Object',
                 }, {
@@ -382,7 +382,7 @@ class TestIntrospection(tb.QueryTestCase):
                     } ORDER BY .name
                 }
                 FILTER
-                    .name = 'test::URL'
+                    .name = 'default::URL'
             """,
             [{
                 'properties': [{
@@ -430,7 +430,7 @@ class TestIntrospection(tb.QueryTestCase):
                     NOT EXISTS .<constraints;
             """,
             [{
-                'name': 'test::my_one_of',
+                'name': 'default::my_one_of',
                 'params': [
                     {
                         'num': 1,
@@ -463,7 +463,7 @@ class TestIntrospection(tb.QueryTestCase):
                     NOT EXISTS .<constraints;
             """,
             [{
-                'name': 'test::my_one_of',
+                'name': 'default::my_one_of',
                 'params': [
                     {
                         'num': 1,
@@ -537,7 +537,7 @@ class TestIntrospection(tb.QueryTestCase):
                 FILTER
                     .subject.name = 'body'
                     AND .subject[IS schema::Property].source.name
-                        = 'test::Text';
+                        = 'default::Text';
             """,
             [{
                 'name': 'std::max_len_value',
@@ -575,10 +575,10 @@ class TestIntrospection(tb.QueryTestCase):
                         },
                     } ORDER BY .name,
                 }
-                FILTER .name = 'test::Text';
+                FILTER .name = 'default::Text';
             """,
             [{
-                'name': 'test::Text',
+                'name': 'default::Text',
                 'properties': [
                     {
                         'name': 'body',
@@ -647,17 +647,17 @@ class TestIntrospection(tb.QueryTestCase):
                         errmessage,
                     },
                 }
-                FILTER .name = 'test::EmulatedEnum';
+                FILTER .name = 'default::EmulatedEnum';
             """,
             [{
 
-                'name': 'test::EmulatedEnum',
+                'name': 'default::EmulatedEnum',
                 'constraints': [
                     {
                         'name': 'std::one_of',
                         'expr': 'std::contains(vals, __subject__)',
                         'annotations': {},
-                        'subject': {'name': 'test::EmulatedEnum'},
+                        'subject': {'name': 'default::EmulatedEnum'},
                         'params': [
                             {
                                 'name': 'vals',
@@ -1080,17 +1080,17 @@ class TestIntrospection(tb.QueryTestCase):
                     name
                 }
                 FILTER
-                    re_test(r'^test::\w+$', InheritingObject.name)
+                    re_test(r'^default::\w+$', InheritingObject.name)
                     AND InheritingObject.name NOT LIKE '%:Virtual_%'
                     AND InheritingObject.abstract
                 ORDER BY InheritingObject.name;
             """,
             [
-                {'name': 'test::Dictionary'},
-                {'name': 'test::Named'},
-                {'name': 'test::Owned'},
-                {'name': 'test::Text'},
-                {'name': 'test::my_one_of'},
+                {'name': 'default::Dictionary'},
+                {'name': 'default::Named'},
+                {'name': 'default::Owned'},
+                {'name': 'default::Text'},
+                {'name': 'default::my_one_of'},
             ]
         )
 
@@ -1172,12 +1172,12 @@ class TestIntrospection(tb.QueryTestCase):
                     name,
                     abstract
                 }
-                FILTER .name IN {'test::Comment', 'test::Text'}
+                FILTER .name IN {'default::Comment', 'default::Text'}
                 ORDER BY .name;
             ''',
             [
-                {'name': 'test::Comment', 'abstract': False},
-                {'name': 'test::Text', 'abstract': True},
+                {'name': 'default::Comment', 'abstract': False},
+                {'name': 'default::Text', 'abstract': True},
             ],
         )
 
@@ -1210,11 +1210,11 @@ class TestIntrospection(tb.QueryTestCase):
                         readonly
                     } ORDER BY .name
                 }
-                FILTER .name = 'test::Comment';
+                FILTER .name = 'default::Comment';
             ''',
             [
                 {
-                    'name': 'test::Comment',
+                    'name': 'default::Comment',
                     'links': [
                         {
                             'name': '__type__',
@@ -1279,37 +1279,30 @@ class TestIntrospection(tb.QueryTestCase):
 
     async def test_edgeql_introspection_count_01(self):
         await self.con.execute(r"""
-            WITH MODULE test
             INSERT Priority {
                 name := 'High'
             };
 
-            WITH MODULE test
             INSERT Priority {
                 name := 'Low'
             };
 
-            WITH MODULE test
             INSERT Status {
                 name := 'Open'
             };
 
-            WITH MODULE test
             INSERT Status {
                 name := 'Closed'
             };
 
-            WITH MODULE test
             INSERT Status {
                 name := 'Flagged'
             };
 
-            WITH MODULE test
             INSERT User {
                 name := 'Elvis'
             };
 
-            WITH MODULE test
             INSERT User {
                 name := 'Yury'
             };
@@ -1328,32 +1321,32 @@ class TestIntrospection(tb.QueryTestCase):
                     )
                 }
                 FILTER
-                    .name LIKE 'test::%'
+                    .name LIKE 'default::%'
                     AND NOT .compound_type
                 ORDER BY
                     .name;
             """,
             [
-                {'name': 'test::Comment', 'count': 0},
-                {'name': 'test::Dictionary', 'count': 0},
-                {'name': 'test::File', 'count': 0},
-                {'name': 'test::Issue', 'count': 0},
-                {'name': 'test::LogEntry', 'count': 0},
-                {'name': 'test::Named', 'count': 0},
-                {'name': 'test::Owned', 'count': 0},
-                {'name': 'test::Priority', 'count': 2},
-                {'name': 'test::Publication', 'count': 0},
-                {'name': 'test::Status', 'count': 3},
-                {'name': 'test::Text', 'count': 0},
-                {'name': 'test::URL', 'count': 0},
-                {'name': 'test::User', 'count': 2},
+                {'name': 'default::Comment', 'count': 0},
+                {'name': 'default::Dictionary', 'count': 0},
+                {'name': 'default::File', 'count': 0},
+                {'name': 'default::Issue', 'count': 0},
+                {'name': 'default::LogEntry', 'count': 0},
+                {'name': 'default::Named', 'count': 0},
+                {'name': 'default::Owned', 'count': 0},
+                {'name': 'default::Priority', 'count': 2},
+                {'name': 'default::Publication', 'count': 0},
+                {'name': 'default::Status', 'count': 3},
+                {'name': 'default::Text', 'count': 0},
+                {'name': 'default::URL', 'count': 0},
+                {'name': 'default::User', 'count': 2},
             ]
         )
 
         await self.con.execute(r"""
-            DELETE test::Priority;
-            DELETE test::Status;
-            DELETE test::User;
+            DELETE Priority;
+            DELETE Status;
+            DELETE User;
         """)
 
     async def test_edgeql_introspection_database_01(self):

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -36,7 +36,13 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def run_test(self, *, source, spec, expected):
         qltree = qlparser.parse(source)
-        ir = compiler.compile_ast_to_ir(qltree, self.schema)
+        ir = compiler.compile_ast_to_ir(
+            qltree,
+            self.schema,
+            options=compiler.CompilerOptions(
+                modaliases={None: 'default'},
+            ),
+        )
 
         # The expected cardinality is either given for the whole query
         # (by default) or for a specific element of the top-level

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -78,7 +78,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_00(self):
         """
-        WITH MODULE test
         SELECT Card
 % OK %
         MANY
@@ -86,7 +85,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_01(self):
         """
-        WITH MODULE test
         SELECT Card FILTER Card.name = 'Djinn'
 % OK %
         AT_MOST_ONE
@@ -94,7 +92,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_02(self):
         """
-        WITH MODULE test
         SELECT Card FILTER 'Djinn' = Card.name
 % OK %
         AT_MOST_ONE
@@ -102,7 +99,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_03(self):
         """
-        WITH MODULE test
         SELECT Card FILTER 'foo' = 'foo' AND 'Djinn' = Card.name
 % OK %
         AT_MOST_ONE
@@ -110,7 +106,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_04(self):
         """
-        WITH MODULE test
         SELECT Card FILTER 'foo' = 'foo' OR 'Djinn' = Card.name
 % OK %
         MANY
@@ -118,7 +113,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_05(self):
         """
-        WITH MODULE test
         SELECT Card FILTER Card.id = <uuid>'...'
 % OK %
         AT_MOST_ONE
@@ -126,7 +120,7 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_06(self):
         """
-        WITH MODULE test, C2 := Card
+        WITH C2 := Card
         SELECT Card FILTER Card = (SELECT C2 FILTER C2.name = 'Djinn')
 % OK %
         AT_MOST_ONE
@@ -134,7 +128,7 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_07(self):
         """
-        WITH MODULE test, C2 := DETACHED Card
+        WITH C2 := DETACHED Card
         SELECT Card FILTER Card = (SELECT C2 FILTER C2.name = 'Djinn')
 % OK %
         AT_MOST_ONE
@@ -142,7 +136,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_08(self):
         """
-        WITH MODULE test
         SELECT Card LIMIT 1
 % OK %
         AT_MOST_ONE
@@ -150,7 +143,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_09(self):
         """
-        WITH MODULE test
         SELECT Card FILTER Card.<deck[IS User].name = 'Bob'
 % OK %
         MANY
@@ -172,7 +164,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_12(self):
         """
-        WITH MODULE test
         SELECT {1, 2, 3, Card.cost}
 % OK %
         AT_LEAST_ONE
@@ -187,7 +178,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_14(self):
         """
-        WITH MODULE test
         SELECT array_agg(Card.cost)
 % OK %
         ONE
@@ -195,7 +185,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_15(self):
         """
-        WITH MODULE test
         SELECT to_str(Card.cost)
 % OK %
         MANY
@@ -203,7 +192,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_16(self):
         """
-        WITH MODULE test
         SELECT to_str((SELECT Card.cost LIMIT 1))
 % OK %
         AT_MOST_ONE
@@ -211,7 +199,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_17(self):
         """
-        WITH MODULE test
         SELECT to_str({1, (SELECT Card.cost LIMIT 1)})
 % OK %
         AT_LEAST_ONE
@@ -240,7 +227,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_21(self):
         """
-        WITH MODULE test
         SELECT 1 + Card.cost
 % OK %
         MANY
@@ -248,7 +234,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_22(self):
         """
-        WITH MODULE test
         SELECT (SELECT Card LIMIT 1).cost ?? 99
 % OK %
         ONE
@@ -256,7 +241,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_23(self):
         """
-        WITH MODULE test
         SELECT (SELECT Card LIMIT 1).element ?? (SELECT User LIMIT 1).name
 % OK %
         AT_MOST_ONE
@@ -264,7 +248,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_24(self):
         """
-        WITH MODULE test
         SELECT (SELECT Card LIMIT 1).element ?= 'fire'
 % OK %
         ONE
@@ -272,7 +255,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_25(self):
         """
-        WITH MODULE test
         SELECT Named {
             name
         }
@@ -282,7 +264,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_26(self):
         """
-        WITH MODULE test
         SELECT User {
             foo := .name
         }
@@ -292,7 +273,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_27(self):
         """
-        WITH MODULE test
         SELECT User {
             foo := 'prefix_' ++ .name
         }
@@ -302,7 +282,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_28(self):
         """
-        WITH MODULE test
         SELECT User {
             deck_cost
         }
@@ -312,7 +291,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_29(self):
         """
-        WITH MODULE test
         SELECT User {
             dc := sum(.deck.cost)
         }
@@ -322,7 +300,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_30(self):
         """
-        WITH MODULE test
         SELECT User {
             deck
         }
@@ -332,7 +309,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_31(self):
         """
-        WITH MODULE test
         SELECT Card {
             owners
         }
@@ -343,7 +319,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_card_inference_32(self):
         """
         WITH
-            MODULE test,
             A := (SELECT Award LIMIT 1)
         # the "awards" are exclusive
         SELECT A.<awards[IS User]
@@ -353,7 +328,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_33(self):
         """
-        WITH MODULE test
         SELECT Award {
             # the "awards" are exclusive
             recipient := .<awards[IS User]
@@ -364,7 +338,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_34(self):
         """
-        WITH MODULE test
         SELECT Award {
             rec
         }
@@ -374,7 +347,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_35(self):
         """
-        WITH MODULE test
         SELECT AwardAlias {
             recipient
         }
@@ -384,7 +356,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_36(self):
         """
-        WITH MODULE test
         SELECT Eert {
             parent
         }
@@ -394,7 +365,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_37(self):
         """
-        WITH MODULE test
         SELECT Report {
             user_name := .user.name
         }
@@ -404,7 +374,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_38(self):
         """
-        WITH MODULE test
         SELECT Report {
             name := .user.name
         }
@@ -413,20 +382,18 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         """
 
     @tb.must_fail(errors.QueryError,
-                  "possibly an empty set", line=4, col=13)
+                  "possibly an empty set", line=3, col=13)
     def test_edgeql_ir_card_inference_39(self):
         """
-        WITH MODULE test
         SELECT Report {
             name := <str>{}
         }
         """
 
     @tb.must_fail(errors.QueryError,
-                  "possibly more than one element", line=4, col=13)
+                  "possibly more than one element", line=3, col=13)
     def test_edgeql_ir_card_inference_40(self):
         """
-        WITH MODULE test
         SELECT Report {
             single foo := User.name
         }
@@ -434,7 +401,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_41(self):
         """
-        WITH MODULE test
         SELECT User.deck@count
 % OK %
         MANY
@@ -442,7 +408,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_42(self):
         """
-        WITH MODULE test
         SELECT Report.user@note
 % OK %
         MANY
@@ -450,7 +415,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_43(self):
         """
-        WITH MODULE test
         SELECT User {
             foo := .deck@count
         }
@@ -460,7 +424,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_44(self):
         """
-        WITH MODULE test
         SELECT Report {
             foo := .user@note
         }
@@ -470,7 +433,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_45(self):
         """
-        WITH MODULE test
         SELECT Report {
             subtitle := 'aaa'
         }
@@ -480,7 +442,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_46(self):
         """
-        WITH MODULE test
         SELECT Named {
             as_card := Named[IS Card]
         }
@@ -490,7 +451,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_47(self):
         """
-        WITH MODULE test
         SELECT User {
             foo := EXISTS(.friends)
         }
@@ -500,8 +460,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_48(self):
         """
-        WITH
-            MODULE test
         SELECT Card {
             o_name := .owners.name,
         }
@@ -511,7 +469,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_49(self):
         """
-        WITH MODULE test
         SELECT User {
             name,
             fire_deck := (
@@ -526,7 +483,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_50(self):
         """
-        WITH MODULE test
         INSERT User {name := "Timmy"}
         UNLESS CONFLICT
 % OK %
@@ -535,7 +491,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_51(self):
         """
-        WITH MODULE test
         INSERT User {name := "Johnny"}
         UNLESS CONFLICT ON (.name)
         ELSE User
@@ -545,7 +500,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_52(self):
         """
-        WITH MODULE test
         INSERT User {name := "Spike"}
         UNLESS CONFLICT ON (.name)
         ELSE Card
@@ -555,7 +509,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_53(self):
         """
-        WITH MODULE test
         INSERT User {name := "Madz"}
         UNLESS CONFLICT ON (.name)
         ELSE (INSERT User {name := "Madz2"})
@@ -566,7 +519,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
     # some tests of object constraints
     def test_edgeql_ir_card_inference_54(self):
         """
-        WITH MODULE test
         SELECT Person FILTER .first = "Phil" AND .last = "Emarg"
 % OK %
         AT_MOST_ONE
@@ -574,7 +526,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_55(self):
         """
-        WITH MODULE test
         SELECT Person FILTER .first = "Phil"
 % OK %
         MANY
@@ -582,7 +533,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_56(self):
         """
-        WITH MODULE test
         SELECT Person FILTER .email = "test@example.com"
 % OK %
         AT_MOST_ONE
@@ -590,7 +540,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_57(self):
         """
-        WITH MODULE test
         SELECT Person FILTER .p = 7 AND .q = 3
 % OK %
         AT_MOST_ONE
@@ -598,7 +547,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_58(self):
         """
-        WITH MODULE test
         SELECT Person FILTER .last = "Hatch" AND .first = "Madeline"
 % OK %
         AT_MOST_ONE
@@ -606,7 +554,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_59(self):
         """
-        WITH MODULE test
         SELECT Person FILTER .p = 7 AND .q = 3 AND .first = "???"
 % OK %
         AT_MOST_ONE
@@ -614,7 +561,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_60(self):
         """
-        WITH MODULE test
         SELECT Person
         FILTER .p = 12 AND .card = (SELECT Card FILTER .name = 'Imp')
 % OK %
@@ -623,7 +569,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_61(self):
         """
-        WITH MODULE test
         SELECT Person FILTER .first = "Phil" OR .last = "Emarg"
 % OK %
         MANY
@@ -631,7 +576,6 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_62(self):
         """
-        WITH MODULE test
         SELECT Person FILTER .p = 7 AND .q = 3 AND .last = "Whatever"
 % OK %
         AT_MOST_ONE

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -42,6 +42,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
             self.schema,
             options=compiler.CompilerOptions(
                 validate_multiplicity=True
+                modaliases={None: 'default'},
             )
         )
 

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -41,7 +41,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
             qltree,
             self.schema,
             options=compiler.CompilerOptions(
-                validate_multiplicity=True
+                validate_multiplicity=True,
                 modaliases={None: 'default'},
             )
         )

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -54,7 +54,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_00(self):
         """
-        WITH MODULE test
         SELECT Card
 % OK %
         ONE
@@ -62,7 +61,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_01(self):
         """
-        WITH MODULE test
         SELECT Card.id
 % OK %
         ONE
@@ -70,7 +68,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_02(self):
         """
-        WITH MODULE test
         SELECT User.name
 % OK %
         ONE
@@ -79,7 +76,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_mult_inference_03(self):
         # Unconstrained property
         """
-        WITH MODULE test
         SELECT User.deck_cost
 % OK %
         MANY
@@ -87,7 +83,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_04(self):
         """
-        WITH MODULE test
         SELECT Card FILTER Card.name = 'Djinn'
 % OK %
         ONE
@@ -95,7 +90,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_05(self):
         """
-        WITH MODULE test
         SELECT Card LIMIT 1
 % OK %
         ONE
@@ -124,7 +118,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_09(self):
         """
-        WITH MODULE test
         SELECT User.deck
 % OK %
         ONE
@@ -132,7 +125,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_10(self):
         """
-        WITH MODULE test
         SELECT Card.cost
 % OK %
         MANY
@@ -140,7 +132,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_11(self):
         """
-        WITH MODULE test
         SELECT Card.owners
 % OK %
         ONE
@@ -155,7 +146,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
     ''')
     def test_edgeql_ir_mult_inference_12(self):
         """
-        WITH MODULE test
         SELECT {Card, User}
 % OK %
         ONE
@@ -184,7 +174,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_16(self):
         """
-        WITH MODULE test
         SELECT 'pre_' ++ Card.name
 % OK %
         ONE
@@ -192,7 +181,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_17(self):
         """
-        WITH MODULE test
         SELECT User.name ++ Card.name
 % OK %
         MANY
@@ -207,7 +195,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_19(self):
         """
-        WITH MODULE test
         SELECT (1, Card.name)
 % OK %
         ONE
@@ -222,7 +209,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_21(self):
         """
-        WITH MODULE test
         SELECT ['card', Card.name]
 % OK %
         ONE
@@ -230,7 +216,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_22(self):
         """
-        WITH MODULE test
         SELECT User.name ++ Card.name
 % OK %
         MANY
@@ -246,7 +231,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_mult_inference_24(self):
         """
         WITH
-            MODULE test,
             C := (SELECT Card FILTER .name = 'Imp')
         SELECT str_split(<str>C.id, '')
 % OK %
@@ -262,7 +246,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         # We also don't know that an element-wise function doesn't end
         # up with collisions.
         """
-        WITH MODULE test
         SELECT str_split(<str>Card.id, '')
 % OK %
         MANY
@@ -277,7 +260,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         # We also don't know that an element-wise function doesn't end
         # up with collisions.
         """
-        WITH MODULE test
         SELECT array_unpack(str_split(<str>Card.id, ''))
 % OK %
         MANY
@@ -285,7 +267,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_27(self):
         """
-        WITH MODULE test
         SELECT count(Card)
 % OK %
         ONE
@@ -293,7 +274,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_28(self):
         """
-        WITH MODULE test
         SELECT 1 IN {1, 2, 3}
 % OK %
         ONE
@@ -301,7 +281,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_29(self):
         """
-        WITH MODULE test
         SELECT 1 IN {1, 1, 3}
 % OK %
         ONE
@@ -309,7 +288,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_30(self):
         """
-        WITH MODULE test
         SELECT {1, 2} IN {1, 2, 3}
 % OK %
         MANY
@@ -317,7 +295,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_31(self):
         """
-        WITH MODULE test
         SELECT Card.name IN {'Imp', 'Dragon'}
 % OK %
         MANY
@@ -339,7 +316,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_34(self):
         """
-        WITH MODULE test
         SELECT <str>Card.id
 % OK %
         ONE
@@ -347,7 +323,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_35(self):
         """
-        WITH MODULE test
         SELECT <json>User.name
 % OK %
         ONE
@@ -355,7 +330,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_36(self):
         """
-        WITH MODULE test
         SELECT <str>Card.cost
 % OK %
         MANY
@@ -363,7 +337,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_37(self):
         """
-        WITH MODULE test
         SELECT User.deck[IS SpecialCard]
 % OK %
         ONE
@@ -371,7 +344,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_38(self):
         """
-        WITH MODULE test
         SELECT Award.<awards[IS User]
 % OK %
         ONE
@@ -379,7 +351,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_39(self):
         """
-        WITH MODULE test
         SELECT (1, Card.name).0
 % OK %
         MANY
@@ -391,7 +362,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
     ''')
     def test_edgeql_ir_mult_inference_40(self):
         """
-        WITH MODULE test
         SELECT (1, Card.name).1
 % OK %
         ONE
@@ -399,7 +369,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_41(self):
         """
-        WITH MODULE test
         SELECT ['card', Card.name][0]
 % OK %
         MANY
@@ -409,7 +378,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         # It's probably impractical to even try to infer that we're
         # only fetching a unique array element here.
         """
-        WITH MODULE test
         SELECT ['card', Card.name][1]
 % OK %
         MANY
@@ -417,7 +385,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_43(self):
         """
-        WITH MODULE test
         SELECT DISTINCT Card.element
 % OK %
         ONE
@@ -425,7 +392,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_44(self):
         """
-        WITH MODULE test
         SELECT User {
             friends_of_friends := .friends.friends,
             others := (
@@ -438,7 +404,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_45(self):
         """
-        WITH MODULE test
         SELECT Award {
             owner := .<awards[IS User]
         }
@@ -448,7 +413,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_46(self):
         """
-        WITH MODULE test
         SELECT User {
             card_names := .deck.name,
             card_elements := DISTINCT .deck.element,
@@ -469,7 +433,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_48(self):
         """
-        WITH MODULE test
         SELECT Award IS Named
 % OK %
         MANY
@@ -478,7 +441,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_mult_inference_49(self):
         """
         WITH
-            MODULE test,
             A := (
                 SELECT Award FILTER .name = 'Wow'
             )
@@ -489,7 +451,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_50(self):
         """
-        WITH MODULE test
         SELECT Award.name IS str
 % OK %
         MANY
@@ -497,7 +458,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_51(self):
         """
-        WITH MODULE test
         SELECT INTROSPECT TYPEOF User.deck
 % OK %
         ONE
@@ -505,7 +465,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_52(self):
         """
-        WITH MODULE test
         SELECT (INTROSPECT TYPEOF User.deck).name
 % OK %
         ONE
@@ -513,7 +472,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_53(self):
         """
-        WITH MODULE test
         SELECT User {
             card_elements := .deck.element
         }
@@ -523,7 +481,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_54(self):
         """
-        WITH MODULE test
         SELECT User {
             foo := {1, 1, 2}
         }
@@ -533,7 +490,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_55(self):
         """
-        WITH MODULE test
         FOR x IN {'fire', 'water'}
         UNION (
             SELECT Card
@@ -545,7 +501,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_56(self):
         """
-        WITH MODULE test
         SELECT User {
             wishlist := (
                 FOR x IN {'fire', 'water'}
@@ -568,7 +523,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_58(self):
         """
-        WITH MODULE test
         SELECT enumerate(Card)
 % OK %
         ONE
@@ -576,7 +530,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_59(self):
         """
-        WITH MODULE test
         FOR x IN {enumerate({'fire', 'water'})}
         UNION (
             SELECT Card
@@ -588,7 +541,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_60(self):
         """
-        WITH MODULE test
         FOR x IN {
             enumerate(
                 DISTINCT array_unpack(['fire', 'water']))
@@ -603,7 +555,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_mult_inference_61(self):
         """
-        WITH MODULE test
         FOR x IN {
             enumerate(
                 array_unpack(['A', 'B']))
@@ -621,10 +572,9 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     @tb.must_fail(errors.QueryError,
                   r"possibly not a strict set.+computable bad_link",
-                  line=4, col=13)
+                  line=3, col=13)
     def test_edgeql_ir_mult_inference_error_01(self):
         """
-        WITH MODULE test
         SELECT User {
             bad_link := {Card, Card},
             name,
@@ -633,11 +583,10 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 
     @tb.must_fail(errors.QueryError,
                   r"possibly not a strict set.+computable bad_link",
-                  line=6, col=13)
+                  line=5, col=13)
     def test_edgeql_ir_mult_inference_error_02(self):
         """
         WITH
-            MODULE test,
             A := {Card, Card}
         SELECT User {
             bad_link := A,

--- a/tests/test_edgeql_ir_pathid.py
+++ b/tests/test_edgeql_ir_pathid.py
@@ -33,14 +33,14 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
                           'cards.esdl')
 
     def test_edgeql_ir_pathid_basic(self):
-        User = self.schema.get('test::User')
+        User = self.schema.get('default::User')
         deck_ptr = User.getptr(self.schema, s_name.UnqualName('deck'))
         count_prop = deck_ptr.getptr(self.schema, s_name.UnqualName('count'))
 
         pid_1 = pathid.PathId.from_type(self.schema, User)
         self.assertEqual(
             str(pid_1),
-            '(test::User)')
+            '(default::User)')
 
         self.assertTrue(pid_1.is_objtype_path())
         self.assertFalse(pid_1.is_scalar_path())
@@ -57,7 +57,7 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
         pid_2 = pid_1.extend(ptrref=deck_ptr_ref)
         self.assertEqual(
             str(pid_2),
-            '(test::User).>deck[IS test::Card]')
+            '(default::User).>deck[IS default::Card]')
 
         self.assertEqual(pid_2.rptr().name, deck_ptr.get_name(self.schema))
         self.assertEqual(pid_2.rptr_dir(),
@@ -68,7 +68,7 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
         ptr_pid = pid_2.ptr_path()
         self.assertEqual(
             str(ptr_pid),
-            '(test::User).>deck[IS test::Card]@')
+            '(default::User).>deck[IS default::Card]@')
 
         self.assertTrue(ptr_pid.is_ptr_path())
         self.assertFalse(ptr_pid.is_objtype_path())
@@ -83,7 +83,7 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
         prop_pid = ptr_pid.extend(ptrref=count_prop_ref)
         self.assertEqual(
             str(prop_pid),
-            '(test::User).>deck[IS test::Card]@count[IS std::int64]')
+            '(default::User).>deck[IS default::Card]@count[IS std::int64]')
 
         self.assertFalse(prop_pid.is_ptr_path())
         self.assertFalse(prop_pid.is_objtype_path())
@@ -92,7 +92,7 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
         self.assertEqual(prop_pid.src_path(), ptr_pid)
 
     def test_edgeql_ir_pathid_startswith(self):
-        User = self.schema.get('test::User')
+        User = self.schema.get('default::User')
         deck_ptr = User.getptr(self.schema, s_name.UnqualName('deck'))
         deck_ptr_ref = irtyputils.ptrref_from_ptrcls(
             schema=self.schema,
@@ -121,7 +121,7 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
         self.assertTrue(prop_pid.startswith(ptr_pid))
 
     def test_edgeql_ir_pathid_namespace_01(self):
-        User = self.schema.get('test::User')
+        User = self.schema.get('default::User')
         deck_ptr = User.getptr(self.schema, s_name.UnqualName('deck'))
         deck_ptr_ref = irtyputils.ptrref_from_ptrcls(
             schema=self.schema,
@@ -150,8 +150,8 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_pathid_namespace_02(self):
         # Test cases where the prefix is in a different namespace
 
-        Card = self.schema.get('test::Card')
-        User = self.schema.get('test::User')
+        Card = self.schema.get('default::Card')
+        User = self.schema.get('default::User')
         owners_ptr = Card.getptr(self.schema, s_name.UnqualName('owners'))
         owners_ptr_ref = irtyputils.ptrref_from_ptrcls(
             schema=self.schema,
@@ -191,9 +191,9 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
         self.assertEqual(
             prefixes,
             [
-                '(test::Card)',
-                'foo@@(test::Card).>owners[IS test::User]',
-                'bar@foo@@(test::Card).>owners[IS test::User]'
-                '.>deck[IS test::Card]',
+                '(default::Card)',
+                'foo@@(default::Card).>owners[IS default::User]',
+                'bar@foo@@(default::Card).>owners[IS default::User]'
+                '.>deck[IS default::Card]',
             ]
         )

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -42,6 +42,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             self.schema,
             options=compiler.CompilerOptions(
                 apply_query_rewrites=False,
+                modaliases={None: 'default'},
             )
         )
 

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -71,28 +71,25 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_scope_tree_01(self):
         """
-        WITH MODULE test
         SELECT (Card, Card.id)
 % OK %
         "FENCE": {
-            "(test::Card)",
-            "(test::Card).>id[IS std::uuid]"
+            "(default::Card)",
+            "(default::Card).>id[IS std::uuid]"
         }
         """
 
     def test_edgeql_ir_scope_tree_02(self):
         """
-        WITH MODULE test
         SELECT Card{name, cost}
 % OK %
         "FENCE": {
-            "(test::Card)"
+            "(default::Card)"
         }
         """
 
     def test_edgeql_ir_scope_tree_03(self):
         """
-        WITH MODULE test
         SELECT (
             Card {
                 owner := (SELECT Card.<deck[IS User])
@@ -102,22 +99,22 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(test::Card)",
-            "(test::Card).<deck[IS __derived__::(opaque: test:User)]\
-.>indirection[IS test::User]": {
-                "(test::Card).<deck[IS __derived__::(opaque: test:User)]",
-                "[ns~1]@[ns~2]@@(test::Card).<deck[IS __derived__::\
-(opaque: test:User)]"
+            "(default::Card)",
+            "(default::Card).<deck[IS __derived__::(opaque: default:User)]\
+.>indirection[IS default::User]": {
+                "(default::Card)\
+.<deck[IS __derived__::(opaque: default:User)]",
+                "[ns~1]@[ns~2]@@(default::Card)\
+.<deck[IS __derived__::(opaque: default:User)]"
             },
             "FENCE": {
-                "(test::Card).>owner[IS test::User]"
+                "(default::Card).>owner[IS default::User]"
             }
         }
         """
 
     def test_edgeql_ir_scope_tree_04(self):
         """
-        WITH MODULE test
         SELECT (
             Card.<deck[IS User],
             Card {
@@ -127,15 +124,16 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(test::Card).<deck[IS __derived__::(opaque: test:User)]\
-.>indirection[IS test::User]": {
-                "(test::Card).<deck[IS __derived__::(opaque: test:User)]",
-                "[ns~1]@[ns~2]@@(test::Card).<deck[IS __derived__::\
-(opaque: test:User)]"
+            "(default::Card).<deck[IS __derived__::(opaque: default:User)]\
+.>indirection[IS default::User]": {
+                "(default::Card)\
+.<deck[IS __derived__::(opaque: default:User)]",
+                "[ns~1]@[ns~2]@@(default::Card)\
+.<deck[IS __derived__::(opaque: default:User)]"
             },
-            "(test::Card)",
+            "(default::Card)",
             "FENCE": {
-                "(test::Card).>owner[IS test::User]"
+                "(default::Card).>owner[IS default::User]"
             }
         }
         """
@@ -143,7 +141,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_scope_tree_05(self):
         """
         WITH
-            MODULE test,
             U := User
         SELECT (
             Card {
@@ -156,76 +153,72 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "FENCE": {
                 "FENCE": {
-                    "[ns~1]@@(test::User)"
+                    "[ns~1]@@(default::User)"
                 }
             },
-            "(test::Card)",
-            "(test::User)",
+            "(default::Card)",
+            "(default::User)",
             "FENCE": {
                 "[ns~2]@[ns~3]@@(__derived__::__derived__|U@w~1)",
-                "(test::Card).>users[IS test::User]"
+                "(default::Card).>users[IS default::User]"
             }
         }
         """
 
     def test_edgeql_ir_scope_tree_06(self):
         """
-        WITH MODULE test
         SELECT count(User) + count(User)
 
 % OK %
         "FENCE": {
             "FENCE": {
-                "(test::User)"
+                "(default::User)"
             },
             "FENCE": {
-                "(test::User)"
+                "(default::User)"
             }
         }
         """
 
     def test_edgeql_ir_scope_tree_07(self):
         """
-        WITH MODULE test
         SELECT User.deck
 
 % OK %
         "FENCE": {
-            "(test::User).>deck[IS test::Card]": {
-                "(test::User)"
+            "(default::User).>deck[IS default::Card]": {
+                "(default::User)"
             }
         }
         """
 
     def test_edgeql_ir_scope_tree_08(self):
         """
-        WITH MODULE test
         SELECT (User.friends, User.friends@nickname)
 
 % OK %
         "FENCE": {
-            "(test::User).>friends[IS test::User]",
-            "(test::User)",
-            "(test::User).>friends[IS test::User]@nickname[IS std::str]"
+            "(default::User).>friends[IS default::User]",
+            "(default::User)",
+            "(default::User).>friends[IS default::User]@nickname[IS std::str]"
         }
         """
 
     def test_edgeql_ir_scope_tree_09(self):
         """
-        WITH MODULE test
         SELECT (SELECT User FILTER User.name = 'Bob').friends
 
 % OK %
         "FENCE": {
             "FENCE": {
                 "FENCE": {
-                    "(test::User)",
+                    "(default::User)",
                     "FENCE": {
-                        "(test::User).>name[IS std::str]"
+                        "(default::User).>name[IS std::str]"
                     }
                 }
             },
-            "(__derived__::expr~6).>friends[IS test::User]": {
+            "(__derived__::expr~6).>friends[IS default::User]": {
                 "(__derived__::expr~6)"
             }
         }
@@ -233,16 +226,15 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_scope_tree_10(self):
         """
-        WITH MODULE test
         SELECT (Card.element ?? <str>Card.cost, count(Card))
 
 % OK %
         "FENCE": {
             "FENCE": {
-                "(test::Card).>cost[IS std::int64]"
+                "(default::Card).>cost[IS std::int64]"
             },
-            "(test::Card) [OPT]",
-            "(test::Card).>element[IS std::str] [OPT]"
+            "(default::Card) [OPT]",
+            "(default::Card).>element[IS std::str] [OPT]"
         }
         """
 
@@ -289,7 +281,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_scope_tree_13(self):
         """
-        WITH MODULE test
         SELECT User {
             friends := (User.friends
                         IF EXISTS User.friends
@@ -299,49 +290,51 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(test::User)",
+            "(default::User)",
             "FENCE": {
                 "FENCE": {
-                    "[ns~1]@[ns~2]@@(test::User).>friends[IS test::User]"
+                    "[ns~1]@[ns~2]@@(default::User).>friends[IS default::User]"
                 },
                 "FENCE": {
-                    "[ns~1]@[ns~2]@@(test::User).>deck[IS test::Card]\
-.<deck[IS __derived__::(opaque: test:User)].>indirection[IS test::User]": {
-                        "[ns~1]@[ns~2]@@(test::User).>deck[IS test::Card]\
-.<deck[IS __derived__::(opaque: test:User)]": {
-                            "[ns~1]@[ns~2]@@(test::User).>deck[IS test::Card]"
+                    "[ns~1]@[ns~2]@@(default::User).>deck[IS default::Card]\
+.<deck[IS __derived__::(opaque: default:User)]\
+.>indirection[IS default::User]": {
+                        "[ns~1]@[ns~2]@@(default::User)\
+.>deck[IS default::Card].<deck[IS __derived__::(opaque: default:User)]": {
+                            "[ns~1]@[ns~2]@@(default::User)\
+.>deck[IS default::Card]"
                         }
                     }
                 },
                 "FENCE": {
-                    "[ns~1]@[ns~2]@@(test::User).>friends[IS test::User]"
+                    "[ns~1]@[ns~2]@@(default::User).>friends[IS default::User]"
                 },
-                "(test::User).>friends[IS test::User]",
+                "(default::User).>friends[IS default::User]",
                 "[ns~1]@[ns~2]@@(__derived__::expr~13)"
             },
             "FENCE": {
-                "(test::User).>name[IS std::str]"
+                "(default::User).>name[IS std::str]"
             }
         }
         """
 
     def test_edgeql_ir_scope_tree_14(self):
         """
-        WITH MODULE test
         SELECT Card.owners
 
 % OK %
         "FENCE": {
-            "(test::Card).>owners[IS test::User]": {
+            "(default::Card).>owners[IS default::User]": {
                 "BRANCH": {
-                    "(test::Card)"
+                    "(default::Card)"
                 },
                 "FENCE": {
-                    "ns~1@@(test::Card).<deck[IS __derived__::\
-(opaque: test:User)].>indirection[IS test::User]": {
-                        "ns~1@@(test::Card).<deck[IS __derived__::\
-(opaque: test:User)]": {
-                            "(test::Card)"
+                    "ns~1@@(default::Card)\
+.<deck[IS __derived__::(opaque: default:User)]\
+.>indirection[IS default::User]": {
+                        "ns~1@@(default::Card)\
+.<deck[IS __derived__::(opaque: default:User)]": {
+                            "(default::Card)"
                         }
                     }
                 }
@@ -351,7 +344,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_scope_tree_15(self):
         """
-        WITH MODULE test
         SELECT (
             (SELECT Card FILTER Card.element = 'Air'),
             (SELECT Card FILTER Card.element = 'Earth')
@@ -360,15 +352,15 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "FENCE": {
-                "(test::Card)",
+                "(default::Card)",
                 "FENCE": {
-                    "(test::Card).>element[IS std::str]"
+                    "(default::Card).>element[IS std::str]"
                 }
             },
             "FENCE": {
-                "(test::Card)",
+                "(default::Card)",
                 "FENCE": {
-                    "(test::Card).>element[IS std::str]"
+                    "(default::Card).>element[IS std::str]"
                 }
             },
             "(__derived__::expr~5)",
@@ -380,8 +372,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         # Apparent misplaced "(__derived__::__derived__|U@w~1)" in the FILTER
         # fence is due to a alias_map replacement artifact.
         """
-        WITH MODULE test,
-            U := (
+        WITH U := (
                 SELECT User {
                     cards := (
                         SELECT Card {
@@ -397,24 +388,25 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "FENCE": {
                 "FENCE": {
-                    "[ns~1]@@(test::User)",
+                    "[ns~1]@@(default::User)",
                     "FENCE": {
-                        "[ns~1]@@(test::User).>name[IS std::str]"
+                        "[ns~1]@@(default::User).>name[IS std::str]"
                     }
                 }
             },
-            "(__derived__::__derived__|U@w~1).>cards[IS test::Card]\
+            "(__derived__::__derived__|U@w~1).>cards[IS default::Card]\
 .>foo[IS std::float64]": {
                 "BRANCH": {
-                    "(__derived__::__derived__|U@w~1).>cards[IS test::Card]": {
+                    "(__derived__::__derived__|U@w~1)\
+.>cards[IS default::Card]": {
                         "BRANCH": {
                             "(__derived__::__derived__|U@w~1)"
                         },
                         "FENCE": {
-                            "[ns~2]@@(test::Card)",
+                            "[ns~2]@@(default::Card)",
                             "FENCE": {
                                 "[ns~2]@@(__derived__::__derived__|U@w~1)\
-.>deck[IS test::Card]": {
+.>deck[IS default::Card]": {
                                     "(__derived__::__derived__|U@w~1)"
                                 }
                             }
@@ -427,7 +419,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_scope_tree_17(self):
         """
-        WITH MODULE test
         SELECT
             Card
         ORDER BY
@@ -435,10 +426,10 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(test::Card)",
+            "(default::Card)",
             "FENCE": {
                 "FENCE": {
-                    "(test::Card).>name[IS std::str]"
+                    "(default::Card).>name[IS std::str]"
                 }
             }
         }
@@ -446,7 +437,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_scope_tree_18(self):
         """
-        WITH MODULE test
         SELECT User
         ORDER BY (
             (SELECT User.friends
@@ -456,15 +446,15 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(test::User)",
+            "(default::User)",
             "FENCE": {
                 "FENCE": {
                     "FENCE": {
                         "FENCE": {
-                            "(test::User).>friends[IS test::User]",
+                            "(default::User).>friends[IS default::User]",
                             "FENCE": {
-                                "(test::User)\
-.>friends[IS test::User]@nickname[IS std::str]"
+                                "(default::User)\
+.>friends[IS default::User]@nickname[IS std::str]"
                             }
                         }
                     }
@@ -478,7 +468,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_scope_tree_19(self):
         """
-        WITH MODULE test
         SELECT
             x := (
                 User.friends.deck_cost / count(User.friends.deck),
@@ -490,26 +479,26 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "FENCE": {
                 "FENCE": {
-                    "[ns~1]@@(test::User).>friends[IS test::User]": {
-                        "[ns~1]@@(test::User)"
+                    "[ns~1]@@(default::User).>friends[IS default::User]": {
+                        "[ns~1]@@(default::User)"
                     },
-                    "[ns~1]@@(test::User).>friends[IS test::User]\
+                    "[ns~1]@@(default::User).>friends[IS default::User]\
 .>deck_cost[IS std::int64]": {
                         "FENCE": {
                             "FENCE": {
                                 "FENCE": {
-                                    "[ns~1]@ns~2@@(test::User)\
-.>friends[IS test::User].>deck[IS test::Card].>cost[IS std::int64]": {
-                                        "[ns~1]@ns~2@@(test::User)\
-.>friends[IS test::User].>deck[IS test::Card]"
+                                    "[ns~1]@ns~2@@(default::User)\
+.>friends[IS default::User].>deck[IS default::Card].>cost[IS std::int64]": {
+                                        "[ns~1]@ns~2@@(default::User)\
+.>friends[IS default::User].>deck[IS default::Card]"
                                     }
                                 }
                             }
                         }
                     },
                     "FENCE": {
-                        "[ns~1]@@(test::User).>friends[IS test::User]\
-.>deck[IS test::Card]"
+                        "[ns~1]@@(default::User).>friends[IS default::User]\
+.>deck[IS default::Card]"
                     }
                 }
             },
@@ -522,22 +511,21 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_scope_tree_20(self):
         """
-        WITH
-            MODULE test
         SELECT
             Card.name ++ <str>count(Card.owners)
 
 % OK %
         "FENCE": {
-            "(test::Card)",
-            "(test::Card).>name[IS std::str]",
+            "(default::Card)",
+            "(default::Card).>name[IS std::str]",
             "FENCE": {
-                "(test::Card).>owners[IS test::User]": {
+                "(default::Card).>owners[IS default::User]": {
                     "FENCE": {
-                        "ns~1@@(test::Card).<deck\
-[IS __derived__::(opaque: test:User)].>indirection[IS test::User]": {
-                            "ns~1@@(test::Card).<deck\
-[IS __derived__::(opaque: test:User)]"
+                        "ns~1@@(default::Card)\
+.<deck[IS __derived__::(opaque: default:User)]\
+.>indirection[IS default::User]": {
+                            "ns~1@@(default::Card)\
+.<deck[IS __derived__::(opaque: default:User)]"
                         }
                     }
                 }
@@ -547,15 +535,13 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_scope_tree_21(self):
         """
-        WITH
-            MODULE test
         SELECT
             Card.element ++ ' ' ++ (SELECT Card).name
 
 % OK %
         "FENCE": {
-            "(test::Card)",
-            "(test::Card).>element[IS std::str]",
+            "(default::Card)",
+            "(default::Card).>element[IS std::str]",
             "(__derived__::expr~7).>name[IS std::str]": {
                 "(__derived__::expr~7)"
             }
@@ -564,7 +550,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_scope_tree_22(self):
         """
-        WITH MODULE test
         SELECT User {
             name,
             deck: {
@@ -574,41 +559,42 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(test::User)",
+            "(default::User)",
             "FENCE": {
-                "[ns~1]@[ns~2]@@(test::User).>deck[IS test::Card]",
+                "[ns~1]@[ns~2]@@(default::User).>deck[IS default::Card]",
                 "FENCE": {
-                    "[ns~1]@[ns~2]@@(test::User)\
-.>deck[IS test::Card]@count[IS std::int64]"
+                    "[ns~1]@[ns~2]@@(default::User)\
+.>deck[IS default::Card]@count[IS std::int64]"
                 },
-                "(test::User).>deck[IS test::Card]"
+                "(default::User).>deck[IS default::Card]"
             },
             "FENCE": {
-                "(test::User).>deck[IS test::Card]": {
+                "(default::User).>deck[IS default::Card]": {
                     "FENCE": {
-                        "[ns~1]@[ns~4]@@(test::User).>deck[IS test::Card]",
+                        "[ns~1]@[ns~4]@@(default::User)\
+.>deck[IS default::Card]",
                         "FENCE": {
-                            "[ns~1]@[ns~4]@@(test::User)\
-.>deck[IS test::Card]@count[IS std::int64]"
+                            "[ns~1]@[ns~4]@@(default::User)\
+.>deck[IS default::Card]@count[IS std::int64]"
                         }
                     },
                     "FENCE": {
-                        "[ns~1]@[ns~3]@@(test::User).>deck[IS test::Card]",
+                        "[ns~1]@[ns~3]@@(default::User)\
+.>deck[IS default::Card]",
                         "FENCE": {
-                            "[ns~1]@[ns~3]@@(test::User)\
-.>deck[IS test::Card]@count[IS std::int64]"
+                            "[ns~1]@[ns~3]@@(default::User)\
+.>deck[IS default::Card]@count[IS std::int64]"
                         }
                     }
                 },
-                "(test::User).>deck[IS test::Card].>cost[IS std::int64]",
-                "(test::User).>deck[IS test::Card]@count[IS std::int64]"
+                "(default::User).>deck[IS default::Card].>cost[IS std::int64]",
+                "(default::User).>deck[IS default::Card]@count[IS std::int64]"
             }
         }
         """
 
     def test_edgeql_ir_scope_tree_23(self):
         """
-        WITH MODULE test
         SELECT User {
             name,
             deck := (SELECT x := User.deck ORDER BY x.name)
@@ -616,12 +602,12 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(test::User)",
+            "(default::User)",
             "FENCE": {
                 "FENCE": {
                     "FENCE": {
-                        "[ns~1]@[ns~3]@[ns~4]@@(test::User)\
-.>deck[IS test::Card]"
+                        "[ns~1]@[ns~3]@[ns~4]@@(default::User)\
+.>deck[IS default::Card]"
                     }
                 },
                 "[ns~1]@[ns~3]@@(__derived__::__derived__|x@w~2)",
@@ -629,7 +615,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                     "[ns~1]@[ns~3]@@(__derived__::__derived__|x@w~2)\
 .>name[IS std::str]"
                 },
-                "(test::User).>deck[IS test::Card]"
+                "(default::User).>deck[IS default::Card]"
             }
         }
         """
@@ -637,7 +623,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_scope_tree_24(self):
         """
         WITH
-            MODULE test,
             A := {1, 2}
         SELECT _ := (User{name, a := A}, A)
 
@@ -645,7 +630,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "FENCE": {
                 "FENCE": {
-                    "[ns~2]@@(test::User)",
+                    "[ns~2]@@(default::User)",
                     "[ns~2]@@(__derived__::__derived__|A@w~1)"
                 }
             },
@@ -655,7 +640,6 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_scope_tree_25(self):
         """
-        WITH MODULE test
         SELECT User {
             select_deck := (
                 FOR letter IN {'I', 'B'}
@@ -671,30 +655,30 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(test::User)",
+            "(default::User)",
             "FENCE": {
                 "[ns~1]@[ns~4]@@(__derived__::__derived__|letter@w~1)",
                 "FENCE": {
                     "FENCE": {
-                        "[ns~1]@[ns~4]@@(test::User).>deck[IS test::Card]",
+                        "[ns~1]@[ns~4]@@(default::User)\
+.>deck[IS default::Card]",
                         "FENCE": {
-                            "[ns~1]@[ns~4]@@(test::User).>deck[IS test::Card]\
-.>name[IS std::str]"
+                            "[ns~1]@[ns~4]@@(default::User)\
+.>deck[IS default::Card].>name[IS std::str]"
                         }
                     }
                 },
-                "(test::User).>select_deck[IS test::Card]",
+                "(default::User).>select_deck[IS default::Card]",
                 "[ns~1]@[ns~4]@@(__derived__::expr~26)"
             },
             "FENCE": {
-                "(test::User).>name[IS std::str]"
+                "(default::User).>name[IS std::str]"
             }
         }
         """
 
     def test_edgeql_ir_scope_tree_26(self):
         """
-        WITH MODULE test
         SELECT User {
             select_deck := (
                 FOR letter IN {'I', 'B'}
@@ -710,33 +694,32 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(test::User)",
+            "(default::User)",
             "FENCE": {
                 "[ns~1]@[ns~5]@@(__derived__::__derived__|letter@w~1)",
                 "FENCE": {
                     "FENCE": {
                         "FENCE": {
-                            "[ns~1]@[ns~5]@[ns~7]@@(test::User)\
-.>deck[IS test::Card]",
+                            "[ns~1]@[ns~5]@[ns~7]@@(default::User)\
+.>deck[IS default::Card]",
                             "FENCE": {
-                                "[ns~1]@[ns~5]@[ns~7]@@(test::User)\
-.>deck[IS test::Card].>name[IS std::str]"
+                                "[ns~1]@[ns~5]@[ns~7]@@(default::User)\
+.>deck[IS default::Card].>name[IS std::str]"
                             }
                         }
                     }
                 },
-                "(test::User).>select_deck[IS test::Card]",
+                "(default::User).>select_deck[IS default::Card]",
                 "[ns~1]@[ns~5]@@(__derived__::__derived__|foo@w~2)"
             },
             "FENCE": {
-                "(test::User).>name[IS std::str]"
+                "(default::User).>name[IS std::str]"
             }
         }
         """
 
     def test_edgeql_ir_scope_tree_27(self):
         """
-        WITH MODULE test
         INSERT User {
             name := 'Carol',
             deck := (
@@ -746,15 +729,15 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(test::User)",
+            "(default::User)",
             "FENCE": {
-                "[ns~1]@[ns~5]@@(test::Card)",
+                "[ns~1]@[ns~5]@@(default::Card)",
                 "FENCE": {
-                    "[ns~1]@[ns~5]@@(test::Card).>element[IS std::str]"
+                    "[ns~1]@[ns~5]@@(default::Card).>element[IS std::str]"
                 },
-                "(test::User).>deck[IS test::Card]",
+                "(default::User).>deck[IS default::Card]",
                 "FENCE": {
-                    "[ns~1]@[ns~2]@[ns~5]@[ns~6]@@(test::Card)\
+                    "[ns~1]@[ns~2]@[ns~5]@[ns~6]@@(default::Card)\
 .>cost[IS std::int64]"
                 }
             }
@@ -763,36 +746,34 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_scope_tree_28(self):
         """
-        WITH MODULE test
         SELECT <str>count((WITH A := Card SELECT A.owners)) ++ Card.name
 
 % OK %
         "FENCE": {
             "FENCE": {
-                "(__derived__::__derived__|A@w~1).>owners[IS test::User]": {
+                "(__derived__::__derived__|A@w~1).>owners[IS default::User]": {
                     "BRANCH": {
                         "(__derived__::__derived__|A@w~1)"
                     },
                     "FENCE": {
                         "ns~2@@(__derived__::__derived__|A@w~1)\
-.<deck[IS __derived__::(opaque: test:User)].>indirection[IS test::User]": {
+.<deck[IS __derived__::(opaque: default:User)]\
+.>indirection[IS default::User]": {
                             "ns~2@@(__derived__::__derived__|A@w~1)\
-.<deck[IS __derived__::(opaque: test:User)]": {
+.<deck[IS __derived__::(opaque: default:User)]": {
                                 "(__derived__::__derived__|A@w~1)"
                             }
                         }
                     }
                 }
             },
-            "(test::Card)",
-            "(test::Card).>name[IS std::str]"
+            "(default::Card)",
+            "(default::Card).>name[IS std::str]"
         }
         """
 
     def test_edgeql_ir_scope_tree_29(self):
         """
-        WITH
-            MODULE test
         SELECT Card {
             name,
             alice := (SELECT User FILTER User.name = 'Alice')
@@ -800,74 +781,69 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 
 % OK %
         "FENCE": {
-            "(test::Card)",
+            "(default::Card)",
             "FENCE": {
-                "[ns~1]@[ns~2]@@(test::User)",
+                "[ns~1]@[ns~2]@@(default::User)",
                 "FENCE": {
-                    "[ns~1]@[ns~2]@@(test::User).>name[IS std::str]"
+                    "[ns~1]@[ns~2]@@(default::User).>name[IS std::str]"
                 },
-                "(test::Card).>alice[IS test::User]"
+                "(default::Card).>alice[IS default::User]"
             },
             "FENCE": {
-                "(test::Card).>alice[IS test::User]": {
+                "(default::Card).>alice[IS default::User]": {
                     "FENCE": {
-                        "[ns~1]@[ns~3]@@(test::User)",
+                        "[ns~1]@[ns~3]@@(default::User)",
                         "FENCE": {
-                            "[ns~1]@[ns~3]@@(test::User).>name[IS std::str]"
+                            "[ns~1]@[ns~3]@@(default::User).>name[IS std::str]"
                         }
                     }
                 },
-                "(test::User)",
-                "(test::Card).>name[IS std::str]"
+                "(default::User)",
+                "(default::Card).>name[IS std::str]"
             }
         }
         """
 
     @tb.must_fail(errors.QueryError,
                   "reference to 'User.name' changes the interpretation",
-                  line=4, col=9)
+                  line=3, col=9)
     def test_edgeql_ir_scope_tree_bad_01(self):
         """
-        WITH MODULE test
         SELECT User.deck
         FILTER User.name
         """
 
     @tb.must_fail(errors.QueryError,
                   "reference to 'User' changes the interpretation",
-                  line=4, col=9)
+                  line=3, col=9)
     def test_edgeql_ir_scope_tree_bad_02(self):
         """
-        WITH MODULE test
         SELECT User.deck
         FILTER User.deck@count
         """
 
     @tb.must_fail(errors.QueryError,
                   "reference to 'User' changes the interpretation",
-                  line=3, col=35)
+                  line=2, col=35)
     def test_edgeql_ir_scope_tree_bad_03(self):
         """
-        WITH MODULE test
         SELECT User.deck { foo := User }
         """
 
     @tb.must_fail(errors.QueryError,
                   "reference to 'User.name' changes the interpretation",
-                  line=3, col=40)
+                  line=2, col=40)
     def test_edgeql_ir_scope_tree_bad_04(self):
         """
-        WITH MODULE test
         UPDATE User.deck SET { name := User.name }
         """
 
     @tb.must_fail(errors.QueryError,
                   "reference to 'U.r' changes the interpretation",
-                  line=7, col=58)
+                  line=6, col=58)
     def test_edgeql_ir_scope_tree_bad_05(self):
         """
         WITH
-            MODULE test,
             U := User {id, r := random()}
         SELECT
             (

--- a/tests/test_edgeql_ir_volatility_inference.py
+++ b/tests/test_edgeql_ir_volatility_inference.py
@@ -50,7 +50,6 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_volatility_inference_00(self):
         """
-        WITH MODULE test
         SELECT Card
 % OK %
         Stable
@@ -59,7 +58,6 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
     def test_edgeql_ir_volatility_inference_01(self):
         """
         WITH
-            MODULE test,
             foo := random()
         SELECT
             foo
@@ -69,8 +67,6 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_volatility_inference_02(self):
         """
-        WITH
-            MODULE test
         SELECT
             Card
         FILTER
@@ -81,8 +77,6 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_volatility_inference_03(self):
         """
-        WITH
-            MODULE test
         SELECT
             Card
         ORDER BY
@@ -93,8 +87,6 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_volatility_inference_04(self):
         """
-        WITH
-            MODULE test
         SELECT
             Card
         LIMIT
@@ -105,8 +97,6 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_volatility_inference_05(self):
         """
-        WITH
-            MODULE test
         SELECT
             Card
         OFFSET
@@ -117,8 +107,6 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_volatility_inference_06(self):
         """
-        WITH
-            MODULE test
         INSERT
             Card {
                 name := 'foo',
@@ -131,8 +119,6 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_volatility_inference_07(self):
         """
-        WITH
-            MODULE test
         UPDATE
             Card
         SET {
@@ -144,8 +130,6 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_volatility_inference_08(self):
         """
-        WITH
-            MODULE test
         DELETE
             Card
 % OK %

--- a/tests/test_edgeql_ir_volatility_inference.py
+++ b/tests/test_edgeql_ir_volatility_inference.py
@@ -35,7 +35,13 @@ class TestEdgeQLVolatilityInference(tb.BaseEdgeQLCompilerTest):
 
     def run_test(self, *, source, spec, expected):
         qltree = qlparser.parse(source)
-        ir = compiler.compile_ast_to_ir(qltree, self.schema)
+        ir = compiler.compile_ast_to_ir(
+            qltree,
+            self.schema,
+            options=compiler.CompilerOptions(
+                modaliases={None: 'default'},
+            ),
+        )
 
         expected_volatility = qltypes.Volatility(
             textwrap.dedent(expected).strip(' \n'))

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -202,7 +202,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         """Check that JSON of array preserves order."""
 
         await self.assert_query_result(
-            '''WITH MODULE test
+            r'''
                 SELECT <json>array_agg(
                     (SELECT JSONTest{number}
                      FILTER .number IN {0, 1}
@@ -338,7 +338,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             """)
 
     async def test_edgeql_json_accessor_13(self):
-        await self.con.execute('SET MODULE test;')
 
         await self.assert_query_result(
             r"""
@@ -364,7 +363,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 r'json index 10 is out of bounds'):
             await self.con.query(r"""
                 WITH
-                    MODULE test,
                     JT3 := (SELECT JSONTest FILTER .number = 3)
                 SELECT JT3.data[4]['b']['bar'][10]['bingo'];
             """)
@@ -375,7 +373,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 r'json index -10 is out of bounds'):
             await self.con.query(r"""
                 WITH
-                    MODULE test,
                     JT3 := (SELECT JSONTest FILTER .number = 3)
                 SELECT JT3.data[-10]['b']['bar'][2]['bingo'];
             """)
@@ -386,7 +383,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 r'cannot index json array by text'):
             await self.con.query(r"""
                 WITH
-                    MODULE test,
                     JT3 := (SELECT JSONTest FILTER .number = 3)
                 SELECT JT3.data['4']['b']['bar'][10]['bingo'];
             """)
@@ -397,7 +393,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 r"json index 'c' is out of bounds"):
             await self.con.execute(r"""
                 WITH
-                    MODULE test,
                     JT3 := (SELECT JSONTest FILTER .number = 3)
                 SELECT JT3.data[4]['b']['c'][2]['bingo'];
             """)
@@ -408,7 +403,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 r'cannot index json object by bigint'):
             await self.con.query(r"""
                 WITH
-                    MODULE test,
                     JT3 := (SELECT JSONTest FILTER .number = 3)
                 SELECT JT3.data[4][1]['bar'][2]['bingo'];
             """)
@@ -419,7 +413,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 r'cannot index json null'):
             await self.con.execute(r"""
                 WITH
-                    MODULE test,
                     JT3 := (SELECT JSONTest FILTER .number = 3)
                 SELECT JT3.data[4]['b']['bar'][0]['bingo'];
             """)
@@ -430,7 +423,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 r'cannot index json boolean'):
             await self.con.execute(r"""
                 WITH
-                    MODULE test,
                     JT3 := (SELECT JSONTest FILTER .number = 3)
                 SELECT JT3.data[-1]['b']['bar'][2]['bingo'];
             """)
@@ -441,7 +433,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 r'cannot index json number'):
             await self.con.query(r"""
                 WITH
-                    MODULE test,
                     JT3 := (SELECT JSONTest FILTER .number = 3)
                 SELECT JT3.data[0]['b']['bar'][2]['bingo'];
             """)
@@ -452,7 +443,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 r'cannot index json string'):
             await self.con.execute(r"""
                 WITH
-                    MODULE test,
                     JT3 := (SELECT JSONTest FILTER .number = 3)
                 SELECT JT3.data[2]['b']['bar'][2]['bingo'];
             """)
@@ -460,7 +450,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_null_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (
                     SELECT JSONTest FILTER .number = 0
                 ).data ?= <json>{};
@@ -470,7 +459,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (
                     SELECT JSONTest FILTER .number = 0
                 ).data ?= to_json('null');
@@ -480,7 +468,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (
                     SELECT JSONTest FILTER .number = 2
                 ).data ?= <json>{};
@@ -490,7 +477,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (
                     SELECT JSONTest FILTER .number = 2
                 ).data ?= to_json('null');
@@ -550,7 +536,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         )
 
     async def test_edgeql_json_typeof_02(self):
-        await self.con.execute('SET MODULE test;')
         await self.assert_query_result(
             r'''SELECT json_typeof(JSONTest.j_string);''',
             ['string', 'string', 'string'],
@@ -639,7 +624,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 r"operator '=' cannot.*'std::json' and 'std::int64'"):
             await self.con.query_json(r'''
                 WITH
-                    MODULE test,
                     JT0 := (SELECT JSONTest FILTER .number = 0)
                 SELECT json_array_unpack(JT0.j_array) = 1;
             ''')
@@ -648,7 +632,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     JT0 := (SELECT JSONTest FILTER .number = 0)
                 # unpacking [1, 1, 1]
                 SELECT json_array_unpack(JT0.j_array) = to_json('1');
@@ -660,7 +643,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     JT0 := (SELECT JSONTest FILTER .number = 2)
                 # unpacking [2, "q", [3], {}, null], should preserve the
                 # order
@@ -674,7 +656,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     JT0 := (SELECT JSONTest FILTER .number = 2)
                 # unpacking [2, "q", [3], {}, null], should preserve the
                 # order
@@ -728,7 +709,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_object_unpack_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT
                     _ := json_object_unpack(JSONTest.j_object)
                 ORDER BY _.0 THEN _.1;
@@ -741,7 +721,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT json_object_unpack(JSONTest.j_object) =
                     ('c', to_json('1'));
             ''',
@@ -750,7 +729,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT json_object_unpack(JSONTest.j_object).0 IN
                     {'a', 'b', 'c'};
             ''',
@@ -759,7 +737,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT json_object_unpack(JSONTest.j_object).1 IN
                     <json>{1, 2};
             ''',
@@ -768,7 +745,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT json_object_unpack(JSONTest.j_object).1 IN
                     <json>{'1', '2'};
             ''',
@@ -783,7 +759,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                 r'cannot call jsonb_each on a non-object'):
             await self.con.query_json(r'''
                 WITH
-                    MODULE test,
                     JT0 := (SELECT JSONTest FILTER .number = 0)
                 SELECT
                     count(json_object_unpack(JT0.data));
@@ -793,7 +768,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     JT1 := (SELECT JSONTest FILTER .number = 1),
                     JT2 := (SELECT JSONTest FILTER .number = 2)
                 SELECT (
@@ -823,8 +797,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         )
 
     async def test_edgeql_json_get_01(self):
-        await self.con.execute('SET MODULE test')
-
         await self.assert_query_result(
             r'''
             WITH JT3 := (SELECT JSONTest FILTER .number = 3)
@@ -918,8 +890,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         # since only one JSONTest has a non-trivial `data`, we
         # don't need to filter to get the same results as above
 
-        await self.con.execute('SET MODULE test')
-
         await self.assert_query_result(
             r'''SELECT json_get(JSONTest.data, '2');''',
             {'Fraka'},
@@ -988,8 +958,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_get_03(self):
         # chaining json_get should get the same effect as a single call
 
-        await self.con.execute('SET MODULE test')
-
         await self.assert_query_result(
             r'''
                 SELECT json_get(JSONTest.data, '4', 'b', 'bar', '2', 'bingo');
@@ -1017,8 +985,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         )
 
     async def test_edgeql_json_get_04(self):
-        await self.con.execute('SET MODULE test')
-
         await self.assert_query_result(
             r'''SELECT json_get(JSONTest.data, 'bogus') ?? <json>'oups';''',
             # JSON
@@ -1180,7 +1146,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 # base case
-                WITH MODULE test
                 SELECT
                     JSONTest {number, edb_string};
             """,
@@ -1195,7 +1160,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
                     JSONTest {number, edb_string}
                 FILTER
@@ -1213,7 +1177,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
                     JSONTest {number, edb_string}
                 FILTER
@@ -1230,7 +1193,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
                     JSONTest {number, edb_string}
                 FILTER
@@ -1250,7 +1212,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
                     JSONTest {number, edb_string}
                 FILTER
@@ -1343,7 +1304,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         )
 
     async def test_edgeql_json_slice_02(self):
-        await self.con.execute('SET MODULE test;')
 
         await self.assert_query_result(
             r'''
@@ -1418,7 +1378,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_alias_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT _ := json_get(JSONTest.j_array, '0')
             ORDER BY _;
             ''',
@@ -1430,7 +1389,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT _ := json_get(JSONTest.j_array, '10')
             ORDER BY _;
             ''',
@@ -1439,7 +1397,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT _ := json_get(JSONTest.j_array, {'-1', '4'})
             ORDER BY _;
             ''',
@@ -1451,7 +1408,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT _ := json_get(
                 JSONTest.data,
                 # Each of the variadic "steps" is a set, so we should
@@ -1472,7 +1428,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_alias_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT _ := json_get(
                 JSONTest.data,
                 # Each of the variadic "steps" is a set, so we should
@@ -1502,7 +1457,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH
-                MODULE test,
                 JT := JSONTest
             SELECT JSONTest {
                 a0 := (
@@ -1553,7 +1507,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_alias_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT _ := json_get(
                     JSONTest.data,
                     '0', '1', '2',
@@ -1574,7 +1527,6 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     JT := JSONTest
                 SELECT JSONTest {
                     a4 := (
@@ -1691,7 +1643,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
         result = (f'"_{i}": {v}' for i, v in enumerate(range(count)))
         await self.assert_query_result(
             f'''
-                SELECT to_str(<json>test::JSONTest{{ {", ".join(args)} }})
+                SELECT to_str(<json>JSONTest{{ {", ".join(args)} }})
                 LIMIT 1
             ''',
             {f'{{{", ".join(result)}}}'},

--- a/tests/test_edgeql_linkatoms.py
+++ b/tests/test_edgeql_linkatoms.py
@@ -34,7 +34,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_basic_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     name,
                     tag_set1,
@@ -90,7 +89,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_map_scalars_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     name,
                     tag_set1 ORDER BY Item.tag_set1 DESC,
@@ -137,7 +135,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_map_scalars_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     name,
                     tag_set1 ORDER BY Item.tag_set1 DESC LIMIT 1,
@@ -184,7 +181,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_map_scalars_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     name,
                     tag_set1 FILTER Item.tag_set1 > 'p',
@@ -231,7 +227,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_set_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER 'plastic' = .tag_set1
                 ORDER BY .name;
@@ -244,7 +239,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER 'plastic' = .tag_set2
                 ORDER BY .name;
@@ -259,7 +253,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_set_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER 'plastic' IN .tag_set1
                 ORDER BY .name;
@@ -272,7 +265,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER 'plastic' IN .tag_set2
                 ORDER BY .name;
@@ -287,7 +279,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_set_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER
                     array_agg(Item.tag_set1 ORDER BY Item.tag_set1) =
@@ -302,7 +293,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER
                     array_agg(Item.tag_set2 ORDER BY Item.tag_set2) =
@@ -317,7 +307,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_set_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER .tag_set1 = {'rectangle', 'wood'}
                 ORDER BY .name;
@@ -330,7 +319,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER .tag_set2 = {'rectangle', 'wood'}
                 ORDER BY .name;
@@ -346,7 +334,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             r'''
                 # subsets
                 #
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER .tag_set1 IN {'rectangle', 'wood'}
                 ORDER BY .name;
@@ -359,7 +346,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER .tag_set2 IN {'rectangle', 'wood'}
                 ORDER BY .name;
@@ -373,7 +359,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_set_06(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     name,
                     foo := (
@@ -430,7 +415,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # subsets
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER count( (
                     # XXX: check test_edgeql_expr_alias for failures first
@@ -447,7 +431,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER count( (
                     # XXX: check test_edgeql_expr_alias for failures first
@@ -466,7 +449,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             r'''
                 # match sets
                 WITH
-                    MODULE test,
                     cmp := {'rectangle', 'wood'},
                     cmp_count := count(cmp)
                 SELECT Item {name}
@@ -485,7 +467,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     cmp := {'rectangle', 'wood'},
                     cmp_count := count(cmp)
                 SELECT Item {name}
@@ -506,7 +487,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
                 # same as previous, but with a different syntax, leading
                 # to a different failure scenario
                 WITH
-                    MODULE test,
                     cmp := {'rectangle', 'wood'},
                     cmp_count := count(cmp)
                 # includes tag_set1 in the shape
@@ -526,7 +506,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     cmp := {'rectangle', 'wood'},
                     cmp_count := count(cmp)
                 # includes tag_set1 in the shape
@@ -545,7 +524,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_set_11(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER
                     array_agg(Item.tag_set1 ORDER BY Item.tag_set1) =
@@ -567,7 +545,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             r'''
                 # find an item with a unique quality
                 WITH
-                    MODULE test,
                     I2 := Item
                 SELECT Item {
                     name,
@@ -614,7 +591,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             r'''
                 # find an item with a unique quality
                 WITH
-                    MODULE test,
                     I2 := Item
                 SELECT Item {
                     name,
@@ -644,7 +620,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             r'''
                 # find an item with a unique quality
                 WITH
-                    MODULE test,
                     I2 := Item
                 SELECT Item {
                     name,
@@ -674,7 +649,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # subsets
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER .tag_set1 IN {'wood', 'plastic'}
                 ORDER BY count((
@@ -694,8 +668,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # just a simple unpack
-                WITH
-                    MODULE test
                 SELECT Item {
                     name,
                     unpack := (SELECT array_unpack(Item.tag_array))
@@ -735,8 +707,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # just a simple unpack
-                WITH
-                    MODULE test
                 SELECT Item {
                     name,
                     unpack := array_unpack(Item.tag_array)
@@ -775,7 +745,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_array_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER 'metal' IN array_unpack(.tag_array)
                 ORDER BY .name;
@@ -788,7 +757,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_array_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER 'metal' = array_unpack(.tag_array)
                 ORDER BY .name;
@@ -801,7 +769,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_array_05(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 # array_get is used to safely default to {}
                 FILTER array_get(.tag_array, 0) = 'metal'
@@ -815,7 +782,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_array_06(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER .tag_array = ['metal', 'plastic']
                 ORDER BY .name;
@@ -828,7 +794,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_array_07(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 FILTER NOT EXISTS .tag_array
                 ORDER BY .name;
@@ -843,7 +808,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_array_08(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {name}
                 # no item has 3 elements
                 FILTER NOT EXISTS array_get(.tag_array, 3)
@@ -866,7 +830,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             r'''
                 # find an item with a unique quality
                 WITH
-                    MODULE test,
                     I2 := Item
                 SELECT Item {
                     name,
@@ -915,7 +878,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             r'''
                 # find an item with a unique quality
                 WITH
-                    MODULE test,
                     I2 := Item
                 SELECT Item {
                     name,
@@ -947,7 +909,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             r'''
                 # find an item with ALL unique qualities
                 WITH
-                    MODULE test,
                     I2 := Item
                 SELECT Item {
                     name,
@@ -981,7 +942,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_derived_tuple_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     n1 := (Item.name,),
                     n2 := (Item.name,).0,
@@ -1024,7 +984,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_derived_tuple_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     n1 := (Item.name, 'foo'),
                 }
@@ -1043,7 +1002,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_derived_array_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     n1 := [Item.name],
                     n2 := [Item.name][0],
@@ -1092,7 +1050,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_derived_array_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     n1 := [Item.name],
                     n2 := array_get([Item.name], 0),
@@ -1141,7 +1098,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_derived_array_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     name,
                     a_a1 := Item.tag_array[{0, 1}],
@@ -1173,7 +1129,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_derived_array_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     name,
                     a_a1 := array_get(Item.tag_array, {0, 1}),
@@ -1205,7 +1160,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_derived_array_05(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     name,
                     a_a1 := array_get(Item.tag_array, {0, 2}),
@@ -1241,7 +1195,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_derived_array_06(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     name,
                     a_a1 := Item.tag_array[1:20],
@@ -1277,7 +1230,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_derived_array_07(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     name,
                     a_a1 := Item.tag_array[{1, 2}:20],
@@ -1315,7 +1267,6 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
     async def test_edgeql_links_derived_array_08(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Item {
                     name,
                     re := re_match(Item.tag_set1, Item.tag_set2),

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -34,7 +34,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
     async def test_edgeql_props_basic_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     name,
                     deck: {
@@ -206,7 +205,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             r'''
                 # get users and only cards that have the same count and
                 # cost in the decks
-                WITH MODULE test
                 SELECT User {
                     name,
                     deck: {
@@ -262,7 +260,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # get only users who have the same count and cost in the decks
-                WITH MODULE test
                 SELECT User {
                     name,
                     deck: {
@@ -341,7 +338,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             r'''
                 # get all cards that match their cost to the count in at
                 # least some deck
-                WITH MODULE test
                 SELECT Card {
                     name,
                     element,
@@ -369,7 +365,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # get all the friends of Alice and their nicknames
-                WITH MODULE test
                 SELECT User {
                     name,
                     friends: {
@@ -394,7 +389,7 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
     async def test_edgeql_props_basic_06(self):
         await self.assert_query_result(
             r'''
-                SELECT test::User.avatar@text;
+                SELECT User.avatar@text;
             ''',
             [
                 'Best'
@@ -404,7 +399,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
     async def test_edgeql_props_basic_07(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     avatar: {
                         @text
@@ -420,7 +414,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # get cards that have the same count in some deck as their cost
-                WITH MODULE test
                 SELECT Card {
                     name,
                 }
@@ -437,7 +430,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # get cards that have the same count in some deck as their cost
-                WITH MODULE test
                 SELECT Card {
                     name,
                     same := EXISTS (
@@ -466,7 +458,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # get cards that have the same count in some deck as their cost
-                WITH MODULE test
                 SELECT Card {
                     name,
                     same := EXISTS (
@@ -496,7 +487,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # get cards that have the same count in some deck as their cost
-                WITH MODULE test
                 SELECT Card {
                     name,
                     same := (
@@ -523,7 +513,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # count of 1 in at least some deck implies 'Fire'
-                WITH MODULE test
                 SELECT Card {
                     name,
                     element,
@@ -604,7 +593,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
             r'''
                 # FILTER by NOT (count of 1 implies 'Fire')
                 # in at least some deck
-                WITH MODULE test
                 SELECT Card {
                     name,
                 }
@@ -625,7 +613,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # same as above, refactored
-                WITH MODULE test
                 SELECT Card {
                     name,
                 }
@@ -646,7 +633,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # count of 1 implies 'Fire' in the deck of Dave
-                WITH MODULE test
                 SELECT User {
                     name,
                     deck: {
@@ -714,7 +700,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
     async def test_edgeql_props_setops_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT DISTINCT User.deck@count;
             ''',
             {1, 2, 3, 4},
@@ -722,7 +707,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT DISTINCT (
                     SELECT User.deck@count FILTER User.deck.element = 'Fire'
                 );
@@ -732,7 +716,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT DISTINCT (
                     SELECT User.deck@count FILTER User.deck.element = 'Water'
                 );
@@ -742,7 +725,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT DISTINCT (
                     SELECT (
                         SELECT Card FILTER Card.element = 'Water'
@@ -756,7 +738,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     C := (
                         SELECT User FILTER User.name = 'Carol').deck.name,
                     D := (
@@ -785,7 +766,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     C := (
                         SELECT User FILTER User.name = 'Carol').deck.name,
                     D := (
@@ -808,7 +788,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
     async def test_edgeql_props_setops_03(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT _ := {
                     # this is equivalent to UNION
                     User.name,
@@ -825,7 +804,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT _ := DISTINCT {
                     User.name,
                     User.friends@nickname,
@@ -843,7 +821,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     A := (SELECT User FILTER User.name = 'Alice')
                     # the set of distinct values of card counts in
                     # the deck of Alice is {2, 3}
@@ -859,8 +836,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
     async def test_edgeql_props_setops_05(self):
         await self.assert_query_result(
             r'''
-                WITH
-                    MODULE test
                 SELECT DISTINCT
                         (
                             SELECT User FILTER User.name = 'Alice'
@@ -872,7 +847,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
     async def test_edgeql_props_computable_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     name,
                     my_deck := (SELECT Card { @foo := Card.name }
@@ -892,7 +866,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     MyUser := (
                         SELECT
                             User {
@@ -919,8 +892,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
     async def test_edgeql_props_abbrev(self):
         await self.assert_query_result(
             r'''
-                WITH
-                    MODULE test
                 SELECT User {
                     name,
                     my_deck := (SELECT .deck {
@@ -943,7 +914,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
     async def test_edgeql_props_agg_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT sum(User.deck@count);
             ''',
             [51],
@@ -951,7 +921,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT _ := (sum(User.deck@count), User.name)
                 ORDER BY _;
             ''',
@@ -963,7 +932,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
     async def test_edgeql_props_link_shadow_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     name,
                     deck := (SELECT x := User.deck
@@ -997,7 +965,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     AliasedUser := User {
                         name,
                         deck := (SELECT User.deck ORDER BY .name LIMIT 2)
@@ -1022,7 +989,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
     async def test_edgeql_props_link_computed_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     name,
                     deck: {name, @total_cost} ORDER BY .name
@@ -1044,7 +1010,6 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
     async def test_edgeql_props_link_computed_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     name,
                     avatar: { @tag },

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -39,7 +39,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     A := {1, 2},
                     U := (SELECT User FILTER User.name IN {'Alice', 'Bob'})
                 SELECT _ := (U{name}, A)
@@ -58,7 +57,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     A := {1, 2}
                 SELECT _ := (User{name, a := A}, A)
                 ORDER BY _.1 THEN _.0.name;
@@ -79,7 +77,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     A := {1, 2}
                 SELECT _ := (A, User{name, a := A})
                 ORDER BY _.0 THEN _.1.name;
@@ -99,7 +96,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_tuple_03(self):
         # get the User names and ids
         res = await self.con.query(r'''
-            WITH MODULE test
             SELECT User {
                 name,
                 id
@@ -109,7 +105,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT _ := (User { name }, User { id })
                 ORDER BY _.0.name;
             ''',
@@ -122,7 +117,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_tuple_04a(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT _ := (
                     # User.friends is a common path, so it refers to the
                     # SAME object in both tuple elements. In particular
@@ -183,7 +177,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         # N.B: for reproducing, I needed \set limit 0
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT _ := (
                     User.friends {name},
                     # User.friends is a common path, so it refers to the
@@ -245,7 +238,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             r'''
                 # Same as above, but with a computable instead of real
                 # "friends"
-                WITH MODULE test
                 SELECT _ := (
                     User {
                         name,
@@ -301,7 +293,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     U2 := User
                 SELECT x := (
                     User {name, foo := U2 {name}},
@@ -353,7 +344,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_tuple_07(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     name,
                     foo := (
@@ -390,7 +380,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 # compare to test_edgeql_scope_filter_03 to see how it
                 # works out without tuples
                 WITH
-                    MODULE test,
                     U2 := User
                 SELECT (
                     User {
@@ -459,7 +448,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 # compare to test_edgeql_scope_filter_03 to see how it
                 # works out without tuples
                 WITH
-                    MODULE test,
                     U2 := User
                 SELECT _ := (
                     User {
@@ -529,7 +517,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_tuple_10(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT (User.name, User.deck_cost, count(User.deck),
                         User.deck_cost / count(User.deck))
                 ORDER BY User.name;
@@ -544,7 +531,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # in the below expression User.friends is the
                 # longest common prefix, so we know that for
                 # each friend, the average cost will be
@@ -561,7 +547,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 # in the below expression User.friends is the
                 # longest common prefix, so we know that for
                 # each friend, the average cost will be
@@ -575,7 +560,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_tuple_11(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT x := (
                     Card {
                         name,
@@ -643,7 +627,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # this is similar to test_edgeql_scope_tuple_04
-                WITH MODULE test
                 SELECT _ := (
                     # User.friends is a common path, so it refers to the
                     # SAME object in both tuple elements. In particular
@@ -682,7 +665,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 letter := {'A', 'B'},
                 tup := (
                     letter,
@@ -706,7 +688,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 letter := {'A', 'B'},
                 tup := (
                     (
@@ -740,7 +721,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 letter := {'A', 'B'},
                 tup := (
                     letter,
@@ -766,7 +746,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
     async def test_edgeql_scope_tuple_15(self):
         res = await self.con.query(r"""
-            WITH MODULE test
             SELECT ((SELECT User {deck}), User.deck);
         """)
 
@@ -778,7 +757,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 L := (FOR name in {'Alice', 'Bob'} UNION (
                     SELECT User
                     FILTER .name = name
@@ -798,7 +776,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 name := {'Alice', 'Bob'},
                 L := (name, (
                     SELECT User
@@ -819,7 +796,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 name := {'Alice', 'Bob'},
                 L := ((
                     SELECT User
@@ -840,7 +816,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 name := {'Alice', 'Bob'},
                 L := (name, (
                     SELECT User
@@ -881,8 +856,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_binding_06(self):
         await self.assert_query_result(
             r"""
-            WITH
-                MODULE test,
             SELECT stdgraphql::Query {
                 lol := (
                     WITH L := (FOR name in {'Alice', 'Bob'} UNION (
@@ -909,8 +882,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_binding_07(self):
         await self.assert_query_result(
             r"""
-            WITH
-                MODULE test,
             SELECT stdgraphql::Query {
                 lol := (
                     WITH Y := (FOR x IN {1, 2} UNION (x + 1)),
@@ -925,7 +896,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_with_subquery_01(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT count((
                     Card.name,
                     (WITH X := (SELECT Card) SELECT X.name),
@@ -938,7 +908,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     U2 := User
                 SELECT User {
                     name,
@@ -992,7 +961,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_filter_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User.friends {name}
                 FILTER User.friends NOT IN <Object>{}
                 ORDER BY User.friends.name;
@@ -1008,7 +976,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     U2 := User
                 SELECT User {
                     name,
@@ -1056,7 +1023,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_filter_04(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     name,
                     friends: {
@@ -1082,7 +1048,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             r'''
                 # User.name is wrapped into a SELECT, so it's a SET OF
                 # w.r.t FILTER
-                WITH MODULE test
                 SELECT (SELECT User.name)
                 FILTER User.name = 'Alice';
             ''',
@@ -1094,7 +1059,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             r'''
                 # User is wrapped into a SELECT, so it's a SET OF
                 # w.r.t FILTER
-                WITH MODULE test
                 SELECT (SELECT User).name
                 FILTER User.name = 'Alice';
             ''',
@@ -1106,7 +1070,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             r'''
                 # User.name is a SET OF argument of ??, so it's unaffected
                 # by the FILTER
-                WITH MODULE test
                 SELECT (<str>{} ?? User.name)
                 FILTER User.name = 'Alice';
             ''',
@@ -1118,7 +1081,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             r'''
                 # User is a SET OF argument of ??, so it's unaffected
                 # by the FILTER
-                WITH MODULE test
                 SELECT (<User>{} ?? User).name
                 FILTER User.name = 'Alice';
             ''',
@@ -1128,7 +1090,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_order_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     name,
                     friends: {
@@ -1174,7 +1135,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_offset_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     name,
                     friends: {
@@ -1224,7 +1184,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_offset_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     name,
                     friends: {
@@ -1265,7 +1224,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_limit_01(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     name,
                     friends: {
@@ -1317,7 +1275,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_limit_02(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT User {
                     name,
                     friends: {
@@ -1359,7 +1316,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # control query Q1
-                WITH MODULE test
                 SELECT Card.element ++ ' ' ++ Card.name
                 FILTER Card.name > Card.element
                 ORDER BY Card.name;
@@ -1377,7 +1333,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 # work out because they all refer to a singleton with same
                 # value as A.
                 WITH
-                    MODULE test,
                     A := Card
                 SELECT
                     A.element ++ ' ' ++ (WITH B := A SELECT B).name
@@ -1401,7 +1356,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 # semantically same as control query Q1, with lots of
                 # nested shapes
                 WITH
-                    MODULE test,
                     A := Card
                 SELECT
                     A.element ++ ' ' ++ (WITH B := A SELECT B).name
@@ -1422,7 +1376,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_nested_05(self):
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT
                     Card {
                         foo := Card.element ++ <str>count(Card.name)
@@ -1445,7 +1398,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # control query Q2
-                WITH MODULE test
                 # combination of element + SET OF with a common prefix
                 SELECT Card.name ++ <str>count(Card.owners)
                 FILTER
@@ -1466,7 +1418,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 # semantically same as control query Q2, with lots of
                 # nested aliases
                 WITH
-                    MODULE test,
                     A := Card
                 SELECT
                     A.name ++ (WITH B := A SELECT <str>count(B.owners))
@@ -1494,7 +1445,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 # semantically same as control query Q2, with lots of
                 # nested aliases, all referring to the top level alias
                 WITH
-                    MODULE test,
                     A := Card
                 SELECT
                     A.name ++ (WITH B := A SELECT <str>count(B.owners))
@@ -1519,7 +1469,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # control query Q3
-                WITH MODULE test
                 SELECT Card.name ++ <str>count(Card.owners);
             ''',
             {'Imp1', 'Dragon2', 'Bog monster4', 'Giant turtle4', 'Dwarf2',
@@ -1531,7 +1480,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             r'''
                 # semantically same as control query Q3, except that some
                 # aliases are introduced
-                WITH MODULE test
                 SELECT Card.name ++
                        <str>count((WITH A := Card SELECT A).owners);
             ''',
@@ -1541,7 +1489,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT Card.name ++
                        <str>count((WITH A := Card SELECT A.owners));
             ''',
@@ -1551,7 +1498,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT <str>count((WITH A := Card SELECT A.owners)) ++
                        Card.name;
             ''',
@@ -1563,7 +1509,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             r'''
                 # semantically same as control query Q3, except that some
                 # aliases are introduced
-                WITH MODULE test
                 SELECT (Card.name,
                         count((WITH A := Card SELECT A).owners));
             ''',
@@ -1576,8 +1521,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_nested_12(self):
         await self.assert_query_result(
             r'''
-                WITH
-                    MODULE test
                 SELECT Card {
                     name,
                     owner := (
@@ -1601,7 +1544,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             r"""
                 # U2 is a combination of DETACHED and non-DETACHED expression
                 WITH
-                    MODULE test,
                     U2 := User.name ++ DETACHED User.name
                 SELECT U2 ++ U2;
             """,
@@ -1614,7 +1556,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 # DETACHED is reused directly
-                WITH MODULE test
                 SELECT User.name ++ DETACHED User.name ++
                        User.name ++ DETACHED User.name;
             """,
@@ -1627,7 +1568,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_detached_02(self):
         # calculate some useful base expression
         names = await self.con.query(r"""
-            WITH MODULE test
             SELECT User.name ++ <str>count(User.deck);
         """)
 
@@ -1636,7 +1576,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 # Let's say we need a tournament where everybody will play
                 # with everybody twice.
                 WITH
-                    MODULE test,
                     # calculate some expression ("full" name)
                     U0 := User.name ++ <str>count(User.deck),
                     # make a copy of U0 so that we can do cross product
@@ -1656,7 +1595,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     # make 3 copies of User.name
                     U0 := DETACHED User.name,
                     U1 := DETACHED User.name,
@@ -1674,7 +1612,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             r"""
                 # same thing, but building it up differently
                 WITH
-                    MODULE test,
                     # calculate some expression ("full" name)
                     U0 := User.name,
                     # make that expression DETACHED so that we can do
@@ -1703,7 +1640,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 r"'User' changes the interpretation of 'User'"):
             async with self.con.transaction():
                 await self.con.query(r"""
-                    WITH MODULE test
                     SELECT User.friends
                     FILTER User.friends@nickname = 'Firefighter';
                 """)
@@ -1714,7 +1650,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"'User' changes the interpretation of 'User'"):
             await self.con.query(r"""
-                WITH MODULE test
                 SELECT User.friends
                 FILTER (
                     # create an independent link target set
@@ -1729,7 +1664,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 # Natural syntax for filtering friends based on nickname:
-                WITH MODULE test
                 SELECT User {
                     name,
                     friends: {
@@ -1750,7 +1684,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             r"""
                 # Alternative natural syntax for filtering friends based
                 # on nickname:
-                WITH MODULE test
                 SELECT User {
                     name,
                     fr := (
@@ -1774,7 +1707,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             r"""
                 # The above query is legal, but the reason why may be more
                 # obvious with the equivalent query below.
-                WITH MODULE test
                 SELECT User {
                     name,
                     fr := (
@@ -1803,7 +1735,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     U2 := DETACHED User
                 SELECT User {
                     name,
@@ -1857,7 +1788,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_detached_07(self):
         # compare detached to regular expression
         res = await self.con.query_json(r'''
-            WITH MODULE test
             SELECT User {
                 name,
                 fire_deck := (
@@ -1873,7 +1803,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # adding a top-level DETACHED should not change anything at all
-                WITH MODULE test
                 SELECT DETACHED User {
                     name,
                     fire_deck := (
@@ -1889,7 +1818,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
     async def test_edgeql_scope_detached_08(self):
         res = await self.con.query_json(r'''
-            WITH MODULE test
             SELECT User {
                 name,
                 fire_deck := (
@@ -1905,7 +1833,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # adding a top-level DETACHED should not change anything at all
-                WITH MODULE test
                 SELECT DETACHED User {
                     name,
                     fire_deck := (
@@ -1925,7 +1852,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
             async with self.con.transaction():
                 await self.con.execute(r"""
-                    WITH MODULE test
                     SELECT DETACHED User {name}
                     # a subtle error
                     ORDER BY User.name;
@@ -1933,7 +1859,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT DETACHED User {name}
                 # correct usage
                 ORDER BY .name;
@@ -1950,7 +1875,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    MODULE test,
                     Card := (SELECT Card FILTER .name = 'Bog monster')
                 # The contents of the shape will be detached, thus
                 # the `Card` mentioned in the shape will be referring to
@@ -2024,7 +1948,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             r'''
                 # UNION and `{...}` should create SET OF scoped operands,
                 # therefore `count` should operate on the entire set
-                WITH MODULE test
                 SELECT len(User.name) UNION count(User);
             ''',
             [3, 4, 4, 5, 5],
@@ -2033,7 +1956,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT {len(User.name), count(User)};
             ''',
             [3, 4, 4, 5, 5],
@@ -2045,7 +1967,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             r'''
                 # UNION and `{...}` should create SET OF scoped operands,
                 # therefore FILTER should not be effective
-                WITH MODULE test
                 SELECT len(User.name)
                 FILTER User.name > 'C';
             ''',
@@ -2055,7 +1976,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT {len(User.name)}
                 FILTER User.name > 'C';
             ''',
@@ -2065,7 +1985,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test
                 SELECT {len(User.name), count(User)}
                 FILTER User.name > 'C';
             ''',
@@ -2078,8 +1997,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         # do not leak out into the query.
         await self.assert_query_result(
             r"""
-                WITH
-                    MODULE test
                 SELECT x := (User.name, User.deck.name, User.deck_cost)
                 FILTER x.0 = 'Alice'
                 ORDER BY x.1;
@@ -2094,8 +2011,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH
-                    MODULE test
                 SELECT x := (User.name, User.deck.name, sum(User.deck.cost))
                 FILTER x.0 = 'Alice'
                 ORDER BY x.1;
@@ -2113,8 +2028,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         # of the type variant do not leak out into the query.
         await self.assert_query_result(
             r"""
-                WITH
-                    MODULE test
                 SELECT Card {
                     name,
                     alice := (SELECT User FILTER User.name = 'Alice')
@@ -2128,8 +2041,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_03(self):
         await self.assert_query_result(
             r"""
-                WITH
-                    MODULE test
                 SELECT User {
                     name,
                     # a sub-shape with a computable property is ordered
@@ -2155,8 +2066,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_04(self):
         await self.assert_query_result(
             r"""
-                WITH
-                    MODULE test
                 SELECT User {
                     name,
                     # a sub-shape with a computable link is ordered
@@ -2197,8 +2106,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_05(self):
         await self.assert_query_result(
             r"""
-                WITH
-                    MODULE test
                 SELECT User {
                     name,
                     # a sub-shape with a computable derived from a
@@ -2237,8 +2144,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_06(self):
         await self.assert_query_result(
             r"""
-                WITH
-                    MODULE test
                 SELECT User {
                     name,
                     # a sub-shape with some arbitrary computable link
@@ -2263,8 +2168,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_07a(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test,
-                     U := User { cards := .deck },
+                WITH U := User { cards := .deck },
                 SELECT count((U.cards.name, U.cards.cost));
             """,
             [9],
@@ -2273,8 +2177,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_07b(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test,
-                     U := User { cards := Card },
+                WITH U := User { cards := Card },
                 SELECT count((U.cards.name, U.cards.cost));
             """,
             [9],
@@ -2283,8 +2186,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_07c(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test,
-                     U := (SELECT User { cards := Card }
+                WITH U := (SELECT User { cards := Card }
                            FILTER .name = "Phil"),
                 SELECT count((U.cards.name, U.cards.cost));
             """,
@@ -2294,7 +2196,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_08(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test,
                 SELECT count((Card.owners.name, Card.owners.deck_cost));
             """,
             [4],
@@ -2303,8 +2204,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_09a(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test,
-                    U := User {
+                WITH U := User {
                         unowned := (SELECT Card FILTER Card NOT IN User.deck)
                     },
                 SELECT _ := U.unowned.name ORDER BY _;
@@ -2318,8 +2218,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_09b(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test,
-                    U := (SELECT User {
+                WITH U := (SELECT User {
                         unowned := (SELECT Card FILTER Card NOT IN User.deck)
                     } FILTER .name IN {'Carol', 'Dave'}),
                 SELECT _ := U.unowned.name ORDER BY _;
@@ -2332,8 +2231,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_09c(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test,
-                    U := (SELECT User {
+                WITH U := (SELECT User {
                         unowned := (SELECT Card FILTER Card NOT IN User.deck)
                     } FILTER .name IN {'Carol', 'Dave'}),
                 SELECT _ := (U.unowned.name, U.unowned.cost) ORDER BY _;
@@ -2346,8 +2244,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_10(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test,
-                     U := User { cards := (.deck UNION .deck) },
+                WITH U := User { cards := (.deck UNION .deck) },
                 SELECT count(U.cards);
             """,
             [9],
@@ -2356,8 +2253,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_11a(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test,
-                    U := (SELECT User {
+                WITH U := (SELECT User {
                         deck: {name, a := Award},
                     }),
                 SELECT count((U.deck.a.name, U.deck.a.id, U.deck.name));
@@ -2369,8 +2265,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_computables_11b(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test,
-                    U := (SELECT User {
+                WITH U := (SELECT User {
                         cards := .deck {name, a := Award},
                     }),
                 SELECT count((U.cards.a.name, U.cards.a.id, U.cards.name));
@@ -2385,8 +2280,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
         # ... make sure we output legit objects in this case
         await self.assert_query_result(
             r"""
-                WITH MODULE test,
-                    U := (SELECT User {
+                WITH U := (SELECT User {
                         cards := .deck {name, a := Award},
                     }),
                 SELECT (U.cards.a.name, U.cards.a.id, U.cards) LIMIT 1;
@@ -2401,7 +2295,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     User := User,
                     User := User,
                     User := User
@@ -2413,7 +2306,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     User := Card,
                     User := User
                 # this is a Card.name now
@@ -2426,7 +2318,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     User := User,
                     User := User.deck,
                     User := User.element,
@@ -2443,7 +2334,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     X := {1, 2},
                     Y := X + 1,
                 SELECT _ := (X, Y) ORDER BY _;
@@ -2457,7 +2347,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     a := count({Card.name})
                 SELECT Card {name, a := a} FILTER .name = 'Imp';
             """,
@@ -2501,7 +2390,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         # bug that inspired this.
         await self.assert_query_result(
             """
-                WITH MODULE test
                 SELECT User {
                     name,
                     deck: {
@@ -2522,7 +2410,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_nested_computable_02(self):
         await self.assert_query_result(
             """
-                WITH MODULE test
                 SELECT User {
                     name,
                 }
@@ -2538,7 +2425,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_link_narrow_card_01(self):
         await self.assert_query_result(
             """
-                WITH MODULE test
                 SELECT User {
                     name,
                     specials := .deck[IS SpecialCard].name

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1923,8 +1923,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tvariant_bad_03(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,
-            "cannot redefine link 'related_to' of object type 'default::Issue' "
-            "as scalar type 'std::int64'",
+            "cannot redefine link 'related_to' of object type "
+            "'default::Issue' as scalar type 'std::int64'",
             _position=66,
         ):
             await self.con.execute("""
@@ -1936,8 +1936,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tvariant_bad_04(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,
-            "cannot redefine link 'related_to' of object type 'default::Issue' "
-            "as object type 'default::Text'",
+            "cannot redefine link 'related_to' of object type "
+            "'default::Issue' as object type 'default::Text'",
             _position=66,
         ):
             await self.con.execute("""

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -4630,7 +4630,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 FILTER Issue.number = '1'
             ).__type__.name[:2];
             """,
-            ['te'],
+            ['de'],
         )
 
         await self.assert_query_result(
@@ -4640,7 +4640,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 FILTER Issue.number = '1'
             ).__type__.name[2:-1];
             """,
-            ['st::Issu'],
+            ['fault::Issu'],
         )
 
         await self.assert_query_result(

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -35,7 +35,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_unique_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue.watchers.<owner[IS Issue] {
                     name
@@ -55,7 +54,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_unique_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue.owner{name}
             ORDER BY Issue.owner.name;
             ''',
@@ -67,7 +65,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {
                     number,
@@ -89,7 +86,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {
                     number,
@@ -109,7 +105,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_03(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 User {
                     name,
@@ -139,7 +134,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH
-                MODULE test,
                 # we aren't referencing User in any way, so this works
                 # best as a subquery, rather than inline computable
                 sub := (
@@ -170,7 +164,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH
-                MODULE test,
                 # we aren't referencing User in any way, so this works
                 # best as a subquery, than inline computable
                 sub := (
@@ -214,7 +207,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_06(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 User {
                     name,
@@ -242,7 +234,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_07(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 User {
                     name,
@@ -270,7 +261,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r"""
             # get a user + the latest issue (regardless of owner), which has
             # the same number of characters in the status as the user's name
-            WITH MODULE test
             SELECT User{
                 name,
                 special_issue := (
@@ -310,7 +300,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_09(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Text{
                 body,
                 name := Text[IS Issue].name IF Text IS Issue      ELSE
@@ -340,7 +329,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_10(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue{
                 name,
                 number,
@@ -360,7 +348,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH
-                MODULE test,
                 sub := (
                     SELECT
                         Text
@@ -379,7 +366,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH
-                MODULE test,
                 sub := (
                     SELECT
                         Text
@@ -391,14 +377,13 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             SELECT
                 sub.__type__.name;
             ''',
-            ['test::Issue']
+            ['default::Issue']
         )
 
     async def test_edgeql_select_computable_13(self):
         await self.assert_query_result(
             r'''
             WITH
-                MODULE test,
                 sub := (
                     SELECT
                         Text
@@ -416,7 +401,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_14(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue{
                 name,
                 number,
@@ -437,9 +421,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"possibly more than one element returned by an expression "
                 r"for a computable property 'foo' declared as 'single'",
-                _position=199):
+                _position=166):
             await self.con.query("""\
-                WITH MODULE test
                 SELECT Issue{
                     name,
                     number,
@@ -452,7 +435,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_16(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue{
                 name,
                 number,
@@ -474,10 +456,9 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"possibly more than one element returned by an expression "
                 r"for a computable property 'foo' declared as 'single'",
-                _position=248):
+                _position=215):
             await self.con.query("""\
                 WITH
-                    MODULE test,
                     V := (SELECT Issue {
                         foo := {1, 2}
                     } FILTER .number = '1')
@@ -491,7 +472,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         async with self._run_and_rollback():
             await self.con.execute(
                 '''
-                    WITH MODULE test
                     INSERT Publication {
                         title := 'aaa'
                     }
@@ -500,7 +480,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
             await self.assert_query_result(
                 r"""
-                    WITH MODULE test
                     SELECT Publication {
                         title,
                         title1,
@@ -526,7 +505,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_19(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue{
                 number,
                 required foo := 42,
@@ -542,7 +520,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_20(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue{
                 number,
                 required foo := <int64>.number,
@@ -566,9 +543,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
                 r"a computable property 'foo' declared as 'required'",
-                _position=111):
+                _position=78):
             await self.con.query("""\
-                WITH MODULE test
                 SELECT Issue{
                     number,
                     required foo := <int64>{},
@@ -581,9 +557,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
                 r"a computable property 'foo' declared as 'required'",
-                _position=111):
+                _position=78):
             await self.con.query("""\
-                WITH MODULE test
                 SELECT Issue{
                     number,
                     required single foo := <int64>{},
@@ -596,9 +571,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
                 r"a computable property 'foo' declared as 'required'",
-                _position=111):
+                _position=78):
             await self.con.query("""\
-                WITH MODULE test
                 SELECT Issue{
                     number,
                     required multi foo := <int64>{},
@@ -611,9 +585,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"possibly more than one element returned by an expression "
                 r"for a computable property 'foo' declared as 'single'",
-                _position=111):
+                _position=78):
             await self.con.query("""\
-                WITH MODULE test
                 SELECT Issue{
                     number,
                     required single foo := {1, 2},
@@ -626,9 +599,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
                 r"a computable property 'foo' declared as 'required'",
-                _position=111):
+                _position=78):
             await self.con.query("""\
-                WITH MODULE test
                 SELECT Issue{
                     number,
                     required foo := <str>.time_estimate,
@@ -641,9 +613,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
                 r"a computable property 'foo' declared as 'required'",
-                _position=111):
+                _position=78):
             await self.con.query("""\
-                WITH MODULE test
                 SELECT Issue{
                     number,
                     required single foo := <str>.time_estimate,
@@ -656,9 +627,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
                 r"a computable property 'foo' declared as 'required'",
-                _position=111):
+                _position=78):
             await self.con.query("""\
-                WITH MODULE test
                 SELECT Issue{
                     number,
                     required multi foo := <str>.time_estimate,
@@ -669,7 +639,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_28(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue{
                 number,
                 required foo := .owner{
@@ -703,9 +672,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
                 r"a computable link 'foo' declared as 'required'",
-                _position=111):
+                _position=78):
             await self.con.query("""\
-                WITH MODULE test
                 SELECT Issue{
                     number,
                     required multi foo := .owner.todo,
@@ -727,7 +695,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_match_01(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Issue {number}
             FILTER
@@ -739,7 +706,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Issue {number}
             FILTER
@@ -751,7 +717,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Issue {number}
             FILTER
@@ -764,7 +729,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_match_02(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Issue {number}
             FILTER
@@ -777,7 +741,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Issue {number}
             FILTER
@@ -789,7 +752,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Issue {number}
             FILTER
@@ -802,7 +764,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_match_03(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Issue {number}
             FILTER
@@ -814,7 +775,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Issue {number}
             FILTER
@@ -826,7 +786,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Issue {number}
             FILTER
@@ -840,7 +799,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_match_04(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Issue {number}
             FILTER
@@ -852,7 +810,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Issue {number}
             FILTER
@@ -864,7 +821,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Issue {number}
             FILTER
@@ -877,7 +833,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_match_07(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Text {body}
             FILTER
@@ -891,7 +846,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Text {body}
             FILTER
@@ -904,7 +858,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Text {body}
             FILTER
@@ -918,7 +871,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_match_08(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Text {body}
             FILTER
@@ -933,7 +885,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Text {body}
             FILTER
@@ -948,7 +899,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 Text {body}
             FILTER
@@ -963,7 +913,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_type_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {
                     number,
@@ -976,17 +925,16 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ''',
             [{
                 'number': '1',
-                '__type__': {'name': 'test::Issue'},
+                '__type__': {'name': 'default::Issue'},
             }],
         )
 
     async def test_edgeql_select_type_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT User.__type__.name LIMIT 1;
             ''',
-            ['test::User']
+            ['default::User']
         )
 
     async def test_edgeql_select_type_03(self):
@@ -994,7 +942,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 'invalid property reference'):
             await self.con.query(r'''
-                WITH MODULE test
                 SELECT User.name.__type__.name LIMIT 1;
             ''')
 
@@ -1003,7 +950,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # as a direct schema::ObjectType query. As long as this is true,
         # we can test the schema separately without any other data.
         res = await self.con.query_one(r'''
-            WITH MODULE test
             SELECT User {
                 __type__: {
                     name,
@@ -1018,7 +964,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             SELECT `ObjectType` {
                 name,
                 id,
-            } FILTER `ObjectType`.name = 'test::User';
+            } FILTER `ObjectType`.name = 'default::User';
             ''',
             [{
                 'name': res.__type__.name,
@@ -1029,11 +975,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_type_05(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT User.__type__ { name };
             ''',
             [{
-                'name': 'test::User'
+                'name': 'default::User'
             }]
         )
 
@@ -1041,7 +986,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_recursive_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {
                     number,
@@ -1062,7 +1006,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {
                     number,
@@ -1082,7 +1025,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_limit_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {number}
             ORDER BY Issue.number
@@ -1093,7 +1035,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {number}
             ORDER BY Issue.number
@@ -1104,7 +1045,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {number}
             ORDER BY Issue.number
@@ -1116,7 +1056,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_limit_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {number}
             ORDER BY Issue.number
@@ -1127,7 +1066,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {number}
             ORDER BY Issue.number
@@ -1138,7 +1076,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {number}
             ORDER BY Issue.number
@@ -1150,7 +1087,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_limit_03(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {number}
             ORDER BY Issue.number
@@ -1161,7 +1097,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {number}
             ORDER BY Issue.number
@@ -1172,7 +1107,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {number}
             ORDER BY Issue.number
@@ -1185,7 +1119,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_limit_04(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 User {
                     name,
@@ -1213,7 +1146,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_limit_05(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 User {
                     name,
@@ -1245,7 +1177,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 r'where only singletons are allowed'):
 
             await self.con.query("""
-                WITH MODULE test
                 SELECT
                     User { name }
                 LIMIT <int64>User.<owner[IS Issue].number;
@@ -1258,7 +1189,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 r'where only singletons are allowed'):
 
             await self.con.query("""
-                WITH MODULE test
                 SELECT
                     User { name }
                 OFFSET <int64>User.<owner[IS Issue].number;
@@ -1270,7 +1200,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 r'could not resolve partial path'):
 
             await self.con.query("""
-                WITH MODULE test
                 SELECT
                     User { name }
                 LIMIT <int64>.<owner[IS Issue].number;
@@ -1282,7 +1211,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 r'could not resolve partial path'):
 
             await self.con.query("""
-                WITH MODULE test
                 SELECT
                     User { name }
                 OFFSET <int64>.<owner[IS Issue].number;
@@ -1291,7 +1219,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_polymorphic_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Text {body}
             ORDER BY Text.body;
@@ -1309,7 +1236,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Text {
                     [IS Issue].name,
@@ -1337,7 +1263,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_polymorphic_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT User{
                 name,
                 owner_of := User.<owner[IS LogEntry] {
@@ -1356,7 +1281,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_polymorphic_03(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT User{
                 name,
                 owner_of := (
@@ -1383,7 +1307,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r'cannot access id on a polymorphic shape element'):
             await self.con.query(r'''
-                WITH MODULE test
                 SELECT User {
                     [IS Named].id,
                 };
@@ -1398,7 +1321,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r'cannot access __type__ on a polymorphic shape element'):
             await self.con.query(r'''
-                WITH MODULE test
                 SELECT User {
                     [IS Named].__type__: {
                         name
@@ -1409,7 +1331,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_polymorphic_06(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Object[IS Status].name;
             ''',
             {
@@ -1420,7 +1341,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Object[IS Priority].name;
             ''',
             {
@@ -1431,7 +1351,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Object[IS Status].name ?? Object[IS Priority].name;
             ''',
             {
@@ -1446,7 +1365,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_polymorphic_07(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Object[IS Status | Priority].name;
             # the above should be equivalent to this:
             # SELECT Object[IS Status].name ?? Object[IS Priority].name;
@@ -1463,7 +1381,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_polymorphic_08(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Object {
                 [IS Status | Priority].name,
             } ORDER BY .name;
@@ -1490,7 +1407,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             # the above should be equivalent to this:
-            WITH MODULE test
             SELECT Object {
                 name := Object[IS Status].name ?? Object[IS Priority].name,
             } ORDER BY .name;
@@ -1519,7 +1435,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # of a shape element.
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Named {
                 name,
                 [IS Issue].references[IS File]: {
@@ -1548,7 +1463,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_polymorphic_10(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 count(Object[IS Named][IS Text])
                 != count(Object[IS Text]);
@@ -1558,7 +1472,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 count(User.<owner[IS Named][IS Text])
                 != count(User.<owner[IS Text]);
@@ -1570,7 +1483,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH
-                MODULE test,
                 Texts := Text {
                     [IS LogEntry].spent_time
                 }
@@ -1584,7 +1496,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_polymorphic_12(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT Issue {
                 name := 'Polymorphic Test 12',
                 body := 'foo',
@@ -1608,7 +1519,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue {
                 references: {
                     [IS Publication].authors: {
@@ -1633,7 +1543,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_polymorphic_13(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT Issue {
                 name := 'Polymorphic Test 13',
                 body := 'foo',
@@ -1657,7 +1566,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue {
                 references[IS Publication]: {
                     title
@@ -1679,7 +1587,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_reverse_link_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 (INTROSPECT TYPEOF User.<owner).name;
             ''',
@@ -1689,7 +1596,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_reverse_link_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 User.<owner[IS Issue]@since
             ''',
@@ -1698,7 +1604,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 User.<owner[IS Named]@since
             ''',
@@ -1716,7 +1621,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # and Comment.owner.
             await self.con.execute(
                 r'''
-                WITH MODULE test
                 SELECT
                     User.<owner[IS Text]@since
                 ''',
@@ -1729,7 +1633,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         ):
             await self.con.execute(
                 r'''
-                WITH MODULE test
                 SELECT
                     Issue.<related_to.number
                 ''',
@@ -1738,7 +1641,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_reverse_link_05(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT (User.<owner[IS Comment], User.<owner[IS Issue]);
             ''',
             [],
@@ -1754,7 +1656,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # property on.
             await self.con.execute(
                 r'''
-                WITH MODULE test
                 SELECT
                     User.<owner[IS Status]@since
                 ''',
@@ -1763,7 +1664,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_nested_redefined_link(self):
         await self.assert_query_result(
             '''
-                WITH MODULE test
                 SELECT (SELECT (SELECT Issue { watchers: {name} }).watchers);
             ''',
             [
@@ -1776,7 +1676,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tvariant_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{
                 number,
                 related_to: {
@@ -1809,7 +1708,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tvariant_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT User{
                 name,
                 owner_of := (
@@ -1837,7 +1735,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tvariant_03(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT User{
                 name,
                 owner_of := (
@@ -1870,7 +1767,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 L := LogEntry   # there happens to only be 1 entry
             SELECT
                 # define a type variant that assigns a log to every Issue
@@ -1890,7 +1786,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tvariant_05(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue.owner {
                 name,
                 # this path extends `Issue.owner` from top scope
@@ -1922,7 +1817,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tvariant_06(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT User {
                 name,
                 foo := (
@@ -1945,7 +1839,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # semantically identical to the previous test
-            WITH MODULE test
             SELECT User {
                 name,
                 foo := {
@@ -1972,13 +1865,12 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r"""
             # semantically similar to previous test, but involving
             # schema (since schema often has special handling)
-            WITH MODULE test
             SELECT User {
                 name,
                 foo := {
                     (
                         SELECT schema::ObjectType
-                        FILTER schema::ObjectType.name = 'test::User'
+                        FILTER schema::ObjectType.name = 'default::User'
                     ).name
                 }
             } FILTER User.name = 'Elvis';
@@ -1986,7 +1878,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [
                 {
                     'name': 'Elvis',
-                    'foo': ['test::User'],
+                    'foo': ['default::User'],
                 },
             ],
         )
@@ -1994,8 +1886,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tvariant_09(self):
         await self.assert_query_result(
             r"""
-                WITH
-                    MODULE test,
                 SELECT
                     (((SELECT Issue {
                         x := .number ++ "!"
@@ -2007,12 +1897,11 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tvariant_bad_01(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,
-            "cannot redefine property 'name' of object type 'test::User' "
+            "cannot redefine property 'name' of object type 'default::User' "
             "as scalar type 'std::int64'",
-            _position=92,
+            _position=59,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT User {
                     name := 1
                 }
@@ -2021,12 +1910,11 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tvariant_bad_02(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,
-            "cannot redefine property 'name' of object type 'test::User' "
-            "as object type 'test::Issue'",
-            _position=92,
+            "cannot redefine property 'name' of object type 'default::User' "
+            "as object type 'default::Issue'",
+            _position=59,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT User {
                     name := Issue
                 }
@@ -2035,12 +1923,11 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tvariant_bad_03(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,
-            "cannot redefine link 'related_to' of object type 'test::Issue' "
+            "cannot redefine link 'related_to' of object type 'default::Issue' "
             "as scalar type 'std::int64'",
-            _position=99,
+            _position=66,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT Issue {
                     related_to := 1
                 }
@@ -2049,12 +1936,11 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tvariant_bad_04(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,
-            "cannot redefine link 'related_to' of object type 'test::Issue' "
-            "as object type 'test::Text'",
-            _position=99,
+            "cannot redefine link 'related_to' of object type 'default::Issue' "
+            "as object type 'default::Text'",
+            _position=66,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT Issue {
                     related_to := Text
                 }
@@ -2065,10 +1951,9 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             edgedb.QueryError,
             "possibly more than one element returned by an expression for a "
             "computable link 'priority' declared as 'single'",
-            _position=85,
+            _position=52,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT Issue {
                     priority := Priority
                 }
@@ -2078,11 +1963,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             "cannot redefine the cardinality of link 'owner': it is defined "
-            "as 'single' in the base object type 'test::Issue'",
-            _position=100,
+            "as 'single' in the base object type 'default::Issue'",
+            _position=67,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT Issue {
                     multi owner := User
                 }
@@ -2092,11 +1976,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             "cannot redefine the cardinality of link 'related_to': it is "
-            "defined as 'multi' in the base object type 'test::Issue'",
-            _position=106,
+            "defined as 'multi' in the base object type 'default::Issue'",
+            _position=73,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT Issue {
                     single related_to := (SELECT Issue LIMIT 1)
                 }
@@ -2107,10 +1990,9 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             edgedb.QueryError,
             "possibly an empty set returned by an expression for a "
             "computable link 'owner' declared as 'required'",
-            _position=85,
+            _position=52,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT Issue {
                     owner := User
                 }
@@ -2119,7 +2001,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_instance_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Text {body}
             FILTER Text IS Comment
@@ -2133,7 +2014,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_instance_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Text {body}
             FILTER Text IS NOT Comment | Issue
@@ -2147,7 +2027,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_instance_03(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Text {body}
             FILTER Text IS Issue AND Text[IS Issue].number = '1'
@@ -2161,7 +2040,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_setops_01(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 (Issue UNION Comment) {
                     [IS Issue].name,  # name is not in the duck type
@@ -2187,7 +2065,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH
-                MODULE test,
                 Obj := (SELECT Issue UNION Comment)
             SELECT Obj {
                 [IS Issue].name,
@@ -2210,7 +2087,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # XXX: I think we should be able to drop [IS Text] from
             # the query below.
             WITH
-                MODULE test,
                 Obj := (SELECT Issue UNION Comment)
             SELECT Obj[IS Text] { id, body }
             ORDER BY Obj[IS Text].body;
@@ -2228,7 +2104,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_setops_03(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue {
                 number,
                 # open := 'yes' IF Issue.status.name = 'Open' ELSE 'no'
@@ -2260,7 +2135,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # equivalent to ?=
-            WITH MODULE test
             SELECT Issue {number}
             FILTER
                 # Issue.priority.name ?= 'High'
@@ -2279,7 +2153,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # using DISTINCT on a UNION with overlapping sets of Objects
-            WITH MODULE test
             SELECT _ := (
                 DISTINCT ((
                     # Issue 1, 4
@@ -2304,7 +2177,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # using DISTINCT on a UNION with overlapping sets of Objects
-            WITH MODULE test
             SELECT _ := count(DISTINCT ((
                 # Issue 1, 4
                 (SELECT User
@@ -2326,7 +2198,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # using UNION with overlapping sets of Objects
-            WITH MODULE test
             SELECT _ := {  # equivalent to UNION for Objects
                 # Issue 1, 4
                 (
@@ -2346,7 +2217,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # using implicit nested UNION with overlapping sets of Objects
-            WITH MODULE test
             SELECT _ := {  # equivalent to UNION for Objects
                 # Issue 1, 4
                 (
@@ -2390,7 +2260,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # same as above but with a DISTINCT
-            WITH MODULE test
             SELECT _ := (DISTINCT {  # equivalent to UNION for Objects
                 # Issue 1, 4
                 (
@@ -2433,7 +2302,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # using UNION in a FILTER
-            WITH MODULE test
             SELECT _ := User{name}
             FILTER (
                 (
@@ -2453,7 +2321,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 L := LogEntry  # there happens to only be 1 entry
             SELECT
                 (Issue.time_spent_log UNION L) {
@@ -2471,7 +2338,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 L := LogEntry  # there happens to only be 1 entry
             SELECT
                 (DISTINCT (Issue.time_spent_log UNION L)) {
@@ -2488,7 +2354,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 L := LogEntry  # there happens to only be 1 entry
             SELECT
                 (Issue.time_spent_log UNION L, Issue).0 {
@@ -2515,7 +2380,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 L := LogEntry  # there happens to only be 1 entry
             SELECT
                 (SELECT (Issue.time_spent_log UNION L, Issue)).0 {
@@ -2542,7 +2406,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # of the UNION because ultimately it's the duck type of
             # the operands, which are both Issue with the real
             # property 'number'.
-            WITH MODULE test
             SELECT {
                 Issue{number := 'foo'}, Issue
             }.number;
@@ -2559,7 +2422,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # the operands, which are both Issue with the real
             # property 'number'.
             WITH
-                MODULE test,
                 I := Issue{number := 'foo'}
             SELECT {I, Issue}.number;
             """,
@@ -2571,7 +2433,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # Named doesn't have a property number.
-            WITH MODULE test
             SELECT Issue[IS Named].number;
             """,
             ['1', '2', '3', '4'],
@@ -2584,7 +2445,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             await self.con.query(r"""
                 # UNION between Issue and empty set Named should be
                 # duck-typed to be effectively equivalent to Issue[IS Named].
-                WITH MODULE test
                 SELECT (Issue UNION <Named>{}).number;
             """)
 
@@ -2593,7 +2453,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r"""
             # UNION between Issue and empty set Named should be
             # duck-typed to be effectively equivalent to Issue[IS Named].
-            WITH MODULE test
             SELECT (Issue UNION <Named>{}).name;
             """,
             {
@@ -2610,7 +2469,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # UNION between Issue and empty set Issue should be
             # duck-typed to be effectively equivalent to Issue[IS
             # Issue], which is just an Issue.
-            WITH MODULE test
             SELECT (Issue UNION <Issue>{}).name;
             """,
             {
@@ -2623,7 +2481,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (Issue UNION <Issue>{}).number;
             """,
             {'1', '2', '3', '4'},
@@ -2632,7 +2489,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_order_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue {name}
             ORDER BY Issue.priority.name ASC EMPTY LAST THEN Issue.name;
             ''',
@@ -2646,7 +2502,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue {name}
             ORDER BY Issue.priority.name ASC EMPTY FIRST THEN Issue.name;
             ''',
@@ -2661,7 +2516,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_order_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Text {body}
             ORDER BY len(Text.body) DESC;
             ''',
@@ -2679,7 +2533,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_order_03(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT User {name}
             ORDER BY (
                 SELECT sum(<int64>User.<watchers[IS Issue].number)
@@ -2698,7 +2551,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 r'where only singletons are allowed'):
 
             await self.con.query("""
-                WITH MODULE test
                 SELECT
                     User { name }
                 ORDER BY User.<owner[IS Issue].number;
@@ -2707,7 +2559,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_where_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             # issue where the owner also has a comment with non-empty body
             FILTER Issue.owner.<owner[IS Comment].body != ''
@@ -2719,7 +2570,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_where_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             # issue where the owner also has a comment to it
             FILTER Issue.owner.<owner[IS Comment].issue = Issue;
@@ -2730,7 +2580,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_where_03(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{
                 name,
                 number,
@@ -2759,7 +2608,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_func_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT std::len(User.name) ORDER BY User.name;
             ''',
             [5, 4],
@@ -2767,7 +2615,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT std::sum(<std::int64>Issue.number);
             ''',
             [10]
@@ -2775,7 +2622,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_func_05(self):
         await self.con.execute(r'''
-            CREATE FUNCTION test::concat1(VARIADIC s: anytype) -> std::str
+            CREATE FUNCTION concat1(VARIADIC s: anytype) -> std::str
                 USING SQL FUNCTION 'concat';
         ''')
 
@@ -2789,7 +2636,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                         name
                     }
                 }
-            } FILTER schema::Function.name = 'test::concat1';
+            } FILTER schema::Function.name = 'default::concat1';
             ''',
             [{'params': [
                 {
@@ -2807,26 +2654,26 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 r'function .+ does not exist'):
             async with self.con.transaction():
                 await self.con.query(
-                    "SELECT test::concat1('aaa', 'bbb', 2);")
+                    "SELECT concat1('aaa', 'bbb', 2);")
 
         await self.con.execute(r'''
-            DROP FUNCTION test::concat1(VARIADIC s: anytype);
+            DROP FUNCTION concat1(VARIADIC s: anytype);
         ''')
 
     async def test_edgeql_select_func_06(self):
         await self.con.execute(r'''
-            CREATE FUNCTION test::concat2(VARIADIC s: std::str) -> std::str
+            CREATE FUNCTION concat2(VARIADIC s: std::str) -> std::str
                 USING SQL FUNCTION 'concat';
         ''')
 
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r'function .+ does not exist'):
-            await self.con.execute(r'SELECT test::concat2(123);')
+            await self.con.execute(r'SELECT concat2(123);')
 
     async def test_edgeql_select_func_07(self):
         await self.con.execute(r'''
-            CREATE FUNCTION test::concat3(sep: OPTIONAL std::str,
+            CREATE FUNCTION concat3(sep: OPTIONAL std::str,
                                           VARIADIC s: std::str)
                     -> std::str
                 USING EdgeQL $$
@@ -2856,7 +2703,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                     name
                 },
                 return_typemod
-            } FILTER schema::Function.name = 'test::concat3';
+            } FILTER schema::Function.name = 'default::concat3';
             ''',
             [{
                 'params': [
@@ -2892,29 +2739,28 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r'function .+ does not exist'):
             async with self.con.transaction():
-                await self.con.query(r'SELECT test::concat3(123);')
+                await self.con.query(r'SELECT concat3(123);')
 
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r'function .+ does not exist'):
             async with self.con.transaction():
-                await self.con.query(r'SELECT test::concat3("a", 123);')
+                await self.con.query(r'SELECT concat3("a", 123);')
 
         await self.assert_query_result(
             r'''
-            SELECT test::concat3('|', '1', '2');
+            SELECT concat3('|', '1', '2');
             ''',
             ['1|2'],
         )
 
         await self.con.execute(r'''
-            DROP FUNCTION test::concat3(sep: std::str, VARIADIC s: std::str);
+            DROP FUNCTION concat3(sep: std::str, VARIADIC s: std::str);
         ''')
 
     async def test_edgeql_select_exists_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {
                     number
@@ -2929,7 +2775,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {
                     number
@@ -2945,7 +2790,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_exists_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {
                     number
@@ -2961,7 +2805,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_exists_03(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {
                     number
@@ -2977,7 +2820,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_exists_04(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 Issue {
                     number
@@ -2993,7 +2835,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_exists_05(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.priority           # has Priority [2, 3]
@@ -3007,7 +2848,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # to using object types
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.priority.id        # has Priority [2, 3]
@@ -3019,7 +2859,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_exists_07(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.<issue             # has Comment [1]
@@ -3033,7 +2872,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # to using object types
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.<issue.id          # has Comment [1]
@@ -3045,7 +2883,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_exists_09(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.priority       # has no Priority [1, 4]
@@ -3059,7 +2896,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # to using object types
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.priority.id    # has no Priority [1, 4]
@@ -3071,7 +2907,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_exists_11(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.<issue         # has no Comment [2, 3, 4]
@@ -3085,7 +2920,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # to using object types
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.<issue.id      # has no Comment [2, 3, 4]
@@ -3097,7 +2931,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_exists_13(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             # issue where the owner also has a comment
             FILTER EXISTS Issue.owner.<owner[IS Comment]
@@ -3109,7 +2942,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_exists_14(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             # issue where the owner also has a comment to it
             FILTER
@@ -3129,7 +2961,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_exists_15(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             # issue where the owner also has a comment, but not to the
             # issue itself
@@ -3150,7 +2981,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_exists_16(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             # issue where the owner also has a comment, but not to the
             # issue itself
@@ -3171,7 +3001,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_exists_17(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             # issue where the owner also has a comment, but not to the
             # issue itself
@@ -3192,7 +3021,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_exists_18(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT EXISTS (
                 SELECT Issue
                 FILTER Issue.status.name = 'Open'
@@ -3204,7 +3032,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_coalesce_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{
                 kind := Issue.priority.name ?? Issue.status.name
             }
@@ -3220,7 +3047,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 r"operator '\?\?' cannot.*'std::str' and 'std::int64'"):
 
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT Issue{
                     kind := Issue.priority.name ?? 1
                 };
@@ -3228,7 +3054,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_coalesce_03(self):
         issues_h = await self.con.query(r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 Issue.priority.name = 'High'
@@ -3236,7 +3061,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         ''')
 
         issues_n = await self.con.query(r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.priority
@@ -3245,7 +3069,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 Issue.priority.name ?? 'High' = 'High'
@@ -3258,7 +3081,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_equivalence_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue {
                 number,
                 h1 := Issue.priority.name = 'High',
@@ -3301,7 +3123,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # get Issues such that there's another Issue with
             # equivalent priority
             WITH
-                MODULE test,
                 I2 := Issue
             SELECT Issue {number}
             FILTER
@@ -3317,7 +3138,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             # get Issues with priority equivalent to empty
-            WITH MODULE test
             SELECT Issue {number}
             FILTER
                 Issue.priority.name ?= <str>{}
@@ -3330,7 +3150,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             # get Issues with priority equivalent to empty
-            WITH MODULE test
             SELECT Issue {number}
             FILTER
                 NOT Issue.priority.name ?!= <str>{}
@@ -3343,7 +3162,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # NOTE: for the expected ordering of Text see instance04 test
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT (SELECT T := Text[IS Issue] ORDER BY T.body).number;
             ''',
             ['4', '1', '3', '2'],
@@ -3352,7 +3170,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_as_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT (
                 SELECT T := Text[IS Issue]
                 FILTER T.body LIKE '%EdgeDB%'
@@ -3365,7 +3182,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_and_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.priority           # has Priority [2, 3]
@@ -3379,7 +3195,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_and_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.priority.id        # has Priority [2, 3]
@@ -3393,7 +3208,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_and_03(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.priority       # has no Priority [1, 4]
@@ -3407,7 +3221,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_and_04(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.priority.id    # has no Priority [1, 4]
@@ -3421,7 +3234,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_and_05(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.priority       # has no Priority [1, 4]
@@ -3435,7 +3247,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_and_06(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.priority       # has no Priority [1, 4]
@@ -3449,7 +3260,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_and_07(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.priority           # has Priority [2, 3]
@@ -3463,7 +3273,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_and_08(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.priority           # has Priority [2, 3]
@@ -3476,7 +3285,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_or_01(self):
         issues_h = await self.con.query(r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 Issue.priority.name = 'High'
@@ -3484,7 +3292,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         ''')
 
         issues_l = await self.con.query(r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 Issue.priority.name = 'Low'
@@ -3493,7 +3300,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 Issue.priority.name = 'High'
@@ -3507,7 +3313,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_or_04(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 Issue.priority.name = 'High'
@@ -3520,7 +3325,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 Issue.priority.name = 'High'
@@ -3536,7 +3340,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 Issue.priority.name IN {'High', 'Low'}
@@ -3550,7 +3353,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_or_05(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.priority.id
@@ -3564,7 +3366,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             # should be identical
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.priority
@@ -3578,7 +3379,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_or_06(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.priority           # has Priority [2, 3]
@@ -3592,7 +3392,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_or_07(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.priority.id        # has Priority [2, 3]
@@ -3606,7 +3405,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_or_08(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.priority       # has no Priority [1, 4]
@@ -3621,7 +3419,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_or_09(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.priority.id    # has no Priority [1, 4]
@@ -3636,7 +3433,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_or_10(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.priority       # has no Priority [1, 4]
@@ -3650,7 +3446,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_or_11(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT EXISTS Issue.priority       # has no Priority [1, 4]
@@ -3664,7 +3459,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_or_12(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.priority           # has Priority [2, 3]
@@ -3678,7 +3472,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_or_13(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.priority           # has Priority [2, 3]
@@ -3694,7 +3487,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r'''
             # Find Issues that have status 'Closed' or number 2 or 3
             #
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 Issue.status.name = 'Closed'
@@ -3712,7 +3504,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r'''
             # Find Issues that have status 'Closed' or number 2 or 3
             #
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 (
@@ -3736,7 +3527,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_not_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER NOT Issue.priority.name = 'High'
             ORDER BY Issue.number;
@@ -3746,7 +3536,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER Issue.priority.name != 'High'
             ORDER BY Issue.number;
@@ -3758,7 +3547,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # testing double negation
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER NOT NOT NOT Issue.priority.name = 'High'
             ORDER BY Issue.number;
@@ -3768,7 +3556,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER NOT NOT Issue.priority.name != 'High'
             ORDER BY Issue.number;
@@ -3780,7 +3567,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # test that: a OR b = NOT( NOT a AND NOT b)
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 NOT (
@@ -3802,7 +3588,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # Any binary operator with one operand as empty results in an
             # empty result, because the cross product of anything with an
             # empty set is empty.
-            SELECT test::Issue.number = <str>{};
+            SELECT Issue.number = <str>{};
             """,
             [],
         )
@@ -3811,28 +3597,28 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # Test short-circuiting operations with empty
-            SELECT test::Issue.number = '1' OR <bool>{};
+            SELECT Issue.number = '1' OR <bool>{};
             """,
             [],
         )
 
         await self.assert_query_result(
             r"""
-            SELECT test::Issue.number = 'X' OR <bool>{};
+            SELECT Issue.number = 'X' OR <bool>{};
             """,
             [],
         )
 
         await self.assert_query_result(
             r"""
-            SELECT test::Issue.number = '1' AND <bool>{};
+            SELECT Issue.number = '1' AND <bool>{};
             """,
             [],
         )
 
         await self.assert_query_result(
             r"""
-            SELECT test::Issue.number = 'X' AND <bool>{};
+            SELECT Issue.number = 'X' AND <bool>{};
             """,
             [],
         )
@@ -3841,28 +3627,28 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # Test short-circuiting operations with empty
-            SELECT count(test::Issue.number = '1' OR <bool>{});
+            SELECT count(Issue.number = '1' OR <bool>{});
             """,
             [0],
         )
 
         await self.assert_query_result(
             r"""
-            SELECT count(test::Issue.number = 'X' OR <bool>{});
+            SELECT count(Issue.number = 'X' OR <bool>{});
             """,
             [0],
         )
 
         await self.assert_query_result(
             r"""
-            SELECT count(test::Issue.number = '1' AND <bool>{});
+            SELECT count(Issue.number = '1' AND <bool>{});
             """,
             [0],
         )
 
         await self.assert_query_result(
             r"""
-            SELECT count(test::Issue.number = 'X' AND <bool>{});
+            SELECT count(Issue.number = 'X' AND <bool>{});
             """,
             [0],
         )
@@ -3871,7 +3657,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # Perfectly legal way to mask 'time_estimate' with empty set.
-            WITH MODULE test
             SELECT Issue {
                 number,
                 time_estimate := <int64>{}
@@ -3890,7 +3675,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError,
                 r'expression returns value of indeterminate type'):
             await self.con.query(r"""
-                WITH MODULE test
                 SELECT Issue {
                     number,
                     # the empty set is of an unspecified type
@@ -3901,7 +3685,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_empty_object_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT <Issue>{}
             ''',
             [],
@@ -3910,7 +3693,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_empty_object_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT NOT EXISTS (<Issue>{})
             ''',
             [True],
@@ -3919,7 +3701,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_empty_object_03(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT ((SELECT Issue FILTER false) ?= <Issue>{})
             ''',
             [True],
@@ -3928,7 +3709,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_empty_object_04(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT count(<Issue>{}) = 0
             ''',
             [True],
@@ -3938,7 +3718,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # the cross product of status and priority names
-            WITH MODULE test
             SELECT Status.name ++ Priority.name
             ORDER BY Status.name THEN Priority.name;
             """,
@@ -3949,7 +3728,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # status and priority name for each issue
-            WITH MODULE test
             SELECT Issue.status.name ++ Issue.priority.name
             ORDER BY Issue.number;
             """,
@@ -3960,7 +3738,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # cross-product of all user names and issue numbers
-            WITH MODULE test
             SELECT User.name ++ Issue.number
             ORDER BY User.name THEN Issue.number;
             """,
@@ -3972,7 +3749,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # concatenate the user name with every issue number that user has
-            WITH MODULE test
             SELECT User.name ++ User.<owner[IS Issue].number
             ORDER BY User.name THEN User.<owner[IS Issue].number;
             """,
@@ -3982,7 +3758,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_cross05(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             # tuples will not exist for the Issue without watchers
             SELECT _ := (Issue.owner.name, Issue.watchers.name)
             ORDER BY _;
@@ -3993,7 +3768,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_cross06(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             # tuples will not exist for the Issue without watchers
             SELECT _ := Issue.owner.name ++ Issue.watchers.name
             ORDER BY _;
@@ -4004,7 +3778,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_cross_07(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT _ := count(Issue.owner.name ++ Issue.watchers.name);
             """,
             [3],
@@ -4012,7 +3785,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT _ := count(DISTINCT (
                 Issue.owner.name ++ Issue.watchers.name));
             """,
@@ -4022,7 +3794,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_cross08(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT _ := Issue.owner.name ++ <str>count(Issue.watchers.name)
             ORDER BY _;
             """,
@@ -4032,7 +3803,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_cross_09(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT _ := count(
                 Issue.owner.name ++ <str>count(Issue.watchers.name));
             """,
@@ -4043,7 +3813,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 # this select shows all the relevant data for next tests
                 x := (SELECT Issue {
                     name := Issue.owner.name,
@@ -4057,7 +3826,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_cross_11(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT count(
                 Issue.owner.name ++
                 <str>count(Issue.watchers) ++
@@ -4072,7 +3840,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # which should collapse the counted set to a single element.
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT count(
                 Issue.owner.name ++
                 <str>count(Issue.watchers) ++
@@ -4085,7 +3852,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_cross_13(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT count(count( Issue.watchers));
             """,
             [{}],
@@ -4093,7 +3859,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT count(
                 (Issue, count(Issue.watchers))
             );
@@ -4105,7 +3870,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 Issue2 := Issue
             # this is string concatenation, not integer arithmetic
             SELECT Issue.number ++ Issue2.number
@@ -4117,7 +3881,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_subqueries_02(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 Issue.number IN {'2', '3', '4'}
@@ -4136,7 +3899,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 sub := (
                     SELECT Issue FILTER Issue.number IN {'1', '6'}
                 )
@@ -4155,7 +3917,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 sub := (
                     SELECT
                         Issue
@@ -4180,7 +3941,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # find all issues such that there's at least one more
             # issue with the same priority
             WITH
-                MODULE test,
                 Issue2 := (SELECT Issue)
             SELECT
                 Issue {
@@ -4203,7 +3963,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # find all issues such that there's at least one more
             # issue with the same priority (even if the "same" means empty)
             WITH
-                MODULE test,
                 Issue2 := Issue
             SELECT
                 Issue {
@@ -4222,7 +3981,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r"""
             # find all issues such that there's at least one more
             # issue watched by the same user as this one
-            WITH MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.watchers
@@ -4246,8 +4004,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r"""
             # find all issues such that there's at least one more
             # issue watched by the same user as this one
-            WITH
-                MODULE test
             SELECT Issue{number}
             FILTER
                 EXISTS Issue.watchers
@@ -4270,7 +4026,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_subqueries_09(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue.number ++ (SELECT Issue.number);
             """,
             ['11', '22', '33', '44'],
@@ -4281,7 +4036,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 sub := (SELECT Issue.number)
             SELECT
                 Issue.number ++ sub;
@@ -4294,7 +4048,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_subqueries_11(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Text{
                 [IS Issue].number,
                 body_length := len(Text.body)
@@ -4314,7 +4067,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r"""
             # find all issues such that there's at least one more
             # Text item of similar body length (+/-5 characters)
-            WITH MODULE test
             SELECT Issue{
                 number,
             }
@@ -4335,7 +4087,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # same as above, but also include the body_length computable
-            WITH MODULE test
             SELECT Issue{
                 number,
                 body_length := len(Issue.body)
@@ -4362,7 +4113,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_subqueries_13(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT User{name}
             FILTER
                 EXISTS (
@@ -4377,7 +4127,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_subqueries_14(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT User{name}
             FILTER
                 EXISTS (
@@ -4397,7 +4146,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # Find all issues such that there's at least one more
             # issue watched by the same user as this one, this user
             # must have at least one Comment.
-            WITH MODULE test
             SELECT Issue {
                 number
             }
@@ -4429,7 +4177,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # testing IN and a subquery
-            WITH MODULE test
             SELECT Comment{body}
             FILTER
                 Comment.owner IN (
@@ -4445,7 +4192,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # get a comment whose owner is part of the users who own Issue "1"
-            WITH MODULE test
             SELECT Comment{body}
             FILTER
                 Comment.owner IN (
@@ -4467,7 +4213,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # here, DETACHED doesn't do anything special, because the
             # symbol U2 is reused on both sides of '+'
             WITH
-                MODULE test,
                 U2 := DETACHED User
             SELECT U2.name ++ U2.name;
             """,
@@ -4477,7 +4222,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # DETACHED is reused on both sides of '+' directly
-            WITH MODULE test
             SELECT (DETACHED User).name ++ (DETACHED User).name;
             """,
             {'ElvisElvis', 'ElvisYury', 'YuryElvis', 'YuryYury'},
@@ -4487,7 +4231,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # Direct reference to a computable element in a subquery
-            WITH MODULE test
             SELECT
                 (
                     SELECT User {
@@ -4503,8 +4246,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r"""
             # Reference to a computable element in a subquery
             # defined as an alias.
-            WITH MODULE test,
-                U := (
+            WITH U := (
                     SELECT User {
                         num_issues := count(User.<owner[IS Issue])
                     } FILTER .name = 'Elvis'
@@ -4519,8 +4261,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # Reference a computed object set in an alias.
-            WITH MODULE test,
-                U := (
+            WITH U := (
                     WITH U2 := User
                     SELECT User {
                         friend := (
@@ -4537,8 +4278,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_alias_indirection_04(self):
         result = await self.con.query(r"""
             # Reference a constant expression in an alias.
-            WITH MODULE test,
-                U := (
+            WITH U := (
                     SELECT User {
                         issues := (
                             SELECT Issue {
@@ -4557,8 +4297,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # Reference multiple aliases.
-            WITH MODULE test,
-                U := (
+            WITH U := (
                     SELECT User FILTER User.name = 'Elvis'
                 ),
                 I := (
@@ -4574,8 +4313,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # Reference another alias from an alias.
-            WITH MODULE test,
-                U := (
+            WITH U := (
                     SELECT User FILTER User.name = 'Elvis'
                 ),
                 I := (
@@ -4593,8 +4331,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # A combination of the above two.
-            WITH MODULE test,
-                U := (
+            WITH U := (
                     SELECT User FILTER User.name = 'Elvis'
                 ),
                 I := (
@@ -4614,8 +4351,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # A slightly more complex type variant.
-             WITH MODULE test,
-                 U := (
+             WITH U := (
                      WITH U2 := User
                      SELECT User {
                          friends := (
@@ -4648,7 +4384,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH
-                MODULE test,
                 sub := (
                     SELECT
                         Text {
@@ -4681,7 +4416,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH
-                MODULE test,
                 sub := (
                     SELECT
                         Text {
@@ -4708,7 +4442,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH
-                MODULE test,
                 Developers := (
                     SELECT
                         User {
@@ -4761,7 +4494,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # full name of the Issue is 'Release EdgeDB'
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
@@ -4772,7 +4504,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
@@ -4783,7 +4514,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
@@ -4794,7 +4524,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
@@ -4805,7 +4534,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
@@ -4816,7 +4544,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
@@ -4827,7 +4554,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
@@ -4838,7 +4564,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
@@ -4850,29 +4575,26 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_slice_02(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
             ).__type__.name;
             """,
-            ['test::Issue'],
+            ['default::Issue'],
         )
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
             ).__type__.name[2];
             """,
-            ['s'],
+            ['f'],
         )
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
@@ -4883,29 +4605,26 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
             ).__type__.name[2:4];
             """,
-            ['st'],
+            ['fa'],
         )
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
             ).__type__.name[2:];
             """,
-            ['st::Issue'],
+            ['fault::Issue'],
         )
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
@@ -4916,7 +4635,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
@@ -4927,7 +4645,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
@@ -4938,19 +4655,17 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (
                 SELECT Issue
                 FILTER Issue.number = '1'
             ).__type__.name[:-2];
             """,
-            ['test::Iss'],
+            ['default::Iss'],
         )
 
     async def test_edgeql_select_slice_03(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue{
                 name,
                 type_name := Issue.__type__.name,
@@ -4962,10 +4677,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             """,
             [{
                 'name': 'Release EdgeDB',
-                'type_name': 'test::Issue',
+                'type_name': 'default::Issue',
                 'a': 'l',
                 'b': 'lease EdgeD',
-                'c': 'st::Issu',
+                'c': 'fault::Issu',
             }],
         )
 
@@ -4973,7 +4688,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # get tuples (status, number of issues)
-            WITH MODULE test
             SELECT (Status.name, count(Status.<status))
             ORDER BY Status.name;
             """,
@@ -4984,7 +4698,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # nested tuples
-            WITH MODULE test
             SELECT
                 _ := (
                     User.name, (
@@ -5010,7 +4723,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 _ := {('Elvis',), ('Yury',)}
             SELECT
                 User {
@@ -5030,7 +4742,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tuple_04(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT
                 User {
                     t := {(1, 2), (3, 4)}
@@ -5048,7 +4759,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_tuple_05(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (
                     statuses := count(Status),
                     issues := count(Issue),
@@ -5062,7 +4772,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 counts := (SELECT (
                     statuses := count(Status),
                     issues := count(Issue),
@@ -5078,7 +4787,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 criteria := (SELECT (
                     user := (SELECT User FILTER User.name = 'Yury'),
                     status := (SELECT Status FILTER Status.name = 'Open'),
@@ -5098,8 +4806,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # Object in a tuple returned directly.
         await self.assert_query_result(
             r"""
-            WITH
-                MODULE test
             SELECT
                 (
                     user := (SELECT User{name} FILTER User.name = 'Yury')
@@ -5116,8 +4822,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # Object in a tuple referred to directly.
         await self.assert_query_result(
             r"""
-            WITH
-                MODULE test
             SELECT
                 (
                     user := (SELECT User{name} FILTER User.name = 'Yury')
@@ -5131,7 +4835,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 U1 := User,
                 U2 := User
             SELECT
@@ -5145,7 +4848,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 U1 := User,
                 U2 := User
             SELECT
@@ -5160,7 +4862,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_linkproperty_01(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT User.todo@rank + <int64>User.todo.number
             ORDER BY User.todo.number;
             """,
@@ -5170,7 +4871,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_linkproperty_02(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue.<todo[IS User]@rank + <int64>Issue.number
             ORDER BY Issue.number;
             """,
@@ -5180,7 +4880,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_linkproperty_03(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT User {
                 name,
                 todo: {
@@ -5219,7 +4918,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         ):
             await self.con.execute(
                 r'''
-                WITH MODULE test
                 SELECT
                     Issue { since := (SELECT .owner)@since }
                 ''',
@@ -5233,7 +4931,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         ):
             await self.con.execute(
                 r'''
-                WITH MODULE test
                 SELECT
                     Issue { since := [.owner]@since }
                 ''',
@@ -5242,7 +4939,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_if_else_01(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue {
                 number,
                 open := 'yes' IF Issue.status.name = 'Open' ELSE 'no'
@@ -5267,7 +4963,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_if_else_02(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue {
                 number,
                 # foo is 'bar' for Issue number 1 and status name for the rest
@@ -5295,7 +4990,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                                     r'operator.*IF.*cannot be applied'):
 
             await self.con.execute(r"""
-                WITH MODULE test
                 SELECT Issue {
                     foo := 'bar' IF Issue.number = '1' ELSE 123
                 };
@@ -5304,7 +4998,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_if_else_04(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue{
                 kind := (Issue.priority.name
                          IF EXISTS Issue.priority.name
@@ -5319,7 +5012,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # Above IF is equivalent to ??,
-            WITH MODULE test
             SELECT Issue{
                 kind := Issue.priority.name ?? Issue.status.name
             }
@@ -5332,7 +5024,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_if_else_05(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue {number}
             FILTER
                 Issue.priority.name = 'High'
@@ -5346,7 +5037,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # Above IF is equivalent to ?=,
-            WITH MODULE test
             SELECT Issue {number}
             FILTER
                 Issue.priority.name ?= 'High'
@@ -5358,7 +5048,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_if_else_06(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT Issue {number}
             FILTER
                 Issue.priority.name != 'High'
@@ -5372,7 +5061,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             # Above IF is equivalent to !?=,
-            WITH MODULE test
             SELECT Issue {number}
             FILTER
                 Issue.priority.name ?!= 'High'
@@ -5384,8 +5072,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_if_else_07(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test,
-                 a := (SELECT Issue FILTER .number = '2'),
+            WITH a := (SELECT Issue FILTER .number = '2'),
                  b := (SELECT Issue FILTER .number = '1'),
             SELECT a.number IF a.time_estimate < b.time_estimate ELSE b.number;
             ''',
@@ -5395,7 +5082,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_partial_01(self):
         await self.assert_query_result(
             '''
-            WITH MODULE test
             SELECT
                 Issue {
                     number
@@ -5411,7 +5097,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_partial_02(self):
         await self.assert_query_result(
             '''
-            WITH MODULE test
             SELECT
                 Issue.watchers {
                     name
@@ -5427,7 +5112,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_partial_03(self):
         await self.assert_query_result(
             '''
-            WITH MODULE test
             SELECT Issue {
                 number,
                 watchers: {
@@ -5448,7 +5132,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_partial_04(self):
         await self.assert_query_result(
             '''
-            WITH MODULE test
             SELECT Issue {
                 number,
             } FILTER .number > '1'
@@ -5463,8 +5146,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_partial_05(self):
         await self.assert_query_result('''
-            WITH
-                MODULE test
             SELECT
                 Issue{
                     sub := (SELECT .number)
@@ -5479,14 +5160,12 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                                     'invalid property reference on a '
                                     'primitive type expression'):
             await self.con.execute('''
-                WITH MODULE test
                 SELECT Issue.number FILTER .number > '1';
             ''')
 
     async def test_edgeql_union_target_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue {
                 number,
             } FILTER EXISTS (.references)
@@ -5499,7 +5178,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue {
                 number,
             } FILTER .references[IS URL].address = 'https://edgedb.com'
@@ -5512,7 +5190,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue {
                 number,
             } FILTER .references[IS Named].name = 'screenshot.png'
@@ -5525,7 +5202,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue {
                 number,
                 references[IS Named]: {
@@ -5544,13 +5220,13 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                     {
                         'name': 'edgedb.com',
                         '__type__': {
-                            'name': 'test::URL'
+                            'name': 'default::URL'
                         }
                     },
                     {
                         'name': 'screenshot.png',
                         '__type__': {
-                            'name': 'test::File'
+                            'name': 'default::File'
                         }
                     }
                 ]
@@ -5560,7 +5236,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_for_01(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT Issue := (
                 FOR x IN {1, 4}
                 UNION (
@@ -5583,7 +5258,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_for_02(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT I := (
                 FOR x IN {1, 3, 4}
                 UNION (
@@ -5620,7 +5294,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_for_03(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             FOR x IN {1, 3, 4}
             UNION (
                 SELECT Issue {
@@ -5655,7 +5328,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             # cast a type variant into a set of json
-            WITH MODULE test
             SELECT (
                 SELECT <json>Issue {
                     number,
@@ -5668,7 +5340,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT (
                 SELECT <json>Issue {
                     number,
@@ -5682,22 +5353,20 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_bad_reference_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r"object type or alias 'test::Usr' does not exist",
+                r"object type or alias 'default::Usr' does not exist",
                 _hint="did you mean one of these: User, URL?"):
 
             await self.con.query("""
-                WITH MODULE test
                 SELECT Usr;
             """)
 
     async def test_edgeql_select_bad_reference_02(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r"'test::User' has no link or property 'nam'",
+                r"'default::User' has no link or property 'nam'",
                 _hint="did you mean 'name'?"):
 
             await self.con.query("""
-                WITH MODULE test
                 SELECT User.nam;
             """)
 
@@ -5715,7 +5384,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 edgedb.QueryError, r'index indirection cannot.*int64.*'):
 
             await self.con.query("""
-                WITH MODULE test
                 # index access is higher precedence than cast
                 SELECT <str>Issue.time_estimate[0];
             """)
@@ -5730,7 +5398,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT (<str>Issue.time_estimate)[0];
             ''',
             ['3'],
@@ -5739,7 +5406,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_precedence_04(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT EXISTS Issue{number};
             ''',
             [True],
@@ -5747,7 +5413,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT EXISTS Issue;
             ''',
             [True],
@@ -5756,7 +5421,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_precedence_05(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT EXISTS Issue{number};
             ''',
             [True],
@@ -5855,7 +5519,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         )
 
     async def test_edgeql_select_is_03(self):
-        await self.con.execute('SET MODULE test;')
 
         await self.assert_query_result(
             r'''SELECT Issue.time_estimate IS int64 LIMIT 1;''',
@@ -5903,7 +5566,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         )
 
     async def test_edgeql_select_is_04(self):
-        await self.con.execute('SET MODULE test;')
 
         await self.assert_query_result(
             r'''SELECT Issue.number IS int64 LIMIT 1;''',
@@ -5951,7 +5613,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         )
 
     async def test_edgeql_select_is_05(self):
-        await self.con.execute('SET MODULE test;')
 
         await self.assert_query_result(
             r'''SELECT Issue.status IS int64 LIMIT 1;''',
@@ -6025,7 +5686,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_is_09(self):
         await self.assert_query_result(
             r'''
-            SELECT test::Issue.time_estimate IS anytype LIMIT 1;
+            SELECT Issue.time_estimate IS anytype LIMIT 1;
             ''',
             [True]
         )
@@ -6065,7 +5726,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_is_13(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test
             SELECT
                 NOT all([Text] IS (array<Issue>))
                 AND any([Text] IS (array<Issue>));
@@ -6077,11 +5737,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             "duplicate definition of property 'name' of object type "
-            "'test::User'",
-            _position=110,
+            "'default::User'",
+            _position=77,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT User {
                     name,
                     name
@@ -6092,11 +5751,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             "duplicate definition of property 'name' of object type "
-            "'test::User'",
-            _position=110,
+            "'default::User'",
+            _position=77,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT User {
                     name,
                     name := "new_name"
@@ -6107,11 +5765,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             "duplicate definition of link 'todo' of object type "
-            "'test::User'",
-            _position=110,
+            "'default::User'",
+            _position=77,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT User {
                     todo,
                     todo
@@ -6142,7 +5799,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             "shapes cannot be applied to scalar type 'std::str'",
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT User {
                     todo: { name: {bogus} }
                 }
@@ -6151,7 +5807,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_revlink_on_union(self):
         await self.assert_query_result(
             """
-                WITH MODULE test
                 SELECT
                     File {
                         referrers := (
@@ -6179,7 +5834,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_expr_objects_01(self):
         await self.assert_query_result(
             r'''
-                SELECT array_agg(test::Issue ORDER BY .body)[0].owner.name;
+                SELECT array_agg(Issue ORDER BY .body)[0].owner.name;
             ''',
             ["Elvis"],
         )
@@ -6187,7 +5842,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_expr_objects_02(self):
         await self.assert_query_result(
             r'''
-                SELECT _ := array_unpack(array_agg(test::Issue)).owner.name
+                SELECT _ := array_unpack(array_agg(Issue)).owner.name
                 ORDER BY _;
             ''',
             ["Elvis", "Yury"],
@@ -6196,14 +5851,14 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_expr_objects_03(self):
         await self.con.execute(
             '''
-                CREATE FUNCTION test::issues() -> SET OF test::Issue
-                USING (test::Issue);
+                CREATE FUNCTION issues() -> SET OF Issue
+                USING (Issue);
             '''
         )
 
         await self.assert_query_result(
             r'''
-                SELECT _ := test::issues().owner.name ORDER BY _;
+                SELECT _ := issues().owner.name ORDER BY _;
             ''',
             ["Elvis", "Yury"],
         )
@@ -6211,8 +5866,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_expr_objects_04(self):
         await self.assert_query_result(
             r'''
-                WITH items := array_agg((SELECT test::Named ORDER BY .name))
-                SELECT items[0] IS test::Status;
+                WITH items := array_agg((SELECT Named ORDER BY .name))
+                SELECT items[0] IS Status;
             ''',
             [True],
         )
@@ -6220,9 +5875,9 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH items := array_agg((
-                    SELECT test::Named ORDER BY .name LIMIT 1))
+                    SELECT Named ORDER BY .name LIMIT 1))
                 SELECT (items, items[0], items[0].name,
-                        items[0] IS test::Status);
+                        items[0] IS Status);
             ''',
             [
                 [[{}], {}, "Closed", True]
@@ -6231,8 +5886,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH MODULE test,
-                     items := (User.name, array_agg(User.todo ORDER BY .name))
+                WITH items := (User.name, array_agg(User.todo ORDER BY .name))
                 SELECT _ := (items.0, items.1, items.1[0].name) ORDER BY _.0;
             ''',
             [
@@ -6253,7 +5907,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
             WITH
-                MODULE test,
                 L := ('x', User)
             SELECT (L, L);
             """,
@@ -6266,7 +5919,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_expr_objects_06(self):
         await self.assert_query_result(
             r"""
-            WITH MODULE test
             SELECT (User, User {name}) ORDER BY .1.name;
             """,
             [
@@ -6278,7 +5930,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_expr_objects_07(self):
         # get the User names and ids
         res = await self.con.query(r'''
-            WITH MODULE test
             SELECT User {
                 name,
                 id
@@ -6292,7 +5943,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH
-                MODULE test,
                 L := ('x', User),
             SELECT _ := (L, L.1 {name})
             ORDER BY _.1.name;
@@ -6306,7 +5956,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
             WITH
-                MODULE test,
                 L := ('x', User),
             SELECT _ := (L.1 {name}, L)
             ORDER BY _.0.name;
@@ -6320,7 +5969,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_expr_objects_08(self):
         await self.assert_query_result(
             r'''
-            WITH MODULE test,
             SELECT DISTINCT
                 [(SELECT Issue {number, name} FILTER .number = "1")];
             ''',
@@ -6331,7 +5979,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH MODULE test,
             SELECT DISTINCT
                 ((SELECT Issue {number, name} FILTER .number = "1"),
                  Issue.status.name);
@@ -6344,12 +5991,11 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     @test.xfail("We produce results that don't decode properly")
     async def test_edgeql_select_array_common_type_01(self):
         res = await self.con._fetchall("""
-            WITH MODULE test
             SELECT [User, Issue];
         """, __typenames__=True)
         for row in res:
-            self.assertEqual(row[0].__tname__, "test::User")
-            self.assertEqual(row[1].__tname__, "test::Issue")
+            self.assertEqual(row[0].__tname__, "default::User")
+            self.assertEqual(row[1].__tname__, "default::Issue")
 
     @test.xfail("""
         SchemaDefinitionError: cannot alter object type 'std::Object':

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1203,34 +1203,34 @@ aa';
     def test_edgeql_syntax_shape_19(self):
         """
             SELECT
-                test::Issue {
+                Issue {
                     number
                 }
             FILTER
-                (((test::Issue)).number) = '1';
+                (((Issue)).number) = '1';
 
             SELECT
-                (test::Issue) {
+                (Issue) {
                     number
                 }
             FILTER
-                (((test::Issue)).number) = '1';
+                (((Issue)).number) = '1';
 
 % OK %
 
             SELECT
-                test::Issue {
+                Issue {
                     number
                 }
             FILTER
-                (test::Issue.number = '1');
+                (Issue.number = '1');
 
             SELECT
-                test::Issue {
+                Issue {
                     number
                 }
             FILTER
-                (test::Issue.number = '1');
+                (Issue.number = '1');
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -2336,7 +2336,6 @@ aa';
     def test_edgeql_syntax_with_01(self):
         """
         WITH
-            MODULE test,
             extra AS MODULE lib.extra,
             foo := Bar.foo,
             baz := (SELECT extra::Foo.baz)
@@ -2346,29 +2345,26 @@ aa';
         } FILTER (foo = 'special');
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=6, col=9)
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=5, col=9)
     def test_edgeql_syntax_with_02(self):
         """
         WITH
-            MODULE test,
             foo := Bar.foo,
             baz := (SELECT Foo.baz)
         COMMIT;
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=4, col=16)
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=3, col=16)
     def test_edgeql_syntax_with_03(self):
         """
-        WITH
-            MODULE test
+        WITH MODULE welp
         CREATE DATABASE sample;
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError, line=4, col=14)
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=3, col=14)
     def test_edgeql_syntax_with_04(self):
         """
-        WITH
-            MODULE test
+        WITH MODULE welp
         DROP DATABASE sample;
         """
 
@@ -2529,30 +2525,22 @@ aa';
 
     def test_edgeql_syntax_select_05(self):
         """
-        WITH MODULE test
         SELECT 42;
-        WITH MODULE test
         SELECT User{name};
-        WITH MODULE test
         SELECT User{name}
             FILTER (User.age > 42);
-        WITH MODULE test
         SELECT User{name}
             ORDER BY User.name ASC;
-        WITH MODULE test
         SELECT User{name}
             OFFSET 2;
-        WITH MODULE test
         SELECT User{name}
             LIMIT 5;
-        WITH MODULE test
         SELECT User{name}
             OFFSET 2 LIMIT 5;
         """
 
     def test_edgeql_syntax_select_06(self):
         """
-        WITH MODULE test
         SELECT
             User.name
         FILTER
@@ -2570,7 +2558,6 @@ aa';
 
     def test_edgeql_syntax_select_08(self):
         """
-        WITH MODULE test
         SELECT User{name} ORDER BY User.name ASC;
         SELECT User{name} ORDER BY User.name ASC;
         SELECT User{name} OFFSET 2;
@@ -2729,13 +2716,11 @@ aa';
 
     def test_edgeql_syntax_insert_03(self):
         """
-        WITH MODULE test
         INSERT Foo;
         """
 
     def test_edgeql_syntax_insert_04(self):
         """
-        WITH MODULE test
         INSERT Foo{bar := 42};
         """
 
@@ -2871,7 +2856,6 @@ aa';
 
     def test_edgeql_syntax_delete_02(self):
         """
-        WITH MODULE test
         DELETE Foo;
         """
 
@@ -2889,7 +2873,6 @@ aa';
 
     def test_edgeql_syntax_delete_05(self):
         """
-        WITH MODULE test
         DELETE
             User.name
         FILTER
@@ -2916,9 +2899,7 @@ aa';
 
     def test_edgeql_syntax_update_02(self):
         """
-        WITH MODULE test
         UPDATE Foo SET {bar := 42};
-        WITH MODULE test
         UPDATE Foo FILTER (Foo.bar = 24) SET {bar := 42};
         """
 
@@ -3687,7 +3668,7 @@ aa';
 
     def test_edgeql_syntax_ddl_delta_02(self):
         """
-        START MIGRATION TO {type test::Foo;};
+        START MIGRATION TO {type default::Foo;};
         ALTER MIGRATION m1231231231fd
             SET message := 'foo';
         COMMIT MIGRATION;
@@ -3706,7 +3687,7 @@ aa';
                   "Unexpected 'BadLang'", line=2, col=28)
     def test_edgeql_syntax_ddl_delta_04(self):
         """
-        START MIGRATION TO BadLang $$type test::Foo$$;
+        START MIGRATION TO BadLang $$type Foo$$;
         """
 
     def test_edgeql_syntax_ddl_delta_05(self):
@@ -4043,14 +4024,14 @@ aa';
 
     def test_edgeql_syntax_ddl_constraint_08(self):
         """
-        CREATE ABSTRACT CONSTRAINT test::len_fail(f: std::str) {
+        CREATE ABSTRACT CONSTRAINT len_fail(f: std::str) {
             USING (__subject__ <= f);
             SET subjectexpr := len(__subject__);
         };
 
 % OK %
 
-        CREATE ABSTRACT CONSTRAINT test::len_fail(f: std::str) {
+        CREATE ABSTRACT CONSTRAINT len_fail(f: std::str) {
             USING ((__subject__ <= f));
             SET subjectexpr := (len(__subject__));
         };

--- a/tests/test_edgeql_tree.py
+++ b/tests/test_edgeql_tree.py
@@ -32,22 +32,22 @@ class TestTree(tb.QueryTestCase):
 
     async def test_edgeql_tree_delete_01(self):
         await self.con.execute(r"""
-            DELETE test::Tree;
+            DELETE Tree;
         """)
         await self.assert_query_result(
             r"""
-                SELECT test::Tree;
+                SELECT Tree;
             """,
             [],
         )
 
     async def test_edgeql_tree_delete_02(self):
         await self.con.execute(r"""
-            DELETE test::Eert FILTER .val = '0';
+            DELETE Eert FILTER .val = '0';
         """)
         await self.assert_query_result(
             r"""
-                SELECT test::Eert FILTER .val = '0';
+                SELECT Eert FILTER .val = '0';
             """,
             [],
         )
@@ -55,7 +55,7 @@ class TestTree(tb.QueryTestCase):
     @test.xfail('''
         This test fails with the following error:
 
-        edgedb.errors.QueryError: invalid reference to test::Tree:
+        edgedb.errors.QueryError: invalid reference to Tree:
         self-referencing INSERTs are not allowed
 
         This test is part of several versions of how nested INSERT
@@ -66,7 +66,6 @@ class TestTree(tb.QueryTestCase):
     async def test_edgeql_tree_insert_01(self):
         # Test nested insert of a tree branch.
         await self.con.execute(r"""
-            WITH MODULE test
             INSERT Tree {
                 val := 'i2',
                 parent := (
@@ -83,7 +82,6 @@ class TestTree(tb.QueryTestCase):
         """)
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Tree {
                     val,
                     children: {
@@ -123,7 +121,6 @@ class TestTree(tb.QueryTestCase):
     async def test_edgeql_tree_insert_02(self):
         # Test nested insert of a tree branch.
         await self.con.execute(r"""
-            WITH MODULE test
             INSERT Eert {
                 val := 'i0',
                 children := (
@@ -140,7 +137,6 @@ class TestTree(tb.QueryTestCase):
         """)
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Eert {
                     val,
                     children: {
@@ -184,7 +180,6 @@ class TestTree(tb.QueryTestCase):
         # Test nested insert of a tree branch.
         await self.con.execute(r"""
             WITH
-                MODULE test,
                 T1 := Tree,
                 T2 := Tree,
             INSERT Tree {
@@ -203,7 +198,6 @@ class TestTree(tb.QueryTestCase):
         """)
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Tree {
                     val,
                     children: {
@@ -232,7 +226,6 @@ class TestTree(tb.QueryTestCase):
     async def test_edgeql_tree_select_01(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Tree {
                     val,
                     children: {
@@ -281,7 +274,6 @@ class TestTree(tb.QueryTestCase):
     async def test_edgeql_tree_select_02(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Eert {
                     val,
                     children: {
@@ -330,7 +322,6 @@ class TestTree(tb.QueryTestCase):
     async def test_edgeql_tree_select_03(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Tree.parent.parent.val;
             """,
             ['0'],
@@ -339,7 +330,6 @@ class TestTree(tb.QueryTestCase):
     async def test_edgeql_tree_select_04(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Eert.parent.parent.val;
             """,
             ['0'],
@@ -348,7 +338,6 @@ class TestTree(tb.QueryTestCase):
     async def test_edgeql_tree_select_05(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Eert.<children[IS Eert].<children[IS Eert].val;
             """,
             ['0'],
@@ -358,7 +347,6 @@ class TestTree(tb.QueryTestCase):
         # 1098
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Eert.children.children.val;
             """,
             {'000', '010'},
@@ -367,7 +355,6 @@ class TestTree(tb.QueryTestCase):
     async def test_edgeql_tree_select_07(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Tree.children.children.val;
             """,
             {'000', '010'},
@@ -376,7 +363,6 @@ class TestTree(tb.QueryTestCase):
     async def test_edgeql_tree_select_08(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Tree.<parent[IS Tree].<parent[IS Tree].val;
             """,
             {'000', '010'},
@@ -385,7 +371,6 @@ class TestTree(tb.QueryTestCase):
     async def test_edgeql_tree_select_09(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Tree {val}
                 FILTER
                     .children.children.val = '000'
@@ -397,7 +382,6 @@ class TestTree(tb.QueryTestCase):
     async def test_edgeql_tree_select_10(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Eert {val}
                 FILTER
                     .children.children.val = '000'
@@ -410,7 +394,6 @@ class TestTree(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     x := '010',
                 SELECT Tree {
                     val,
@@ -458,7 +441,6 @@ class TestTree(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     x := '12',
                 SELECT Tree {
                     val,
@@ -498,7 +480,6 @@ class TestTree(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     x := '010',
                 SELECT Eert {
                     val,
@@ -546,7 +527,6 @@ class TestTree(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     x := '12',
                 SELECT Eert {
                     val,
@@ -587,7 +567,6 @@ class TestTree(tb.QueryTestCase):
         # vals.
         await self.con.execute(
             r"""
-                WITH MODULE test
                 UPDATE Tree
                 SET {
                     val := array_join(
@@ -603,7 +582,6 @@ class TestTree(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Tree {
                     val,
                     children: {
@@ -654,7 +632,6 @@ class TestTree(tb.QueryTestCase):
         # vals.
         await self.con.execute(
             r"""
-                WITH MODULE test
                 UPDATE Eert
                 SET {
                     val := array_join(
@@ -670,7 +647,6 @@ class TestTree(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Eert {
                     val,
                     children: {
@@ -721,7 +697,6 @@ class TestTree(tb.QueryTestCase):
         # val.
         await self.con.execute(
             r"""
-                WITH MODULE test
                 UPDATE Tree
                 SET {
                     val := .val ++ '_p' ++ (('_' ++ .parent.val) ?? '')
@@ -731,7 +706,6 @@ class TestTree(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Tree {val}
                 ORDER BY .val;
             """,
@@ -755,7 +729,6 @@ class TestTree(tb.QueryTestCase):
         # val.
         await self.con.execute(
             r"""
-                WITH MODULE test
                 UPDATE Eert
                 SET {
                     val := .val ++ '_p' ++ (('_' ++ .parent.val) ?? '')
@@ -765,7 +738,6 @@ class TestTree(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Eert {val}
                 ORDER BY .val;
             """,
@@ -793,7 +765,6 @@ class TestTree(tb.QueryTestCase):
         await self.con.execute(
             r"""
                 WITH
-                    MODULE test,
                     # start with node '00'
                     T00 := (
                         SELECT Tree
@@ -813,7 +784,6 @@ class TestTree(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Tree {
                     val,
                     children: {
@@ -871,7 +841,6 @@ class TestTree(tb.QueryTestCase):
         await self.con.execute(
             r"""
                 WITH
-                    MODULE test,
                     # start with node '00'
                     T00 := (
                         SELECT Eert
@@ -912,7 +881,6 @@ class TestTree(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Eert {
                     val,
                     children: {
@@ -958,7 +926,6 @@ class TestTree(tb.QueryTestCase):
         await self.con.execute(
             r"""
                 WITH
-                    MODULE test,
                     # start with node '000', get its parent
                     TP := (
                         SELECT Tree
@@ -977,7 +944,6 @@ class TestTree(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Tree {
                     val,
                     children: {
@@ -1029,7 +995,6 @@ class TestTree(tb.QueryTestCase):
         await self.con.execute(
             r"""
                 WITH
-                    MODULE test,
                     # start with node '000'
                     T000 := (
                         SELECT Eert
@@ -1065,7 +1030,6 @@ class TestTree(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT Eert {
                     val,
                     children: {

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -41,7 +41,6 @@ class TestUpdate(tb.QueryTestCase):
     @classmethod
     async def _setup_objects(cls):
         cls.original = await cls.con.query_json(r"""
-            WITH MODULE test
             SELECT UpdateTest {
                 id,
                 name,
@@ -57,7 +56,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_simple_01(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 # bad name doesn't exist, so no update is expected
                 FILTER .name = 'bad name'
@@ -70,7 +68,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     id,
                     name,
@@ -88,7 +85,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -101,7 +97,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     id,
                     name,
@@ -129,7 +124,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test2'
                 SET {
@@ -141,7 +135,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     id,
                     name,
@@ -170,7 +163,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 SET {
                     comment := UpdateTest.comment ++ "!",
@@ -182,7 +174,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     id,
                     name,
@@ -223,7 +214,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (
                     UPDATE UpdateTest
                     FILTER UpdateTest.name = 'update-test2'
@@ -248,7 +238,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (
                     UPDATE UpdateTest
                     SET {
@@ -297,7 +286,6 @@ class TestUpdate(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     U := (
                         UPDATE UpdateTest
                         FILTER UpdateTest.name = 'update-test2'
@@ -318,7 +306,6 @@ class TestUpdate(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     Q := (
                         UPDATE UpdateTest
                         SET {
@@ -370,12 +357,12 @@ class TestUpdate(tb.QueryTestCase):
         try:
             data = []
             data.append(await self.con.query_one(r"""
-                INSERT test::UpdateTest {
+                INSERT UpdateTest {
                     name := 'ret5.1'
                 };
             """))
             data.append(await self.con.query_one(r"""
-                INSERT test::UpdateTest {
+                INSERT UpdateTest {
                     name := 'ret5.2'
                 };
             """))
@@ -383,7 +370,6 @@ class TestUpdate(tb.QueryTestCase):
 
             await self.assert_query_result(
                 r"""
-                    WITH MODULE test
                     SELECT UpdateTest {
                         id,
                         name
@@ -405,7 +391,6 @@ class TestUpdate(tb.QueryTestCase):
 
             await self.assert_query_result(
                 r"""
-                    WITH MODULE test
                     UPDATE UpdateTest
                     FILTER UpdateTest.name LIKE '%ret5._'
                     SET {
@@ -418,7 +403,6 @@ class TestUpdate(tb.QueryTestCase):
 
             await self.assert_query_result(
                 r"""
-                    WITH MODULE test
                     SELECT UpdateTest {
                         id,
                         name
@@ -440,7 +424,6 @@ class TestUpdate(tb.QueryTestCase):
 
             objs = await self.con._fetchall(
                 r"""
-                    WITH MODULE test
                     UPDATE UpdateTest
                     FILTER UpdateTest.name LIKE '%ret5._'
                     SET {
@@ -451,19 +434,18 @@ class TestUpdate(tb.QueryTestCase):
                 __typeids__=True
             )
             self.assertTrue(hasattr(objs[0], '__tid__'))
-            self.assertEqual(objs[0].__tname__, 'test::UpdateTest')
+            self.assertEqual(objs[0].__tname__, 'default::UpdateTest')
 
         finally:
             await self.con.execute(r"""
                 DELETE (
-                    SELECT test::UpdateTest
+                    SELECT UpdateTest
                     FILTER .name LIKE '%ret5._'
                 );
             """)
 
     async def test_edgeql_update_generic_01(self):
         status = await self.con.query_one(r"""
-            WITH MODULE test
             SELECT Status{id}
             FILTER Status.name = 'Open'
             LIMIT 1;
@@ -472,7 +454,6 @@ class TestUpdate(tb.QueryTestCase):
 
         updated = await self.con.query(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test3'
                 SET {
@@ -488,7 +469,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     status: {
@@ -509,7 +489,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_filter_01(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE (SELECT UpdateTest)
                 # this FILTER is trivial because UpdateTest is wrapped
                 # into a SET OF by SELECT
@@ -523,7 +502,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest.comment;
             """,
             ['bad test'] * 3,
@@ -532,7 +510,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_filter_02(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE (<UpdateTest>{} ?? UpdateTest)
                 # this FILTER is trivial because UpdateTest is wrapped
                 # into a SET OF by ??
@@ -546,7 +523,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest.comment;
             """,
             ['bad test'] * 3,
@@ -555,7 +531,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_multiple_01(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -567,7 +542,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     tags: {
@@ -592,7 +566,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_multiple_02(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -604,7 +577,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     tags: {
@@ -625,7 +597,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_multiple_03(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -637,7 +608,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     tags: {
@@ -661,7 +631,6 @@ class TestUpdate(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 # first add a tag to UpdateTest
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -676,7 +645,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     tags: {
@@ -695,7 +663,6 @@ class TestUpdate(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 # now add another tag, but keep the existing one, too
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -710,7 +677,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     tags: {
@@ -732,7 +698,6 @@ class TestUpdate(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     U2 := UpdateTest
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
@@ -745,7 +710,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     related: {
@@ -769,7 +733,6 @@ class TestUpdate(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     U2 := UpdateTest
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
@@ -784,7 +747,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     annotated_tests: {
@@ -811,7 +773,6 @@ class TestUpdate(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 WITH
-                    MODULE test,
                     U2 := UpdateTest
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
@@ -828,7 +789,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     annotated_tests: {
@@ -853,17 +813,14 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_multiple_08(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-8-1',
             };
 
-            WITH MODULE test
             INSERT UpdateTestSubType {
                 name := 'update-test-8-2',
             };
 
-            WITH MODULE test
             INSERT UpdateTestSubSubType {
                 name := 'update-test-8-3',
             };
@@ -873,7 +830,6 @@ class TestUpdate(tb.QueryTestCase):
             r"""
                 # make tests related to the other 2
                 WITH
-                    MODULE test,
                     UT := (SELECT UpdateTest
                            FILTER .name LIKE 'update-test-8-%')
                 UPDATE UpdateTest
@@ -891,7 +847,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest{
                     name,
                     related: {name} ORDER BY .name
@@ -928,7 +883,6 @@ class TestUpdate(tb.QueryTestCase):
             r"""
                 # now update related tests based on existing related tests
                 WITH
-                    MODULE test,
                     UT := (SELECT UpdateTest
                            FILTER .name LIKE 'update-test-8-%')
                 UPDATE UpdateTest
@@ -948,7 +902,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest{
                     name,
                     related: {name} ORDER BY .name
@@ -986,17 +939,14 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_multiple_09(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-9-1',
             };
 
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-9-2',
             };
 
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-9-3',
             };
@@ -1006,7 +956,6 @@ class TestUpdate(tb.QueryTestCase):
             r"""
                 # make tests related to the other 2
                 WITH
-                    MODULE test,
                     UT := (SELECT UpdateTest
                            FILTER .name LIKE 'update-test-9-%')
                 UPDATE UpdateTest
@@ -1024,7 +973,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest{
                     name,
                     related: {name} ORDER BY .name
@@ -1061,7 +1009,6 @@ class TestUpdate(tb.QueryTestCase):
             r"""
                 # now update related tests based on existing related tests
                 WITH
-                    MODULE test,
                     UT := (SELECT UpdateTest
                            FILTER .name LIKE 'update-test-9-%')
                 UPDATE UpdateTest
@@ -1080,7 +1027,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest{
                     name,
                     related: {name} ORDER BY .name
@@ -1112,17 +1058,14 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_multiple_10(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-10-1',
             };
 
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-10-2',
             };
 
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-10-3',
             };
@@ -1132,7 +1075,6 @@ class TestUpdate(tb.QueryTestCase):
             r"""
                 # make each test related to 'update-test-10-1'
                 WITH
-                    MODULE test,
                     UT := (
                         SELECT UpdateTest FILTER .name = 'update-test-10-1'
                     )
@@ -1151,7 +1093,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest{
                     name,
                     related: {name} ORDER BY .name
@@ -1184,7 +1125,6 @@ class TestUpdate(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 # now update related tests
-                WITH MODULE test
                 # there's only one item in the UPDATE set
                 UPDATE UpdateTest.related
                 FILTER .name LIKE 'update-test-10-%'
@@ -1198,7 +1138,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest{
                     name,
                     related: {name} ORDER BY .name
@@ -1233,7 +1172,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_props_01(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -1252,7 +1190,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     weighted_tags: {
@@ -1281,7 +1218,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_props_02(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -1294,7 +1230,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     weighted_tags: {
@@ -1317,7 +1252,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_props_03(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -1333,7 +1267,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     weighted_tags: {
@@ -1359,7 +1292,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_props_05(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -1375,7 +1307,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     annotated_status: {
@@ -1398,7 +1329,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_props_06(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -1414,7 +1344,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     annotated_status: {
@@ -1437,7 +1366,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_props_07(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -1451,7 +1379,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     annotated_status: {
@@ -1474,7 +1401,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_props_08(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -1491,7 +1417,6 @@ class TestUpdate(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 # update again, erasing the 'note' value
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER UpdateTest.name = 'update-test1'
                 SET {
@@ -1505,7 +1430,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     annotated_status: {
@@ -1528,7 +1452,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_for_01(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 FOR x IN {
                         (name := 'update-test1', comment := 'foo'),
                         (name := 'update-test2', comment := 'bar')
@@ -1546,7 +1469,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     comment
@@ -1571,7 +1493,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_for_02(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 FOR x IN {
                         'update-test1',
                         'update-test2',
@@ -1589,7 +1510,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     comment
@@ -1614,7 +1534,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_for_03(self):
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 FOR x IN {
                         'update-test1',
                         'update-test2',
@@ -1632,7 +1551,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     str_tags,
@@ -1658,7 +1576,6 @@ class TestUpdate(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 # just clear all the comments
-                WITH MODULE test
                 UPDATE UpdateTest
                 SET {
                     comment := {}
@@ -1669,7 +1586,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest.comment;
             """,
             {},
@@ -1681,7 +1597,6 @@ class TestUpdate(tb.QueryTestCase):
                 r"invalid target for property.*std::int64.*expecting .*str'"):
             await self.con.execute(r"""
                 # just clear all the comments
-                WITH MODULE test
                 UPDATE UpdateTest
                 SET {
                     comment := <int64>{}
@@ -1694,7 +1609,6 @@ class TestUpdate(tb.QueryTestCase):
                 r"missing value for required property"):
             await self.con.execute(r"""
                 # just clear all the comments
-                WITH MODULE test
                 UPDATE UpdateTest
                 SET {
                     name := {}
@@ -1705,7 +1619,6 @@ class TestUpdate(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 # just clear all the statuses
-                WITH MODULE test
                 UPDATE UpdateTest
                 SET {
                     status := {}
@@ -1716,7 +1629,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest.status;
             """,
             {},
@@ -1726,10 +1638,9 @@ class TestUpdate(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.InvalidLinkTargetError,
                 r"invalid target for link.*std::Object.*"
-                r"expecting 'test::Status'"):
+                r"expecting 'default::Status'"):
             await self.con.execute(r"""
                 # just clear all the statuses
-                WITH MODULE test
                 UPDATE UpdateTest
                 SET {
                     status := <Object>{}
@@ -1741,7 +1652,6 @@ class TestUpdate(tb.QueryTestCase):
                 edgedb.QueryError,
                 'single'):
             await self.con.execute(r'''
-                SET MODULE test;
 
                 UPDATE UpdateTest
                 SET {
@@ -1752,7 +1662,6 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_cardinality_02(self):
         await self.assert_query_result(r'''
             WITH
-                MODULE test,
                 x1 := (
                     UPDATE UpdateTest
                     FILTER .name = 'update-test1'
@@ -1783,7 +1692,6 @@ class TestUpdate(tb.QueryTestCase):
         # test and UPDATE with a new object
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER .name = 'update-test1'
                 SET {
@@ -1799,7 +1707,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     tags: {
@@ -1821,7 +1728,6 @@ class TestUpdate(tb.QueryTestCase):
         # test and UPDATE with a new object
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER .name = 'update-test1'
                 SET {
@@ -1837,7 +1743,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     status: {
@@ -1859,7 +1764,6 @@ class TestUpdate(tb.QueryTestCase):
         # test and UPDATE with a collection
         await self.con.execute(
             r"""
-                WITH MODULE test
                 UPDATE CollectionTest
                 FILTER .name = 'collection-test1'
                 SET {
@@ -1870,7 +1774,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT CollectionTest {
                     name,
                     some_tuple,
@@ -1888,7 +1791,6 @@ class TestUpdate(tb.QueryTestCase):
         # test and UPDATE with a collection
         await self.con.execute(
             r"""
-                WITH MODULE test
                 UPDATE CollectionTest
                 FILTER .name = 'collection-test1'
                 SET {
@@ -1899,7 +1801,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT CollectionTest {
                     name,
                     str_array,
@@ -1918,7 +1819,6 @@ class TestUpdate(tb.QueryTestCase):
                 edgedb.QueryError,
                 'UPDATE statements cannot be used'):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT
                     (SELECT UpdateTest)
                     ??
@@ -1930,7 +1830,6 @@ class TestUpdate(tb.QueryTestCase):
                 edgedb.QueryError,
                 'UPDATE statements cannot be used'):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT
                     (SELECT UpdateTest FILTER .name = 'foo')
                     IF EXISTS UpdateTest
@@ -1946,7 +1845,6 @@ class TestUpdate(tb.QueryTestCase):
                 edgedb.QueryError,
                 "cannot reference correlated set 'Status' here"):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT (
                     Status,
                     (UPDATE UpdateTest SET {
@@ -1960,7 +1858,6 @@ class TestUpdate(tb.QueryTestCase):
                 edgedb.QueryError,
                 "cannot reference correlated set 'Status' here"):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT (
                     (UPDATE UpdateTest SET {
                         status := Status
@@ -1974,7 +1871,6 @@ class TestUpdate(tb.QueryTestCase):
                 edgedb.QueryError,
                 "cannot reference correlated set 'UpdateTest' here"):
             await self.con.execute(r'''
-                WITH MODULE test
                 SELECT (
                     UpdateTest,
                     (UPDATE UpdateTest SET {name := 'update bad'}),
@@ -1989,7 +1885,6 @@ class TestUpdate(tb.QueryTestCase):
             _position=180,
         ):
             await self.con.execute(r'''
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER .name = 'update-test-readonly'
                 SET {
@@ -2005,7 +1900,6 @@ class TestUpdate(tb.QueryTestCase):
             _position=181,
         ):
             await self.con.execute(r'''
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER .name = 'update-test-readonly'
                 SET {
@@ -2021,7 +1915,6 @@ class TestUpdate(tb.QueryTestCase):
             _position=223,
         ):
             await self.con.execute(r'''
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER .name = 'update-test-readonly'
                 SET {
@@ -2033,17 +1926,14 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_append_01(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-append-1',
             };
 
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-append-2',
             };
 
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-append-3',
             };
@@ -2051,7 +1941,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.con.execute("""
             WITH
-                MODULE test,
                 U2 := UpdateTest
             UPDATE UpdateTest
             FILTER .name = 'update-test-append-1'
@@ -2064,7 +1953,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     annotated_tests: {
@@ -2086,7 +1974,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.con.execute("""
             WITH
-                MODULE test,
                 U2 := UpdateTest
             UPDATE UpdateTest
             FILTER .name = 'update-test-append-1'
@@ -2100,7 +1987,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     annotated_tests: {
@@ -2131,7 +2017,6 @@ class TestUpdate(tb.QueryTestCase):
             _position=147,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER .name = 'foo'
                 SET {
@@ -2148,7 +2033,6 @@ class TestUpdate(tb.QueryTestCase):
             _position=123,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 INSERT UpdateTest
                 {
                     annotated_status += (
@@ -2164,7 +2048,6 @@ class TestUpdate(tb.QueryTestCase):
             _position=123,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 SELECT UpdateTest
                 {
                     annotated_status += (
@@ -2175,17 +2058,14 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_subtract_01(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-subtract-1',
             };
 
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-subtract-2',
             };
 
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-subtract-3',
             };
@@ -2193,7 +2073,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.con.execute("""
             WITH
-                MODULE test,
                 U2 := UpdateTest
             UPDATE UpdateTest
             FILTER .name = 'update-test-subtract-1'
@@ -2214,7 +2093,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.con.execute("""
             WITH
-                MODULE test,
                 U2 := UpdateTest
             UPDATE UpdateTest
             FILTER .name = 'update-test-subtract-3'
@@ -2234,7 +2112,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     annotated_tests: {
@@ -2271,7 +2148,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.con.execute("""
             WITH
-                MODULE test,
                 U2 := UpdateTest
             UPDATE UpdateTest
             FILTER .name = 'update-test-subtract-1'
@@ -2285,7 +2161,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     annotated_tests: {
@@ -2319,7 +2194,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_subtract_02(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-subtract-various',
                 annotated_status := (
@@ -2334,7 +2208,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     annotated_status: {
                         name,
@@ -2359,8 +2232,6 @@ class TestUpdate(tb.QueryTestCase):
 
         # Check that singleton links work.
         await self.con.execute("""
-            WITH
-                MODULE test
             UPDATE UpdateTest
             FILTER .name = 'update-test-subtract-various'
             SET {
@@ -2370,7 +2241,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     annotated_status: {
                         name,
@@ -2388,8 +2258,6 @@ class TestUpdate(tb.QueryTestCase):
 
         # And singleton properties too.
         await self.con.execute("""
-            WITH
-                MODULE test
             UPDATE UpdateTest
             FILTER .name = 'update-test-subtract-various'
             SET {
@@ -2399,7 +2267,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     comment,
                 } FILTER
@@ -2414,8 +2281,6 @@ class TestUpdate(tb.QueryTestCase):
 
         # And multi properties as well.
         await self.con.execute("""
-            WITH
-                MODULE test
             UPDATE UpdateTest
             FILTER .name = 'update-test-subtract-various'
             SET {
@@ -2425,7 +2290,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     str_tags,
                 } FILTER
@@ -2440,7 +2304,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_subtract_required(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT MultiRequiredTest {
                 name := 'update-test-subtract-required',
                 prop := {'one', 'two'},
@@ -2449,7 +2312,6 @@ class TestUpdate(tb.QueryTestCase):
         """)
 
         await self.con.execute("""
-            WITH MODULE test
             UPDATE MultiRequiredTest
             FILTER .name = 'update-test-subtract-required'
             SET {
@@ -2459,7 +2321,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT MultiRequiredTest {
                     prop,
                 } FILTER
@@ -2477,7 +2338,6 @@ class TestUpdate(tb.QueryTestCase):
             r"missing value for required property 'prop'",
         ):
             await self.con.execute("""
-                WITH MODULE test
                 UPDATE MultiRequiredTest
                 FILTER .name = 'update-test-subtract-required'
                 SET {
@@ -2486,7 +2346,6 @@ class TestUpdate(tb.QueryTestCase):
             """)
 
         await self.con.execute("""
-            WITH MODULE test
             UPDATE MultiRequiredTest
             FILTER .name = 'update-test-subtract-required'
             SET {
@@ -2496,7 +2355,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT MultiRequiredTest {
                     tags: {name}
                 } FILTER
@@ -2514,7 +2372,6 @@ class TestUpdate(tb.QueryTestCase):
             r"missing value for required link 'tags'",
         ):
             await self.con.execute("""
-                WITH MODULE test
                 UPDATE MultiRequiredTest
                 FILTER .name = 'update-test-subtract-required'
                 SET {
@@ -2529,7 +2386,6 @@ class TestUpdate(tb.QueryTestCase):
             _position=123,
         ):
             await self.con.execute("""
-                WITH MODULE test
                 INSERT UpdateTest
                 {
                     annotated_status -= (
@@ -2540,7 +2396,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_insert_01(self):
         await self.con.execute('''
-            WITH MODULE test
             UPDATE UpdateTest SET {
                 tags := (INSERT Tag { name := <str>random() })
             };
@@ -2548,7 +2403,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT count(UpdateTest.tags);
             """,
             [3],
@@ -2556,7 +2410,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_insert_02(self):
         await self.con.execute('''
-            WITH MODULE test
             UPDATE UpdateTest SET {
                 status := (INSERT Status { name := <str>random() })
             };
@@ -2564,7 +2417,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT count(UpdateTest.status);
             """,
             [3],
@@ -2572,7 +2424,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_inheritance_01(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-inh-supertype-1',
                 related := (
@@ -2581,7 +2432,6 @@ class TestUpdate(tb.QueryTestCase):
                 )
             };
 
-            WITH MODULE test
             INSERT UpdateTestSubType {
                 name := 'update-test-inh-subtype-1',
                 related := (
@@ -2593,7 +2443,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER .name = 'update-test-inh-subtype-1'
                 SET {
@@ -2609,7 +2458,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     comment,
@@ -2640,7 +2488,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_inheritance_02(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT UpdateTest {
                 name := 'update-test-inh-supertype-1',
                 related := (
@@ -2649,7 +2496,6 @@ class TestUpdate(tb.QueryTestCase):
                 )
             };
 
-            WITH MODULE test
             INSERT UpdateTestSubType {
                 name := 'update-test-inh-subtype-1',
                 related := (
@@ -2658,7 +2504,6 @@ class TestUpdate(tb.QueryTestCase):
                 )
             };
 
-            WITH MODULE test
             INSERT UpdateTestSubSubType {
                 name := 'update-test-inh-subtype-1',
                 related := (
@@ -2670,7 +2515,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTest
                 FILTER .name = 'update-test-inh-subtype-1'
                 SET {
@@ -2686,7 +2530,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     name,
                     comment,
@@ -2724,7 +2567,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_inheritance_03(self):
         await self.con.execute('''
-            WITH MODULE test
             INSERT UpdateTestSubSubType {
                 name := 'update-test-w-insert',
             };
@@ -2732,7 +2574,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 UPDATE UpdateTestSubType
                 FILTER .name = 'update-test-w-insert'
                 SET {
@@ -2744,7 +2585,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT UpdateTest {
                     tags: {name},
                 }
@@ -2761,7 +2601,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_add_dupes_01a(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTestSubSubType {
                 name := 'add-dupes-scalar',
                 str_tags := {'foo', 'bar'},
@@ -2770,7 +2609,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (
                     UPDATE UpdateTestSubSubType
                     FILTER .name = 'add-dupes-scalar'
@@ -2787,12 +2625,10 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_add_dupes_01b(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTestSubSubType {
                 name := 'add-dupes-scalar-foo',
                 str_tags := {'foo', 'baz'},
             };
-            WITH MODULE test
             INSERT UpdateTestSubSubType {
                 name := 'add-dupes-scalar-bar',
                 str_tags := {'bar', 'baz'},
@@ -2801,7 +2637,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (
                     FOR x in {'foo', 'bar'} UNION (
                         UPDATE UpdateTestSubSubType
@@ -2826,7 +2661,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (
                     FOR x in {'foo', 'bar'} UNION (
                         UPDATE UpdateTestSubSubType
@@ -2851,7 +2685,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (
                     FOR x in {'foo', 'bar'} UNION (
                         UPDATE UpdateTestSubSubType
@@ -2876,7 +2709,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_add_dupes_02(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTestSubSubType {
                 name := 'add-dupes',
                 tags := (SELECT Tag FILTER .name IN {'fun', 'wow'})
@@ -2885,7 +2717,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (
                     UPDATE UpdateTestSubSubType
                     FILTER .name = 'add-dupes'
@@ -2910,7 +2741,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_add_dupes_03(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTestSubSubType {
                 name := 'add-dupes',
                 tags := (SELECT Tag FILTER .name IN {'fun', 'wow'})
@@ -2919,7 +2749,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (
                     UPDATE UpdateTestSubSubType
                     FILTER .name = 'add-dupes'
@@ -2945,7 +2774,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_add_dupes_04(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTestSubSubType {
                 name := 'add-dupes-lprop',
                 weighted_tags := (
@@ -2956,7 +2784,6 @@ class TestUpdate(tb.QueryTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT (
                     UPDATE UpdateTestSubSubType
                     FILTER .name = 'add-dupes-lprop'
@@ -2980,7 +2807,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_covariant_01(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTestSubSubType {
                 name := 'update-covariant',
             };
@@ -2989,7 +2815,6 @@ class TestUpdate(tb.QueryTestCase):
         # Covariant updates should work if the types actually work at
         # runtime
         await self.con.execute("""
-            WITH MODULE test
             UPDATE UpdateTestSubType
             FILTER .name = "update-covariant"
             SET {
@@ -3001,10 +2826,9 @@ class TestUpdate(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidLinkTargetError,
                 r"invalid target for link 'status' of object type "
-                r"'test::UpdateTestSubSubType': 'test::Status' "
-                r"\(expecting 'test::MajorLifeEvent'\)"):
+                r"'default::UpdateTestSubSubType': 'default::Status' "
+                r"\(expecting 'default::MajorLifeEvent'\)"):
             await self.con.execute("""
-                WITH MODULE test
                 UPDATE UpdateTestSubType
                 FILTER .name = "update-covariant"
                 SET {
@@ -3015,10 +2839,9 @@ class TestUpdate(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidLinkTargetError,
                 r"invalid target for link 'status' of object type "
-                r"'test::UpdateTestSubSubType': 'test::Status' "
-                r"\(expecting 'test::MajorLifeEvent'\)"):
+                r"'default::UpdateTestSubSubType': 'default::Status' "
+                r"\(expecting 'default::MajorLifeEvent'\)"):
             await self.con.execute("""
-                WITH MODULE test
                 UPDATE UpdateTestSubType
                 FILTER .name = "update-covariant"
                 SET {
@@ -3028,7 +2851,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_covariant_02(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTestSubSubType {
                 name := 'update-covariant',
             };
@@ -3037,7 +2859,6 @@ class TestUpdate(tb.QueryTestCase):
         # Covariant updates should work if the types actually work at
         # runtime
         await self.con.execute("""
-            WITH MODULE test
             UPDATE UpdateTestSubType
             FILTER .name = "update-covariant"
             SET {
@@ -3050,10 +2871,9 @@ class TestUpdate(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidLinkTargetError,
                 r"invalid target for link 'statuses' of object type "
-                r"'test::UpdateTestSubSubType': 'test::Status' "
-                r"\(expecting 'test::MajorLifeEvent'\)"):
+                r"'default::UpdateTestSubSubType': 'default::Status' "
+                r"\(expecting 'default::MajorLifeEvent'\)"):
             await self.con.execute("""
-                WITH MODULE test
                 UPDATE UpdateTestSubType
                 FILTER .name = "update-covariant"
                 SET {
@@ -3064,10 +2884,9 @@ class TestUpdate(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidLinkTargetError,
                 r"invalid target for link 'statuses' of object type "
-                r"'test::UpdateTestSubSubType': 'test::Status' "
-                r"\(expecting 'test::MajorLifeEvent'\)"):
+                r"'default::UpdateTestSubSubType': 'default::Status' "
+                r"\(expecting 'default::MajorLifeEvent'\)"):
             await self.con.execute("""
-                WITH MODULE test
                 UPDATE UpdateTestSubType
                 FILTER .name = "update-covariant"
                 SET {
@@ -3077,7 +2896,6 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_covariant_03(self):
         await self.con.execute("""
-            WITH MODULE test
             INSERT UpdateTestSubSubType {
                 name := 'update-covariant',
             };
@@ -3088,7 +2906,6 @@ class TestUpdate(tb.QueryTestCase):
         # Covariant updates should work if the types actually work at
         # runtime
         await self.con.execute("""
-            WITH MODULE test
             UPDATE UpdateTestSubType
             FILTER .name = "update-covariant"
             SET {
@@ -3102,10 +2919,9 @@ class TestUpdate(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidLinkTargetError,
                 r"invalid target for link 'statuses' of object type "
-                r"'test::UpdateTestSubSubType': 'test::Status' "
-                r"\(expecting 'test::MajorLifeEvent'\)"):
+                r"'default::UpdateTestSubSubType': 'default::Status' "
+                r"\(expecting 'default::MajorLifeEvent'\)"):
             await self.con.execute("""
-                WITH MODULE test
                 UPDATE UpdateTestSubType
                 FILTER .name = "update-covariant"
                 SET {
@@ -3120,10 +2936,9 @@ class TestUpdate(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidLinkTargetError,
                 r"invalid target for link 'statuses' of object type "
-                r"'test::UpdateTestSubSubType': 'test::Status' "
-                r"\(expecting 'test::MajorLifeEvent'\)"):
+                r"'default::UpdateTestSubSubType': 'default::Status' "
+                r"\(expecting 'default::MajorLifeEvent'\)"):
             await self.con.execute("""
-                WITH MODULE test
                 UPDATE UpdateTestSubType
                 FILTER .name = "update-covariant"
                 SET {

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -1882,7 +1882,7 @@ class TestUpdate(tb.QueryTestCase):
             edgedb.QueryError,
             "cannot update link 'readonly_tag': "
             "it is declared as read-only",
-            _position=180,
+            _position=147,
         ):
             await self.con.execute(r'''
                 UPDATE UpdateTest
@@ -1897,7 +1897,7 @@ class TestUpdate(tb.QueryTestCase):
             edgedb.QueryError,
             "cannot update property 'readonly_note': "
             "it is declared as read-only",
-            _position=181,
+            _position=148,
         ):
             await self.con.execute(r'''
                 UPDATE UpdateTest
@@ -1912,7 +1912,7 @@ class TestUpdate(tb.QueryTestCase):
             edgedb.QueryError,
             "cannot update property 'readonly_note': "
             "it is declared as read-only",
-            _position=223,
+            _position=190,
         ):
             await self.con.execute(r'''
                 UPDATE UpdateTest
@@ -2014,7 +2014,7 @@ class TestUpdate(tb.QueryTestCase):
             edgedb.QueryError,
             "possibly more than one element returned by an expression"
             " for a computable link 'annotated_status' declared as 'single'",
-            _position=147,
+            _position=114,
         ):
             await self.con.execute("""
                 UPDATE UpdateTest
@@ -2030,7 +2030,7 @@ class TestUpdate(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             r"unexpected '\+='",
-            _position=123,
+            _position=90,
         ):
             await self.con.execute("""
                 INSERT UpdateTest
@@ -2045,7 +2045,7 @@ class TestUpdate(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             r"unexpected '\+='",
-            _position=123,
+            _position=90,
         ):
             await self.con.execute("""
                 SELECT UpdateTest
@@ -2383,7 +2383,7 @@ class TestUpdate(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             r"unexpected '-='",
-            _position=123,
+            _position=90,
         ):
             await self.con.execute("""
                 INSERT UpdateTest

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -24,6 +24,9 @@ from edb.testbase import server as tb
 
 class TestEdgeQLUserDDL(tb.DDLTestCase):
     INTERNAL_TESTMODE = False
+    # This is a hack but INTERNAL_TESTMODE breaks somehow without the
+    # test module.
+    DEFAULT_MODULE = 'test'
 
     async def test_edgeql_userddl_01(self):
         # testing anytype polymorphism

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -29,11 +29,11 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
         # testing anytype polymorphism
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
-                r'cannot create.*test::func_01.*'
+                r'cannot create.*func_01.*'
                 r'generic types are not supported in '
                 r'user-defined functions'):
             await self.con.execute('''
-                CREATE FUNCTION test::func_01(
+                CREATE FUNCTION func_01(
                     a: anytype
                 ) -> bool
                     USING EdgeQL $$
@@ -45,11 +45,11 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
         # testing anyreal polymorphism, which is an actual abstract
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
-                r'cannot create.*test::func_02.*'
+                r'cannot create.*func_02.*'
                 r'generic types are not supported in '
                 r'user-defined functions'):
             await self.con.execute('''
-                CREATE FUNCTION test::func_02(
+                CREATE FUNCTION func_02(
                     a: anyreal
                 ) -> bool
                     USING EdgeQL $$
@@ -61,11 +61,11 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
         # testing anytype as return type
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
-                r'cannot create.*test::func_03.*'
+                r'cannot create.*func_03.*'
                 r'generic types are not supported in '
                 r'user-defined functions'):
             await self.con.execute('''
-                CREATE FUNCTION test::func_03(
+                CREATE FUNCTION func_03(
                     a: str
                 ) -> anytype
                     USING EdgeQL $$
@@ -77,11 +77,11 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
         # testing anyreal as return type
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
-                r'cannot create.*test::func_04.*'
+                r'cannot create.*func_04.*'
                 r'generic types are not supported in '
                 r'user-defined functions'):
             await self.con.execute('''
-                CREATE FUNCTION test::func_04(
+                CREATE FUNCTION func_04(
                     a: str
                 ) -> anyscalar
                     USING EdgeQL $$
@@ -92,11 +92,11 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
     async def test_edgeql_userddl_05(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
-                r'cannot create.*test::func_05.*'
+                r'cannot create.*func_05.*'
                 r'USING SQL FUNCTION.*not supported in '
                 r'user-defined functions'):
             await self.con.execute('''
-                CREATE FUNCTION test::func_05(
+                CREATE FUNCTION func_05(
                     a: str
                 ) -> str
                     USING SQL FUNCTION 'lower';
@@ -105,11 +105,11 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
     async def test_edgeql_userddl_06(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,
-                r'cannot create.*test::func_06.*'
+                r'cannot create.*func_06.*'
                 r'USING SQL.*not supported in '
                 r'user-defined functions'):
             await self.con.execute('''
-                CREATE FUNCTION test::func_06(
+                CREATE FUNCTION func_06(
                     a: str
                 ) -> str
                     USING SQL $$ SELECT "a" $$;
@@ -233,11 +233,11 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
     async def test_edgeql_userddl_19(self):
         with self.assertRaisesRegex(
                 edgedb.UnsupportedFeatureError,
-                r'cannot create.*test::func_19.*'
+                r'cannot create.*func_19.*'
                 r'SET OF parameters in user-defined EdgeQL '
                 r'functions are not supported'):
             await self.con.execute('''
-                CREATE FUNCTION test::func_19(
+                CREATE FUNCTION func_19(
                     a: SET OF str
                 ) -> bool
                     USING EdgeQL $$
@@ -247,7 +247,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
 
     async def test_edgeql_userddl_20(self):
         await self.con.execute('''
-            CREATE FUNCTION test::func_20(
+            CREATE FUNCTION func_20(
                 a: str
             ) -> SET OF str
                 USING EdgeQL $$
@@ -257,14 +257,14 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''
-                SELECT test::func_20('q');
+                SELECT func_20('q');
             ''',
             {'q', 'a'},
         )
 
         await self.assert_query_result(
             r'''
-            SELECT count(test::func_20({'q', 'w'}));
+            SELECT count(func_20({'q', 'w'}));
             ''',
             {4},
         )
@@ -274,7 +274,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 edgedb.SchemaDefinitionError,
                 r"'force_return_cast' is not a valid field"):
             await self.con.execute('''
-                CREATE FUNCTION test::func(
+                CREATE FUNCTION func(
                     a: str
                 ) -> bool
                 {
@@ -287,20 +287,20 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
 
     async def test_edgeql_userddl_22(self):
         await self.con.execute('''
-            CREATE ABSTRACT CONSTRAINT test::uppercase {
+            CREATE ABSTRACT CONSTRAINT uppercase {
                 CREATE ANNOTATION title := "Upper case constraint";
                 USING (str_upper(__subject__) = __subject__);
                 SET errmessage := "{__subject__} is not in upper case";
             };
 
-            CREATE SCALAR TYPE test::upper_str EXTENDING str {
-                CREATE CONSTRAINT test::uppercase
+            CREATE SCALAR TYPE upper_str EXTENDING str {
+                CREATE CONSTRAINT uppercase
             };
         ''')
 
         await self.assert_query_result(
             r'''
-                SELECT <test::upper_str>'123_HELLO';
+                SELECT <upper_str>'123_HELLO';
             ''',
             {'123_HELLO'},
         )
@@ -335,7 +335,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 edgedb.SchemaDefinitionError,
                 r"'fallback' is not a valid field"):
             await self.con.execute(r'''
-                CREATE FUNCTION test::func_25(
+                CREATE FUNCTION func_25(
                     a: bool
                 ) -> bool {
                     SET fallback := true;
@@ -348,7 +348,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
     async def test_edgeql_userddl_26(self):
         # testing fallback
         await self.con.execute(r'''
-            CREATE FUNCTION test::func_26(
+            CREATE FUNCTION func_26(
                 a: bool
             ) -> bool {
                 USING (
@@ -361,7 +361,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 edgedb.SchemaDefinitionError,
                 r"'fallback' is not a valid field"):
             await self.con.execute(r'''
-                ALTER FUNCTION test::func_26(
+                ALTER FUNCTION func_26(
                     a: bool
                 ) {
                     SET fallback := true;
@@ -371,7 +371,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
     async def test_edgeql_userddl_27(self):
         # testing fallback
         await self.con.execute(r'''
-            CREATE FUNCTION test::func_27(
+            CREATE FUNCTION func_27(
                 a: bool
             ) -> bool {
                 USING (
@@ -384,7 +384,7 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
                 edgedb.SchemaDefinitionError,
                 r"'fallback' is not a valid field"):
             await self.con.execute(r'''
-                ALTER FUNCTION test::func_27(
+                ALTER FUNCTION func_27(
                     a: bool
                 ) {
                     # Even altering to set fallback to False should not be

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -138,7 +138,8 @@ class TestIndexes(tb.DDLTestCase):
 
         with self.assertRaisesRegex(
             edgedb.InvalidReferenceError,
-            r"index on \(.name\) does not exist on object type 'default::User'",
+            r"index on \(.name\) does not exist on object type "
+            r"'default::User'",
         ):
             await self.con.execute("""
                 ALTER TYPE User DROP INDEX ON (.name)

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -44,7 +44,7 @@ class TestIndexes(tb.DDLTestCase):
                             expr
                         }
                     }
-                FILTER schema::ObjectType.name = 'test::Person';
+                FILTER schema::ObjectType.name = 'default::Person';
             """,
             [{
                 'indexes': [{
@@ -54,7 +54,7 @@ class TestIndexes(tb.DDLTestCase):
         )
 
         await self.con.execute(r"""
-            INSERT test::Person {
+            INSERT Person {
                 first_name := 'Elon',
                 last_name := 'Musk'
             };
@@ -62,7 +62,6 @@ class TestIndexes(tb.DDLTestCase):
 
         await self.assert_query_result(
             r"""
-                WITH MODULE test
                 SELECT
                     Person {
                         first_name
@@ -77,7 +76,7 @@ class TestIndexes(tb.DDLTestCase):
 
         await self.con.execute(
             """
-                ALTER TYPE test::Person
+                ALTER TYPE Person
                 DROP INDEX ON ((.first_name, .last_name));
             """
         )
@@ -90,7 +89,7 @@ class TestIndexes(tb.DDLTestCase):
                             expr
                         }
                     }
-                FILTER schema::ObjectType.name = 'test::Person';
+                FILTER schema::ObjectType.name = 'default::Person';
             """,
             [{
                 'indexes': []
@@ -100,7 +99,7 @@ class TestIndexes(tb.DDLTestCase):
     async def test_index_02(self):
         await self.con.execute(r"""
             # setup delta
-            CREATE TYPE test::User {
+            CREATE TYPE User {
                 CREATE PROPERTY title -> str;
                 CREATE INDEX ON (.title);
             };
@@ -114,7 +113,7 @@ class TestIndexes(tb.DDLTestCase):
                             expr
                         }
                     }
-                FILTER .name = 'test::User';
+                FILTER .name = 'default::User';
             """,
             [{
                 'indexes': [{
@@ -125,12 +124,12 @@ class TestIndexes(tb.DDLTestCase):
 
         # simply test that the type can be dropped
         await self.con.execute(r"""
-            DROP TYPE test::User;
+            DROP TYPE User;
         """)
 
     async def test_index_03(self):
         await self.con.execute(r"""
-            CREATE TYPE test::User {
+            CREATE TYPE User {
                 CREATE PROPERTY name -> str;
                 CREATE PROPERTY title -> str;
                 CREATE INDEX ON (.title);
@@ -139,8 +138,8 @@ class TestIndexes(tb.DDLTestCase):
 
         with self.assertRaisesRegex(
             edgedb.InvalidReferenceError,
-            r"index on \(.name\) does not exist on object type 'test::User'",
+            r"index on \(.name\) does not exist on object type 'default::User'",
         ):
             await self.con.execute("""
-                ALTER TYPE test::User DROP INDEX ON (.name)
+                ALTER TYPE User DROP INDEX ON (.name)
             """)

--- a/tests/test_link_target_delete.py
+++ b/tests/test_link_target_delete.py
@@ -42,7 +42,7 @@ class TestLinkTargetDeleteSchema(tb.BaseSchemaLoadTest):
             };
         """)
 
-        obj = schema.get('test::Object')
+        obj = schema.get('default::Object')
 
         self.assertEqual(
             obj.getptr(schema, s_name.UnqualName('foo')).get_on_target_delete(
@@ -75,13 +75,13 @@ class TestLinkTargetDeleteSchema(tb.BaseSchemaLoadTest):
             };
         """)
 
-        obj2 = schema.get('test::Object2')
+        obj2 = schema.get('default::Object2')
         self.assertEqual(
             obj2.getptr(schema, s_name.UnqualName('foo')).get_on_target_delete(
                 schema),
             s_links.LinkTargetDeleteAction.Allow)
 
-        obj3 = schema.get('test::Object3')
+        obj3 = schema.get('default::Object3')
         self.assertEqual(
             obj3.getptr(schema, s_name.UnqualName('foo')).get_on_target_delete(
                 schema),
@@ -89,7 +89,7 @@ class TestLinkTargetDeleteSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.SchemaError,
                   "cannot implicitly resolve the `on target delete` action "
-                  "for 'test::C.foo'")
+                  "for 'default::C.foo'")
     def test_schema_on_target_delete_03(self):
         """
             type A {
@@ -120,14 +120,14 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
     async def test_link_on_target_delete_restrict_01(self):
         async with self._run_and_rollback():
             await self.con.execute("""
-                INSERT test::Target1 {
+                INSERT Target1 {
                     name := 'Target1.1'
                 };
 
-                INSERT test::Source1 {
+                INSERT Source1 {
                     name := 'Source1.1',
                     tgt1_restrict := (
-                        SELECT test::Target1
+                        SELECT Target1
                         FILTER .name = 'Target1.1'
                     )
                 };
@@ -135,22 +135,22 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             with self.assertRaisesRegex(
                     edgedb.ConstraintViolationError,
-                    'deletion of test::Target1.* is prohibited by link'):
+                    'deletion of default::Target1.* is prohibited by link'):
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                    DELETE (SELECT Target1 FILTER .name = 'Target1.1');
                 """)
 
     async def test_link_on_target_delete_restrict_02(self):
         async with self._run_and_rollback():
             await self.con.execute("""
-                INSERT test::Target1Child {
+                INSERT Target1Child {
                     name := 'Target1Child.1'
                 };
 
-                INSERT test::Source1 {
+                INSERT Source1 {
                     name := 'Source1.1',
                     tgt1_restrict := (
-                        SELECT test::Target1
+                        SELECT Target1
                         FILTER .name = 'Target1Child.1'
                     )
                 };
@@ -158,23 +158,23 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             with self.assertRaisesRegex(
                     edgedb.ConstraintViolationError,
-                    'deletion of test::Target1.* is prohibited by link'):
+                    'deletion of default::Target1.* is prohibited by link'):
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1Child
+                    DELETE (SELECT Target1Child
                             FILTER .name = 'Target1Child.1');
                 """)
 
     async def test_link_on_target_delete_restrict_03(self):
         async with self._run_and_rollback():
             await self.con.execute("""
-                INSERT test::Target1 {
+                INSERT Target1 {
                     name := 'Target1.1'
                 };
 
-                INSERT test::Source3 {
+                INSERT Source3 {
                     name := 'Source3.1',
                     tgt1_restrict := (
-                        SELECT test::Target1
+                        SELECT Target1
                         FILTER .name = 'Target1.1'
                     )
                 };
@@ -182,22 +182,22 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             with self.assertRaisesRegex(
                     edgedb.ConstraintViolationError,
-                    'deletion of test::Target1 .* is prohibited by link'):
+                    'deletion of default::Target1 .* is prohibited by link'):
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                    DELETE (SELECT Target1 FILTER .name = 'Target1.1');
                 """)
 
     async def test_link_on_target_delete_restrict_04(self):
         async with self._run_and_rollback():
             await self.con.execute("""
-                INSERT test::Target1Child {
+                INSERT Target1Child {
                     name := 'Target1Child.1'
                 };
 
-                INSERT test::Source3 {
+                INSERT Source3 {
                     name := 'Source3.1',
                     tgt1_restrict := (
-                        SELECT test::Target1
+                        SELECT Target1
                         FILTER .name = 'Target1Child.1'
                     )
                 };
@@ -205,9 +205,9 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             with self.assertRaisesRegex(
                     edgedb.ConstraintViolationError,
-                    'deletion of test::Target1.* is prohibited by link'):
+                    'deletion of default::Target1.* is prohibited by link'):
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1Child
+                    DELETE (SELECT Target1Child
                             FILTER .name = 'Target1Child.1');
                 """)
 
@@ -216,7 +216,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
         async with self._run_and_rollback():
             await self.con.execute(r"""
-                SET MODULE test;
 
                 INSERT Target1 {
                     name := 'Target1.1'
@@ -235,7 +234,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
         async with self._run_and_rollback():
             await self.con.execute("""
-                SET MODULE test;
 
                 INSERT Target1 {
                     name := 'Target1.1'
@@ -262,7 +260,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
         async with self._run_and_rollback():
             await self.con.execute("""
-                SET MODULE test;
 
                 FOR name IN {'Target1.1', 'Target1.2', 'Target1.3'}
                 UNION (
@@ -291,25 +288,25 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.ConstraintViolationError,
-                'deletion of test::Target1 .* is prohibited by link'):
+                'deletion of default::Target1 .* is prohibited by link'):
 
             async with self.con.transaction():
                 await self.con.execute("""
-                    INSERT test::Target1 {
+                    INSERT Target1 {
                         name := 'Target1.1'
                     };
 
-                    INSERT test::Source1 {
+                    INSERT Source1 {
                         name := 'Source1.1',
                         tgt1_deferred_restrict := (
-                            SELECT test::Target1
+                            SELECT Target1
                             FILTER .name = 'Target1.1'
                         )
                     };
                 """)
 
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1
+                    DELETE (SELECT Target1
                             FILTER .name = 'Target1.1');
                 """)
 
@@ -322,25 +319,25 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.ConstraintViolationError,
-                'deletion of test::Target1 .* is prohibited by link'):
+                'deletion of default::Target1 .* is prohibited by link'):
 
             async with self.con.transaction():
                 await self.con.execute("""
-                    INSERT test::Target1 {
+                    INSERT Target1 {
                         name := 'Target1.1'
                     };
 
-                    INSERT test::Source3 {
+                    INSERT Source3 {
                         name := 'Source3.1',
                         tgt1_deferred_restrict := (
-                            SELECT test::Target1
+                            SELECT Target1
                             FILTER .name = 'Target1.1'
                         )
                     };
                 """)
 
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1
+                    DELETE (SELECT Target1
                             FILTER .name = 'Target1.1');
                 """)
 
@@ -353,7 +350,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
         async with self._run_and_rollback():
             await self.con.execute("""
-                SET MODULE test;
 
                 INSERT Target1 {
                     name := 'Target1.1'
@@ -378,7 +374,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
         try:
             async with self.con.transaction():
                 await self.con.execute(r"""
-                    SET MODULE test;
 
                     INSERT Target1 {
                         name := 'Target4.1'
@@ -413,7 +408,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT Target1 { name }
                     FILTER .name = 'Target4.2';
                 ''',
@@ -423,23 +417,23 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
         finally:
             # cleanup
             await self.con.execute("""
-                DELETE (SELECT test::Source1
+                DELETE (SELECT Source1
                         FILTER .name = 'Source4.1');
-                DELETE (SELECT test::Target1
+                DELETE (SELECT Target1
                         FILTER .name = 'Target4.2');
             """)
 
     async def test_link_on_target_delete_allow_01(self):
         async with self._run_and_rollback():
             await self.con.execute("""
-                INSERT test::Target1 {
+                INSERT Target1 {
                     name := 'Target1.1'
                 };
 
-                INSERT test::Source1 {
+                INSERT Source1 {
                     name := 'Source1.1',
                     tgt1_allow := (
-                        SELECT test::Target1
+                        SELECT Target1
                         FILTER .name = 'Target1.1'
                     )
                 };
@@ -447,7 +441,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source1 {
                             tgt1_allow: {
@@ -461,12 +454,11 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE (SELECT Target1 FILTER .name = 'Target1.1');
             """)
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source1 {
                             tgt1_allow: {
@@ -484,14 +476,14 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
     async def test_link_on_target_delete_allow_02(self):
         async with self._run_and_rollback():
             await self.con.execute("""
-                INSERT test::Target1 {
+                INSERT Target1 {
                     name := 'Target1.1'
                 };
 
-                INSERT test::Source3 {
+                INSERT Source3 {
                     name := 'Source3.1',
                     tgt1_allow := (
-                        SELECT test::Target1
+                        SELECT Target1
                         FILTER .name = 'Target1.1'
                     )
                 };
@@ -499,7 +491,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source3 {
                             tgt1_allow: {
@@ -513,12 +504,11 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE (SELECT Target1 FILTER .name = 'Target1.1');
             """)
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source3 {
                             tgt1_allow: {
@@ -536,7 +526,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
     async def test_link_on_target_delete_allow_03(self):
         async with self._run_and_rollback():
             await self.con.execute("""
-                SET MODULE test;
 
                 FOR name IN {'Target1.1', 'Target1.2', 'Target1.3'}
                 UNION (
@@ -556,7 +545,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source1 {
                             name,
@@ -578,12 +566,11 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE (SELECT Target1 FILTER .name = 'Target1.1');
             """)
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source1 {
                             name,
@@ -605,7 +592,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Target1 {
                             name
@@ -624,22 +610,22 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
     async def test_link_on_target_delete_delete_source_01(self):
         async with self._run_and_rollback():
             await self.con.execute("""
-                INSERT test::Target1 {
+                INSERT Target1 {
                     name := 'Target1.1'
                 };
 
-                INSERT test::Source1 {
+                INSERT Source1 {
                     name := 'Source1.1',
                     tgt1_del_source := (
-                        SELECT test::Target1
+                        SELECT Target1
                         FILTER .name = 'Target1.1'
                     )
                 };
 
-                INSERT test::Source2 {
+                INSERT Source2 {
                     name := 'Source2.1',
                     src1_del_source := (
-                        SELECT test::Source1
+                        SELECT Source1
                         FILTER .name = 'Source1.1'
                     )
                 };
@@ -647,7 +633,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source2 {
                             src1_del_source: {
@@ -669,12 +654,11 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE (SELECT Target1 FILTER .name = 'Target1.1');
             """)
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source2
                     FILTER
@@ -684,7 +668,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source1
                     FILTER
@@ -696,7 +679,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
     async def test_link_on_target_delete_delete_source_02(self):
         async with self._run_and_rollback():
             await self.con.execute("""
-                SET MODULE test;
 
                 INSERT Target1 {
                     name := 'Target1.1'
@@ -729,7 +711,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source2 {
                             src1_del_source: {
@@ -752,7 +733,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                WITH MODULE test
                 SELECT
                     Source1 {
                         name,
@@ -776,12 +756,11 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE (SELECT Target1 FILTER .name = 'Target1.1');
             """)
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source2
                     FILTER
@@ -792,7 +771,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source1
                     FILTER
@@ -804,7 +782,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
     async def test_link_on_target_delete_delete_source_03(self):
         async with self._run_and_rollback():
             await self.con.execute("""
-                SET MODULE test;
 
                 FOR name IN {'Target1.1', 'Target1.2', 'Target1.3'}
                 UNION (
@@ -824,7 +801,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source1 {
                             name,
@@ -846,12 +822,11 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE (SELECT Target1 FILTER .name = 'Target1.1');
             """)
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source1 {
                             name,
@@ -867,7 +842,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Target1 {
                             name
@@ -886,7 +860,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
     async def test_link_on_target_delete_delete_source_04(self):
         async with self._run_and_rollback():
             await self.con.execute("""
-                SET MODULE test;
 
                 INSERT Target1 {
                     name := 'Target1.1'
@@ -919,7 +892,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source2 {
                             src1_del_source: {
@@ -942,7 +914,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                WITH MODULE test
                 SELECT
                     Source3 {
                         name,
@@ -966,12 +937,11 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
             )
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE (SELECT Target1 FILTER .name = 'Target1.1');
             """)
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source3
                     FILTER
@@ -982,7 +952,6 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         Source2
                     FILTER
@@ -994,26 +963,25 @@ class TestLinkTargetDeleteDeclarative(stb.QueryTestCase):
     async def test_link_on_target_delete_delete_source_05(self):
         async with self._run_and_rollback():
             await self.con.execute("""
-                INSERT test::Target1 {
+                INSERT Target1 {
                     name := 'Target1.1'
                 };
 
-                INSERT test::ChildSource1 {
+                INSERT ChildSource1 {
                     name := 'Source1.1',
                     tgt1_del_source := (
-                        SELECT test::Target1
+                        SELECT Target1
                         FILTER .name = 'Target1.1'
                     )
                 };
             """)
 
             await self.con.execute("""
-                DELETE (SELECT test::Target1 FILTER .name = 'Target1.1');
+                DELETE (SELECT Target1 FILTER .name = 'Target1.1');
             """)
 
             await self.assert_query_result(
                 r'''
-                    WITH MODULE test
                     SELECT
                         ChildSource1
                     FILTER
@@ -1040,17 +1008,17 @@ class TestLinkTargetDeleteMigrations(stb.DDLTestCase):
             await self.migrate(schema)
 
             await self.con.execute('''
-                INSERT test::Target1 {name := 'Target1_migration_01'};
+                INSERT Target1 {name := 'Target1_migration_01'};
 
-                INSERT test::ObjectType4 {
+                INSERT ObjectType4 {
                     foo := (
-                        SELECT test::Target1
+                        SELECT Target1
                         FILTER .name = 'Target1_migration_01'
                     )
                 };
 
                 DELETE (
-                    SELECT test::AbstractObjectType
+                    SELECT AbstractObjectType
                     FILTER .foo.name = 'Target1_migration_01'
                 );
             ''')
@@ -1067,14 +1035,14 @@ class TestLinkTargetDeleteMigrations(stb.DDLTestCase):
             await self.migrate(schema)
 
             await self.con.execute("""
-                INSERT test::Target1 {
+                INSERT Target1 {
                     name := 'Target1.m02'
                 };
 
-                INSERT test::Source1 {
+                INSERT Source1 {
                     name := 'Source1.m02',
                     tgt1_deferred_restrict := (
-                        SELECT test::Target1
+                        SELECT Target1
                         FILTER .name = 'Target1.m02'
                     )
                 };
@@ -1084,7 +1052,7 @@ class TestLinkTargetDeleteMigrations(stb.DDLTestCase):
             # since the policy is no longer "DEFERRED"
             with self.assertRaisesRegex(
                     edgedb.ConstraintViolationError,
-                    'deletion of test::Target1 .* is prohibited by link'):
+                    'deletion of default::Target1 .* is prohibited by link'):
                 await self.con.execute("""
-                    DELETE (SELECT test::Target1 FILTER .name = 'Target1.m02');
+                    DELETE (SELECT Target1 FILTER .name = 'Target1.m02');
                 """)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -43,6 +43,8 @@ if TYPE_CHECKING:
 
 
 class TestSchema(tb.BaseSchemaLoadTest):
+    DEFAULT_MODULE = 'test'
+
     def test_schema_overloaded_01(self):
         """
             type UniqueName {
@@ -5667,6 +5669,8 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""
 
+    DEFAULT_MODULE = 'test'
+
     re_filter = re.compile(r'[\s]+|(,(?=\s*[})]))')
     maxDiff = 10000
 
@@ -5690,7 +5694,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                 current_schema=schema,
             )
         else:
-            schema = self.load_schema(schema_text)
+            schema = self.load_schema(schema_text, modname=default_module)
 
         tests = [iter(tests)] * 2
 

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -49,7 +49,7 @@ class TestServerCompiler(tb.BaseSchemaLoadTest):
         compiler = tb.new_compiler()
         context = edbcompiler.new_compiler_context(
             user_schema=self.schema,
-            modaliases={None: 'test'},
+            modaliases={None: 'default'},
         )
 
         edbcompiler.compile_edgeql_script(


### PR DESCRIPTION
I didn't do test_schema or test_edgeql_data_migration.

The bulk of the work was done with the following sed script, followed
by a couple hours worth of manual cleanup:
```
/WITH MODULE test$/d
/^ *MODULE test,/d
s/WITH MODULE test //

 # change test to default when it is a string, otherwise drop it
s/'test::/'default::/g
s/"test::/"default::/g
s/test:://g

 # lots of nasty comma stuff
/WITH$/N;/WITH.*MODULE test$/d;s/\n *MODULE test,//
/WITH$/N
/WITH MODULE test,$/N;s/MODULE test,\n *//
s/WITH\n\? *\(SELECT\|UPDATE\|DELETE\|FOR\|INSERT\)/\1/
/SET MODULE test/d
```