### PR TITLE
Implement a toy evaluator model

### DIFF
--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -702,7 +702,9 @@ def eval(node: qlast.Base, ctx: EvalContext) -> Result:
 
 
 def get_links(obj: Data, key: str) -> Result:
-    out = obj.get(key, [])
+    out = obj.get(key)
+    if out is None:
+        out = []
     if not isinstance(out, list):
         out = [out]
     return out

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -1,0 +1,271 @@
+# mypy: no-ignore-errors, strict-optional, disallow-any-generics
+
+"""Toy evaluator model for an edgeql subset.
+
+The idea here is to be able to test queries against a simple semantics
+driven evaluator model.
+
+This version does not have any understanding of schemas.
+
+It is a goal that this can be scaled up to be pointed at different
+corners of the language. It is a non-goal that it can be scaled up to
+be a full evaluator model.
+
+Also a non-goal: performance.
+
+"""
+
+from typing import *
+
+from pathlib import Path
+import sys
+EDB_DIR = Path(__file__).parent.parent.parent.resolve()
+sys.path.insert(0, str(EDB_DIR))
+
+from edb.common import debug
+from edb import edgeql
+
+from edb.common.ast import NodeVisitor
+from edb.edgeql import ast as qlast
+# from edb.edgeql import qltypes as ft
+
+from dataclasses import dataclass
+
+import uuid
+
+
+T = TypeVar('T')
+
+
+SCHEMA = '''
+type Note {
+    required single property name -> str;
+    optional single property note -> str;
+}
+type Noob {
+    required single property name -> str; // exclusive
+    optional multi property multi_prop -> str; // exclusive
+    multi link notes -> Note;
+    optional single property tag -> str;
+'''
+
+
+def bsid(n: int) -> uuid.UUID:
+    return uuid.UUID(f'ffffffff-ffff-ffff-ffff-{n:012x}')
+
+
+# ############# Data model
+
+NoobT = "Noob"
+NoteT = "Note"
+
+Data = Any
+DB = Dict[uuid.UUID, Dict[str, Data]]
+
+
+def mk_db(data: Iterable[Dict[str, Data]]) -> DB:
+    return {x["id"]: x for x in data}
+
+
+def mk_obj(x: uuid.UUID) -> Data:
+    return {"id": x}
+
+
+def bslink(n: int) -> Data:
+    return mk_obj(bsid(n))
+
+
+DB1 = mk_db([
+    # Noob
+    {"id": bsid(0x10), "__type__": NoobT,
+     "name": "Phil Emarg", "notes": [bslink(0x20), bslink(0x21)]},
+    {"id": bsid(0x11), "__type__": NoobT,
+     "name": "Madeline Hatch", "notes": [bslink(0x21)]},
+    # Note
+    {"id": bsid(0x20), "__type__": NoteT, "name": "boxing"},
+    {"id": bsid(0x21), "__type__": NoteT, "name": "unboxing", "note": "lolol"},
+])
+
+
+# #############
+class IORef(NamedTuple):
+    name: str
+
+
+class IPtr(NamedTuple):
+    ptr: str
+    direction: Optional[str]
+
+
+IPathElement = Union[IORef, IPtr]
+IPath = Tuple[IPathElement, ...]
+
+# ############### Evaluation???
+
+
+@dataclass
+class EvalContext:
+    query_input_list: List[IPath]
+    input_tuple: Tuple[Data, ...]
+    db: DB  # or not?
+
+
+def eval_ptr(base: Data, ptr: IPtr, ctx: EvalContext) -> List[Data]:
+    assert ptr.direction == '>'
+    obj = ctx.db[base["id"]]
+    out = obj.get(ptr.ptr, [])
+    if not isinstance(out, list):
+        out = [out]
+    return out
+
+
+# This should only get called during input tuple building
+def eval_objref(name: str, ctx: EvalContext) -> List[Data]:
+    return [
+        mk_obj(obj["id"]) for obj in ctx.db.values()
+        if obj["__type__"] == name
+    ]
+
+
+def eval_path(path: IPath, ctx: EvalContext) -> List[Data]:
+    # Base case for stuff in the input list
+    if path in ctx.query_input_list:
+        i = ctx.query_input_list.index(path)
+        obj = ctx.input_tuple[i]
+        return [obj] if obj else []
+
+    if len(path) == 1:
+        assert(isinstance(path[0], IORef))
+        return eval_objref(path[0].name, ctx)
+
+    base = eval_path(path[:-1], ctx)
+    out = []
+    ptr = path[-1]
+    assert isinstance(ptr, IPtr)
+    for obj in base:
+        out.extend(eval_ptr(obj, ptr, ctx))
+
+    return out
+
+
+@dataclass
+class PrepContext:
+    db: DB
+
+
+def build_input_tuples(
+        qil: List[IPath], ctx: PrepContext) -> List[Tuple[Data, ...]]:
+    data: List[Tuple[Data, ...]] = [()]
+    for i, in_path in enumerate(qil):
+        new_data: List[Tuple[Data, ...]] = []
+        new_qil = qil[:i]
+        for row in data:
+            eval_ctx = EvalContext(
+                query_input_list=new_qil, input_tuple=row, db=ctx.db)
+            out = eval_path(in_path, eval_ctx)
+            # TODO: OPTIONAL/SET OF
+            for val in out:
+                new_data.append(row + (val,))
+        data = new_data
+
+    return data
+
+# ############### Preparation
+
+
+class PathFinder(NodeVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.paths: List[qlast.Path] = []
+
+    def visit_Path(self, path: qlast.Path):
+        self.paths.append(path)
+        self.generic_visit(path)
+
+
+def find_paths(e: qlast.Statement) -> List[qlast.Path]:
+    pf = PathFinder()
+    pf.visit(e)
+    return pf.paths
+
+
+def longest_common_prefix(p1: IPath, p2: IPath) -> IPath:
+    common = []
+    for a, b in zip(p1[:-1], p2[:-1]):
+        if a == b:
+            common.append(a)
+        else:
+            break
+    return tuple(common)
+
+
+def dedup(old: List[T]) -> List[T]:
+    new: List[T] = []
+    for x in old:
+        if x not in new:
+            new.append(x)
+    return new
+
+
+def find_common_prefixes(refs: List[IPath]) -> Set[IPath]:
+    prefixes = set()
+    for i, x in enumerate(refs):
+        for y in refs[i:]:
+            pfx = longest_common_prefix(x, y)
+            if pfx:
+                prefixes.add(pfx)
+    return prefixes
+
+
+def make_query_input_list(refs: List[IPath]) -> List[IPath]:
+    refs = dedup(refs)
+    # XXX: assuming everything is simple
+    qil: Set[IPath] = {(x[0],) for x in refs}
+    qil.update(find_common_prefixes(refs))
+    return sorted(qil)
+
+
+def simplify_path(path: qlast.Path) -> IPath:
+    spath: List[IPathElement] = []
+    assert not path.partial
+    for step in path.steps:
+        if isinstance(step, qlast.ObjectRef):
+            spath.append(IORef(step.name))
+        elif isinstance(step, qlast.Ptr):
+            spath.append(IPtr(step.ptr.name, step.direction))
+        else:
+            raise AssertionError(f'{type(step)} not supported yet')
+
+    return tuple(spath)
+
+
+def parse(querystr: str) -> qlast.Statement:
+    source = edgeql.Source.from_string(querystr)
+    statements = edgeql.parse_block(source)
+    assert len(statements) == 1
+    return statements[0]
+
+
+def main() -> None:
+    debug.dump(DB1)
+
+    query = '''
+    SELECT Noob.name ++ Noob.notes.name ++ Noob.notes.note;
+    '''
+
+    q = parse(query)
+
+    debug.dump(q)
+
+    paths = [simplify_path(p) for p in find_paths(q)]
+    debug.dump(paths)
+    qil = make_query_input_list(paths)
+    debug.dump(qil)
+
+    ctx = PrepContext(db=DB1)
+    in_tuples = build_input_tuples(qil, ctx)
+    debug.dump(in_tuples)
+
+
+if __name__ == '__main__':
+    main()

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -5,7 +5,12 @@
 The idea here is to be able to test queries against a simple semantics
 driven evaluator model.
 
-This version does not have any understanding of schemas.
+This version does not have any understanding of schemas and has the
+function signatures and behaviors of a bunch of basic functions
+hardcoded in.
+
+The data model is a super simple in-memory one, though it shouldn't be
+too hard to populate it from a real DB or vice versa to do testing.
 
 It is a goal that this can be scaled up to be pointed at different
 corners of the language. It is a non-goal that it can be scaled up to
@@ -15,23 +20,30 @@ Also a non-goal: performance.
 
 """
 
-from typing import *
+from __future__ import annotations
 
 from pathlib import Path
 import sys
 EDB_DIR = Path(__file__).parent.parent.parent.resolve()
 sys.path.insert(0, str(EDB_DIR))
 
+from typing import *
+
+
 from edb.common import debug
 from edb import edgeql
 
 from edb.common.ast import NodeVisitor
 from edb.edgeql import ast as qlast
-# from edb.edgeql import qltypes as ft
+from edb.edgeql import qltypes as ft
 
 from dataclasses import dataclass
+from collections import defaultdict
 
 import uuid
+import itertools
+import operator
+import functools
 
 
 T = TypeVar('T')
@@ -53,6 +65,24 @@ type Noob {
 def bsid(n: int) -> uuid.UUID:
     return uuid.UUID(f'ffffffff-ffff-ffff-ffff-{n:012x}')
 
+
+# # Toy basis stuff
+
+SET_OF, OPTIONAL, SINGLETON = (
+    ft.TypeModifier.SetOfType, ft.TypeModifier.OptionalType,
+    ft.TypeModifier.SingletonType)
+
+# We just list things with weird behavior
+BASIS = {
+    'count': [SET_OF],
+    'IN': [SINGLETON, SET_OF],
+    '??': [OPTIONAL, SET_OF],
+    'EXISTS': [SET_OF],
+    'IF': [SET_OF, SINGLETON, SET_OF],
+    'UNION': [SET_OF, SET_OF],
+    '?=': [OPTIONAL, OPTIONAL],
+    '?!=': [OPTIONAL, OPTIONAL],
+}
 
 # ############# Data model
 
@@ -81,6 +111,8 @@ DB1 = mk_db([
      "name": "Phil Emarg", "notes": [bslink(0x20), bslink(0x21)]},
     {"id": bsid(0x11), "__type__": NoobT,
      "name": "Madeline Hatch", "notes": [bslink(0x21)]},
+    {"id": bsid(0x12), "__type__": NoobT,
+     "name": "Emmanuel Villip", "notes": [bslink(0x21)]},
     # Note
     {"id": bsid(0x20), "__type__": NoteT, "name": "boxing"},
     {"id": bsid(0x21), "__type__": NoteT, "name": "unboxing", "note": "lolol"},
@@ -102,12 +134,129 @@ IPath = Tuple[IPathElement, ...]
 
 # ############### Evaluation???
 
+# Basic functions
+
+
+class LiftedFunc(Protocol):
+    def __call__(self, *args: List[Data]) -> List[Data]:
+        pass
+
+
+def lift(f: Callable[..., Union[Data, List[Data]]]) -> LiftedFunc:
+    def inner(*args: Data) -> List[Data]:
+        out = []
+        for args1 in itertools.product(*args):
+            val = f(*args1)
+            if isinstance(val, list):
+                out.extend(val)
+            else:
+                out.append(val)
+        return out
+    return inner
+
+
+def opt_eq(x: List[Data], y: List[Data]) -> List[Data]:
+    if not x or not y:
+        return [len(x) == len(y)]
+    return lift(operator.eq)(x, y)
+
+
+def opt_ne(x: List[Data], y: List[Data]) -> List[Data]:
+    if not x or not y:
+        return [len(x) != len(y)]
+    return lift(operator.ne)(x, y)
+
+
+_BASIS_IMPLS: Any = {
+    '+': lift(operator.add),
+    '++': lift(operator.add),
+    '=': lift(operator.eq),
+    '!=': lift(operator.ne),
+    'str': lift(str),
+    'int': lift(int),
+    '?=': opt_eq,
+    '?!=': opt_ne,
+}
+BASIS_IMPLS: Dict[str, LiftedFunc] = _BASIS_IMPLS
+
 
 @dataclass
 class EvalContext:
     query_input_list: List[IPath]
     input_tuple: Tuple[Data, ...]
     db: DB  # or not?
+
+#
+
+
+@functools.singledispatch
+def _eval(
+    node: qlast.Base,
+    ctx: EvalContext,
+) -> List[Data]:
+    raise NotImplementedError(
+        f'no EdgeQL eval handler for {node.__class__}')
+
+
+@_eval.register(qlast.SelectQuery)
+def eval_Select(node: qlast.SelectQuery, ctx: EvalContext) -> List[Data]:
+    # TODO subqueries
+    return eval(node.result, ctx)
+
+
+@_eval.register(qlast.BinOp)
+def eval_BinOp(node: qlast.BinOp, ctx: EvalContext) -> List[Data]:
+    f = BASIS_IMPLS[node.op]
+    return f(eval(node.left, ctx), eval(node.right, ctx))
+
+
+@_eval.register(qlast.FunctionCall)
+def eval_Call(node: qlast.FunctionCall, ctx: EvalContext) -> List[Data]:
+    assert isinstance(node.func, str)
+    f = BASIS_IMPLS[node.func]
+    return f(*(eval(arg, ctx) for arg in node.args))
+
+
+@_eval.register(qlast.StringConstant)
+def eval_StringConstant(
+        node: qlast.StringConstant, ctx: EvalContext) -> List[Data]:
+    return [node.value]
+
+
+@_eval.register(qlast.IntegerConstant)
+def eval_IntegerConstant(
+        node: qlast.IntegerConstant, ctx: EvalContext) -> List[Data]:
+    return [int(node.value)]
+
+
+@_eval.register(qlast.Tuple)
+def eval_Tuple(
+        node: qlast.Tuple, ctx: EvalContext) -> List[Data]:
+    # XXX: only unnamed ones
+    args = [eval(arg, ctx) for arg in node.elements]
+
+    def get(*va):
+        return va
+
+    return lift(get)(*args)
+
+
+@_eval.register(qlast.TypeCast)
+def eval_TypeCast(node: qlast.TypeCast, ctx: EvalContext) -> List[Data]:
+    typ = node.type.maintype.name  # type: ignore  # our types are hinky.
+    f = BASIS_IMPLS[typ]
+    return f(eval(node.expr, ctx))
+
+
+@_eval.register(qlast.Path)
+def eval_Path(node: qlast.Path, ctx: EvalContext) -> List[Data]:
+    return eval_path(simplify_path(node), ctx)
+
+
+def eval(node: qlast.Base, ctx: EvalContext) -> List[Data]:
+    return _eval(node, ctx)
+
+###
 
 
 def eval_ptr(base: Data, ptr: IPtr, ctx: EvalContext) -> List[Data]:
@@ -154,7 +303,8 @@ class PrepContext:
 
 
 def build_input_tuples(
-        qil: List[IPath], ctx: PrepContext) -> List[Tuple[Data, ...]]:
+        qil: List[IPath], always_optional: Dict[IPath, bool],
+        ctx: PrepContext) -> List[Tuple[Data, ...]]:
     data: List[Tuple[Data, ...]] = [()]
     for i, in_path in enumerate(qil):
         new_data: List[Tuple[Data, ...]] = []
@@ -166,6 +316,8 @@ def build_input_tuples(
             # TODO: OPTIONAL/SET OF
             for val in out:
                 new_data.append(row + (val,))
+            if not out and always_optional[in_path]:
+                new_data.append(row + (None,))
         data = new_data
 
     return data
@@ -176,14 +328,52 @@ def build_input_tuples(
 class PathFinder(NodeVisitor):
     def __init__(self) -> None:
         super().__init__()
-        self.paths: List[qlast.Path] = []
+        self.query_depth = 0
+        self.in_optional = False
+        self.paths: List[Tuple[qlast.Path, bool]] = []
 
-    def visit_Path(self, path: qlast.Path):
-        self.paths.append(path)
+    def visit_Path(self, path: qlast.Path) -> None:
+        self.paths.append((path, self.in_optional))
         self.generic_visit(path)
 
+    def visit_SelectQuery(self, query: qlast.SelectQuery) -> None:
+        # TODO: there are lots of implicit subqueries (clauses)
+        # and we need to care about them
+        if self.query_depth:
+            return
+        self.query_depth += 1
+        self.generic_visit(query)
+        self.query_depth -= 1
 
-def find_paths(e: qlast.Statement) -> List[qlast.Path]:
+    def visit_func_or_op(self, op: str, args: List[qlast.Expr]) -> None:
+        # Totally ignoring that polymorpic whatever is needed
+        arg_specs = BASIS.get(op)
+        old = self.in_optional
+        for i, arg in enumerate(args):
+            if arg_specs:
+                # SET OF is a subquery so we skip it
+                if arg_specs[i] == SET_OF:
+                    continue
+                elif arg_specs[i] == OPTIONAL:
+                    self.in_optional = True
+            self.visit(arg)
+            self.in_optional = old
+
+    def visit_BinOp(self, query: qlast.BinOp) -> None:
+        self.visit_func_or_op(query.op, [query.left, query.right])
+
+    def visit_FunctionCall(self, query: qlast.FunctionCall) -> None:
+        assert not query.kwargs
+        assert isinstance(query.func, str)
+        self.visit_func_or_op(query.func, query.args)
+        assert not query.window  # done last or we get dced.
+
+    def visit_IfElse(self, query: qlast.IfElse) -> None:
+        self.visit_func_or_op(
+            'IF', [query.if_expr, query.condition, query.else_expr])
+
+
+def find_paths(e: qlast.Expr) -> List[Tuple[qlast.Path, bool]]:
     pf = PathFinder()
     pf.visit(e)
     return pf.paths
@@ -246,25 +436,47 @@ def parse(querystr: str) -> qlast.Statement:
     return statements[0]
 
 
-def main() -> None:
-    debug.dump(DB1)
-
-    query = '''
-    SELECT Noob.name ++ Noob.notes.name ++ Noob.notes.note;
-    '''
-
-    q = parse(query)
-
+def go(q: qlast.Expr) -> None:
     debug.dump(q)
 
-    paths = [simplify_path(p) for p in find_paths(q)]
-    debug.dump(paths)
-    qil = make_query_input_list(paths)
-    debug.dump(qil)
+    paths_opt = [(simplify_path(p), optional)
+                 for p, optional in find_paths(q)]
+    always_optional = defaultdict(bool)
+    for path, optional in paths_opt:
+        if not optional:
+            for i in range(1, len(path) + 1):
+                always_optional[path[:i]] = False
 
-    ctx = PrepContext(db=DB1)
-    in_tuples = build_input_tuples(qil, ctx)
-    debug.dump(in_tuples)
+    paths = [path for path, _ in paths_opt]
+
+    qil = make_query_input_list(paths)
+
+    db = DB1
+    pctx = PrepContext(db=db)  # no
+    in_tuples = build_input_tuples(qil, always_optional, pctx)
+
+    # Actually eval it
+    out = []
+    for row in in_tuples:
+        eval_ctx = EvalContext(query_input_list=qil, input_tuple=row, db=db)
+        out.extend(eval(q, eval_ctx))
+
+    debug.dump(out)
+
+
+QUERY = '''
+SELECT Noob.name ++ "-" ++ Noob.notes.name
+'''
+QUERY1 = '''
+SELECT (Noob.name, Noob.name)
+'''
+QUERY2 = '''
+SELECT (Note.note ?= "lolol", Note)
+'''
+
+
+def main() -> None:
+    go(parse(QUERY2))
 
 
 if __name__ == '__main__':

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -139,6 +139,7 @@ BASIS = {
     'NOT IN': [SINGLETON, SET_OF],
     '??': [OPTIONAL, SET_OF],
     'EXISTS': [SET_OF],
+    'DISTINCT': [SET_OF],
     'IF': [SET_OF, SINGLETON, SET_OF],
     'UNION': [SET_OF, SET_OF],
     '?=': [OPTIONAL, OPTIONAL],
@@ -222,6 +223,10 @@ def exists(x: List[Data]) -> List[Data]:
     return [bool(x)]
 
 
+def distinct(x: List[Data]) -> List[Data]:
+    return dedup(x)
+
+
 def union(x: List[Data], y: List[Data]) -> List[Data]:
     return x + y
 
@@ -251,6 +256,7 @@ _BASIS_IMPLS: Any = {
     'NOT IN': not_contains,
     '??': coalesce,
     'EXISTS': exists,
+    'DISTINCT': distinct,
     'UNION': union,
     'IF': IF,
 }
@@ -300,6 +306,11 @@ def eval_func_or_op(op: str, args: List[qlast.Expr],
 @_eval.register(qlast.BinOp)
 def eval_BinOp(node: qlast.BinOp, ctx: EvalContext) -> List[Data]:
     return eval_func_or_op(node.op.upper(), [node.left, node.right], ctx)
+
+
+@_eval.register(qlast.UnaryOp)
+def eval_UnaryOp(node: qlast.UnaryOp, ctx: EvalContext) -> List[Data]:
+    return eval_func_or_op(node.op.upper(), [node.operand], ctx)
 
 
 @_eval.register(qlast.FunctionCall)

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -727,11 +727,15 @@ def eval_fwd_ptr(base: Data, ptr: IPtr, ctx: EvalContext) -> Result:
 
 def eval_bwd_ptr(base: Data, ptr: IPtr, ctx: EvalContext) -> Result:
     # XXX: This is slow even by the standards of this terribly slow model
-    return [
-        Obj(obj["id"])
-        for obj in ctx.db.values()
-        if base in get_links(obj, ptr.ptr)
-    ]
+    res = []
+    for obj in ctx.db.values():
+        for tgt in get_links(obj, ptr.ptr):
+            if base == tgt:
+                # Extract any lprops and put them on the backlink
+                data = {k: v for k, v in tgt.data.items() if k[0] == '@'}
+                res.append(Obj(obj['id'], data=data))
+                break
+    return res
 
 
 def eval_ptr(base: Data, ptr: IPtr, ctx: EvalContext) -> Result:

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -70,20 +70,6 @@ import traceback
 T = TypeVar('T')
 
 
-# This is just documentation I guess.
-SCHEMA = '''
-type Note {
-    required single property name -> str;
-    optional single property note -> str;
-}
-type Person {
-    required single property name -> str;
-    optional multi property multi_prop -> str;
-    multi link notes -> Note;
-    optional single property tag -> str;
-'''
-
-
 def bsid(n: int) -> uuid.UUID:
     return uuid.UUID(f'ffffffff-ffff-ffff-ffff-{n:012x}')
 
@@ -897,6 +883,20 @@ def repl(db: DB, print_asts: bool=False) -> None:
 
 # Our toy DB
 # Make this UUIDs?
+# This is just documentation I guess.
+SCHEMA = '''
+type Note {
+    required single property name -> str;
+    optional single property note -> str;
+}
+type Person {
+    required single property name -> str;
+    optional multi property multi_prop -> str;
+    multi link notes -> Note;
+    optional single property tag -> str;
+'''
+
+
 PersonT = "Person"
 NoteT = "Note"
 DB1 = mk_db([

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -631,7 +631,10 @@ class PathFinder(NodeVisitor):
             self.in_optional, self.in_subquery = old
 
     def visit_BinOp(self, query: qlast.BinOp) -> None:
-        self.visit_func_or_op(query.op, [query.left, query.right])
+        self.visit_func_or_op(query.op.upper(), [query.left, query.right])
+
+    def visit_UnaryOp(self, query: qlast.UnaryOp) -> None:
+        self.visit_func_or_op(query.op.upper(), [query.operand])
 
     def visit_FunctionCall(self, query: qlast.FunctionCall) -> None:
         assert not query.kwargs

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -3,20 +3,37 @@
 """Toy evaluator model for an edgeql subset.
 
 The idea here is to be able to test queries against a simple semantics
-driven evaluator model.
+driven evaluator model. The core of this is basically a transcription
+of the "EdgeQL - Overview" section of the docs.
 
 This version does not have any understanding of schemas and has the
 function signatures and behaviors of a bunch of basic functions
 hardcoded in.
 
-The data model is a super simple in-memory one, though it shouldn't be
-too hard to populate it from a real DB or vice versa to do testing.
+The data model is a super simple in-memory one hardcoded into this
+file, though it shouldn't be too hard to populate it from a real DB or
+vice versa to do testing.
 
-It is a goal that this can be scaled up to be pointed at different
-corners of the language. It is a non-goal that it can be scaled up to
-be a full evaluator model.
+It is a goal that this can usefully be pointed at different corners of
+the language for testing. It is a non-goal that it can be scaled up to
+be a full evaluator model; if it can serve as the basis of one, great,
+but I'm not worrying about that yet. If we have to start from scratch,
+also fine, because this one is pretty simple so not much will be lost
+in throwing it away.
 
 Also a non-goal: performance.
+
+Right now we support some really basic queries:
+ * SELECT with no clauses and no shapes
+ * A smattering of basic functions, including OPTIONAL and SET OF ones
+ * Tuples, int and str literals, set literals, str and int casts
+ * Properties, forward links
+
+There is no type or error checking.
+
+Run this with -i as an argument for a bad REPL that can be noodled
+around in. I've tested out a bunch of queries playing around but this
+hasn't gotten any particular rigorous testing against the real DB.
 
 """
 

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -457,6 +457,19 @@ def go(q: qlast.Expr) -> None:
     debug.dump(out)
 
 
+def repl() -> None:
+    # for now just use rlwrap since I don't want to fiddle with
+    # history or anything
+    while True:
+        print("> ", end="", flush=True)
+        s = ""
+        while ';' not in s:
+            s += sys.stdin.readline()
+            if not s:
+                return
+        go(parse(s))
+
+
 QUERY = '''
 SELECT Person.name ++ "-" ++ Person.notes.name
 '''
@@ -471,6 +484,9 @@ SELECT (Person.name, (SELECT Note.name), (SELECT Note.name));
 '''
 
 def main() -> None:
+    if sys.argv[1:] == ['-i']:
+        return repl()
+
     q = parse(QUERY3)
     debug.dump(q)
     go(q)

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -23,12 +23,20 @@ in throwing it away.
 
 Also a non-goal: performance.
 
-Right now we support some really basic queries:
- * SELECT, including shapes (but computables can't be reused)
- * WITH, FOR
- * A smattering of basic functions, including OPTIONAL and SET OF ones
- * Tuples, int, bool, float str literals, set literals, str and int casts
- * Properties, links, type intersections
+Right now we support a lot of the core SELECT fragment of the language,
+but are missing:
+ * Any DML at all
+ * DETACHED
+ * Losing shape information from non-visible queries
+ * Most casts (we support int and str casts)
+ * Most of the standard library, except for some basic functions
+ * Any understanding of modules
+ * Any understanding of the schema or the type hierarchy
+ * Cardinality inference for shape elements; everything is reported as as list
+
+Cardinality inference is one of the big open design questions that I have:
+is there a reasonable way that we could implement it as a mostly-dynamic
+analysis, without needing a full separate cardinality checker?
 
 There is no type or error checking.
 

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -1397,6 +1397,19 @@ DB1 = mk_db([
     # Foo
     {"id": bsid(0x30), "__type__": FooT, "val": "a"},
     {"id": bsid(0x31), "__type__": FooT, "val": "b", "opt": 111},
+
+    # volatility
+    {"id": bsid(0x81), "__type__": "Tgt", "n": 1},
+    {"id": bsid(0x82), "__type__": "Tgt", "n": 2},
+    {"id": bsid(0x83), "__type__": "Tgt", "n": 3},
+    {"id": bsid(0x84), "__type__": "Tgt", "n": 4},
+
+    {"id": bsid(0x91), "__type__": "Obj", "n": 1,
+     "tgt": [bslink(0x81), bslink(0x82)]},
+    {"id": bsid(0x92), "__type__": "Obj", "n": 2,
+     "tgt": [bslink(0x82), bslink(0x83)]},
+    {"id": bsid(0x93), "__type__": "Obj", "n": 3,
+     "tgt": [bslink(0x83), bslink(0x84)]},
 ] + load_json_db(CARDS_DB))
 
 parser = argparse.ArgumentParser(description='Toy EdgeQL eval model')

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -61,6 +61,7 @@ import uuid
 import itertools
 import operator
 import functools
+import traceback
 
 
 T = TypeVar('T')
@@ -635,8 +636,8 @@ def go(q: qlast.Expr, db: DB=DB1) -> None:
 
 
 def repl() -> None:
-    # for now just use rlwrap since I don't want to fiddle with
-    # history or anything
+    # for now users should just invoke this script with rlwrap since I
+    # don't want to fiddle with history or anything
     while True:
         print("> ", end="", flush=True)
         s = ""
@@ -644,7 +645,10 @@ def repl() -> None:
             s += sys.stdin.readline()
             if not s:
                 return
-        go(parse(s))
+        try:
+            go(parse(s))
+        except Exception:
+            traceback.print_exception(*sys.exc_info())
 
 
 QUERY = '''

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -609,7 +609,7 @@ def eval_ptr(base: Data, ptr: IPtr, ctx: EvalContext) -> List[Data]:
 def eval_intersect(
         base: Data, ptr: ITypeIntersection, ctx: EvalContext) -> List[Data]:
     # TODO: we want actual types but for now we just match directly
-    typ = ctx.db[base["id"]]["__type__"]
+    typ = ctx.db[base.id]["__type__"]
     return [base] if typ == ptr.typ else []
 
 
@@ -945,6 +945,207 @@ type Foo {
 '''
 
 
+def load_json_obj(obj):
+    new_obj = {}
+    for k, v in obj.items():
+        if k == 'id':
+            v = uuid.UUID(v)
+        elif k == 'typ':
+            k = '__type__'
+            v = v.replace('test::', '')
+
+        vs = v if isinstance(v, list) else [v]
+        nvs = []
+        for v1 in vs:
+            if isinstance(v1, dict):
+                lprops = {lk[1:]: lv for lk, lv in v1.items() if lk[0] == '@'}
+                v1 = Obj(uuid.UUID(v1['id']), lprops=lprops)
+            nvs.append(v1)
+        nv = nvs if isinstance(v, list) else nvs[0]
+
+        new_obj[k] = nv
+    return new_obj
+
+
+def load_json_db(data):
+    return [load_json_obj(obj) for obj in data]
+
+
+null: None = None
+CARDS_DB = [
+    {
+        "avatar": {
+            "@text": "Best",
+            "id": "81537667-c308-11eb-98b8-e7ee6a203949"
+        },
+        "awards": [
+            {"id": "81537661-c308-11eb-98b8-d7ab026ed715"},
+            {"id": "81537663-c308-11eb-98b8-47f340f064e1"}
+        ],
+        "deck": [
+            {"@count": 2, "id": "81537666-c308-11eb-98b8-67d1235c4527"},
+            {"@count": 2, "id": "81537667-c308-11eb-98b8-e7ee6a203949"},
+            {"@count": 3, "id": "81537668-c308-11eb-98b8-2b363efb8a80"},
+            {"@count": 3, "id": "81537669-c308-11eb-98b8-c37076e778d2"}
+        ],
+        "friends": [
+            {
+                "@nickname": "Swampy",
+                "id": "81537670-c308-11eb-98b8-d3d2e939fbfc"
+            },
+            {
+                "@nickname": "Firefighter",
+                "id": "81537671-c308-11eb-98b8-6b6a92e0be3e"
+            },
+            {
+                "@nickname": "Grumpy",
+                "id": "81537672-c308-11eb-98b8-53b70c263a56"
+            }
+        ],
+        "id": "8153766f-c308-11eb-98b8-af7e8ffd99f3",
+        "name": "Alice",
+        "typ": "test::User"
+    },
+    {
+        "avatar": null,
+        "awards": [{"id": "81537665-c308-11eb-98b8-a7fee63c63ca"}],
+        "deck": [
+            {"@count": 3, "id": "81537668-c308-11eb-98b8-2b363efb8a80"},
+            {"@count": 3, "id": "81537669-c308-11eb-98b8-c37076e778d2"},
+            {"@count": 3, "id": "8153766a-c308-11eb-98b8-330dce42eb46"},
+            {"@count": 3, "id": "8153766b-c308-11eb-98b8-430d489d7125"}
+        ],
+        "friends": [],
+        "id": "81537670-c308-11eb-98b8-d3d2e939fbfc",
+        "name": "Bob",
+        "typ": "test::User"
+    },
+    {
+        "avatar": null,
+        "awards": [],
+        "deck": [
+            {"@count": 3, "id": "81537668-c308-11eb-98b8-2b363efb8a80"},
+            {"@count": 2, "id": "81537669-c308-11eb-98b8-c37076e778d2"},
+            {"@count": 4, "id": "8153766a-c308-11eb-98b8-330dce42eb46"},
+            {"@count": 2, "id": "8153766b-c308-11eb-98b8-430d489d7125"},
+            {"@count": 4, "id": "8153766c-c308-11eb-98b8-5bd98eec95bd"},
+            {"@count": 3, "id": "8153766d-c308-11eb-98b8-8b072b1a5f69"},
+            {"@count": 1, "id": "8153766e-c308-11eb-98b8-1b59432eef87"}
+        ],
+        "friends": [],
+        "id": "81537671-c308-11eb-98b8-6b6a92e0be3e",
+        "name": "Carol",
+        "typ": "test::User"
+    },
+    {
+        "avatar": null,
+        "awards": [],
+        "deck": [
+            {"@count": 1, "id": "81537667-c308-11eb-98b8-e7ee6a203949"},
+            {"@count": 1, "id": "81537668-c308-11eb-98b8-2b363efb8a80"},
+            {"@count": 1, "id": "81537669-c308-11eb-98b8-c37076e778d2"},
+            {"@count": 1, "id": "8153766b-c308-11eb-98b8-430d489d7125"},
+            {"@count": 4, "id": "8153766c-c308-11eb-98b8-5bd98eec95bd"},
+            {"@count": 1, "id": "8153766d-c308-11eb-98b8-8b072b1a5f69"},
+            {"@count": 1, "id": "8153766e-c308-11eb-98b8-1b59432eef87"}
+        ],
+        "friends": [
+            {"@nickname": null, "id": "81537670-c308-11eb-98b8-d3d2e939fbfc"}
+        ],
+        "id": "81537672-c308-11eb-98b8-53b70c263a56",
+        "name": "Dave",
+        "typ": "test::User"
+    },
+    {
+        "awards": [{"id": "81537663-c308-11eb-98b8-47f340f064e1"}],
+        "cost": 1,
+        "element": "Fire",
+        "id": "81537666-c308-11eb-98b8-67d1235c4527",
+        "name": "Imp",
+        "typ": "test::Card"
+    },
+    {
+        "awards": [{"id": "81537661-c308-11eb-98b8-d7ab026ed715"}],
+        "cost": 5,
+        "element": "Fire",
+        "id": "81537667-c308-11eb-98b8-e7ee6a203949",
+        "name": "Dragon",
+        "typ": "test::Card"
+    },
+    {
+        "awards": [],
+        "cost": 2,
+        "element": "Water",
+        "id": "81537668-c308-11eb-98b8-2b363efb8a80",
+        "name": "Bog monster",
+        "typ": "test::Card"
+    },
+    {
+        "awards": [],
+        "cost": 3,
+        "element": "Water",
+        "id": "81537669-c308-11eb-98b8-c37076e778d2",
+        "name": "Giant turtle",
+        "typ": "test::Card"
+    },
+    {
+        "awards": [],
+        "cost": 1,
+        "element": "Earth",
+        "id": "8153766a-c308-11eb-98b8-330dce42eb46",
+        "name": "Dwarf",
+        "typ": "test::Card"
+    },
+    {
+        "awards": [],
+        "cost": 3,
+        "element": "Earth",
+        "id": "8153766b-c308-11eb-98b8-430d489d7125",
+        "name": "Golem",
+        "typ": "test::Card"
+    },
+    {
+        "awards": [],
+        "cost": 1,
+        "element": "Air",
+        "id": "8153766c-c308-11eb-98b8-5bd98eec95bd",
+        "name": "Sprite",
+        "typ": "test::Card"
+    },
+    {
+        "awards": [],
+        "cost": 2,
+        "element": "Air",
+        "id": "8153766d-c308-11eb-98b8-8b072b1a5f69",
+        "name": "Giant eagle",
+        "typ": "test::Card"
+    },
+    {
+        "awards": [{"id": "81537665-c308-11eb-98b8-a7fee63c63ca"}],
+        "cost": 4,
+        "element": "Air",
+        "id": "8153766e-c308-11eb-98b8-1b59432eef87",
+        "name": "Djinn",
+        "typ": "test::SpecialCard"
+    },
+    {
+        "id": "81537661-c308-11eb-98b8-d7ab026ed715",
+        "name": "1st",
+        "typ": "test::Award"
+    },
+    {
+        "id": "81537663-c308-11eb-98b8-47f340f064e1",
+        "name": "2nd",
+        "typ": "test::Award"
+    },
+    {
+        "id": "81537665-c308-11eb-98b8-a7fee63c63ca",
+        "name": "3rd",
+        "typ": "test::Award"
+    }
+]
+
+
 PersonT = "Person"
 NoteT = "Note"
 FooT = "Foo"
@@ -965,7 +1166,7 @@ DB1 = mk_db([
     # Foo
     {"id": bsid(0x30), "__type__": FooT, "val": "a"},
     {"id": bsid(0x31), "__type__": FooT, "val": "b", "opt": 111},
-])
+] + load_json_db(CARDS_DB))
 
 
 def main() -> None:

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -916,11 +916,17 @@ type Person {
     optional multi property multi_prop -> str;
     multi link notes -> Note;
     optional single property tag -> str;
+}
+type Foo {
+    required single property val -> str;
+    optional single property opt -> int64;
+}
 '''
 
 
 PersonT = "Person"
 NoteT = "Note"
+FooT = "Foo"
 DB1 = mk_db([
     # Person
     {"id": bsid(0x10), "__type__": PersonT,
@@ -933,6 +939,10 @@ DB1 = mk_db([
     {"id": bsid(0x20), "__type__": NoteT, "name": "boxing"},
     {"id": bsid(0x21), "__type__": NoteT, "name": "unboxing", "note": "lolol"},
     {"id": bsid(0x22), "__type__": NoteT, "name": "dynamic", "note": "blarg"},
+
+    # Foo
+    {"id": bsid(0x30), "__type__": FooT, "val": "a"},
+    {"id": bsid(0x31), "__type__": FooT, "val": "b", "opt": 111},
 ])
 
 

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -364,6 +364,9 @@ def eval_Select(node: qlast.SelectQuery, ctx: EvalContext) -> List[Data]:
     subqs = [node.where] + [x.path for x in orderby]
     new_qil, out = subquery_full(node.result, extra_subqs=subqs, ctx=ctx)
     new_qil += [(IPartial(),)]
+    if node.result_alias:
+        out = [row + (row[-1],) for row in out]
+        new_qil += [(IORef(node.result_alias),)]
 
     out = eval_filter(node.where, new_qil, out, ctx=ctx)
     out = eval_orderby(orderby, new_qil, out, ctx=ctx)

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -561,7 +561,7 @@ def eval_path(path: IPath, ctx: EvalContext) -> List[Data]:
         else:
             out.extend(eval_intersect(obj, ptr, ctx))
     # We need to deduplicate links.
-    if isinstance(base, Obj) and out and isinstance(out[0], Obj):
+    if base and isinstance(base[0], Obj) and out and isinstance(out[0], Obj):
         out = dedup(out)
 
     return out

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -894,7 +894,8 @@ class PathFinder(NodeVisitor):
             self.visit(shape.elements)
 
     def visit_ShapeElement(self, el: qlast.ShapeElement) -> None:
-        self.visit_Path(el.expr, always_partial=True)
+        if not el.compexpr:
+            self.visit_Path(el.expr, always_partial=True)
         self.visit(el.compexpr)
         with self.subquery(), self.update_path(el.expr):
             self.visit(el.elements)

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -56,6 +56,7 @@ from typing import *
 
 
 from edb.common import debug
+from edb.common.compiler import SimpleCounter
 from edb import edgeql
 
 from edb.common.ast import NodeVisitor
@@ -256,6 +257,16 @@ def if_(x: Result, bs: Result, y: Result) -> Result:
     return out
 
 
+def bad_array_cast(x: Data) -> Result:
+    if x != []:
+        raise ValueError("We only know how to cast empty arrays")
+    return x
+
+
+# For implementing a next() testing function
+NextCounter = SimpleCounter()
+
+
 _BASIS_BINOP_IMPLS: Any = {
     '+': lift(operator.add),
     '-': lift(operator.sub),
@@ -293,6 +304,8 @@ _BASIS_CAST_IMPLS: Any = {
     'str': lift(str),
     'int32': lift(int),
     'int64': lift(int),
+    'uuid': lift(uuid.UUID),
+    'array': lift(bad_array_cast),
 }
 _BASIS_FUNC_IMPLS: Any = {
     'enumerate': enumerate_,
@@ -308,6 +321,8 @@ _BASIS_FUNC_IMPLS: Any = {
     'random': lift(random.random),
     'contains': lift(operator.contains),
     'round': lift(round),
+    'next': lift(NextCounter.nextval),  # testing func, not really in std
+    'uuid_generate_v1mc': lift(uuid.uuid4),
 }
 
 BASIS_IMPLS: Dict[Tuple[str, str], LiftedFunc] = {

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -413,3 +413,23 @@ class TestModelSmokeTests(unittest.TestCase):
             ],
             sort=False,
         )
+
+    def test_edgeql_shape_for_01(self):
+        # we have a lot of trouble with this one in the real compiler.
+        self.assert_test_query(
+            r"""
+            SELECT (FOR x IN {1,2} UNION (SELECT User { m := x })) { name, m }
+            ORDER BY .name THEN .m;
+            """,
+            [
+                {'m': [1], 'name': ['Alice']},
+                {'m': [2], 'name': ['Alice']},
+                {'m': [1], 'name': ['Bob']},
+                {'m': [2], 'name': ['Bob']},
+                {'m': [1], 'name': ['Carol']},
+                {'m': [2], 'name': ['Carol']},
+                {'m': [1], 'name': ['Dave']},
+                {'m': [2], 'name': ['Dave']},
+            ],
+            sort=False,
+        )

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -316,3 +316,100 @@ class TestModelSmokeTests(unittest.TestCase):
             ''',
             [0]
         )
+
+    def test_edgeql_shape_01(self):
+        self.assert_test_query(
+            r"""
+            SELECT User {
+                name,
+                deck: {
+                    name, tag := <str>.cost ++ ' ' ++ .element, @count
+               } ORDER BY .cost
+            } ORDER BY .name DESC;
+            """,
+            [
+                {
+                    "deck": [
+                        {"@count": [4], "name": ["Sprite"], "tag": ["1 Air"]},
+                        {
+                            "@count": [1],
+                            "name": ["Bog monster"],
+                            "tag": ["2 Water"],
+                        },
+                        {
+                            "@count": [1],
+                            "name": ["Giant eagle"],
+                            "tag": ["2 Air"],
+                        },
+                        {
+                            "@count": [1],
+                            "name": ["Giant turtle"],
+                            "tag": ["3 Water"],
+                        },
+                        {"@count": [1], "name": ["Golem"], "tag": ["3 Earth"]},
+                        {"@count": [1], "name": ["Djinn"], "tag": ["4 Air"]},
+                        {"@count": [1], "name": ["Dragon"], "tag": ["5 Fire"]},
+                    ],
+                    "name": ["Dave"],
+                },
+                {
+                    "deck": [
+                        {"@count": [4], "name": ["Dwarf"], "tag": ["1 Earth"]},
+                        {"@count": [4], "name": ["Sprite"], "tag": ["1 Air"]},
+                        {
+                            "@count": [3],
+                            "name": ["Bog monster"],
+                            "tag": ["2 Water"],
+                        },
+                        {
+                            "@count": [3],
+                            "name": ["Giant eagle"],
+                            "tag": ["2 Air"],
+                        },
+                        {
+                            "@count": [2],
+                            "name": ["Giant turtle"],
+                            "tag": ["3 Water"],
+                        },
+                        {"@count": [2], "name": ["Golem"], "tag": ["3 Earth"]},
+                        {"@count": [1], "name": ["Djinn"], "tag": ["4 Air"]},
+                    ],
+                    "name": ["Carol"],
+                },
+                {
+                    "deck": [
+                        {"@count": [3], "name": ["Dwarf"], "tag": ["1 Earth"]},
+                        {
+                            "@count": [3],
+                            "name": ["Bog monster"],
+                            "tag": ["2 Water"],
+                        },
+                        {
+                            "@count": [3],
+                            "name": ["Giant turtle"],
+                            "tag": ["3 Water"],
+                        },
+                        {"@count": [3], "name": ["Golem"], "tag": ["3 Earth"]},
+                    ],
+                    "name": ["Bob"],
+                },
+                {
+                    "deck": [
+                        {"@count": [2], "name": ["Imp"], "tag": ["1 Fire"]},
+                        {
+                            "@count": [3],
+                            "name": ["Bog monster"],
+                            "tag": ["2 Water"],
+                        },
+                        {
+                            "@count": [3],
+                            "name": ["Giant turtle"],
+                            "tag": ["3 Water"],
+                        },
+                        {"@count": [2], "name": ["Dragon"], "tag": ["5 Fire"]},
+                    ],
+                    "name": ["Alice"],
+                },
+            ],
+            sort=False,
+        )

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -433,3 +433,11 @@ class TestModelSmokeTests(unittest.TestCase):
             ],
             sort=False,
         )
+
+    def test_edgeql_detached_01(self):
+        self.assert_test_query(
+            r"""
+            SELECT count((User.deck.name, DETACHED User.name));
+            """,
+            [36],
+        )

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -314,7 +314,20 @@ class TestModelSmokeTests(unittest.TestCase):
                 ),
                 ('Bob', []),
                 ('Carol', []),
-                ('Dave', [])]
+                ('Dave', []),
+            ]
+        )
+
+    def test_edgeql_lprop_reverse_01(self):
+        self.assert_test_query(
+            r'''
+                SELECT count((
+                    Card.name,
+                    Card.<deck[IS User].name,
+                    Card.<deck[IS User]@count,
+                ));
+            ''',
+            [22]
         )
 
     def test_edgeql_partial_path_01(self):

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -249,3 +249,11 @@ class TestModelSmokeTests(unittest.TestCase):
             ''',
             [['Emmanuel Villip', 'Madeline Hatch', 'Phil Emarg']]
         )
+
+    def test_edgeql_lprop_01(self):
+        self.assert_test_query(
+            r'''
+            SELECT (Person.notes.name, Person.notes@metanote ?? '<n/a>')
+            ''',
+            [('boxing', '<n/a>'), ('unboxing', 'arg!'), ('unboxing', 'sigh')],
+        )

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -115,6 +115,30 @@ class TestModelSmokeTests(unittest.TestCase):
             [('boxing', False), ('unboxing', True), ('dynamic', True)]
         )
 
+    def test_model_optional_prop_05(self):
+        self.assert_test_query(
+            r"""
+            SELECT (User.name ++ User.avatar.name) ?? 'hm';
+            """,
+            ['AliceDragon'],
+        )
+
+    def test_model_optional_prop_06(self):
+        self.assert_test_query(
+            r"""
+            SELECT User.name ?= User.name;
+            """,
+            [True, True, True, True],
+        )
+
+    def test_model_optional_prop_07(self):
+        self.assert_test_query(
+            r"""
+            SELECT (User.name ?= 'Alice', count(User.name))
+            """,
+            [(True, 1), (False, 1), (False, 1), (False, 1)],
+        )
+
     def test_model_subqueries_01(self):
         self.assert_test_query(
             r"""

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -1,0 +1,227 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2012-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import unittest
+
+from edb.tools import toy_eval_model as model
+
+
+class TestModelSmokeTests(unittest.TestCase):
+    """Unit tests for the toy evaluator model.
+
+    These are intended as smoke tests. Since obviously we don't want
+    two totally parallel sets of tests for EdgeQL queries, an eventual
+    goal should be that we could run the real tests against the model.
+    """
+
+    DB1 = model.DB1
+
+    def assert_test_query(self, query, expected, *, db=DB1, sort=True):
+        qltree = model.parse(query)
+        result = model.go(qltree, db)
+        if sort:
+            result.sort()
+            expected.sort()
+
+        self.assertEqual(expected, result)
+
+    def test_model_basic_01(self):
+        self.assert_test_query(
+            "SELECT 1",
+            [1],
+        )
+
+    def test_model_basic_02(self):
+        self.assert_test_query(
+            r"""
+            SELECT Person.name
+            """,
+            ['Phil Emarg', 'Madeline Hatch', 'Emmanuel Villip'],
+        )
+
+    def test_model_basic_03(self):
+        self.assert_test_query(
+            r"""
+            SELECT (Person.name, Person.name)
+            """,
+            [('Phil Emarg', 'Phil Emarg'),
+             ('Madeline Hatch', 'Madeline Hatch'),
+             ('Emmanuel Villip', 'Emmanuel Villip')]
+        )
+
+    def test_model_link_dedup(self):
+        self.assert_test_query(
+            r"""
+            SELECT Person.notes.name
+            """,
+            ['boxing', 'unboxing'],
+        )
+
+    def test_model_link_correlation(self):
+        self.assert_test_query(
+            r"""
+            SELECT Person.name ++ "-" ++ Person.notes.name
+            """,
+            ['Phil Emarg-boxing', 'Phil Emarg-unboxing',
+             'Madeline Hatch-unboxing']
+        )
+
+    def test_model_optional_prop_01(self):
+        self.assert_test_query(
+            r"""
+            SELECT (Note.note ?= "lolol", Note.name)
+            """,
+            [(False, 'boxing'), (True, 'unboxing'), (False, 'dynamic')]
+        )
+
+    def test_model_optional_prop_02(self):
+        self.assert_test_query(
+            r"""
+            SELECT (Note.note = "lolol", Note.name)
+            """,
+            [(False, 'dynamic'), (True, 'unboxing')]
+        )
+
+    def test_model_optional_prop_03(self):
+        self.assert_test_query(
+            r"""
+            SELECT (Note.name, ('SOME "' ++ Note.note ++ '"') ?? 'NONE')
+            """,
+            [('boxing', 'NONE'), ('unboxing', 'SOME "lolol"'),
+             ('dynamic', 'SOME "blarg"')]
+        )
+
+    def test_model_optional_prop_04(self):
+        self.assert_test_query(
+            r"""
+            SELECT (Note.name, EXISTS Note.note)
+            """,
+            [('boxing', False), ('unboxing', True), ('dynamic', True)]
+        )
+
+    def test_model_subqueries_01(self):
+        self.assert_test_query(
+            r"""
+            SELECT count(((SELECT Person), (SELECT Person)))
+            """,
+            [9]
+        )
+
+    def test_model_subqueries_02(self):
+        self.assert_test_query(
+            r"""
+            WITH X := {true, false, true} SELECT (any(X), all(X))
+            """,
+            [(True, False)]
+        )
+
+    def test_model_subqueries_03(self):
+        self.assert_test_query(
+            r"""
+            SELECT enumerate((SELECT X := {"foo", "bar", "baz"} ORDER BY X));
+            """,
+            [(0, 'bar'), (1, 'baz'), (2, 'foo')],
+            sort=False,
+        )
+
+    def test_edgeql_coalesce_set_of_01(self):
+        self.assert_test_query(
+            r'''
+
+                SELECT <str>Publication.id ?? <str>count(Publication)
+            ''',
+            ['0'],
+        )
+
+    def test_edgeql_coalesce_set_of_02(self):
+        self.assert_test_query(
+            r'''
+                SELECT (
+                    Publication ?= Publication,
+                    (Publication.title++Publication.title
+                       ?= Publication.title) ?=
+                    (Publication ?!= Publication)
+                )
+            ''',
+            [(True, False)]
+        )
+
+    def test_edgeql_select_clauses_01(self):
+        self.assert_test_query(
+            r'''
+            SELECT (Person.name, Person.notes.name)
+            FILTER Person.name != "Madeline Hatch"
+            ORDER BY .1 DESC;
+            ''',
+            [('Phil Emarg', 'unboxing'), ('Phil Emarg', 'boxing')],
+            sort=False,
+        )
+
+    def test_edgeql_select_clauses_02(self):
+        # This is a funky one.
+        self.assert_test_query(
+            r'''
+            SELECT (
+                Person.name,
+                (SELECT Person.notes.name
+                 ORDER BY Person.notes.name DESC
+                 LIMIT (0 if Person.name = "Madeline Hatch" ELSE 1)));
+            ''',
+            [('Phil Emarg', 'unboxing')]
+        )
+
+    def test_edgeql_select_clauses_03(self):
+        self.assert_test_query(
+            r'''
+            WITH X := {9, 8, 7, 6, 5, 4, 3, 2, 1}
+            SELECT _ := X
+            FILTER _ % 2 = 1
+            ORDER BY _
+            OFFSET 2
+            LIMIT 2
+            ''',
+            [5, 7],
+        )
+
+    def test_edgeql_for_01(self):
+        self.assert_test_query(
+            r'''
+            FOR X IN {1,2,3} UNION ((SELECT X), (SELECT X));
+            ''',
+            [(1, 1), (2, 2), (3, 3)],
+        )
+
+    def test_edgeql_with_01(self):
+        self.assert_test_query(
+            r'''
+            WITH X := {1, 2} SELECT ((SELECT X), (SELECT X));
+            ''',
+            [(1, 1), (1, 2), (2, 1), (2, 2)]
+        )
+
+    def test_edgeql_with_02(self):
+        # For a while, the model produced the right answer here while
+        # the real compiler didn't!
+        # See https://github.com/edgedb/edgedb/issues/1381
+        self.assert_test_query(
+            r'''
+            WITH X := {1, 2}, Y := X+1 SELECT (X, Y);
+            ''',
+            [(1, 2), (1, 3), (2, 2), (2, 3)]
+        )

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -257,3 +257,38 @@ class TestModelSmokeTests(unittest.TestCase):
             ''',
             [('boxing', '<n/a>'), ('unboxing', 'arg!'), ('unboxing', 'sigh')],
         )
+
+    def test_edgeql_lprop_02(self):
+        self.assert_test_query(
+            r'''
+            SELECT (User.name,
+                    (SELECT (User.friends.name, User.friends@nickname)));
+            ''',
+            [
+                ("Alice", ("Bob", "Swampy")),
+                ("Alice", ("Carol", "Firefighter")),
+                ("Alice", ("Dave", "Grumpy"))
+            ]
+        )
+
+    def test_edgeql_lprop_03(self):
+        self.assert_test_query(
+            r'''
+                SELECT (
+                    User.name,
+                    array_agg(
+                        (SELECT (User.friends.name, User.friends@nickname))));
+            ''',
+            [
+                (
+                    'Alice',
+                    [
+                        ('Bob', 'Swampy'),
+                        ('Carol', 'Firefighter'),
+                        ('Dave', 'Grumpy')
+                    ],
+                ),
+                ('Bob', []),
+                ('Carol', []),
+                ('Dave', [])]
+        )

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -225,3 +225,27 @@ class TestModelSmokeTests(unittest.TestCase):
             ''',
             [(1, 2), (1, 3), (2, 2), (2, 3)]
         )
+
+    def test_edgeql_array_01(self):
+        self.assert_test_query(
+            r'''
+            WITH X := [0,1,2,3,4,5,6,7,8,9] SELECT X[{1,2}:{5,6}];
+            ''',
+            [[1, 2, 3, 4], [1, 2, 3, 4, 5], [2, 3, 4], [2, 3, 4, 5]],
+        )
+
+    def test_edgeql_array_02(self):
+        self.assert_test_query(
+            r'''
+            SELECT array_unpack({[1,2,3],[3,4,5]});
+            ''',
+            [1, 2, 3, 3, 4, 5]
+        )
+
+    def test_edgeql_array_03(self):
+        self.assert_test_query(
+            r'''
+            SELECT array_agg(Person.name ORDER BY Person.name);
+            ''',
+            [['Emmanuel Villip', 'Madeline Hatch', 'Phil Emarg']]
+        )

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -292,3 +292,27 @@ class TestModelSmokeTests(unittest.TestCase):
                 ('Carol', []),
                 ('Dave', [])]
         )
+
+    def test_edgeql_partial_path_01(self):
+        self.assert_test_query(
+            r'''
+            SELECT (SELECT User FILTER User.deck != .deck).name;
+            ''',
+            []
+        )
+
+    def test_edgeql_partial_path_02(self):
+        self.assert_test_query(
+            r'''
+            SELECT count((SELECT X := User FILTER User.deck != .deck));
+            ''',
+            [4]
+        )
+
+    def test_edgeql_partial_path_03(self):
+        self.assert_test_query(
+            r'''
+            SELECT count((SELECT X := User FILTER X.deck != .deck));
+            ''',
+            [0]
+        )

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -231,6 +231,14 @@ class TestModelSmokeTests(unittest.TestCase):
             [(1, 1), (2, 2), (3, 3)],
         )
 
+    def test_edgeql_for_02(self):
+        self.assert_test_query(
+            r'''
+            WITH X := 1, FOR x in {X} UNION (x);
+            ''',
+            [1],
+        )
+
     def test_edgeql_with_01(self):
         self.assert_test_query(
             r'''

--- a/tests/test_eval_model.py
+++ b/tests/test_eval_model.py
@@ -318,6 +318,14 @@ class TestModelSmokeTests(unittest.TestCase):
             ]
         )
 
+    def test_edgeql_lprop_04(self):
+        self.assert_test_query(
+            r'''
+                SELECT count(Card.<deck[IS User]@count);
+            ''',
+            [22]
+        )
+
     def test_edgeql_lprop_reverse_01(self):
         self.assert_test_query(
             r'''
@@ -328,6 +336,21 @@ class TestModelSmokeTests(unittest.TestCase):
                 ));
             ''',
             [22]
+        )
+
+    def test_edgeql_lprop_reverse_02(self):
+        # This should (I claim), but does not yet, work for real.
+        self.assert_test_query(
+            r'''
+                SELECT Card {
+                    name,
+                    z := .<deck[IS User] { name, @count }
+                } FILTER .name = 'Dragon'
+            ''',
+            [{"name": ["Dragon"], "z": [
+                {"name": ["Alice"], "@count": [2]},
+                {"name": ["Dave"], "@count": [1]},
+            ]}]
         )
 
     def test_edgeql_partial_path_01(self):


### PR DESCRIPTION
It can handle a pretty big chunk of the non-DML side of the language.
It operates against a hard-coded in-memory database that contains
the `cards` test database and some other stuff.

The *biggest* limitations right now is that it doesn't have any
understanding of a schema (so no inheritance or schema-defined
computables) and that it doesn't understand cardinality at all, so
all shape elements are returned as lists.

I've found this pretty useful in trying to double-check whether real
compiler behaviors seem correct or not.