### PR TITLE
add --auto-shutdown-after option to edgedb-server

### DIFF
--- a/docs/cheatsheet/select.rst
+++ b/docs/cheatsheet/select.rst
@@ -157,3 +157,18 @@ Perform a set intersection of all actors with all directors:
         Director := Movie.director,
     # set intersection is done via the FILTER clause
     SELECT Actor FILTER Actor IN Director;
+
+
+----------
+
+
+To order a set of scalars first assign the set to a variable and use the
+variable in the ORDER BY clause.
+
+.. code-block:: edgeql
+
+    SELECT numbers := {3, 1, 2} ORDER BY numbers;
+
+    # alternativly
+    WITH numbers := {3, 1, 2}
+    SELECT numbers ORDER BY numbers;

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -186,7 +186,7 @@ async def _run_server(
             compiler_pool_size=args.compiler_pool_size,
             nethost=args.bind_address,
             netport=args.port,
-            auto_shutdown=args.auto_shutdown,
+            auto_shutdown_after=args.auto_shutdown_after,
             echo_runtime_info=args.echo_runtime_info,
             status_sink=args.status_sink,
             startup_script=args.startup_script,

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1547,7 +1547,7 @@ class _EdgeDBServer:
             cmd += ['--bootstrap-command', bootstrap_command]
 
         if self.auto_shutdown:
-            cmd += ['--auto-shutdown']
+            cmd += ['--auto-shutdown-after', '0']
 
         if self.runstate_dir:
             cmd += ['--runstate-dir', self.runstate_dir]

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -52,7 +52,7 @@ class TestServerOps(tb.TestCase):
         #
         # * "--port=auto"
         # * "--temp-dir"
-        # * "--auto-shutdown"
+        # * "--auto-shutdown-after=0"
         # * "--emit-server-status"
 
         async with tb.start_edgedb_server(
@@ -73,7 +73,7 @@ class TestServerOps(tb.TestCase):
             with self.assertRaises(
                     (ConnectionError, edgedb.ClientConnectionError)):
                 # Since both con1 and con2 are now disconnected and
-                # the cluster was started with an "--auto-shutdown"
+                # the cluster was started with an "--auto-shutdown-after=0"
                 # option, we expect this connection to be rejected
                 # and the cluster to be shutdown soon.
                 await edgedb.async_connect(


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb/issues/2565

The new option shuts down the server when all clients have disconnected and no new clients have connected in N seconds.