### PR TITLE
add IF NOT EXISTS to DESCRIBE ROLES output

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -2387,10 +2387,10 @@ class DescribeRolesAsDDLFunction(dbops.Function):
                             WHERE member.source = role.id
                         ), ' EXTENDING '),
                         CASE WHEN role.{qi(pass_col)} IS NOT NULL THEN
-                            concat(' {{ SET password_hash := ',
+                            concat(' IF NOT EXISTS {{ SET password_hash := ',
                                    quote_literal(role.{qi(pass_col)}),
                                    '}};')
-                        ELSE ';' END
+                        ELSE ' IF NOT EXISTS;' END
                     )
                 END,
                 '\n'

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6629,8 +6629,8 @@ type default::Foo {
             };
         """)
         roles = next(iter(await self.con.query("DESCRIBE ROLES")))
-        base1 = roles.index('CREATE SUPERUSER ROLE `base1`;')
-        base2 = roles.index('CREATE SUPERUSER ROLE `base 2`;')
+        base1 = roles.index('CREATE SUPERUSER ROLE `base1` IF NOT EXISTS;')
+        base2 = roles.index('CREATE SUPERUSER ROLE `base 2` IF NOT EXISTS;')
         child1 = roles.index('CREATE SUPERUSER ROLE `child1`')
         child2 = roles.index('CREATE SUPERUSER ROLE `child2`')
         child3 = roles.index('CREATE SUPERUSER ROLE `child3`')


### PR DESCRIPTION
This allows restoring from a dump when the dumped roles already exist in the target instance.