### PR TITLE
Get rid of the temporary scope mechanism

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -91,11 +91,7 @@ def new_set(
 
         with ctx.detached() as subctx:
             subctx.expr_exposed = False
-            # This is a global rewrite operation that is done once
-            # per type, and so we don't really care if we're in a
-            # temporary scope or not.
             subctx.path_scope = subctx.env.path_scope.root
-            subctx.in_temp_scope = False
             # Put a placeholder to prevent recursion.
             subctx.type_rewrites[stype] = irast.Set()
             filtered_set = dispatch.compile(qry, ctx=subctx)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -585,17 +585,19 @@ def compile_InsertQuery(
 
         result = fini_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 
-        # If we have an ELSE clause, we need to compile_query_subject
-        # *again* on the outer query, in order to produce a view for
-        # the joined output, which we need to have to generate the
-        # proper type descriptor.
-        # This feels like somewhat of a hack; I think it might be
-        # possible to do something more general elsewhere.
-        if expr.unless_conflict and expr.unless_conflict[1]:
+        # If we have an ELSE clause, and this is a toplevel statement,
+        # we need to compile_query_subject *again* on the outer query,
+        # in order to produce a view for the joined output, which we
+        # need to have to generate the proper type descriptor.  This
+        # feels like somewhat of a hack; I think it might be possible
+        # to do something more general elsewhere.
+        if (
+            expr.unless_conflict
+            and expr.unless_conflict[1]
+            and ictx.stmt is ctx.toplevel_stmt
+        ):
             with ictx.new() as resultctx:
-                if ictx.stmt is ctx.toplevel_stmt:
-                    resultctx.expr_exposed = True
-
+                resultctx.expr_exposed = True
                 result = compile_query_subject(
                     result,
                     view_name=ctx.toplevel_result_view_name,

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -573,8 +573,7 @@ def declare_view_from_schema(
 
         vc = subctx.aliased_views[viewcls_name]
         assert vc is not None
-        if not ctx.in_temp_scope:
-            ctx.env.schema_view_cache[viewcls] = vc
+        ctx.env.schema_view_cache[viewcls] = vc
         ctx.source_map.update(subctx.source_map)
         ctx.aliased_views[viewcls_name] = subctx.aliased_views[viewcls_name]
         ctx.view_nodes[vc.get_name(ctx.env.schema)] = vc

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -82,7 +82,9 @@ def _ql_typeexpr_to_type(
         ctx: context.ContextLevel) -> List[s_types.Type]:
 
     if isinstance(ql_t, qlast.TypeOf):
-        with ctx.newscope(fenced=True, temporary=True) as subctx:
+        with ctx.new() as subctx:
+            # Use an empty scope tree, to avoid polluting things pointlessly
+            subctx.path_scope = irast.ScopeTreeNode()
             ir_set = setgen.ensure_set(dispatch.compile(ql_t.expr, ctx=subctx),
                                        ctx=subctx)
             stype = setgen.get_set_type(ir_set, ctx=subctx)

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -78,8 +78,10 @@ def process_view(
     if view_scls is not None:
         return view_scls
 
-    with ctx.newscope(fenced=True, temporary=True) as scopectx:
+    with ctx.newscope(fenced=True) as scopectx:
         scopectx.path_scope.attach_path(path_id, context=parser_context)
+        if ctx.path_log is not None:
+            ctx.path_log.append(path_id)
         view_path_id_ns = None
         if ctx.expr_exposed or is_insert or is_update:
             view_path_id_ns = irast.WeakNamespace(ctx.aliases.get('ns'))
@@ -524,8 +526,10 @@ def _normalize_view_ptr_expr(
                 ns=ctx.path_id_namespace,
                 ctx=ctx)
 
-            ctx.path_scope.attach_path(sub_path_id,
-                                       context=shape_el.context)
+            if ctx.path_log is not None:
+                ctx.path_log.append(sub_path_id)
+            ctx.path_scope.attach_path(
+                sub_path_id, context=shape_el.context)
 
             if not isinstance(ptr_target, s_objtypes.ObjectType):
                 raise errors.QueryError(

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -111,24 +111,6 @@ class ScopeTreeNode:
         name = 'ScopeFenceNode' if self.fenced else 'ScopeTreeNode'
         return (f'<{name} {self.path_id!r} at {id(self):0x}>')
 
-    def _copy(self, parent: Optional[ScopeTreeNode]) -> ScopeTreeNode:
-        cp = self.__class__(
-            path_id=self.path_id,
-            fenced=self.fenced)
-        cp.optional_count = self.optional_count
-        cp.unnest_fence = self.unnest_fence
-        cp.factoring_fence = self.factoring_fence
-        cp.namespaces = set(self.namespaces)
-        cp.unique_id = self.unique_id
-        cp.factoring_allowlist = set(self.factoring_allowlist)
-        cp.protect_parent = self.protect_parent
-        cp._set_parent(parent)
-
-        for child in self.children:
-            child._copy(parent=cp)
-
-        return cp
-
     @property
     def forwarded(self) -> ScopeTreeNode:
         node = self
@@ -908,21 +890,6 @@ class ScopeTreeNode:
                 return node
 
         return None
-
-    def copy(self) -> ScopeTreeNode:
-        """Return a complete copy of this subtree."""
-        return self._copy(parent=None)
-
-    def copy_all(self) -> Tuple[ScopeTreeNode, ScopeTreeNode]:
-        """Make a copy the entire tree and return the copy of this node."""
-        if self.unique_id is None:
-            self.unique_id = -1
-        new = self.root.copy()
-        me = new.find_by_unique_id(self.unique_id)
-        assert me
-        if self.unique_id == -1:
-            self.unique_id = None
-        return new, me
 
     def pformat(self) -> str:
         if self.children:

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -102,6 +102,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(default::Card)",
             "(default::Card).<deck[IS __derived__::(opaque: default:User)]\
 .>indirection[IS default::User]": {
+                "[ns~1]@@(default::Card)\
+.<deck[IS __derived__::(opaque: default:User)]",
                 "(default::Card)\
 .<deck[IS __derived__::(opaque: default:User)]",
                 "[ns~1]@[ns~2]@@(default::Card)\
@@ -128,6 +130,10 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 .>indirection[IS default::User]": {
                 "(default::Card)\
 .<deck[IS __derived__::(opaque: default:User)]",
+                "[ns~1]@@(default::Card)\
+.<deck[IS __derived__::(opaque: default:User)]": {
+                    "[ns~1]@@(default::Card)"
+                },
                 "[ns~1]@[ns~2]@@(default::Card)\
 .<deck[IS __derived__::(opaque: default:User)]"
             },
@@ -157,6 +163,15 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 }
             },
             "(default::Card)",
+            "FENCE": {
+                "FENCE": {
+                    "FENCE": {
+                        "FENCE": {
+                            "[ns~2]@@(__derived__::__derived__|U@w~1)"
+                        }
+                    }
+                }
+            },
             "(default::User)",
             "FENCE": {
                 "[ns~2]@[ns~3]@@(__derived__::__derived__|U@w~1)",
@@ -250,6 +265,11 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(schema::Type)",
             "FENCE": {
+                "FENCE": {
+                    "[ns~1]@@(schema::Type).>element_type[IS schema::Type]"
+                }
+            },
+            "FENCE": {
                 "(schema::Type).>indirection[IS schema::Array]",
                 "[ns~1]@[ns~2]@@(schema::Type).>indirection[IS schema::Array]\
 .>element_type[IS schema::Type]",
@@ -291,6 +311,31 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "(default::User)",
+            "FENCE": {
+                "FENCE": {
+                    "FENCE": {
+                        "FENCE": {
+                            "FENCE": {
+                                "(default::User).>friends[IS default::User]"
+                            },
+                            "FENCE": {
+                                "(default::User).>deck[IS default::Card]\
+.<deck[IS __derived__::(opaque: default:User)]\
+.>indirection[IS default::User]": {
+                                    "(default::User).>deck[IS default::Card]\
+.<deck[IS __derived__::(opaque: default:User)]": {
+                                        "(default::User)\
+.>deck[IS default::Card]"
+                                    }
+                                }
+                            },
+                            "FENCE": {
+                                "(default::User).>friends[IS default::User]"
+                            }
+                        }
+                    }
+                }
+            },
             "FENCE": {
                 "FENCE": {
                     "[ns~1]@[ns~2]@@(default::User).>friends[IS default::User]"
@@ -389,6 +434,19 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "FENCE": {
                 "FENCE": {
                     "[ns~1]@@(default::User)",
+                    "FENCE": {
+                        "FENCE": {
+                            "FENCE": {
+                                "FENCE": {
+                                    "[ns~1]@@(default::Card)",
+                                    "FENCE": {
+                                        "[ns~1]@@(default::User)\
+.>deck[IS default::Card]"
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "FENCE": {
                         "[ns~1]@@(default::User).>name[IS std::str]"
                     }
@@ -561,6 +619,11 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(default::User)",
             "FENCE": {
+                "FENCE": {
+                    "[ns~1]@@(default::User).>deck[IS default::Card]"
+                }
+            },
+            "FENCE": {
                 "[ns~1]@[ns~2]@@(default::User).>deck[IS default::Card]",
                 "FENCE": {
                     "[ns~1]@[ns~2]@@(default::User)\
@@ -603,6 +666,24 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "(default::User)",
+            "FENCE": {
+                "FENCE": {
+                    "FENCE": {
+                        "FENCE": {
+                            "FENCE": {
+                                "FENCE": {
+                                    "(default::User).>deck[IS default::Card]"
+                                }
+                            },
+                            "[ns~1]@@(__derived__::__derived__|x@w~1)",
+                            "FENCE": {
+                                "[ns~1]@@(__derived__::__derived__|x@w~1)\
+.>name[IS std::str]"
+                            }
+                        }
+                    }
+                }
+            },
             "FENCE": {
                 "FENCE": {
                     "FENCE": {
@@ -657,6 +738,24 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(default::User)",
             "FENCE": {
+                "FENCE": {
+                    "FENCE": {
+                        "FENCE": {
+                            "[ns~1]@@(__derived__::__derived__|letter@w~1)",
+                            "FENCE": {
+                                "FENCE": {
+                                    "(default::User).>deck[IS default::Card]",
+                                    "FENCE": {
+                                        "(default::User)\
+.>deck[IS default::Card].>name[IS std::str]"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "FENCE": {
                 "[ns~1]@[ns~4]@@(__derived__::__derived__|letter@w~1)",
                 "FENCE": {
                     "FENCE": {
@@ -696,6 +795,28 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(default::User)",
             "FENCE": {
+                "FENCE": {
+                    "FENCE": {
+                        "FENCE": {
+                            "[ns~1]@@(__derived__::__derived__|letter@w~1)",
+                            "FENCE": {
+                                "FENCE": {
+                                    "FENCE": {
+                                        "(default::User)\
+.>deck[IS default::Card]",
+                                        "FENCE": {
+                                            "(default::User)\
+.>deck[IS default::Card].>name[IS std::str]"
+                                        }
+                                    }
+                                },
+                                "[ns~1]@@(__derived__::__derived__|foo@w~2)"
+                            }
+                        }
+                    }
+                }
+            },
+            "FENCE": {
                 "[ns~1]@[ns~5]@@(__derived__::__derived__|letter@w~1)",
                 "FENCE": {
                     "FENCE": {
@@ -730,6 +851,28 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "(default::User)",
+            "FENCE": {
+                "FENCE": {
+                    "FENCE": {
+                        "FENCE": {
+                            "[ns~1]@@(default::Card)",
+                            "FENCE": {
+                                "FENCE": {
+                                    "FENCE": {
+                                        "FENCE": {
+                                            "[ns~1]@@(default::Card)\
+.>cost[IS std::int64]"
+                                        }
+                                    }
+                                }
+                            },
+                            "FENCE": {
+                                "[ns~1]@@(default::Card).>element[IS std::str]"
+                            }
+                        }
+                    }
+                }
+            },
             "FENCE": {
                 "[ns~1]@[ns~5]@@(default::Card)",
                 "FENCE": {
@@ -782,6 +925,18 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "(default::Card)",
+            "FENCE": {
+                "FENCE": {
+                    "FENCE": {
+                        "FENCE": {
+                            "[ns~1]@@(default::User)",
+                            "FENCE": {
+                                "[ns~1]@@(default::User).>name[IS std::str]"
+                            }
+                        }
+                    }
+                }
+            },
             "FENCE": {
                 "[ns~1]@[ns~2]@@(default::User)",
                 "FENCE": {


### PR DESCRIPTION
The temporary scope mechanism is a bit of kludgy machinery in the
middle of an important system (process_view), and it would be nice to
have it be gone.

The main technical motivation for this change is that it enables doing
proper cardinality checking on computable pointers that are declared
in shapes not exposed to output.

There wasn't much to fix when removing it: some path_ids need to be
added to the path_log, and some hacky code dealing with UNLESS
CONFLICT ELSE clauses needed to be tweaked.

Main downside to this change is that it makes the scope tree a little
noisier.