### PR TITLE
Do proper cardinality inference on computables at their declaration point

### DIFF
--- a/edb/edgeql/compiler/inference/__init__.py
+++ b/edb/edgeql/compiler/inference/__init__.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 __all__ = (
     'amend_empty_set_type',
-    'infer_cardinality',
+    'infer_toplevel_cardinality',
     'infer_type',
     'infer_volatility',
     'infer_multiplicity',
@@ -29,7 +29,7 @@ __all__ = (
     'make_ctx',
 )
 
-from .cardinality import infer_cardinality  # NOQA
+from .cardinality import infer_toplevel_cardinality  # NOQA
 from .context import InfCtx, make_ctx  # NOQA
 from .multiplicity import infer_multiplicity  # NOQA
 from .types import amend_empty_set_type, infer_type  # NOQA

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -119,9 +119,10 @@ def fini_expression(
     # The inference context object will be shared between
     # cardinality and multiplicity inferrers.
     inf_ctx = inference.make_ctx(env=ctx.env)
-    cardinality = inference.infer_cardinality(
+    cardinality = inference.infer_toplevel_cardinality(
         ir,
         scope_tree=ctx.path_scope,
+        source_map=ctx.source_map,
         ctx=inf_ctx,
     )
     multiplicity: Optional[qltypes.Multiplicity] = None

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -79,18 +79,21 @@ def process_view(
         return view_scls
 
     with ctx.newscope(fenced=True) as scopectx:
-        scopectx.path_scope.attach_path(path_id, context=parser_context)
-        if ctx.path_log is not None:
-            ctx.path_log.append(path_id)
         view_path_id_ns = None
+        new_path_id = path_id
         if ctx.expr_exposed or is_insert or is_update:
             view_path_id_ns = irast.WeakNamespace(ctx.aliases.get('ns'))
             scopectx.path_id_namespace |= {view_path_id_ns}
             scopectx.path_scope.add_namespaces({view_path_id_ns})
+            new_path_id = path_id.merge_namespace({view_path_id_ns})
+
+        scopectx.path_scope.attach_path(new_path_id, context=parser_context)
+        if ctx.path_log is not None:
+            ctx.path_log.append(path_id)
 
         view_scls = _process_view(
             stype=stype,
-            path_id=path_id,
+            path_id=new_path_id,
             elements=elements,
             view_rptr=view_rptr,
             view_name=view_name,
@@ -362,6 +365,7 @@ def _normalize_view_ptr_expr(
     target_typexpr = None
     source: qlast.Base
     base_ptrcls_is_alias = False
+    irexpr = None
 
     if plen >= 2 and isinstance(steps[-1], qlast.TypeIntersection):
         # Target type intersection: foo: Type
@@ -831,6 +835,7 @@ def _normalize_view_ptr_expr(
     if qlexpr is not None:
         ctx.source_map[ptrcls] = irast.ComputableInfo(
             qlexpr=qlexpr,
+            irexpr=irexpr,
             context=ctx,
             path_id=path_id,
             path_id_ns=path_id_namespace,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -470,6 +470,7 @@ class Param:
 class ComputableInfo(typing.NamedTuple):
 
     qlexpr: qlast.Expr
+    irexpr: typing.Optional[typing.Union[Set, Expr]]
     context: compiler.ContextLevel
     path_id: PathId
     path_id_ns: typing.Optional[WeakNamespace]

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -350,14 +350,18 @@ def _merge_types(
         return schema, current_target
 
 
+def get_root_source(
+    obj: Optional[so.Object], schema: s_schema.Schema
+) -> Optional[so.Object]:
+    while isinstance(obj, Pointer):
+        obj = obj.get_source(schema)
+    return obj
+
+
 def _is_view_source(
         source: Optional[so.Object], schema: s_schema.Schema) -> bool:
-    if isinstance(source, Pointer):
-        return _is_view_source(source.get_source(schema), schema)
-    elif isinstance(source, s_types.Type):
-        return source.is_view(schema)
-    else:
-        return False
+    source = get_root_source(source, schema)
+    return isinstance(source, s_types.Type) and source.is_view(schema)
 
 
 Pointer_T = TypeVar("Pointer_T", bound="Pointer")

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -44,6 +44,9 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
             ),
         )
 
+        if not expected:
+            return
+
         # The expected cardinality is either given for the whole query
         # (by default) or for a specific element of the top-level
         # shape. In case of the specific element the name of the shape
@@ -579,4 +582,26 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         SELECT Person FILTER .p = 7 AND .q = 3 AND .last = "Whatever"
 % OK %
         AT_MOST_ONE
+        """
+
+    @tb.must_fail(errors.QueryError,
+                  "possibly more than one element")
+    def test_edgeql_ir_card_inference_63(self):
+        """
+        WITH X := User { busted := (SELECT 1 ORDER BY {1,2}) },
+        SELECT X
+        """
+
+    def test_edgeql_ir_card_inference_64(self):
+        """
+        SELECT (FOR x IN {1,2} UNION (SELECT User { m := x })) { m }
+% OK %
+        m: ONE
+        """
+
+    def test_edgeql_ir_card_inference_65(self):
+        """
+        SELECT (SELECT User { multi m := 1 }) { m }
+% OK %
+        m: MANY
         """

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -266,7 +266,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(schema::Type)",
             "FENCE": {
                 "FENCE": {
-                    "[ns~1]@@(schema::Type).>element_type[IS schema::Type]"
+                    "(schema::Type).>element_type[IS schema::Type]"
                 }
             },
             "FENCE": {
@@ -620,7 +620,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(default::User)",
             "FENCE": {
                 "FENCE": {
-                    "[ns~1]@@(default::User).>deck[IS default::Card]"
+                    "(default::User).>deck[IS default::Card]"
                 }
             },
             "FENCE": {
@@ -744,7 +744,10 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                             "[ns~1]@@(__derived__::__derived__|letter@w~1)",
                             "FENCE": {
                                 "FENCE": {
-                                    "(default::User).>deck[IS default::Card]",
+                                    "(default::User)\
+.>deck[IS default::Card]": {
+                                        "[ns~1]@[ns~3]@@(default::User)"
+                                    },
                                     "FENCE": {
                                         "(default::User)\
 .>deck[IS default::Card].>name[IS std::str]"
@@ -803,7 +806,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                                 "FENCE": {
                                     "FENCE": {
                                         "(default::User)\
-.>deck[IS default::Card]",
+.>deck[IS default::Card]": {
+                                            "[ns~1]@[ns~3]@[ns~4]@@(default::User)"
+                                        },
                                         "FENCE": {
                                             "(default::User)\
 .>deck[IS default::Card].>name[IS std::str]"

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -692,6 +692,17 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_select_computable_31(self):
+        await self.assert_query_result(
+            r"""
+                WITH O := (SELECT stdgraphql::Query {multi m := 10}),
+                SELECT (O {m});
+            """,
+            [
+                {'m': [10]},
+            ]
+        )
+
     async def test_edgeql_select_match_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
This allows us to enforce and take advantage of specified cardinality
on non-exposed shapes, as well as correctly infer the cardinalities of
computables that depend on FOR iterators and the like.

(We still can't *compile* those properly, and so some tests like
test_edgeql_for_in_computable_10 and test_edgeql_scope_tuple_14
that previously returned invalid data now ISE when they return
multiple rows for what we now expect to be a singleton.)