### PR TITLE
Register path prefixes in the scope tree when evaluating clauses

### DIFF
--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -36,6 +36,7 @@ from . import inference
 from . import polyres
 from . import schemactx
 from . import setgen
+from . import pathctx
 
 
 def compile_where_clause(
@@ -45,6 +46,9 @@ def compile_where_clause(
 
     if where is None:
         return
+
+    if ctx.partial_path_prefix:
+        pathctx.register_set_in_scope(ctx.partial_path_prefix, ctx=ctx)
 
     with ctx.newscope(fenced=True) as subctx:
         subctx.path_scope.unnest_fence = True
@@ -62,6 +66,9 @@ def compile_orderby_clause(
     result: List[irast.SortExpr] = []
     if not sortexprs:
         return result
+
+    if ctx.partial_path_prefix:
+        pathctx.register_set_in_scope(ctx.partial_path_prefix, ctx=ctx)
 
     with ctx.new() as subctx:
         for sortexpr in sortexprs:

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -605,3 +605,17 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         m: MANY
         """
+
+    def test_edgeql_ir_card_inference_66(self):
+        """
+        WITH Z := (SELECT (SELECT User) ORDER BY .name), SELECT Z
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_card_inference_67(self):
+        """
+        SELECT stdgraphql::Query { o := (SELECT (SELECT User) ORDER BY .name) }
+% OK %
+        MANY
+        """


### PR DESCRIPTION
This prevents incorrectly rejecting some queries in contexts where
the path is not forced by a shape.