### PR TITLE
Implement anonymous shapes

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -517,7 +517,7 @@ class ShapeElement(OffsetLimitMixin, OrderByMixin, FilterMixin, Expr):
 
 
 class Shape(Expr):
-    expr: Expr
+    expr: typing.Optional[Expr]
     elements: typing.List[ShapeElement]
 
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -495,10 +495,8 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_Shape(self, node: qlast.Shape) -> None:
         if node.expr is not None:
-            # shape.expr may be None in Function RETURNING declaration,
-            # when the shape is used to described a returned struct.
             self.visit(node.expr)
-        self.write(' ')
+            self.write(' ')
         self._visit_shape(node.elements)
 
     def _visit_shape(self, shape: Sequence[qlast.ShapeElement]) -> None:

--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -73,7 +73,8 @@ def is_ql_empty_set(expr: qlast.Expr) -> bool:
 
 def is_ql_path(qlexpr: qlast.Expr) -> bool:
     if isinstance(qlexpr, qlast.Shape):
-        qlexpr = qlexpr.expr
+        if qlexpr.expr:
+            qlexpr = qlexpr.expr
 
     if not isinstance(qlexpr, qlast.Path):
         return False

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1042,7 +1042,8 @@ def compile_DescribeStmt(
 @dispatch.compile.register(qlast.Shape)
 def compile_Shape(
         shape: qlast.Shape, *, ctx: context.ContextLevel) -> irast.Set:
-    expr = setgen.ensure_set(dispatch.compile(shape.expr, ctx=ctx), ctx=ctx)
+    shape_expr = shape.expr or qlutils.ANONYMOUS_SHAPE_EXPR
+    expr = setgen.ensure_set(dispatch.compile(shape_expr, ctx=ctx), ctx=ctx)
     expr_stype = setgen.get_set_type(expr, ctx=ctx)
     if not isinstance(expr_stype, s_objtypes.ObjectType):
         raise errors.QueryError(
@@ -1217,7 +1218,7 @@ def compile_result_clause(
         shape: Optional[Sequence[qlast.ShapeElement]]
 
         if isinstance(result, qlast.Shape):
-            result_expr = result.expr
+            result_expr = result.expr or qlutils.ANONYMOUS_SHAPE_EXPR
             shape = result.elements
         else:
             result_expr = result

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -305,6 +305,14 @@ class TypedShape(Nonterm):
         )
 
 
+class AnonShape(Nonterm):
+    def reduce_LBRACE_AnonComputableShapePointerList_RBRACE(self, *kids):
+        self.val = qlast.Shape(elements=kids[1].val)
+
+    def reduce_LBRACE_AnonComputableShapePointerList_COMMA_RBRACE(self, *kids):
+        self.val = qlast.Shape(elements=kids[1].val)
+
+
 class OptAnySubShape(Nonterm):
     def reduce_COLON_Shape(self, *kids):
         self.val = kids[1].val
@@ -344,7 +352,7 @@ class ShapeElementList(ListNonterm, element=ShapeElement,
     pass
 
 
-class SimpleShapePath(Nonterm):
+class VerySimpleShapePath(Nonterm):
 
     def reduce_PathStepName(self, *kids):
         from edb.schema import pointers as s_pointers
@@ -357,6 +365,12 @@ class SimpleShapePath(Nonterm):
         ]
 
         self.val = qlast.Path(steps=steps)
+
+
+class SimpleShapePath(Nonterm):
+
+    def reduce_VerySimpleShapePath(self, *kids):
+        self.val = kids[0].val
 
     def reduce_AT_ShortNodeName(self, *kids):
         self.val = qlast.Path(
@@ -372,6 +386,19 @@ class SimpleShapePath(Nonterm):
 class SimpleShapePointer(Nonterm):
 
     def reduce_SimpleShapePath(self, *kids):
+        self.val = qlast.ShapeElement(
+            expr=kids[0].val
+        )
+
+
+# Shape pointers in anonymous shapes are not allowed to be link
+# properties. This is because we need to be able to distinguish
+# anonymous shapes from set literals with only one token of lookahead
+# (since this is an LL(1) parser) and seeing the := after @ident would
+# require two tokens of lookahead.
+class AnonSimpleShapePointer(Nonterm):
+
+    def reduce_VerySimpleShapePath(self, *kids):
         self.val = qlast.ShapeElement(
             expr=kids[0].val
         )
@@ -588,6 +615,100 @@ class ComputableShapePointer(Nonterm):
         )
 
 
+# This is the same as the above ComputableShapePointer, except using
+# AnonSimpleShapePointer and not allowing +=/-=.
+class AnonComputableShapePointer(Nonterm):
+    def reduce_OPTIONAL_AnonSimpleShapePointer_ASSIGN_Expr(self, *kids):
+        self.val = kids[1].val
+        self.val.compexpr = kids[3].val
+        self.val.required = False
+        self.val.operation = qlast.ShapeOperation(
+            op=qlast.ShapeOp.ASSIGN,
+            context=kids[2].context,
+        )
+
+    def reduce_REQUIRED_AnonSimpleShapePointer_ASSIGN_Expr(self, *kids):
+        self.val = kids[1].val
+        self.val.compexpr = kids[3].val
+        self.val.required = True
+        self.val.operation = qlast.ShapeOperation(
+            op=qlast.ShapeOp.ASSIGN,
+            context=kids[2].context,
+        )
+
+    def reduce_MULTI_AnonSimpleShapePointer_ASSIGN_Expr(self, *kids):
+        self.val = kids[1].val
+        self.val.compexpr = kids[3].val
+        self.val.cardinality = qltypes.SchemaCardinality.Many
+        self.val.operation = qlast.ShapeOperation(
+            op=qlast.ShapeOp.ASSIGN,
+            context=kids[2].context,
+        )
+
+    def reduce_SINGLE_AnonSimpleShapePointer_ASSIGN_Expr(self, *kids):
+        self.val = kids[1].val
+        self.val.compexpr = kids[3].val
+        self.val.cardinality = qltypes.SchemaCardinality.One
+        self.val.operation = qlast.ShapeOperation(
+            op=qlast.ShapeOp.ASSIGN,
+            context=kids[2].context,
+        )
+
+    def reduce_OPTIONAL_MULTI_AnonSimpleShapePointer_ASSIGN_Expr(self, *kids):
+        self.val = kids[2].val
+        self.val.compexpr = kids[4].val
+        self.val.required = False
+        self.val.cardinality = qltypes.SchemaCardinality.Many
+        self.val.operation = qlast.ShapeOperation(
+            op=qlast.ShapeOp.ASSIGN,
+            context=kids[3].context,
+        )
+
+    def reduce_OPTIONAL_SINGLE_AnonSimpleShapePointer_ASSIGN_Expr(self, *kids):
+        self.val = kids[2].val
+        self.val.compexpr = kids[4].val
+        self.val.required = False
+        self.val.cardinality = qltypes.SchemaCardinality.One
+        self.val.operation = qlast.ShapeOperation(
+            op=qlast.ShapeOp.ASSIGN,
+            context=kids[3].context,
+        )
+
+    def reduce_REQUIRED_MULTI_AnonSimpleShapePointer_ASSIGN_Expr(self, *kids):
+        self.val = kids[2].val
+        self.val.compexpr = kids[4].val
+        self.val.required = True
+        self.val.cardinality = qltypes.SchemaCardinality.Many
+        self.val.operation = qlast.ShapeOperation(
+            op=qlast.ShapeOp.ASSIGN,
+            context=kids[3].context,
+        )
+
+    def reduce_REQUIRED_SINGLE_AnonSimpleShapePointer_ASSIGN_Expr(self, *kids):
+        self.val = kids[2].val
+        self.val.compexpr = kids[4].val
+        self.val.required = True
+        self.val.cardinality = qltypes.SchemaCardinality.One
+        self.val.operation = qlast.ShapeOperation(
+            op=qlast.ShapeOp.ASSIGN,
+            context=kids[3].context,
+        )
+
+    def reduce_AnonSimpleShapePointer_ASSIGN_Expr(self, *kids):
+        self.val = kids[0].val
+        self.val.compexpr = kids[2].val
+        self.val.operation = qlast.ShapeOperation(
+            op=qlast.ShapeOp.ASSIGN,
+            context=kids[1].context,
+        )
+
+
+class AnonComputableShapePointerList(ListNonterm,
+                                     element=AnonComputableShapePointer,
+                                     separator=tokens.T_COMMA):
+    pass
+
+
 class UnlessConflictSpecifier(Nonterm):
     def reduce_ON_Expr_ELSE_Expr(self, *kids):
         self.val = (kids[1].val, kids[3].val)
@@ -755,6 +876,9 @@ class Expr(Nonterm):
 
     def reduce_Expr_Shape(self, *kids):
         self.val = qlast.Shape(expr=kids[0].val, elements=kids[1].val)
+
+    def reduce_AnonShape(self, *kids):
+        self.val = kids[0].val
 
     def reduce_Constant(self, *kids):
         self.val = kids[0].val

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -30,6 +30,13 @@ from edb.schema import functions as s_func
 from . import ast as qlast
 
 
+ANONYMOUS_SHAPE_EXPR = qlast.DetachedExpr(
+    expr=qlast.Path(
+        steps=[qlast.ObjectRef(module='std', name='VirtualObject')],
+    ),
+)
+
+
 class ParameterInliner(ast.NodeTransformer):
 
     def __init__(self, args_map: Mapping[str, qlast.Base]) -> None:

--- a/edb/lib/std/60-baseobject.edgeql
+++ b/edb/lib/std/60-baseobject.edgeql
@@ -44,6 +44,11 @@ CREATE ABSTRACT TYPE std::Object EXTENDING std::BaseObject {
         'Root object type for user-defined types';
 };
 
+CREATE TYPE std::VirtualObject EXTENDING std::BaseObject {
+    CREATE ANNOTATION std::description :=
+        'Object type for anonymous shapes';
+};
+
 # 'USING SQL EXPRESSION' creates an EdgeDB Operator for purposes of
 # introspection and validation by the EdgeQL compiler. However, no
 # object is created in Postgres and the EdgeQL->SQL compiler is expected

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -928,6 +928,7 @@ async def _populate_data(schema, compiler, conn):
     script = '''
         INSERT stdgraphql::Query;
         INSERT stdgraphql::Mutation;
+        INSERT std::VirtualObject;
     '''
 
     schema, sql = compile_bootstrap_script(compiler, schema, script)

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,7 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_05_19_00_00
+EDGEDB_CATALOG_VERSION = 2021_06_09_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -10832,7 +10832,7 @@ type default::Foo {
         ):
             await self.con.execute("""
                 CREATE TYPE Foo {
-                    CREATE PROPERTY foo := (SELECT stdgraphql::Query {
+                    CREATE PROPERTY foo := (SELECT {
                         asdf := random()
                     }).asdf
                 }

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -657,7 +657,7 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
     async def test_edgeql_aliases_nested_02(self):
         await self.assert_query_result(
             r"""
-                SELECT stdgraphql::Query {
+                SELECT {
                     foo := (
                         SELECT AwardAlias {
                             name,

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -488,7 +488,7 @@ class TestEdgeQLFor(tb.QueryTestCase):
             SELECT User {
                 select_deck := (
                     WITH ps := (FOR x IN {"!", "?"} UNION (
-                        SELECT stdgraphql::Query { z := x }).z),
+                        SELECT { z := x }).z),
                     FOR letter IN {'I', 'B'}
                     UNION (
                         SELECT .deck {

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2266,7 +2266,7 @@ class TestInsert(tb.QueryTestCase):
                         UNLESS CONFLICT ON .name
                         ELSE (DETACHED Person)
                     )
-                SELECT stdgraphql::Query {
+                SELECT {
                     single foo := X
                 };
             ''')
@@ -2281,7 +2281,7 @@ class TestInsert(tb.QueryTestCase):
                         UNLESS CONFLICT ON .name
                         ELSE Note
                     )
-                SELECT stdgraphql::Query {
+                SELECT {
                     single foo := X
                 };
             ''')
@@ -2295,7 +2295,7 @@ class TestInsert(tb.QueryTestCase):
                         INSERT Person {name := "hello"}
                         UNLESS CONFLICT ON .name
                     )
-                SELECT stdgraphql::Query {
+                SELECT {
                     required foo := X
                 };
             ''')
@@ -3105,7 +3105,7 @@ class TestInsert(tb.QueryTestCase):
                             notes := N,
                         }
                     )),
-                SELECT stdgraphql::Query {
+                SELECT {
                     x := (SELECT X { name } ORDER BY .name),
                     n := N { name },
                 };

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -856,7 +856,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_binding_06(self):
         await self.assert_query_result(
             r"""
-            SELECT stdgraphql::Query {
+            SELECT {
                 lol := (
                     WITH L := (FOR name in {'Alice', 'Bob'} UNION (
                         SELECT User
@@ -882,7 +882,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_binding_07(self):
         await self.assert_query_result(
             r"""
-            SELECT stdgraphql::Query {
+            SELECT {
                 lol := (
                     WITH Y := (FOR x IN {1, 2} UNION (x + 1)),
                     SELECT _ := ((SELECT Y), (SELECT Y))

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -6031,6 +6031,23 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_select_banned_anonymous_01(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "cannot use DISTINCT on anonymous shape",
+        ):
+            await self.con.execute("""
+                SELECT DISTINCT {{ z := 1 }, { z := 2 }};
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "cannot use DISTINCT on anonymous shape",
+        ):
+            await self.con.execute("""
+                SELECT DISTINCT { z := 1 } = { z := 2 };
+            """)
+
     @test.xfail("We produce results that don't decode properly")
     async def test_edgeql_select_array_common_type_01(self):
         res = await self.con._fetchall("""

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -684,7 +684,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_30(self):
         await self.assert_query_result(
             r"""
-                WITH O := (SELECT stdgraphql::Query {m := 10}),
+                WITH O := (SELECT {m := 10}),
                 SELECT (O {m}, O.m);
             """,
             [
@@ -695,7 +695,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_computable_31(self):
         await self.assert_query_result(
             r"""
-                WITH O := (SELECT stdgraphql::Query {multi m := 10}),
+                WITH O := (SELECT {multi m := 10}),
                 SELECT (O {m});
             """,
             [

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1187,8 +1187,6 @@ aa';
         };
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Unexpected ':='", line=3, col=18)
     def test_edgeql_syntax_shape_14(self):
         """
         SELECT {

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -1674,7 +1674,7 @@ class TestUpdate(tb.QueryTestCase):
                         )
                     }
                 )
-            SELECT stdgraphql::Query {
+            SELECT {
                 multi x0 := (
                     SELECT x1 {
                         name,


### PR DESCRIPTION
Add a std::VirtualObject singleton object, similar to
stdgraphql::Query, and make `SELECT { foo := expr, ... }` implicity
operate on a detached VirtualObject.

For annoying LR(1) reasons, we don't support link properties in
anonymous shapes, but that doesn't seem like a big problem.

Elvis suggested removing stdgraphql::Query/Mutation, but I'm holding
off on that in this version because those have an extra __typename
field that would require some handling and I didn't want to muck
around with the graphql compiler in this version. (I tried making
them aliases but trying to create aliases in std library modules
triggers errors about them being read-only.)

Fixes #2533.