### PR TITLE
Fix a migration regression that results in extra prompts

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1045,8 +1045,12 @@ class Compiler:
                                 schema=schema,
                                 modaliases=current_tx.get_modaliases(),
                             )
+                            _, prompt_text = top_op2.get_user_prompt()
 
-                            prompt_id, prompt_text = top_op2.get_user_prompt()
+                            # The prompt_id still needs to come from
+                            # the original op, though, since
+                            # orig_cmd_class is lost in ddl.
+                            prompt_id, _ = top_op.get_user_prompt()
                             confidence = top_op.get_annotation('confidence')
                             assert confidence is not None
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -8608,9 +8608,13 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.fast_forward_describe_migration(limit=1)
 
+        # N.B: It is important that the prompt_id here match the
+        # prompt_id in the first migration, so that the migration tool
+        # will automatically apply this proposal as part of the
+        # earlier action.
         await self.assert_describe_migration({
             'proposed': {
-                'prompt_id': 'CreateLink LINK test::`__|spam@test|Bar`',
+                'prompt_id': 'CreateObjectType TYPE test::Bar',
                 'statements': [{
                     'text': """
                         ALTER TYPE test::Bar {


### PR DESCRIPTION
I broke this in #2561; we had a test for this,
test_edgeql_migration_prompt_id_01, but I just updated the test to
want the regressed behavior. Sorry.

Fixes #2591.