### PR TITLE
Docs

### DIFF
--- a/docs/cheatsheet/insert.rst
+++ b/docs/cheatsheet/insert.rst
@@ -97,29 +97,104 @@ Insert several nested objects at once:
 ----------
 
 
-"Upserts" as well as and other combinations of :eql:stmt:`INSERT` and
-some alternative operation are possible:
+Sometimes it's necessary to check whether some object exists and
+create it if it doesn't. If this type of object has an exclusive
+property, the ``UNLESS CONFLICT`` clause can make the ``INSERT``
+command indempotent. So running such a command would guarantee that a
+copy of the object exists without the need for more complex logic:
 
 .. code-block:: edgeql
 
-    WITH MODULE people
+    # Try to create a new User
+    INSERT User {
+        name := "Alice",
+        image := "default_avatar.jpg",
+    }
+    # and do nothing if a User with this name already exists
+    UNLESS CONFLICT
+
+If more than one property is exclusive, it is possible to specify
+which one of them is considered when a conflict is detected:
+
+.. code-block:: edgeql
+
+    # Try to create a new User
+    INSERT User {
+        name := "Alice",
+        image := "default_avatar.jpg",
+    }
+    # and do nothing if a User with this name already exists
+    UNLESS CONFLICT ON .name
+
+
+----------
+
+
+"Upserts" can be performed by using the ``UNLESS CONFLICT`` clause and
+specifying what needs to be updated:
+
+.. code-block:: edgeql
+
     SELECT (
-        # Try to create a new Person,
-        INSERT Person {
-            name := "Łukasz Langa",
-            is_admin := true
+        # Try to create a new User,
+        INSERT User {
+            name := "Alice",
+            image := "my_face.jpg",
         }
 
-        # but if a Person with this name already exists,
+        # but if a User with this name already exists,
         UNLESS CONFLICT ON .name
         ELSE (
-            # update that Person's record instead.
-            UPDATE Person
+            # update that User's record instead.
+            UPDATE User
             SET {
-                is_admin := true
+                image := "my_face.jpg"
             }
         )
     ) {
         name,
-        is_admin
-    };
+        image
+    }
+
+
+----------
+
+
+Rather than acting as an "upsert", the ``UNLESS CONFLICT`` clause can
+be used to insert or select an existing record, which is handy for
+inserting nested structures:
+
+.. code-block:: edgeql
+
+    # Create a new review and a new user in one step.
+    INSERT Review {
+        body := 'Loved it!!!',
+        rating := 5,
+        # The movie record already exists, so SELECT it.
+        movie := (
+            SELECT Movie
+            FILTER
+                .title = 'Dune'
+                AND
+                .year = 2020
+            # the LIMIT is needed to satisfy the single
+            # link requirement validation
+            LIMIT 1
+        ),
+
+        # This might be a new user or an existing user. Some
+        # other part of the app handles authentication, this
+        # endpoint is used as a generic way to post a review.
+        author := (
+            # Try to create a new User,
+            INSERT User {
+                name := "dune_fan_2020",
+                image := "default_avatar.jpg",
+            }
+
+            # but if a User with this name already exists,
+            UNLESS CONFLICT ON .name
+            # just pick that existing User as the author.
+            ELSE User
+        )
+    }

--- a/docs/cheatsheet/migrations.rst
+++ b/docs/cheatsheet/migrations.rst
@@ -13,9 +13,14 @@ Migrate to a new schema using SDL:
             required property image -> str;
             index on (.image);
         }
+
         type User extending HasImage {
-            required property name -> str;
+            required property name -> str {
+                # Ensure unique name for each User.
+                constraint exclusive;
+            }
         }
+
         type Review {
             required property body -> str;
             required property rating -> int64 {
@@ -31,6 +36,7 @@ Migrate to a new schema using SDL:
                 default := datetime_current();
             }
         }
+
         type Person extending HasImage {
             required property first_name -> str {
                 default := '';
@@ -55,14 +61,18 @@ Migrate to a new schema using SDL:
                 );
             property bio -> str;
         }
+
         abstract link crew {
             # Provide a way to specify some "natural"
             # ordering, as relevant to the movie. This
             # may be order of importance, appearance, etc.
             property list_order -> int64;
         }
+
         abstract link directors extending crew;
+
         abstract link actors extending crew;
+
         type Movie extending HasImage {
             required property title -> str;
             required property year -> int64;
@@ -77,6 +87,7 @@ Migrate to a new schema using SDL:
             property avg_rating :=
                 math::mean(.<movie[IS Review].rating);
         }
+
         type Label {
             annotation description :=
                 'Special label to stick on reviews';
@@ -86,12 +97,14 @@ Migrate to a new schema using SDL:
                     'This review needs some attention';
             };
         }
+
         alias ReviewAlias := Review {
             # It will already have all the Review
             # properties and links.
             author_name := .author.name,
             movie_title := .movie.title,
         };
+
         alias MovieAlias := Movie {
             # A computable link for accessing all the
             # reviews for this movie.

--- a/docs/cheatsheet/types.rst
+++ b/docs/cheatsheet/types.rst
@@ -31,7 +31,10 @@ Define a type extending from the abstract:
 .. code-block:: sdl
 
     type User extending HasImage {
-        required property name -> str;
+        required property name -> str {
+            # Ensure unique name for each User.
+            constraint exclusive;
+        }
     }
 
 


### PR DESCRIPTION
Update the cheatsheets with more `INSERT` examples.
    
Add more `UNLESS CONFLICT` and nested `INSERT` examples.
    
Fixes #2401