### PR TITLE
Ban "$" as the first character in identifiers.

### DIFF
--- a/edb/edgeql-parser/src/tokenizer.rs
+++ b/edb/edgeql-parser/src/tokenizer.rs
@@ -296,6 +296,11 @@ impl<'a> TokenStream<'a> {
                                 "backtick-quoted name cannot \
                                     start with char `@`"));
                         }
+                        if val.starts_with("`$") {
+                            return Err(Error::unexpected_static_message(
+                                "backtick-quoted name cannot \
+                                    start with char `$`"));
+                        }
                         if val.contains("::") {
                             return Err(Error::unexpected_static_message(
                                 "backtick-quoted name cannot \

--- a/edb/edgeql-parser/tests/tokenizer.rs
+++ b/edb/edgeql-parser/tests/tokenizer.rs
@@ -696,6 +696,8 @@ fn strings() {
         allowed: `b`, `r``");
     assert_eq!(tok_err(r#"`@x`"#),
         "Unexpected `backtick-quoted name cannot start with char `@``");
+    assert_eq!(tok_err(r#"`$x`"#),
+        "Unexpected `backtick-quoted name cannot start with char `$``");
     assert_eq!(tok_err(r#"`a::b`"#),
         "Unexpected `backtick-quoted name cannot contain `::``");
     assert_eq!(tok_err(r#"`__x__`"#),

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1048,6 +1048,17 @@ aa';
         SELECT ``::Bar;
         """
 
+    @tb.must_fail(errors.EdgeQLSyntaxError, line=2, col=16)
+    def test_edgeql_syntax_name_27(self):
+        """
+        SELECT `$event`;
+        """
+
+    def test_edgeql_syntax_name_28(self):
+        """
+        SELECT `ok$event`;
+        """
+
     def test_edgeql_syntax_shape_01(self):
         """
         SELECT Foo {bar};


### PR DESCRIPTION
Much like the leading "@" is banned in backtick-quoted identifiers, so
is the leading "$".