### PR TITLE
Get rid of find_by_unique_id

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -208,6 +208,9 @@ class Environment:
     #: A list of bindings that should be assumed to be singletons.
     singletons: List[irast.PathId]
 
+    scope_tree_nodes: Dict[int, irast.ScopeTreeNode]
+    """Map from unique_id to nodes."""
+
     def __init__(
         self,
         *,
@@ -244,6 +247,7 @@ class Environment:
         self.pointer_derivation_map = collections.defaultdict(list)
         self.pointer_specified_info = {}
         self.singletons = []
+        self.scope_tree_nodes = {}
 
     def add_schema_ref(
             self, sobj: s_obj.Object, expr: Optional[qlast.Base]) -> None:

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -26,6 +26,7 @@ import collections
 import dataclasses
 import enum
 import uuid
+import weakref
 
 from edb.common import compiler
 from edb.common import parsing
@@ -208,7 +209,7 @@ class Environment:
     #: A list of bindings that should be assumed to be singletons.
     singletons: List[irast.PathId]
 
-    scope_tree_nodes: Dict[int, irast.ScopeTreeNode]
+    scope_tree_nodes: MutableMapping[int, irast.ScopeTreeNode]
     """Map from unique_id to nodes."""
 
     def __init__(
@@ -247,7 +248,7 @@ class Environment:
         self.pointer_derivation_map = collections.defaultdict(list)
         self.pointer_specified_info = {}
         self.singletons = []
-        self.scope_tree_nodes = {}
+        self.scope_tree_nodes = weakref.WeakValueDictionary()
 
     def add_schema_ref(
             self, sobj: s_obj.Object, expr: Optional[qlast.Base]) -> None:

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -115,15 +115,11 @@ def _bounds_to_card(
 
 def _get_set_scope(
         ir_set: irast.Set,
-        scope_tree: irast.ScopeTreeNode) -> irast.ScopeTreeNode:
+        scope_tree: irast.ScopeTreeNode,
+        ctx: inference_context.InfCtx) -> irast.ScopeTreeNode:
 
     if ir_set.path_scope_id:
-        # Work-around the fact that unique ids are not actually
-        # unique, and search our local tree first.
-        new_scope = scope_tree.find_by_unique_id(ir_set.path_scope_id)
-        if new_scope is None:
-            new_scope = scope_tree.root.find_by_unique_id(
-                ir_set.path_scope_id)
+        new_scope = ctx.env.scope_tree_nodes.get(ir_set.path_scope_id)
         if new_scope is None:
             raise errors.InternalServerError(
                 f'dangling scope pointer to node with uid'
@@ -530,7 +526,7 @@ def _infer_shape(
     ctx: inference_context.InfCtx,
 ) -> None:
     for shape_set, shape_op in ir.shape:
-        new_scope = _get_set_scope(shape_set, scope_tree)
+        new_scope = _get_set_scope(shape_set, scope_tree, ctx=ctx)
         if shape_set.expr and shape_set.rptr:
             ptrref = shape_set.rptr.ptrref
 
@@ -588,7 +584,7 @@ def _infer_set_inner(
     ctx: inference_context.InfCtx,
 ) -> qltypes.Cardinality:
     rptr = ir.rptr
-    new_scope = _get_set_scope(ir, scope_tree)
+    new_scope = _get_set_scope(ir, scope_tree, ctx=ctx)
 
     if ir.expr:
         expr_card = infer_cardinality(ir.expr, scope_tree=new_scope, ctx=ctx)
@@ -878,7 +874,7 @@ def extract_filters(
 
     env = ctx.env
     schema = env.schema
-    scope_tree = _get_set_scope(filter_set, scope_tree)
+    scope_tree = _get_set_scope(filter_set, scope_tree, ctx=ctx)
 
     ptr: s_pointers.Pointer
 
@@ -1073,7 +1069,7 @@ def __infer_select_stmt(
 
     for part in [ir.limit, ir.offset] + [sort.expr for sort in ir.orderby]:
         if part:
-            new_scope = _get_set_scope(part, scope_tree)
+            new_scope = _get_set_scope(part, scope_tree, ctx=ctx)
             card = infer_cardinality(part, scope_tree=new_scope, ctx=ctx)
             if card.is_multi():
                 raise errors.QueryError(
@@ -1104,7 +1100,7 @@ def __infer_insert_stmt(
     infer_cardinality(
         ir.subject, is_mutation=True, scope_tree=scope_tree, ctx=ctx
     )
-    new_scope = _get_set_scope(ir.result, scope_tree)
+    new_scope = _get_set_scope(ir.result, scope_tree, ctx=ctx)
     infer_cardinality(
         ir.result, is_mutation=True, scope_tree=new_scope, ctx=ctx
     )

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -137,7 +137,7 @@ def _infer_shape(
     ctx: inference_context.InfCtx,
 ) -> None:
     for shape_set, _ in ir.shape:
-        new_scope = cardinality._get_set_scope(shape_set, scope_tree)
+        new_scope = cardinality._get_set_scope(shape_set, scope_tree, ctx=ctx)
         if shape_set.expr and shape_set.rptr:
             expr_mult = infer_multiplicity(
                 shape_set.expr, scope_tree=new_scope, ctx=ctx)
@@ -183,7 +183,7 @@ def _infer_set_inner(
     ctx: inference_context.InfCtx,
 ) -> qltypes.Multiplicity:
     rptr = ir.rptr
-    new_scope = cardinality._get_set_scope(ir, scope_tree)
+    new_scope = cardinality._get_set_scope(ir, scope_tree, ctx=ctx)
 
     if rptr is not None:
         # Validate the source
@@ -506,7 +506,7 @@ def __infer_select_stmt(
     # validated.
     for part in [ir.limit, ir.offset] + [sort.expr for sort in ir.orderby]:
         if part:
-            new_scope = cardinality._get_set_scope(part, scope_tree)
+            new_scope = cardinality._get_set_scope(part, scope_tree, ctx=ctx)
             infer_multiplicity(part, scope_tree=new_scope, ctx=ctx)
 
     if itmult is not None:
@@ -531,7 +531,7 @@ def __infer_insert_stmt(
     infer_multiplicity(
         ir.subject, is_mutation=True, scope_tree=scope_tree, ctx=ctx
     )
-    new_scope = cardinality._get_set_scope(ir.result, scope_tree)
+    new_scope = cardinality._get_set_scope(ir.result, scope_tree, ctx=ctx)
     infer_multiplicity(
         ir.result, is_mutation=True, scope_tree=new_scope, ctx=ctx
     )

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -113,6 +113,7 @@ def assign_set_scope(
     else:
         if scope.unique_id is None:
             scope.unique_id = ctx.scope_id_ctr.nextval()
+            ctx.env.scope_tree_nodes[scope.unique_id] = scope
         ir_set.path_scope_id = scope.unique_id
         if scope.find_child(ir_set.path_id):
             raise RuntimeError('scoped set must not contain itself')
@@ -128,7 +129,7 @@ def get_set_scope(
     if ir_set.path_scope_id is None:
         return None
     else:
-        scope = ctx.path_scope.root.find_by_unique_id(ir_set.path_scope_id)
+        scope = ctx.env.scope_tree_nodes.get(ir_set.path_scope_id)
         if scope is None:
             raise errors.InternalServerError(
                 f'dangling scope pointer to node with uid'

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -332,7 +332,7 @@ def _rewrite_weak_namespaces(
         if path_scope_id is not None:
             # Some entries in set_types are from compiling views
             # in temporary scopes, so we need to just skip those.
-            if scope := tree.find_by_unique_id(path_scope_id):
+            if scope := ctx.env.scope_tree_nodes.get(path_scope_id):
                 _try_namespace_fix(scope, ir_set)
 
 

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -983,13 +983,6 @@ class ScopeTreeNode:
 
         return best
 
-    def find_by_unique_id(self, unique_id: int) -> Optional[ScopeTreeNode]:
-        for node in self.descendants:
-            if node.unique_id == unique_id:
-                return node
-
-        return None
-
     def pformat(self) -> str:
         if self.children:
             child_formats = []

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -69,6 +69,11 @@ def compile_ir_to_sql_tree(
         else:
             scope_tree = irast.new_scope_tree()
 
+        scope_tree_nodes = {
+            node.unique_id: node for node in scope_tree.descendants
+            if node.unique_id is not None
+        }
+
         env = context.Environment(
             output_format=output_format,
             expected_cardinality_one=expected_cardinality_one,
@@ -78,6 +83,7 @@ def compile_ir_to_sql_tree(
             ignore_object_shapes=ignore_shapes,
             explicit_top_cast=explicit_top_cast,
             singleton_mode=singleton_mode,
+            scope_tree_nodes=scope_tree_nodes,
             external_rvars=external_rvars,
         )
 

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -368,6 +368,7 @@ class Environment:
     singleton_mode: bool
     query_params: List[irast.Param]
     type_rewrites: Dict[uuid.UUID, irast.Set]
+    scope_tree_nodes: Dict[int, irast.ScopeTreeNode]
     external_rvars: Mapping[Tuple[irast.PathId, str], pgast.PathRangeVar]
 
     def __init__(
@@ -381,6 +382,7 @@ class Environment:
         explicit_top_cast: Optional[irast.TypeRef],
         query_params: List[irast.Param],
         type_rewrites: Dict[uuid.UUID, irast.Set],
+        scope_tree_nodes: Dict[int, irast.ScopeTreeNode],
         external_rvars: Optional[
             Mapping[Tuple[irast.PathId, str], pgast.PathRangeVar]
         ] = None,
@@ -395,6 +397,7 @@ class Environment:
         self.explicit_top_cast = explicit_top_cast
         self.query_params = query_params
         self.type_rewrites = type_rewrites
+        self.scope_tree_nodes = scope_tree_nodes
         self.external_rvars = external_rvars or {}
 
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -698,7 +698,7 @@ def get_scope(
     result: Optional[irast.ScopeTreeNode] = None
 
     if ir_set.path_scope_id is not None:
-        result = ctx.scope_tree.root.find_by_unique_id(ir_set.path_scope_id)
+        result = ctx.env.scope_tree_nodes.get(ir_set.path_scope_id)
 
     return result
 


### PR DESCRIPTION
Use a dict to look up by unique id instead of rummaging around the
scope tree.

This speeds up compile_edgeql_script_schema_introspection by 1.82x but
doesn't really do anything for compile_edgeql_script_webapp_get_movie,
where find_by_unique_id doesn't show up much on the profile.