### PR TITLE
Do a big overhaul of scope tree prefix factoring

### DIFF
--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -643,7 +643,7 @@ class TestEdgeQLFor(tb.QueryTestCase):
                 SELECT count((
                     WITH X := {1, 2}
                     SELECT (X, (FOR x in {X} UNION (SELECT x)))
-               ));
+                ));
             ''',
             [2],
         )
@@ -653,7 +653,7 @@ class TestEdgeQLFor(tb.QueryTestCase):
                 SELECT count((
                     WITH X := {1, 2}
                     SELECT ((FOR x in {X} UNION (SELECT x)), X)
-               ));
+                ));
             ''',
             [2],
         )

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -102,12 +102,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(default::Card)",
             "(default::Card).<deck[IS __derived__::(opaque: default:User)]\
 .>indirection[IS default::User]": {
-                "[ns~1]@@(default::Card)\
-.<deck[IS __derived__::(opaque: default:User)]",
-                "(default::Card)\
-.<deck[IS __derived__::(opaque: default:User)]",
-                "[ns~1]@[ns~2]@@(default::Card)\
-.<deck[IS __derived__::(opaque: default:User)]"
+                "(default::Card).<deck[IS __derived__::(opaque: default:User)]"
             },
             "FENCE": {
                 "(default::Card).>owner[IS default::User]"
@@ -128,14 +123,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "(default::Card).<deck[IS __derived__::(opaque: default:User)]\
 .>indirection[IS default::User]": {
-                "(default::Card)\
-.<deck[IS __derived__::(opaque: default:User)]",
-                "[ns~1]@@(default::Card)\
-.<deck[IS __derived__::(opaque: default:User)]": {
-                    "[ns~1]@@(default::Card)"
-                },
-                "[ns~1]@[ns~2]@@(default::Card)\
-.<deck[IS __derived__::(opaque: default:User)]"
+                "(default::Card).<deck[IS __derived__::(opaque: default:User)]"
             },
             "(default::Card)",
             "FENCE": {
@@ -370,7 +358,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "(default::Card).>owners[IS default::User]": {
-                "BRANCH": {
+                "CBRANCH": {
                     "(default::Card)"
                 },
                 "FENCE": {
@@ -454,10 +442,10 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             },
             "(__derived__::__derived__|U@w~1).>cards[IS default::Card]\
 .>foo[IS std::float64]": {
-                "BRANCH": {
+                "CBRANCH": {
                     "(__derived__::__derived__|U@w~1)\
 .>cards[IS default::Card]": {
-                        "BRANCH": {
+                        "CBRANCH": {
                             "(__derived__::__derived__|U@w~1)"
                         },
                         "FENCE": {
@@ -744,10 +732,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                             "[ns~1]@@(__derived__::__derived__|letter@w~1)",
                             "FENCE": {
                                 "FENCE": {
-                                    "(default::User)\
-.>deck[IS default::Card]": {
-                                        "[ns~1]@[ns~3]@@(default::User)"
-                                    },
+                                    "(default::User).>deck[IS default::Card]",
                                     "FENCE": {
                                         "(default::User)\
 .>deck[IS default::Card].>name[IS std::str]"
@@ -806,9 +791,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                                 "FENCE": {
                                     "FENCE": {
                                         "(default::User)\
-.>deck[IS default::Card]": {
-                                            "[ns~1]@[ns~3]@[ns~4]@@(default::User)"
-                                        },
+.>deck[IS default::Card]",
                                         "FENCE": {
                                             "(default::User)\
 .>deck[IS default::Card].>name[IS std::str]"
@@ -900,7 +883,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "FENCE": {
                 "(__derived__::__derived__|A@w~1).>owners[IS default::User]": {
-                    "BRANCH": {
+                    "CBRANCH": {
                         "(__derived__::__derived__|A@w~1)"
                     },
                     "FENCE": {

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2437,3 +2437,33 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 {"name": "Dave", "specials": ["Djinn"]}
             ],
         )
+
+    async def test_edgeql_scope_branch_01(self):
+        await self.assert_query_result(
+            """
+                SELECT count(((SELECT User), ((User),).0));
+            """,
+            [4],
+        )
+
+    async def test_edgeql_scope_branch_02(self):
+        await self.assert_query_result(
+            """
+                SELECT count((
+                    (SELECT User.name),
+                    ((SELECT User.name) ++ (User.name),).0,
+                 ));
+            """,
+            [4],
+        )
+
+    async def test_edgeql_scope_branch_03(self):
+        await self.assert_query_result(
+            """
+                SELECT count((
+                    (SELECT User.name),
+                    ((SELECT User.name) ++ (User.name)) ?? "uhoh",
+                 ));
+            """,
+            [4],
+        )

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -703,6 +703,38 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_select_computable_32(self):
+        await self.assert_query_result(
+            r"""
+            SELECT _ := (User {x := .name}.x, (SELECT User.name)) ORDER BY _;
+            """,
+            [
+                ['Elvis', 'Elvis'],
+                ['Yury', 'Yury'],
+            ]
+        )
+
+        await self.assert_query_result(
+            r"""
+            SELECT _ := ((SELECT User.name), User {x := .name}.x) ORDER BY _;
+            """,
+            [
+                ['Elvis', 'Elvis'],
+                ['Yury', 'Yury'],
+            ]
+        )
+
+        await self.assert_query_result(
+            r"""
+            SELECT _ := ((SELECT User.name), (User {x := .name},).0.x)
+            ORDER BY _;
+            """,
+            [
+                ['Elvis', 'Elvis'],
+                ['Yury', 'Yury'],
+            ]
+        )
+
     async def test_edgeql_select_match_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
The meat of this rework is in the "unfenced path" case of attach_path,
which had issues when factoring out of an unfenced BRANCH.
In particular, consider the case with a tree like:
```
FENCE {
    FENCE {
        User
    },
    BRANCH,
}
```
and we want to attach User to the BRANCH.
(This would be generated by `((SELECT User), ((User),).0)`,
see test_edgeql_scope_branch_01).
This should result in User being factored to the top FENCE, but
currently this does not happen, because the factoring procedure is
to look at all descendant nodes and then look for any unfenced
descendants of an ancestor; because the existing User is fenced,
it is not found. However, if the tuple was processed in the other
order, we get the right results.

In order to factor, at most one of the paths can be fenced. This means
that the correct approach is to search unfenced paths as long as we
have not seen a fence between the attachment node and the ancestor we
are searching for. Thus, `find_unfenced` becomes `find_factoring_point`
and is able to subsume the old call to `find_descendant_and_ns`.
We also need to search for the *highest* such point.

As part of this, fix some issues in computing which namespaces to strip
when factoring, and make sure that the namespace stripping is applied
to all relevant paths.

I also pulled the error checking for factoring into its own function,
which I think helps make the happy case flow clearer.

Also fix an issue that I introduced in #2569 while fixing computable
paths. In #2569 I identified a BRANCH-protected computable path just
by looking to see if it was covered by a single BRANCH. This is wrong,
since there are other ways to introduce something covered by a BRANCH!
Add a computable_branch flag to directly represent this case.