### PR TITLE
Fix data mending of empty arrays.

### DIFF
--- a/tests/schemas/dump04_default.esdl
+++ b/tests/schemas/dump04_default.esdl
@@ -1,0 +1,25 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+type Test1 {
+    property t1 -> array<tuple<name: str, severity: int16>> {
+        # https://github.com/edgedb/edgedb/issues/2606
+        default := <array<tuple<name: str, severity: int16>>>[]
+    };
+};

--- a/tests/schemas/dump04_setup.edgeql
+++ b/tests/schemas/dump04_setup.edgeql
@@ -1,0 +1,1 @@
+INSERT Test1;  # https://github.com/edgedb/edgedb/issues/2606

--- a/tests/test_dump03.py
+++ b/tests/test_dump03.py
@@ -80,3 +80,12 @@ class TestDump03(tb.StableDumpTestCase, DumpTestCaseMixin):
     async def test_dump03_dump_restore(self):
         await self.check_dump_restore(
             DumpTestCaseMixin.ensure_schema_data_integrity)
+
+
+class TestDump03Compat(
+    tb.DumpCompatTestCase,
+    DumpTestCaseMixin,
+    dump_subdir='dump03',
+    check_method=DumpTestCaseMixin.ensure_schema_data_integrity,
+):
+    pass

--- a/tests/test_dump04.py
+++ b/tests/test_dump04.py
@@ -1,0 +1,52 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os.path
+
+from edb.testbase import server as tb
+
+
+class DumpTestCaseMixin:
+
+    async def ensure_schema_data_integrity(self):
+        tx = self.con.transaction()
+        await tx.start()
+        try:
+            await self._ensure_schema_data_integrity()
+        finally:
+            await tx.rollback()
+
+    async def _ensure_schema_data_integrity(self):
+        pass
+
+
+class TestDump04(tb.StableDumpTestCase, DumpTestCaseMixin):
+    DEFAULT_MODULE = 'test'
+
+    SCHEMA_DEFAULT = os.path.join(os.path.dirname(__file__), 'schemas',
+                                  'dump04_default.esdl')
+
+    SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
+                         'dump04_setup.edgeql')
+
+    STABLE_DUMP = False
+
+    async def test_dump04_dump_restore(self):
+        await self.check_dump_restore(
+            DumpTestCaseMixin.ensure_schema_data_integrity)


### PR DESCRIPTION
The old code seems to be designed for handling multi-dimensional arrays
but did not have a guard against zero-dimensional arrays (empty).  Since
we don't support multi-dimensional arrays I'm simplifying the code.

Fixes issue #2606.