### PR TITLE
Fix a cluster of bugs having to do with OPTIONAL or tuples or both

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -41,7 +41,6 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes as ft
 from edb.edgeql import parser as qlparser
 
-from . import astutils
 from . import casts
 from . import context
 from . import dispatch
@@ -314,6 +313,8 @@ def compile_operator(
             arg_ir = setgen.scoped_set(
                 setgen.ensure_stmt(arg_ir, ctx=fencectx),
                 ctx=fencectx)
+
+            arg_ir = setgen.ensure_set(arg_ir, srcctx=qlarg.context, ctx=ctx)
 
             arg_ctxs[arg_ir] = fencectx
 
@@ -663,10 +664,11 @@ def compile_call_arg(
         # matching.  We will remove it if necessary in `finalize_args()`.
         # Similarly, delay the decision to inject the implicit limit to
         # `finalize_args()`.
-        arg_ql = astutils.ensure_qlstmt(arg_ql)
+        arg_ql = qlast.SelectQuery(result=arg_ql, implicit=True)
         argctx.inhibit_implicit_limit = True
         return setgen.ensure_set(
             dispatch.compile(arg_ql, ctx=argctx),
+            srcctx=arg_ql.context,
             ctx=argctx,
         ), argctx
 
@@ -738,6 +740,31 @@ def process_path_log(arg_ctx: Optional[context.ContextLevel],
         arg_ctx.path_log = []
 
 
+def _is_empty_tuple(t: s_types.Type, ctx: context.ContextLevel) -> bool:
+    return (
+        isinstance(t, s_types.Tuple)
+        and all(
+            _is_empty_tuple(x, ctx) for x in t.get_subtypes(ctx.env.schema)
+        )
+    )
+
+
+def _check_arg(
+    bound_arg: polyres.BoundArg,
+    param_mod: ft.TypeModifier, *,
+    ctx: context.ContextLevel,
+) -> None:
+    if param_mod is ft.TypeModifier.OptionalType:
+        # We disallow use of empty tuples (and degenerate tuples
+        # containing only empty tuples) as optional arguments because there
+        # is no data in them to be NULL. This could be worked around, but
+        # it does not seem particularly important to do so.
+        if _is_empty_tuple(bound_arg.param_type, ctx=ctx):
+            raise errors.QueryError(
+                f'empty tuple may not be used as an optional argument',
+                context=bound_arg.val.context)
+
+
 def finalize_args(
     bound_call: polyres.BoundCall, *,
     arg_ctxs: Dict[irast.Set, context.ContextLevel],
@@ -763,10 +790,11 @@ def finalize_args(
         else:
             param_mod = param.get_typemod(ctx.env.schema)
 
+        _check_arg(barg, param_mod, ctx=ctx)
+
         typemods.append(param_mod)
 
-        orig_arg = arg
-        arg_ctx = arg_ctxs.get(orig_arg)
+        arg_ctx = arg_ctxs.get(arg)
         arg_scope = pathctx.get_set_scope(arg, ctx=ctx)
         if param_mod is not ft.TypeModifier.SetOfType:
             param_shortname = param.get_parameter_name(ctx.env.schema)
@@ -789,13 +817,11 @@ def finalize_args(
 
                 pathctx.register_set_in_scope(arg, optional=True, ctx=ctx)
 
-                if arg_scope is not None:
+                if arg_scope is not None and arg.path_scope_id is None:
                     pathctx.assign_set_scope(arg, branch, ctx=ctx)
 
             elif arg_scope is not None:
                 arg_scope.collapse()
-                if arg is orig_arg:
-                    pathctx.assign_set_scope(arg, None, ctx=ctx)
         else:
             process_path_log(arg_ctx, arg_scope)
             is_array_agg = (

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -740,31 +740,6 @@ def process_path_log(arg_ctx: Optional[context.ContextLevel],
         arg_ctx.path_log = []
 
 
-def _is_empty_tuple(t: s_types.Type, ctx: context.ContextLevel) -> bool:
-    return (
-        isinstance(t, s_types.Tuple)
-        and all(
-            _is_empty_tuple(x, ctx) for x in t.get_subtypes(ctx.env.schema)
-        )
-    )
-
-
-def _check_arg(
-    bound_arg: polyres.BoundArg,
-    param_mod: ft.TypeModifier, *,
-    ctx: context.ContextLevel,
-) -> None:
-    if param_mod is ft.TypeModifier.OptionalType:
-        # We disallow use of empty tuples (and degenerate tuples
-        # containing only empty tuples) as optional arguments because there
-        # is no data in them to be NULL. This could be worked around, but
-        # it does not seem particularly important to do so.
-        if _is_empty_tuple(bound_arg.param_type, ctx=ctx):
-            raise errors.QueryError(
-                f'empty tuple may not be used as an optional argument',
-                context=bound_arg.val.context)
-
-
 def finalize_args(
     bound_call: polyres.BoundCall, *,
     arg_ctxs: Dict[irast.Set, context.ContextLevel],
@@ -789,8 +764,6 @@ def finalize_args(
             param_mod = actual_typemods[i]
         else:
             param_mod = param.get_typemod(ctx.env.schema)
-
-        _check_arg(barg, param_mod, ctx=ctx)
 
         typemods.append(param_mod)
 

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -1218,6 +1218,8 @@ def __infer_tuple(
     scope_tree: irast.ScopeTreeNode,
     ctx: inference_context.InfCtx,
 ) -> qltypes.Cardinality:
+    if not ir.elements:
+        return ONE
     return _common_cardinality(
         [el.val for el in ir.elements], scope_tree=scope_tree, ctx=ctx
     )

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -973,6 +973,7 @@ def ensure_set(
         type_override: Optional[s_types.Type]=None,
         typehint: Optional[s_types.Type]=None,
         path_id: Optional[irast.PathId]=None,
+        srcctx: Optional[parsing.ParserContext]=None,
         ctx: context.ContextLevel) -> irast.Set:
 
     if not isinstance(expr, irast.Set):
@@ -989,6 +990,10 @@ def ensure_set(
             ir_set, stype=type_override, preserve_scope_ns=True, ctx=ctx)
 
         stype = type_override
+
+    if srcctx is not None:
+        ir_set = new_set_from_set(
+            ir_set, preserve_scope_ns=True, context=srcctx, ctx=ctx)
 
     if (isinstance(ir_set, irast.EmptySet)
             and (stype is None or stype.is_any(ctx.env.schema))

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -216,7 +216,7 @@ def array_as_json_object(
                         )
                     ]
                 )
-            ]
+            ] if el_type.subtypes else [],
         )
     else:
         return pgast.FuncCall(
@@ -315,7 +315,7 @@ def unnamed_tuple_as_json_object(
                         )
                     ]
                 )
-            ]
+            ] if styperef.subtypes else []
         )
 
 
@@ -400,7 +400,7 @@ def named_tuple_as_json_object(
                         )
                     ]
                 )
-            ]
+            ] if styperef.subtypes else []
         )
 
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1712,10 +1712,10 @@ class Tuple(
         return True
 
     def find_common_implicitly_castable_type(
-        self: Tuple_T,
+        self,
         other: Type,
         schema: s_schema.Schema,
-    ) -> typing.Tuple[s_schema.Schema, Optional[Tuple_T]]:
+    ) -> typing.Tuple[s_schema.Schema, Optional[Tuple]]:
 
         if not isinstance(other, Tuple):
             return schema, None
@@ -1741,11 +1741,11 @@ class Tuple(
             my_names = self.get_element_names(schema)
             other_names = other.get_element_names(schema)
             if my_names == other_names:
-                return type(self).from_subtypes(
+                return Tuple.from_subtypes(
                     schema, dict(zip(my_names, new_types)), {"named": True}
                 )
 
-        return type(self).from_subtypes(schema, new_types)
+        return Tuple.from_subtypes(schema, new_types)
 
     def get_typemods(self, schema: s_schema.Schema) -> Dict[str, bool]:
         return {'named': self.is_named(schema)}

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4257,6 +4257,12 @@ aa \
             [[1, [2, 3]]],
         )
 
+    async def test_edgeql_expr_setop_13(self):
+        await self.assert_query_result(
+            r'''SELECT <tuple<int64, int64>>{} UNION (1, 2);''',
+            [[1, 2]],
+        )
+
     async def test_edgeql_expr_cardinality_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -882,17 +882,20 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 % OK %
         "FENCE": {
             "FENCE": {
-                "(__derived__::__derived__|A@w~1).>owners[IS default::User]": {
-                    "CBRANCH": {
-                        "(__derived__::__derived__|A@w~1)"
-                    },
-                    "FENCE": {
-                        "ns~2@@(__derived__::__derived__|A@w~1)\
+                "FENCE": {
+                    "(__derived__::__derived__|A@w~1)\
+.>owners[IS default::User]": {
+                        "CBRANCH": {
+                            "(__derived__::__derived__|A@w~1)"
+                        },
+                        "FENCE": {
+                            "ns~2@@(__derived__::__derived__|A@w~1)\
 .<deck[IS __derived__::(opaque: default:User)]\
 .>indirection[IS default::User]": {
-                            "ns~2@@(__derived__::__derived__|A@w~1)\
+                                "ns~2@@(__derived__::__derived__|A@w~1)\
 .<deck[IS __derived__::(opaque: default:User)]": {
-                                "(__derived__::__derived__|A@w~1)"
+                                    "(__derived__::__derived__|A@w~1)"
+                                }
                             }
                         }
                     }

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -6048,23 +6048,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 SELECT DISTINCT { z := 1 } = { z := 2 };
             """)
 
-    async def test_edgeql_select_empty_optional_01(self):
-        async with self.assertRaisesRegexTx(
-            edgedb.QueryError,
-            "empty tuple may not be used as an optional argument",
-        ):
-            await self.con.execute("""
-                SELECT () ?? ()
-            """)
-
-        async with self.assertRaisesRegexTx(
-            edgedb.QueryError,
-            "empty tuple may not be used as an optional argument",
-        ):
-            await self.con.execute("""
-                SELECT ((), ()) ?? ((), ())
-            """)
-
     @test.xfail("We produce results that don't decode properly")
     async def test_edgeql_select_array_common_type_01(self):
         res = await self.con._fetchall("""

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -6048,6 +6048,23 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 SELECT DISTINCT { z := 1 } = { z := 2 };
             """)
 
+    async def test_edgeql_select_empty_optional_01(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "empty tuple may not be used as an optional argument",
+        ):
+            await self.con.execute("""
+                SELECT () ?? ()
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "empty tuple may not be used as an optional argument",
+        ):
+            await self.con.execute("""
+                SELECT ((), ()) ?? ((), ())
+            """)
+
     @test.xfail("We produce results that don't decode properly")
     async def test_edgeql_select_array_common_type_01(self):
         res = await self.con._fetchall("""


### PR DESCRIPTION
* Always wrap function arguments in a SELECT, which fixes an
   issue with optional function arguments that are already SELECTs.
 * Don't overwrite the path_scope_id of an optional argument
   during finalize_args if it already has one
 * Check the scope tree for optionality in both the new and old
   original scope (needed to properly handle WITH bound optional args)
 * Populate optional wrappers with *serialized* tuple vars as
   well as value ones, to avoid column mismatches
 * Don't force non-nullability of tuple elements in _get_path_output,
   since that prevents things from working in an OPTIONAL way.
   Instead, enforce non-nullability of tuple elements as part of
   tuple creation.
 * Make Tuple.find_common_implicitly_castable_type always create
   *Tuples*, even if it an aliased Tuple. Currently it will try to
   *make a new TupleExprAlias which will not work.
 * Disallow passing empty tuples (or tuples of empty tuples) as
   optional arguments, since we can't represent a missing empty
   tuple. We could fix this probably by adding some dummy data for
   empty tuples and letting that be NULL, but it seems pretty
   marginal at this point.

Fixes #2602.