### PR TITLE
Ban backlinks on computable links.

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -664,6 +664,15 @@ def resolve_ptr(
                     ctx.env.add_schema_ref(
                         p.get_nearest_non_derived_parent(ctx.env.schema),
                         track_ref)
+            for ptr in ptrs:
+                if ptr.is_pure_computable(ctx.env.schema):
+                    vname = ptr.get_verbosename(ctx.env.schema,
+                                                with_parent=True)
+                    raise errors.InvalidReferenceError(
+                        f'cannot follow backlink {pointer_name!r} because '
+                        f'{vname} is computable',
+                        context=source_context
+                    )
 
             opaque = not far_endpoints
             ctx.env.schema, ptr = s_pointers.get_or_create_union_pointer(

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -592,14 +592,19 @@ def trace_Path(
                         # However, we need to make it dependent on
                         # every link of the same name now.
                         for fqname, obj in ctx.objects.items():
-                            # Ignore what appears to not be a link.
-                            if isinstance(obj, (s_pointers.Pointer,
-                                                Pointer)):
+                            # Ignore what appears to not be a link
+                            # with the right name.
+                            if (isinstance(obj, (s_pointers.Pointer,
+                                                 Pointer)) and
+                                fqname.name.split('@', 1)[1] ==
+                                    step.ptr.name):
+
                                 target = obj.get_target(ctx.schema)
-                                if (target is not None and
-                                    not target.is_scalar() and
-                                    fqname.name.split('@', 1)[1] ==
-                                        step.ptr.name):
+                                # Ignore scalars, but include other
+                                # computables to produce better error
+                                # messages.
+                                if (target is None or
+                                        not target.is_scalar()):
                                     # Record link with matching short
                                     # name.
                                     ctx.refs.add(fqname)

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -52,7 +52,7 @@ type User extending Named {
 type Card extending Named {
     required property element -> str;
     required property cost -> int64;
-    multi link owners := __source__.<deck[IS User];
+    multi link owners := .<deck[IS User];
     # computable property
     property elemental_cost := <str>.cost ++ ' ' ++ .element;
     multi link awards -> Award;

--- a/tests/schemas/cards_ir_inference.esdl
+++ b/tests/schemas/cards_ir_inference.esdl
@@ -48,7 +48,7 @@ type User extending Named {
 type Card extending Named {
     required property element -> str;
     required property cost -> int64;
-    multi link owners := __source__.<deck[IS User];
+    multi link owners := .<deck[IS User];
     # computable property
     property elemental_cost := <str>.cost ++ ' ' ++ .element;
 }

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -22,6 +22,8 @@ import os.path
 
 from edb.testbase import server as tb
 
+import edgedb
+
 
 class TestEdgeQLExprAliases(tb.QueryTestCase):
     '''The scope is to test expression aliases.'''
@@ -1004,3 +1006,21 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
                 }]
             }]
         )
+
+    async def test_edgeql_aliases_backlinks_01(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidReferenceError,
+            "cannot follow backlink 'owners'",
+        ):
+            await self.con.execute("""
+                SELECT User.<owners[Is Card];
+            """)
+
+    async def test_edgeql_aliases_backlinks_02(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidReferenceError,
+            "cannot follow backlink 'owners'",
+        ):
+            await self.con.execute("""
+                SELECT User.<owners;
+            """)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1430,6 +1430,72 @@ class TestSchema(tb.BaseSchemaLoadTest):
             )
         )
 
+    @tb.must_fail(errors.InvalidReferenceError,
+                  "cannot follow backlink 'bar'",
+                  line=4, col=27)
+    def test_schema_backlink_01(self):
+        """
+            type Bar {
+                link foo -> Foo;
+                link f := .<bar[IS Foo];
+            }
+
+            type Foo {
+                link bar := .<foo[IS Bar];
+            }
+        """
+
+    @tb.must_fail(errors.InvalidReferenceError,
+                  "cannot follow backlink 'bar'",
+                  line=4, col=27)
+    def test_schema_backlink_02(self):
+        """
+            type Bar {
+                link foo -> Foo;
+                link f := .<bar;
+            }
+
+            type Foo {
+                link bar := .<foo;
+            }
+        """
+
+    @tb.must_fail(errors.InvalidReferenceError,
+                  "cannot follow backlink 'bar'",
+                  line=3, col=22)
+    def test_schema_backlink_03(self):
+        """
+            alias B := Bar {
+                f := .<bar[IS Foo]
+            };
+
+            type Bar {
+                link foo -> Foo;
+            }
+
+            type Foo {
+                link bar := .<foo[IS Bar];
+            }
+        """
+
+    @tb.must_fail(errors.InvalidReferenceError,
+                  "cannot follow backlink 'bar'",
+                  line=3, col=20)
+    def test_schema_backlink_04(self):
+        """
+            function foo() -> uuid using (
+                Bar.<bar[IS Foo].id
+            );
+
+            type Bar {
+                link foo -> Foo;
+            }
+
+            type Foo {
+                link bar := .<foo[IS Bar];
+            }
+        """
+
 
 class TestGetMigration(tb.BaseSchemaLoadTest):
     """Test migration deparse consistency.


### PR DESCRIPTION
Following a computable link backwards is technically possible, but
generally suboptimal. Until such a time when we might have reasonable
strategies for implementing this, the backlinks on computables are
banned.