### PR TITLE
Get rid of MetaAST

### DIFF
--- a/edb/common/ast/match.py
+++ b/edb/common/ast/match.py
@@ -24,10 +24,10 @@ from __future__ import annotations
 import collections.abc
 import types
 
-from edb.common import adapter, ast
+from edb.common import adapter
 
 
-class MatchASTMeta(adapter.Adapter, ast.MetaAST):
+class MatchASTMeta(adapter.Adapter):
     pass
 
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -398,8 +398,8 @@ class Pointer(Base):
     target: Set
     ptrref: BasePointerRef
     direction: s_pointers.PointerDirection
-    anchor: typing.Union[str, ast.MetaAST]
-    show_as_anchor: typing.Union[str, ast.MetaAST]
+    anchor: str
+    show_as_anchor: str
 
     @property
     def is_inbound(self) -> bool:


### PR DESCRIPTION
Switch AST over to just using __init_subclass__, since it doesn't
actually need any more than that.

I think it should be pretty easy to make mypyc play nicely with this
sort of simple __init_subclass__, generalizing slightly the hacks we
do to support dataclasses:
https://github.com/python/mypy/blob/f91fb1a6ee0908faf856684dc2e60afc8b9a9daf/mypyc/lib-rt/misc_ops.c#L310-L380