### PR TITLE
When aliasing SQL functions in stdlib, make sure the return types match

### DIFF
--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -136,6 +136,7 @@ std::_gen_series(
 ) -> SET OF std::bigint
 {
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'generate_series';
 };
 
@@ -147,6 +148,7 @@ std::_gen_series(
 ) -> SET OF std::bigint
 {
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'generate_series';
 };
 

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -1190,6 +1190,7 @@ std::min(vals: SET OF cal::local_datetime) -> OPTIONAL cal::local_datetime
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1200,6 +1201,7 @@ std::min(vals: SET OF cal::local_date) -> OPTIONAL cal::local_date
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1210,6 +1212,7 @@ std::min(vals: SET OF cal::local_time) -> OPTIONAL cal::local_time
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1220,6 +1223,7 @@ std::min(vals: SET OF array<cal::local_datetime>) -> OPTIONAL array<cal::local_d
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1230,6 +1234,7 @@ std::min(vals: SET OF array<cal::local_date>) -> OPTIONAL array<cal::local_date>
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1240,6 +1245,7 @@ std::min(vals: SET OF array<cal::local_time>) -> OPTIONAL array<cal::local_time>
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1250,6 +1256,7 @@ std::min(vals: SET OF array<cal::relative_duration>) -> OPTIONAL array<cal::rela
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1260,6 +1267,7 @@ std::max(vals: SET OF cal::local_datetime) -> OPTIONAL cal::local_datetime
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -1270,6 +1278,7 @@ std::max(vals: SET OF cal::local_date) -> OPTIONAL cal::local_date
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -1280,6 +1289,7 @@ std::max(vals: SET OF cal::local_time) -> OPTIONAL cal::local_time
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -1290,6 +1300,7 @@ std::max(vals: SET OF array<cal::local_datetime>) -> OPTIONAL array<cal::local_d
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -1300,6 +1311,7 @@ std::max(vals: SET OF array<cal::local_date>) -> OPTIONAL array<cal::local_date>
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -1310,6 +1322,7 @@ std::max(vals: SET OF array<cal::local_time>) -> OPTIONAL array<cal::local_time>
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -1320,5 +1333,6 @@ std::max(vals: SET OF array<cal::relative_duration>) -> OPTIONAL array<cal::rela
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'max';
 };

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -218,6 +218,7 @@ std::min(vals: SET OF datetime) -> OPTIONAL datetime
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -228,6 +229,7 @@ std::min(vals: SET OF duration) -> OPTIONAL duration
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -293,6 +295,7 @@ std::max(vals: SET OF datetime) -> OPTIONAL datetime
     CREATE ANNOTATION std::description :=
         'Return the greatest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -303,6 +306,7 @@ std::max(vals: SET OF duration) -> OPTIONAL duration
     CREATE ANNOTATION std::description :=
         'Return the greatest value of the input set.';
     SET volatility := 'Immutable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'max';
 };
 

--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -26,6 +26,7 @@ std::datetime_current() -> std::datetime
     CREATE ANNOTATION std::description :=
         'Return the current server date and time.';
     SET volatility := 'Volatile';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'clock_timestamp';
 };
 
@@ -36,6 +37,7 @@ std::datetime_of_transaction() -> std::datetime
     CREATE ANNOTATION std::description :=
         'Return the date and time of the start of the current transaction.';
     SET volatility := 'Stable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'transaction_timestamp';
 };
 
@@ -46,6 +48,7 @@ std::datetime_of_statement() -> std::datetime
     CREATE ANNOTATION std::description :=
         'Return the date and time of the start of the current statement.';
     SET volatility := 'Stable';
+    SET force_return_cast := true;
     USING SQL FUNCTION 'statement_timestamp';
 };
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2360,6 +2360,17 @@ def process_set_as_func_expr(
                 ]
             )
 
+        if expr.force_return_cast:
+            # The underlying function has a return value type
+            # different from that of the EdgeQL function declaration,
+            # so we need to make an explicit cast here.
+            set_expr = pgast.TypeCast(
+                arg=set_expr,
+                type_name=pgast.TypeName(
+                    name=pg_types.pg_type_from_ir_typeref(expr.typeref)
+                )
+            )
+
         func_rel = newctx.rel
 
     return _compile_func_epilogue(

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -95,7 +95,7 @@ class Operator(
         elif kind is ft.OperatorKind.Postfix:
             return f'{params[0]} {name}'
         elif kind is ft.OperatorKind.Prefix:
-            return f'{name} {params[1]}'
+            return f'{name} {params[0]}'
         elif kind is ft.OperatorKind.Ternary:
             return f'{name} ({", ".join(params)})'
         else:

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -908,7 +908,7 @@ async def _execute_ddl(conn, sql_text):
 
         if point is not None:
             context = parser_context.ParserContext(
-                'query', text, start=point, end=point)
+                'query', text, start=point, end=point, context_lines=30)
             exceptions.replace_context(e, context)
 
         raise

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,7 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_06_09_00_00
+EDGEDB_CATALOG_VERSION = 2021_07_02_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3669,8 +3669,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_function_17(self):
         await self.con.execute(r'''
-            CREATE FUNCTION ddlf_17(str: std::str) -> int64
-                USING SQL FUNCTION 'whatever';
+            CREATE FUNCTION ddlf_17(str: std::str) -> int32
+                USING SQL FUNCTION 'char_length';
         ''')
 
         with self.assertRaisesRegex(
@@ -3680,7 +3680,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
             async with self.con.transaction():
                 await self.con.execute(r'''
-                    CREATE FUNCTION ddlf_17(str: std::int64) -> int64
+                    CREATE FUNCTION ddlf_17(str: std::int64) -> int32
                         USING SQL FUNCTION 'whatever2';
                 ''')
 
@@ -3958,6 +3958,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             await self.con.execute('''\
                 CREATE FUNCTION foo() -> str USING ('a');
                 CREATE TYPE foo;
+            ''')
+
+    async def test_edgeql_ddl_function_30(self):
+        with self.assertRaisesRegex(
+            edgedb.InternalServerError,
+            r'declared to return SQL type "int8", but the underlying '
+            r'SQL function returns "integer"'
+        ):
+            await self.con.execute(r'''
+                CREATE FUNCTION ddlf_30(str: std::str) -> int64
+                    USING SQL FUNCTION 'char_length';
             ''')
 
     async def test_edgeql_ddl_function_rename_01(self):
@@ -4490,13 +4501,18 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_operator_02(self):
         try:
             await self.con.execute('''
-                CREATE POSTFIX OPERATOR `!`
-                    (operand: int64) -> int64
-                    USING SQL OPERATOR r'!';
-
                 CREATE PREFIX OPERATOR `!`
                     (operand: int64) -> int64
-                    USING SQL OPERATOR r'!!';
+                {
+                    USING SQL OPERATOR r'+';
+                };
+
+                CREATE INFIX OPERATOR `!`
+                    (l: int64, r: int64) -> int64
+                {
+                    SET commutator := 'default::!';
+                    USING SQL OPERATOR r'+';
+                };
             ''')
 
             await self.assert_query_result(
@@ -4514,7 +4530,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 [
                     {
                         'name': 'default::!',
-                        'operator_kind': 'Postfix',
+                        'operator_kind': 'Infix',
                     },
                     {
                         'name': 'default::!',
@@ -4525,8 +4541,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         finally:
             await self.con.execute('''
-                DROP POSTFIX OPERATOR `!`
-                    (operand: int64);
+                DROP INFIX OPERATOR `!`
+                    (l: int64, r: int64);
 
                 DROP PREFIX OPERATOR `!`
                     (operand: int64);
@@ -4703,6 +4719,19 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 `IN` (l: std::int64, r: std::int64) -> std::bool {
                     USING SQL EXPRESSION;
                     SET derivative_of := 'std::=';
+                };
+            ''')
+
+    async def test_edgeql_ddl_operator_12(self):
+        with self.assertRaisesRegex(
+            edgedb.InternalServerError,
+            r'operator "! std::int64" is declared to return SQL type "int8", '
+            r'but the underlying SQL function returns "numeric"',
+        ):
+            await self.con.execute('''
+                CREATE PREFIX OPERATOR
+                `!` (l: std::int64) -> std::int64 {
+                    USING SQL OPERATOR '!!';
                 };
             ''')
 


### PR DESCRIPTION
The return value of all EdgeQL functions must always satisfy the declared
return type.  However, currently, when declaring a `USING SQL FUNCTION`
function we don't properly enforce the rule, which allows for broken
declarations, e.g. `std::datetime_current` returning a plain
`timestamptz` instead of `edgedb.timestamptz_t`, which would then
confuse downstream function and operator dispatch.  Fix this by adding a
validation check for `USING SQL FUNCTION` functions, and fix all
violations in the stdlib.

Fixes: #2617