### PR TITLE
Implement path-like syntax for accessing enum types' members

### DIFF
--- a/docs/datamodel/scalars/enum.rst
+++ b/docs/datamodel/scalars/enum.rst
@@ -19,7 +19,14 @@ Enum
 
         scalar type Color extending enum<Red, Green, Blue>;
 
-    :eql:op:`Casting <CAST>` is required to obtain an
+    Enum values can then be accessed directly:
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT Color.Red IS Color;
+        {true}
+
+    :eql:op:`Casting <CAST>` can be used to obtain an
     enum value in an expression:
 
     .. code-block:: edgeql-repl
@@ -27,6 +34,8 @@ Enum
         db> SELECT 'Red' IS Color;
         {false}
         db> SELECT <Color>'Red' IS Color;
+        {true}
+        db> SELECT <Color>'Red' = Color.Red;
         {true}
 
     .. note::

--- a/docs/edgeql/funcops/sys.rst
+++ b/docs/edgeql/funcops/sys.rst
@@ -73,7 +73,7 @@ System
     .. code-block:: edgeql-repl
 
         db> SELECT sys::get_transaction_isolation();
-        {<enum>'RepeatableRead'}
+        {sys::TransactionIsolation.RepeatableRead}
 
 
 ----------

--- a/edb/common/levenshtein.py
+++ b/edb/common/levenshtein.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 
-def distance(s, t):
+def distance(s: str, t: str) -> int:
     """Calculates Levenshtein distance between s and t."""
 
     m, n = len(s), len(t)


### PR DESCRIPTION
The current syntax requires casting of string values into enums, e.g.
`<Color>'Red'`. There are a few shortcomings of this syntax:

* The casting is cumbersome and makes enums feel like non-first-class
  citizens of the spec.

* In EdgeQL query builders for TypeScript (and Python) enum values
  will use the standard attribute access syntax, which would make
  casting in EdgeQL look confusing.

* Our REPL, currently, renders enum values as idents, without qualifying
  the actual type name, e.g. `Red`.  With the new syntax it would be
  possible to switch the REPL (and the interactive tutorial / EdgeDB
  Studio) to render fully-qualifies enum member names, as in
  'default::Color.Red'.

This commit implements path-like syntax for accessing enum values.
Instead of `SELECT <Color>'Red';` it is now possible to run
`SELECT Color.Red;`.