### PR TITLE
Specify the mypy plugin by path instead of module

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 python_version = 3.8
-plugins = edb.tools.mypy.plugin
+plugins = edb/tools/mypy/plugin.py
 follow_imports = normal
 ignore_missing_imports = True
 warn_redundant_casts = True


### PR DESCRIPTION
This will make it so that `mypy edb` works, instead of needing to do
`python3 -m mypy edb`.