### PR TITLE
Compile non-computable qlexprs when they have clauses

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -74,6 +74,10 @@ def compile_SelectQuery(
             sctx.partial_path_prefix = ctx.partial_path_prefix
             stmt.implicit_wrapper = True
 
+        # If there is an offset or a limit, this query was a wrapper
+        # around something else, and we need to forward_rptr
+        forward_rptr = bool(expr.offset or expr.limit)
+
         if (
             (ctx.expr_exposed or sctx.stmt is ctx.toplevel_stmt)
             and ctx.implicit_limit
@@ -88,6 +92,7 @@ def compile_SelectQuery(
             view_rptr=ctx.view_rptr,
             result_alias=expr.result_alias,
             view_name=ctx.toplevel_result_view_name,
+            forward_rptr=forward_rptr,
             ctx=sctx)
 
         clauses.compile_where_clause(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -557,6 +557,7 @@ def _normalize_view_ptr_expr(
                 and ctx.implicit_limit
                 and not base_is_singleton
             ):
+                qlexpr = qlast.SelectQuery(result=qlexpr, implicit=True)
                 qlexpr.limit = qlast.IntegerConstant(
                     value=str(ctx.implicit_limit),
                 )
@@ -688,6 +689,7 @@ def _normalize_view_ptr_expr(
                 and ctx.implicit_limit
                 and isinstance(qlexpr, qlast.OffsetLimitMixin)
                 and not qlexpr.limit):
+            qlexpr = qlast.SelectQuery(result=qlexpr, implicit=True)
             qlexpr.limit = qlast.IntegerConstant(value=str(ctx.implicit_limit))
 
         irexpr, sub_view_rptr = _compile_qlexpr(

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -21,6 +21,7 @@ import json
 import os.path
 
 from edb.testbase import server as tb
+from edb.tools import test
 
 
 class TestEdgeQLExprAliases(tb.QueryTestCase):
@@ -777,6 +778,7 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             ],
         )
 
+    @test.xfail('Busted because of #2629')
     async def test_edgeql_aliases_ignore_alias(self):
         await self.con.execute('''
 

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -21,7 +21,6 @@ import json
 import os.path
 
 from edb.testbase import server as tb
-from edb.tools import test
 
 
 class TestEdgeQLExprAliases(tb.QueryTestCase):
@@ -778,7 +777,6 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             ],
         )
 
-    @test.xfail('Busted because of #2629')
     async def test_edgeql_aliases_ignore_alias(self):
         await self.con.execute('''
 

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -23,7 +23,6 @@ import uuid
 import edgedb
 
 from edb.testbase import server as tb
-from edb.tools import test
 
 
 class TestInsert(tb.QueryTestCase):
@@ -322,12 +321,6 @@ class TestInsert(tb.QueryTestCase):
             }],
         )
 
-    @test.xfail('''
-        This test fails with the following error:
-        invalid reference to link property in top level shape
-
-        The culprit appears to be specifically the LIMIT 1.
-    ''')
     async def test_edgeql_insert_nested_06(self):
         await self.con.execute('''
             INSERT Subordinate {
@@ -435,10 +428,6 @@ class TestInsert(tb.QueryTestCase):
             }
         }])
 
-    @test.xfail('''
-        edgedb.errors.QueryError: invalid reference to link property
-        in top level shape
-    ''')
     async def test_edgeql_insert_nested_10(self):
         # test a single link with a link property
         await self.con.execute(r'''

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -611,19 +611,19 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 "FENCE": {
                     "FENCE": {
                         "FENCE": {
+                            "(default::User).>deck[IS default::Card]",
                             "FENCE": {
                                 "(default::User)\
 .>deck[IS default::Card]@count[IS std::int64]"
                             }
                         }
-                    },
-                    "(default::User).>deck[IS default::Card]"
+                    }
                 }
             },
             "FENCE": {
-                "[ns~1]@[ns~2]@@(default::User).>deck[IS default::Card]",
+                "[ns~1]@[ns~3]@@(default::User).>deck[IS default::Card]",
                 "FENCE": {
-                    "[ns~1]@[ns~2]@@(default::User)\
+                    "[ns~1]@[ns~3]@@(default::User)\
 .>deck[IS default::Card]@count[IS std::int64]"
                 },
                 "(default::User).>deck[IS default::Card]"
@@ -631,18 +631,18 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "FENCE": {
                 "(default::User).>deck[IS default::Card]": {
                     "FENCE": {
-                        "[ns~1]@[ns~4]@@(default::User)\
+                        "[ns~1]@[ns~5]@@(default::User)\
 .>deck[IS default::Card]",
                         "FENCE": {
-                            "[ns~1]@[ns~4]@@(default::User)\
+                            "[ns~1]@[ns~5]@@(default::User)\
 .>deck[IS default::Card]@count[IS std::int64]"
                         }
                     },
                     "FENCE": {
-                        "[ns~1]@[ns~3]@@(default::User)\
+                        "[ns~1]@[ns~4]@@(default::User)\
 .>deck[IS default::Card]",
                         "FENCE": {
-                            "[ns~1]@[ns~3]@@(default::User)\
+                            "[ns~1]@[ns~4]@@(default::User)\
 .>deck[IS default::Card]@count[IS std::int64]"
                         }
                     }

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -258,9 +258,10 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 }
             },
             "FENCE": {
-                "(schema::Type).>indirection[IS schema::Array]",
                 "[ns~1]@[ns~2]@@(schema::Type).>indirection[IS schema::Array]\
-.>element_type[IS schema::Type]",
+.>element_type[IS schema::Type]": {
+                    "(schema::Type).>indirection[IS schema::Array]"
+                },
                 "(schema::Type).>element_type[IS schema::Type]"
             }
         }
@@ -608,6 +609,14 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(default::User)",
             "FENCE": {
                 "FENCE": {
+                    "FENCE": {
+                        "FENCE": {
+                            "FENCE": {
+                                "(default::User)\
+.>deck[IS default::Card]@count[IS std::int64]"
+                            }
+                        }
+                    },
                     "(default::User).>deck[IS default::Card]"
                 }
             },

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -1846,6 +1846,23 @@ class TestEdgeQLScope(tb.QueryTestCase):
             sort=lambda x: x['name']
         )
 
+        await self.assert_query_result(
+            r'''
+                # adding a top-level DETACHED should not change anything at all
+                SELECT DETACHED User {
+                    name,
+                    fire_deck := (
+                        SELECT User.deck {name, element}
+                        FILTER .element = 'Fire'
+                        ORDER BY .name
+                    ).name
+                };
+            ''',
+            res,
+            implicit_limit=100,
+            sort=lambda x: x['name']
+        )
+
     async def test_edgeql_scope_detached_09(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError, r'only singletons are allowed'):


### PR DESCRIPTION
This is needed for materialization, since clauses on a
"non-computable" shape element might be volatile.

I'm putting this up on its own because it is self-contained but also
pretty noisy.