### PR TITLE
consolidate protocol cardinality enums

### DIFF
--- a/docs/internals/protocol/messages.rst
+++ b/docs/internals/protocol/messages.rst
@@ -280,11 +280,11 @@ Known headers:
 * 0xFF04 ``ALLOW_CAPABILITIES``: ``uint64`` -- optional bitmask of
   capabilities allowed for this query.  See RFC1004_ for more information.
 
-* 0xFF05 ``EXPLICIT_OBJECTIDS`` -- If set to "true" returned objects will 
-  not have an implicit ``id`` property i.e. query shapes will have to 
+* 0xFF05 ``EXPLICIT_OBJECTIDS`` -- If set to "true" returned objects will
+  not have an implicit ``id`` property i.e. query shapes will have to
   explicitly list id properties.
 
-.. eql:struct:: edb.testbase.protocol.Cardinality
+.. eql:struct:: edb.server.compiler.Cardinality
 
 
 .. _ref_protocol_msg_describe_statement:
@@ -326,7 +326,7 @@ Format:
 
 .. eql:struct:: edb.testbase.protocol.CommandDataDescription
 
-.. eql:struct:: edb.testbase.protocol.Cardinality
+.. eql:struct:: edb.server.compiler.Cardinality
 
 
 The format of the *input_typedesc* and *output_typedesc* fields is described
@@ -450,8 +450,8 @@ Known headers:
 * 0xFF04 ``ALLOW_CAPABILITIES``: ``uint64`` -- optional bitmask of
   capabilities allowed for this query.  See RFC1004_ for more information.
 
-* 0xFF05 ``EXPLICIT_OBJECTIDS`` -- If set to "true" returned objects will 
-  not have an implicit ``id`` property i.e. query shapes will have to 
+* 0xFF05 ``EXPLICIT_OBJECTIDS`` -- If set to "true" returned objects will
+  not have an implicit ``id`` property i.e. query shapes will have to
   explicitly list id properties.
 
 .. _ref_protocol_msg_data:
@@ -558,7 +558,7 @@ Format:
 
 .. eql:struct:: edb.testbase.protocol.PrepareComplete
 
-.. eql:struct:: edb.testbase.protocol.Cardinality
+.. eql:struct:: edb.server.compiler.Cardinality
 
 Known headers:
 

--- a/docs/internals/protocol/typedesc.rst
+++ b/docs/internals/protocol/typedesc.rst
@@ -84,12 +84,7 @@ Object Shape Descriptor
         uint16          type_pos;
     };
 
-    enum Cardinality {
-        AT_MOST_ONE     = 0x0;
-        ONE             = 0x1;
-        MANY            = 0x2;
-        AT_LEAST_ONE    = 0x3;
-    };
+.. eql:struct:: edb.server.compiler.Cardinality
 
 Objects are encoded on the wire as :ref:`tuples <ref_protocol_fmt_tuple>`.
 

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -25,16 +25,17 @@ from .compiler import compile_edgeql_script
 from .compiler import load_std_schema
 from .compiler import new_compiler, new_compiler_context
 from .dbstate import QueryUnit
-from .enums import Capability, CompileStatementMode, ResultCardinality
+from .enums import Capability, CompileStatementMode, Cardinality
 from .enums import IoFormat
 
 
 __all__ = (
+    'Cardinality',
     'Compiler',
     'CompileContext',
     'CompilerDatabaseState',
     'QueryUnit',
-    'Capability', 'CompileStatementMode', 'ResultCardinality', 'IoFormat',
+    'Capability', 'CompileStatementMode', 'IoFormat',
     'compile_edgeql_script',
     'load_std_schema',
     'new_compiler',

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -588,12 +588,12 @@ class Compiler:
         )
 
         if ir.cardinality.is_single():
-            result_cardinality = enums.ResultCardinality.ONE
+            result_cardinality = enums.Cardinality.AT_MOST_ONE
         else:
-            result_cardinality = enums.ResultCardinality.MANY
+            result_cardinality = enums.Cardinality.MANY
             if ctx.expected_cardinality_one:
                 raise errors.ResultCardinalityMismatchError(
-                    f'the query has cardinality {result_cardinality} '
+                    f'the query has cardinality {result_cardinality.name} '
                     f'which does not match the expected cardinality ONE')
 
         sql_text, argmap = pg_compiler.compile_ir_to_sql(
@@ -1614,7 +1614,7 @@ class Compiler:
         # That means that the returned QueryUnit has to have the in/out codec
         # information, correctly inferred "singleton_result" field etc.
         single_stmt_mode = ctx.stmt_mode is enums.CompileStatementMode.SINGLE
-        default_cardinality = enums.ResultCardinality.NO_RESULT
+        default_cardinality = enums.Cardinality.NO_RESULT
 
         statements = edgeql.parse_block(source)
         statements_len = len(statements)
@@ -1820,7 +1820,7 @@ class Compiler:
         for unit in units:  # pragma: no cover
             # Sanity checks
             na_cardinality = (
-                unit.cardinality is enums.ResultCardinality.NO_RESULT
+                unit.cardinality is enums.Cardinality.NO_RESULT
             )
             if unit.cacheable and (
                 unit.config_ops or unit.modaliases or unit.user_schema or

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -82,7 +82,7 @@ class Query(BaseQuery):
 
     sql_hash: bytes
 
-    cardinality: enums.ResultCardinality
+    cardinality: enums.Cardinality
 
     out_type_data: bytes
     out_type_id: bytes
@@ -237,8 +237,8 @@ class QueryUnit:
 
     # Cardinality of the result set.  Set to NO_RESULT if the
     # unit represents multiple queries compiled as one script.
-    cardinality: enums.ResultCardinality = \
-        enums.ResultCardinality.NO_RESULT
+    cardinality: enums.Cardinality = \
+        enums.Cardinality.NO_RESULT
 
     out_type_data: bytes = sertypes.NULL_TYPE_DESC
     out_type_id: bytes = sertypes.NULL_TYPE_ID

--- a/edb/server/compiler/enums.py
+++ b/edb/server/compiler/enums.py
@@ -32,19 +32,24 @@ class CompileStatementMode(enum.Enum):
     SINGLE = 'single'
 
 
-class ResultCardinality(strenum.StrEnum):
-
-    # Cardinality is 1 or 0
-    ONE = 'ONE'
-
-    # Cardinality is >= 0
-    MANY = 'MANY'
-
+class Cardinality(enum.Enum):
     # Cardinality isn't applicable for the query:
     # * the query is a command like CONFIGURE that
     #   does not return any data;
     # * the query is composed of multiple queries.
-    NO_RESULT = 'NO_RESULT'
+    NO_RESULT = 0x6e
+
+    # Cardinality is 1 or 0
+    AT_MOST_ONE = 0x6f
+
+    # Cardinality is 1
+    ONE = 0x41
+
+    # Cardinality is >= 0
+    MANY = 0x6d
+
+    # Cardinality is >= 1
+    AT_LEAST_ONE = 0x4d
 
 
 if TYPE_CHECKING:

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -78,7 +78,7 @@ DEF TCP_KEEPCNT = 3
 DEF COPY_SIGNATURE = b"PGCOPY\n\377\r\n\0"
 
 
-cdef object CARD_NO_RESULT = compiler.ResultCardinality.NO_RESULT
+cdef object CARD_NO_RESULT = compiler.Cardinality.NO_RESULT
 
 
 cdef bytes INIT_CON_SCRIPT = None

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -82,9 +82,9 @@ DEF FLUSH_BUFFER_AFTER = 100_000
 cdef bytes ZERO_UUID = b'\x00' * 16
 cdef bytes EMPTY_TUPLE_UUID = s_obj.get_known_type_id('empty-tuple').bytes
 
-cdef object CARD_NO_RESULT = compiler.ResultCardinality.NO_RESULT
-cdef object CARD_ONE = compiler.ResultCardinality.ONE
-cdef object CARD_MANY = compiler.ResultCardinality.MANY
+cdef object CARD_NO_RESULT = compiler.Cardinality.NO_RESULT
+cdef object CARD_AT_MOST_ONE = compiler.Cardinality.AT_MOST_ONE
+cdef object CARD_MANY = compiler.Cardinality.MANY
 
 cdef object FMT_BINARY = compiler.IoFormat.BINARY
 cdef object FMT_JSON = compiler.IoFormat.JSON
@@ -1185,11 +1185,11 @@ cdef class EdgeConnection:
         )
 
     cdef parse_cardinality(self, bytes card):
-        if card == b'm':
+        if card[0] == CARD_MANY.value:
             return CARD_MANY
-        elif card == b'o':
-            return CARD_ONE
-        elif card == b'n':
+        elif card[0] == CARD_AT_MOST_ONE.value:
+            return CARD_AT_MOST_ONE
+        elif card[0] == CARD_NO_RESULT:
             raise errors.BinaryProtocolError(
                 'cardinality NO_RESULT cannot be requested')
         else:
@@ -1197,15 +1197,7 @@ cdef class EdgeConnection:
                 f'unknown expected cardinality "{repr(card)[2:-1]}"')
 
     cdef char render_cardinality(self, query_unit) except -1:
-        if query_unit.cardinality is CARD_NO_RESULT:
-            return <char>(b'n')
-        elif query_unit.cardinality is CARD_ONE:
-            return <char>(b'o')
-        elif query_unit.cardinality is CARD_MANY:
-            return <char>(b'm')
-        else:
-            raise errors.InternalServerError(
-                f'unknown cardinality {query_unit.cardinality!r}')
+        return query_unit.cardinality.value
 
     cdef parse_io_format(self, bytes mode):
         if mode == b'j':
@@ -1254,7 +1246,7 @@ cdef class EdgeConnection:
 
         io_format = self.parse_io_format(self.buffer.read_byte())
         expect_one = (
-            self.parse_cardinality(self.buffer.read_byte()) is CARD_ONE
+            self.parse_cardinality(self.buffer.read_byte()) is CARD_AT_MOST_ONE
         )
 
         if parse_stmt_name:

--- a/edb/testbase/protocol/messages.py
+++ b/edb/testbase/protocol/messages.py
@@ -25,6 +25,7 @@ import io
 import typing
 
 from edb.common import binwrapper
+from edb.server import compiler
 
 from . import render_utils
 
@@ -544,19 +545,13 @@ class CommandComplete(ServerMessage):
     status = String('Command status.')
 
 
-class Cardinality(enum.Enum):
-    NO_RESULT = 0x6e
-    ONE = 0x6f
-    MANY = 0x6d
-
-
 class CommandDataDescription(ServerMessage):
 
     mtype = MessageType('T')
     message_length = MessageLength
     headers = Headers
     result_cardinality = EnumOf(
-        UInt8, Cardinality, 'Actual result cardinality.')
+        UInt8, compiler.Cardinality, 'Actual result cardinality.')
     input_typedesc_id = UUID('Argument data descriptor ID.')
     input_typedesc = Bytes('Argument data descriptor.')
     output_typedesc_id = UUID('Output data descriptor ID.')
@@ -633,7 +628,7 @@ class PrepareComplete(ServerMessage):
     mtype = MessageType('1')
     message_length = MessageLength
     headers = Headers
-    cardinality = EnumOf(UInt8, Cardinality, 'Result cardinality.')
+    cardinality = EnumOf(UInt8, compiler.Cardinality, 'Result cardinality.')
     input_typedesc_id = UUID('Argument data descriptor ID.')
     output_typedesc_id = UUID('Result data descriptor ID.')
 
@@ -717,7 +712,7 @@ class Prepare(ClientMessage):
     message_length = MessageLength
     headers = Headers
     io_format = EnumOf(UInt8, IOFormat, 'Data I/O format.')
-    expected_cardinality = EnumOf(UInt8, Cardinality,
+    expected_cardinality = EnumOf(UInt8, compiler.Cardinality,
                                   'Expected result cardinality')
     statement_name = Bytes('Prepared statement name. Currently must be empty.')
     command = String('Command text.')
@@ -796,7 +791,7 @@ class OptimisticExecute(ClientMessage):
     message_length = MessageLength
     headers = Headers
     io_format = EnumOf(UInt8, IOFormat, 'Data I/O format.')
-    expected_cardinality = EnumOf(UInt8, Cardinality,
+    expected_cardinality = EnumOf(UInt8, compiler.Cardinality,
                                   'Expected result cardinality.')
     command_text = String('Command text.')
     input_typedesc_id = UUID('Argument data descriptor ID.')

--- a/tests/test_docs_sphinx_ext.py
+++ b/tests/test_docs_sphinx_ext.py
@@ -772,7 +772,7 @@ class TestEqlStatement(unittest.TestCase, BaseDomainTest):
         src = '''
         .. eql:struct:: edb.testbase.protocol.AuthenticationSASLFinal
 
-        .. eql:struct:: edb.testbase.protocol.Cardinality
+        .. eql:struct:: edb.server.compiler.Cardinality
         '''
 
         out = self.build(src, format='xml')

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -20,6 +20,7 @@
 import asyncio
 import edgedb
 
+from edb.server import compiler
 from edb.testbase import protocol
 from edb.testbase.protocol.test import ProtocolTestCase
 
@@ -125,7 +126,7 @@ class TestProtocol(ProtocolTestCase):
             protocol.Prepare(
                 headers=[],
                 io_format=protocol.IOFormat.BINARY,
-                expected_cardinality=protocol.Cardinality.ONE,
+                expected_cardinality=compiler.Cardinality.AT_MOST_ONE,
                 statement_name=b'',
                 command='SEL ECT 1',
             )
@@ -146,7 +147,7 @@ class TestProtocol(ProtocolTestCase):
             protocol.Prepare(
                 headers=[],
                 io_format=protocol.IOFormat.BINARY,
-                expected_cardinality=protocol.Cardinality.ONE,
+                expected_cardinality=compiler.Cardinality.AT_MOST_ONE,
                 statement_name=b'',
                 command='SELECT 1',
             ),
@@ -154,7 +155,7 @@ class TestProtocol(ProtocolTestCase):
         )
         await self.con.recv_match(
             protocol.PrepareComplete,
-            cardinality=protocol.Cardinality.ONE,
+            cardinality=compiler.Cardinality.AT_MOST_ONE,
         )
 
         # Test that Flush has completed successfully -- the


### PR DESCRIPTION
Instead of having an enum for top level query cardinality and a second for shape field cardinality merge them into one enum.