### PR TITLE
Validate explicit type specification in computables

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1295,12 +1295,19 @@ def get_ddl_field_value(
     return cmd.value if cmd is not None else None
 
 
+def get_ddl_subcommand(
+    ddlcmd: DDLOperation,
+    cmdtype: typing.Type[DDLOperation],
+) -> typing.Optional[DDLOperation]:
+    for cmd in ddlcmd.commands:
+        if isinstance(cmd, cmdtype):
+            return cmd
+    else:
+        return None
+
+
 def has_ddl_subcommand(
     ddlcmd: DDLOperation,
     cmdtype: typing.Type[DDLOperation],
 ) -> bool:
-    for cmd in ddlcmd.commands:
-        if isinstance(cmd, cmdtype):
-            return True
-    else:
-        return False
+    return bool(get_ddl_subcommand(ddlcmd, cmdtype))

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1427,6 +1427,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 len(node.commands) == 1
                 and isinstance(node.commands[0], qlast.SetField)
                 and node.commands[0].name == 'expr'
+                and not isinstance(node.target, qlast.TypeExpr)
             )
         )
 
@@ -1553,6 +1554,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 len(node.commands) == 1
                 and isinstance(node.commands[0], qlast.SetField)
                 and node.commands[0].name == 'expr'
+                and not isinstance(node.target, qlast.TypeExpr)
             )
         )
 

--- a/edb/schema/lproperties.py
+++ b/edb/schema/lproperties.py
@@ -390,14 +390,13 @@ class AlterProperty(
         schema: s_schema.Schema,
         astnode: qlast.DDLOperation,
         context: sd.CommandContext,
-    ) -> referencing.AlterReferencedInheritingObject[Property]:
+    ) -> AlterProperty:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
-
+        assert isinstance(cmd, AlterProperty)
         if isinstance(astnode, qlast.CreateConcreteProperty):
-            assert isinstance(cmd, pointers.PointerCommand)
             cmd._process_create_or_alter_ast(schema, astnode, context)
-
-        assert isinstance(cmd, referencing.AlterReferencedInheritingObject)
+        else:
+            cmd._process_alter_ast(schema, astnode, context)
         return cmd
 
     def _apply_field_ast(

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -4963,6 +4963,44 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_ddl_type_19(self):
+        """
+        ALTER TYPE Foo {
+            CREATE PROPERTY bar -> str {
+                USING (4);
+            };
+        };
+        """
+
+    def test_edgeql_syntax_ddl_type_20(self):
+        """
+        ALTER TYPE Foo {
+            ALTER PROPERTY bar {
+                SET TYPE str;
+                USING (4);
+            };
+        };
+        """
+
+    def test_edgeql_syntax_ddl_type_21(self):
+        """
+        ALTER TYPE Foo {
+            CREATE LINK bar -> Object {
+                USING (SELECT Object);
+            };
+        };
+        """
+
+    def test_edgeql_syntax_ddl_type_22(self):
+        """
+        ALTER TYPE Foo {
+            ALTER LINK bar {
+                SET TYPE Object;
+                USING (SELECT Object);
+            };
+        };
+        """
+
     def test_edgeql_syntax_set_command_01(self):
         """
         SET MODULE default;

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -557,6 +557,55 @@ class TestSchema(tb.BaseSchemaLoadTest):
             }
         """
 
+    @tb.must_fail(
+        errors.SchemaDefinitionError,
+        "the type inferred from the expression of the computable property "
+        "'title' of object type 'test::A' is scalar type 'std::int64', "
+        "which does not match the explicitly specified scalar type 'std::str'",
+        line=3, col=35)
+    def test_schema_target_consistency_check_01(self):
+        """
+            type A {
+                property title -> str {
+                    using (1)
+                }
+            }
+        """
+
+    @tb.must_fail(
+        errors.SchemaDefinitionError,
+        "the type inferred from the expression of the computable property "
+        "'title' of object type 'test::A' is collection "
+        "'tuple<std::int64, std::int64>', which does not match the explicitly "
+        "specified collection 'tuple<std::str, std::str>'",
+        line=3, col=35)
+    def test_schema_target_consistency_check_02(self):
+        """
+            type A {
+                property title -> tuple<str, str> {
+                    using ((1, 2))
+                }
+            }
+        """
+
+    @tb.must_fail(
+        errors.SchemaDefinitionError,
+        "the type inferred from the expression of the computable link "
+        "'foo' of object type 'test::C' is object type 'test::B', "
+        "which does not match the explicitly specified object type 'test::A'",
+        line=6, col=29)
+    def test_schema_target_consistency_check_03(self):
+        """
+            type A;
+            type B;
+
+            type C {
+                link foo -> A {
+                    using (SELECT B)
+                }
+            }
+        """
+
     def test_schema_refs_01(self):
         schema = self.load_schema("""
             type Object1;


### PR DESCRIPTION
Currently, the following would be accepted without error:

```
ALTER TYPE Foo CREATE PROPERTY bar -> str { USING (1) };
```

The explicit type specification would be silently ignored in favor of
the type inferred from the expression.  This is obviously wrong, so make
sure we raise a `SchemaDefinitionError` in cases like this.