### PR TITLE
Materialize volatile (and some other) sets in binding constructs

### DIFF
--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -324,7 +324,7 @@ class ImmutableASTMixin:
 
 
 @markup.serializer.serializer.register(AST)
-def _serialize_to_markup(ast, *, ctx):
+def serialize_to_markup(ast, *, ctx):
     node = markup.elements.lang.TreeNode(id=id(ast), name=type(ast).__name__)
     include_meta = ctx.kwargs.get('_ast_include_meta', True)
     exclude_unset = ctx.kwargs.get('_ast_exclude_unset', True)

--- a/edb/common/ast/visitor.py
+++ b/edb/common/ast/visitor.py
@@ -19,6 +19,8 @@
 
 from __future__ import annotations
 
+from typing import *
+
 from edb.common import typeutils
 
 from . import base
@@ -112,6 +114,7 @@ class NodeVisitor:
     """
 
     skip_hidden = False
+    extra_skips: AbstractSet[str] = frozenset()
 
     def __init__(self, *, context=None, memo=None):
         if memo is not None:
@@ -174,6 +177,8 @@ class NodeVisitor:
         for field, value in base.iter_fields(node, include_meta=False):
             field_spec = node._fields[field]
             if self.skip_hidden and field_spec.hidden:
+                continue
+            if field in self.extra_skips:
                 continue
 
             res = self.visit(value)

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -499,6 +499,7 @@ class ShapeOp(s_enum.StrEnum):
     APPEND = 'APPEND'
     SUBTRACT = 'SUBTRACT'
     ASSIGN = 'ASSIGN'
+    MATERIALIZE = 'MATERIALIZE'  # This is an internal implementation artifact
 
 
 # Need indirection over ShapeOp to preserve the source context.

--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -82,3 +82,14 @@ def is_ql_path(qlexpr: qlast.Expr) -> bool:
     start = qlexpr.steps[0]
 
     return isinstance(start, (qlast.Source, qlast.ObjectRef, qlast.Ptr))
+
+
+def is_nontrivial_shape_element(shape_el: qlast.ShapeElement) -> bool:
+    return bool(
+        shape_el.where
+        or shape_el.orderby
+        or shape_el.offset
+        or shape_el.limit
+        or shape_el.compexpr
+        or any(is_nontrivial_shape_element(el) for el in shape_el.elements)
+    )

--- a/edb/edgeql/compiler/inference/context.py
+++ b/edb/edgeql/compiler/inference/context.py
@@ -36,8 +36,6 @@ class InfCtx(NamedTuple):
         qltypes.Multiplicity]
     singletons: Collection[irast.PathId]
     bindings: Dict[irast.PathId, irast.ScopeTreeNode]
-    volatile_uses: Dict[irast.PathId, irast.ScopeTreeNode]
-    in_for_body: bool
 
 
 def make_ctx(env: context.Environment) -> InfCtx:
@@ -47,6 +45,4 @@ def make_ctx(env: context.Environment) -> InfCtx:
         inferred_multiplicity={},
         singletons=frozenset(env.singletons),
         bindings={},
-        volatile_uses={},
-        in_for_body=False,
     )

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -499,8 +499,6 @@ def __infer_select_stmt(
             ir.iterator_stmt, scope_tree=scope_tree, ctx=ctx,
         )
 
-        ctx = ctx._replace(in_for_body=True)
-
     # OFFSET, LIMIT and ORDER BY have already been validated to be
     # singletons, but their sub-expressions (if any) still need to be
     # validated.

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -118,9 +118,8 @@ def fini_expression(
         ir = setgen.scoped_set(ir, ctx=ctx)
 
     # Make sure that all materialized sets have their views compiled
-    v = ast_visitor.NodeVisitor()
-    v.node_visit(ir)
-    children = [x for x in v.memo if isinstance(x, irast.Stmt)]
+    children = ast_visitor.find_children(
+        ir, lambda n: isinstance(n, irast.Stmt))
     for stmt in children:
         for key in list(stmt.materialized_sets):
             mat_set = stmt.materialized_sets[key]

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -739,7 +739,7 @@ class TypeCast(ImmutableExpr):
 
 class MaterializedSet(Base):
     # Hide uses to reduce spew; we produce our own simpler uses
-    __ast_hidden__ = {'uses'}
+    __ast_hidden__ = {'use_sets'}
     materialized: Set
     # We really only want the *paths* of all the places it is used,
     # but we need to store the sets to take advantage of weak

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -69,7 +69,7 @@ import dataclasses
 import typing
 import uuid
 
-from edb.common import ast, compiler, parsing
+from edb.common import ast, compiler, parsing, markup
 
 from edb.schema import modules as s_mod
 from edb.schema import name as sn
@@ -182,7 +182,10 @@ class BasePointerRef(ImmutableBase):
     __ast_hidden__ = {'children'}
 
     # cardinality fields need to be mutable for lazy cardinality inference.
-    __ast_mutable_fields__ = frozenset(('dir_cardinality', 'out_cardinality'))
+    # and children because we update pointers with newly derived children
+    __ast_mutable_fields__ = frozenset(
+        ('dir_cardinality', 'out_cardinality', 'children')
+    )
 
     # The defaults set here are mostly to try to reduce debug spew output.
     name: sn.QualName
@@ -475,6 +478,7 @@ class ComputableInfo(typing.NamedTuple):
     path_id: PathId
     path_id_ns: typing.Optional[WeakNamespace]
     shape_op: qlast.ShapeOp
+    should_materialize: bool
 
 
 class Statement(Command):
@@ -733,6 +737,30 @@ class TypeCast(ImmutableExpr):
     sql_expr: bool
 
 
+class MaterializedSet(Base):
+    # Hide uses to reduce spew; we produce our own simpler uses
+    __ast_hidden__ = {'uses'}
+    materialized: Set
+    # We really only want the *paths* of all the places it is used,
+    # but we need to store the sets to take advantage of weak
+    # namespace rewriting.
+    use_sets: typing.List[Set]
+    cardinality: qltypes.Cardinality = qltypes.Cardinality.UNKNOWN
+
+    @property
+    def uses(self) -> typing.List[PathId]:
+        return [x.path_id for x in self.use_sets]
+
+
+@markup.serializer.serializer.register(MaterializedSet)
+def _serialize_to_markup(
+        ir: MaterializedSet, *, ctx: typing.Any) -> typing.Any:
+    # We want to show the path_ids but *not* to show the full uses
+    node = ast.serialize_to_markup(ir, ctx=ctx)
+    node.add_child(label='uses', node=markup.serialize(ir.uses, ctx=ctx))
+    return node
+
+
 class Stmt(Expr):
     __abstract_node__ = True
     # Hide parent_stmt to reduce debug spew and to hide it from find_children
@@ -743,6 +771,8 @@ class Stmt(Expr):
     parent_stmt: typing.Optional[Stmt]
     iterator_stmt: typing.Optional[Set]
     bindings: typing.List[Set]
+    # Sets to materialize at this point, keyed by the type/ptr id.
+    materialized_sets: typing.Dict[uuid.UUID, MaterializedSet]
 
 
 class FilteredStmt(Stmt):

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -363,6 +363,11 @@ class PathId:
         """
         result = self.__class__(self)
         result._namespace = frozenset(namespace)
+
+        if result._prefix is not None:
+            result._prefix = result._get_minimal_prefix(
+                result._prefix)
+
         return result
 
     def merge_namespace(
@@ -637,6 +642,9 @@ class PathId:
                         prefix, replacement)
                 else:
                     result._prefix = replacement._prefix
+
+                result._prefix = result._get_minimal_prefix(
+                    result._prefix)
 
                 return result
             else:

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -322,6 +322,47 @@ def contains_dml(stmt: irast.Base, *, skip_bindings: bool=False) -> bool:
     return res
 
 
+class ContainsBindingVisitor(ast.NodeVisitor):
+    skip_hidden = True
+    extra_skips = frozenset(['materialized_sets'])
+
+    def __init__(self, to_skip: AbstractSet[irast.PathId]) -> None:
+        super().__init__()
+        self.to_skip = to_skip
+
+    def combine_field_results(self, xs: List[Optional[bool]]) -> bool:
+        return any(
+            x is True
+            or (isinstance(x, list) and self.combine_field_results(x))
+            for x in xs
+        )
+
+    def visit_Set(self, node: irast.Set) -> bool:
+        if node.path_id in self.to_skip:
+            return False
+
+        if node.is_binding:
+            return True
+
+        results = []
+        results.append(self.visit(node.rptr))
+        results.append(self.visit(node.shape))
+        if not node.rptr:
+            results.append(self.visit(node.expr))
+
+        # Visit sub-trees
+        return self.combine_field_results(results)
+
+
+def contains_binding(
+    stmt: irast.Base, to_skip: AbstractSet[irast.PathId]=frozenset()
+) -> bool:
+    """Check whether a statement contains any bindings in a subtree."""
+    # TODO: Make this caching.
+    visitor = ContainsBindingVisitor(to_skip=to_skip)
+    return visitor.visit(stmt) is True
+
+
 def contains_set_of_op(ir: irast.Base) -> bool:
     flt = (lambda n: isinstance(n, irast.Call)
            and any(x == ft.TypeModifier.SetOfType

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -420,8 +420,10 @@ class Query(ReturningQuery):
             typing.Tuple[irast.PathId, str], PathRangeVar]:
         if flavor == 'packed':
             return self.path_packed_rvar_map
-        else:
+        elif flavor == 'normal':
             return self.path_rvar_map
+        else:
+            raise AssertionError(f'unexpected flavor "{flavor}"')
 
     @property
     def ser_safe(self):

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -133,6 +133,12 @@ class EdgeQLPathInfo(Base):
     # Map of res target names corresponding to paths.
     path_outputs: typing.Dict[typing.Tuple[irast.PathId, str], OutputVar]
 
+    # Map of res target names corresponding to materialized paths.
+    packed_path_outputs: typing.Dict[
+        typing.Tuple[irast.PathId, str],
+        typing.Tuple[OutputVar, bool],
+    ]
+
     path_id_mask: typing.Set[irast.PathId]
 
     # Map of col refs corresponding to paths.
@@ -394,16 +400,28 @@ class Query(ReturningQuery):
     """Generic superclass representing a query."""
 
     # Ignore the below fields in AST visitor/transformer.
-    __ast_meta__ = {'path_rvar_map',
+    __ast_meta__ = {'path_rvar_map', 'path_packed_rvar_map',
                     'view_path_id_map', 'argnames', 'nullable'}
 
     view_path_id_map: typing.Dict[irast.PathId, irast.PathId]
     # Map of RangeVars corresponding to paths.
     path_rvar_map: typing.Dict[typing.Tuple[irast.PathId, str], PathRangeVar]
+    # Map of materialized RangeVars corresponding to paths.
+    path_packed_rvar_map: typing.Dict[
+        typing.Tuple[irast.PathId, str],
+        PathRangeVar,
+    ]
 
     argnames: typing.Dict[str, Param]
 
     ctes: typing.List[CommonTableExpr]
+
+    def get_rvar_map(self, flavor: str) -> typing.Dict[
+            typing.Tuple[irast.PathId, str], PathRangeVar]:
+        if flavor == 'packed':
+            return self.path_packed_rvar_map
+        else:
+            return self.path_rvar_map
 
     @property
     def ser_safe(self):

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 def tuple_element_for_shape_el(
     shape_el: irast.Set,
-    value: Optional[pgast.BaseExpr],
+    value: Optional[pgast.BaseExpr]=None,
     *,
     ctx: context.CompilerContextLevel
 ) -> pgast.TupleElementBase:

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -620,6 +620,14 @@ def _compile_shape(
         pathctx.put_path_serialized_var(
             ctx.rel, element.path_id, element.val, force=True, env=ctx.env)
 
+    # When we compile a shape during materialization, stash the
+    # set away so we can consume it in unpack_rvar.
+    if (
+        ctx.materializing
+        and ir_set.typeref.id not in ctx.env.materialized_views
+    ):
+        ctx.env.materialized_views[ir_set.typeref.id] = ir_set
+
     ser_elements = []
     for el in result.elements:
         ser_val = pathctx.get_path_serialized_or_value_var(

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -27,6 +27,9 @@ import uuid
 
 from edb import errors
 
+from edb.edgeql import qltypes
+from edb.edgeql import ast as qlast
+
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
 from edb.ir import utils as irutils
@@ -41,6 +44,7 @@ from edb.pgsql import types as pg_types
 from . import astutils
 from . import context
 from . import dispatch
+from . import output
 from . import pathctx
 
 
@@ -53,8 +57,9 @@ def init_toplevel_query(
     ctx.pending_query = ctx.rel
 
 
-def pull_path_namespace(
+def _pull_path_namespace(
         *, target: pgast.Query, source: pgast.PathRangeVar,
+        flavor: str='normal',
         replace_bonds: bool=True, ctx: context.CompilerContextLevel) -> None:
 
     squery = source.query
@@ -69,12 +74,18 @@ def pull_path_namespace(
 
     for source_q in source_qs:
         s_paths: Set[Tuple[irast.PathId, str]] = set()
-        if hasattr(source_q, 'path_outputs'):
-            s_paths.update(source_q.path_outputs)
-        if hasattr(source_q, 'path_namespace'):
-            s_paths.update(source_q.path_namespace)
-        if isinstance(source_q, pgast.Query):
-            s_paths.update(source_q.path_rvar_map)
+        if flavor == 'normal':
+            if hasattr(source_q, 'path_outputs'):
+                s_paths.update(source_q.path_outputs)
+            if hasattr(source_q, 'path_namespace'):
+                s_paths.update(source_q.path_namespace)
+            if isinstance(source_q, pgast.Query):
+                s_paths.update(source_q.path_rvar_map)
+        else:
+            if hasattr(source_q, 'packed_path_outputs'):
+                s_paths.update(source_q.packed_path_outputs)
+            if isinstance(source_q, pgast.Query):
+                s_paths.update(source_q.path_packed_rvar_map)
 
         view_path_id_map = getattr(source_q, 'view_path_id_map', {})
 
@@ -85,21 +96,31 @@ def pull_path_namespace(
             # Skip pulling paths that match the path_id_mask before or after
             # doing path id mapping. We need to look at before as well
             # to prevent paths leaking out under a different name.
-            if (
+            if flavor == 'normal' and (
                 path_id in squery.path_id_mask
                 or orig_path_id in squery.path_id_mask
             ):
                 continue
 
             rvar = pathctx.maybe_get_path_rvar(
-                target, path_id, aspect=aspect, env=ctx.env)
+                target, path_id, aspect=aspect, flavor=flavor, env=ctx.env)
             if rvar is None:
                 pathctx.put_path_rvar(
-                    target, path_id, source, aspect=aspect, env=ctx.env)
+                    target, path_id, source, aspect=aspect, flavor=flavor,
+                    env=ctx.env)
+
+
+def pull_path_namespace(
+        *, target: pgast.Query, source: pgast.PathRangeVar,
+        replace_bonds: bool=True, ctx: context.CompilerContextLevel) -> None:
+    for flavor in ('normal', 'packed'):
+        _pull_path_namespace(target=target, source=source, flavor=flavor,
+                             replace_bonds=replace_bonds, ctx=ctx)
 
 
 def find_rvar(
         stmt: pgast.Query, *,
+        flavor: str='normal',
         source_stmt: Optional[pgast.Query]=None,
         path_id: irast.PathId,
         ctx: context.CompilerContextLevel) -> \
@@ -111,6 +132,9 @@ def find_rvar(
 
     :param stmt:
         The statement to ensure range var visibility in.
+
+    :param flavor:
+        Whether to look for normal rvars or packed rvars
 
     :param source_stmt:
         An optional statement object which is used as the starting SQL scope
@@ -131,17 +155,18 @@ def find_rvar(
         source_stmt = stmt
 
     rvar = maybe_get_path_rvar(source_stmt, path_id=path_id,
-                               aspect='value', ctx=ctx)
+                               aspect='value', flavor=flavor, ctx=ctx)
     if rvar is not None:
         pathctx.put_path_rvar_if_not_exists(
-            stmt, path_id, rvar, aspect='value', env=ctx.env)
+            stmt, path_id, rvar, aspect='value', flavor=flavor, env=ctx.env)
 
         src_rvar = maybe_get_path_rvar(source_stmt, path_id=path_id,
-                                       aspect='source', ctx=ctx)
+                                       aspect='source', flavor=flavor, ctx=ctx)
 
         if src_rvar is not None:
             pathctx.put_path_rvar_if_not_exists(
-                stmt, path_id, src_rvar, aspect='source', env=ctx.env)
+                stmt, path_id, src_rvar,
+                aspect='source', flavor=flavor, env=ctx.env)
 
     return rvar
 
@@ -152,7 +177,8 @@ def include_rvar(
         path_id: irast.PathId, *,
         overwrite_path_rvar: bool=False,
         pull_namespace: bool=True,
-        aspects: Optional[Iterable[str]]=None,
+        flavor: str='normal',
+        aspects: Optional[Tuple[str, ...]]=None,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
     """Ensure that *rvar* is visible in *stmt* as a value/source aspect.
 
@@ -164,6 +190,9 @@ def include_rvar(
 
     :param join_type:
         JOIN type to use when including *rel*.
+
+    :param flavor:
+        Whether this is a normal or packed rvar
 
     :param aspect:
         The reference aspect of the range var.
@@ -181,6 +210,7 @@ def include_rvar(
         stmt, rvar=rvar, path_id=path_id,
         overwrite_path_rvar=overwrite_path_rvar,
         pull_namespace=pull_namespace,
+        flavor=flavor,
         aspects=aspects,
         ctx=ctx)
 
@@ -191,6 +221,7 @@ def include_specific_rvar(
         path_id: irast.PathId, *,
         overwrite_path_rvar: bool=False,
         pull_namespace: bool=True,
+        flavor: str='normal',
         aspects: Iterable[str]=('value',),
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
     """Make the *aspect* of *path_id* visible in *stmt* as *rvar*.
@@ -204,6 +235,9 @@ def include_specific_rvar(
     :param join_type:
         JOIN type to use when including *rel*.
 
+    :param flavor:
+        Whether this is a normal or packed rvar
+
     :param aspect:
         The reference aspect of the range var.
 
@@ -211,7 +245,7 @@ def include_specific_rvar(
         Compiler context.
     """
 
-    if not has_rvar(stmt, rvar, ctx=ctx):
+    if not has_rvar(stmt, rvar, flavor=flavor, ctx=ctx):
         if not (
             ctx.env.external_rvars
             and has_external_rvar(path_id, aspects, ctx=ctx)
@@ -225,11 +259,12 @@ def include_specific_rvar(
     for aspect in aspects:
         if overwrite_path_rvar:
             pathctx.put_path_rvar(
-                stmt, path_id, rvar, aspect=aspect, env=ctx.env)
+                stmt, path_id, rvar, flavor=flavor, aspect=aspect, env=ctx.env)
         else:
             pathctx.put_path_rvar_if_not_exists(
-                stmt, path_id, rvar, aspect=aspect, env=ctx.env)
+                stmt, path_id, rvar, flavor=flavor, aspect=aspect, env=ctx.env)
 
+    if flavor == 'normal':
         scopes = [ctx.scope_tree]
         parent_scope = ctx.scope_tree.parent
         if parent_scope is not None:
@@ -244,12 +279,13 @@ def include_specific_rvar(
 
 def has_rvar(
         stmt: pgast.Query, rvar: pgast.PathRangeVar, *,
+        flavor: str='normal',
         ctx: context.CompilerContextLevel) -> bool:
 
     curstmt: Optional[pgast.Query] = stmt
 
     while curstmt is not None:
-        if pathctx.has_rvar(curstmt, rvar, env=ctx.env):
+        if pathctx.has_rvar(curstmt, rvar, flavor=flavor, env=ctx.env):
             return True
         curstmt = ctx.rel_hierarchy.get(curstmt)
 
@@ -275,17 +311,19 @@ def _maybe_get_path_rvar(
     stmt: pgast.Query,
     path_id: irast.PathId,
     *,
+    flavor: str='normal',
     aspect: str,
     ctx: context.CompilerContextLevel,
 ) -> Optional[Tuple[pgast.PathRangeVar, irast.PathId]]:
     qry: Optional[pgast.Query] = stmt
     while qry is not None:
         rvar = pathctx.maybe_get_path_rvar(
-            qry, path_id, aspect=aspect, env=ctx.env)
+            qry, path_id, aspect=aspect, flavor=flavor, env=ctx.env)
         if rvar is not None:
             if qry is not stmt:
                 # Cache the rvar reference.
-                pathctx.put_path_rvar(stmt, path_id, rvar, aspect=aspect,
+                pathctx.put_path_rvar(stmt, path_id, rvar,
+                                      flavor=flavor, aspect=aspect,
                                       env=ctx.env)
             return rvar, path_id
         qry = ctx.rel_hierarchy.get(qry)
@@ -297,10 +335,12 @@ def _get_path_rvar(
     stmt: pgast.Query,
     path_id: irast.PathId,
     *,
+    flavor: str='normal',
     aspect: str,
     ctx: context.CompilerContextLevel,
 ) -> Tuple[pgast.PathRangeVar, irast.PathId]:
-    result = _maybe_get_path_rvar(stmt, path_id, aspect=aspect, ctx=ctx)
+    result = _maybe_get_path_rvar(
+        stmt, path_id, flavor=flavor, aspect=aspect, ctx=ctx)
     if result is None:
         raise LookupError(f'there is no range var for {path_id} in {stmt}')
     else:
@@ -309,8 +349,10 @@ def _get_path_rvar(
 
 def get_path_rvar(
         stmt: pgast.Query, path_id: irast.PathId, *,
+        flavor: str='normal',
         aspect: str, ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
-    return _get_path_rvar(stmt, path_id, aspect=aspect, ctx=ctx)[0]
+    return _get_path_rvar(
+        stmt, path_id, flavor=flavor, aspect=aspect, ctx=ctx)[0]
 
 
 def get_path_var(
@@ -328,9 +370,11 @@ def get_path_var(
 
 def maybe_get_path_rvar(
         stmt: pgast.Query, path_id: irast.PathId, *,
+        flavor: str='normal',
         aspect: str, ctx: context.CompilerContextLevel
 ) -> Optional[pgast.PathRangeVar]:
-    result = _maybe_get_path_rvar(stmt, path_id, aspect=aspect, ctx=ctx)
+    result = _maybe_get_path_rvar(stmt, path_id,
+                                  aspect=aspect, flavor=flavor, ctx=ctx)
     return result[0] if result is not None else None
 
 
@@ -734,6 +778,295 @@ def maybe_get_scope_stmt(
     if stmt is None and path_id.is_ptr_path():
         stmt = ctx.path_scope.get(path_id.tgt_path())
     return stmt
+
+
+class UnpackElement(NamedTuple):
+    path_id: irast.PathId
+    colname: str
+    packed: bool
+    multi: bool
+    ref: Optional[pgast.BaseExpr]
+
+
+def unpack_rvar(
+        stmt: pgast.SelectStmt, path_id: irast.PathId, *,
+        packed_rvar: pgast.PathRangeVar,
+        ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
+
+    qry = pgast.SelectStmt()
+
+    ref: pgast.BaseExpr
+    ref, multi = pathctx.get_packed_path_var(
+        packed_rvar, path_id, 'value', env=ctx.env)
+
+    view_tvars: List[Tuple[irast.PathId, pgast.TupleVarBase, bool]] = []
+    els = []
+    ctr = 0
+
+    def walk(ref: pgast.BaseExpr, path_id: irast.PathId, multi: bool) -> None:
+        nonlocal ctr
+
+        coldeflist = []
+        alias = ctx.env.aliases.get('unpack')
+        simple = False
+        if irtyputils.is_tuple(path_id.target):
+            els.append(UnpackElement(
+                path_id, alias, packed=False, multi=False, ref=None
+            ))
+
+            orig_view_count = len(view_tvars)
+            tuple_tvar_elements = []
+            for i, st in enumerate(path_id.target.subtypes):
+                colname = f'_t{ctr}'
+                ctr += 1
+
+                typ = pg_types.pg_type_from_ir_typeref(st)
+                if st.id in ctx.env.materialized_views:
+                    typ = ('record',)
+
+                # Construct a path_id for the element
+                el_name = sn.QualName('__tuple__', st.element_name or str(i))
+                el_ref = irast.TupleIndirectionPointerRef(
+                    name=el_name, shortname=el_name, path_id_name=el_name,
+                    out_source=path_id.target,
+                    out_target=st,
+                    out_cardinality=qltypes.Cardinality.ONE,
+                    dir_cardinality=qltypes.Cardinality.ONE,
+                )
+                el_path_id = path_id.extend(ptrref=el_ref)
+
+                walk(
+                    pgast.ColumnRef(name=[colname]),
+                    el_path_id,
+                    multi=False,
+                )
+                tuple_tvar_elements.append(
+                    pgast.TupleElementBase(
+                        path_id=el_path_id, name=el_name.name
+                    )
+                )
+
+                coldeflist.append(
+                    pgast.ColumnDef(
+                        name=colname,
+                        typename=pgast.TypeName(name=typ)
+                    )
+                )
+
+            if len(view_tvars) > orig_view_count:
+                tuple_tvar = pgast.TupleVarBase(
+                    elements=tuple_tvar_elements,
+                    typeref=path_id.target,
+                    named=any(
+                        st.element_name for st in path_id.target.subtypes),
+                )
+                view_tvars.append((path_id, tuple_tvar, True))
+
+            if irtyputils.is_persistent_tuple(path_id.target):
+                coldeflist = []
+
+        elif irtyputils.is_array(path_id.target) and multi:
+            # TODO: materialized arrays of tuples and arrays are really
+            # quite broken
+            coldeflist = [
+                pgast.ColumnDef(
+                    name='q',
+                    typename=pgast.TypeName(
+                        name=pg_types.pg_type_from_ir_typeref(
+                            path_id.target)
+                    )
+                )
+            ]
+
+            els.append(UnpackElement(
+                path_id, coldeflist[0].name,
+                packed=False, multi=False, ref=None
+            ))
+
+        elif path_id.target.id in ctx.env.materialized_views:
+            view_tuple = ctx.env.materialized_views[path_id.target.id]
+
+            vpath_ids = []
+            id_idx = None
+            for el, _ in view_tuple.shape:
+                src_path, el_ptrref = el.path_id.src_path(), el.path_id.rptr()
+                assert src_path and el_ptrref
+
+                # We want to graft the ptrref for this element onto
+                # the main path_id. To get the right one (that will
+                # match code that wants to consume this), we need to
+                # find the ptrref that matches the path_id view type.
+                ptrref = irtyputils.maybe_find_actual_ptrref(
+                    path_id.target, el_ptrref, material=False)
+                if not ptrref:
+                    # A missing ptrref should mean that this computable isn't
+                    # actually used, so we don't need to worry too hard.
+                    ptrref = el_ptrref
+                el_id = path_id.ptr_path().extend(ptrref=ptrref)
+
+                assert el.rptr
+                card = el.rptr.ptrref.dir_cardinality
+                is_singleton = card.is_single() and not card.can_be_zero()
+                must_pack = not is_singleton
+
+                if (rptr_name := el_id.rptr_name()) and rptr_name.name == 'id':
+                    id_idx = len(els)
+
+                colname = f'_t{ctr}'
+                ctr += 1
+
+                typ = pg_types.pg_type_from_ir_typeref(el_id.target)
+                if el_id.target.id in ctx.env.materialized_views:
+                    typ = ('record',)
+                    must_pack = True
+
+                if not is_singleton:
+                    typ = pg_types.pg_type_array(typ)
+
+                coldeflist.append(
+                    pgast.ColumnDef(
+                        name=colname,
+                        typename=pgast.TypeName(name=typ),
+                    )
+                )
+                els.append(UnpackElement(
+                    el_id, colname,
+                    packed=must_pack, multi=not is_singleton, ref=None
+                ))
+
+                vpath_ids.append(el_id)
+
+            if id_idx is not None:
+                els.append(UnpackElement(
+                    path_id, els[id_idx].colname,
+                    multi=False, packed=False, ref=None,
+                ))
+
+            view_tvars.append((path_id, pgast.TupleVarBase(
+                elements=[
+                    pgast.TupleElementBase(
+                        path_id=pid,
+                        name=astutils.tuple_element_for_shape_el(
+                            el, ctx=ctx).name,
+                    )
+                    for (el, op), pid in zip(view_tuple.shape, vpath_ids)
+                    if op != qlast.ShapeOp.MATERIALIZE or ctx.materializing
+                ],
+                typeref=path_id.target,
+                named=True,
+            ), False))
+
+        else:
+            coldeflist = []
+            simple = not multi
+            els.append(UnpackElement(
+                path_id, alias, multi=False, packed=False,
+                ref=ref if simple else None,
+            ))
+
+        if not simple:
+            if not multi:
+                # Sigh, have to wrap in an array so we can unpack.
+                ref = pgast.ArrayExpr(elements=[ref])
+
+            qry.from_clause[0:0] = [
+                pgast.RangeFunction(
+                    alias=pgast.Alias(
+                        aliasname=alias,
+                    ),
+                    is_rowsfrom=True,
+                    functions=[
+                        pgast.FuncCall(
+                            name=('unnest',),
+                            args=[ref],
+                            coldeflist=coldeflist,
+                        )
+                    ]
+                )
+            ]
+
+    ########################
+
+    walk(ref, path_id, multi)
+
+    rvar = rvar_for_rel(qry, lateral=True, ctx=ctx)
+    include_rvar(stmt, rvar, path_id=path_id, aspects=('value',), ctx=ctx)
+
+    for el in els:
+        el_id = el.path_id
+        cur_ref = el.ref or pgast.ColumnRef(name=[el.colname])
+
+        for aspect in ('value', 'serialized'):
+            pathctx.put_path_var(
+                qry, el_id, cur_ref, aspect=aspect, env=ctx.env,
+            )
+
+        if not el.packed:
+            pathctx.put_path_rvar(
+                stmt, el_id, rvar, aspect='value', env=ctx.env)
+
+            pathctx.put_path_rvar(
+                ctx.rel, el_id, rvar, aspect='value', env=ctx.env)
+        else:
+            cref = pathctx.get_rvar_path_var(rvar, el_id, 'value', env=ctx.env)
+
+            colname = ctx.env.aliases.get("col")
+            sub_packed_stmt = pgast.SelectStmt(
+                target_list=[pgast.ResTarget(name=colname, val=cref)],
+            )
+            sub_packed_stmt.packed_path_outputs[el_id, 'value'] = (
+                pgast.ColumnRef(name=[colname]), el.multi,
+            )
+
+            sub_rvar = rvar_for_rel(sub_packed_stmt, lateral=True, ctx=ctx)
+            # Need to specify value as the aspects because we *don't*
+            # provide the source.
+            include_rvar(
+                stmt, sub_rvar, path_id=el_id, aspects=('value',),
+                flavor='packed', pull_namespace=False, ctx=ctx,
+            )
+
+    # When we're producing an exposed shape, we need to rewrite the
+    # serialized shape.
+    # We also need to rewrite tuples that contain such shapes!
+    # What a pain!
+    # Note, though, that the cases here are:
+    # 1) Any shapes are "implicit" ones, just containing id, __tname, etc
+    # 2) We are still materializing
+    #
+    # We *also* need to rewrite tuple values, so that we don't consider
+    # serialized materialized objects as part of the value of the tuple
+    for view_path_id, view_tvar, is_tuple in view_tvars:
+        if not view_tvar.elements:
+            continue
+
+        rewrite_aspects = []
+        if ctx.expr_exposed:
+            rewrite_aspects.append('serialized')
+        if is_tuple:
+            rewrite_aspects.append('value')
+        for aspect in rewrite_aspects:
+            tv = pathctx.fix_tuple(qry, view_tvar, aspect=aspect, env=ctx.env)
+            sval = (
+                output.output_as_value(tv, env=ctx.env)
+                if aspect == 'value' else
+                output.serialize_expr(tv, path_id=path_id, env=ctx.env)
+            )
+            pathctx.put_path_var(
+                qry, view_path_id, sval, aspect=aspect, env=ctx.env, force=True
+            )
+            pathctx.put_path_rvar(
+                ctx.rel, view_path_id, rvar, aspect=aspect, env=ctx.env
+            )
+
+    # Every time I removed this debug spew I ended up needing it again.
+    # I'll probably remember to remove it before putting up the PR.
+    # print("UNPACK_RVAR", path_id, ref, [el.path_id for el in els])
+    # from edb.common.debug import dump_sql
+    # dump_sql(rvar)
+    # breakpoint()
+
+    return rvar
 
 
 def get_scope_stmt(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1227,7 +1227,8 @@ def process_set_as_subquery(
         if ir_source and (new_rvar := _lookup_set_rvar(ir_set, ctx=ctx)):
             if semi_join:
                 # We need to use DISTINCT, instead of doing an actual
-                # semi-join, unfortunately
+                # semi-join, unfortunately: we need to extract data
+                # out from stmt, which we can't do with a semi-join.
                 value_var = pathctx.get_rvar_path_var(
                     new_rvar, outer_id, aspect='value', env=ctx.env)
                 stmt.distinct_clause = (

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -115,6 +115,33 @@ class OptionalRel(NamedTuple):
     marker: str
 
 
+def _lookup_set_rvar(
+        ir_set: irast.Set, *,
+        scope_stmt: Optional[pgast.SelectStmt]=None,
+        ctx: context.CompilerContextLevel) -> Optional[pgast.PathRangeVar]:
+    path_id = ir_set.path_id
+
+    rvar = relctx.find_rvar(ctx.rel, source_stmt=scope_stmt,
+                            path_id=path_id, ctx=ctx)
+
+    if rvar is not None:
+        return rvar
+
+    # We couldn't find a regular rvar, but maybe we can find a packed one?
+    packed_rvar = relctx.find_rvar(ctx.rel, flavor='packed',
+                                   source_stmt=scope_stmt,
+                                   path_id=path_id, ctx=ctx)
+
+    if packed_rvar is not None:
+        rvar = relctx.unpack_rvar(
+            scope_stmt or ctx.rel,
+            path_id, packed_rvar=packed_rvar, ctx=ctx)
+
+        return rvar
+
+    return None
+
+
 def get_set_rvar(
         ir_set: irast.Set, *,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
@@ -125,10 +152,7 @@ def get_set_rvar(
     path_id = ir_set.path_id
 
     scope_stmt = relctx.maybe_get_scope_stmt(path_id, ctx=ctx)
-    rvar = relctx.find_rvar(ctx.rel, source_stmt=scope_stmt,
-                            path_id=path_id, ctx=ctx)
-
-    if rvar is not None:
+    if rvar := _lookup_set_rvar(ir_set, scope_stmt=scope_stmt, ctx=ctx):
         return rvar
 
     if ctx.toplevel_stmt is context.NO_STMT:
@@ -453,6 +477,7 @@ def set_as_subquery(
 
 def set_to_array(
         ir_set: irast.Set, query: pgast.Query, *,
+        materializing: bool=False,
         ctx: context.CompilerContextLevel) -> pgast.Query:
     """Collapse a set into an array."""
     subrvar = pgast.RangeSubselect(
@@ -477,6 +502,10 @@ def set_to_array(
             value_var, path_id=ir_set.path_id, env=ctx.env)
         pathctx.put_path_serialized_var(
             result, ir_set.path_id, val, force=True, env=ctx.env)
+
+    if isinstance(val, pgast.TupleVarBase):
+        val = output.serialize_expr(
+            val, path_id=ir_set.path_id, env=ctx.env)
 
     pg_type = output.get_pg_type(ir_set.typeref, ctx=ctx)
     orig_val = val
@@ -514,8 +543,9 @@ def set_to_array(
 
     result.target_list = [
         pgast.ResTarget(
+            name=ctx.env.aliases.get('v'),
             val=agg_expr,
-            ser_safe=array_agg.ser_safe,
+            ser_safe=agg_expr.ser_safe,
         )
     ]
 
@@ -1107,6 +1137,23 @@ def process_set_as_path(
     return SetRVars(main=main_rvar, new=rvars)
 
 
+def _new_subquery_stmt_set_rvar(
+    ir_set: irast.Set,
+    stmt: pgast.Query,
+    *,
+    ctx: context.CompilerContextLevel,
+) -> SetRVars:
+    aspects = pathctx.list_path_aspects(
+        stmt, ir_set.path_id, env=ctx.env)
+    if ir_set.path_id.is_tuple_path():
+        # If we are wrapping a tuple expression, make sure not to
+        # over-represent it in terms of the exposed aspects.
+        aspects -= {'serialized'}
+
+    return new_stmt_set_rvar(
+        ir_set, stmt, aspects=aspects, ctx=ctx)
+
+
 def process_set_as_subquery(
         ir_set: irast.Set, stmt: pgast.SelectStmt, *,
         ctx: context.CompilerContextLevel) -> SetRVars:
@@ -1139,9 +1186,6 @@ def process_set_as_subquery(
         outer_id = ir_set.path_id
         inner_id = inner_set.path_id
         semi_join = False
-
-        if inner_id != outer_id:
-            pathctx.put_path_id_map(ctx.rel, outer_id, inner_id)
 
         if ir_source is not None:
             if ir_source.path_id != ctx.current_insert_path_id:
@@ -1176,6 +1220,25 @@ def process_set_as_subquery(
                 relctx.include_rvar(
                     stmt, subrvar, ir_source.path_id, ctx=ctx)
 
+        # If we are looking at a materialized computable, running
+        # get_set_rvar on the source above may have made it show
+        # up. So try to lookup the rvar again, and if we find it,
+        # skip compiling the computable.
+        if ir_source and (new_rvar := _lookup_set_rvar(ir_set, ctx=ctx)):
+            if semi_join:
+                # We need to use DISTINCT, instead of doing an actual
+                # semi-join, unfortunately
+                value_var = pathctx.get_rvar_path_var(
+                    new_rvar, outer_id, aspect='value', env=ctx.env)
+                stmt.distinct_clause = (
+                    pathctx.get_rvar_output_var_as_col_list(
+                        subrvar, value_var, aspect='value', env=ctx.env))
+
+            return _new_subquery_stmt_set_rvar(ir_set, stmt, ctx=ctx)
+
+        if inner_id != outer_id:
+            pathctx.put_path_id_map(ctx.rel, outer_id, inner_id)
+
         if (isinstance(ir_set.expr, irast.MutatingStmt)
                 and ir_set.expr in ctx.dml_stmts):
             # The DML table-routing logic may result in the same
@@ -1204,13 +1267,7 @@ def process_set_as_subquery(
             stmt.where_clause = astutils.extend_binop(
                 stmt.where_clause, cond_expr)
 
-    aspects = pathctx.list_path_aspects(stmt, inner_id, env=ctx.env)
-    if inner_id.is_tuple_path():
-        # If we are wrapping a tuple expression, make sure not to
-        # over-represent it in terms of the exposed aspects.
-        aspects -= {'serialized'}
-
-    return new_stmt_set_rvar(ir_set, stmt, aspects=aspects, ctx=ctx)
+    return _new_subquery_stmt_set_rvar(ir_set, stmt, ctx=ctx)
 
 
 def process_set_as_membership_expr(
@@ -1696,6 +1753,10 @@ def process_set_as_tuple_indirection(
     with ctx.new() as subctx:
         subctx.expr_exposed = False
         rvar = get_set_rvar(tuple_set, ctx=subctx)
+
+        # Check if unpack_rvar has found our answer for us.
+        if ret_rvar := _lookup_set_rvar(ir_set, ctx=ctx):
+            return new_simple_set_rvar(ir_set, ret_rvar, aspects=('value',))
 
         source_rvar = relctx.maybe_get_path_rvar(
             stmt, tuple_set.path_id, aspect='source', ctx=subctx)

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -89,6 +89,9 @@ def compile_SelectStmt(
                     )
                 last_iterator = iterator_set
 
+        # Process materialized sets
+        clauses.compile_materialized_exprs(query, stmt, ctx=ctx)
+
         # Process the result expression.
         with ctx.new() as ictx:
             clauses.setup_iterator_volatility(last_iterator, ctx=ictx)

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -153,6 +153,13 @@ def pg_type_from_scalar(
     return column_type
 
 
+def pg_type_array(tp: Tuple[str, ...]) -> Tuple[str, ...]:
+    if len(tp) == 1:
+        return (tp[0] + '[]',)
+    else:
+        return (tp[0], tp[1] + '[]')
+
+
 def pg_type_from_object(
         schema: s_schema.Schema,
         obj: s_obj.Object,

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -184,10 +184,7 @@ def pg_type_from_object(
             tp = pg_type_from_object(
                 schema, obj.get_subtypes(schema)[0],
                 persistent_tuples=persistent_tuples)
-            if len(tp) == 1:
-                return (tp[0] + '[]',)
-            else:
-                return (tp[0], tp[1] + '[]')
+            return pg_type_array(tp)
 
     elif isinstance(obj, s_objtypes.ObjectType):
         return ('uuid',)

--- a/tests/schemas/volatility.esdl
+++ b/tests/schemas/volatility.esdl
@@ -19,6 +19,7 @@
 
 type Obj {
     required property n -> int64;
+    multi link tgt -> Tgt;
 }
 
 type Tgt {

--- a/tests/schemas/volatility_setup.edgeql
+++ b/tests/schemas/volatility_setup.edgeql
@@ -63,11 +63,20 @@ CREATE FUNCTION rand_int(top: int64) -> int64 {
     USING (<int64>(random() * top))
 };
 
+CREATE FUNCTION vol_id(x: int64) -> int64 {
+    SET volatility := 'Volatile';
+    USING (x)
+};
 
-INSERT Obj { n := 1 };
-INSERT Obj { n := 2 };
-INSERT Obj { n := 3 };
+CREATE SCALAR TYPE TestCounter extending std::sequence;
+CREATE FUNCTION next() -> int64 USING (
+	SELECT sequence_next(INTROSPECT TestCounter)
+);
+
 INSERT Tgt { n := 1 };
 INSERT Tgt { n := 2 };
 INSERT Tgt { n := 3 };
 INSERT Tgt { n := 4 };
+INSERT Obj { n := 1, tgt := (SELECT Tgt FILTER .n IN {1, 2}) };
+INSERT Obj { n := 2, tgt := (SELECT Tgt FILTER .n IN {2, 3}) };
+INSERT Obj { n := 3, tgt := (SELECT Tgt FILTER .n IN {3, 4}) };

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -637,6 +637,16 @@ class TestEdgeQLFor(tb.QueryTestCase):
             }
         )
 
+    async def test_edgeql_for_and_computable_01(self):
+        await self.assert_query_result(
+            r'''
+                WITH X := (SELECT (FOR x IN {1,2} UNION (
+                    SELECT User { m := x }))),
+                SELECT count(X.m);
+            ''',
+            [8],
+        )
+
     async def test_edgeql_for_correlated_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -155,14 +155,14 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 "FENCE": {
                     "FENCE": {
                         "FENCE": {
-                            "[ns~2]@@(__derived__::__derived__|U@w~1)"
+                            "[tmpns~1]@@(__derived__::__derived__|U@w~1)"
                         }
                     }
                 }
             },
             "(default::User)",
             "FENCE": {
-                "[ns~2]@[ns~3]@@(__derived__::__derived__|U@w~1)",
+                "[ns~2]@[tmpns~1]@@(__derived__::__derived__|U@w~1)",
                 "(default::Card).>users[IS default::User]"
             }
         }
@@ -258,7 +258,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 }
             },
             "FENCE": {
-                "[ns~1]@[ns~2]@@(schema::Type).>indirection[IS schema::Array]\
+                "(schema::Type).>indirection[IS schema::Array]\
 .>element_type[IS schema::Type]": {
                     "(schema::Type).>indirection[IS schema::Array]"
                 },
@@ -283,7 +283,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             },
             "(__derived__::expr~3)",
             "FENCE": {
-                "[ns~2]@[ns~3]@@(__derived__::expr~3).>foo[IS std::str]"
+                "(__derived__::expr~3).>foo[IS std::str]"
             }
         }
         """
@@ -327,24 +327,23 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             },
             "FENCE": {
                 "FENCE": {
-                    "[ns~1]@[ns~2]@@(default::User).>friends[IS default::User]"
+                    "(default::User).>friends[IS default::User]"
                 },
                 "FENCE": {
-                    "[ns~1]@[ns~2]@@(default::User).>deck[IS default::Card]\
+                    "(default::User).>deck[IS default::Card]\
 .<deck[IS __derived__::(opaque: default:User)]\
 .>indirection[IS default::User]": {
-                        "[ns~1]@[ns~2]@@(default::User)\
-.>deck[IS default::Card].<deck[IS __derived__::(opaque: default:User)]": {
-                            "[ns~1]@[ns~2]@@(default::User)\
-.>deck[IS default::Card]"
+                        "(default::User).>deck[IS default::Card]\
+.<deck[IS __derived__::(opaque: default:User)]": {
+                            "(default::User).>deck[IS default::Card]"
                         }
                     }
                 },
                 "FENCE": {
-                    "[ns~1]@[ns~2]@@(default::User).>friends[IS default::User]"
+                    "(default::User).>friends[IS default::User]"
                 },
                 "(default::User).>friends[IS default::User]",
-                "[ns~1]@[ns~2]@@(__derived__::expr~13)"
+                "[ns~1]@[tmpns~1]@@(__derived__::expr~13)"
             },
             "FENCE": {
                 "(default::User).>name[IS std::str]"
@@ -366,7 +365,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                     "ns~1@@(default::Card)\
 .<deck[IS __derived__::(opaque: default:User)]\
 .>indirection[IS default::User]": {
-                        "ns~1@@(default::Card)\
+                        "(default::Card)\
 .<deck[IS __derived__::(opaque: default:User)]": {
                             "(default::Card)"
                         }
@@ -438,23 +437,33 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                     },
                     "FENCE": {
                         "[ns~1]@@(default::User).>name[IS std::str]"
+                    },
+                    "(__derived__::__derived__|U@w~1)",
+                    "FENCE": {
+                        "[ns~1]@[ns~4]@@(default::Card)",
+                        "FENCE": {
+                            "[ns~1]@@(default::User).>deck[IS default::Card]"
+                        },
+                        "[ns~1]@@(default::User).>cards[IS default::Card]"
                     }
                 }
             },
-            "(__derived__::__derived__|U@w~1).>cards[IS default::Card]\
+            "FENCE": {
+                "(__derived__::__derived__|U@w~1).>cards[IS default::Card]\
 .>foo[IS std::float64]": {
-                "CBRANCH": {
-                    "(__derived__::__derived__|U@w~1)\
+                    "CBRANCH": {
+                        "(__derived__::__derived__|U@w~1)\
 .>cards[IS default::Card]": {
-                        "CBRANCH": {
-                            "(__derived__::__derived__|U@w~1)"
-                        },
-                        "FENCE": {
-                            "[ns~2]@@(default::Card)",
+                            "CBRANCH": {
+                                "(__derived__::__derived__|U@w~1)"
+                            },
                             "FENCE": {
-                                "[ns~2]@@(__derived__::__derived__|U@w~1)\
+                                "[ns~2]@@(default::Card)",
+                                "FENCE": {
+                                    "(__derived__::__derived__|U@w~1)\
 .>deck[IS default::Card]": {
-                                    "(__derived__::__derived__|U@w~1)"
+                                        "(__derived__::__derived__|U@w~1)"
+                                    }
                                 }
                             }
                         }
@@ -534,9 +543,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                         "FENCE": {
                             "FENCE": {
                                 "FENCE": {
-                                    "[ns~1]@ns~2@@(default::User)\
+                                    "[ns~1]@@(default::User)\
 .>friends[IS default::User].>deck[IS default::Card].>cost[IS std::int64]": {
-                                        "[ns~1]@ns~2@@(default::User)\
+                                        "[ns~1]@@(default::User)\
 .>friends[IS default::User].>deck[IS default::Card]"
                                     }
                                 }
@@ -568,10 +577,10 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "FENCE": {
                 "(default::Card).>owners[IS default::User]": {
                     "FENCE": {
-                        "ns~1@@(default::Card)\
+                        "(default::Card)\
 .<deck[IS __derived__::(opaque: default:User)]\
 .>indirection[IS default::User]": {
-                            "ns~1@@(default::Card)\
+                            "(default::Card)\
 .<deck[IS __derived__::(opaque: default:User)]"
                         }
                     }
@@ -621,9 +630,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 }
             },
             "FENCE": {
-                "[ns~1]@[ns~3]@@(default::User).>deck[IS default::Card]",
+                "(default::User).>deck[IS default::Card]",
                 "FENCE": {
-                    "[ns~1]@[ns~3]@@(default::User)\
+                    "(default::User)\
 .>deck[IS default::Card]@count[IS std::int64]"
                 },
                 "(default::User).>deck[IS default::Card]"
@@ -631,18 +640,16 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "FENCE": {
                 "(default::User).>deck[IS default::Card]": {
                     "FENCE": {
-                        "[ns~1]@[ns~5]@@(default::User)\
-.>deck[IS default::Card]",
+                        "(default::User).>deck[IS default::Card]",
                         "FENCE": {
-                            "[ns~1]@[ns~5]@@(default::User)\
+                            "(default::User)\
 .>deck[IS default::Card]@count[IS std::int64]"
                         }
                     },
                     "FENCE": {
-                        "[ns~1]@[ns~4]@@(default::User)\
-.>deck[IS default::Card]",
+                        "(default::User).>deck[IS default::Card]",
                         "FENCE": {
-                            "[ns~1]@[ns~4]@@(default::User)\
+                            "(default::User)\
 .>deck[IS default::Card]@count[IS std::int64]"
                         }
                     }
@@ -672,9 +679,9 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                                     "(default::User).>deck[IS default::Card]"
                                 }
                             },
-                            "[ns~1]@@(__derived__::__derived__|x@w~1)",
+                            "[tmpns~1]@@(__derived__::__derived__|x@w~1)",
                             "FENCE": {
-                                "[ns~1]@@(__derived__::__derived__|x@w~1)\
+                                "[tmpns~1]@@(__derived__::__derived__|x@w~1)\
 .>name[IS std::str]"
                             }
                         }
@@ -684,13 +691,12 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "FENCE": {
                 "FENCE": {
                     "FENCE": {
-                        "[ns~1]@[ns~3]@[ns~4]@@(default::User)\
-.>deck[IS default::Card]"
+                        "(default::User).>deck[IS default::Card]"
                     }
                 },
-                "[ns~1]@[ns~3]@@(__derived__::__derived__|x@w~2)",
+                "[ns~2]@[tmpns~1]@@(__derived__::__derived__|x@w~2)",
                 "FENCE": {
-                    "[ns~1]@[ns~3]@@(__derived__::__derived__|x@w~2)\
+                    "[ns~2]@[tmpns~1]@@(__derived__::__derived__|x@w~2)\
 .>name[IS std::str]"
                 },
                 "(default::User).>deck[IS default::Card]"
@@ -738,7 +744,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 "FENCE": {
                     "FENCE": {
                         "FENCE": {
-                            "[ns~1]@@(__derived__::__derived__|letter@w~1)",
+                            "[tmpns~1]@@(__derived__::__derived__|letter@w~1)",
                             "FENCE": {
                                 "FENCE": {
                                     "(default::User).>deck[IS default::Card]",
@@ -753,19 +759,18 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 }
             },
             "FENCE": {
-                "[ns~1]@[ns~4]@@(__derived__::__derived__|letter@w~1)",
+                "[ns~2]@[tmpns~1]@@(__derived__::__derived__|letter@w~1)",
                 "FENCE": {
                     "FENCE": {
-                        "[ns~1]@[ns~4]@@(default::User)\
-.>deck[IS default::Card]",
+                        "(default::User).>deck[IS default::Card]",
                         "FENCE": {
-                            "[ns~1]@[ns~4]@@(default::User)\
-.>deck[IS default::Card].>name[IS std::str]"
+                            "(default::User).>deck[IS default::Card]\
+.>name[IS std::str]"
                         }
                     }
                 },
                 "(default::User).>select_deck[IS default::Card]",
-                "[ns~1]@[ns~4]@@(__derived__::expr~26)"
+                "[ns~2]@[tmpns~1]@@(__derived__::expr~26)"
             },
             "FENCE": {
                 "(default::User).>name[IS std::str]"
@@ -795,7 +800,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 "FENCE": {
                     "FENCE": {
                         "FENCE": {
-                            "[ns~1]@@(__derived__::__derived__|letter@w~1)",
+                            "[tmpns~1]@@(__derived__::__derived__|letter@w~1)",
                             "FENCE": {
                                 "FENCE": {
                                     "FENCE": {
@@ -807,28 +812,27 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                                         }
                                     }
                                 },
-                                "[ns~1]@@(__derived__::__derived__|foo@w~2)"
+                                "[tmpns~1]@@(__derived__::__derived__|foo@w~2)"
                             }
                         }
                     }
                 }
             },
             "FENCE": {
-                "[ns~1]@[ns~5]@@(__derived__::__derived__|letter@w~1)",
+                "[ns~3]@[tmpns~1]@@(__derived__::__derived__|letter@w~1)",
                 "FENCE": {
                     "FENCE": {
                         "FENCE": {
-                            "[ns~1]@[ns~5]@[ns~7]@@(default::User)\
-.>deck[IS default::Card]",
+                            "(default::User).>deck[IS default::Card]",
                             "FENCE": {
-                                "[ns~1]@[ns~5]@[ns~7]@@(default::User)\
-.>deck[IS default::Card].>name[IS std::str]"
+                                "(default::User).>deck[IS default::Card]\
+.>name[IS std::str]"
                             }
                         }
                     }
                 },
                 "(default::User).>select_deck[IS default::Card]",
-                "[ns~1]@[ns~5]@@(__derived__::__derived__|foo@w~2)"
+                "[ns~3]@[tmpns~1]@@(__derived__::__derived__|foo@w~2)"
             },
             "FENCE": {
                 "(default::User).>name[IS std::str]"
@@ -852,33 +856,33 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 "FENCE": {
                     "FENCE": {
                         "FENCE": {
-                            "[ns~1]@@(default::Card)",
+                            "[tmpns~1]@@(default::Card)",
                             "FENCE": {
                                 "FENCE": {
                                     "FENCE": {
                                         "FENCE": {
-                                            "[ns~1]@@(default::Card)\
+                                            "[tmpns~1]@@(default::Card)\
 .>cost[IS std::int64]"
                                         }
                                     }
                                 }
                             },
                             "FENCE": {
-                                "[ns~1]@@(default::Card).>element[IS std::str]"
+                                "[tmpns~1]@@(default::Card)\
+.>element[IS std::str]"
                             }
                         }
                     }
                 }
             },
             "FENCE": {
-                "[ns~1]@[ns~5]@@(default::Card)",
+                "[ns~3]@[tmpns~1]@@(default::Card)",
                 "FENCE": {
-                    "[ns~1]@[ns~5]@@(default::Card).>element[IS std::str]"
+                    "[ns~3]@[tmpns~1]@@(default::Card).>element[IS std::str]"
                 },
                 "(default::User).>deck[IS default::Card]",
                 "FENCE": {
-                    "[ns~1]@[ns~2]@[ns~5]@[ns~6]@@(default::Card)\
-.>cost[IS std::int64]"
+                    "[ns~3]@[tmpns~1]@@(default::Card).>cost[IS std::int64]"
                 }
             }
         }
@@ -901,7 +905,7 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                             "ns~2@@(__derived__::__derived__|A@w~1)\
 .<deck[IS __derived__::(opaque: default:User)]\
 .>indirection[IS default::User]": {
-                                "ns~2@@(__derived__::__derived__|A@w~1)\
+                                "(__derived__::__derived__|A@w~1)\
 .<deck[IS __derived__::(opaque: default:User)]": {
                                     "(__derived__::__derived__|A@w~1)"
                                 }
@@ -929,27 +933,28 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 "FENCE": {
                     "FENCE": {
                         "FENCE": {
-                            "[ns~1]@@(default::User)",
+                            "[tmpns~1]@@(default::User)",
                             "FENCE": {
-                                "[ns~1]@@(default::User).>name[IS std::str]"
+                                "[tmpns~1]@@(default::User).>name[IS std::str]"
                             }
                         }
                     }
                 }
             },
             "FENCE": {
-                "[ns~1]@[ns~2]@@(default::User)",
+                "[ns~1]@[tmpns~1]@@(default::User)",
                 "FENCE": {
-                    "[ns~1]@[ns~2]@@(default::User).>name[IS std::str]"
+                    "[ns~1]@[tmpns~1]@@(default::User).>name[IS std::str]"
                 },
                 "(default::Card).>alice[IS default::User]"
             },
             "FENCE": {
                 "(default::Card).>alice[IS default::User]": {
                     "FENCE": {
-                        "[ns~1]@[ns~3]@@(default::User)",
+                        "[ns~2]@[tmpns~1]@@(default::User)",
                         "FENCE": {
-                            "[ns~1]@[ns~3]@@(default::User).>name[IS std::str]"
+                            "[ns~2]@[tmpns~1]@@(default::User)\
+.>name[IS std::str]"
                         }
                     }
                 },

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -17,11 +17,13 @@
 #
 
 
+import json
 import os.path
 
 import edgedb
 
 from edb.testbase import server as tb
+from edb.testbase import serutils
 from edb.tools import test
 
 
@@ -31,6 +33,35 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
 
     SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
                          'volatility_setup.edgeql')
+
+    def _check_crossproduct(self, res):
+        ns = set()
+        pairs = set()
+        for row in res:
+            ns.add(row[0])
+            pairs.add((row[0], row[1]))
+
+        self.assertEqual(
+            pairs,
+            {(n1, n2) for n1 in ns for n2 in ns},
+        )
+
+    def test_loop(self, n=None, *, one=False):
+        async def json_query(*args, **kwargs):
+            q = self.con.query_one_json if one else self.con.query_json
+            res = await q(*args, **kwargs)
+            return json.loads(res)
+
+        async def native_query(*args, **kwargs):
+            q = self.con.query_one if one else self.con.query
+            res = await q(*args, **kwargs)
+            return serutils.serialize(res)
+
+        qs = [json_query, native_query]
+        if n is None:
+            n = len(qs)
+        for i in range(n):
+            yield qs[i % len(qs)]
 
     async def test_edgeql_volatility_function_01(self):
         result = await self.con.query(
@@ -257,17 +288,12 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
         )
 
     async def test_edgeql_volatility_for_10(self):
-        # We would eventually like to compute this correctly instead
-        async with self._run_and_rollback():
-            with self.assertRaisesRegex(
-                    edgedb.QueryError,
-                    "volatile aliased expressions may not be used "
-                    "inside FOR bodies"):
-                await self.con.execute(
-                    r'''
-                    WITH x := random() FOR y in {1,2,3} UNION (x);
-                    ''',
-                )
+        res = await self.con.query(
+            r'''
+            WITH x := random() FOR y in {1,2,3} UNION (x);
+            ''',
+        )
+        self.assertEqual(len(set(res)), 1)
 
     async def test_edgeql_volatility_select_clause_01a(self):
         # Spurious failure probability: 1/100!
@@ -366,35 +392,40 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
         )
 
     async def test_edgeql_volatility_with_01(self):
-        # We would eventually like to compute this correctly instead
-        async with self._run_and_rollback():
-            with self.assertRaisesRegex(
-                    edgedb.QueryError,
-                    "volatile aliased expressions may not be used "
-                    "in multiple subqueries"):
-                await self.con.execute(
-                    r'''
-                    WITH X := random() SELECT sum(X) = sum(X);
-                    ''',
-                )
+        await self.assert_query_result(
+            r'''
+                WITH X := random() SELECT sum(X) = sum(X);
+            ''',
+            [True],
+        )
 
-    @test.xfail('''
-        Broken by #2137.
-        We need to be a little smarter about tracking volatility in
-        WITH bindings.
-    ''')
     async def test_edgeql_volatility_with_02(self):
-        # We would eventually like to compute this correctly instead
-        async with self._run_and_rollback():
-            with self.assertRaisesRegex(
-                    edgedb.QueryError,
-                    "volatile aliased expressions may not be used "
-                    "in multiple subqueries"):
-                await self.con.execute(
-                    r'''
-                    WITH X := random(), Y := X SELECT sum(Y) = sum(Y);
-                    ''',
-                )
+        await self.assert_query_result(
+            r'''
+                WITH X := random(), Y := X SELECT sum(Y) = sum(Y)
+            ''',
+            [True],
+        )
+
+    async def test_edgeql_volatility_with_03(self):
+        await self.assert_query_result(
+            r'''
+                WITH W := random(),
+                     Z := W,
+                SELECT W = Z;
+            ''',
+            [True],
+        )
+
+    async def test_edgeql_volatility_with_04(self):
+        await self.assert_query_result(
+            r'''
+                WITH W := {random(), random()},
+                     Z := W+0,
+                SELECT _ := (W = Z) ORDER BY _;
+            ''',
+            [False, False, True, True],
+        )
 
     async def test_edgeql_volatility_update_clause_01(self):
         # Spurious failure probability: 1/2^99
@@ -449,18 +480,981 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             [True],
         )
 
-    async def test_edgeql_volatility_nested_link_01(self):
-        # random() should get called once for each Obj/Tgt pair
-        result = await self.con.query(
-            r"""
-                SELECT Obj {
-                    l := (SELECT Tgt { m := random() }),
-                };
-            """
-        )
+    async def test_edgeql_volatility_select_with_objects_01(self):
+        for query in self.test_loop(10):
+            res = await query("""
+                WITH W := (SELECT Obj FILTER random() > 0.5),
+                SELECT ((SELECT W {n}), (SELECT W {n}))
+            """)
 
-        nums = [t.m for o in result for t in o.l]
-        self.assertEqual(len(nums), len(set(nums)))
+            self._check_crossproduct(
+                [(row[0]['n'], row[1]['n']) for row in res])
+
+    async def test_edgeql_volatility_select_with_objects_02(self):
+        for query in self.test_loop(10):
+            res = await query("""
+                SELECT Obj {n, m := random()}
+                FILTER .m > 0.3 ORDER BY .m;
+            """)
+
+            for row in res:
+                self.assertGreater(row['m'], 0.3)
+            nums = [row['m'] for row in res]
+            self.assertEqual(nums, sorted(nums))
+
+    async def test_edgeql_volatility_select_with_objects_03(self):
+        for query in self.test_loop(10):
+            res = await query("""
+                SELECT {
+                    o := (
+                        SELECT Obj {n, m := random()}
+                        FILTER .m  > 0.3 ORDER BY .m
+                    )
+                };
+            """)
+
+            res = res[0]['o']
+
+            for row in res:
+                self.assertGreater(row['m'], 0.3)
+            nums = [row['m'] for row in res]
+            self.assertEqual(nums, sorted(nums))
+
+    async def test_edgeql_volatility_select_with_objects_04(self):
+        for query in self.test_loop(10):
+            res = await query("""
+                SELECT {
+                    o := (SELECT (
+                        SELECT Obj {n, m := random()}
+                        FILTER .m  > 0.3 ORDER BY .m
+                    ))
+                }
+            """)
+
+            res = res[0]['o']
+
+            for row in res:
+                self.assertGreater(row['m'], 0.3)
+            nums = [row['m'] for row in res]
+            self.assertEqual(nums, sorted(nums))
+
+    async def test_edgeql_volatility_select_with_objects_05(self):
+        for query in self.test_loop(10):
+            res = await query("""
+                SELECT {
+                    o := (SELECT (
+                        SELECT Obj {n, m := random()}
+                        FILTER .m  > 0.3
+                    ) ORDER BY .m)
+                }
+            """)
+
+            res = res[0]['o']
+
+            for row in res:
+                self.assertGreater(row['m'], 0.3)
+            nums = [row['m'] for row in res]
+            self.assertEqual(nums, sorted(nums))
+
+    async def test_edgeql_volatility_select_with_objects_06(self):
+        for query in self.test_loop(10):
+            res = await query("""
+                SELECT (
+                    SELECT Obj {n, m := random()}
+                ) FILTER .m > 0.3 ORDER BY .m
+            """)
+
+            for row in res:
+                self.assertGreater(row['m'], 0.3)
+            nums = [row['m'] for row in res]
+            self.assertEqual(nums, sorted(nums))
+
+    async def test_edgeql_volatility_select_with_objects_07(self):
+        for query in self.test_loop(10):
+            res = await query("""
+                SELECT (
+                    SELECT Obj {n, m := {random(), random()}}
+                ) ORDER BY max(.m)
+            """)
+
+            nums = [row['m'] for row in res]
+            self.assertEqual(nums, sorted(nums, key=max))
+
+    async def test_edgeql_volatility_select_with_objects_08(self):
+        for query in self.test_loop(10):
+            res = await query("""
+                SELECT (
+                    SELECT Obj {n, m := (random(), random())}
+                ) ORDER BY max(.m)
+            """)
+
+            nums = [row['m'] for row in res]
+            self.assertEqual(nums, sorted(nums))
+
+    async def test_edgeql_volatility_select_with_objects_09(self):
+        for query in self.test_loop(10):
+            res = await query("""
+                SELECT (
+                    SELECT Obj {n, m := [random(), random()]}
+                ) ORDER BY max(.m)
+            """)
+
+            nums = [row['m'] for row in res]
+            self.assertEqual(nums, sorted(nums))
+
+    async def test_edgeql_volatility_select_objects_optional_01(self):
+        for _ in range(10):
+            await self.assert_query_result(
+                r'''
+                WITH X := (SELECT Obj {
+                    m := (SELECT .n FILTER random() > 0.5) }),
+                SELECT count(X);
+                ''',
+                [3],
+            )
+
+    async def test_edgeql_volatility_select_objects_optional_02(self):
+        for query in self.test_loop(10, one=True):
+            res = await query("""
+                WITH X := (SELECT Obj {
+                    m := (SELECT .n FILTER random() > 0.5) }),
+                SELECT {
+                    foo := (SELECT X {n, m}),
+                    baz := (SELECT X.m),
+                } LIMIT 1;
+            """)
+
+            foos = [x['m'] for x in res['foo'] if x['m'] is not None]
+            self.assertEqual(set(foos), set(res['baz']))
+
+    async def test_edgeql_volatility_select_hard_objects_01a(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH O := (SELECT Obj {m := next()}),
+                SELECT (O.m, O.m);
+            """)
+
+            self.assertEqual(len(res), 3)
+            for row in res:
+                self.assertEqual(row[0], row[1])
+
+            # Make sure it is really volatile
+            self.assertNotEqual(res[0][0], res[1][0])
+
+    async def test_edgeql_volatility_select_hard_objects_01b(self):
+        for query in self.test_loop():
+            # one side in a subquery, one not
+            res = await query("""
+                WITH O := (SELECT Obj {m := next()}),
+                SELECT ((SELECT O.m), O.m);
+            """)
+
+            self.assertEqual(len(res), 3)
+            for row in res:
+                self.assertEqual(row[0], row[1])
+
+    async def test_edgeql_volatility_select_hard_objects_02a(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH O := (SELECT Obj {m := next()}),
+                SELECT ((SELECT O.m), (SELECT O.m));
+            """)
+
+            self.assertEqual(len(res), 9)
+            self._check_crossproduct(res)
+
+    async def test_edgeql_volatility_select_hard_objects_02b(self):
+        for query in self.test_loop(10):
+            res = await query("""
+                WITH O := (SELECT Obj {m := random()} FILTER .m > 0.3),
+                SELECT ((SELECT O.m), (SELECT O.m));
+            """)
+
+            for row in res:
+                self.assertGreater(row[0], 0.3)
+            self._check_crossproduct(res)
+
+    async def test_edgeql_volatility_select_hard_objects_03(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH O := (SELECT Obj {m := next()}),
+                SELECT (O {m}, O {m});
+            """)
+
+            self.assertEqual(len(res), 3)
+            for row in res:
+                self.assertEqual(row[0]['m'], row[1]['m'])
+
+    async def test_edgeql_volatility_select_hard_objects_04a(self):
+        # TODO: this, but wrapped in DISTINCT
+        # (which breaks the serialization, ugh!)
+        for query in self.test_loop():
+            res = await query("""
+                WITH O := (SELECT Obj {m := next()}),
+                SELECT ((SELECT O {m}), (SELECT O {m}));
+            """)
+
+            self._check_crossproduct(
+                [(row[0]['m'], row[1]['m']) for row in res])
+
+    async def test_edgeql_volatility_select_hard_objects_04b(self):
+        # TODO: this, but wrapped in DISTINCT
+        # (which breaks the serialization, ugh!)
+        for query in self.test_loop(10):
+            res = await query("""
+                WITH O := (SELECT Obj {m := random()} FILTER .m > 0.3),
+                SELECT ((SELECT O {m}), (SELECT O {m}));
+            """)
+
+            for row in res:
+                self.assertGreater(row[0]['m'], 0.3)
+            self._check_crossproduct(
+                [(row[0]['m'], row[1]['m']) for row in res])
+
+    async def test_edgeql_volatility_select_hard_objects_05(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH O := (SELECT {m := next()} LIMIT 1),
+                SELECT (O {m}, O {m});
+            """)
+
+            self.assertEqual(len(res), 1)
+            for row in res:
+                self.assertEqual(row[0]['m'], row[1]['m'])
+
+    async def test_edgeql_volatility_select_hard_objects_06(self):
+        # now let's try it with a multi prop
+        res = await self.con.query("""
+            WITH O := (SELECT Obj {m := {next(), next()} })
+            SELECT ((SELECT O {m}), (SELECT O {m}));
+        """)
+
+        self._check_crossproduct([(row[0].m, row[1].m) for row in res])
+
+    async def test_edgeql_volatility_select_hard_objects_07(self):
+        # now let's try it with a multi prop
+        for query in self.test_loop():
+            res = await query("""
+                WITH O := (SELECT Obj {m := {next(), next()} })
+                SELECT ((O {m}), (O {m}));
+            """)
+
+            self.assertEqual(len(res), 3)
+            for row in res:
+                self.assertEqual(row[0]['m'], row[1]['m'])
+
+    async def test_edgeql_volatility_select_hard_objects_08a(self):
+        for query in self.test_loop(one=True):
+            res = await query("""
+                WITH O := (SELECT Obj {m := next()}),
+                SELECT {
+                    foo := (SELECT O {n, m}),
+                    bar := (SELECT O {n, m}),
+                } LIMIT 1;
+            """)
+
+            self.assertEqual(
+                {(x['n'], x['m']) for x in res['foo']},
+                {(x['n'], x['m']) for x in res['bar']},
+            )
+            self.assertEqual(len(res['foo']), 3)
+
+    async def test_edgeql_volatility_select_hard_objects_08b(self):
+        for query in self.test_loop(one=True):
+            res = await query("""
+                WITH O := (SELECT Obj {m := next()} LIMIT 1),
+                SELECT {
+                    foo := (SELECT O {n, m}),
+                    bar := (SELECT O {n, m}),
+                } LIMIT 1;
+            """)
+
+            self.assertEqual(res['foo']['n'], res['bar']['n'])
+            self.assertEqual(res['foo']['m'], res['bar']['m'])
+
+    async def test_edgeql_volatility_select_hard_objects_09(self):
+        await self.assert_query_result(r'''
+            WITH O := (SELECT Obj {m := next()}),
+            SELECT {
+                foo := (SELECT O),
+                bar := (SELECT O),
+            } LIMIT 1;
+        ''', [
+            {
+                'foo': [{"id": {}}, {"id": {}}, {"id": {}}],
+                'bar': [{"id": {}}, {"id": {}}, {"id": {}}],
+            }
+        ])
+
+    async def test_edgeql_volatility_select_nested_01a(self):
+        for query in self.test_loop(10, one=True):
+            res = await query("""
+                WITH O := (SELECT Obj {
+                         m := next(),
+                         friends := (SELECT Tgt FILTER random() > 0.4)
+                     }),
+                SELECT {
+                    a := (SELECT O {m, friends: {n}} ORDER BY .m),
+                    b := (SELECT O {m, friends: {n}} ORDER BY .m),
+                } LIMIT 1;
+            """)
+
+            nums = [row['m'] for row in res['a']]
+            self.assertEqual(nums, sorted(nums))
+            self.assertEqual(len(res['a']), 3)
+            for ra, rb in zip(res['a'], res['b']):
+                self.assertEqual(ra['m'], rb['m'])
+                self.assertEqual(
+                    {x['n'] for x in ra['friends']},
+                    {x['n'] for x in rb['friends']},
+                )
+
+    async def test_edgeql_volatility_select_nested_1b(self):
+        # same as 1b but without a shape on friends
+        for query in self.test_loop(10, one=True):
+            res = await query("""
+                WITH O := (SELECT Obj {
+                         m := next(),
+                         friends := (SELECT Tgt FILTER random() > 0.4)
+                     }),
+                SELECT {
+                    a := (SELECT O {m, friends} ORDER BY .m),
+                    b := (SELECT O {m, friends} ORDER BY .m),
+                } LIMIT 1;
+            """)
+
+            nums = [row['m'] for row in res['a']]
+            self.assertEqual(nums, sorted(nums))
+            self.assertEqual(len(res['a']), 3)
+            for ra, rb in zip(res['a'], res['b']):
+                self.assertEqual(ra['m'], rb['m'])
+                self.assertEqual(
+                    {x['id'] for x in ra['friends']},
+                    {x['id'] for x in rb['friends']},
+                )
+                self.assertLessEqual(len(ra['friends']), 4)
+
+    async def test_edgeql_volatility_select_nested_02(self):
+        for query in self.test_loop(10, one=True):
+            res = await query("""
+                WITH O := (SELECT Obj {
+                         m := next(),
+                         friends := (SELECT .tgt FILTER random() > 0.4)
+                     }),
+                SELECT {
+                    a := (SELECT O {m, friends: {n}} ORDER BY .m),
+                    b := (SELECT O {m, friend_nums := .friends.n} ORDER BY .m),
+                } LIMIT 1;
+            """)
+
+            nums = [row['m'] for row in res['a']]
+            self.assertEqual(nums, sorted(nums))
+            self.assertEqual(len(res['a']), 3)
+            for ra, rb in zip(res['a'], res['b']):
+                self.assertEqual(ra['m'], rb['m'])
+                self.assertEqual(
+                    {x['n'] for x in ra['friends']},
+                    set(rb['friend_nums']),
+                )
+
+    async def test_edgeql_volatility_select_nested_03a(self):
+        for query in self.test_loop(10, one=True):
+            res = await query("""
+                WITH O := (SELECT Obj {
+                         m := next(),
+                         friends := (SELECT .tgt { x := random() })
+                     }),
+                SELECT {
+                    a := (SELECT O {m, friends: {x}} ORDER BY .m),
+                    b := (SELECT O {m, friend_nums := .friends.x} ORDER BY .m),
+                } LIMIT 1;
+            """)
+
+            nums = [row['m'] for row in res['a']]
+            self.assertEqual(nums, sorted(nums))
+            self.assertEqual(len(res['a']), 3)
+            for ra, rb in zip(res['a'], res['b']):
+                self.assertEqual(ra['m'], rb['m'])
+                self.assertEqual(
+                    {x['x'] for x in ra['friends']},
+                    set(rb['friend_nums']),
+                )
+
+    async def test_edgeql_volatility_select_nested_03b(self):
+        for query in self.test_loop(10, one=True):
+            res = await query("""
+                WITH O := (SELECT Obj {
+                         m := next(),
+                         friends := (SELECT (SELECT .tgt) { @x := next() })
+                     }),
+                SELECT {
+                    a := (SELECT O {m, friends: {@x}} ORDER BY .m),
+                    b := (SELECT O {m, friend_nums := .friends@x} ORDER BY .m),
+                } LIMIT 1;
+            """)
+
+            nums = [row['m'] for row in res['a']]
+            self.assertEqual(nums, sorted(nums))
+            self.assertEqual(len(res['a']), 3)
+            for ra, rb in zip(res['a'], res['b']):
+                self.assertEqual(ra['m'], rb['m'])
+                self.assertEqual(
+                    {x['@x'] for x in ra['friends']},
+                    set(rb['friend_nums']),
+                )
+
+    async def test_edgeql_volatility_select_nested_04a(self):
+        for query in self.test_loop(one=True):
+            res = await query("""
+                WITH O := (SELECT Obj {
+                         friends := (SELECT Tgt { x := next() } )
+                     }),
+                SELECT {
+                    a := (SELECT O {friends: {n, x}}),
+                    b := (SELECT O {friends: {n, x}}),
+                } LIMIT 1;
+            """)
+
+            self.assertEqual(len(res['a']), 3)
+            for ra, rb in zip(res['a'], res['b']):
+                self.assertEqual(len(ra['friends']), 4)
+                self.assertEqual(
+                    sorted((x['n'], x['x']) for x in ra['friends']),
+                    sorted((x['n'], x['x']) for x in rb['friends']),
+                )
+
+    async def test_edgeql_volatility_select_nested_04b(self):
+        for query in self.test_loop(one=True):
+            res = await query("""
+                WITH O := (SELECT Obj {
+                         tgt: { x := next() }
+                     }),
+                SELECT {
+                    a := (SELECT O {tgt: {n, x}}),
+                    b := (SELECT O {tgt: {n, x}}),
+                } LIMIT 1;
+            """)
+
+            self.assertEqual(len(res['a']), 3)
+            for ra, rb in zip(res['a'], res['b']):
+                self.assertEqual(len(ra['tgt']), 2)
+                self.assertEqual(
+                    sorted((x['n'], x['x']) for x in ra['tgt']),
+                    sorted((x['n'], x['x']) for x in rb['tgt']),
+                )
+
+    async def test_edgeql_volatility_select_nested_05(self):
+        for query in self.test_loop(10, one=True):
+            res = await query("""
+                WITH O := (SELECT Obj {
+                         m := rand_int(100),
+                         friends := (SELECT Tgt { x := next() }
+                                     FILTER random() > 0.4)
+                     }),
+                SELECT {
+                    a := (SELECT O {m, n, friends: {n, x}, ha := .friends.x}),
+                    b := (SELECT O {
+                              m,
+                              friends_tuples := (.friends.n, .friends.x),
+                              friend_sums := sum(.friends.x),
+                          }),
+                    c := (O.n, O.friends {n, x}, O.friends {n, x}),
+                } LIMIT 1;
+            """)
+
+            cs = {x['n']: [] for x in res['a']}
+            for rc in res['c']:
+                self.assertEqual(rc[1]['n'], rc[2]['n'])
+                self.assertEqual(rc[1]['x'], rc[2]['x'])
+                cs[rc[0]].append([rc[1]['n'], rc[1]['x']])
+
+            for ra, rb in zip(res['a'], res['b']):
+                self.assertLessEqual(len(ra['friends']), 4)
+
+                self.assertEqual(
+                    sorted(x['x'] for x in ra['friends']),
+                    sorted(ra['ha']),
+                )
+
+                self.assertEqual(
+                    sorted([x['n'], x['x']] for x in ra['friends']),
+                    sorted(rb['friends_tuples']),
+                )
+
+                self.assertEqual(
+                    sorted(cs[ra['n']]),
+                    sorted(rb['friends_tuples']),
+                )
+
+                self.assertEqual(sum(ra['ha']), rb['friend_sums'])
+
+    async def test_edgeql_volatility_select_nested_06a(self):
+        # here we want some deduplicating to happen
+        for query in self.test_loop(one=True):
+            res = await query("""
+                WITH O := (SELECT Obj {
+                         friends := (SELECT Tgt { x := next() })
+                     }),
+                SELECT {
+                    x := (O { friends: {x} }),
+                    y := O.friends.x,
+                } LIMIT 1;
+            """)
+
+            self.assertEqual(len(res['y']), 4)
+            all_xs = {t['x'] for r in res['x'] for t in r['friends']}
+            self.assertTrue(set(res['y']).issubset(all_xs))
+
+    async def test_edgeql_volatility_select_nested_06b(self):
+        # here we want some deduplicating to happen
+        for query in self.test_loop(one=True):
+            res = await query("""
+                WITH O := (SELECT Obj {
+                         friends := (SELECT Tgt { x := next() })
+                     }),
+                SELECT {
+                    x := (O { friends: {n, x} }),
+                    y := O.friends {n, x},
+                } LIMIT 1;
+            """)
+
+            self.assertEqual(len(res['y']), 4)
+            all_xs = {(t['n'], t['x']) for r in res['x'] for t in r['friends']}
+            y = {(t['n'], t['x']) for t in res['y']}
+            self.assertTrue(y.issubset(all_xs))
+
+    async def test_edgeql_volatility_select_nested_06c(self):
+        # here we want some deduplicating to happen
+        for query in self.test_loop():
+            res = await query("""
+                WITH O := (SELECT Obj {
+                         friends := (SELECT Tgt { x := next() })
+                     }),
+                SELECT ((SELECT O.friends.x), (SELECT O.friends.x));
+            """)
+
+            self.assertEqual(len(res), 16)
+
+    async def test_edgeql_volatility_select_nested_06d(self):
+        # here we want some deduplicating to happen
+        for query in self.test_loop():
+            res = await query("""
+                WITH O := (SELECT Obj {
+                         friends := (SELECT Tgt { x := next() })
+                     }),
+                SELECT O.friends;
+            """)
+
+            self.assertEqual(len(res), 4)
+
+            res = await query("""
+                WITH O := (SELECT (SELECT Obj {
+                         friends := (SELECT Tgt { x := next() })
+                     })),
+                SELECT O.friends;
+            """)
+
+            self.assertEqual(len(res), 4)
+
+    async def test_edgeql_volatility_select_nested_07a(self):
+        for query in self.test_loop(10):
+            res = await query("""
+                SELECT Obj {
+                    n,
+                    tgt: {
+                        n,
+                    } FILTER random() < 0.5
+                }
+                FILTER EXISTS (.tgt);
+            """)
+
+            for row in res:
+                self.assertGreater(len(row['tgt']), 0)
+
+    async def test_edgeql_volatility_select_nested_07b(self):
+        for query in self.test_loop(10):
+            res = await query("""
+                SELECT Obj {
+                    n,
+                    tgts := (SELECT .tgt {
+                        n,
+                    } FILTER random() < 0.5)
+                }
+                FILTER EXISTS (.tgts);
+            """)
+
+            for row in res:
+                self.assertGreater(len(row['tgts']), 0)
+
+    @test.xfail("Arrays containing objects are hard; TODO: fail?")
+    async def test_edgeql_volatility_select_arrays_01(self):
+        for query in self.test_loop(one=True):
+            res = await query("""
+                WITH O := [(SELECT Obj {m := next()})],
+                SELECT {
+                    foo := (SELECT O[0] {m}),
+                    bar := (SELECT O[0] {m}),
+                } LIMIT 1;
+            """)
+
+            self.assertEqual(res['foo'], res['bar'])
+            self.assertEqual(len(res['foo']), 3)
+
+    async def test_edgeql_volatility_select_tuples_01(self):
+        for query in self.test_loop(one=True):
+            res = await query("""
+                WITH O := ((SELECT Obj {m := next()}),),
+                SELECT {
+                    foo := (SELECT O.0 {n, m}),
+                    bar := (SELECT O.0 {n, m}),
+                } LIMIT 1;
+            """)
+
+            self.assertEqual(res['foo'], res['bar'])
+            self.assertEqual(len(res['foo']), 3)
+
+    async def test_edgeql_volatility_select_tuples_02(self):
+        for query in self.test_loop(one=True):
+            res = await query("""
+                WITH O := (z := ((SELECT Obj {m := next()}),)),
+                SELECT {
+                    foo := (SELECT O.z.0 {n, m}),
+                    bar := (SELECT O.z.0 {n, m}),
+                    os := O,
+                    ms := O.z.0.m,
+                } LIMIT 1;
+            """)
+
+            self.assertEqual(res['foo'], res['bar'])
+            self.assertEqual(len(res['foo']), 3)
+            self.assertEqual(
+                {x['m'] for x in res['foo']},
+                set(res['ms']),
+            )
+
+    async def test_edgeql_volatility_select_tuples_03(self):
+        await self.assert_query_result(r'''
+            WITH X := ((SELECT Obj { m := next() }),),
+                 Y := ((SELECT Obj { m := next() }),),
+            SELECT count((SELECT (X, Y) FILTER X = Y));
+        ''', [
+            3,
+        ])
+
+        await self.assert_query_result(r'''
+            WITH X := ((SELECT Obj { m := next() }),),
+                 Y := ((SELECT Obj { m := next() }),),
+            SELECT count((SELECT (X, Y) FILTER X < Y));
+        ''', [
+            3,
+        ])
+
+        await self.assert_query_result(r'''
+            WITH X := ((SELECT Obj { m := next() }),),
+                 Y := (Obj,),
+            SELECT count((SELECT (X, Y) FILTER X < Y));
+        ''', [
+            3,
+        ])
+
+    async def test_edgeql_volatility_insert_01(self):
+        for query in self.test_loop(one=True):
+            res = await query("""
+                WITH
+                    Foo := (SELECT (
+                        INSERT Obj {n := 10}
+                    ) { m := next() })
+                SELECT {
+                    foo := Foo {n, m},
+                    bar := Foo {n, m},
+                } LIMIT 1;
+            """)
+
+            self.assertEqual(res['foo']['n'], 10)
+            self.assertEqual(res['foo']['m'], res['bar']['m'])
+
+    async def test_edgeql_volatility_nested_link_01(self):
+        # next() should get called once for each Obj/Tgt pair
+        for query in self.test_loop():
+            res = await query(
+                r"""
+                    SELECT Obj {
+                        l := (SELECT Tgt { m := next() }),
+                    };
+                """
+            )
+
+            nums = [t['m'] for o in res for t in o['l']]
+            self.assertEqual(len(nums), len(set(nums)))
+
+    async def test_edgeql_volatility_hack_01(self):
+        await self.assert_query_result(r'''
+            SELECT (FOR x IN {1,2} UNION (SELECT Obj { m := vol_id(x) }))
+            { n, m } ORDER BY .m THEN .n;
+        ''', [
+            {"m": 1, "n": 1},
+            {"m": 1, "n": 2},
+            {"m": 1, "n": 3},
+            {"m": 2, "n": 1},
+            {"m": 2, "n": 2},
+            {"m": 2, "n": 3},
+        ])
+
+    async def test_edgeql_volatility_hack_02(self):
+        await self.assert_query_result(r'''
+            WITH X := (FOR x IN {1,2} UNION (SELECT Obj { m := vol_id(x) }))
+            SELECT X { n, m } ORDER BY .m THEN .n;
+        ''', [
+            {"m": 1, "n": 1},
+            {"m": 1, "n": 2},
+            {"m": 1, "n": 3},
+            {"m": 2, "n": 1},
+            {"m": 2, "n": 2},
+            {"m": 2, "n": 3},
+        ])
+
+    async def test_edgeql_volatility_hack_03a(self):
+        await self.assert_query_result(r'''
+            WITH X := (WITH x := {1,2}, SELECT (x, Obj {m := vol_id(x)})).1
+            SELECT X { n, m } ORDER BY .m THEN .n;
+        ''', [
+            {"m": 1, "n": 1},
+            {"m": 1, "n": 2},
+            {"m": 1, "n": 3},
+            {"m": 2, "n": 1},
+            {"m": 2, "n": 2},
+            {"m": 2, "n": 3},
+        ])
+
+    async def test_edgeql_volatility_hack_03b(self):
+        await self.assert_query_result(r'''
+            WITH X := (WITH x := {1,2}, SELECT (x, Obj {m := vol_id(x)}).1)
+            SELECT X { n, m } ORDER BY .m THEN .n;
+        ''', [
+            {"m": 1, "n": 1},
+            {"m": 1, "n": 2},
+            {"m": 1, "n": 3},
+            {"m": 2, "n": 1},
+            {"m": 2, "n": 2},
+            {"m": 2, "n": 3},
+        ])
+
+    async def test_edgeql_volatility_hack_04a(self):
+        await self.assert_query_result(r'''
+            SELECT (WITH x := {1,2}, SELECT (x, Obj {m := vol_id(x)})).1
+            { n, m } ORDER BY .m THEN .n;
+        ''', [
+            {"m": 1, "n": 1},
+            {"m": 1, "n": 2},
+            {"m": 1, "n": 3},
+            {"m": 2, "n": 1},
+            {"m": 2, "n": 2},
+            {"m": 2, "n": 3},
+        ])
+
+    async def test_edgeql_volatility_hack_04b(self):
+        await self.assert_query_result(r'''
+            SELECT (WITH x := {1,2}, SELECT (x, Obj {m := vol_id(x)}).1)
+            { n, m } ORDER BY .m THEN .n;
+        ''', [
+            {"m": 1, "n": 1},
+            {"m": 1, "n": 2},
+            {"m": 1, "n": 3},
+            {"m": 2, "n": 1},
+            {"m": 2, "n": 2},
+            {"m": 2, "n": 3},
+        ])
+
+    @test.xfail("We generate SQL with a missing FROM-clause entry")
+    async def test_edgeql_volatility_for_like_hard_01(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH
+                    O := (SELECT Obj { x := next() }),
+                    Z := (O, (SELECT O { n, x, y := -.x })).1
+                SELECT Z { n, x, y };
+            """)
+
+            self.assertEqual(len(res), 3)
+            # TODO: more testing, once it doesn't crash
+
+    @test.xfail("We produce too many rows")
+    async def test_edgeql_volatility_for_like_hard_02(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH
+                    O := (SELECT Obj { x := next() }),
+                    Z := (O, ({ o := O })).1
+                SELECT Z { o: {n, x} };
+            """)
+
+            self.assertEqual(len(res), 3)
+            # TODO: more testing, once the basic stuff works
+
+    @test.xfail("Fails finding a range var")
+    async def test_edgeql_volatility_for_like_hard_03(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH
+                    O := (SELECT Obj { x := next() }),
+                    Za := (O, ({ o := O })),
+                    Z := Za.1
+                SELECT Z { o: {n, x} };
+            """)
+
+            self.assertEqual(len(res), 3)
+            # TODO: more testing, once it doesn't crash
+
+    @test.xfail("We produce too many rows")
+    async def test_edgeql_volatility_for_hard_01(self):
+        # XXX: Z not getting materialized (but that's not all that's wrong?)
+        for query in self.test_loop():
+            res = await query("""
+                WITH Z := (FOR O IN {(
+                    SELECT Obj { x := next() }
+                )} UNION (
+                    SELECT O { y := -.x }
+                )),
+                SELECT Z { n, x, y };
+            """)
+
+            self.assertEqual(len(res), 3)
+            # TODO: more testing, once the very basic thing works
+
+    @test.xfail("We produce too many rows")
+    async def test_edgeql_volatility_for_hard_02(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH Z := (FOR O IN {(
+                    SELECT Obj { x := next() }
+                )} UNION (
+                    SELECT { a := O { n, x, y := -.x } }
+                )),
+                SELECT Z { a: { n, x, y }};
+            """)
+
+            self.assertEqual(len(res), 3)
+            # TODO: more testing, once the very basic thing works
+
+    @test.xfail("We produce too many rows")
+    async def test_edgeql_volatility_for_hard_03(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH Z := (FOR O IN {(
+                    SELECT Obj {
+                        tgt: { x := random() }
+                    }
+                )} UNION (
+                    SELECT O {tgt: {n, x, y := -.x}}
+                )),
+                SELECT Z { tgt: {n, x, y} };
+            """)
+
+            self.assertEqual(len(res), 3)
+            # TODO: more testing, once the very basic thing works
+
+    @test.xfail("We generate SQL with a missing FROM-clause entry")
+    async def test_edgeql_volatility_for_hard_04(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH Z := (FOR O IN {(
+                    SELECT Obj {
+                        tgt: { x := random() }
+                    }
+                )} UNION (
+                    SELECT { a := (O {tgt: {n, x, y := -.x}}) }
+                )),
+                SELECT Z { a: {tgt: {n, x, y} } };
+            """)
+
+            self.assertEqual(len(res), 3)
+            # TODO: actually test the result, once it doesn't crash
+
+    async def test_edgeql_volatility_rebind_flat_01(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH O := (SELECT Obj { x := next() }),
+                     Z := (SELECT O {y := -.x}),
+                SELECT Z { n, x, y };
+            """)
+
+            self.assertEqual(len(res), 3)
+            for obj in res:
+                self.assertEqual(obj['x'], -obj['y'])
+
+    async def test_edgeql_volatility_rebind_flat_02(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH O := (SELECT Obj { x := next() }),
+                     Z := (SELECT O {x, y := -.x}),
+                SELECT Z { n, x, y };
+            """)
+
+            self.assertEqual(len(res), 3)
+            for obj in res:
+                self.assertEqual(obj['x'], -obj['y'])
+
+    async def test_edgeql_volatility_rebind_flat_03(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH O := (SELECT Obj { x := next() }),
+                     Z := (SELECT O {x := .x}),
+                SELECT (Z.n, (SELECT Z.x), (SELECT Z.x));
+            """)
+
+            self.assertEqual(len(res), 3)
+            for _, x1, x2 in res:
+                self.assertEqual(x1, x2)
+
+    async def test_edgeql_volatility_rebind_nested_01(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH O := (
+                    SELECT Obj {
+                        tgt: { x := next() }
+                    }
+                ),
+                Z := (SELECT O {tgt: {n, x, y := -.x}}),
+                SELECT Z { tgt: {n, x, y} };
+            """)
+
+            self.assertEqual(len(res), 3)
+            for obj in res:
+                for tgt in obj['tgt']:
+                    self.assertEqual(tgt['x'], -tgt['y'])
+
+    async def test_edgeql_volatility_rebind_nested_02(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH O := (
+                    SELECT Obj {
+                        tgt: { x := next() }
+                    }
+                ),
+                Z := (SELECT O {tgt: {n, y := -.x}}),
+                SELECT Z { tgt: {n, x, y} };
+            """)
+
+            self.assertEqual(len(res), 3)
+            for obj in res:
+                for tgt in obj['tgt']:
+                    self.assertEqual(tgt['x'], -tgt['y'])
+
+    async def test_edgeql_volatility_rebind_nested_03(self):
+        for query in self.test_loop(one=True):
+            res = await query("""
+                WITH O := (
+                    SELECT Obj {
+                        tgt: { x := next() }
+                    }
+                ),
+                Z := { o := (SELECT O {tgt: {n, y := -.x}}) },
+                SELECT Z { o: {tgt: {n, x, y}} } LIMIT 1;
+            """)
+
+            for obj in res['o']:
+                for tgt in obj['tgt']:
+                    self.assertEqual(tgt['x'], -tgt['y'])
 
     async def test_edgeql_volatility_errors_01(self):
         async with self._run_and_rollback():

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -1276,7 +1276,9 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             """)
 
             self.assertEqual(len(res), 3)
-            # TODO: more testing, once it doesn't crash
+            self.assertNotEqual(res[0]['x'], res[1]['x'])
+            for obj in res:
+                self.assertEqual(obj['x'], -obj['y'])
 
     @test.xfail("We produce too many rows")
     async def test_edgeql_volatility_for_like_hard_02(self):
@@ -1289,7 +1291,7 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             """)
 
             self.assertEqual(len(res), 3)
-            # TODO: more testing, once the basic stuff works
+            self.assertNotEqual(res[0]['o']['x'], res[1]['o']['x'])
 
     @test.xfail("Fails finding a range var")
     async def test_edgeql_volatility_for_like_hard_03(self):
@@ -1303,7 +1305,7 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             """)
 
             self.assertEqual(len(res), 3)
-            # TODO: more testing, once it doesn't crash
+            self.assertNotEqual(res[0]['o']['x'], res[1]['o']['x'])
 
     @test.xfail("We produce too many rows")
     async def test_edgeql_volatility_for_hard_01(self):
@@ -1319,7 +1321,9 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             """)
 
             self.assertEqual(len(res), 3)
-            # TODO: more testing, once the very basic thing works
+            self.assertNotEqual(res[0]['x'], res[1]['x'])
+            for obj in res:
+                self.assertEqual(obj['x'], -obj['y'])
 
     @test.xfail("We produce too many rows")
     async def test_edgeql_volatility_for_hard_02(self):
@@ -1334,7 +1338,9 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             """)
 
             self.assertEqual(len(res), 3)
-            # TODO: more testing, once the very basic thing works
+            self.assertNotEqual(res[0]['a']['x'], res[1]['a']['x'])
+            for obj in res:
+                self.assertEqual(obj['a']['x'], -obj['a']['y'])
 
     @test.xfail("We produce too many rows")
     async def test_edgeql_volatility_for_hard_03(self):
@@ -1342,7 +1348,7 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             res = await query("""
                 WITH Z := (FOR O IN {(
                     SELECT Obj {
-                        tgt: { x := random() }
+                        tgt: { x := next() }
                     }
                 )} UNION (
                     SELECT O {tgt: {n, x, y := -.x}}
@@ -1351,7 +1357,9 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             """)
 
             self.assertEqual(len(res), 3)
-            # TODO: more testing, once the very basic thing works
+            for obj in res:
+                for tgt in obj['tgt']:
+                    self.assertEqual(tgt['x'], -tgt['y'])
 
     @test.xfail("We generate SQL with a missing FROM-clause entry")
     async def test_edgeql_volatility_for_hard_04(self):
@@ -1359,7 +1367,7 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             res = await query("""
                 WITH Z := (FOR O IN {(
                     SELECT Obj {
-                        tgt: { x := random() }
+                        tgt: { x := next() }
                     }
                 )} UNION (
                     SELECT { a := (O {tgt: {n, x, y := -.x}}) }
@@ -1368,7 +1376,9 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             """)
 
             self.assertEqual(len(res), 3)
-            # TODO: actually test the result, once it doesn't crash
+            for obj in res:
+                for tgt in obj['a']['tgt']:
+                    self.assertEqual(tgt['x'], -tgt['y'])
 
     async def test_edgeql_volatility_rebind_flat_01(self):
         for query in self.test_loop():

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -95,7 +95,7 @@ class TestTracer(unittest.TestCase):
                         f'_infer_type for {name} is not implemented')
 
     def test_infer_volatility_dispatch(self):
-        dispatcher = volatility._infer_volatility
+        dispatcher = volatility._infer_volatility_inner
         not_implemented = dispatcher.registry[object]
 
         for name, astcls in inspect.getmembers(irast, inspect.isclass):


### PR DESCRIPTION
Materializing a set of values consists of:
 * Serializing each of the values in native mode, but with computed
   shape fields included.
 * Then, if the value is possibly multi, aggregating it into an array.

We consider materializing a set of values in two of our core binding
constructs:
 * WITH statements
 * ad-hoc computed pointers.
 * We don't materialize the argument to FOR, because I thought that
   FOR's iteration makes it unnecessary. I found some bugs involving
   FOR, though, so maybe that is wrong.

We materialize a set in the following cases:
 * If it is volatile, or uses a bound variable that is volatile
 * If it appears in a computable and refers to a bound variable.
   This is somewhat overly broad, but is intended to allow us to
   capture FOR variables inside a shape, and similar patterns.

The materialized sets are computed at the enclosing statement:
at the WITH statement, or at the shape subject expression.

We detect when a materialized set is referenced by its type/ptrcls.

To support this, queries on the pgast side gain some new fields for
tracking materialized (or packed) data. packed_path_rvar_map tracks
what rvars contain materialized data while packed_path_outputs
contains the actual output vars.

The most involved part of this is unpack_rvar, which extracts a set
from a packed rvar. It inspects the type of the set, generates SQL to
unpack it, and populate the current statement with the appropriate
rvars for accessing it and its fields. Materialized links (to
materialized shapes) and multi properties of shapes are placed in
packed rvars of their own.

Generating path_ids for tuple paths and shape paths on the fly, in
pgsql, is at least a little hair-raising. (Some dubious machinery
needed to be added to typeutils for the latter.)

In order to ensure that shapes (and tuples that contain shapes) can be
correctly output or correctly *rematerialized*, we need to reconstruct
a serialized version when we unpack. Doing this for tuples means we
need to do it for any shapes they contain, which means that unpack
needs to be driven by a recursive traversal of the type.
This also drives a reconstruction of the *value* of tuples, so that
a tuple containing objects can safely compared for equality and the
like, without inadvertantly comparing materialized shape data.

Known issues:
 * We are a little over-eager to materialize. There are many cases
   where we only use a value once where we will materialize.
   (But also cases where we only use values once where we need to.)
 * We materialize AT_MOST_ONE sets as if they were MANY, serializing
   them into an array. This was an implementation expedient; it
   shouldn't be too hard to use NULL instead.

 * Materializing arrays that contain shapes is pretty busted. The
   tricky part is that unpacking rvars with shapes works by populating
   the current rel with rvars for each of the shape fields. This is
   a problem with arrays, because we can't get at those until after
   some elimination form has been done on the array, and there are
   several of those we'll need to deal with.

 * As I was doing final cleanups on this PR, I found a big cluster of
   bugs involving FOR/tricky uses of WITH (
   test_edgeql_volatility_for_like_hard_*,
   test_edgeql_volatility_for_hard_*).
   I am fairly concerned about these, but didn't want to delay
   getting a PR up for review any longer.

Testing this was a little fiddly, since assert_query_result is pretty
useless when the output is volatile. It was important to test in both
json and native mode (since I had regularly bugs that broke only one
of them!), so I ended up building some of my own infrastructure for that.

This fixes some existing tests (including test_edgeql_scope_tuple_14),
though not as many as I hoped. (I was hoping to get some of the FOR
tests, which I'll hopefully take more of a look at soon.)

Closes #2421.

Co-authored-by: Elvis Pranskevichus <elvis@edgedb.com>