### PR TITLE
Adjust the precedence of DETACHED to match EXISTS/DISTINCT

### DIFF
--- a/docs/edgeql/lexical.rst
+++ b/docs/edgeql/lexical.rst
@@ -254,7 +254,7 @@ content with *dollar-quotes* in an unambiguous manner:
 More specifically, a delimiter:
 
 * Must start with an ASCII letter or underscore
-* Has following characters that can be digits 0-9, underscores or 
+* Has following characters that can be digits 0-9, underscores or
   ASCII letters
 
 .. _ref_eql_lexical_bytes:
@@ -438,14 +438,14 @@ EdgeQL operators listed in order of precedence from lowest to highest:
     * - :eql:op:`*<MULT>`, :eql:op:`/<DIV>`,
         :eql:op:`//<FLOORDIV>`, :eql:op:`%<MOD>`
     * - :eql:op:`??<COALESCE>`
-    * - :eql:op:`DISTINCT`, unary :eql:op:`-<UMINUS>`
+    * - :eql:op:`DISTINCT`, :eql:op:`EXISTS`,
+	    :ref:`DETACHED <ref_eql_with_detached>`, unary :eql:op:`-<UMINUS>`
     * - :eql:op:`^<POW>`
     * - :eql:op:`type cast <CAST>`
     * - :eql:op:`array[] <ARRAYIDX>`,
         :eql:op:`str[] <STRIDX>`,
         :eql:op:`json[] <JSONIDX>`,
         :eql:op:`bytes[] <BYTESIDX>`
-    * - :ref:`DETACHED <ref_eql_with_detached>`
 
 .. |neq| replace:: !=
 .. _neq: ./funcops/generic#operator::NEQ

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -120,7 +120,11 @@ def compile_DetachedExpr(
     ctx: context.ContextLevel,
 ) -> typing.Union[irast.Set, irast.Expr]:
     with ctx.detached() as subctx:
-        return dispatch.compile(expr.expr, ctx=subctx)
+        ir = dispatch.compile(expr.expr, ctx=subctx)
+    # Wrap the result in another set, so that the inner namespace
+    # doesn't leak out into any shapes (since computable computation
+    # will pull namespaces from the source path_ids.)
+    return setgen.ensure_set(setgen.ensure_stmt(ir, ctx=ctx), ctx=ctx)
 
 
 @dispatch.compile.register(qlast.Set)

--- a/edb/edgeql/parser/grammar/precedence.py
+++ b/edb/edgeql/parser/grammar/precedence.py
@@ -123,6 +123,11 @@ class P_DISTINCT(Precedence, assoc='right', tokens=('DISTINCT',),
     pass
 
 
+class P_DETACHED(Precedence, assoc='right', tokens=('DETACHED',),
+                 rel_to_last='='):
+    pass
+
+
 class P_POW_OP(Precedence, assoc='right', tokens=('CIRCUMFLEX',)):
     pass
 
@@ -144,10 +149,6 @@ class P_PAREN(Precedence, assoc='left', tokens=('LPAREN', 'RPAREN')):
 
 
 class P_DOT(Precedence, assoc='left', tokens=('DOT', 'DOTBW')):
-    pass
-
-
-class P_DETACHED(Precedence, assoc='right', tokens=('DETACHED',)):
     pass
 
 

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -1956,6 +1956,60 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ],
         )
 
+    async def test_edgeql_scope_detached_11(self):
+        await self.assert_query_result(
+            r"""
+            SELECT _ := (User.name, { x := User.name }) ORDER BY _;
+            """,
+            [
+                ["Alice", {"x": "Alice"}],
+                ["Bob", {"x": "Bob"}],
+                ["Carol", {"x": "Carol"}],
+                ["Dave", {"x": "Dave"}],
+            ]
+        )
+
+    async def test_edgeql_scope_detached_12(self):
+        await self.assert_query_result(
+            r"""
+            SELECT DETACHED User { name2 := User.name } ORDER BY .name;
+            """,
+            [
+                {"name2": "Alice"},
+                {"name2": "Bob"},
+                {"name2": "Carol"},
+                {"name2": "Dave"},
+            ]
+        )
+
+    async def test_edgeql_scope_detached_13(self):
+        # Detached but using a partial path should still give singletons
+        await self.assert_query_result(
+            r"""
+            SELECT (DETACHED User) { name2 := .name } ORDER BY .name;
+            """,
+            [
+                {"name2": "Alice"},
+                {"name2": "Bob"},
+                {"name2": "Carol"},
+                {"name2": "Dave"},
+            ]
+        )
+
+    async def test_edgeql_scope_detached_14(self):
+        # Detached reference to User should be an unrelated one
+        await self.assert_query_result(
+            r"""
+            SELECT (DETACHED User) { names := User.name }
+            """,
+            [
+                {"names": {"Alice", "Bob", "Carol", "Dave"}},
+                {"names": {"Alice", "Bob", "Carol", "Dave"}},
+                {"names": {"Alice", "Bob", "Carol", "Dave"}},
+                {"names": {"Alice", "Bob", "Carol", "Dave"}},
+            ]
+        )
+
     async def test_edgeql_scope_union_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2465,7 +2465,7 @@ aa';
 
 % OK %
 
-        SELECT (DETACHED Foo).bar;
+        SELECT DETACHED Foo.bar;
         """
 
     def test_edgeql_syntax_detached_05(self):
@@ -2474,7 +2474,16 @@ aa';
 
 % OK %
 
-        SELECT (DETACHED mod::Foo).bar;
+        SELECT DETACHED mod::Foo.bar;
+        """
+
+    def test_edgeql_syntax_detached_06(self):
+        """
+        SELECT (DETACHED Foo).bar;
+
+% OK %
+
+        SELECT (DETACHED Foo).bar;
         """
 
     def test_edgeql_syntax_select_01(self):


### PR DESCRIPTION
Currently the situation is that `SELECT DETACHED User { x := User.name }`
parses as `SELECT (DETACHED User) { x := User.name }`,
but the reference to `User` in the shape is still expected to refer
to the same `User` being selected over. (See
`test_edgeql_scope_detached_{07,08}`)

I claim that this makes no sense: `User` is DETACHED, and nothing
outside that detached subexpression ought to be able to correlate with
it.
If we want references inside the body of the shape to correlate, then,
we need to raise the precdence of `DISTINCT` so that the above example
parses as `SELECT DETACHED (User { x := User.name })`.

This also helps solve some other issues with the current implementation:
 * Currently the example query I gave doesn't quite work: it infers
   `x` as multi, and returns the results as sets
 * `SELECT (User.name, { x := User.name })`, which is sugar for
   `SELECT (User.name, (DETACHED VirtualObject) { x := User.name })`,
   ISEs at SQL execution, because the cardinality of `x` is inferred as
   single but `x` is compiled with `User` detached.

These issues are caused by a mismatch between `process_view`, which does
not adopt the namespace of its source, and `_get_computable_ctx`, which
does. In this change, we wrap a DISTINCT expression in another set, to
prevent its freshly generated namespace from leaking out.

I can think of two other ways forward:
 * Accept my claim that a reference to `User` inside
   `SELECT (DETACHED User) { x := User.name }` shouldn't correlate
   with the `User` outside, but don't change the precedence. This breaks
   two tests, but no big deal.
   If somebody really cares about this, they can write
   `SELECT (DETACHED (User { x := User.name }))`, but probably they'd
   actually just use `.name`.

   Implementing this is trivial: keep the change to `expr.py`, revert all
   the parser changes.

   To be honest, I like this approach about as much as actually
   merging this PR. For whatever reason it didn't occur to me that it
   was a reasonable proposal until after I had done the parser changes.
   Oops.

 * Just fix the mismatch between `process_view` and `_get_computable_ctx`,
   preserving both the current parse tree and the (I think) intended semantics.
   I don't like this, because it results in things in the shape being
   essentially detached without actually being detached.

   We could also maybe try to find a way where references to the type
   being selected refers to the detached type (which is in some namespace),
   while other references stay undetached? This might be the actually intended
   semantics, but it's not obvious to me immediately how to implement this,
   and I think it doesn't make a lot of sense.