### PR TITLE
Update Rust version to 1.53

### DIFF
--- a/docs/internals/dev.rst
+++ b/docs/internals/dev.rst
@@ -16,7 +16,7 @@ Linux or macOS.  Windows is not currently supported.
 
 * GNU make version 3.80 or newer;
 * C compiler (GCC or clang);
-* Rust compiler and Cargo 1.45 or later;
+* Rust compiler and Cargo 1.53 or later;
 * autotools;
 * Python 3.9 dev package;
 * Bison 1.875 or later;

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ BUILD_DEPS = [
     CYTHON_DEPENDENCY,
 ]
 
-RUST_VERSION = '1.45.0'  # Also update docs/internal/dev.rst
+RUST_VERSION = '1.53.0'  # Also update docs/internal/dev.rst
 
 EDGEDBCLI_REPO = 'https://github.com/edgedb/edgedb-cli'
 


### PR DESCRIPTION
TLS implementation needs a newer version.

(I'm not sure which one specifically, but upgrading to the current latest should be fine).