### PR TITLE
Fix some migration issues involving SET TYPE and rebasing

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2689,7 +2689,7 @@ class PointerMetaCommand(MetaCommand, sd.ObjectCommand,
             not orig_schema
             or pointer.get_default(orig_schema)
             or (tgt := pointer.get_target(orig_schema)) and tgt.issubclass(
-                schema, schema.get('std::sequence'))
+                orig_schema, schema.get('std::sequence'))
         ):
             return
 


### PR DESCRIPTION
* We need to include an 'alter' action in the graph when we have
   things like SET TYPE
 * SET TYPE needs to depend on rebases that add subtypes to the target
   type

Fixes #2536.