### PR TITLE
RFC 1008: TLS and ALPN

### DIFF
--- a/edb/protocol/protocol.pyx
+++ b/edb/protocol/protocol.pyx
@@ -105,11 +105,14 @@ async def new_connection(
     password: str = None,
     admin: str = None,
     database: str = None,
+    tls_cert_file: str = None,
+    tls_verify_hostname: bool = None,
     timeout: float = 60,
 ):
     addrs, params, config = con_utils.parse_connect_arguments(
         dsn=dsn, host=host, port=port, user=user, password=password,
         admin=admin, database=database,
+        tls_cert_file=tls_cert_file, tls_verify_hostname=tls_verify_hostname,
         timeout=timeout, command_timeout=None, server_settings=None,
         wait_until_available=timeout)
 
@@ -130,7 +133,7 @@ async def new_connection(
                     protocol_factory, addr)
             else:
                 connector = loop.create_connection(
-                    protocol_factory, *addr)
+                    protocol_factory, *addr, ssl=params.ssl_ctx)
 
             before = time.monotonic()
             try:

--- a/edb/protocol/protocol.pyx
+++ b/edb/protocol/protocol.pyx
@@ -108,6 +108,7 @@ async def new_connection(
     tls_cert_file: str = None,
     tls_verify_hostname: bool = None,
     timeout: float = 60,
+    use_tls: bool = True,
 ):
     addrs, params, config = con_utils.parse_connect_arguments(
         dsn=dsn, host=host, port=port, user=user, password=password,
@@ -133,7 +134,9 @@ async def new_connection(
                     protocol_factory, addr)
             else:
                 connector = loop.create_connection(
-                    protocol_factory, *addr, ssl=params.ssl_ctx)
+                    protocol_factory, *addr,
+                    ssl=params.ssl_ctx if use_tls else None,
+                )
 
             before = time.monotonic()
             try:

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -91,7 +91,7 @@ class ServerConfig(NamedTuple):
 
     tls_cert_file: Optional[pathlib.Path]
     tls_key_file: Optional[pathlib.Path]
-    optional_tls: bool
+    allow_cleartext_connections: bool
 
 
 class PathPath(click.Path):
@@ -334,9 +334,8 @@ _server_options = [
              'well. If the private key is protected by a password, specify '
              'with an environment variable EDGEDB_TLS_PRIVATE_KEY_PASSWORD.'),
     click.option(
-        '--optional-tls', type=bool, is_flag=True, hidden=True,
-        help='Run the server in TLS-compatible mode, supporting clients that '
-             'use both TLS and cleartext transports.'),
+        '--allow-cleartext-connections', type=bool, is_flag=True, hidden=True,
+        help='Also allow client connections in cleartext in addition to TLS.'),
     click.option(
         '--version', is_flag=True,
         help='Show the version and exit.')

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -47,7 +47,7 @@ class ClusterError(Exception):
 class BaseCluster:
     def __init__(self, runstate_dir, *, port=edgedb_defines.EDGEDB_PORT,
                  env=None, testmode=False, log_level=None):
-        self._edgedb_cmd = [sys.executable, '-m', 'edb.server.main']
+        self._edgedb_cmd = [sys.executable, '-m', 'edb.tools', 'server']
 
         if log_level:
             self._edgedb_cmd.extend(['--log-level', log_level])

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -47,7 +47,7 @@ class ClusterError(Exception):
 class BaseCluster:
     def __init__(self, runstate_dir, *, port=edgedb_defines.EDGEDB_PORT,
                  env=None, testmode=False, log_level=None):
-        self._edgedb_cmd = [sys.executable, '-m', 'edb.tools', 'server']
+        self._edgedb_cmd = [sys.executable, '-m', 'edb.tools', 'testserver']
 
         if log_level:
             self._edgedb_cmd.extend(['--log-level', log_level])

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -194,7 +194,7 @@ async def _run_server(
             startup_script=args.startup_script,
             tls_cert_file=tls_cert_file,
             tls_key_file=tls_key_file,
-            optional_tls=args.optional_tls,
+            allow_cleartext_connections=args.allow_cleartext_connections,
         )
         await sc.wait_for(ss.init())
 
@@ -264,7 +264,8 @@ def _init_tls_certs(
             )
             return str(cert_file), str(key_file)
 
-    abort("Cannot start EdgeDB server without TLS certificate.")
+    abort("Cannot start EdgeDB server without a TLS certificate, use the"
+          "`--tls-cert-file` command-line argument to specify it.")
 
 
 def run_server(args: srvargs.ServerConfig, *, do_setproctitle: bool=False):
@@ -413,6 +414,9 @@ def run_server(args: srvargs.ServerConfig, *, do_setproctitle: bool=False):
                         do_setproctitle=do_setproctitle,
                     )
                 )
+
+    except server.StartupError as e:
+        abort(str(e))
 
     except BaseException:
         if pg_cluster_init_by_us and not _server_initialized:

--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -26,6 +26,7 @@ cdef class HttpRequest:
         public bytes content_type
         public bytes method
         public bytes body
+        public bytes host
 
 
 cdef class HttpResponse:
@@ -46,9 +47,12 @@ cdef class HttpProtocol:
         object parser
         object transport
         object unprocessed
+        object sslctx
         bint in_response
         bint first_data_call
         bint external_auth
+        bint respond_hsts
+        bint optional_tls
 
         HttpRequest current_request
 

--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -52,7 +52,7 @@ cdef class HttpProtocol:
         bint first_data_call
         bint external_auth
         bint respond_hsts
-        bint optional_tls
+        bint allow_cleartext_connections
 
         HttpRequest current_request
 

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -20,12 +20,15 @@
 include "./consts.pxi"
 
 
+import asyncio
 import collections
 import http
+import ssl
 import urllib.parse
 
 import httptools
 
+from edb import errors
 from edb.common import debug
 from edb.common import markup
 
@@ -56,17 +59,21 @@ cdef class HttpResponse:
 
 cdef class HttpProtocol:
 
-    def __init__(self, server, *, external_auth: bool=False):
+    def __init__(self, server, sslctx, *,
+                 external_auth: bool=False, optional_tls: bool=False):
         self.loop = server.get_loop()
         self.server = server
         self.transport = None
         self.external_auth = external_auth
+        self.sslctx = sslctx
+        self.optional_tls = optional_tls
 
         self.parser = None
         self.current_request = None
         self.in_response = False
         self.unprocessed = None
         self.first_data_call = True
+        self.respond_hsts = False  # redirect non-TLS HTTP clients to TLS URL
 
     def connection_made(self, transport):
         self.transport = transport
@@ -75,25 +82,57 @@ cdef class HttpProtocol:
         self.transport = None
         self.unprocessed = None
 
+    def eof_received(self):
+        pass
+
     def data_received(self, data):
         if self.first_data_call:
             self.first_data_call = False
 
+            # Detect if the client is speaking TLS in the "first" data using
+            # the SSL library. This is not the official handshake as we only
+            # need to know "is_ssl"; the first data is used again for the true
+            # handshake if is_ssl = True. This is for further responding a nice
+            # error message to non-TLS clients.
+            is_ssl = True
+            try:
+                outgoing = ssl.MemoryBIO()
+                incoming = ssl.MemoryBIO()
+                incoming.write(data)
+                sslobj = self.sslctx.wrap_bio(
+                    incoming, outgoing, server_side=True
+                )
+                sslobj.do_handshake()
+            except ssl.SSLWantReadError:
+                pass
+            except ssl.SSLError:
+                is_ssl = False
+
+            if is_ssl:
+                # Most clients should arrive here to continue with TLS
+                self.transport.pause_reading()
+                self.loop.create_task(self._forward_first_data(data))
+                self.loop.create_task(self._start_tls())
+                return
+
+            # In case when we're talking to a non-TLS client, keep using the
+            # legacy magic byte check to choose the HTTP or binary protocol.
             if data[0:2] == b'V\x00':
                 # This is, most likely, our binary protocol,
                 # as its first message kind is `V`.
                 #
                 # Switch protocols now (for compatibility).
-                binproto = binary.EdgeConnection(
-                    self.server, self.external_auth)
-                self.transport.set_protocol(binproto)
-                binproto.connection_made(self.transport)
-                binproto.data_received(data)
+                if self.optional_tls:
+                    self._switch_to_binary_protocol(data)
+                else:
+                    self.loop.create_task(self._return_binary_error(
+                        self._switch_to_binary_protocol()
+                    ))
                 return
             else:
                 # HTTP.
-                self.parser = httptools.HttpRequestParser(self)
-                self.current_request = HttpRequest()
+                self._init_http_parser()
+                self.respond_hsts = not self.optional_tls
 
         try:
             self.parser.feed_data(data)
@@ -107,6 +146,8 @@ cdef class HttpProtocol:
         name = name.lower()
         if name == b'content-type':
             self.current_request.content_type = value
+        elif name == b'host':
+            self.current_request.host = value
 
     def on_body(self, body: bytes):
         self.current_request.body = body
@@ -189,11 +230,87 @@ cdef class HttpProtocol:
             response.body,
             response.close_connection)
 
+    def _switch_to_binary_protocol(self, data=None):
+        binproto = binary.EdgeConnection(self.server, self.external_auth)
+        self.transport.set_protocol(binproto)
+        binproto.connection_made(self.transport)
+        if data:
+            binproto.data_received(data)
+        return binproto
+
+    def _init_http_parser(self):
+        self.parser = httptools.HttpRequestParser(self)
+        self.current_request = HttpRequest()
+
+    async def _forward_first_data(self, data):
+        # As we stole the "first data", we need to manually send it back to
+        # the SSLProtocol. The hack here is highly-coupled with uvloop impl.
+        transport = self.transport  # The TCP transport
+        for i in range(3):
+            await asyncio.sleep(0)
+            ssl_proto = self.transport.get_protocol()
+            if ssl_proto is not self:
+                break
+        else:
+            raise RuntimeError("start_tls() hasn't run in 3 loop iterations")
+
+        # Delay for one more iteration to make sure the first data is fed after
+        # SSLProtocol.connection_made() is called.
+        await asyncio.sleep(0)
+
+        data_len = len(data)
+        buf = ssl_proto.get_buffer(data_len)
+        buf[:data_len] = data
+        ssl_proto.buffer_updated(data_len)
+
+    async def _start_tls(self):
+        self.transport = await self.loop.start_tls(
+            self.transport, self, self.sslctx, server_side=True
+        )
+        sslobj = self.transport.get_extra_info('ssl_object')
+        if sslobj.selected_alpn_protocol() == 'edgedb-binary':
+            self._switch_to_binary_protocol()
+        else:
+            # It's either HTTP as the negotiated protocol, or the negotiation
+            # failed and we have no idea what ALPN the client has set. Here we
+            # just start talking in HTTP, and let the client bindings decide if
+            # this is an error based on the ALPN result.
+            self._init_http_parser()
+
+    async def _return_binary_error(self, proto):
+        await proto.write_error(errors.BinaryProtocolError(
+            'TLS Required',
+            details='The server requires Transport Layer Security (TLS)',
+            hint='Upgrade the client to a newer version that supports TLS'
+        ))
+        proto.close()
+
     async def _handle_request(self, HttpRequest request):
         cdef:
             HttpResponse response = HttpResponse()
 
         if self.transport is None:
+            return
+
+        if self.respond_hsts:
+            if request.host:
+                path = request.url.path.lstrip(b'/')
+                loc = b'https://' + request.host + b'/' + path
+                self.transport.write(
+                    b'HTTP/1.1 301 Moved Permanently\r\n'
+                    b'Strict-Transport-Security: max-age=31536000\r\n'
+                    b'Location: ' + loc + b'\r\n'
+                    b'\r\n'
+                )
+            else:
+                msg = b'Request is missing header: Host\r\n'
+                self.transport.write(
+                    b'HTTP/1.1 400 Bad Request\r\n'
+                    b'Content-Length: ' + str(len(msg)).encode() + b'\r\n'
+                    b'\r\n' + msg
+                )
+
+            self.close()
             return
 
         try:

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1497,7 +1497,7 @@ class _EdgeDBServer:
         status_r, status_w = socket.socketpair()
 
         cmd = [
-            sys.executable, '-m', 'edb.tools', 'server',
+            sys.executable, '-m', 'edb.tools', 'testserver',
             '--port', 'auto',
             '--testmode',
             '--emit-server-status', f'fd://{status_w.fileno()}',

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -772,6 +772,7 @@ class CLITestCaseMixin:
         cmd_args = [
             '--host', conn_args['host'],
             '--port', str(conn_args['port']),
+            '--tls-cert-file', conn_args['tls_cert_file']
         ]
         if conn_args.get('user'):
             cmd_args += ['--user', conn_args['user']]
@@ -1401,6 +1402,7 @@ class _EdgeDBServerData(NamedTuple):
     port: int
     password: str
     server_data: Any
+    tls_cert_file: str
 
     async def connect(self, **kwargs: Any) -> edgedb.AsyncIOConnection:
         conn_args = dict(
@@ -1408,6 +1410,7 @@ class _EdgeDBServerData(NamedTuple):
             password=self.password,
             host=self.host,
             port=self.port,
+            tls_cert_file=self.tls_cert_file,
         )
 
         conn_args.update(kwargs)
@@ -1583,10 +1586,11 @@ class _EdgeDBServer:
             status_w.close()
 
         return _EdgeDBServerData(
-            host=data['socket_dir'],
+            host='127.0.0.1',
             port=data['port'],
             password=password,
             server_data=data,
+            tls_cert_file=data['tls_cert_file'],
         )
 
     async def __aexit__(self, exc_type, exc, tb):

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1435,6 +1435,7 @@ class _EdgeDBServer:
         runstate_dir: Optional[str] = None,
         reset_auth: Optional[bool] = None,
         tenant_id: Optional[str] = None,
+        allow_cleartext_connections: bool = False,
     ) -> None:
         self.auto_shutdown = auto_shutdown
         self.bootstrap_command = bootstrap_command
@@ -1448,6 +1449,7 @@ class _EdgeDBServer:
         self.tenant_id = tenant_id
         self.proc = None
         self.data = None
+        self.allow_cleartext_connections = allow_cleartext_connections
 
     async def wait_for_server_readiness(self, stream: asyncio.StreamReader):
         while True:
@@ -1495,7 +1497,7 @@ class _EdgeDBServer:
         status_r, status_w = socket.socketpair()
 
         cmd = [
-            sys.executable, '-m', 'edb.server.main',
+            sys.executable, '-m', 'edb.tools', 'server',
             '--port', 'auto',
             '--testmode',
             '--emit-server-status', f'fd://{status_w.fileno()}',
@@ -1559,6 +1561,9 @@ class _EdgeDBServer:
         if self.tenant_id:
             cmd += ['--tenant-id', self.tenant_id]
 
+        if self.allow_cleartext_connections:
+            cmd += ['--allow-cleartext-connections']
+
         if self.debug:
             print(f'Starting EdgeDB cluster with the following params: {cmd}')
 
@@ -1609,6 +1614,7 @@ def start_edgedb_server(
     runstate_dir: Optional[str] = None,
     reset_auth: Optional[bool] = None,
     tenant_id: Optional[str] = None,
+    allow_cleartext_connections: bool = False,
 ):
     if not devmode.is_in_dev_mode() and not runstate_dir:
         if postgres_dsn or adjacent_to:
@@ -1628,6 +1634,7 @@ def start_edgedb_server(
         tenant_id=tenant_id,
         runstate_dir=runstate_dir,
         reset_auth=reset_auth,
+        allow_cleartext_connections=allow_cleartext_connections,
     )
 
 

--- a/edb/tools/cli.py
+++ b/edb/tools/cli.py
@@ -17,6 +17,7 @@
 #
 
 
+import subprocess
 import sys
 
 import click
@@ -35,11 +36,25 @@ def cli(args: list[str]):
     args = list(args)
 
     if (
-        '-H' not in args and
         '--host' not in args and
-        not any('--host=' in a for a in args)
+        not any(a.startswith('-H') for a in args) and
+        not any(a.startswith('--host=') for a in args) and
+        '--port' not in args and
+        not any(a.startswith('-P') for a in args) and
+        not any(a.startswith('--port=') for a in args) and
+        '--instance' not in args and
+        not any(a.startswith('-I') for a in args) and
+        not any(a.startswith('--instance=') for a in args)
     ):
-        args += ['-H', 'localhost']
+        args += ['-I', '_localdev']
+        subprocess.check_call([
+            sys.executable,
+            "-m",
+            "edb.cli",
+            "authenticate",
+            "_localdev",
+            "--non-interactive",
+        ])
 
     if (
         '--wait-until-available' not in args and

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -54,6 +54,16 @@ def server(version=False, **kwargs):
     srv_main.server_main(insecure=True, **kwargs)
 
 
+@edbcommands.command(hidden=True)
+@srv_args.server_options(has_devmode=True)
+def testserver(version=False, **kwargs):
+    # This is only used for running tests
+    if version:
+        print(f"edgedb-server, version {buildmeta.get_version()}")
+        sys.exit(0)
+    srv_main.server_main(**kwargs)
+
+
 # Import at the end of the file so that "edb.tools.edb.edbcommands"
 # is defined for all of the below modules when they try to import it.
 from . import cli  # noqa

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -43,7 +43,7 @@ def edbcommands(ctx, devmode: bool):
 
 
 @edbcommands.command()
-@srv_args.server_options
+@srv_args.server_options(has_devmode=True)
 def server(version=False, **kwargs):
     if version:
         print(f"edb, version {buildmeta.get_version()}")

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ RUNTIME_DEPS = [
     'setproctitle~=1.1.10',
     'setuptools-rust==0.10.3',
     'setuptools_scm~=3.2.0',
-    'uvloop @ git+https://github.com/MagicStack/uvloop.git@master',
+    'uvloop~=0.15.3',
     "typing_inspect~=0.5.0;python_version<'3.9'",
     'wcwidth~=0.2.5',
 

--- a/setup.py
+++ b/setup.py
@@ -52,14 +52,14 @@ RUNTIME_DEPS = [
     'setproctitle~=1.1.10',
     'setuptools-rust==0.10.3',
     'setuptools_scm~=3.2.0',
-    'uvloop~=0.15.1',
+    'uvloop @ git+https://github.com/MagicStack/uvloop.git@master',
     "typing_inspect~=0.5.0;python_version<'3.9'",
     'wcwidth~=0.2.5',
 
     'graphql-core~=3.1.5',
     'promise~=2.2.0',
 
-    'edgedb>=0.15.0',
+    'edgedb @ git+https://github.com/edgedb/edgedb-python.git@master',
 ]
 
 CYTHON_DEPENDENCY = 'Cython==0.29.23'

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -43,7 +43,8 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
             self.http_addr, method='POST')  # type: ignore
         req.add_header('Content-Type', 'application/json')
         response = urllib.request.urlopen(
-            req, json.dumps(req_data).encode())
+            req, json.dumps(req_data).encode(), context=self.tls_context
+        )
         resp_data = json.loads(response.read())
         return resp_data
 
@@ -157,7 +158,7 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
     def test_http_notebook_04(self):
         req = urllib.request.Request(self.http_addr + '/status',
                                      method='GET')
-        response = urllib.request.urlopen(req)
+        response = urllib.request.urlopen(req, context=self.tls_context)
         resp_data = json.loads(response.read())
         self.assertEqual(resp_data, {'kind': 'status', 'status': 'OK'})
 

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -80,6 +80,7 @@ class TestServerOps(tb.TestCase):
                     user='edgedb',
                     host=sd.host,
                     port=sd.port,
+                    tls_cert_file=sd.tls_cert_file,
                     wait_until_available=0,
                 )
 

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -95,7 +95,7 @@ class TestServerOps(tb.TestCase):
         # * "--bootstrap-command"
 
         cmd = [
-            sys.executable, '-m', 'edb.tools', 'server',
+            sys.executable, '-m', 'edb.tools', 'testserver',
             '--port', 'auto',
             '--testmode',
             '--temp-dir',
@@ -138,7 +138,7 @@ class TestServerOps(tb.TestCase):
         os.close(status_fd)
 
         cmd = [
-            sys.executable, '-m', 'edb.tools', 'server',
+            sys.executable, '-m', 'edb.tools', 'testserver',
             '--port', 'auto',
             '--testmode',
             '--temp-dir',

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -30,9 +30,12 @@ import tempfile
 import time
 
 import edgedb
+from edgedb import errors
 
+from edb import protocol
 from edb.common import devmode
 from edb.common import taskgroup
+from edb.protocol import protocol as edb_protocol  # type: ignore
 from edb.server import pgcluster, pgconnparams
 from edb.testbase import server as tb
 
@@ -92,7 +95,7 @@ class TestServerOps(tb.TestCase):
         # * "--bootstrap-command"
 
         cmd = [
-            sys.executable, '-m', 'edb.server.main',
+            sys.executable, '-m', 'edb.tools', 'server',
             '--port', 'auto',
             '--testmode',
             '--temp-dir',
@@ -135,7 +138,7 @@ class TestServerOps(tb.TestCase):
         os.close(status_fd)
 
         cmd = [
-            sys.executable, '-m', 'edb.server.main',
+            sys.executable, '-m', 'edb.tools', 'server',
             '--port', 'auto',
             '--testmode',
             '--temp-dir',
@@ -270,3 +273,70 @@ class TestServerOps(tb.TestCase):
                 self.loop.run_until_complete(run())
             finally:
                 cluster.stop()
+
+    async def _test_connection(self, con):
+        await con.connect()
+
+        await con.send(
+            protocol.ExecuteScript(
+                headers=[],
+                script='SELECT 1'
+            )
+        )
+        await con.recv_match(
+            protocol.CommandComplete,
+            status='SELECT'
+        )
+        await con.recv_match(
+            protocol.ReadyForCommand,
+            transaction_state=protocol.TransactionState.NOT_IN_TRANSACTION,
+        )
+
+    async def test_server_ops_downgrade_to_plaintext(self):
+        async with tb.start_edgedb_server(
+            auto_shutdown=True,
+            allow_cleartext_connections=True,
+        ) as sd:
+            con = await edb_protocol.new_connection(
+                user='edgedb',
+                password=sd.password,
+                host=sd.host,
+                port=sd.port,
+                use_tls=False,
+            )
+            try:
+                await self._test_connection(con)
+            finally:
+                await con.aclose()
+
+    async def test_server_ops_no_plaintext(self):
+        async with tb.start_edgedb_server(
+            auto_shutdown=True,
+            allow_cleartext_connections=False,
+        ) as sd:
+            con = await edb_protocol.new_connection(
+                user='edgedb',
+                password=sd.password,
+                host=sd.host,
+                port=sd.port,
+                use_tls=False,
+            )
+            try:
+                with self.assertRaisesRegex(
+                    errors.BinaryProtocolError, "TLS Required"
+                ):
+                    await con.connect()
+            finally:
+                await con.aclose()
+
+            con = await edb_protocol.new_connection(
+                user='edgedb',
+                password=sd.password,
+                host=sd.host,
+                port=sd.port,
+                tls_cert_file=sd.tls_cert_file,
+            )
+            try:
+                await self._test_connection(con)
+            finally:
+                await con.aclose()


### PR DESCRIPTION
* Load certs from `data_dir` if no `--tls-cert-file` given
* Generate dev certs if none found in dev mode
* ~Run tests using `_localtest_PORT` temporary instances~

Closes #2610 