### PR TITLE
Delete some unnecessary introspection viewgen code

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -37,10 +37,8 @@ from edb.schema import objtypes as s_objtypes
 from edb.schema import objects as s_objects
 from edb.schema import pointers as s_pointers
 from edb.schema import types as s_types
-from edb.schema import utils as s_utils
 
 from edb.edgeql import ast as qlast
-from edb.edgeql import parser as qlparser
 from edb.edgeql import qltypes
 
 from . import astutils
@@ -291,61 +289,6 @@ def _process_view(
                         view_rptr=view_rptr,
                         ctx=scopectx,
                     ),
-                )
-
-    elif (
-        stype.get_name(ctx.env.schema).module == 'schema'
-        and ctx.env.options.apply_query_rewrites
-    ):
-        explicit_ptrs = {
-            ptrcls.get_local_name(ctx.env.schema)
-            for ptrcls in pointers
-        }
-        scls_pointers = stype.get_pointers(ctx.env.schema)
-        for pn, ptrcls in scls_pointers.items(ctx.env.schema):
-            if (
-                pn in explicit_ptrs
-                or ptrcls.is_pure_computable(ctx.env.schema)
-            ):
-                continue
-
-            schema_deflt = ptrcls.get_schema_reflection_default(ctx.env.schema)
-            if schema_deflt is None:
-                continue
-
-            with ctx.newscope(fenced=True) as scopectx:
-                ptr_ref = s_utils.name_to_ast_ref(pn)
-                implicit_ql = qlast.ShapeElement(
-                    expr=qlast.Path(steps=[qlast.Ptr(ptr=ptr_ref)]),
-                    compexpr=qlast.BinOp(
-                        left=qlast.Path(
-                            partial=True,
-                            steps=[
-                                qlast.Ptr(
-                                    ptr=ptr_ref,
-                                    direction=(
-                                        s_pointers.PointerDirection.Outbound
-                                    ),
-                                )
-                            ],
-                        ),
-                        right=qlparser.parse_fragment(schema_deflt),
-                        op='??',
-                    ),
-                )
-
-                # Note: we only need to record the schema default
-                # as a computable, but not include it in the type
-                # shape, so we ignore the return value.
-                _normalize_view_ptr_expr(
-                    implicit_ql,
-                    view_scls,
-                    path_id=path_id,
-                    path_id_namespace=path_id_namespace,
-                    is_insert=is_insert,
-                    is_update=is_update,
-                    view_rptr=view_rptr,
-                    ctx=scopectx,
                 )
 
     for ptrcls in pointers:


### PR DESCRIPTION
The logic to inject schema defaults is already present in
computable_ptr_set and isn't needed in process_view.

This speeds up compile_edgeql_script_schema_introspection by 1.6x.