### PR TITLE
Make ObjectShell a Generic type

### DIFF
--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -176,8 +176,8 @@ def is_castable(
 def get_cast_fullname(
     schema: s_schema.Schema,
     module: str,
-    from_type: s_types.TypeShell,
-    to_type: s_types.TypeShell,
+    from_type: s_types.TypeShell[s_types.Type],
+    to_type: s_types.TypeShell[s_types.Type],
 ) -> sn.QualName:
     quals = [str(from_type.get_name(schema)), str(to_type.get_name(schema))]
     shortname = sn.QualName(module, 'cast')
@@ -269,12 +269,14 @@ class CastCommand(sd.QualifiedObjectCommand[Cast],
 
         from_type = utils.ast_to_type_shell(
             astnode.from_type,
+            metaclass=s_types.Type,
             modaliases=modaliases,
             schema=schema,
         )
 
         to_type = utils.ast_to_type_shell(
             astnode.to_type,
+            metaclass=s_types.Type,
             modaliases=modaliases,
             schema=schema,
         )
@@ -330,6 +332,7 @@ class CreateCast(CastCommand, sd.CreateObject[Cast]):
 
         from_type = utils.ast_to_type_shell(
             astnode.from_type,
+            metaclass=s_types.Type,
             modaliases=modaliases,
             schema=schema,
         )
@@ -338,6 +341,7 @@ class CreateCast(CastCommand, sd.CreateObject[Cast]):
 
         to_type = utils.ast_to_type_shell(
             astnode.to_type,
+            metaclass=s_types.Type,
             modaliases=modaliases,
             schema=schema,
         )

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -559,12 +559,13 @@ class ConstraintCommand(
         context: sd.CommandContext,
         refcls: Constraint,
         implicit_bases: List[Constraint],
-    ) -> inheriting.BaseDelta_T:
+    ) -> inheriting.BaseDelta_T[Constraint]:
         child_bases = refcls.get_bases(schema).objects(schema)
 
         return inheriting.delta_bases(
             [b.get_name(schema) for b in child_bases],
             [b.get_name(schema) for b in implicit_bases],
+            t=Constraint,
         )
 
     def get_ast_attr_for_field(
@@ -1177,7 +1178,7 @@ class CreateConstraint(
         schema: s_schema.Schema,
         astnode: qlast.ObjectDDL,
         context: sd.CommandContext,
-    ) -> List[so.ObjectShell]:
+    ) -> List[so.ObjectShell[Constraint]]:
         if isinstance(astnode, qlast.CreateConcreteConstraint):
             classname = cls._classname_from_ast(schema, astnode, context)
             base_name = sn.shortname_from_fullname(classname)
@@ -1438,6 +1439,6 @@ class RebaseConstraint(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
-        bases: Tuple[so.ObjectShell, ...],
-    ) -> Tuple[so.ObjectShell, ...]:
+        bases: Tuple[so.ObjectShell[Constraint], ...],
+    ) -> Tuple[so.ObjectShell[Constraint], ...]:
         return ()

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -3716,6 +3716,7 @@ class AlterObjectProperty(Command):
 
                 new_value = utils.ast_to_object_shell(
                     astnode.value,
+                    metaclass=so.Object,
                     modaliases=context.modaliases,
                     schema=schema,
                 )
@@ -3728,6 +3729,8 @@ class AlterObjectProperty(Command):
                 new_value = None
 
             elif isinstance(astnode.value, qlast.TypeExpr):
+                from . import types as s_types
+
                 if not isinstance(parent_op, QualifiedObjectCommand):
                     raise AssertionError(
                         'cannot determine module for derived compound type: '
@@ -3736,6 +3739,7 @@ class AlterObjectProperty(Command):
 
                 new_value = utils.ast_to_type_shell(
                     astnode.value,
+                    metaclass=s_types.Type,
                     module=parent_op.classname.module,
                     modaliases=context.modaliases,
                     schema=schema,

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -292,7 +292,7 @@ class ExpressionShell(so.Shell):
         self,
         *,
         text: str,
-        refs: Optional[Iterable[so.ObjectShell]],
+        refs: Optional[Iterable[so.ObjectShell[so.Object]]],
         _qlast: Optional[qlast_.Base] = None,
         _irast: Optional[irast_.Command] = None,
     ) -> None:

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -176,7 +176,7 @@ class AliasCommand(
         context: sd.CommandContext,
         is_alter: bool = False,
         parser_context: Optional[parsing.ParserContext] = None,
-    ) -> Tuple[sd.Command, s_types.TypeShell, s_expr.Expression]:
+    ) -> Tuple[sd.Command, s_types.TypeShell[s_types.Type], s_expr.Expression]:
         ir = compile_alias_expr(
             expr.qlast,
             classname,
@@ -392,7 +392,7 @@ def define_alias(
     classname: sn.QualName,
     schema: s_schema.Schema,
     parser_context: Optional[parsing.ParserContext] = None,
-) -> Tuple[sd.Command, s_types.TypeShell]:
+) -> Tuple[sd.Command, s_types.TypeShell[s_types.Type]]:
     from edb.ir import ast as irast
     from . import ordering as s_ordering
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -72,7 +72,7 @@ def param_as_str(
         ret.append(typemod.to_edgeql())
         ret.append(' ')
 
-    paramt: Union[s_types.Type, s_types.TypeShell]
+    paramt: Union[s_types.Type, s_types.TypeShell[s_types.Type]]
     if isinstance(param, ParameterDesc):
         paramt = param.get_type_shell(schema)
     else:
@@ -160,7 +160,7 @@ class ParameterDesc(ParameterLike):
     num: int
     name: sn.Name
     default: Optional[s_expr.Expression]
-    type: s_types.TypeShell
+    type: s_types.TypeShell[s_types.Type]
     typemod: ft.TypeModifier
     kind: ft.ParameterKind
 
@@ -170,7 +170,7 @@ class ParameterDesc(ParameterLike):
         num: int,
         name: sn.Name,
         default: Optional[s_expr.Expression],
-        type: s_types.TypeShell,
+        type: s_types.TypeShell[s_types.Type],
         typemod: ft.TypeModifier,
         kind: ft.ParameterKind,
     ) -> None:
@@ -216,6 +216,7 @@ class ParameterDesc(ParameterLike):
         assert isinstance(paramt_ast, qlast.TypeName)
         paramt = utils.ast_to_type_shell(
             paramt_ast,
+            metaclass=s_types.Type,
             modaliases=modaliases,
             schema=schema,
         )
@@ -244,7 +245,10 @@ class ParameterDesc(ParameterLike):
     def get_type(self, schema: s_schema.Schema) -> s_types.Type:
         return self.type.resolve(schema)
 
-    def get_type_shell(self, schema: s_schema.Schema) -> s_types.TypeShell:
+    def get_type_shell(
+        self,
+        schema: s_schema.Schema,
+    ) -> s_types.TypeShell[s_types.Type]:
         return self.type
 
     def get_typemod(self, _: s_schema.Schema) -> ft.TypeModifier:
@@ -1031,6 +1035,7 @@ class CreateCallableObject(
 
             return_type = utils.ast_to_type_shell(
                 astnode.returning,
+                metaclass=s_types.Type,
                 modaliases=modaliases,
                 schema=schema,
             )

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -96,7 +96,7 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
 
         parent_migration = schema.get_last_migration()
 
-        parent: Optional[so.ObjectShell]
+        parent: Optional[so.ObjectShell[Migration]]
 
         if astnode.parent is None:
             if parent_migration is not None:

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -148,7 +148,7 @@ class PseudoType(
                 f'unexpected pseudo type: {self.get_name(schema)}')
 
 
-class PseudoTypeShell(s_types.TypeShell):
+class PseudoTypeShell(s_types.TypeShell[PseudoType]):
 
     def __init__(self, *, name: sn.Name) -> None:
         super().__init__(name=name, schemaclass=PseudoType)

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -340,7 +340,11 @@ def generate_structure(schema: s_schema.Schema) -> SchemaReflectionParts:
                 rschema_name, type=s_objtypes.ObjectType)
         else:
             ex_bases = schema_objtype.get_bases(schema).names(schema)
-            _, added_bases = s_inh.delta_bases(ex_bases, bases)
+            _, added_bases = s_inh.delta_bases(
+                ex_bases,
+                bases,
+                t=type(schema_objtype),
+            )
 
             if added_bases:
                 for subset, position in added_bases:

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -112,7 +112,7 @@ class RoleCommand(
         schema: s_schema.Schema,
         astnode: qlast.ObjectDDL,
         context: sd.CommandContext,
-    ) -> List[so.ObjectShell]:
+    ) -> List[so.ObjectShell[Role]]:
         result = []
         for b in getattr(astnode, 'bases', None) or []:
             result.append(utils.ast_objref_to_object_shell(

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -252,7 +252,7 @@ class ScalarType(
         return alter
 
 
-class AnonymousEnumTypeShell(s_types.TypeShell):
+class AnonymousEnumTypeShell(s_types.TypeShell[ScalarType]):
 
     elements: Sequence[str]
 
@@ -262,10 +262,10 @@ class AnonymousEnumTypeShell(s_types.TypeShell):
         name: s_name.Name = s_name.QualName(module='std', name='anyenum'),
         elements: Iterable[str],
     ) -> None:
-        super().__init__(name=name)
+        super().__init__(name=name, schemaclass=ScalarType)
         self.elements = list(elements)
 
-    def resolve(self, schema: s_schema.Schema) -> s_types.Type:
+    def resolve(self, schema: s_schema.Schema) -> ScalarType:
         raise NotImplementedError(
             f'cannot resolve {self.__class__.__name__!r}'
         )
@@ -373,6 +373,7 @@ class CreateScalarType(
             bases = [
                 s_utils.ast_to_type_shell(
                     b,
+                    metaclass=ScalarType,
                     modaliases=context.modaliases,
                     schema=schema,
                 )

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -103,15 +103,39 @@ def resolve_name(
     return name
 
 
-def ast_objref_to_object_shell(
+@overload
+def ast_objref_to_object_shell(  # NoQA: F811
     ref: qlast.ObjectRef,
     *,
-    metaclass: Optional[Type[so.Object]] = None,
+    metaclass: Type[so.Object_T],
     modaliases: Mapping[Optional[str], str],
     schema: s_schema.Schema,
-) -> so.ObjectShell:
-    if metaclass is None:
-        metaclass = so.Object
+) -> so.ObjectShell[so.Object_T]:
+    ...
+
+
+@overload
+def ast_objref_to_object_shell(  # NoQA: F811
+    ref: qlast.ObjectRef,
+    *,
+    metaclass: None = None,
+    modaliases: Mapping[Optional[str], str],
+    schema: s_schema.Schema,
+) -> so.ObjectShell[so.Object]:
+    ...
+
+
+def ast_objref_to_object_shell(  # NoQA: F811
+    ref: qlast.ObjectRef,
+    *,
+    metaclass: Optional[Type[so.Object_T]] = None,
+    modaliases: Mapping[Optional[str], str],
+    schema: s_schema.Schema,
+) -> so.ObjectShell[so.Object_T]:
+    if metaclass is not None:
+        mcls = metaclass
+    else:
+        mcls = so.Object  # type: ignore
 
     lname = ast_ref_to_name(ref)
     name = resolve_name(
@@ -124,7 +148,7 @@ def ast_objref_to_object_shell(
     return so.ObjectShell(
         name=name,
         origname=lname,
-        schemaclass=metaclass,
+        schemaclass=mcls,
         sourcectx=ref.context,
     )
 
@@ -132,19 +156,21 @@ def ast_objref_to_object_shell(
 def ast_objref_to_type_shell(
     ref: qlast.ObjectRef,
     *,
-    metaclass: Optional[Type[s_types.Type]] = None,
+    metaclass: Type[s_types.TypeT],
     modaliases: Mapping[Optional[str], str],
     schema: s_schema.Schema,
-) -> s_types.TypeShell:
+) -> s_types.TypeShell[s_types.TypeT]:
     from . import types as s_types
 
-    if metaclass is None:
-        metaclass = s_types.InheritingType
+    if metaclass is not s_types.Type:
+        mcls = metaclass
+    else:
+        mcls = s_types.QualifiedType  # type: ignore
 
     lname = ast_ref_to_name(ref)
     name = resolve_name(
         lname,
-        metaclass=metaclass,
+        metaclass=mcls,
         modaliases=modaliases,
         schema=schema,
     )
@@ -152,7 +178,7 @@ def ast_objref_to_type_shell(
     return s_types.TypeShell(
         name=name,
         origname=lname,
-        schemaclass=metaclass,
+        schemaclass=mcls,
         sourcectx=ref.context,
     )
 
@@ -160,15 +186,16 @@ def ast_objref_to_type_shell(
 def ast_to_type_shell(
     node: qlast.TypeExpr,
     *,
-    metaclass: Optional[Type[s_types.Type]] = None,
+    metaclass: Type[s_types.TypeT_co],
     module: Optional[str] = None,
     modaliases: Mapping[Optional[str], str],
     schema: s_schema.Schema,
-) -> s_types.TypeShell:
+) -> s_types.TypeShell[s_types.TypeT_co]:
 
     if isinstance(node, qlast.TypeOp):
         return type_op_ast_to_type_shell(
             node,
+            metaclass=metaclass,
             module=module,
             modaliases=modaliases,
             schema=schema,
@@ -184,7 +211,7 @@ def ast_to_type_shell(
         assert node.subtypes
 
         if isinstance(node.subtypes[0], qlast.TypeExprLiteral):
-            return s_scalars.AnonymousEnumTypeShell(
+            return s_scalars.AnonymousEnumTypeShell(  # type: ignore
                 elements=[
                     est.val.value
                     for est in cast(List[qlast.TypeExprLiteral], node.subtypes)
@@ -200,7 +227,7 @@ def ast_to_type_shell(
                         context=est.context,
                     )
                 elements.append(est.maintype.name)
-            return s_scalars.AnonymousEnumTypeShell(
+            return s_scalars.AnonymousEnumTypeShell(  # type: ignore
                 elements=elements
             )
 
@@ -215,7 +242,7 @@ def ast_to_type_shell(
             # to assert it is an instance of s_types.Tuple to make mypy happy
             # (rightly so, because later we use from_subtypes method)
 
-            subtypes: Dict[str, s_types.TypeShell] = {}
+            subtypes: Dict[str, s_types.TypeShell[s_types.Type]] = {}
             # tuple declaration must either be named or unnamed, but not both
             names = set()
             named = None
@@ -249,7 +276,7 @@ def ast_to_type_shell(
                 )
 
             try:
-                return coll.create_shell(
+                return coll.create_shell(  # type: ignore
                     schema,
                     subtypes=subtypes,
                     typemods={'named': bool(named)},
@@ -262,7 +289,7 @@ def ast_to_type_shell(
 
         elif issubclass(coll, s_types.Array):
 
-            subtypes_list: List[s_types.TypeShell] = []
+            subtypes_list: List[s_types.TypeShell[s_types.Type]] = []
             for st in node.subtypes:
                 subtypes_list.append(
                     ast_to_type_shell(
@@ -287,7 +314,7 @@ def ast_to_type_shell(
                 )
 
             try:
-                return coll.create_shell(
+                return coll.create_shell(  # type: ignore
                     schema,
                     subtypes=subtypes_list,
                 )
@@ -297,11 +324,13 @@ def ast_to_type_shell(
 
     elif isinstance(node.maintype, qlast.AnyType):
         from . import pseudo as s_pseudo
-        return s_pseudo.PseudoTypeShell(name=sn.UnqualName('anytype'))
+        return s_pseudo.PseudoTypeShell(
+            name=sn.UnqualName('anytype'))  # type: ignore
 
     elif isinstance(node.maintype, qlast.AnyTuple):
         from . import pseudo as s_pseudo
-        return s_pseudo.PseudoTypeShell(name=sn.UnqualName('anytuple'))
+        return s_pseudo.PseudoTypeShell(
+            name=sn.UnqualName('anytuple'))  # type: ignore
 
     assert isinstance(node.maintype, qlast.ObjectRef)
 
@@ -316,10 +345,11 @@ def ast_to_type_shell(
 def type_op_ast_to_type_shell(
     node: qlast.TypeOp,
     *,
+    metaclass: Type[s_types.TypeT],
     module: Optional[str] = None,
     modaliases: Mapping[Optional[str], str],
     schema: s_schema.Schema,
-) -> s_types.TypeExprShell:
+) -> s_types.TypeExprShell[s_types.TypeT]:
 
     from . import types as s_types
 
@@ -339,49 +369,64 @@ def type_op_ast_to_type_shell(
         )
 
     left = ast_to_type_shell(
-        node.left, module=module, modaliases=modaliases, schema=schema,
+        node.left,
+        metaclass=metaclass,
+        module=module,
+        modaliases=modaliases,
+        schema=schema,
     )
     right = ast_to_type_shell(
-        node.right, module=module, modaliases=modaliases, schema=schema)
+        node.right,
+        metaclass=metaclass,
+        module=module,
+        modaliases=modaliases,
+        schema=schema,
+    )
 
     if isinstance(left, s_types.UnionTypeShell):
         if isinstance(right, s_types.UnionTypeShell):
             return s_types.UnionTypeShell(
                 components=left.components + right.components,
                 module=module,
+                schemaclass=metaclass,
             )
         else:
             return s_types.UnionTypeShell(
                 components=left.components + (right,),
                 module=module,
+                schemaclass=metaclass,
             )
     else:
         if isinstance(right, s_types.UnionTypeShell):
             return s_types.UnionTypeShell(
                 components=(left,) + right.components,
+                schemaclass=metaclass,
                 module=module,
             )
         else:
             return s_types.UnionTypeShell(
                 components=(left, right),
                 module=module,
+                schemaclass=metaclass,
             )
 
 
 def ast_to_object_shell(
     node: Union[qlast.ObjectRef, qlast.TypeName],
     *,
-    metaclass: Optional[Type[so.Object]] = None,
+    metaclass: Type[so.Object_T],
+    module: Optional[str] = None,
     modaliases: Mapping[Optional[str], str],
     schema: s_schema.Schema,
-) -> so.ObjectShell:
+) -> so.ObjectShell[so.Object_T]:
     from . import types as s_types
 
     if isinstance(node, qlast.TypeName):
-        if metaclass is not None and issubclass(metaclass, s_types.Type):
-            return ast_to_type_shell(
+        if issubclass(metaclass, s_types.Type):
+            return ast_to_type_shell(  # type: ignore
                 node,
                 metaclass=metaclass,
+                module=module,
                 modaliases=modaliases,
                 schema=schema,
             )
@@ -410,7 +455,7 @@ def ast_to_object_shell(
 
 def typeref_to_ast(
     schema: s_schema.Schema,
-    ref: Union[so.Object, so.ObjectShell],
+    ref: Union[so.Object_T, so.ObjectShell[so.Object_T]],
     *,
     _name: Optional[str] = None,
     disambiguate_std: bool=False,
@@ -423,7 +468,6 @@ def typeref_to_ast(
         t = ref
 
     result: qlast.TypeExpr
-    components: Tuple[so.Object, ...]
 
     if t.is_type() and cast(s_types.Type, t).is_any(schema):
         result = qlast.TypeName(name=_name, maintype=qlast.AnyType())
@@ -493,7 +537,7 @@ def typeref_to_ast(
 
 def shell_to_ast(
     schema: s_schema.Schema,
-    t: so.ObjectShell,
+    t: so.ObjectShell[so.Object],
     *,
     _name: Optional[str] = None,
 ) -> qlast.TypeExpr:
@@ -1132,9 +1176,9 @@ def get_config_type_shape(
 
 def type_shell_substitute(
     name: sn.Name,
-    new: s_types.TypeShell,
-    typ: s_types.TypeShell,
-) -> s_types.TypeShell:
+    new: s_types.TypeShell[s_types.TypeT_co],
+    typ: s_types.TypeShell[s_types.TypeT_co],
+) -> s_types.TypeShell[s_types.TypeT_co]:
     from . import types as s_types
 
     # arguably this would be better done with a method on the types
@@ -1143,7 +1187,9 @@ def type_shell_substitute(
 
     if isinstance(typ, s_types.UnionTypeShell):
         return s_types.UnionTypeShell(
-            module=typ.module, schemaclass=typ.schemaclass, opaque=typ.opaque,
+            module=typ.module,
+            schemaclass=typ.schemaclass,
+            opaque=typ.opaque,
             components=[
                 type_shell_substitute(name, new, c)
                 for c in typ.components
@@ -1151,7 +1197,8 @@ def type_shell_substitute(
         )
     elif isinstance(typ, s_types.IntersectionTypeShell):
         return s_types.IntersectionTypeShell(
-            module=typ.module, schemaclass=typ.schemaclass,
+            module=typ.module,
+            schemaclass=typ.schemaclass,
             components=[
                 type_shell_substitute(name, new, c)
                 for c in typ.components

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -103,40 +103,13 @@ def resolve_name(
     return name
 
 
-@overload
-def ast_objref_to_object_shell(  # NoQA: F811
+def ast_objref_to_object_shell(
     ref: qlast.ObjectRef,
     *,
     metaclass: Type[so.Object_T],
     modaliases: Mapping[Optional[str], str],
     schema: s_schema.Schema,
 ) -> so.ObjectShell[so.Object_T]:
-    ...
-
-
-@overload
-def ast_objref_to_object_shell(  # NoQA: F811
-    ref: qlast.ObjectRef,
-    *,
-    metaclass: None = None,
-    modaliases: Mapping[Optional[str], str],
-    schema: s_schema.Schema,
-) -> so.ObjectShell[so.Object]:
-    ...
-
-
-def ast_objref_to_object_shell(  # NoQA: F811
-    ref: qlast.ObjectRef,
-    *,
-    metaclass: Optional[Type[so.Object_T]] = None,
-    modaliases: Mapping[Optional[str], str],
-    schema: s_schema.Schema,
-) -> so.ObjectShell[so.Object_T]:
-    if metaclass is not None:
-        mcls = metaclass
-    else:
-        mcls = so.Object  # type: ignore
-
     lname = ast_ref_to_name(ref)
     name = resolve_name(
         lname,
@@ -148,7 +121,7 @@ def ast_objref_to_object_shell(  # NoQA: F811
     return so.ObjectShell(
         name=name,
         origname=lname,
-        schemaclass=mcls,
+        schemaclass=metaclass,
         sourcectx=ref.context,
     )
 


### PR DESCRIPTION
`ObjectShell` impersonates a schema object of a specified type, so it
makes sense to expose the underlying object type to the type checker.