### PR TITLE
Fix some issues involving views/path_id_name/schema defaults

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1160,7 +1160,7 @@ def computable_ptr_set(
     ptrcls = typegen.ptrcls_from_ptrref(rptr.ptrref, ctx=ctx)
     source_set = rptr.source
     source_scls = get_set_type(source_set, ctx=ctx)
-    ptrcls_to_shadow = ptrcls
+    ptrcls_to_shadow = None
 
     # process_view() may generate computable pointer expressions
     # in the form "self.linkname".  To prevent infinite recursion,
@@ -1288,7 +1288,9 @@ def computable_ptr_set(
     result_stype = ptrcls.get_target(ctx.env.schema)
     base_object = ctx.env.schema.get('std::BaseObject', type=s_types.Type)
     with newctx() as subctx:
-        subctx.disable_shadowing.add(ptrcls_to_shadow)
+        subctx.disable_shadowing.add(ptrcls)
+        if ptrcls_to_shadow:
+            subctx.disable_shadowing.add(ptrcls_to_shadow)
         if result_stype != base_object:
             subctx.view_scls = result_stype
         subctx.view_rptr = context.ViewRPtr(

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -780,6 +780,18 @@ def extend_path(
     return target_set
 
 
+def is_injected_computable_ptr(
+    ptrcls: s_pointers.PointerLike,
+    *,
+    ctx: context.ContextLevel,
+) -> bool:
+    return (
+        ctx.env.options.apply_query_rewrites
+        and ptrcls not in ctx.disable_shadowing
+        and bool(ptrcls.get_schema_reflection_default(ctx.env.schema))
+    )
+
+
 def _is_computable_ptr(
     ptrcls: s_pointers.PointerLike,
     *,
@@ -794,11 +806,7 @@ def _is_computable_ptr(
 
     return (
         ptrcls.is_pure_computable(ctx.env.schema)
-        or (
-            ctx.env.options.apply_query_rewrites
-            and ptrcls not in ctx.disable_shadowing
-            and bool(ptrcls.get_schema_reflection_default(ctx.env.schema))
-        )
+        or is_injected_computable_ptr(ptrcls, ctx=ctx)
     )
 
 
@@ -1152,6 +1160,8 @@ def computable_ptr_set(
     ptrcls = typegen.ptrcls_from_ptrref(rptr.ptrref, ctx=ctx)
     source_set = rptr.source
     source_scls = get_set_type(source_set, ctx=ctx)
+    ptrcls_to_shadow = ptrcls
+
     # process_view() may generate computable pointer expressions
     # in the form "self.linkname".  To prevent infinite recursion,
     # self must resolve to the parent type of the view NOT the view
@@ -1210,6 +1220,13 @@ def computable_ptr_set(
                     right=qlparser.parse_fragment(schema_deflt),
                     op='??',
                 )
+
+                # Is this is a view, we want to shadow the underlying
+                # ptrcls, since otherwise we will generate this default
+                # code *twice*.
+                if rptr.ptrref.base_ptr:
+                    ptrcls_to_shadow = typegen.ptrcls_from_ptrref(
+                        rptr.ptrref.base_ptr, ctx=ctx)
 
         if schema_qlexpr is None:
             if comp_expr is None:
@@ -1271,7 +1288,7 @@ def computable_ptr_set(
     result_stype = ptrcls.get_target(ctx.env.schema)
     base_object = ctx.env.schema.get('std::BaseObject', type=s_types.Type)
     with newctx() as subctx:
-        subctx.disable_shadowing.add(ptrcls)
+        subctx.disable_shadowing.add(ptrcls_to_shadow)
         if result_stype != base_object:
             subctx.view_scls = result_stype
         subctx.view_rptr = context.ViewRPtr(

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -1356,3 +1356,27 @@ class TestIntrospection(tb.QueryTestCase):
         """)
 
         self.assertGreater(res, 0)
+
+    async def test_edgeql_default_injection_collision_01(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE schema
+                SELECT Pointer {
+                    name,
+                    required,
+                    [IS Link].pointers: {
+                      name,
+                      required,
+                    } FILTER .name = 'value'
+                }
+                FILTER .source.name = 'schema::AnnotationSubject'
+                   AND .name = 'annotations';
+            """,
+            [
+                {
+                    "name": "annotations",
+                    "pointers": [{"name": "value", "required": False}],
+                    "required": False
+                }
+            ]
+        )

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -254,7 +254,14 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
             "(schema::Type)",
             "FENCE": {
                 "FENCE": {
-                    "(schema::Type).>element_type[IS schema::Type]"
+                    "FENCE": {
+                        "FENCE": {
+                            "(schema::Type).>indirection[IS schema::Array]\
+.>element_type[IS schema::Type]": {
+                                "(schema::Type).>indirection[IS schema::Array]"
+                            }
+                        }
+                    }
                 }
             },
             "FENCE": {
@@ -280,6 +287,15 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
         "FENCE": {
             "FENCE": {
                 "(schema::Type)"
+            },
+            "FENCE": {
+                "FENCE": {
+                    "FENCE": {
+                        "FENCE": {
+                            "(__derived__::expr~3).>foo[IS std::str]"
+                        }
+                    }
+                }
             },
             "(__derived__::expr~3)",
             "FENCE": {


### PR DESCRIPTION
* Try to always compile shape elements we generate a qlexpr for,
   to make the logic match up better
 * Disable setting a path_id_name when we are injecting a computable
   pointer for schema introspection reasons
 * Don't create new types to do __tid__ insertion on when
   forward_rptr is set, since creating new types in those sort
   of wrapper cases caused problems. (This might not actually be
   related to the same path_id_name issues, but came up with the
   tests that path_id_name affects.)
 * Don't generate the schema default logic *twice*