### PR TITLE
Fix an issue with cycle detection.

### DIFF
--- a/edb/common/topological.py
+++ b/edb/common/topological.py
@@ -30,8 +30,14 @@ class UnresolvedReferenceError(Exception):
 
 
 class CycleError(Exception):
-    def __init__(self, msg: str, path: Optional[List[Any]] = None) -> None:
+    def __init__(
+        self,
+        msg: str,
+        item: Optional[Any] = None,
+        path: Optional[List[Any]] = None,
+    ) -> None:
         super().__init__(msg)
+        self.item = item
         self.path = path
 
 
@@ -137,9 +143,10 @@ def sort_ex(
     ) -> None:
         if item in visiting:
             raise CycleError(
-                f"dependency cycle between {list(visiting)[1]!r} "
+                f"dependency cycle between {list(visiting)[-1]!r} "
                 f"and {item!r}",
                 path=list(visiting)[1:],
+                item=item,
             )
         if item not in visited:
             visiting.add(item)

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -150,6 +150,10 @@ class ObjectType(Type, Source):
         return False
 
 
+class Alias(ObjectType):
+    pass
+
+
 class UnionType(Type):
 
     def __init__(
@@ -180,6 +184,12 @@ class Pointer(Source):
     def is_pointer(self) -> bool:
         return True
 
+    def is_property(
+        self,
+        schema: s_schema.Schema,
+    ) -> bool:
+        raise NotImplementedError
+
     def maybe_get_ptr(
         self,
         schema: s_schema.Schema,
@@ -201,6 +211,22 @@ class Pointer(Source):
         schema: s_schema.Schema,
     ) -> Optional[SourceLike]:
         return self.source
+
+
+class Property(Pointer):
+    def is_property(
+        self,
+        schema: s_schema.Schema,
+    ) -> bool:
+        return True
+
+
+class Link(Pointer):
+    def is_property(
+        self,
+        schema: s_schema.Schema,
+    ) -> bool:
+        return False
 
 
 def qualify_name(name: sn.QualName, qual: str) -> sn.QualName:

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1771,6 +1771,25 @@ class AlterPointer(
     PointerCommand[Pointer_T],
 ):
 
+    def _alter_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = super()._alter_begin(schema, context)
+
+        if self.get_attribute_value('expr') is not None:
+            # If the expression gets changed, we need to propagate
+            # this change to other expressions referring to this one,
+            # in case there are any cycles caused by this change.
+            schema = self._propagate_if_expr_refs(
+                schema,
+                context,
+                action=self.get_friendly_description(schema=schema),
+            )
+
+        return schema
+
     @classmethod
     def _cmd_tree_from_ast(
         cls,


### PR DESCRIPTION
Migrations introducing cycles into the schema should not cause
InternalServerError.
    
The SDL cycle detection appears to be robust and the error message has
been adjusted.
    
The DDL cycle detection has a few corner cases where the tests are
failing.
