### PR TITLE
Unbreak parser source context dumps in server tracebacks

### DIFF
--- a/edb/common/markup/__init__.py
+++ b/edb/common/markup/__init__.py
@@ -38,7 +38,10 @@ class MarkupCapableMixin:
             serializer.serializer.register(cls)(cls.as_markup)
 
 
-class MarkupExceptionContext(exceptions.ExceptionContext):
+class MarkupExceptionContext(
+    exceptions.ExceptionContext,
+    MarkupCapableMixin,
+):
 
     @abc.abstractclassmethod
     def as_markup(cls, *, ctx):


### PR DESCRIPTION
This is a regression from #2653, where `MarkupExceptionContext` was
erroneously left without the `MarkupCapableMixin` in its bases.