### PR TITLE
Avoid marking `--tls-cert-file` as required on Click level

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -321,7 +321,8 @@ _server_options = [
         help='shutdown the server after the last connection has been closed '
              'for N seconds. N < 0 is treated as infinite.'),
     lambda has_devmode, func: click.option(
-        '--tls-cert-file', type=PathPath(), required=not has_devmode,
+        '--tls-cert-file',
+        type=PathPath(),
         help='Specify a path to a single file in PEM format containing the '
              'TLS certificate as well as any number of CA certificates needed '
              'to establish the certificate’s authenticity.' + (
@@ -435,9 +436,12 @@ def parse_args(**kwargs: Any):
         elif kwargs['postgres_dsn']:
             abort('The -D and --postgres-dsn options are mutually exclusive.')
 
-    if not kwargs['tls_cert_file']:
-        if not devmode.is_in_dev_mode():
-            abort('Please specify a TLS certificate with --tls-cert-file.')
+    if (
+        not kwargs['tls_cert_file']
+        and not devmode.is_in_dev_mode()
+        and not kwargs['bootstrap_only']
+    ):
+        abort('Please specify a TLS certificate with --tls-cert-file.')
 
     bootstrap_script_text: Optional[str]
     if kwargs['bootstrap_script']:

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -47,7 +47,7 @@ class ClusterError(Exception):
 class BaseCluster:
     def __init__(self, runstate_dir, *, port=edgedb_defines.EDGEDB_PORT,
                  env=None, testmode=False, log_level=None):
-        self._edgedb_cmd = [sys.executable, '-m', 'edb.tools', 'server']
+        self._edgedb_cmd = [sys.executable, '-m', 'edb.server.main']
 
         if log_level:
             self._edgedb_cmd.extend(['--log-level', log_level])

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -47,7 +47,7 @@ class ClusterError(Exception):
 class BaseCluster:
     def __init__(self, runstate_dir, *, port=edgedb_defines.EDGEDB_PORT,
                  env=None, testmode=False, log_level=None):
-        self._edgedb_cmd = [sys.executable, '-m', 'edb.tools', 'testserver']
+        self._edgedb_cmd = [sys.executable, '-m', 'edb.tools', 'server']
 
         if log_level:
             self._edgedb_cmd.extend(['--log-level', log_level])

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1497,7 +1497,7 @@ class _EdgeDBServer:
         status_r, status_w = socket.socketpair()
 
         cmd = [
-            sys.executable, '-m', 'edb.tools', 'testserver',
+            sys.executable, '-m', 'edb.tools', 'server',
             '--port', 'auto',
             '--testmode',
             '--emit-server-status', f'fd://{status_w.fileno()}',

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1497,7 +1497,7 @@ class _EdgeDBServer:
         status_r, status_w = socket.socketpair()
 
         cmd = [
-            sys.executable, '-m', 'edb.tools', 'server',
+            sys.executable, '-m', 'edb.server.main',
             '--port', 'auto',
             '--testmode',
             '--emit-server-status', f'fd://{status_w.fileno()}',

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -54,16 +54,6 @@ def server(version=False, **kwargs):
     srv_main.server_main(insecure=True, **kwargs)
 
 
-@edbcommands.command(hidden=True)
-@srv_args.server_options(has_devmode=True)
-def testserver(version=False, **kwargs):
-    # This is only used for running tests
-    if version:
-        print(f"edgedb-server, version {buildmeta.get_version()}")
-        sys.exit(0)
-    srv_main.server_main(**kwargs)
-
-
 # Import at the end of the file so that "edb.tools.edb.edbcommands"
 # is defined for all of the below modules when they try to import it.
 from . import cli  # noqa

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -95,7 +95,7 @@ class TestServerOps(tb.TestCase):
         # * "--bootstrap-command"
 
         cmd = [
-            sys.executable, '-m', 'edb.tools', 'testserver',
+            sys.executable, '-m', 'edb.tools', 'server',
             '--port', 'auto',
             '--testmode',
             '--temp-dir',
@@ -138,7 +138,7 @@ class TestServerOps(tb.TestCase):
         os.close(status_fd)
 
         cmd = [
-            sys.executable, '-m', 'edb.tools', 'testserver',
+            sys.executable, '-m', 'edb.tools', 'server',
             '--port', 'auto',
             '--testmode',
             '--temp-dir',

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -95,7 +95,7 @@ class TestServerOps(tb.TestCase):
         # * "--bootstrap-command"
 
         cmd = [
-            sys.executable, '-m', 'edb.tools', 'server',
+            sys.executable, '-m', 'edb.server.main',
             '--port', 'auto',
             '--testmode',
             '--temp-dir',
@@ -138,7 +138,7 @@ class TestServerOps(tb.TestCase):
         os.close(status_fd)
 
         cmd = [
-            sys.executable, '-m', 'edb.tools', 'server',
+            sys.executable, '-m', 'edb.server.main',
             '--port', 'auto',
             '--testmode',
             '--temp-dir',


### PR DESCRIPTION
This breaks executable invocations that have nothing to do with TLS,
like `edgedb-server --version`.  The check in `parse_args()` is
sufficient.