### PR TITLE
Refactor: optionally generate certs in the server

### DIFF
--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -54,7 +54,7 @@
       id: cli-cache
       with:
         path: build/cli
-        key: edb-cli-v1-${{ env.EDGEDBCLI_GIT_REV }}
+        key: edb-cli-v2-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Handle cached Rust extensions
       uses: actions/cache@v2
@@ -110,9 +110,9 @@
       if: steps.cli-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/cli
-        key: edb-cli-build-v1-${{ env.EDGEDBCLI_GIT_REV }}
+        key: edb-cli-build-v2-${{ env.EDGEDBCLI_GIT_REV }}
         restore-keys: |
-          edb-cli-build-v1-
+          edb-cli-build-v2-
 
     - name: Build EdgeDB CLI
       env:
@@ -282,7 +282,7 @@
       id: cli-cache
       with:
         path: build/cli
-        key: edb-cli-v1-${{ env.EDGEDBCLI_GIT_REV }}
+        key: edb-cli-v2-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
       uses: actions/cache@v2

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -73,7 +73,7 @@ jobs:
       id: cli-cache
       with:
         path: build/cli
-        key: edb-cli-v1-${{ env.EDGEDBCLI_GIT_REV }}
+        key: edb-cli-v2-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Handle cached Rust extensions
       uses: actions/cache@v2
@@ -129,9 +129,9 @@ jobs:
       if: steps.cli-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/cli
-        key: edb-cli-build-v1-${{ env.EDGEDBCLI_GIT_REV }}
+        key: edb-cli-build-v2-${{ env.EDGEDBCLI_GIT_REV }}
         restore-keys: |
-          edb-cli-build-v1-
+          edb-cli-build-v2-
 
     - name: Build EdgeDB CLI
       env:
@@ -353,7 +353,7 @@ jobs:
       id: cli-cache
       with:
         path: build/cli
-        key: edb-cli-v1-${{ env.EDGEDBCLI_GIT_REV }}
+        key: edb-cli-v2-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
       uses: actions/cache@v2
@@ -545,7 +545,7 @@ jobs:
       id: cli-cache
       with:
         path: build/cli
-        key: edb-cli-v1-${{ env.EDGEDBCLI_GIT_REV }}
+        key: edb-cli-v2-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
       uses: actions/cache@v2
@@ -785,7 +785,7 @@ jobs:
       id: cli-cache
       with:
         path: build/cli
-        key: edb-cli-v1-${{ env.EDGEDBCLI_GIT_REV }}
+        key: edb-cli-v2-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
       uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
       id: cli-cache
       with:
         path: build/cli
-        key: edb-cli-v1-${{ env.EDGEDBCLI_GIT_REV }}
+        key: edb-cli-v2-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Handle cached Rust extensions
       uses: actions/cache@v2
@@ -141,9 +141,9 @@ jobs:
       if: steps.cli-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ env.BUILD_TEMP }}/rust/cli
-        key: edb-cli-build-v1-${{ env.EDGEDBCLI_GIT_REV }}
+        key: edb-cli-build-v2-${{ env.EDGEDBCLI_GIT_REV }}
         restore-keys: |
-          edb-cli-build-v1-
+          edb-cli-build-v2-
 
     - name: Build EdgeDB CLI
       env:
@@ -386,7 +386,7 @@ jobs:
       id: cli-cache
       with:
         path: build/cli
-        key: edb-cli-v1-${{ env.EDGEDBCLI_GIT_REV }}
+        key: edb-cli-v2-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
       uses: actions/cache@v2
@@ -509,7 +509,7 @@ jobs:
       id: cli-cache
       with:
         path: build/cli
-        key: edb-cli-v1-${{ env.EDGEDBCLI_GIT_REV }}
+        key: edb-cli-v2-${{ env.EDGEDBCLI_GIT_REV }}
 
     - name: Restore cached Rust extensions
       uses: actions/cache@v2

--- a/edb/protocol/protocol.pyx
+++ b/edb/protocol/protocol.pyx
@@ -105,7 +105,7 @@ async def new_connection(
     password: str = None,
     admin: str = None,
     database: str = None,
-    tls_cert_file: str = None,
+    tls_ca_file: str = None,
     tls_verify_hostname: bool = None,
     timeout: float = 60,
     use_tls: bool = True,
@@ -113,7 +113,7 @@ async def new_connection(
     addrs, params, config = con_utils.parse_connect_arguments(
         dsn=dsn, host=host, port=port, user=user, password=password,
         admin=admin, database=database,
-        tls_cert_file=tls_cert_file, tls_verify_hostname=tls_verify_hostname,
+        tls_ca_file=tls_ca_file, tls_verify_hostname=tls_verify_hostname,
         timeout=timeout, command_timeout=None, server_settings=None,
         wait_until_available=timeout)
 

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -320,15 +320,12 @@ _server_options = [
         '--auto-shutdown-after', type=float, default=-1.0,
         help='shutdown the server after the last connection has been closed '
              'for N seconds. N < 0 is treated as infinite.'),
-    lambda has_devmode, func: click.option(
+    click.option(
         '--tls-cert-file',
         type=PathPath(),
         help='Specify a path to a single file in PEM format containing the '
              'TLS certificate as well as any number of CA certificates needed '
-             'to establish the certificate’s authenticity.' + (
-                 ' If not present, a self-signed certificate will be '
-                 'generated and used instead.' if has_devmode else '')
-    )(func),
+             'to establish the certificate’s authenticity.'),
     click.option(
         '--tls-key-file', type=PathPath(),
         help='Specify a path to a file containing the private key. If not '
@@ -345,15 +342,10 @@ _server_options = [
 ]
 
 
-def server_options(has_devmode=False):
-    def decorator(func):
-        for option in reversed(_server_options):
-            try:
-                func = option(func)
-            except TypeError:
-                func = option(has_devmode, func)
-        return func
-    return decorator
+def server_options(func):
+    for option in reversed(_server_options):
+        func = option(func)
+    return func
 
 
 def parse_args(**kwargs: Any):

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -106,7 +106,7 @@ class BaseCluster:
         return {
             'host': 'localhost',
             'port': self._effective_port,
-            'tls_cert_file': self._tls_cert_file,
+            'tls_ca_file': self._tls_cert_file,
         }
 
     async def async_connect(self, **kwargs):

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -490,7 +490,7 @@ def server_main(*, insecure=False, **kwargs):
 @click.command(
     'EdgeDB Server',
     context_settings=dict(help_option_names=['-h', '--help']))
-@srvargs.server_options()
+@srvargs.server_options
 def main(version=False, **kwargs):
     if version:
         print(f"edgedb-server, version {buildmeta.get_version()}")

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -59,7 +59,7 @@ class BaseHttpTest:
         cls.tls_context.verify_mode = ssl.CERT_REQUIRED
         cls.tls_context.check_hostname = False
         cls.tls_context.load_verify_locations(
-            cafile=cls.get_connect_args()['tls_cert_file']
+            cafile=cls.get_connect_args()['tls_ca_file']
         )
 
         cls.http_host, cls.http_port = cls.con.connected_addr()

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -772,7 +772,7 @@ class CLITestCaseMixin:
         cmd_args = [
             '--host', conn_args['host'],
             '--port', str(conn_args['port']),
-            '--tls-cert-file', conn_args['tls_cert_file']
+            '--tls-ca-file', conn_args['tls_ca_file']
         ]
         if conn_args.get('user'):
             cmd_args += ['--user', conn_args['user']]
@@ -1410,7 +1410,7 @@ class _EdgeDBServerData(NamedTuple):
             password=self.password,
             host=self.host,
             port=self.port,
-            tls_cert_file=self.tls_cert_file,
+            tls_ca_file=self.tls_cert_file,
         )
 
         conn_args.update(kwargs)

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -43,7 +43,7 @@ def edbcommands(ctx, devmode: bool):
 
 
 @edbcommands.command()
-@srv_args.server_options(has_devmode=True)
+@srv_args.server_options
 def server(version=False, **kwargs):
     if version:
         print(f"edb, version {buildmeta.get_version()}")

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ RUNTIME_DEPS = [
     'uvloop~=0.15.3',
     "typing_inspect~=0.5.0;python_version<'3.9'",
     'wcwidth~=0.2.5',
+    'cryptography~=3.4.7',
 
     'graphql-core~=3.1.5',
     'promise~=2.2.0',

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -83,7 +83,7 @@ class TestServerOps(tb.TestCase):
                     user='edgedb',
                     host=sd.host,
                     port=sd.port,
-                    tls_cert_file=sd.tls_cert_file,
+                    tls_ca_file=sd.tls_cert_file,
                     wait_until_available=0,
                 )
 
@@ -334,7 +334,7 @@ class TestServerOps(tb.TestCase):
                 password=sd.password,
                 host=sd.host,
                 port=sd.port,
-                tls_cert_file=sd.tls_cert_file,
+                tls_ca_file=sd.tls_cert_file,
             )
             try:
                 await self._test_connection(con)


### PR DESCRIPTION
Use cryptography to generate self-signed certs if the switch `--generate-self-signed-cert` is set (default for dev mode).

Also fixed to use the latest edgedb-python (`--tls-ca-cert`).