### PR TITLE
Fix a downstream breakage of mypy_primer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ RUNTIME_DEPS = [
     'graphql-core~=3.1.5',
     'promise~=2.2.0',
 
-    'edgedb @ git+https://github.com/edgedb/edgedb-python.git@master',
+    'edgedb@git+https://github.com/edgedb/edgedb-python.git@master',
 ]
 
 CYTHON_DEPENDENCY = 'Cython==0.29.23'


### PR DESCRIPTION
A few weeks ago I added edgedb to mypy_primer
(hauntsaninja/mypy_primer#15), which somewhat hackily reads out our
dependencies from setup.py and passes them to pip.

contributed to mypy_primer chokes on because it passes it on the
command line and it is interpreted as multiple arguments.

Probably the real answer here is for me to find some less fragile and
hacky way to install our deps for mypy_primer (and maybe also for
mypy_primer to be a little more resilient to weird upstream
breakages), but for now let's just remove the space and fix the build.

Thank you to @pranavrajpal for tracking this problem down!