### PR TITLE
workflows: Don't generate snapshot tags for docker images

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -198,12 +198,12 @@ jobs:
         ref: master
         path: dockerfile
     - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@2.6
+      uses: elgohr/Publish-Docker-Github-Action@3.04
       with:
-        name: edgedb/edgedb:nightly
+        name: edgedb/edgedb
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        snapshot: true
+        tags: "nightly,nightly_cv${{ steps.describe.outputs.catalog-version }},nightly_${{ steps.describe.outputs.version-slot }}_cv${{ steps.describe.outputs.catalog-version }}"
         workdir: dockerfile
         buildargs: version=${{ steps.describe.outputs.version-slot }},subdist=.nightly
     <% endif %>

--- a/.github/workflows.src/release.tpl.yml
+++ b/.github/workflows.src/release.tpl.yml
@@ -201,10 +201,10 @@ jobs:
     - name: Publish Docker Image
       uses: elgohr/Publish-Docker-Github-Action@2.6
       with:
-        name: edgedb/edgedb:${{ steps.describe.outputs.version-slot }}
+        name: edgedb/edgedb
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        snapshot: true
+        tags: ${{ steps.describe.outputs.version-slot }}
         workdir: dockerfile
         buildargs: version=${{ steps.describe.outputs.version-slot }}
     <% endif %>

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -479,12 +479,12 @@ jobs:
         ref: master
         path: dockerfile
     - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@2.6
+      uses: elgohr/Publish-Docker-Github-Action@3.04
       with:
-        name: edgedb/edgedb:nightly
+        name: edgedb/edgedb
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        snapshot: true
+        tags: "nightly,nightly_cv${{ steps.describe.outputs.catalog-version }},nightly_${{ steps.describe.outputs.version-slot }}_cv${{ steps.describe.outputs.catalog-version }}"
         workdir: dockerfile
         buildargs: version=${{ steps.describe.outputs.version-slot }},subdist=.nightly
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -474,10 +474,10 @@ jobs:
     - name: Publish Docker Image
       uses: elgohr/Publish-Docker-Github-Action@2.6
       with:
-        name: edgedb/edgedb:${{ steps.describe.outputs.version-slot }}
+        name: edgedb/edgedb
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        snapshot: true
+        tags: ${{ steps.describe.outputs.version-slot }}
         workdir: dockerfile
         buildargs: version=${{ steps.describe.outputs.version-slot }}
     


### PR DESCRIPTION
Now Docker nightly images follow the same pattern as regular packages,
where only the latest version with the same catver is kept and snapshot
tags aren't generated to avoid needlessly polluting the list of tags.