### PR TITLE
Make enumerate work when the result tuple is persistent

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1940,7 +1940,8 @@ def process_set_as_enumerate(
                     val=arg_val,
                 ),
             ],
-            named=named_tuple
+            named=named_tuple,
+            typeref=ir_set.typeref,
         )
 
         for element in set_expr.elements:


### PR DESCRIPTION
Make sure we test both cases. This solves the problem that was causing
failures in #2679.