### PR TITLE
Fix some issues with tuple/union interactions

### DIFF
--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -637,7 +637,7 @@ def get_rvar_path_var(
             and (not rvar.query.path_id.is_type_intersection_path()
                  or rvar.query.path_id.src_path() != path_id)
         ):
-            actual_rptr = irtyputils.find_actual_ptrref(
+            actual_rptr = irtyputils.maybe_find_actual_ptrref(
                 rvar.typeref,
                 rptr,
             )

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1289,7 +1289,16 @@ def range_for_typeref(
         # to SELECTing from a parent table.
         set_ops = []
 
+        # Concrete unions might have view type elements with duplicate
+        # material types, and we need to filter those out.
+        seen = set()
         for child in typeref.union:
+            mat_child = child.material_type or child
+            if mat_child.id in seen:
+                assert typeref.union_is_concrete
+                continue
+            seen.add(mat_child.id)
+
             c_rvar = range_for_typeref(
                 child,
                 path_id=path_id,

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1371,7 +1371,10 @@ def process_set_as_setop(
         subqry.rarg = rarg
 
         union_rvar = relctx.rvar_for_rel(subqry, lateral=True, ctx=subctx)
-        relctx.include_rvar(stmt, union_rvar, ir_set.path_id, ctx=subctx)
+        # No pull_namespace because we don't want the union arguments to
+        # escape, just the final result.
+        relctx.include_rvar(
+            stmt, union_rvar, ir_set.path_id, pull_namespace=False, ctx=subctx)
 
     return new_stmt_set_rvar(ir_set, stmt, ctx=ctx)
 
@@ -1676,8 +1679,11 @@ def process_set_as_coalesce(
 
             subrvar = relctx.rvar_for_rel(subqry, lateral=True, ctx=newctx)
 
+            # No pull_namespace because we don't want the coalesce arguments to
+            # escape, just the final result.
             relctx.include_rvar(
-                stmt, subrvar, path_id=ir_set.path_id, ctx=newctx)
+                stmt, subrvar, path_id=ir_set.path_id,
+                pull_namespace=False, ctx=newctx)
 
             stmt.where_clause = astutils.extend_binop(
                 stmt.where_clause,

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -2393,7 +2393,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
-    @test.xfail('Too many results')
     async def test_edgeql_select_setops_13a(self):
         await self.assert_query_result(
             r"""
@@ -2417,7 +2416,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
-    @test.xfail('The results get deduplicated')
     async def test_edgeql_select_setops_13b(self):
         # This should be equivalent to the above test, but actually we
         # end up deduplicating.
@@ -2529,6 +2527,28 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             """,
             {'1', '2', '3', '4'},
         )
+
+    async def test_edgeql_select_setops_20(self):
+        res = await self.con.query(r'''
+            SELECT (
+                {(SELECT Issue.time_spent_log.body FILTER false), 'asdf'},
+                Issue,
+            )
+        ''')
+        self.assertEqual(len(res), 4)
+        for row in res:
+            self.assertNotEqual(row[1].id, None)
+
+    async def test_edgeql_select_setops_21(self):
+        res = await self.con.query(r'''
+            SELECT (
+                'oh no' ?? (SELECT Issue.time_spent_log.body FILTER false),
+                Issue,
+            )
+        ''')
+        self.assertEqual(len(res), 4)
+        for row in res:
+            self.assertNotEqual(row[1].id, None)
 
     async def test_edgeql_select_order_01(self):
         await self.assert_query_result(


### PR DESCRIPTION
* Don't pull_namespace in UNION and coalesce, since that can
   improperly expose NULL values to correlated sets.
 * Filter types with matching material_types in range_for_typeref
   to avoid incorrect duplicates.