### PR TITLE
Fix source remapping in computables to work when there are WITH bindings

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -443,8 +443,19 @@ class ContextLevel(compiler.ContextLevel):
     banned_paths: Set[irast.PathId]
     """A set of path ids that are considered invalid in this context."""
 
-    view_map: ChainMap[irast.PathId, irast.Set]
-    """Set translation map.  Used for views."""
+    view_map: ChainMap[irast.PathId, Tuple[irast.PathId, irast.Set]]
+    """Set translation map.  Used for mapping computable sources..
+
+    When compiling a computable, we need to be able to map references to
+    the source back to the correct source set.
+
+    This maps from a namespace-stripped source path_id to the expected
+    computable-internal path_id and the actual source set.
+
+    The namespace stripping is necessary to handle the case where
+    bindings have added more namespaces to the source set reference.
+    (See test_edgeql_scope_computables_13.)
+    """
 
     path_scope: irast.ScopeTreeNode
     """Path scope tree, with per-lexical-scope levels."""

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -21,7 +21,6 @@ import json
 import os.path
 
 from edb.testbase import server as tb
-from edb.tools import test
 
 import edgedb
 
@@ -372,15 +371,12 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             }]
         )
 
-    @test.xfail('''
-        edb.errors.InternalServerError: more than one row returned by
-        a subquery used as an expression
-    ''')
     async def test_edgeql_computable_nested_02(self):
         await self.assert_query_result(
             r'''
                 WITH C := Card { ava_owners := .<avatar }
                 SELECT C {
+                    name,
                     ava_owners: {
                         typename := (
                             WITH name := C.ava_owners.__type__.name
@@ -404,10 +400,6 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             }]
         )
 
-    @test.xfail('''
-        AssertionError: data shape differs: unexpected trailing
-        elements in set [path PATH: [0]["ava_owners"][0]["typename"]]
-    ''')
     async def test_edgeql_computable_nested_03(self):
         # This SHOULD be identical to the previous test case, except
         # for the cardinality being forced to be MULTI.

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2538,6 +2538,19 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_scope_computables_13(self):
+        await self.assert_query_result(
+            r"""
+                SELECT User {
+                    title := (SELECT _ := User.name)
+                }
+                FILTER .title = 'Alice';
+            """,
+            [
+                {"title": "Alice"},
+            ]
+        )
+
     async def test_edgeql_scope_with_01(self):
         # Test that same symbol can be re-used in WITH block.
         await self.assert_query_result(


### PR DESCRIPTION
I think this should unblock #2692.