### PR TITLE
Fix binding of shape name references in result aliased expressions

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1254,20 +1254,10 @@ def compile_result_clause(
             sctx.view_rptr = view_rptr
             # sctx.view_scls = view_scls
 
-        result_expr: qlast.Expr
-        shape: Optional[Sequence[qlast.ShapeElement]]
-
-        if isinstance(result, qlast.Shape):
-            result_expr = result.expr or qlutils.ANONYMOUS_SHAPE_EXPR
-            shape = result.elements
-        else:
-            result_expr = result
-            shape = None
-
         if result_alias:
             # `SELECT foo := expr` is equivalent to
             # `WITH foo := expr SELECT foo`
-            rexpr = astutils.ensure_ql_select(result_expr)
+            rexpr = astutils.ensure_ql_select(result)
             if (
                 sctx.implicit_limit
                 and rexpr.limit is None
@@ -1293,9 +1283,19 @@ def compile_result_clause(
                 ctx=sctx,
             )
 
-            result_expr = qlast.Path(
+            result = qlast.Path(
                 steps=[qlast.ObjectRef(name=result_alias)]
             )
+
+        result_expr: qlast.Expr
+        shape: Optional[Sequence[qlast.ShapeElement]]
+
+        if isinstance(result, qlast.Shape):
+            result_expr = result.expr or qlutils.ANONYMOUS_SHAPE_EXPR
+            shape = result.elements
+        else:
+            result_expr = result
+            shape = None
 
         if astutils.is_ql_empty_set(result_expr):
             expr = setgen.new_empty_set(

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2786,7 +2786,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         )
 
     async def test_edgeql_scope_reverse_lprop_01(self):
-        # try injecting something myself?
         await self.assert_query_result(
             """
             WITH X1 := (Card { z := (.<deck[IS User], .<deck[IS User]@count)}),

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -6095,3 +6095,20 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     async def test_edgeql_select_anonymous_shape_01(self):
         res = await self.con.query_one('SELECT {test := 1}')
         self.assertEqual(res.test, 1)
+
+    async def test_edgeql_select_result_alias_binding_01(self):
+        await self.assert_query_result(
+            r'''
+                SELECT _ := (User { tag := User.name }) ORDER BY _.name;
+            ''',
+            [{"tag": "Elvis"}, {"tag": "Yury"}]
+        )
+
+    async def test_edgeql_select_result_alias_binding_02(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidReferenceError,
+            "object type or alias 'default::_' does not exist",
+        ):
+            await self.con.query(r'''
+                SELECT _ := (User { tag := _.name });
+            ''')


### PR DESCRIPTION
In `SELECT _ := (User { tag := User.name })`, the inner User should
correlate with the outer user while
`SELECT _ := (User { tag := _.name })` should be an error.

Fix this by splitting the shape off *after* processing result aliases.