### PR TITLE
Fix notebook protocol version handling + improve error message when query contains params

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1884,6 +1884,7 @@ class Compiler:
         database_config: Mapping[str, config.SettingValue],
         system_config: Mapping[str, config.SettingValue],
         queries: List[str],
+        protocol_version: tuple,
         implicit_limit: int = 0,
     ) -> List[dbstate.QueryUnit]:
 
@@ -1905,6 +1906,7 @@ class Compiler:
             inline_typenames=True,
             stmt_mode=enums.CompileStatementMode.SINGLE,
             json_parameters=False,
+            protocol_version=protocol_version
         )
 
         ctx.state.start_tx()
@@ -1929,7 +1931,8 @@ class Compiler:
                     inline_typenames=True,
                     stmt_mode=enums.CompileStatementMode.SINGLE,
                     json_parameters=False,
-                    source=source
+                    source=source,
+                    protocol_version=protocol_version
                 )
 
                 result.append(

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -115,7 +115,7 @@ async def handle_request(
     except Exception as ex:
         return handle_error(request, response, ex)
     else:
-        response.headers['EdgeDB-Protocol-Version'] = \
+        response.custom_headers['EdgeDB-Protocol-Version'] = \
             f'{CURRENT_PROTOCOL[0]}.{CURRENT_PROTOCOL[1]}'
         response.body = b'{"kind": "results", "results":' + result + b'}'
 

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -115,9 +115,9 @@ async def handle_request(
     except Exception as ex:
         return handle_error(request, response, ex)
     else:
-        response.body = b'{"kind": "results", "protocol_version": ' + \
-            json.dumps(CURRENT_PROTOCOL).encode() + \
-            b', "results":' + result + b'}'
+        response.headers['EdgeDB-Protocol-Version'] = \
+            f'{CURRENT_PROTOCOL[0]}.{CURRENT_PROTOCOL[1]}'
+        response.body = b'{"kind": "results", "results":' + result + b'}'
 
 
 async def heartbeat_check(db, server):

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -34,6 +34,8 @@ from edb.server import compiler
 from edb.server.compiler import IoFormat
 from edb.server.compiler import enums
 
+include "./consts.pxi"
+
 
 ALLOWED_CAPABILITIES = (
     enums.Capability.MODIFICATIONS |
@@ -55,7 +57,7 @@ cdef handle_error(
 
     response.body = json.dumps({
         'kind': 'error',
-        'error':{
+        'error': {
             'message': str(error),
             'type': er_type.__name__,
         }
@@ -113,7 +115,9 @@ async def handle_request(
     except Exception as ex:
         return handle_error(request, response, ex)
     else:
-        response.body = b'{"kind": "results", "results":' + result + b'}'
+        response.body = b'{"kind": "results", "protocol_version": ' + \
+            json.dumps(CURRENT_PROTOCOL).encode() + \
+            b', "results":' + result + b'}'
 
 
 async def heartbeat_check(db, server):
@@ -134,6 +138,7 @@ async def compile(db, server, list queries):
         db.db_config,
         server.get_compilation_system_config(),
         queries,
+        CURRENT_PROTOCOL,
         50,  # implicit limit
     )
 

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -166,6 +166,10 @@ async def execute(db, server, queries: list):
                         errors.UnsupportedCapabilityError,
                     )
                 try:
+                    if query_unit.in_type_args:
+                        raise errors.QueryError(
+                            'cannot use query parameters in tutorial')
+
                     data = await pgcon.parse_execute_notebook(
                         query_unit.sql[0], dbver)
                 except Exception as ex:

--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -35,7 +35,7 @@ cdef class HttpResponse:
         public object status
         public bint close_connection
         public bytes content_type
-        public dict headers
+        public dict custom_headers
         public bytes body
 
 
@@ -58,7 +58,7 @@ cdef class HttpProtocol:
         HttpRequest current_request
 
     cdef _write(self, bytes req_version, bytes resp_status,
-                bytes content_type, dict headers, bytes body,
+                bytes content_type, dict custom_headers, bytes body,
                 bint close_connection)
 
     cdef write(self, HttpRequest request, HttpResponse response)

--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -35,6 +35,7 @@ cdef class HttpResponse:
         public object status
         public bint close_connection
         public bytes content_type
+        public dict headers
         public bytes body
 
 
@@ -57,7 +58,8 @@ cdef class HttpProtocol:
         HttpRequest current_request
 
     cdef _write(self, bytes req_version, bytes resp_status,
-                bytes content_type, bytes body, bint close_connection)
+                bytes content_type, dict headers, bytes body,
+                bint close_connection)
 
     cdef write(self, HttpRequest request, HttpResponse response)
 

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -53,6 +53,7 @@ cdef class HttpResponse:
     def __cinit__(self):
         self.status = HTTPStatus.OK
         self.content_type = b'text/plain'
+        self.headers = {}
         self.body = b''
         self.close_connection = False
 
@@ -187,6 +188,7 @@ cdef class HttpProtocol:
             b'1.0',
             b'400 Bad Request',
             b'text/plain',
+            {},
             f'{type(ex).__name__}: {ex}'.encode(),
             True)
 
@@ -203,7 +205,8 @@ cdef class HttpProtocol:
             self.transport.resume_reading()
 
     cdef _write(self, bytes req_version, bytes resp_status,
-                bytes content_type, bytes body, bint close_connection):
+                bytes content_type, dict headers, bytes body,
+                bint close_connection):
         if self.transport is None:
             return
         data = [
@@ -212,8 +215,14 @@ cdef class HttpProtocol:
             b'Content-Length: ', f'{len(body)}'.encode(), b'\r\n',
         ]
 
+        for key, value in headers.items():
+            data.append(f'{key}: {value}\r\n'.encode())
+
         if debug.flags.http_inject_cors:
             data.append(b'Access-Control-Allow-Origin: *\r\n')
+            if headers:
+                data.append(b'Access-Control-Expose-Headers: ' + \
+                    ', '.join(headers.keys()).encode() + b'\r\n')
 
         if close_connection:
             data.append(b'Connection: close\r\n')
@@ -228,6 +237,7 @@ cdef class HttpProtocol:
             request.version,
             f'{response.status.value} {response.status.phrase}'.encode(),
             response.content_type,
+            response.headers,
             response.body,
             response.close_connection)
 

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -58,6 +58,7 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
             results,
             {
                 'kind': 'results',
+                'protocol_version': [0, 11],
                 'results': [
                     {
                         'kind': 'data',
@@ -92,6 +93,7 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
             results,
             {
                 'kind': 'results',
+                'protocol_version': [0, 11],
                 'results': [
                     {
                         'kind': 'data',
@@ -137,6 +139,7 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
             results,
             {
                 'kind': 'results',
+                'protocol_version': [0, 11],
                 'results': [
                     {
                         'kind': 'error',
@@ -173,6 +176,7 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
             results,
             {
                 'kind': 'results',
+                'protocol_version': [0, 11],
                 'results': [
                     {
                         'kind': 'data',
@@ -192,3 +196,11 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
                 ]
             }
         )
+
+    def test_http_notebook_06(self):
+        results = self.run_queries([
+            'SELECT {protocol := "notebook"}'
+        ])
+
+        self.assertEqual(results['kind'], 'results')
+        self.assertEqual(results['results'][0]['kind'], 'data')

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -58,7 +58,6 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
             results,
             {
                 'kind': 'results',
-                'protocol_version': [0, 11],
                 'results': [
                     {
                         'kind': 'data',
@@ -93,7 +92,6 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
             results,
             {
                 'kind': 'results',
-                'protocol_version': [0, 11],
                 'results': [
                     {
                         'kind': 'data',
@@ -139,7 +137,6 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
             results,
             {
                 'kind': 'results',
-                'protocol_version': [0, 11],
                 'results': [
                     {
                         'kind': 'error',
@@ -176,7 +173,6 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
             results,
             {
                 'kind': 'results',
-                'protocol_version': [0, 11],
                 'results': [
                     {
                         'kind': 'data',

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -45,6 +45,9 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
         response = urllib.request.urlopen(
             req, json.dumps(req_data).encode(), context=self.tls_context
         )
+
+        self.assertIsNotNone(response.headers['EdgeDB-Protocol-Version'])
+
         resp_data = json.loads(response.read())
         return resp_data
 


### PR DESCRIPTION
- Pass protocol version to compiler from `compile_notebook` (Fixes #2618)
- Return protocol version in notebook response http header (Fixes #2630)
- Improve error message when query contains parameters (Fixes https://github.com/edgedb/edgedb.com/issues/205)