### PR TITLE
Prohibit navigational nesting in UPDATE

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -462,8 +462,8 @@ def _normalize_view_ptr_expr(
     ptrname = lexpr.ptr.name
 
     compexpr: Optional[qlast.Expr] = shape_el.compexpr
-    if compexpr is None and is_insert and shape_el.elements:
-        # Short shape form in INSERT, e.g
+    if compexpr is None and (is_insert or is_update) and shape_el.elements:
+        # Short shape form in INSERT or UPDATE, e.g
         #     INSERT Foo { bar: Spam { name := 'name' }}
         # is prohibited.
         raise errors.EdgeQLSyntaxError(

--- a/tests/schemas/updates.esdl
+++ b/tests/schemas/updates.esdl
@@ -47,6 +47,7 @@ type UpdateTest {
     multi link tags -> Tag;
     multi link weighted_tags -> Tag {
         property weight -> int64;
+        property note -> str;
         property readonly_note -> str {
             readonly := true;
         }

--- a/tests/test_dump01.py
+++ b/tests/test_dump01.py
@@ -1821,6 +1821,8 @@ class DumpTestCaseMixin:
             ],
         )
 
+        """XXX: uncomment the below once direct link property updates are
+                implemented
         # validate read-only
         with self.assertRaisesRegex(
                 edgedb.QueryError,
@@ -1872,6 +1874,7 @@ class DumpTestCaseMixin:
                         rol1: {@rolp11 := 1},
                     };
                     ''')
+        """
 
 
 class TestDump01(tb.StableDumpTestCase, DumpTestCaseMixin):

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -5769,7 +5769,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             UPDATE
                 Base
             SET {
-                foo: {
+                foo := .foo {
                     @bar := 'lp01'
                 }
             };
@@ -5800,7 +5800,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             INSERT Base {foo := (INSERT Child)};
             UPDATE Base
             SET {
-                foo: {@bar := 'lp02'},
+                foo := .foo { @bar := 'lp02' },
             };
         """)
 
@@ -5840,7 +5840,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             INSERT Base {foo := (INSERT Child)};
             UPDATE Base
             SET {
-                foo: {@bar := 3},
+                foo := .foo { @bar := 3 },
             };
         """)
 
@@ -5880,7 +5880,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             INSERT Base {foo := (INSERT Child)};
             UPDATE Base
             SET {
-                foo: {@bar := 'lp04'},
+                foo := .foo { @bar := 'lp04' },
             };
         """)
 
@@ -5920,7 +5920,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             INSERT Base {foo := (INSERT Child)};
             UPDATE Base
             SET {
-                foo: {@bar := 'lp05'},
+                foo := .foo { @bar := 'lp05' },
             };
         """)
 
@@ -5962,7 +5962,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             INSERT Base {child := (INSERT Child)};
             UPDATE Base
             SET {
-                child: {
+                child := .child {
                     @foo := 'lp06',
                 },
             };
@@ -5983,8 +5983,9 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         await self.con.execute(r"""
             UPDATE Base
             SET {
-                child: {
+                child := .child {
                     @bar := 111,
+                    @foo := 'lp06',
                 },
             };
         """)
@@ -6026,7 +6027,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             INSERT Derived {child := (INSERT Child)};
             UPDATE Derived
             SET {
-                child: {
+                child := .child {
                     @foo := 'lp07',
                 },
             };
@@ -6080,7 +6081,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         await self.con.execute(r"""
             UPDATE Derived
             SET {
-                child: {
+                child := .child {
                     @foo := 'lp08',
                 },
             };
@@ -6147,7 +6148,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             INSERT Derived {child := (INSERT Child)};
             UPDATE Derived
             SET {
-                child: {
+                child := .child {
                     @foo := 'lp09',
                 },
             };
@@ -6204,7 +6205,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             INSERT Derived {child := (INSERT Child)};
             UPDATE Derived
             SET {
-                child: {
+                child := .child {
                     @foo := 'lp10',
                 },
             };
@@ -6265,7 +6266,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             INSERT Owner {item := (INSERT Thing)};
             UPDATE Owner
             SET {
-                item: {
+                item := .item {
                     @foo := 'owner_lp11',
                 },
             };
@@ -6273,7 +6274,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             INSERT Renter {item := (INSERT Thing)};
             UPDATE Renter
             SET {
-                item: {
+                item := .item {
                     @foo := 'renter_lp11',
                 },
             };
@@ -6346,7 +6347,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             INSERT Owner {item := (INSERT Thing)};
             UPDATE Owner
             SET {
-                item: {
+                item := .item {
                     @foo := 'owner_lp11',
                 },
             };
@@ -6354,7 +6355,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             INSERT Renter {item := (INSERT Thing)};
             UPDATE Renter
             SET {
-                item: {
+                item := .item {
                     @bar := 'renter_lp11',
                 },
             };


### PR DESCRIPTION
Currently, we allow the following `UPDATE` syntax:

```
UPDATE Foo
FILTER .foo_name = 'First'
SET {
   bar: {
       spam := true
   } FILTER .bar_name = 'Blah'
}
```

The intuitive interpretation is that it should update an object of name
`Blah` specifically linked to a `Foo` object of name `First`.  However,
currently this is what the statement gets transformed into:

```
UPDATE Foo
FILTER .foo_name = 'First'
SET {
   bar := (SELECT .bar {
       spam := true
   } FILTER .bar_name = 'Blah')
}
```

It's the standard `SELECT` transform, but it's quite wrong for `UPDATE`,
since instead of updating a single linked object, it actually _replaces_
the entire linked set `bar`.

We intend to support the nested `UPDATE` case properly soon, but for now
we should just ban the syntax.

While at it, fix a bug whereby UPDATEs that reassign a link to an
overlapping set don't get the link properties erased properly.