### PR TITLE
Use `--quiet` in a call to `edgedb authenticate` in `edb cli`

### DIFF
--- a/edb/tools/cli.py
+++ b/edb/tools/cli.py
@@ -54,6 +54,7 @@ def cli(args: list[str]):
             "authenticate",
             "_localdev",
             "--non-interactive",
+            "--quiet",
         ])
 
     if (


### PR DESCRIPTION
The dev CLI spews lots of unnecessary output otherwise.