### PR TITLE
Fix some materialization related issues

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -220,11 +220,11 @@ class Environment:
 
     materialized_sets: Dict[
         Union[s_types.Type, s_pointers.PointerLike],
-        qlast.Statement,
+        Union[qlast.Shape, qlast.Statement],
     ]
     """A mapping of computed sets that must be computed only once."""
 
-    compiled_stmts: Dict[qlast.Statement, irast.Stmt]
+    compiled_stmts: Dict[Union[qlast.Shape, qlast.Statement], irast.Stmt]
     """A mapping of from input edgeql to compiled IR"""
 
     def __init__(
@@ -428,7 +428,7 @@ class ContextLevel(compiler.ContextLevel):
     stmt: Optional[irast.Stmt]
     """Statement node currently being built."""
 
-    qlstmt: Optional[qlast.Statement]
+    qlstmt: Optional[Union[qlast.Statement, qlast.Shape]]
     """Statement source node currently being built."""
 
     path_id_namespace: FrozenSet[str]

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -220,11 +220,11 @@ class Environment:
 
     materialized_sets: Dict[
         Union[s_types.Type, s_pointers.PointerLike],
-        Union[qlast.Shape, qlast.Statement],
+        qlast.Statement,
     ]
     """A mapping of computed sets that must be computed only once."""
 
-    compiled_stmts: Dict[Union[qlast.Shape, qlast.Statement], irast.Stmt]
+    compiled_stmts: Dict[qlast.Statement, irast.Stmt]
     """A mapping of from input edgeql to compiled IR"""
 
     def __init__(
@@ -428,7 +428,7 @@ class ContextLevel(compiler.ContextLevel):
     stmt: Optional[irast.Stmt]
     """Statement node currently being built."""
 
-    qlstmt: Optional[Union[qlast.Statement, qlast.Shape]]
+    qlstmt: Optional[qlast.Statement]
     """Statement source node currently being built."""
 
     path_id_namespace: FrozenSet[str]

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1430,20 +1430,15 @@ def maybe_materialize(
 
         assert not isinstance(stype, s_pointers.PseudoPointer)
         if stype.id not in materialize_in_stmt.materialized_sets:
+            saved = (
+                None if isinstance(stype, s_pointers.Pointer) and not ir.rptr
+                else ir
+            )
             materialize_in_stmt.materialized_sets[stype.id] = (
-                irast.MaterializedSet(materialized=ir, use_sets=[]))
-        materialize_in_stmt.materialized_sets[stype.id].use_sets.append(ir)
+                irast.MaterializedSet(materialized=saved, use_sets=[]))
 
-        # When the source typeref doesn't match the source id, take the
-        # current ir to be the canonical one.
-        # Otherwise the volatility refs get broken.
-        # XXX: This is a hack, originally written to solve a different
-        # problem, and I don't really understand why it is needed to
-        # solve this one.
-        if ir.rptr:
-            if ir.rptr.source.typeref.id != ir.rptr.source.path_id.target.id:
-                mat_set = materialize_in_stmt.materialized_sets[stype.id]
-                mat_set.materialized = ir
+        mat_set = materialize_in_stmt.materialized_sets[stype.id]
+        mat_set.use_sets.append(ir)
 
 
 def force_materialized_volatile(

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1049,9 +1049,9 @@ def compile_Shape(
         shape: qlast.Shape, *, ctx: context.ContextLevel) -> irast.Set:
     shape_expr = shape.expr or qlutils.ANONYMOUS_SHAPE_EXPR
     with ctx.new() as subctx:
-        subctx.qlstmt = shape
+        subctx.qlstmt = astutils.ensure_qlstmt(shape)
         subctx.stmt = stmt = irast.SelectStmt()
-        ctx.env.compiled_stmts[shape] = stmt
+        ctx.env.compiled_stmts[subctx.qlstmt] = stmt
         subctx.class_view_overrides = subctx.class_view_overrides.copy()
 
         with ctx.new() as exposed_ctx:

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1049,21 +1049,38 @@ def compile_Shape(
         shape: qlast.Shape, *, ctx: context.ContextLevel) -> irast.Set:
     shape_expr = shape.expr or qlutils.ANONYMOUS_SHAPE_EXPR
     with ctx.new() as subctx:
-        subctx.expr_exposed = False
-        expr = setgen.ensure_set(
-            dispatch.compile(shape_expr, ctx=subctx), ctx=subctx)
-    expr_stype = setgen.get_set_type(expr, ctx=ctx)
-    if not isinstance(expr_stype, s_objtypes.ObjectType):
-        raise errors.QueryError(
-            f'shapes cannot be applied to '
-            f'{expr_stype.get_verbosename(ctx.env.schema)}',
-            context=shape.context,
-        )
-    view_type = viewgen.process_view(
-        stype=expr_stype, path_id=expr.path_id,
-        elements=shape.elements, parser_context=shape.context, ctx=ctx)
+        subctx.qlstmt = shape
+        subctx.stmt = stmt = irast.SelectStmt()
+        ctx.env.compiled_stmts[shape] = stmt
+        subctx.class_view_overrides = subctx.class_view_overrides.copy()
 
-    return setgen.ensure_set(expr, type_override=view_type, ctx=ctx)
+        with ctx.new() as exposed_ctx:
+            exposed_ctx.expr_exposed = False
+            expr = setgen.ensure_set(
+                dispatch.compile(shape_expr, ctx=exposed_ctx), ctx=exposed_ctx)
+
+        expr_stype = setgen.get_set_type(expr, ctx=ctx)
+        if not isinstance(expr_stype, s_objtypes.ObjectType):
+            raise errors.QueryError(
+                f'shapes cannot be applied to '
+                f'{expr_stype.get_verbosename(ctx.env.schema)}',
+                context=shape.context,
+            )
+        view_type = viewgen.process_view(
+            stype=expr_stype, path_id=expr.path_id,
+            elements=shape.elements, parser_context=shape.context, ctx=subctx)
+
+        stmt.result = compile_query_subject(
+            expr,
+            view_scls=view_type,
+            compile_views=False,
+            ctx=subctx,
+            parser_context=expr.context)
+
+        ir_result = setgen.ensure_set(
+            stmt, type_override=view_type, ctx=subctx)
+
+    return ir_result
 
 
 def init_stmt(
@@ -1449,7 +1466,8 @@ def compile_query_subject(
         expr = setgen.ensure_set(expr, type_override=view_scls, ctx=ctx)
         expr_stype = view_scls
 
-    if compile_views:
+    if compile_views or (
+            view_scls and setgen.should_materialize_type(view_scls, ctx=ctx)):
         rptr = view_rptr.rptr if view_rptr is not None else None
         if is_update:
             with ctx.new() as subctx:

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -488,6 +488,7 @@ def _normalize_view_ptr_expr(
             name=ptrcls.get_shortname(ctx.env.schema).name,
         )
 
+        base_required = base_ptrcls.get_required(ctx.env.schema)
         base_cardinality = _get_base_ptr_cardinality(base_ptrcls, ctx=ctx)
         base_is_singleton = False
         if base_cardinality is not None and base_cardinality.is_known():
@@ -553,6 +554,7 @@ def _normalize_view_ptr_expr(
             assert _ptr_target
             ptr_target = _ptr_target
 
+        ptr_required = base_required
         ptr_cardinality = base_cardinality
         if ptr_cardinality is None or not ptr_cardinality.is_known():
             # We do not know the parent's pointer cardinality yet.
@@ -706,6 +708,7 @@ def _normalize_view_ptr_expr(
                 ctx.env.schema, 'owned', True)
 
         ptr_cardinality = None
+        ptr_required = False
 
         if (
             isinstance(ptr_target, s_types.Collection)
@@ -802,6 +805,7 @@ def _normalize_view_ptr_expr(
             assert existing_target is not None
             if ctx.recompiling_schema_alias:
                 ptr_cardinality = existing.get_cardinality(ctx.env.schema)
+                ptr_required = existing.get_required(ctx.env.schema)
             if ptr_target == existing_target:
                 ptrcls = existing
             elif ptr_target.implicitly_castable_to(
@@ -884,6 +888,8 @@ def _normalize_view_ptr_expr(
     if ptr_cardinality is not None:
         ctx.env.schema = ptrcls.set_field_value(
             ctx.env.schema, 'cardinality', ptr_cardinality)
+        ctx.env.schema = ptrcls.set_field_value(
+            ctx.env.schema, 'required', ptr_required)
     else:
         if qlexpr is None and ptrcls is not base_ptrcls:
             ctx.env.pointer_derivation_map[base_ptrcls].append(ptrcls)
@@ -1089,7 +1095,7 @@ def _inline_type_computable(
         ptr = setgen.resolve_ptr(stype, compname, track_ref=None, ctx=ctx)
         # The pointer might exist on the base type. That doesn't count,
         # and we need to re-inject it.
-        if not ptr.get_computable(ctx.env.schema):
+        if ptr not in ctx.source_map:
             ptr = None
     except errors.InvalidReferenceError:
         ptr = None

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -423,6 +423,9 @@ class TupleIndirectionPointer(Pointer):
 class Expr(Base):
     __abstract_node__ = True
 
+    # Sets to materialize at this point, keyed by the type/ptr id.
+    materialized_sets: typing.Dict[uuid.UUID, MaterializedSet]
+
 
 class ImmutableExpr(Expr, ImmutableBase):
     __abstract_node__ = True
@@ -740,7 +743,7 @@ class TypeCast(ImmutableExpr):
 class MaterializedSet(Base):
     # Hide uses to reduce spew; we produce our own simpler uses
     __ast_hidden__ = {'use_sets'}
-    materialized: Set
+    materialized: typing.Optional[Set]
     # We really only want the *paths* of all the places it is used,
     # but we need to store the sets to take advantage of weak
     # namespace rewriting.
@@ -771,8 +774,6 @@ class Stmt(Expr):
     parent_stmt: typing.Optional[Stmt]
     iterator_stmt: typing.Optional[Set]
     bindings: typing.List[Set]
-    # Sets to materialize at this point, keyed by the type/ptr id.
-    materialized_sets: typing.Dict[uuid.UUID, MaterializedSet]
 
 
 class FilteredStmt(Stmt):

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -353,6 +353,15 @@ class ScopeTreeNode:
         return None
 
     @property
+    def parent_branch(self) -> Optional[ScopeTreeNode]:
+        """The nearest strict ancestor branch or fence."""
+        for ancestor in self.strict_ancestors:
+            if ancestor.path_id is None and not ancestor.computable_branch:
+                return ancestor
+
+        return None
+
+    @property
     def root(self) -> ScopeTreeNode:
         """The root of this tree."""
         node = self

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -153,6 +153,7 @@ def compile_materialized_exprs(
         for mat_set in stmt.materialized_sets.values():
             if len(mat_set.uses) <= 1:
                 continue
+            assert mat_set.materialized
             if relctx.find_rvar(
                     query, flavor='packed',
                     path_id=mat_set.materialized.path_id, ctx=matctx):

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1176,7 +1176,7 @@ def process_set_as_subquery(
         else:
             # Non-scalar computable pointer.  Check if path source is
             # visible in the outer scope.
-            outer_fence = ctx.scope_tree.parent_fence
+            outer_fence = ctx.scope_tree.parent_branch
             assert outer_fence is not None
             source_is_visible = outer_fence.is_visible(ir_source.path_id)
 

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -603,7 +603,7 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         """
         SELECT (SELECT User { multi m := 1 }) { m }
 % OK %
-        m: MANY
+        m: AT_LEAST_ONE
         """
 
     def test_edgeql_ir_card_inference_66(self):


### PR DESCRIPTION
The main thing here is to rework the selection of which materialized
set is compiled to ensure that we always compile one with an
appropriate rptr source, if it is a computable.

Additionally we need to store materialized computables on a non-SELECT
shape with the shape statement, not with whatever edgeql statement is
surrounding it, which requires shifting how things are tracked.

These reworkings fixed some volatility cross product errors we were
missing.

Modify the test_volatility tests to also insert typenames, and fix
some issues that shook out.

As part of dealing with the changes to non-SELECT shape compilation, I
needed to make the visibility checks in cardinality inference and
subquery compilation be done from the parent *branch* instead of the
parent *fence*. I am not super confident about this change.