### PR TITLE
Fix certgen issue with multiple hosts

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -74,7 +74,7 @@ class ServerConfig(NamedTuple):
     default_database_user: Optional[str]
     devmode: bool
     testmode: bool
-    bind_address: str
+    bind_addresses: tuple[str]
     port: int
     background: bool
     pidfile_dir: pathlib.Path
@@ -268,8 +268,9 @@ _server_options = [
         help='enable or disable the test mode',
         default=False),
     click.option(
-        '-I', '--bind-address', type=str, default=None,
-        help='IP address to listen on'),
+        '-I', '--bind-address', type=str, multiple=True,
+        help='IP addresses to listen on, specify multiple times for more than '
+             'one address to listen on'),
     click.option(
         '-P', '--port', type=PortType(), default=None,
         help='port to listen on'),
@@ -363,6 +364,8 @@ def server_options(func):
 
 
 def parse_args(**kwargs: Any):
+    kwargs['bind_addresses'] = kwargs.pop('bind_address')
+
     if kwargs['echo_runtime_info']:
         warnings.warn(
             "The `--echo-runtime-info` option is deprecated, use "

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -185,7 +185,7 @@ async def _run_server(
             internal_runstate_dir=internal_runstate_dir,
             max_backend_connections=args.max_backend_connections,
             compiler_pool_size=args.compiler_pool_size,
-            nethost=args.bind_address,
+            nethosts=args.bind_addresses,
             netport=args.port,
             auto_shutdown_after=args.auto_shutdown_after,
             echo_runtime_info=args.echo_runtime_info,
@@ -199,7 +199,7 @@ async def _run_server(
             ss.init_tls(
                 *_generate_cert(
                     args.data_dir or pathlib.Path(internal_runstate_dir),
-                    ss.get_listen_host(),
+                    ss.get_listen_hosts(),
                 )
             )
 
@@ -233,7 +233,7 @@ async def _run_server(
 
 
 def _generate_cert(
-    cert_dir: pathlib.Path, listen_host: Union[str, Iterable]
+    cert_dir: pathlib.Path, listen_hosts: Iterable[str]
 ) -> Tuple[pathlib.Path, Optional[pathlib.Path]]:
     logger.info("Generating self-signed TLS certificate.")
 
@@ -251,7 +251,6 @@ def _generate_cert(
     subject = x509.Name(
         [x509.NameAttribute(oid.NameOID.COMMON_NAME, "EdgeDB Server")]
     )
-    alt_names = [listen_host] if isinstance(listen_host, str) else listen_host
     certificate = (
         x509.CertificateBuilder()
         .subject_name(subject)
@@ -266,7 +265,8 @@ def _generate_cert(
         )
         .add_extension(
             x509.SubjectAlternativeName(
-                [x509.DNSName(name) for name in alt_names if name != '0.0.0.0']
+                [x509.DNSName(name) for name in listen_hosts
+                 if name != '0.0.0.0']
             ),
             critical=False,
         )


### PR DESCRIPTION
If `listen_addresses` was set to multiple hosts, the certgen would fail. This PR fixes this issue.

Also allowed to specify `--bind-address` multiple times.