### PR TITLE
Reduce the size of pools on low memory systems

### DIFF
--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -19,8 +19,6 @@
 
 from __future__ import annotations
 
-import os
-
 
 EDGEDB_PORT = 5656
 EDGEDB_SUPERGROUP = 'edgedb_supergroup'
@@ -42,12 +40,8 @@ EDGEDB_CATALOG_VERSION = 2021_07_23_14_00
 # We try to bump the rlimit on server start if pemitted.
 EDGEDB_MIN_RLIMIT_NOFILE = 2048
 
-
-BACKEND_CONNECTIONS_MIN = 10
-BACKEND_CONNECTIONS_DEFAULT = 100
-
+BACKEND_CONNECTIONS_MIN = 4
 BACKEND_COMPILER_POOL_SIZE_MIN = 1
-BACKEND_COMPILER_POOL_SIZE_DEFAULT = max(os.cpu_count() or 0, 6) // 2
 
 _MAX_QUERIES_CACHE = 1000
 

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -327,7 +327,8 @@ def run_server(args: srvargs.ServerConfig, *, do_setproctitle: bool=False):
 
         cluster = pgcluster.get_local_pg_cluster(
             args.data_dir,
-            max_connections=pg_max_connections,
+            # Plus two below to account for system connections.
+            max_connections=pg_max_connections + 2,
             tenant_id=tenant_id,
         )
         default_runstate_dir = cluster.get_data_dir()

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -470,6 +470,16 @@ class Cluster(BaseCluster):
             # we're using superuser only now (so all connections available),
             # and we don't support reserving connections for now
             'max_connections': str(self._instance_params.max_connections),
+            # From Postgres docs:
+            #
+            #   You might need to raise this value if you have queries that
+            #   touch many different tables in a single transaction, e.g.,
+            #   query of a parent table with many children.
+            #
+            # EdgeDB queries might touch _lots_ of tables, especially in deep
+            # inheritance hierarchies.  This is especially important in low
+            # `max_connections` scenarios.
+            'max_locks_per_transaction': 256,
         }
 
         if os.getenv('EDGEDB_DEBUG_PGSERVER'):

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -213,7 +213,7 @@ class TestServerOps(tb.TestCase):
                 max_connections = await con.query_one(
                     'SELECT cfg::InstanceConfig.__pg_max_connections LIMIT 1'
                 )  # TODO: remove LIMIT 1 after #2402
-                self.assertEqual(int(max_connections), actual)
+                self.assertEqual(int(max_connections), actual + 2)
             finally:
                 await con.aclose()
 


### PR DESCRIPTION
When available system RAM is tight (<1GiB), reduce the sizes of the
compiler pool and the PostgreSQL connection pool to a minimum (2 and 4).