### PR TITLE
Fix applying changes to listen_addresses

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -74,7 +74,7 @@ class ServerConfig(NamedTuple):
     default_database_user: Optional[str]
     devmode: bool
     testmode: bool
-    bind_address: str
+    bind_addresses: tuple[str]
     port: int
     background: bool
     pidfile_dir: pathlib.Path
@@ -268,8 +268,9 @@ _server_options = [
         help='enable or disable the test mode',
         default=False),
     click.option(
-        '-I', '--bind-address', type=str, default=None,
-        help='IP address to listen on'),
+        '-I', '--bind-address', type=str, multiple=True,
+        help='IP addresses to listen on, specify multiple times for more than '
+             'one address to listen on'),
     click.option(
         '-P', '--port', type=PortType(), default=None,
         help='port to listen on'),
@@ -363,6 +364,8 @@ def server_options(func):
 
 
 def parse_args(**kwargs: Any):
+    kwargs['bind_addresses'] = kwargs.pop('bind_address')
+
     if kwargs['echo_runtime_info']:
         warnings.warn(
             "The `--echo-runtime-info` option is deprecated, use "

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -185,7 +185,7 @@ async def _run_server(
             internal_runstate_dir=internal_runstate_dir,
             max_backend_connections=args.max_backend_connections,
             compiler_pool_size=args.compiler_pool_size,
-            nethost=args.bind_address,
+            nethosts=args.bind_addresses,
             netport=args.port,
             auto_shutdown_after=args.auto_shutdown_after,
             echo_runtime_info=args.echo_runtime_info,
@@ -199,7 +199,7 @@ async def _run_server(
             ss.init_tls(
                 *_generate_cert(
                     args.data_dir or pathlib.Path(internal_runstate_dir),
-                    ss.get_listen_host(),
+                    ss.get_listen_hosts(),
                 )
             )
 
@@ -233,7 +233,7 @@ async def _run_server(
 
 
 def _generate_cert(
-    cert_dir: pathlib.Path, listen_host: Union[str, Iterable]
+    cert_dir: pathlib.Path, listen_hosts: Iterable[str]
 ) -> Tuple[pathlib.Path, Optional[pathlib.Path]]:
     logger.info("Generating self-signed TLS certificate.")
 
@@ -251,7 +251,6 @@ def _generate_cert(
     subject = x509.Name(
         [x509.NameAttribute(oid.NameOID.COMMON_NAME, "EdgeDB Server")]
     )
-    alt_names = [listen_host] if isinstance(listen_host, str) else listen_host
     certificate = (
         x509.CertificateBuilder()
         .subject_name(subject)
@@ -266,7 +265,8 @@ def _generate_cert(
         )
         .add_extension(
             x509.SubjectAlternativeName(
-                [x509.DNSName(name) for name in alt_names if name != '0.0.0.0']
+                [x509.DNSName(name) for name in listen_hosts
+                 if name != '0.0.0.0']
             ),
             critical=False,
         )

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -60,6 +60,7 @@ from edb.server.pgcon import errors as pgcon_errors
 from . import dbview
 
 
+ADMIN_PLACEHOLDER = "<edgedb:admin>"
 logger = logging.getLogger('edb.server')
 log_metrics = logging.getLogger('edb.server.metrics')
 
@@ -89,7 +90,7 @@ class Server:
     _schema_class_layout: s_refl.SchemaTypeLayout
 
     _sys_pgcon_waiter: asyncio.Lock
-    _servers: List[asyncio.AbstractServer]
+    _servers: Mapping[str, asyncio.AbstractServer]
 
     _task_group: Optional[taskgroup.TaskGroup]
     _binary_conns: Set[binary.EdgeConnection]
@@ -173,7 +174,7 @@ class Server:
         self._binary_conns = set()
         self._accepting_connections = False
 
-        self._servers = []
+        self._servers = {}
 
         self._http_query_cache = cache.StatementsCache(
             maxsize=defines.HTTP_PORT_QUERY_CACHE_SIZE)
@@ -638,11 +639,60 @@ class Server:
     async def _restart_servers_new_addr(self, nethosts, netport):
         if not netport:
             raise RuntimeError('cannot restart without network port specified')
-        old_servers = self._servers
-        self._servers, _ = await self._start_servers(nethosts, netport)
+        servers_to_stop = []
+        servers = {}
+        if self._listen_port == netport:
+            hosts_to_start = [
+                host for host in nethosts if host not in self._servers
+            ]
+            for host, srv in self._servers.items():
+                if host == ADMIN_PLACEHOLDER or host in nethosts:
+                    servers[host] = srv
+                else:
+                    servers_to_stop.append(srv)
+            admin = False
+        else:
+            hosts_to_start = nethosts
+            servers_to_stop = self._servers.values()
+            admin = True
+
+        new_servers, *_ = await self._start_servers(
+            hosts_to_start, netport, admin
+        )
+        servers.update(new_servers)
+        self._servers = servers
         self._listen_hosts = nethosts
         self._listen_port = netport
-        await self._stop_servers(old_servers)
+
+        addrs = []
+        unix_addr = None
+        port = None
+        for srv in servers_to_stop:
+            for s in srv.sockets:
+                addr = s.getsockname()
+                if isinstance(addr, tuple):
+                    addrs.append(addr)
+                    if port is None:
+                        port = addr[1]
+                    elif port != addr[1]:
+                        port = 0
+                else:
+                    unix_addr = addr
+        if len(addrs) > 1:
+            if port:
+                addr_str = f"{{{', '.join(addr[0] for addr in addrs)}}}:{port}"
+            else:
+                addr_str = f"{{{', '.join('%s:%d' % addr for addr in addrs)}}}"
+        elif addrs:
+            addr_str = "%s:%d" % addrs[0]
+        else:
+            addr_str = None
+        if addr_str:
+            logger.info('Stopping to serve on %s', addr_str)
+        if unix_addr:
+            logger.info('Stopping to serve admin on %s', unix_addr)
+
+        await self._stop_servers(servers_to_stop)
 
     async def _on_before_drop_db(
         self,
@@ -905,44 +955,74 @@ class Server:
         finally:
             await self._destroy_compiler_pool()
 
-    async def _start_servers(self, hosts, port):
-        nethosts = await _fix_localhost(hosts)
+    async def _start_server(
+        self, host: str, port: int
+    ) -> asyncio.AbstractServer:
+        if host == "localhost":
+            host = await _resolve_localhost()
 
-        tcp_srv = await self._loop.create_server(
+        return await self._loop.create_server(
             lambda: protocol.HttpProtocol(
                 self, self._sslctx,
                 allow_cleartext_connections=self._allow_cleartext_connections,
             ),
-            host=nethosts, port=port)
+            host=host, port=port)
 
-        if port == 0:
-            port = tcp_srv.sockets[0].getsockname()[1]
-
-        try:
-            admin_unix_sock_path = os.path.join(
-                self._runstate_dir, f'.s.EDGEDB.admin.{port}')
-            admin_unix_srv = await self._loop.create_unix_server(
-                lambda: binary.EdgeConnection(self, external_auth=True),
-                admin_unix_sock_path)
-            os.chmod(admin_unix_sock_path, stat.S_IRUSR | stat.S_IWUSR)
-        except Exception:
-            tcp_srv.close()
-            await tcp_srv.wait_closed()
-            raise
-
-        servers = []
-
-        servers.append(tcp_srv)
-        if len(nethosts) > 1:
-            host_str = f"{{{', '.join(nethosts)}}}"
-        else:
-            host_str = next(iter(nethosts))
-
-        logger.info('Serving on %s:%s', host_str, port)
-        servers.append(admin_unix_srv)
+    async def _start_admin_server(self, port: int) -> asyncio.AbstractServer:
+        admin_unix_sock_path = os.path.join(
+            self._runstate_dir, f'.s.EDGEDB.admin.{port}')
+        admin_unix_srv = await self._loop.create_unix_server(
+            lambda: binary.EdgeConnection(self, external_auth=True),
+            admin_unix_sock_path
+        )
+        os.chmod(admin_unix_sock_path, stat.S_IRUSR | stat.S_IWUSR)
         logger.info('Serving admin on %s', admin_unix_sock_path)
+        return admin_unix_srv
 
-        return servers, port
+    async def _start_servers(self, hosts, port, admin=True):
+        servers = {}
+        try:
+            async with taskgroup.TaskGroup() as g:
+                for host in hosts:
+                    servers[host] = g.create_task(
+                        self._start_server(host, port)
+                    )
+        except Exception:
+            await self._stop_servers([
+                fut.result() for fut in servers.values()
+                if fut.done() and fut.exception() is None
+            ])
+            raise
+        servers = {host: fut.result() for host, fut in servers.items()}
+
+        addrs = []
+        for tcp_srv in servers.values():
+            for s in tcp_srv.sockets:
+                addrs.append(s.getsockname())
+
+        if len(addrs) > 1:
+            if port:
+                addr_str = f"{{{', '.join(addr[0] for addr in addrs)}}}:{port}"
+            else:
+                addr_str = f"{{{', '.join('%s:%d' % addr for addr in addrs)}}}"
+        elif addrs:
+            addr_str = "%s:%d" % addrs[0]
+            port = addrs[0][1]
+        else:
+            addr_str = None
+
+        if addr_str:
+            logger.info('Serving on %s', addr_str)
+
+        if admin and port:
+            try:
+                admin_unix_srv = await self._start_admin_server(port)
+            except Exception:
+                await self._stop_servers(servers.values())
+                raise
+            servers[ADMIN_PLACEHOLDER] = admin_unix_srv
+
+        return servers, port, addrs
 
     def init_tls(self, tls_cert_file, tls_key_file):
         assert self._sslctx is None
@@ -1026,7 +1106,7 @@ class Server:
                 script=self._startup_script.text,
             )
 
-        self._servers, actual_port = await self._start_servers(
+        self._servers, actual_port, listen_addrs = await self._start_servers(
             self._listen_hosts, self._listen_port)
         if self._listen_port == 0:
             self._listen_port = actual_port
@@ -1044,6 +1124,7 @@ class Server:
 
         if self._status_sink is not None:
             status = {
+                "listen_addrs": listen_addrs,
                 "port": self._listen_port,
                 "socket_dir": str(self._runstate_dir),
                 "main_pid": os.getpid(),
@@ -1060,8 +1141,8 @@ class Server:
             if self._http_request_logger is not None:
                 self._http_request_logger.cancel()
 
-            await self._stop_servers(self._servers)
-            self._servers = []
+            await self._stop_servers(self._servers.values())
+            self._servers = {}
 
             for conn in self._binary_conns:
                 conn.stop()
@@ -1116,19 +1197,11 @@ class Server:
             self._pg_unavailable_msg = msg
 
 
-async def _fix_localhost(host: Iterable[str]) -> List[str]:
+async def _resolve_localhost() -> List[str]:
     # On many systems 'localhost' resolves to _both_ IPv4 and IPv6
     # addresses, even if the system is not capable of handling
     # IPv6 connections.  Due to the common nature of this issue
     # we explicitly disable the AF_INET6 component of 'localhost'.
-
-    hosts = list(host)
-
-    try:
-        idx = hosts.index('localhost')
-    except ValueError:
-        # No localhost, all good
-        return hosts
 
     loop = asyncio.get_running_loop()
     localhost = await loop.getaddrinfo(
@@ -1145,12 +1218,12 @@ async def _fix_localhost(host: Iterable[str]) -> List[str]:
     if not infos:
         # "localhost" did not resolve to an IPv4 address,
         # let create_server handle the situation.
-        return hosts
+        return ["localhost"]
 
     # Replace 'localhost' with explicitly resolved AF_INET addresses.
-    hosts.pop(idx)
+    hosts = []
     for info in reversed(infos):
         addr, *_ = info[4]
-        hosts.insert(idx, addr)
+        hosts.append(addr)
 
     return hosts

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -959,15 +959,16 @@ class Server:
     async def _start_server(
         self, host: str, port: int
     ) -> asyncio.AbstractServer:
+        nethost = None
         if host == "localhost":
-            host = await _resolve_localhost()
+            nethost = await _resolve_localhost()
 
         return await self._loop.create_server(
             lambda: protocol.HttpProtocol(
                 self, self._sslctx,
                 allow_cleartext_connections=self._allow_cleartext_connections,
             ),
-            host=host, port=port)
+            host=nethost or host, port=port)
 
     async def _start_admin_server(self, port: int) -> asyncio.AbstractServer:
         admin_unix_sock_path = os.path.join(


### PR DESCRIPTION
Now we'll have one TCP server for each `listen_addresses`, and updating `listen_addresses` will only start the new servers and stop the servers that is not in the update.

At the same time, we are broadcasting new `listen_addrs` in the `--emit-server-status` file or socket, because `--port=auto` may lead to different ports bound on different hosts. The admin UNIX socket will not be created until there is a single TCP port.

Because a single `listen_address` may be resolved into multiple IPs and this PR left the resolution work to asyncio `start_server()`, there is a case when the `listen_addresses` is updated to a different name but resolves into the same IP, the issue described in #2696 would still happen.

Fixes #2696, depends on #2733