### PR TITLE
Remove `--admin` usage from the docs.

### DIFF
--- a/docs/admin/setup.rst
+++ b/docs/admin/setup.rst
@@ -68,5 +68,5 @@ method with the ``Trust`` method:
 
 .. code-block:: bash
 
-    $ edgedb -I <instance-name> --admin configure insert Auth \
-             --method=Trust --priority=0
+    $ edgedb -I <instance-name> -c "CONFIGURE INSTANCE INSERT \
+        Auth {priority := 0, method := (INSERT Trust)}"

--- a/docs/edgeql/admin/configure.rst
+++ b/docs/edgeql/admin/configure.rst
@@ -80,6 +80,16 @@ Set the same parameter, but for the current database:
 
     CONFIGURE CURRENT DATABASE SET query_work_mem := '4MB';
 
+Add a Trust authentication method for "my_user":
+
+.. code-block:: edgeql
+
+    CONFIGURE INSTANCE INSERT Auth {
+        priority := 1,
+        method := (INSERT Trust),
+        user := 'my_user'
+    };
+
 Remove all Trust authentication methods:
 
 .. code-block:: edgeql


### PR DESCRIPTION
Rewrite the passwordless connection creation example without the use of
deprecated `--admin`. Add that example to the `CONFIGRE` documentaion as
well.
