### PR TITLE
Allow compiler pool to be of size 1

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -173,9 +173,12 @@ def compute_default_compiler_pool_size() -> int:
     total_mem = psutil.virtual_memory().total
     total_mem_mb = total_mem // MIB
     if total_mem_mb <= 1024:
-        return 1
+        return defines.BACKEND_COMPILER_POOL_SIZE_MIN
     else:
-        return max(psutil.cpu_count(logical=False) or 0, 2)
+        return max(
+            psutil.cpu_count(logical=False) or 0,
+            defines.BACKEND_COMPILER_POOL_SIZE_MIN,
+        )
 
 
 def _validate_tenant_id(ctx, param, value):

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -212,12 +212,15 @@ class Pool(amsg.ServerProtocol):
         self._workers[pid] = worker
         self._workers_queue.release(worker)
 
-        logger.debug("Worker with PID %s is ready.", pid)
+        logger.debug("started compiler worker process (PID %s)", pid)
         if (
             not self._ready_evt.is_set()
             and len(self._workers) == self._pool_size
         ):
-            logger.info("All %s compiler Workers are ready.", self._pool_size)
+            logger.info(
+                f"started {self._pool_size} compiler worker "
+                f"process{'es' if self._pool_size > 1 else ''}",
+            )
             self._ready_evt.set()
 
         return worker

--- a/edb/server/compiler_pool/worker.py
+++ b/edb/server/compiler_pool/worker.py
@@ -366,7 +366,7 @@ def main():
     args = parser.parse_args()
 
     numproc = int(args.numproc)
-    assert numproc > 1
+    assert numproc >= 1
 
     # Abort the template process if more than `max_worker_spawns`
     # new workers are created continuously - it probably means the


### PR DESCRIPTION
Currently, the process pool code is asserting the pool size to be
greater than 1 for no apparent reason.  Take the opportunity to
editorialize the nearby log messages a bit.