### PR TITLE
More properly fix issue with introspection defaults when prop used twice

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -851,8 +851,7 @@ def _normalize_view_ptr_expr(
             irexpr = setgen.ensure_set(irexpr, ctx=ctx)
             setgen.maybe_materialize(ptrcls, irexpr, ctx=ctx)
 
-    if qlexpr is None and not setgen.is_injected_computable_ptr(
-            ptrcls, ctx=ctx):
+    if qlexpr is None:
         # This is not a computable, just a pointer
         # to a nested shape.  Have it reuse the original
         # pointer name so that in `Foo.ptr.name` and

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1164,7 +1164,10 @@ def range_for_material_objtype(
                 alias=pgast.Alias(aliasname=env.aliases.get('t'))
             )
             pathctx.put_path_id_map(sctx.rel, path_id, rewrite.path_id)
-            include_rvar(sctx.rel, cte_rvar, rewrite.path_id, ctx=sctx)
+            include_rvar(
+                sctx.rel, cte_rvar, rewrite.path_id, pull_namespace=False,
+                ctx=sctx,
+            )
             rvar = rvar_for_rel(sctx.rel, typeref=typeref, ctx=sctx)
     else:
         assert isinstance(typeref.name_hint, sn.QualName)

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -1380,3 +1380,27 @@ class TestIntrospection(tb.QueryTestCase):
                 }
             ]
         )
+
+    async def test_edgeql_default_injection_collision_02(self):
+        await self.assert_query_result(
+            r"""
+                WITH MODULE schema
+                SELECT Pointer {
+                    name,
+                    required,
+                    [IS Link].pointers: {
+                      name,
+                      asdf := .required,
+                    } FILTER .name = 'value'
+                }
+                FILTER .source.name = 'schema::AnnotationSubject'
+                   AND .name = 'annotations';
+            """,
+            [
+                {
+                    "name": "annotations",
+                    "pointers": [{"name": "value", "asdf": False}],
+                    "required": False
+                }
+            ]
+        )


### PR DESCRIPTION
This was worked around in #2667, but the main underlying issue was
that the pull_namespace on the type_cte meant that one Pointer
accessing required would cause it to eagerly get pulled up into other
queries.

Fix that, and revert the workaround from #2667.