### PR TITLE
Adopt "computed" link/property instead of "computable".

### DIFF
--- a/docs/cheatsheet/aliases.rst
+++ b/docs/cheatsheet/aliases.rst
@@ -12,7 +12,7 @@ Aliases
 ----------
 
 
-Define an alias that merges some information from links as computable
+Define an alias that merges some information from links as computed
 properties, this is a way of flattening a nested structure:
 
 .. code-block:: sdl
@@ -34,7 +34,7 @@ Define an alias for traversing a :ref:`backlink
 .. code-block:: sdl
 
     alias MovieAlias := Movie {
-        # A computable link for accessing all the
+        # A computed link for accessing all the
         # reviews for this movie.
         reviews := .<movie[IS Review]
     }

--- a/docs/cheatsheet/boolean.rst
+++ b/docs/cheatsheet/boolean.rst
@@ -134,7 +134,7 @@ accounts that are less than half-way completed"*:
 ----------
 
 
-The above will end up including the computable flag ``too_few_steps``
+The above will end up including the computed flag ``too_few_steps``
 in the output, but this is sometimes undesirable. In order to avoid
 including it, the query can be refactored like this:
 
@@ -190,10 +190,10 @@ result is already non-empty and so no coalescing will take place.
 
 Computables in shapes get evaluated *for each object*, whereas path
 expressions only produce as many values as are *reachable* by the
-path. So when all objects must be considered, computables in shapes
-are a good way to handle complex expressions or filters. When only
-objects with specific properties are relevant, path expressions are a
-good compact way of handling this.
+path. So when all objects must be considered, computed links and
+properties in shapes are a good way to handle complex expressions or
+filters. When only objects with specific properties are relevant, path
+expressions are a good compact way of handling this.
 
 
 ----------

--- a/docs/cheatsheet/migrations.rst
+++ b/docs/cheatsheet/migrations.rst
@@ -106,7 +106,7 @@ Migrate to a new schema using SDL:
         };
 
         alias MovieAlias := Movie {
-            # A computable link for accessing all the
+            # A computed link for accessing all the
             # reviews for this movie.
             reviews := .<movie[IS Review]
         };

--- a/docs/cheatsheet/types.rst
+++ b/docs/cheatsheet/types.rst
@@ -122,7 +122,7 @@ Define an abstract links:
 ----------
 
 
-Define a type using abstract links and a computable property that
+Define a type using abstract links and a computed property that
 aggregates values from another linked type:
 
 .. code-block:: sdl

--- a/docs/clients/99_graphql/protocol.rst
+++ b/docs/clients/99_graphql/protocol.rst
@@ -66,6 +66,6 @@ actually occurred.
     losslessly represented in JSON. However, JSON decoders in many
     languages will read all such numbers as some kind of of 32- or
     64-bit number type, which may result in errors or precision loss.
-    If such loss is unacceptable, then consider creating a computable
+    If such loss is unacceptable, then consider creating a computed
     property which casts the value into ``str`` and decoding it on the
     client side into a more appropriate type.

--- a/docs/datamodel/aliases.rst
+++ b/docs/datamodel/aliases.rst
@@ -22,7 +22,7 @@ Consider the following:
     }
 
     alias UserAlias := User {
-        # declare a computable link
+        # declare a computed link
         friend_of := User.<friends[IS User]
     };
 
@@ -44,7 +44,7 @@ more legible:
         .name = 'Alice';
 
 Another benefit is that this ``UserAlias`` can now be exposed via
-:ref:`GraphQL <ref_graphql_index>` providing access to the computable
+:ref:`GraphQL <ref_graphql_index>` providing access to the computed
 link ``friend_of``, that would otherwise be inexpressible in GraphQL:
 
 .. code-block:: graphql

--- a/docs/datamodel/computables.rst
+++ b/docs/datamodel/computables.rst
@@ -1,29 +1,29 @@
 .. _ref_datamodel_computables:
 
-===========
-Computables
-===========
+=============================
+Computed Links and Properties
+=============================
 
 :ref:`Links <ref_datamodel_links>` and :ref:`properties <ref_datamodel_props>`
-may be declared as *computable*.
+may be declared as *computed* by an expression.
 
-The values of computable properties and links are not persisted in the
-database and are computed using the specified expression every time they
-are referenced in a query.  The type of the property or link is determined
-from the expression.  Other than that, computables behave exactly like their
-non-computable counterparts.
+The values of computed properties and links are not persisted in the
+database and are computed using the specified expression every time
+they are referenced in a query.  The type of the property or link is
+determined from the expression.  Other than that, computed properties
+and links behave exactly like their static counterparts.
 
 Links and properties have a *source* and one or more *targets*.  The
 *source* is always the object on which the link is defined. *Targets*
 are either the objects to which the link points or the property
-values.  The computable expressions define one or more *targets* and
-can refer to the *source* as ``__source__``.
+values.  The expressions of computed links or properties define one or
+more *targets* and can refer to the *source* as ``__source__``.
 
 Computables are useful in the situations where there is a frequent need for
 some value that is derived from the values of existing properties and links.
 
 For example, here we define the ``User`` type to contain the
-``fullname`` computable property that is derived from user's first and
+``fullname`` computed property that is derived from user's first and
 last name:
 
 .. code-block:: sdl
@@ -36,7 +36,7 @@ last name:
              __source__.lastname);
     }
 
-If the computable expression is simple (i.e. not a subquery), shortcut
+If the computed expression is simple (i.e. not a subquery), shortcut
 paths may also be used instead of explicit references to ``__source__``:
 
 .. code-block:: sdl
@@ -50,7 +50,7 @@ paths may also be used instead of explicit references to ``__source__``:
 
 Computables are also often used in :ref:`aliases <ref_datamodel_aliases>`.
 For example, using the ``User`` from the above example, a ``UserAlias``
-can be defined with a ``lastname_first`` computable which lists the
+can be defined with a computed ``lastname_first`` which lists the
 full name in the format which is often used in formal alphabetized
 lists:
 

--- a/docs/datamodel/index.rst
+++ b/docs/datamodel/index.rst
@@ -18,7 +18,7 @@ Start putting your **Object Types** together with **properties** and
 **links**. Then build on them with items like **annotations** (readable
 notes for others), **constraints** to set limits (e.g. maximum length,
 minimum value, or even create your own), **indexes** for faster querying,
-and **computables** to use expressions to define properties or links
+and **computed** properties or links to define useful expressions
 (e.g. ``property email := .user_name ++ '@' ++ .provider_name``).
 
 **Expression Aliases** let you use existing types under new names to build

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -82,7 +82,7 @@ can be re-written like this:
 
     SELECT Person {
         name,
-        # let's use a computable here
+        # let's use a computed "shirts" expression here
         shirts := .<owner[IS Shirt] {
             description
         }
@@ -111,7 +111,7 @@ following schema:
     }
 
 It's possible to include both links ``owner`` and ``shirts`` to a
-schema, making one of them a :ref:`computable link
+schema, making one of them a :ref:`computed link
 <ref_datamodel_computables>` expressed in terms of the other.
 
 .. code-block:: sdl
@@ -120,7 +120,7 @@ schema, making one of them a :ref:`computable link
         required property name -> str {
             constraint exclusive;
         }
-        # A computable link used for convenience.
+        # A computed link used for convenience.
         multi link shirts := .<owner[IS Shirt];
     }
     type Shirt {
@@ -135,7 +135,7 @@ schema, making one of them a :ref:`computable link
 So fundamentally there's no difference in terms of the data for the
 two schemas specifying many-to-one or one-to-many relationship between
 ``Person`` and ``Shirt``. Nor is there any difference in terms of
-querying that data, because computable links can be added to the
+querying that data, because computed links can be added to the
 schema. Instead the difference is in how the data is modified or
 reasoned about. For example, expressing "Billie bought some yellow
 shirts" using the first and second version of the schema would look

--- a/docs/datamodel/objects.rst
+++ b/docs/datamodel/objects.rst
@@ -14,7 +14,7 @@ Every object has a globally unique *identity* represented by a ``UUID``
 value. An object's identity is assigned upon creation and never changes.
 Referring to its id property yields its identity as a
 :eql:type:`uuid` value.  Once set, the value of the ``id`` property
-cannot be changed or masked with a different :ref:`computable
+cannot be changed or masked with a different :ref:`computed
 <ref_datamodel_computables>` expression.
 
 Object types can *extend* other object types, in which case the

--- a/docs/edgeql/ddl/links.rst
+++ b/docs/edgeql/ddl/links.rst
@@ -64,7 +64,7 @@ a new concrete link for a given object type.
 There are three forms of ``CREATE LINK``, as shown in the syntax synopsis
 above.  The first form is the canonical definition form, the second
 form is a syntax shorthand for defining a
-:ref:`computable link <ref_datamodel_computables>`, and the third is a
+:ref:`computed link <ref_datamodel_computables>`, and the third is a
 form to define an abstract link item.  The abstract form allows creating
 the link in the specified :eql:synopsis:`<module>`.  Concrete link forms
 are always created in the same module as the containing object type.
@@ -126,9 +126,9 @@ Define a new link ``interests`` on the ``User`` object type:
         CREATE MULTI LINK friends -> User
     };
 
-Define a new link ``special_group`` as a
-:ref:`computable <ref_datamodel_computables>` on the ``User``
-object type, which contains all the friends from the same town:
+Define a new :ref:`computed link <ref_datamodel_computables>`
+``special_group`` on the ``User`` object type, which contains all the
+friends from the same town:
 
 .. code-block:: edgeql
 
@@ -194,7 +194,7 @@ Change the definition of a :ref:`link <ref_datamodel_links>`.
       RESET CARDINALITY
       SET TYPE <typename> [USING (<conversion-expr)]
       RESET TYPE
-      USING (<computable-expr>)
+      USING (<computed-expr>)
       CREATE ANNOTATION <annotation-name> := <value>
       ALTER ANNOTATION <annotation-name> := <value>
       DROP ANNOTATION <annotation-name>
@@ -287,9 +287,9 @@ The following subcommands are allowed in the ``ALTER LINK`` block:
     name in supertypes.  It is an error to ``RESET TYPE`` on a link that is
     not inherited.
 
-:eql:synopsis:`USING (<computable-expr>)`
-    Change the expression of a :ref:`computable <ref_datamodel_computables>`
-    link.  Only valid for concrete links.
+:eql:synopsis:`USING (<computed-expr>)`
+    Change the expression of a :ref:`computed link
+    <ref_datamodel_computables>`.  Only valid for concrete links.
 
 :eql:synopsis:`ALTER ANNOTATION <annotation-name>;`
     Alter link annotation :eql:synopsis:`<annotation-name>`.
@@ -349,7 +349,7 @@ Rename the abstract link ``orderable`` to ``sorted``:
 
     ALTER ABSTRACT LINK orderable RENAME TO sorted;
 
-Redefine the :ref:`computable <ref_datamodel_computables>` link
+Redefine the :ref:`computed link <ref_datamodel_computables>`
 ``special_group`` to be those who have some shared interests:
 
 .. code-block:: edgeql

--- a/docs/edgeql/ddl/props.rst
+++ b/docs/edgeql/ddl/props.rst
@@ -61,7 +61,7 @@ concrete property for a given object type or link.
 There are three forms of ``CREATE PROPERTY``, as shown in the syntax synopsis
 above.  The first form is the canonical definition form, the second
 form is a syntax shorthand for defining a
-:ref:`computable property <ref_datamodel_computables>`, and the third
+:ref:`computed property <ref_datamodel_computables>`, and the third
 is a form to define an abstract property item.  The abstract form
 allows creating the property in the specified
 :eql:synopsis:`<module>`.  Concrete property forms are always
@@ -108,9 +108,9 @@ Define a new link ``address`` on the ``User`` object type:
         CREATE PROPERTY address -> str
     };
 
-Define a new property ``number_of_connections`` as a
-:ref:`computable <ref_datamodel_computables>` on the ``User``
-object type counting the number of interests:
+Define a new :ref:`computed property <ref_datamodel_computables>`
+``number_of_connections`` on the ``User`` object type counting the
+number of interests:
 
 .. code-block:: edgeql
 
@@ -168,7 +168,7 @@ Change the definition of a :ref:`property <ref_datamodel_props>`.
       RESET CARDINALITY
       SET TYPE <typename> [USING (<conversion-expr)]
       RESET TYPE
-      USING (<computable-expr>)
+      USING (<computed-expr>)
       CREATE ANNOTATION <annotation-name> := <value>
       ALTER ANNOTATION <annotation-name> := <value>
       DROP ANNOTATION <annotation-name>
@@ -268,9 +268,9 @@ The following subcommands are allowed in the ``ALTER LINK`` block:
     of the same name in supertypes.  It is an error to ``RESET TYPE`` on
     a property that is not inherited.
 
-:eql:synopsis:`USING (<computable-expr>)`
-    Change the expression of a :ref:`computable <ref_datamodel_computables>`
-    property.  Only valid for concrete properties.
+:eql:synopsis:`USING (<computed-expr>)`
+    Change the expression of a :ref:`computed property
+    <ref_datamodel_computables>`.  Only valid for concrete properties.
 
 :eql:synopsis:`ALTER ANNOTATION <annotation-name>;`
     Alter property annotation :eql:synopsis:`<annotation-name>`.
@@ -333,7 +333,7 @@ Rename the property ``weight`` of link ``orderable`` to ``sort_by``:
         ALTER PROPERTY weight RENAME TO sort_by;
     };
 
-Redefine the :ref:`computable <ref_datamodel_computables>` property
+Redefine the :ref:`computed property <ref_datamodel_computables>`
 ``number_of_connections`` to be the number of friends:
 
 .. code-block:: edgeql

--- a/docs/edgeql/expressions/parameters.rst
+++ b/docs/edgeql/expressions/parameters.rst
@@ -149,7 +149,7 @@ When assigning the result of a similar query, you can see the following error:
     ... };
     Parameter <int32>$limit: 1
     error: possibly more than one element returned by an expression
-    for a computable property 'name' declared as 'single'
+    for a computed property 'name' declared as 'single'
        ┌── query:1:15 ───
        │
      2 │     name := (SELECT User.name ORDER BY .rating DESC

--- a/docs/edgeql/expressions/shapes.rst
+++ b/docs/edgeql/expressions/shapes.rst
@@ -36,7 +36,7 @@ the :eql:synopsis:`<expr>` set that are instances of
 - a name of an existing link or property of a type produced
   by :eql:synopsis:`<expr>`;
 
-- a declaration of a computable link or property in the form
+- a declaration of a computed link or property in the form
 
   .. eql:synopsis ::
 
@@ -119,9 +119,10 @@ Cardinality
 
 Typically the cardinality of an expression can be statically
 determined from the individual parts. Sometimes it is necessary to
-specify the cardinality explicitly. For example, when using
-computables in shapes it may be desirable to specify the cardinality
-of the computable because it affects serialization.
+specify the cardinality explicitly. For example, when using computed
+expressions in shapes it may be desirable to specify the cardinality
+of the computed link or property they represent because it affects
+serialization.
 
 .. code-block:: edgeql
 
@@ -134,7 +135,7 @@ of the computable because it affects serialization.
 
 Cardinality is normally statically inferred from the query, so
 overruling this inference may only be done to *relax* the cardinality,
-so it is not valid to specify the ``single`` qualifier for a computable
+so it is not valid to specify the ``single`` qualifier if the computed
 expression that may return multiple items.
 
 
@@ -176,7 +177,7 @@ shape annotation can be used to provide an alias for the link:
         }
     };
 
-When a simple path is used as the definition of a computable link,
+When a simple path is used as the definition of a computed link,
 that has the effect of aliasing the underlying link and thus
 preserving any link properties as well. For a path that has more than
 one step, it is always the *last* step that is aliased.

--- a/docs/edgeql/funcops/set.rst
+++ b/docs/edgeql/funcops/set.rst
@@ -284,11 +284,12 @@ Set
 
     Check that the input set contains no more than one element.
 
-    If the input set contains more than one element, ``assert_single`` raises
-    a ``CardinalityViolationError``.  This function is useful as a runtime
-    cardinality assertion in queries and computables that should always return
-    sets with at most a single element, but where static cardinality inference
-    is not capable enough or outright impossible.
+    If the input set contains more than one element, ``assert_single``
+    raises a ``CardinalityViolationError``.  This function is useful
+    as a runtime cardinality assertion in queries and computed
+    expressions that should always return sets with at most a single
+    element, but where static cardinality inference is not capable
+    enough or outright impossible.
 
     .. code-block:: edgeql-repl
 

--- a/docs/edgeql/funcops/type.rst
+++ b/docs/edgeql/funcops/type.rst
@@ -212,7 +212,7 @@ Types
                 Text[IS Issue].name IF Text IS Issue ELSE
                 <str>{},
                 # the cast to str is necessary here, because
-                # the type of the computable must be defined
+                # the type of the computed expression must be defined
             body,
         };
 
@@ -226,8 +226,8 @@ Types
             name,
             friends := <User>{}
             # the cast is the only way to indicate that the
-            # computable 'friends' is supposed to be a set of
-            # Users
+            # computed link 'friends' is supposed to refer to
+            # a set of Users
         };
 
 

--- a/docs/edgeql/overview.rst
+++ b/docs/edgeql/overview.rst
@@ -307,7 +307,7 @@ syntax can be used:
             # specific to User
             [IS User].avatar,
 
-            # a computable value tracking how many favorites
+            # a computed property tracking how many favorites
             # does my favorite User have?
             favorites_count := count(
                 # start the path at the root of the shape

--- a/docs/edgeql/sdl/aliases.rst
+++ b/docs/edgeql/sdl/aliases.rst
@@ -12,12 +12,12 @@ Example
 -------
 
 Declare a "UserAlias" that provides additional information for a "User"
-via a :ref:`computable link <ref_datamodel_computables>` "friend_of":
+via a :ref:`computed link <ref_datamodel_computables>` "friend_of":
 
 .. code-block:: sdl
 
     alias UserAlias := User {
-        # declare a computable link
+        # declare a computed link
         friend_of := User.<friends[IS User]
     };
 

--- a/docs/edgeql/sdl/links.rst
+++ b/docs/edgeql/sdl/links.rst
@@ -113,7 +113,7 @@ Description
 There are several forms of ``link`` declaration, as shown in the
 syntax synopsis above.  The first form is the canonical definition
 form, the second and third forms are used for defining a
-:ref:`computable link <ref_datamodel_computables>`, and the last one
+:ref:`computed link <ref_datamodel_computables>`, and the last one
 is a form to define an ``abstract link``.  The abstract form
 allows declaring the link directly inside a :ref:`module
 <ref_eql_sdl_modules>`.  Concrete link forms are always used as

--- a/docs/edgeql/sdl/props.rst
+++ b/docs/edgeql/sdl/props.rst
@@ -102,7 +102,7 @@ Description
 There are several forms of ``property`` declaration, as shown in the
 syntax synopsis above.  The first form is the canonical definition
 form, the second and third forms are used for defining a
-:ref:`computable property <ref_datamodel_computables>`, and the last
+:ref:`computed property <ref_datamodel_computables>`, and the last
 one is a form to define an ``abstract property``.  The abstract
 form allows declaring the property directly inside a :ref:`module
 <ref_eql_sdl_modules>`.  Concrete property forms are always used

--- a/docs/internals/protocol/messages.rst
+++ b/docs/internals/protocol/messages.rst
@@ -270,12 +270,12 @@ Known headers:
 
 * 0xFF02 ``IMPLICIT_TYPENAMES`` -- if set to "true" all returned objects have
   a ``__tname__`` property set to their type name (equivalent to having
-  an implicit "__tname__ := .__type__.name" computable.)  Note that specifying
-  this header might slow down queries.
+  an implicit "__tname__ := .__type__.name" computed property.)
+  Note that specifying this header might slow down queries.
 
 * 0xFF03 ``IMPLICIT_TYPEIDS`` -- if set to "true" all returned objects have
   a ``__tid__`` property set to their type ID (equivalent to having
-  an implicit "__tid__ := .__type__.id" computable.)
+  an implicit "__tid__ := .__type__.id" computed property.)
 
 * 0xFF04 ``ALLOW_CAPABILITIES``: ``uint64`` -- optional bitmask of
   capabilities allowed for this query.  See RFC1004_ for more information.
@@ -440,12 +440,12 @@ Known headers:
 
 * 0xFF02 ``IMPLICIT_TYPENAMES`` -- if set to "true" all returned objects have
   a ``__tname__`` property set to their type name (equivalent to having
-  an implicit "__tname__ := .__type__.name" computable.)  Note that specifying
-  this header might slow down queries.
+  an implicit "__tname__ := .__type__.name" computed property.)
+  Note that specifying this header might slow down queries.
 
 * 0xFF03 ``IMPLICIT_TYPEIDS`` -- if set to "true" all returned objects have
   a ``__tid__`` property set to their type ID (equivalent to having
-  an implicit "__tid__ := .__type__.id" computable.)
+  an implicit "__tid__ := .__type__.id" computed property.)
 
 * 0xFF04 ``ALLOW_CAPABILITIES``: ``uint64`` -- optional bitmask of
   capabilities allowed for this query.  See RFC1004_ for more information.

--- a/docs/tutorial/queries.rst
+++ b/docs/tutorial/queries.rst
@@ -159,7 +159,7 @@ Let's get more details about the ``Movie``:
     }
 
 Instead of listing the ``actors`` let's just count how many people are
-there in the ``actors`` by using a :ref:`computable
+there in the ``actors`` by using a :ref:`computed property
 <ref_datamodel_computables>`:
 
 .. code-block:: edgeql-repl
@@ -258,7 +258,7 @@ And we can update "Dune":
     {default::Movie {id: 4d0c8ddc-54d4-11e9-8c54-7776f6130e05}}
 
 For querying convenience let's update the schema so that a ``Person``
-will also have a :ref:`computable <ref_datamodel_computables>`
+will also have a :ref:`computed property <ref_datamodel_computables>`
 ``name`` that combines the ``first_name`` and ``last_name``
 properties. The new ``dbschema/schema.esdl`` should look like
 this:

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -165,7 +165,7 @@ def compile_FunctionCall(
             # DML is not allowed in the computable, but it may
             # be possible to refactor it.
             raise errors.QueryError(
-                f'mutations are invalid in a shape computable',
+                f"mutations are invalid in a shape's computed expression",
                 hint=(
                     f'To resolve this try to factor out the mutation '
                     f'expression into the top-level WITH block.'

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -437,7 +437,7 @@ def _infer_pointer_cardinality(
                 else:
                     raise errors.QueryError(
                         f'possibly an empty set returned by an '
-                        f'expression for a computable '
+                        f'expression for a computed '
                         f'{ptrcls.get_verbosename(env.schema)} '
                         f"declared as 'required'",
                         context=source_ctx
@@ -445,7 +445,7 @@ def _infer_pointer_cardinality(
             else:
                 raise errors.QueryError(
                     f'possibly more than one element returned by an '
-                    f'expression for a computable '
+                    f'expression for a computed '
                     f'{ptrcls.get_verbosename(env.schema)} '
                     f"declared as 'single'",
                     context=source_ctx

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -146,10 +146,10 @@ def _infer_shape(
             if expr_mult is MANY and irtyputils.is_object(ptrref.out_target):
                 raise errors.QueryError(
                     f'possibly not a strict set returned by an '
-                    f'expression for a computable '
+                    f'expression for a computed '
                     f'{ptrref.shortname.name}.',
                     hint=(
-                        f'Use DISTINCT for the entire computable expression '
+                        f'Use DISTINCT for the entire computed expression '
                         f'to resolve this.'
                     ),
                     context=shape_set.context

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -680,7 +680,7 @@ def resolve_ptr(
                                                 with_parent=True)
                     raise errors.InvalidReferenceError(
                         f'cannot follow backlink {pointer_name!r} because '
-                        f'{vname} is computable',
+                        f'{vname} is computed',
                         context=source_context
                     )
 
@@ -1240,7 +1240,7 @@ def computable_ptr_set(
             if comp_expr is None:
                 ptrcls_sn = ptrcls.get_shortname(ctx.env.schema)
                 raise errors.InternalServerError(
-                    f'{ptrcls_sn!r} is not a computable pointer')
+                    f'{ptrcls_sn!r} is not a computed pointer')
 
             comp_qlexpr = qlparser.parse(comp_expr.text)
             assert isinstance(comp_qlexpr, qlast.Expr), 'expected qlast.Expr'

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1105,7 +1105,7 @@ def init_stmt(
             # DML is not allowed in the computable, but it may
             # be possible to refactor it.
             raise errors.QueryError(
-                f'mutations are invalid in a shape computable',
+                f"mutations are invalid in a shape's computed expression",
                 hint=(
                     f'To resolve this try to factor out the mutation '
                     f'expression into the top-level WITH block.'

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1385,13 +1385,13 @@ class CreateConcretePropertyStmt(Nonterm):
             if isinstance(cmd, qlast.SetField) and cmd.name == 'expr':
                 if target is not None:
                     raise EdgeQLSyntaxError(
-                        f'computable property with more than one expression',
+                        f'computed property with more than one expression',
                         context=kids[3].context)
                 target = cmd.value
 
         if target is None:
             raise EdgeQLSyntaxError(
-                f'computable property without expression',
+                f'computed property without expression',
                 context=kids[3].context)
 
         self.val = qlast.CreateConcreteProperty(
@@ -1684,13 +1684,13 @@ class CreateConcreteLinkStmt(Nonterm):
             if isinstance(cmd, qlast.SetField) and cmd.name == 'expr':
                 if target is not None:
                     raise EdgeQLSyntaxError(
-                        f'computable link with more than one expression',
+                        f'computed link with more than one expression',
                         context=kids[3].context)
                 target = cmd.value
 
         if target is None:
             raise EdgeQLSyntaxError(
-                f'computable link without expression',
+                f'computed link without expression',
                 context=kids[3].context)
 
         self.val = qlast.CreateConcreteLink(

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -620,13 +620,13 @@ class ConcretePropertyBlock(Nonterm):
             if isinstance(cmd, qlast.SetField) and cmd.name == 'expr':
                 if target is not None:
                     raise errors.EdgeQLSyntaxError(
-                        f'computable property with more than one expression',
+                        f'computed property with more than one expression',
                         context=context)
                 target = cmd.value
 
         if not overloaded and target is None:
             raise errors.EdgeQLSyntaxError(
-                f'computable property without expression',
+                f'computed property without expression',
                 context=context)
 
         return target, cmds
@@ -810,13 +810,13 @@ class ConcreteLinkBlock(Nonterm):
             if isinstance(cmd, qlast.SetField) and cmd.name == 'expr':
                 if target is not None:
                     raise errors.EdgeQLSyntaxError(
-                        f'computable link with more than one expression',
+                        f'computed link with more than one expression',
                         context=context)
                 target = cmd.value
 
         if not overloaded and target is None:
             raise errors.EdgeQLSyntaxError(
-                f'computable link without expression',
+                f'computed link without expression',
                 context=context)
 
         return target, cmds

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -159,7 +159,7 @@ class AliasCommand(
             srcctx = self.get_attribute_source_context('expr')
             raise errors.SchemaDefinitionError(
                 f'volatile functions are not permitted in schema-defined '
-                f'computables',
+                f'computed expressions',
                 context=srcctx
             )
 
@@ -376,7 +376,7 @@ def compile_alias_expr(
     if ir.volatility == qltypes.Volatility.Volatile:
         raise errors.SchemaDefinitionError(
             f'volatile functions are not permitted in schema-defined '
-            f'computables',
+            f'computed expressions',
             context=parser_context,
         )
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1170,7 +1170,7 @@ class PointerCommandOrFragment(
                 srcctx = self.get_attribute_source_context('target')
                 raise errors.SchemaDefinitionError(
                     f'the type inferred from the expression '
-                    f'of the computable {ptr_name} '
+                    f'of the computed {ptr_name} '
                     f'is {inferred_target_type.get_verbosename(mschema)}, '
                     f'which does not match the explicitly specified '
                     f'{spec_target_type.get_verbosename(schema)}',
@@ -1181,7 +1181,7 @@ class PointerCommandOrFragment(
             srcctx = self.get_attribute_source_context('target')
             raise errors.SchemaDefinitionError(
                 f'possibly an empty set returned by an '
-                f'expression for the computable '
+                f'expression for the computed '
                 f'{ptr_name} '
                 f"explicitly declared as 'required'",
                 context=srcctx
@@ -1194,7 +1194,7 @@ class PointerCommandOrFragment(
             srcctx = self.get_attribute_source_context('target')
             raise errors.SchemaDefinitionError(
                 f'possibly more than one element returned by an '
-                f'expression for the computable '
+                f'expression for the computed '
                 f'{ptr_name} '
                 f"explicitly declared as 'single'",
                 context=srcctx
@@ -1213,7 +1213,7 @@ class PointerCommandOrFragment(
             srcctx = self.get_attribute_source_context('target')
             raise errors.SchemaDefinitionError(
                 f'volatile functions are not permitted in schema-defined '
-                f'computables',
+                f'computed expressions',
                 context=srcctx
             )
 
@@ -1323,7 +1323,7 @@ class PointerCommandOrFragment(
             ptr_name = self.get_verbosename(parent=parent_vname)
             in_ddl_context_name = None
             if field.name == 'expr':
-                in_ddl_context_name = f'computable {ptr_name}'
+                in_ddl_context_name = f'computed {ptr_name}'
 
             return self._compile_expr(
                 schema,
@@ -1415,7 +1415,7 @@ class PointerCommand(
         if is_computable and is_owned:
             # Overloading with a computable
             raise errors.SchemaDefinitionError(
-                f'it is illegal for the computable '
+                f'it is illegal for the computed '
                 f'{scls.get_verbosename(schema, with_parent=True)} '
                 f'to overload an existing '
                 f'{scls.get_schema_class_displayname()}',
@@ -1426,7 +1426,7 @@ class PointerCommand(
                 raise errors.SchemaDefinitionError(
                     f'it is illegal for the '
                     f'{scls.get_verbosename(schema, with_parent=True)} '
-                    f'to extend both a computable and a non-computable '
+                    f'to extend both a computed and a non-computed '
                     f'{scls.get_schema_class_displayname()}',
                     context=self.source_context,
                 )
@@ -1434,7 +1434,7 @@ class PointerCommand(
                 raise errors.SchemaDefinitionError(
                     f'it is illegal for the '
                     f'{scls.get_verbosename(schema, with_parent=True)} '
-                    f'to extend more than one computable '
+                    f'to extend more than one computed '
                     f'{scls.get_schema_class_displayname()}',
                     context=self.source_context,
                 )
@@ -2663,7 +2663,7 @@ def get_or_create_union_pointer(
         p = components[0]
         raise errors.SchemaError(
             f'it is illegal to create a type union that causes '
-            f'a computable {p.get_verbosename(schema)} to mix '
+            f'a computed {p.get_verbosename(schema)} to mix '
             f'with other versions of the same {p.get_verbosename(schema)}',
         )
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -8866,7 +8866,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.QueryError,
             "it is illegal to create a type union that causes a "
-            "computable property 'deleted' to mix with other versions of the "
+            "computed property 'deleted' to mix with other versions of the "
             "same property 'deleted'"
         ):
             await self.migrate('''

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3010,7 +3010,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_bad_07(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
-                r"mutations are invalid in computable link 'foo'"):
+                r"mutations are invalid in computed link 'foo'"):
             async with self.con.transaction():
                 await self.con.execute(r"""
                     CREATE TYPE Foo;
@@ -3023,7 +3023,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_bad_08(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
-                r"mutations are invalid in computable link 'foo'"):
+                r"mutations are invalid in computed link 'foo'"):
             async with self.con.transaction():
                 await self.con.execute(r"""
                     CREATE TYPE Foo;
@@ -3039,7 +3039,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_bad_09(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
-                r"mutations are invalid in computable property 'foo'"):
+                r"mutations are invalid in computed property 'foo'"):
             async with self.con.transaction():
                 await self.con.execute(r"""
                     CREATE TYPE Foo;
@@ -8634,7 +8634,7 @@ type default::Foo {
     async def test_edgeql_ddl_prop_overload_01(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
-                "it is illegal for the computable property 'val' "
+                "it is illegal for the computed property 'val' "
                 "of object type 'default::UniqueName_2' to overload "
                 "an existing property"):
             await self.con.execute("""
@@ -8651,7 +8651,7 @@ type default::Foo {
     async def test_edgeql_ddl_prop_overload_02(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
-                "it is illegal for the computable property 'val' "
+                "it is illegal for the computed property 'val' "
                 "of object type 'default::UniqueName_2' to overload "
                 "an existing property"):
             await self.con.execute("""
@@ -8669,8 +8669,8 @@ type default::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "it is illegal for the property 'val' of object "
-                "type 'default::UniqueName_3' to extend both a computable "
-                "and a non-computable property"):
+                "type 'default::UniqueName_3' to extend both a computed "
+                "and a non-computed property"):
             await self.con.execute("""
                 CREATE TYPE UniqueName {
                     CREATE PROPERTY val := 'ok';
@@ -8686,7 +8686,7 @@ type default::Foo {
                 edgedb.SchemaDefinitionError,
                 "it is illegal for the property 'val' of object "
                 "type 'default::UniqueName_3' to extend more than one "
-                "computable property"):
+                "computed property"):
             await self.con.execute("""
                 CREATE TYPE UniqueName {
                     CREATE PROPERTY val := 'ok';
@@ -8711,8 +8711,8 @@ type default::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "it is illegal for the property 'val' of object "
-                "type 'default::UniqueName_3' to extend both a computable "
-                "and a non-computable property"):
+                "type 'default::UniqueName_3' to extend both a computed "
+                "and a non-computed property"):
             await self.con.execute("""
                 ALTER TYPE UniqueName {
                     ALTER PROPERTY val {
@@ -8738,8 +8738,8 @@ type default::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "it is illegal for the property 'val' of object "
-                "type 'default::UniqueName_4' to extend both a computable "
-                "and a non-computable property"):
+                "type 'default::UniqueName_4' to extend both a computed "
+                "and a non-computed property"):
             await self.con.execute("""
                 ALTER TYPE UniqueName_4 EXTENDING UniqueName_3;
             """)
@@ -8759,8 +8759,8 @@ type default::Foo {
         with self.assertRaisesRegex(
                 edgedb.SchemaDefinitionError,
                 "it is illegal for the property 'val' of object "
-                "type 'default::UniqueName_4' to extend both a computable "
-                "and a non-computable property"):
+                "type 'default::UniqueName_4' to extend both a computed "
+                "and a non-computed property"):
             await self.con.execute("""
                 ALTER TYPE UniqueName_3 EXTENDING UniqueName_2;
             """)
@@ -11009,7 +11009,7 @@ type default::Foo {
         async with self.assertRaisesRegexTx(
             edgedb.QueryError,
             "volatile functions are not permitted in schema-defined "
-            "computables",
+            "computed expressions",
         ):
             await self.con.execute("""
                 CREATE TYPE Foo {
@@ -11020,7 +11020,7 @@ type default::Foo {
         async with self.assertRaisesRegexTx(
             edgedb.QueryError,
             "volatile functions are not permitted in schema-defined "
-            "computables",
+            "computed expressions",
         ):
             await self.con.execute("""
                 CREATE TYPE Foo {
@@ -11033,7 +11033,7 @@ type default::Foo {
         async with self.assertRaisesRegexTx(
             edgedb.QueryError,
             "volatile functions are not permitted in schema-defined "
-            "computables",
+            "computed expressions",
         ):
             await self.con.execute("""
                 CREATE TYPE Noob {
@@ -11047,7 +11047,7 @@ type default::Foo {
         async with self.assertRaisesRegexTx(
             edgedb.QueryError,
             "volatile functions are not permitted in schema-defined "
-            "computables",
+            "computed expressions",
         ):
             await self.con.execute("""
                 CREATE TYPE Noob {
@@ -11060,7 +11060,7 @@ type default::Foo {
         async with self.assertRaisesRegexTx(
             edgedb.QueryError,
             "volatile functions are not permitted in schema-defined "
-            "computables",
+            "computed expressions",
         ):
             await self.con.execute("""
                 CREATE ALIAS Asdf := Object { foo := random() };

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2248,7 +2248,7 @@ class TestInsert(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.QueryError,
                 "possibly more than one element returned by an expression "
-                "for a computable link 'foo' declared as 'single'"):
+                "for a computed link 'foo' declared as 'single'"):
             await self.con.query(r'''
                 WITH X := (
                         INSERT Person {name := "hello"}
@@ -2263,7 +2263,7 @@ class TestInsert(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.QueryError,
                 "possibly more than one element returned by an expression "
-                "for a computable link 'foo' declared as 'single'"):
+                "for a computed link 'foo' declared as 'single'"):
             await self.con.query(r'''
                 WITH X := (
                         INSERT Person {name := "hello"}
@@ -2278,7 +2278,7 @@ class TestInsert(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.QueryError,
                 "possibly an empty set returned by an expression for a "
-                "computable link 'foo' declared as 'required'"):
+                "computed link 'foo' declared as 'required'"):
             await self.con.query(r'''
                 WITH X := (
                         INSERT Person {name := "hello"}
@@ -2837,7 +2837,7 @@ class TestInsert(tb.QueryTestCase):
     async def test_edgeql_insert_dependent_07(self):
         async with self.assertRaisesRegexTx(
                 edgedb.QueryError,
-                "mutations are invalid in a shape computable"):
+                "mutations are invalid in a shape's computed expression"):
             await self.con.execute(
                 r"""
                     SELECT Person {

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -571,7 +571,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         """
 
     @tb.must_fail(errors.QueryError,
-                  r"possibly not a strict set.+computable bad_link",
+                  r"possibly not a strict set.+computed bad_link",
                   line=3, col=13)
     def test_edgeql_ir_mult_inference_error_01(self):
         """
@@ -582,7 +582,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         """
 
     @tb.must_fail(errors.QueryError,
-                  r"possibly not a strict set.+computable bad_link",
+                  r"possibly not a strict set.+computed bad_link",
                   line=5, col=13)
     def test_edgeql_ir_mult_inference_error_02(self):
         """

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -420,7 +420,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r"possibly more than one element returned by an expression "
-                r"for a computable property 'foo' declared as 'single'",
+                r"for a computed property 'foo' declared as 'single'",
                 _position=166):
             await self.con.query("""\
                 SELECT Issue{
@@ -455,7 +455,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r"possibly more than one element returned by an expression "
-                r"for a computable property 'foo' declared as 'single'",
+                r"for a computed property 'foo' declared as 'single'",
                 _position=215):
             await self.con.query("""\
                 WITH
@@ -542,7 +542,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
-                r"a computable property 'foo' declared as 'required'",
+                r"a computed property 'foo' declared as 'required'",
                 _position=78):
             await self.con.query("""\
                 SELECT Issue{
@@ -556,7 +556,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
-                r"a computable property 'foo' declared as 'required'",
+                r"a computed property 'foo' declared as 'required'",
                 _position=78):
             await self.con.query("""\
                 SELECT Issue{
@@ -570,7 +570,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
-                r"a computable property 'foo' declared as 'required'",
+                r"a computed property 'foo' declared as 'required'",
                 _position=78):
             await self.con.query("""\
                 SELECT Issue{
@@ -584,7 +584,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r"possibly more than one element returned by an expression "
-                r"for a computable property 'foo' declared as 'single'",
+                r"for a computed property 'foo' declared as 'single'",
                 _position=78):
             await self.con.query("""\
                 SELECT Issue{
@@ -598,7 +598,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
-                r"a computable property 'foo' declared as 'required'",
+                r"a computed property 'foo' declared as 'required'",
                 _position=78):
             await self.con.query("""\
                 SELECT Issue{
@@ -612,7 +612,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
-                r"a computable property 'foo' declared as 'required'",
+                r"a computed property 'foo' declared as 'required'",
                 _position=78):
             await self.con.query("""\
                 SELECT Issue{
@@ -626,7 +626,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
-                r"a computable property 'foo' declared as 'required'",
+                r"a computed property 'foo' declared as 'required'",
                 _position=78):
             await self.con.query("""\
                 SELECT Issue{
@@ -671,7 +671,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r"possibly an empty set returned by an expression for "
-                r"a computable link 'foo' declared as 'required'",
+                r"a computed link 'foo' declared as 'required'",
                 _position=78):
             await self.con.query("""\
                 SELECT Issue{
@@ -1993,7 +1993,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             "possibly more than one element returned by an expression for a "
-            "computable link 'priority' declared as 'single'",
+            "computed link 'priority' declared as 'single'",
             _position=52,
         ):
             await self.con.execute("""
@@ -2032,7 +2032,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             "possibly an empty set returned by an expression for a "
-            "computable link 'owner' declared as 'required'",
+            "computed link 'owner' declared as 'required'",
             _position=52,
         ):
             await self.con.execute("""
@@ -2445,7 +2445,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.SchemaError,
             "it is illegal to create a type union that causes "
-            "a computable property 'number' to mix with other "
+            "a computed property 'number' to mix with other "
             "versions of the same property 'number'"
         ):
             await self.con.execute(
@@ -2460,7 +2460,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.SchemaError,
             "it is illegal to create a type union that causes "
-            "a computable property 'number' to mix with other "
+            "a computed property 'number' to mix with other "
             "versions of the same property 'number'"
         ):
             await self.con.execute(
@@ -6056,7 +6056,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
             edgedb.QueryError,
             "it is illegal to create a type union that causes a "
-            "computable property 'z' to mix with other versions of the "
+            "computed property 'z' to mix with other versions of the "
             "same property 'z'"
         ):
             await self.con.execute("""

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -2060,7 +2060,7 @@ class TestUpdate(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             "possibly more than one element returned by an expression"
-            " for a computable link 'annotated_status' declared as 'single'",
+            " for a computed link 'annotated_status' declared as 'single'",
             _position=114,
         ):
             await self.con.execute("""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -88,7 +88,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
         """
 
     @tb.must_fail(errors.SchemaDefinitionError,
-                  "it is illegal for the computable property 'val' "
+                  "it is illegal for the computed property 'val' "
                   "of object type 'test::UniqueName_2' to overload "
                   "an existing property")
     def test_schema_overloaded_prop_04(self):
@@ -106,7 +106,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
         """
 
     @tb.must_fail(errors.SchemaDefinitionError,
-                  "it is illegal for the computable property 'val' "
+                  "it is illegal for the computed property 'val' "
                   "of object type 'test::UniqueName_2' to overload "
                   "an existing property")
     def test_schema_overloaded_prop_05(self):
@@ -125,8 +125,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.SchemaDefinitionError,
                   "it is illegal for the property 'val' of object "
-                  "type 'test::UniqueName_3' to extend both a computable "
-                  "and a non-computable property")
+                  "type 'test::UniqueName_3' to extend both a computed "
+                  "and a non-computed property")
     def test_schema_overloaded_prop_06(self):
         """
             type UniqueName {
@@ -141,7 +141,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
     @tb.must_fail(errors.SchemaDefinitionError,
                   "it is illegal for the property 'val' of object "
                   "type 'test::UniqueName_3' to extend more than one "
-                  "computable property")
+                  "computed property")
     def test_schema_overloaded_prop_07(self):
         """
             type UniqueName {
@@ -157,8 +157,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.SchemaDefinitionError,
                   "it is illegal for the property 'val' of object "
-                  "type 'test::UniqueName_4' to extend both a computable "
-                  "and a non-computable property")
+                  "type 'test::UniqueName_4' to extend both a computed "
+                  "and a non-computed property")
     def test_schema_overloaded_prop_08(self):
         """
             type UniqueName {
@@ -173,7 +173,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.SchemaError,
                   "it is illegal to create a type union that causes "
-                  "a computable property 'val' to mix with other "
+                  "a computed property 'val' to mix with other "
                   "versions of the same property 'val'")
     def test_schema_overloaded_prop_09(self):
         # Overloading implicitly via a type UNION.
@@ -189,7 +189,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.SchemaError,
                   "it is illegal to create a type union that causes "
-                  "a computable property 'val' to mix with other "
+                  "a computed property 'val' to mix with other "
                   "versions of the same property 'val'")
     def test_schema_overloaded_prop_10(self):
         # Overloading implicitly via a type UNION.
@@ -206,7 +206,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
         """
 
     @tb.must_fail(errors.SchemaDefinitionError,
-                  "it is illegal for the computable link 'foo' "
+                  "it is illegal for the computed link 'foo' "
                   "of object type 'test::UniqueName_2' to overload "
                   "an existing link")
     def test_schema_overloaded_link_01(self):
@@ -223,7 +223,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
         """
 
     @tb.must_fail(errors.SchemaDefinitionError,
-                  "it is illegal for the computable link 'foo' "
+                  "it is illegal for the computed link 'foo' "
                   "of object type 'test::UniqueName_2' to overload "
                   "an existing link")
     def test_schema_overloaded_link_02(self):
@@ -243,8 +243,8 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.SchemaDefinitionError,
                   "it is illegal for the link 'foo' of object "
-                  "type 'test::UniqueName_3' to extend both a computable "
-                  "and a non-computable link")
+                  "type 'test::UniqueName_3' to extend both a computed "
+                  "and a non-computed link")
     def test_schema_overloaded_link_03(self):
         """
             type Foo;
@@ -260,7 +260,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
     @tb.must_fail(errors.SchemaDefinitionError,
                   "it is illegal for the link 'foo' of object "
                   "type 'test::UniqueName_3' to extend more than one "
-                  "computable link")
+                  "computed link")
     def test_schema_overloaded_link_04(self):
         """
             type Foo;
@@ -481,7 +481,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.SchemaDefinitionError,
                   "possibly more than one element returned by an expression "
-                  "for the computable link 'ham' of object type 'test::Spam' "
+                  "for the computed link 'ham' of object type 'test::Spam' "
                   "explicitly declared as 'single'",
                   line=5, col=36)
     def test_schema_computable_cardinality_inference_03(self):
@@ -495,7 +495,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.SchemaDefinitionError,
                   "possibly more than one element returned by an expression "
-                  "for the computable property 'hams' of object type "
+                  "for the computed property 'hams' of object type "
                   "'test::Spam' explicitly declared as 'single'",
                   line=5, col=41)
     def test_schema_computable_cardinality_inference_04(self):
@@ -509,7 +509,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(errors.SchemaDefinitionError,
                   "possibly an empty set returned by an expression for "
-                  "the computable property 'hams' of object type "
+                  "the computed property 'hams' of object type "
                   "'test::Spam' explicitly declared as 'required'",
                   line=5, col=43)
     def test_schema_computable_cardinality_inference_05(self):
@@ -559,7 +559,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.SchemaDefinitionError,
-        "the type inferred from the expression of the computable property "
+        "the type inferred from the expression of the computed property "
         "'title' of object type 'test::A' is scalar type 'std::int64', "
         "which does not match the explicitly specified scalar type 'std::str'",
         line=3, col=35)
@@ -574,7 +574,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.SchemaDefinitionError,
-        "the type inferred from the expression of the computable property "
+        "the type inferred from the expression of the computed property "
         "'title' of object type 'test::A' is collection "
         "'tuple<std::int64, std::int64>', which does not match the explicitly "
         "specified collection 'tuple<std::str, std::str>'",
@@ -590,7 +590,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.SchemaDefinitionError,
-        "the type inferred from the expression of the computable link "
+        "the type inferred from the expression of the computed link "
         "'foo' of object type 'test::C' is object type 'test::B', "
         "which does not match the explicitly specified object type 'test::A'",
         line=6, col=29)
@@ -2689,7 +2689,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         # the real error.
         with self.assertRaisesRegex(
             errors.SchemaDefinitionError,
-            "mutations are invalid in computable property 'comp'"
+            "mutations are invalid in computed property 'comp'"
         ):
             schema = r'''
             type Foo {
@@ -2717,7 +2717,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         # the real error.
         with self.assertRaisesRegex(
             errors.SchemaDefinitionError,
-            "mutations are invalid in computable property 'comp'"
+            "mutations are invalid in computed property 'comp'"
         ):
             schema = r'''
             type Foo {
@@ -6377,7 +6377,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         with self.assertRaisesRegex(
             errors.QueryError,
             "it is illegal to create a type union that causes a "
-            "computable property 'deleted' to mix with other versions of the "
+            "computed property 'deleted' to mix with other versions of the "
             "same property 'deleted'"
         ):
             self._assert_migration_equivalence([r"""


### PR DESCRIPTION
The "computed" link or property is a little more straightforward name
for the comcept. The link or property are indeed computed by an
expression as opposed to being statically defined. It also appears that
this term is used to denote similar concepts elsewhere and thus will be
easier to search for and understand.

Update the docs, error messages and tests.