### PR TITLE
Adopts "backlink" instead of "backward link" in docs.

### DIFF
--- a/docs/cheatsheet/aliases.rst
+++ b/docs/cheatsheet/aliases.rst
@@ -28,8 +28,8 @@ properties, this is a way of flattening a nested structure:
 ----------
 
 
-Define an alias for traversing a link backwards, this is especially
-useful for GraphQL access:
+Define an alias for traversing a :ref:`backlink
+<ref_datamodel_links>`, this is especially useful for GraphQL access:
 
 .. code-block:: sdl
 
@@ -41,9 +41,9 @@ useful for GraphQL access:
 
 .. note::
 
-    Aliases allow to use the full power of EdgeQL (expressions, aggregate
-    functions, backwards link navigation) from :ref:`GraphQL
-    <ref_graphql_index>`.
+    Aliases allow to use the full power of EdgeQL (expressions,
+    aggregate functions, :ref:`backlink <ref_datamodel_links>`
+    navigation) from :ref:`GraphQL <ref_graphql_index>`.
 
 The aliases defined above allow you to query ``MovieAlias`` with
 :ref:`GraphQL <ref_cheatsheet_graphql>`.

--- a/docs/cookbook/links.rst
+++ b/docs/cookbook/links.rst
@@ -4,9 +4,10 @@
 Links
 =====
 
-Links define a specific relationship between two object types.
-Links have a direction, but can be traversed in both ways forward and
-:ref:`backward <ref_cookbook_links_bw>`.
+Links define a specific relationship between two object types. Links
+have a direction, and when traversed in the opposite direction from
+how they are defined they are called :ref:`backlinks
+<ref_cookbook_links_bw>`.
 
 
 Movie Example
@@ -66,8 +67,8 @@ You can find more information on aggregates in the
 
 .. _ref_cookbook_links_bw:
 
-Backward Links
---------------
+Backlinks
+---------
 
 In the movie example above, we have only shown a forward link traversal:
 
@@ -104,7 +105,7 @@ need to alias the field with ``:=``:
         }
     }}
 
-To find all movies that a person is starred in we use a **backward link**
+To find all movies that a person is starred in we use a *backlink*
 traversal ``.<`` operator:
 
 .. code-block:: edgeql-repl
@@ -121,12 +122,13 @@ traversal ``.<`` operator:
     }}
 
 You might also note that we've added ``[IS Movie]``, which we call
-:eql:op:`type intersection <ISINTERSECT>` operator. This is how backward link
-traversal works: EdgeDB fetches every object in the entire database having the
-field ``actors`` which is a ``Person``. So we narrow down the set of objects to
-``Movie`` and select a title from it.
+:eql:op:`type intersection <ISINTERSECT>` operator. This is how
+*backlink* traversal works: EdgeDB fetches every object in the
+entire database having the field ``actors`` which is a ``Person``.
+So we narrow down the set of objects to ``Movie`` and select a
+title from it.
 
-All other tools work on backward link:
+All other tools work on *backlink*:
 
 .. code-block:: edgeql-repl
 
@@ -175,7 +177,7 @@ himself. To fix it we can add a filter:
     .........     ),
     ......... } FILTER .first_name = 'Ryan';
 
-Note: we wrapped a backward link access by ``SELECT`` subquery to add a filter.
+Note: we wrapped a *backlink* access by ``SELECT`` subquery to add a filter.
 
 The last query can be rewritten in a nicer way using an alias:
 

--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -200,7 +200,8 @@ The standard library defines the following constraints:
 
     * The expression can only contain references to the immediate
       properties or links of the type.
-    * No backward links or long paths are allowed.
+    * No :ref:`backlinks <ref_datamodel_links>` or long paths are
+      allowed.
     * Only ``Immutable`` functions are allowed in the constraint
       expression.
 

--- a/docs/datamodel/links.rst
+++ b/docs/datamodel/links.rst
@@ -29,6 +29,10 @@ same target via the :eql:constraint:`exclusive` constraint. Using
 these tools it's possible to specify common relationships between
 things: *many-to-one*, *one-to-one*, and *many-to-many*.
 
+It is possible to think of any link as going backwards from *target*
+to *source*. This is referred to as a *backlink* and we use the ``.<``
+:ref:`syntax <ref_eql_expr_paths>` to denote it.
+
 
 Many-to-One
 -----------
@@ -70,10 +74,9 @@ the following query:
     }
     FILTER .owner.name = 'Billie';
 
-It is possible to traverse any link backwards. When a *many-to-one*
-link is traversed backwards, the result represents a *one-to-many*
-relationship instead. For example, the previous query can be
-re-written like this:
+When a *many-to-one* link is treated as a *backlink* it becomes a
+*one-to-many* relationship instead. For example, the previous query
+can be re-written like this:
 
 .. code-block:: edgeql
 
@@ -203,7 +206,7 @@ either end. To get the assigned ``ReservedParking`` given an
     };
 
 The reverse lookup of who owns a particular ``ReservedParking`` spot
-can be done by using a backward link traversal like so:
+can be done by using a *backlink* traversal like so:
 
 .. code-block:: edgeql
 
@@ -214,8 +217,9 @@ can be done by using a backward link traversal like so:
         name
     };
 
-Backward link traversal requires to specify the original link's source
-type, but other than that it works the same way as forward traversal.
+In practice, *backlink* traversal requires to specify the original
+link's source type, but other than that it works the same way as
+forward traversal.
 
 
 Many-to-Many
@@ -242,9 +246,9 @@ relationship without any exclusivity. For example, ``Person`` and
 A ``Person`` can like multiple movies and each ``Movie`` can be liked
 by multiple people, thus making ``likes`` a *many-to-many*
 relationship. This type of relationship has the same symmetry as a
-*one-to-one* w.r.t. link traversal forward and backward, except that
-potentially multiple objects can reached in either direction. Here's
-the query for getting every ``Movie`` a given ``Person`` likes:
+*one-to-one* w.r.t. regular link and *backlink* traversal, except that
+potentially multiple objects can be reached in either direction.
+Here's the query for getting every ``Movie`` a given ``Person`` likes:
 
 .. code-block:: edgeql
 
@@ -255,7 +259,7 @@ the query for getting every ``Movie`` a given ``Person`` likes:
         title
     };
 
-The reverse lookup of who likes a particular ``Movie``:
+The *backlink* lookup of who likes a particular ``Movie``:
 
 .. code-block:: edgeql
 

--- a/docs/edgeql/expressions/paths.rst
+++ b/docs/edgeql/expressions/paths.rst
@@ -34,8 +34,9 @@ The individual path components are:
 :eql:synopsis:`<step-direction>`
     It can be one of the following:
 
-    - ``.`` for an outgoing or "forward" link reference
-    - ``.<`` for an incoming or "backward" link reference
+    - ``.`` for an outgoing link reference
+    - ``.<`` for an incoming or :ref:`backlink <ref_datamodel_links>`
+      reference
     - ``@`` for a link property reference
 
 :eql:synopsis:`<pointer-name>`
@@ -74,7 +75,7 @@ And this represents all sources of the ``owner`` links that have a
 
     SELECT User.<owner;
 
-By default backward links don't infer any type information beyond the
+By default *backlinks* don't infer any type information beyond the
 fact that it's an :eql:type:`Object`. To ensure that this path
 specifically reaches ``Issue`` a :eql:op:`type intersection <ISINTERSECT>`
 operator must be used:

--- a/docs/edgeql/funcops/set.rst
+++ b/docs/edgeql/funcops/set.rst
@@ -232,7 +232,7 @@ Set
     guarantees the type of the result set, all the links and properties
     associated with the specified type can now be used on the
     resulting expression. This is especially useful in combination
-    with :ref:`backward links <ref_eql_expr_paths>`.
+    with :ref:`backlinks <ref_datamodel_links>`.
 
     Consider the following types:
 
@@ -261,10 +261,10 @@ Set
 
         SELECT User.<owner;
 
-    By default backward links don't infer any type information beyond the
-    fact that it's an :eql:type:`Object`. To ensure that this path
-    specifically reaches ``Issue`` the type intersection operator must
-    be used:
+    By default :ref:`backlinks <ref_datamodel_links>` don't infer any
+    type information beyond the fact that it's an :eql:type:`Object`.
+    To ensure that this path specifically reaches ``Issue`` the type
+    intersection operator must be used:
 
     .. code-block:: edgeql
 


### PR DESCRIPTION
The term "backlink" is shorter and seems clearer than "backward link"
(which is inaccurate as all links are definitionally "forward") or
"backward link traversal".

The term "backlink", much like "link" can refer to the relational
connection between objects as well as to the syntax denoting the
traversal.