### PR TITLE
Add a debug flag to emit EdgeQL text being compiled

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -85,6 +85,9 @@ class flags(metaclass=FlagsMeta):
     edgeql_compile = Flag(
         doc="Dump EdgeQL/IR/SQL ASTs.")
 
+    edgeql_compile_edgeql_text = Flag(
+        doc="Dump EdgeQL Text (subset of `edgeql_compile').")
+
     edgeql_compile_edgeql_ast = Flag(
         doc="Dump EdgeQL AST (subset of `edgeql_compile').")
 

--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -138,6 +138,7 @@ import functools
 from edb import errors
 
 from edb.edgeql import ast as qlast
+from edb.edgeql import codegen as qlcodegen
 from edb.edgeql import parser as qlparser
 
 from edb.common import debug
@@ -213,6 +214,10 @@ def compile_ast_to_ir(
     """
     if options is None:
         options = CompilerOptions()
+
+    if debug.flags.edgeql_compile or debug.flags.edgeql_compile_edgeql_text:
+        debug.header('EdgeQL Text')
+        debug.dump_code(qlcodegen.generate_source(tree, pretty=True))
 
     if debug.flags.edgeql_compile or debug.flags.edgeql_compile_edgeql_ast:
         debug.header('Compiler Options')


### PR DESCRIPTION
The new `EDGEDB_DEBUG_EDGEQL_COMPILE_EDGEQL_TEXT` prints the text of every
compiled EdgeQL query.