### PR TITLE
Turn on AST `__init__` synthesis for edgeql AST

### DIFF
--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -50,6 +50,9 @@ class Field:
         self.meta = field_meta
 
 
+container_factory: Any = object()
+
+
 def _check_type_passthrough(type_, value, raise_error):
     pass
 
@@ -393,7 +396,7 @@ def _check_annotation(f_type, f_fullname, f_default):
             _check_annotation(t, f_fullname, f_default)
 
     elif typing_inspect.is_generic_type(f_type):
-        if f_default is not None:
+        if f_default is not None and f_default is not container_factory:
             raise RuntimeError(
                 f'invalid type annotation on {f_fullname}: '
                 f'default is defined for container type '

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -85,27 +85,27 @@ class DescribeGlobal(s_enum.StrEnum):
 class Base(ast.AST):
     __abstract_node__ = True
     __ast_hidden__ = {'context'}
-    context: parsing.ParserContext
+    context: typing.Optional[parsing.ParserContext] = None
     # System-generated comment.
-    system_comment: str
+    system_comment: typing.Optional[str] = None
 
     # parent: typing.Optional[Base]
 
 
 class OffsetLimitMixin(Base):
     __abstract_node__ = True
-    offset: typing.Optional[Expr]
-    limit: typing.Optional[Expr]
+    offset: typing.Optional[Expr] = None
+    limit: typing.Optional[Expr] = None
 
 
 class OrderByMixin(Base):
     __abstract_node__ = True
-    orderby: typing.List[SortExpr]
+    orderby: typing.Optional[typing.List[SortExpr]] = None
 
 
 class FilterMixin(Base):
     __abstract_node__ = True
-    where: typing.Optional[Expr]
+    where: typing.Optional[Expr] = None
 
 
 class OptionValue(Base):
@@ -167,8 +167,8 @@ class Clause(Base):
 
 class SortExpr(Clause):
     path: Expr
-    direction: typing.Optional[SortOrder]
-    nones_order: typing.Optional[str]
+    direction: typing.Optional[SortOrder] = None
+    nones_order: typing.Optional[str] = None
 
 
 class BaseAlias(Clause):
@@ -224,8 +224,8 @@ class BaseObjectRef(Base):
 
 class ObjectRef(BaseObjectRef):
     name: str
-    module: typing.Optional[str]
-    itemclass: typing.Optional[qltypes.SchemaObjectClass]
+    module: typing.Optional[str] = None
+    itemclass: typing.Optional[qltypes.SchemaObjectClass] = None
 
 
 class PseudoObjectRef(BaseObjectRef):
@@ -288,9 +288,9 @@ class WindowSpec(Clause, OrderByMixin):
 
 class FunctionCall(Expr):
     func: typing.Union[tuple, str]
-    args: typing.List[Expr]
-    kwargs: typing.Dict[str, Expr]
-    window: typing.Optional[WindowSpec]
+    args: typing.List[Expr] = ast.container_factory
+    kwargs: typing.Dict[str, Expr] = ast.container_factory
+    window: typing.Optional[WindowSpec] = None
 
 
 class BaseConstant(Expr):
@@ -357,7 +357,7 @@ class UnaryOp(Expr):
 
 
 class TypeExpr(Base):
-    name: str  # name is used for types in named tuples
+    name: typing.Optional[str] = None  # name is used for types in named tuples
 
 
 class TypeOf(TypeExpr):
@@ -371,8 +371,8 @@ class TypeExprLiteral(TypeExpr):
 
 class TypeName(TypeExpr):
     maintype: BaseObjectRef
-    subtypes: typing.Optional[typing.List[TypeExpr]]
-    dimensions: typing.Optional[typing.List[int]]
+    subtypes: typing.Optional[typing.List[TypeExpr]] = None
+    dimensions: typing.Optional[typing.List[int]] = None
 
 
 class TypeOp(TypeExpr):
@@ -386,7 +386,7 @@ class FuncParam(Base):
     type: TypeExpr
     typemod: qltypes.TypeModifier = qltypes.TypeModifier.SingletonType
     kind: qltypes.ParameterKind
-    default: typing.Optional[Expr]
+    default: typing.Optional[Expr] = None
 
 
 class IsOp(Expr):
@@ -401,19 +401,22 @@ class TypeIntersection(Base):
 
 class Ptr(Base):
     ptr: ObjectRef
-    direction: typing.Optional[str]
-    type: typing.Optional[str]
+    direction: typing.Optional[str] = None
+    type: typing.Optional[str] = None
+
+
+PathElement = typing.Union[Expr, Ptr, TypeIntersection, ObjectRef]
 
 
 class Path(Expr):
-    steps: typing.List[typing.Union[Expr, Ptr, TypeIntersection, ObjectRef]]
+    steps: typing.List[PathElement]
     partial: bool = False
 
 
 class TypeCast(Expr):
     expr: Expr
     type: TypeExpr
-    cardinality_mod: typing.Optional[CardinalityModifier]
+    cardinality_mod: typing.Optional[CardinalityModifier] = None
 
 
 class Introspect(Expr):
@@ -470,7 +473,8 @@ class GroupBuiltin(ByExprBase):
 
 class Command(Base):
     __abstract_node__ = True
-    aliases: typing.List[typing.Union[AliasedExpr, ModuleAliasDecl]]
+    aliases: typing.Optional[
+        typing.List[typing.Union[AliasedExpr, ModuleAliasDecl]]] = None
 
 
 class Statement(Command, Expr):
@@ -480,13 +484,13 @@ class Statement(Command, Expr):
 class SubjectMixin(Base):
     __abstract_node__ = True
     subject: Expr
-    subject_alias: typing.Optional[str]
+    subject_alias: typing.Optional[str] = None
 
 
 class ReturningMixin(Base):
     __abstract_node__ = True
     result: Expr
-    result_alias: typing.Optional[str]
+    result_alias: typing.Optional[str] = None
 
 
 class SelectClauseMixin(OrderByMixin, OffsetLimitMixin, FilterMixin):
@@ -510,9 +514,9 @@ class ShapeOperation(Base):
 
 class ShapeElement(OffsetLimitMixin, OrderByMixin, FilterMixin, Expr):
     expr: Path
-    elements: typing.List[ShapeElement]
-    compexpr: typing.Optional[Expr]
-    cardinality: typing.Optional[qltypes.SchemaCardinality]
+    elements: typing.Optional[typing.List[ShapeElement]] = None
+    compexpr: typing.Optional[Expr] = None
+    cardinality: typing.Optional[qltypes.SchemaCardinality] = None
     required: bool = False
     operation: ShapeOperation = ShapeOperation(op=ShapeOp.ASSIGN)
 
@@ -540,7 +544,7 @@ class InsertQuery(Query, SubjectMixin):
     subject: Path
     shape: typing.List[ShapeElement]
     unless_conflict: typing.Optional[
-        typing.Tuple[typing.Optional[Expr], typing.Optional[Expr]]]
+        typing.Tuple[typing.Optional[Expr], typing.Optional[Expr]]] = None
 
 
 class UpdateQuery(Query, SubjectMixin, FilterMixin):
@@ -607,13 +611,13 @@ class BasesMixin(DDL):
 
 
 class Position(DDL):
-    ref: typing.Optional[ObjectRef]
+    ref: typing.Optional[ObjectRef] = None
     position: str
 
 
 class DDLOperation(DDL):
     __abstract_node__ = True
-    commands: typing.List[DDLOperation]
+    commands: typing.List[DDLOperation] = ast.container_factory
 
 
 class DDLCommand(Command, DDLOperation):
@@ -621,7 +625,7 @@ class DDLCommand(Command, DDLOperation):
 
 
 class AlterAddInherit(DDLOperation, BasesMixin):
-    position: typing.Optional[Position]
+    position: typing.Optional[Position] = None
 
 
 class AlterDropInherit(DDLOperation, BasesMixin):
@@ -646,20 +650,20 @@ class SetField(DDLOperation):
 class SetPointerType(SetField):
     name: str = 'target'
     special_syntax: bool = True
-    value: TypeExpr
-    cast_expr: typing.Optional[Expr]
+    value: typing.Optional[TypeExpr]
+    cast_expr: typing.Optional[Expr] = None
 
 
 class SetPointerCardinality(SetField):
     name: str = 'cardinality'
     special_syntax: bool = True
-    conv_expr: typing.Optional[Expr]
+    conv_expr: typing.Optional[Expr] = None
 
 
 class SetPointerOptionality(SetField):
     name: str = 'required'
     special_syntax: bool = True
-    fill_expr: typing.Optional[Expr]
+    fill_expr: typing.Optional[Expr] = None
 
 
 class NamedDDL(DDLCommand):
@@ -827,15 +831,15 @@ class ModuleCommand(UnqualifiedObjectCommand):
         qltypes.SchemaObjectClass.MODULE)
 
 
-class CreateModule(CreateObject, ModuleCommand):
+class CreateModule(ModuleCommand, CreateObject):
     pass
 
 
-class AlterModule(AlterObject, ModuleCommand):
+class AlterModule(ModuleCommand, AlterObject):
     pass
 
 
-class DropModule(DropObject, ModuleCommand):
+class DropModule(ModuleCommand, DropObject):
     pass
 
 
@@ -1055,15 +1059,15 @@ class ConcreteConstraintOp(ConstraintCommand):
     subjectexpr: typing.Optional[Expr]
 
 
-class CreateConcreteConstraint(CreateObject, ConcreteConstraintOp):
+class CreateConcreteConstraint(ConcreteConstraintOp, CreateObject):
     delegated: bool = False
 
 
-class AlterConcreteConstraint(AlterObject, ConcreteConstraintOp):
+class AlterConcreteConstraint(ConcreteConstraintOp, AlterObject):
     pass
 
 
-class DropConcreteConstraint(DropObject, ConcreteConstraintOp):
+class DropConcreteConstraint(ConcreteConstraintOp, DropObject):
     pass
 
 
@@ -1075,27 +1079,27 @@ class IndexCommand(ObjectDDL):
         qltypes.SchemaObjectClass.INDEX)
 
 
-class CreateIndex(CreateObject, IndexCommand):
+class CreateIndex(IndexCommand, CreateObject):
     pass
 
 
-class AlterIndex(AlterObject, IndexCommand):
+class AlterIndex(IndexCommand, AlterObject):
     pass
 
 
-class DropIndex(DropObject, IndexCommand):
+class DropIndex(IndexCommand, DropObject):
     pass
 
 
-class CreateAnnotationValue(CreateObject, AnnotationCommand):
+class CreateAnnotationValue(AnnotationCommand, CreateObject):
     value: Expr
 
 
-class AlterAnnotationValue(AlterObject, AnnotationCommand):
+class AlterAnnotationValue(AnnotationCommand, AlterObject):
     value: typing.Optional[Expr]
 
 
-class DropAnnotationValue(DropObject, AnnotationCommand):
+class DropAnnotationValue(AnnotationCommand, DropObject):
     pass
 
 
@@ -1106,9 +1110,9 @@ class Language(s_enum.StrEnum):
 
 class FunctionCode(Clause):
     language: Language = Language.EdgeQL
-    code: typing.Optional[str]
-    nativecode: typing.Optional[Expr]
-    from_function: typing.Optional[str]
+    code: typing.Optional[str] = None
+    nativecode: typing.Optional[Expr] = None
+    from_function: typing.Optional[str] = None
     from_expr: bool = False
 
 
@@ -1141,9 +1145,9 @@ class DropFunction(DropObject, FunctionCommand):
 class OperatorCode(Clause):
     language: Language
     from_operator: typing.Optional[typing.Tuple[str, ...]]
-    from_function: str
+    from_function: typing.Optional[str]
     from_expr: bool
-    code: str
+    code: typing.Optional[str]
 
 
 class OperatorCommand(CallableObjectCommand):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1492,6 +1492,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             def after_name() -> None:
                 if type_cmd is not None:
                     self.write(' -> ')
+                    assert type_cmd.value
                     self.visit(type_cmd.value)
 
         keywords.append('PROPERTY')
@@ -1593,6 +1594,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                     self._ddl_visit_bases(inherit_cmd)
                 if type_cmd is not None:
                     self.write(' -> ')
+                    assert type_cmd.value
                     self.visit(type_cmd.value)
         else:
             after_name = None

--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -91,5 +91,8 @@ def is_nontrivial_shape_element(shape_el: qlast.ShapeElement) -> bool:
         or shape_el.offset
         or shape_el.limit
         or shape_el.compexpr
-        or any(is_nontrivial_shape_element(el) for el in shape_el.elements)
+        or (
+            shape_el.elements and
+            any(is_nontrivial_shape_element(el) for el in shape_el.elements)
+        )
     )

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -580,7 +580,6 @@ def _cast_array(
                                     qlast.Ptr(
                                         ptr=qlast.ObjectRef(
                                             name='1',
-                                            direction='>',
                                         ),
                                     ),
                                 ],
@@ -599,7 +598,6 @@ def _cast_array(
                                         qlast.Ptr(
                                             ptr=qlast.ObjectRef(
                                                 name='0',
-                                                direction='>',
                                             ),
                                         ),
                                     ],

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -199,6 +199,7 @@ def _inject_tname(
         if isinstance(el.compexpr, qlast.InsertQuery):
             _inject_tname(el.compexpr, ctx=ctx)
 
+    assert isinstance(insert_stmt.subject.steps[0], qlast.BaseObjectRef)
     insert_stmt.shape.append(
         qlast.ShapeElement(
             expr=qlast.Path(

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -151,7 +151,7 @@ class Environment:
     set_types: Dict[irast.Set, s_types.Type]
     """A dictionary of all Set instances and their schema types."""
 
-    type_origins: Dict[s_types.Type, parsing.ParserContext]
+    type_origins: Dict[s_types.Type, Optional[parsing.ParserContext]]
     """A dictionary of notable types and their source origins.
 
     This is used to trace where a particular type instance originated in
@@ -399,7 +399,7 @@ class ContextLevel(compiler.ContextLevel):
 
     must_use_views: Dict[
         s_types.Type,
-        Tuple[s_name.Name, parsing.ParserContext],
+        Tuple[s_name.Name, Optional[parsing.ParserContext]],
     ]
     """A set of views that *must* be used in an expression."""
 

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -210,8 +210,10 @@ def compile_FunctionCall(
     func_initial_value: Optional[irast.Set]
 
     if matched_func_initial_value is not None:
+        frag = qlparser.parse_fragment(matched_func_initial_value.text)
+        assert isinstance(frag, qlast.Expr)
         iv_ql = qlast.TypeCast(
-            expr=qlparser.parse_fragment(matched_func_initial_value.text),
+            expr=frag,
             type=typegen.type_to_ql_typeref(matched_call.return_type, ctx=ctx),
         )
         func_initial_value = setgen.ensure_set(

--- a/edb/edgeql/compiler/normalization.py
+++ b/edb/edgeql/compiler/normalization.py
@@ -64,13 +64,13 @@ def renormalize_compat(
 
     norm_aliases: Dict[Optional[str], str] = {}
     assert isinstance(norm_qltree, qlast.Command)
-    for alias in norm_qltree.aliases:
+    for alias in (norm_qltree.aliases or ()):
         if isinstance(alias, qlast.ModuleAliasDecl):
             norm_aliases[alias.alias] = alias.module
 
     if isinstance(orig_qltree, qlast.Command):
         orig_aliases: Dict[Optional[str], str] = {}
-        for alias in orig_qltree.aliases:
+        for alias in (orig_qltree.aliases or ()):
             if isinstance(alias, qlast.ModuleAliasDecl):
                 orig_aliases[alias.alias] = alias.module
 
@@ -164,7 +164,7 @@ def _normalize_with_block(
     modaliases = dict(modaliases)
     newaliases: List[Union[qlast.AliasedExpr, qlast.ModuleAliasDecl]] = []
 
-    for alias in node.aliases:
+    for alias in (node.aliases or ()):
         if isinstance(alias, qlast.ModuleAliasDecl):
             if alias.alias:
                 modaliases[alias.alias] = alias.module

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -598,7 +598,7 @@ def ptr_step_set(
         expr: Optional[qlast.Base],
         ptr_name: str,
         direction: PtrDir = PtrDir.Outbound,
-        source_context: parsing.ParserContext,
+        source_context: Optional[parsing.ParserContext],
         ignore_computable: bool=False,
         ctx: context.ContextLevel) -> irast.Set:
     ptrcls = resolve_ptr(

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -238,7 +238,7 @@ def compile_insert_unless_conflict_select(
     *,
     obj_constrs: Sequence[s_constr.Constraint],
     constrs: Dict[str, Tuple[s_pointers.Pointer, List[s_constr.Constraint]]],
-    parser_context: pctx.ParserContext,
+    parser_context: Optional[pctx.ParserContext],
     ctx: context.ContextLevel,
 ) -> irast.Set:
     """Synthesize a select of conflicting objects for UNLESS CONFLICT
@@ -1215,6 +1215,9 @@ def process_with_block(
         edgeql_tree: qlast.Statement, *,
         ctx: context.ContextLevel,
         parent_ctx: context.ContextLevel) -> List[irast.Set]:
+    if edgeql_tree.aliases is None:
+        return []
+
     had_materialized = False
     results = []
     for with_entry in edgeql_tree.aliases:
@@ -1285,7 +1288,7 @@ def compile_result_clause(
                 # make sure we don't mangle it with an implicit
                 # limit.
                 rexpr.limit = qlast.TypeCast(
-                    expr=qlast.Set(),
+                    expr=qlast.Set(elements=[]),
                     type=qlast.TypeName(
                         maintype=qlast.ObjectRef(
                             module='__std__',

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -67,7 +67,7 @@ def process_view(
     is_insert: bool = False,
     is_update: bool = False,
     is_delete: bool = False,
-    parser_context: pctx.ParserContext,
+    parser_context: Optional[pctx.ParserContext],
     ctx: context.ContextLevel,
 ) -> s_objtypes.ObjectType:
 
@@ -114,13 +114,13 @@ def _process_view(
     stype: s_objtypes.ObjectType,
     path_id: irast.PathId,
     path_id_namespace: Optional[irast.Namespace] = None,
-    elements: List[qlast.ShapeElement],
+    elements: Optional[Sequence[qlast.ShapeElement]],
     view_rptr: Optional[context.ViewRPtr] = None,
     view_name: Optional[sn.QualName] = None,
     is_insert: bool = False,
     is_update: bool = False,
     is_delete: bool = False,
-    parser_context: pctx.ParserContext,
+    parser_context: Optional[pctx.ParserContext],
     ctx: context.ContextLevel,
 ) -> s_objtypes.ObjectType:
 
@@ -175,6 +175,7 @@ def _process_view(
 
     pointers = []
 
+    elements = elements or ()
     for shape_el in elements:
         with ctx.newscope(fenced=True) as scopectx:
             pointer = _normalize_view_ptr_expr(

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -929,8 +929,8 @@ def _register_item(
         if subcmds:
             assert isinstance(decl, qlast.ObjectDDL)
             alter_name = f"Alter{decl.__class__.__name__[len('Create'):]}"
-            alter_cls: Type[qlast.ObjectDDL] = getattr(qlast, alter_name)
-            alter_cmd = alter_cls(name=decl.name)
+            alter_cls = getattr(qlast, alter_name)
+            alter_cmd: qlast.ObjectDDL = alter_cls(name=decl.name)
 
             # indexes need to preserve their "on" expression
             if isinstance(decl, qlast.CreateIndex):
@@ -1151,7 +1151,7 @@ def _resolve_type_expr(
     if isinstance(texpr, qlast.TypeName):
         if texpr.subtypes:
             return qltracer.Type(
-                name=s_name.QualName(module='__coll__', name=texpr.name),
+                name=s_name.QualName(module='__coll__', name=texpr.name or ''),
             )
         else:
             return cast(
@@ -1269,7 +1269,7 @@ def _validate_schema_ref(
 def _resolve_schema_ref(
     name: s_name.Name,
     type: Type[s_obj.Object_T],
-    sourcectx: parsing.ParserContext,
+    sourcectx: Optional[parsing.ParserContext],
     *,
     ctx: LayoutTraceContext,
 ) -> s_obj.Object_T:

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -40,17 +40,19 @@ def append_module_aliases(tree, aliases):
     return tree
 
 
-def parse_fragment(source: Union[qltokenizer.Source, str]) -> qlast.Base:
+def parse_fragment(source: Union[qltokenizer.Source, str]) -> qlast.Expr:
     if isinstance(source, str):
         source = qltokenizer.Source.from_string(source)
     parser = qlparser.EdgeQLExpressionParser()
-    return parser.parse(source)
+    res = parser.parse(source)
+    assert isinstance(res, qlast.Expr)
+    return res
 
 
 def parse(
     source: Union[qltokenizer.Source, str],
     module_aliases: Optional[Mapping[Optional[str], str]] = None,
-) -> qlast.Base:
+) -> qlast.Expr:
     tree = parse_fragment(source)
 
     if not isinstance(tree, qlast.Command):

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -331,7 +331,7 @@ class TracerContext:
 @contextmanager
 def alias_context(
     ctx: TracerContext,
-    aliases: List[Union[qlast.AliasedExpr, qlast.ModuleAliasDecl]],
+    aliases: Optional[List[Union[qlast.AliasedExpr, qlast.ModuleAliasDecl]]],
 ) -> Generator[TracerContext, None, None]:
     module = None
     modaliases: Dict[Optional[str], str] = {}
@@ -340,7 +340,7 @@ def alias_context(
     objects = dict(ctx.objects)
     ctx_changed = False
 
-    for alias in aliases:
+    for alias in (aliases or ()):
         # module and modalias in ctx needs to be amended
         if isinstance(alias, qlast.ModuleAliasDecl):
             ctx_changed = True
@@ -833,8 +833,9 @@ def trace_Shape(
 def trace_ShapeElement(node: qlast.ShapeElement, *,
                        ctx: TracerContext) -> None:
     trace(node.expr, ctx=ctx)
-    for element in node.elements:
-        trace(element, ctx=ctx)
+    if node.elements:
+        for element in node.elements:
+            trace(element, ctx=ctx)
     trace(node.where, ctx=ctx)
     if node.orderby:
         for sortexpr in node.orderby:

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -76,11 +76,11 @@ def index_parameters(
 ) -> Dict[str, qlast.Base]:
 
     result: Dict[str, qlast.Base] = {}
-    varargs: Optional[List[qlast.Base]] = None
+    varargs: Optional[List[qlast.Expr]] = None
     variadic = parameters.find_variadic(schema)
     variadic_num = variadic.get_num(schema) if variadic else -1  # type: ignore
 
-    e: qlast.Base
+    e: qlast.Expr
     p: s_func.ParameterLike
     for (i, e), p in itertools.zip_longest(enumerate(ql_args),
                                            parameters.objects(schema),

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -93,7 +93,7 @@ class Base(ast.AST):
     __abstract_node__ = True
     __ast_hidden__ = {'context'}
 
-    context: parsing.ParserContext
+    context: typing.Optional[parsing.ParserContext] = None
 
     def __repr__(self) -> str:
         return (

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -1387,6 +1387,7 @@ class AlterConstraint(
             ast = qlast.CreateConcreteConstraint(
                 name=qlast.ObjectRef(name=name.name, module=name.module),
                 subjectexpr=subjectexpr.qlast,
+                args=[],
             )
             quals = sn.quals_from_fullname(self.classname)
             new_name = self._classname_from_ast_and_referrer(

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -890,7 +890,7 @@ class Command(
         context: CommandContext,
     ) -> Dict[Optional[str], str]:
         modaliases = {}
-        if isinstance(astnode, qlast.DDLCommand):
+        if isinstance(astnode, qlast.DDLCommand) and astnode.aliases:
             for alias in astnode.aliases:
                 if isinstance(alias, qlast.ModuleAliasDecl):
                     modaliases[alias.alias] = alias.module
@@ -905,7 +905,7 @@ class Command(
         context: CommandContext,
     ) -> Set[str]:
         localnames: Set[str] = set()
-        if isinstance(astnode, qlast.DDLCommand):
+        if isinstance(astnode, qlast.DDLCommand) and astnode.aliases:
             for alias in astnode.aliases:
                 if isinstance(alias, qlast.AliasedExpr):
                     localnames.add(alias.alias)
@@ -1411,7 +1411,7 @@ class Query(Command):
         return cls(
             source_context=astnode.context,
             expr=s_expr.Expression.from_ast(
-                astnode,
+                astnode,  # type: ignore
                 schema=schema,
                 modaliases=context.modaliases,
                 localnames=context.localnames,
@@ -2023,7 +2023,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
 
         if astnode.get_field('name'):
             name = context.early_renames.get(self.classname, self.classname)
-            op = astnode(
+            op = astnode(  # type: ignore
                 name=self._deparse_name(schema, context, name),
             )
         else:
@@ -3138,7 +3138,7 @@ class RenameObject(AlterObjectFragment[so.Object_T]):
         self._log_all_renames(context)
 
         if (orig_ref.module, orig_ref.name) != (ref.module, ref.name):
-            return astnode(new_name=ref)
+            return astnode(new_name=ref)  # type: ignore
         else:
             return None
 

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -124,7 +124,7 @@ class AliasCommand(
 
     def _compile_alias_expr(
         self,
-        expr: qlast.Base,
+        expr: qlast.Expr,
         classname: sn.QualName,
         schema: s_schema.Schema,
         context: sd.CommandContext,
@@ -341,7 +341,7 @@ class DeleteAlias(
 
 
 def compile_alias_expr(
-    expr: qlast.Base,
+    expr: qlast.Expr,
     classname: sn.QualName,
     schema: s_schema.Schema,
     context: sd.CommandContext,

--- a/edb/schema/extensions.py
+++ b/edb/schema/extensions.py
@@ -158,7 +158,9 @@ class CreateExtensionPackage(
         if op.property == 'script':
             node.body = qlast.NestedQLBlock(
                 text=op.new_value,
-                commands=qlparser.parse_block(op.new_value),
+                commands=cast(
+                    List[qlast.DDLOperation],
+                    qlparser.parse_block(op.new_value)),
             )
         elif op.property == 'version':
             node.version = qlast.StringConstant(

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1880,7 +1880,7 @@ class AlterFunction(AlterCallableObject[Function], FunctionCommand):
                     context=astnode.context
                 )
 
-            nativecode_expr: Optional[qlast.Base] = None
+            nativecode_expr: Optional[qlast.Expr] = None
             if astnode.nativecode is not None:
                 nativecode_expr = astnode.nativecode
             elif astnode.code.code is not None:

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -1114,7 +1114,10 @@ class RebaseInheritingObject(
         if dropped:
             parent_node.commands.append(
                 qlast.AlterDropInherit(
-                    bases=[utils.typeref_to_ast(schema, b) for b in dropped],
+                    bases=[
+                        cast(qlast.TypeName, utils.typeref_to_ast(schema, b))
+                        for b in dropped
+                    ],
                 )
             )
 
@@ -1127,6 +1130,7 @@ class RebaseInheritingObject(
                 typ = utils.typeref_to_ast(schema, pos[1])
                 assert isinstance(typ, qlast.TypeName)
 
+                assert isinstance(typ.maintype, qlast.ObjectRef)
                 pos_node = qlast.Position(
                     position=pos[0],
                     ref=typ.maintype,
@@ -1137,7 +1141,10 @@ class RebaseInheritingObject(
 
             parent_node.commands.append(
                 qlast.AlterAddInherit(
-                    bases=[utils.typeref_to_ast(schema, b) for b in bases],
+                    bases=[
+                        cast(qlast.TypeName, utils.typeref_to_ast(schema, b))
+                        for b in bases
+                    ],
                     position=pos_node,
                 )
             )

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -208,7 +208,10 @@ class CreateMigration(MigrationCommand, sd.CreateObject[Migration]):
         assert isinstance(node, qlast.CreateMigration)
         if op.property == 'script':
             node.body = qlast.NestedQLBlock(
-                commands=qlparser.parse_block(op.new_value),
+                commands=cast(
+                    List[qlast.DDLOperation],
+                    qlparser.parse_block(op.new_value),
+                ),
                 text=op.new_value,
             )
         elif op.property == 'parents':

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -971,11 +971,11 @@ PointerLike = Union[Pointer, PseudoPointer]
 class ComputableRef:
     """A shell for a computed target type."""
 
-    expr: qlast.Base
+    expr: qlast.Expr
 
     def __init__(
         self,
-        expr: qlast.Base,
+        expr: qlast.Expr,
         specified_type: Optional[s_types.TypeShell[s_types.Type]] = None,
     ) -> None:
         self.expr = expr
@@ -1070,7 +1070,7 @@ class PointerCommandOrFragment(
 
     def _parse_computable(
         self,
-        expr: qlast.Base,
+        expr: qlast.Expr,
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> Tuple[
@@ -1705,6 +1705,7 @@ class PointerCommand(
         if expr_cmd is not None:
             expr = expr_cmd.value
             if expr is not None:
+                assert isinstance(expr, qlast.Expr)
                 qlcompiler.normalize(
                     expr,
                     schema=schema,
@@ -2182,6 +2183,7 @@ class SetPointerType(
             return None
         else:
             assert isinstance(set_field, qlast.SetField)
+            assert not isinstance(set_field.value, qlast.Expr)
             return qlast.SetPointerType(
                 value=set_field.value,
                 cast_expr=(

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -624,7 +624,7 @@ class CreateReferencedObject(
     ) -> qlast.ObjectDDL:
         nref = cls.get_inherited_ref_name(schema, context, parent, refname)
         astnode_cls = cls.referenced_astnode
-        astnode = astnode_cls(name=nref)
+        astnode = astnode_cls(name=nref)  # type: ignore
         assert isinstance(astnode, qlast.ObjectDDL)
         return astnode
 
@@ -1391,7 +1391,7 @@ class RenameReferencedInheritingObject(
             sd.RenameObject, type(scls))
 
         def _ref_rename(alter_cmd: sd.Command, refname: sn.Name) -> None:
-            astnode = rename_cmdcls.astnode(
+            astnode = rename_cmdcls.astnode(  # type: ignore
                 new_name=utils.name_to_ast_ref(refname),
             )
 

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -593,7 +593,7 @@ def shell_to_ast(
         else:
             qlref = qlast.ObjectRef(
                 module='',
-                name=name,
+                name=name.name,
             )
         result = qlast.TypeName(
             name=_name,
@@ -1075,7 +1075,7 @@ def const_ast_from_python(val: Any) -> qlast.BaseConstant:
 def get_config_type_shape(
     schema: s_schema.Schema,
     stype: s_objtypes.ObjectType,
-    path: List[qlast.Base],
+    path: List[qlast.PathElement],
 ) -> List[qlast.ShapeElement]:
     from . import objtypes as s_objtypes
     shape = []
@@ -1091,7 +1091,7 @@ def get_config_type_shape(
             if pn in ('id', '__type__') or pn in seen:
                 continue
 
-            elem_path: List[qlast.Base] = []
+            elem_path: List[qlast.PathElement] = []
 
             if t != stype:
                 elem_path.append(

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -629,7 +629,7 @@ def eval_UnaryOp(node: qlast.UnaryOp, ctx: EvalContext) -> Result:
 @_eval.register
 def eval_Call(node: qlast.FunctionCall, ctx: EvalContext) -> Result:
     assert isinstance(node.func, str)
-    return eval_func_or_op(node.func, node.args, 'func', ctx)
+    return eval_func_or_op(node.func, node.args or [], 'func', ctx)
 
 
 @_eval.register


### PR DESCRIPTION
I needed to fix a defer related bug in the plugin, and I felt that it
was a little too harsh to ban *all* container construction defaults,
so I added a `container_factory` sentinel object for when we still
want the behavior. (Probably we want eventually want to drop all the
magic use of type annotations to produce the defaults and specify them
explicitly?)