### PR TITLE
Make `dispatch.compile` always return irast.Set

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -550,13 +550,10 @@ def _cast_array(
                 ],
             )
 
-            enumerated = setgen.ensure_set(
-                dispatch.compile(
-                    qlast.FunctionCall(
-                        func=('__std__', 'enumerate'),
-                        args=[unpacked],
-                    ),
-                    ctx=subctx,
+            enumerated = dispatch.compile(
+                qlast.FunctionCall(
+                    func=('__std__', 'enumerate'),
+                    args=[unpacked],
                 ),
                 ctx=subctx,
             )

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -60,7 +60,7 @@ class SettingInfo(NamedTuple):
 def compile_ConfigSet(
     expr: qlast.ConfigSet, *,
     ctx: context.ContextLevel,
-) -> irast.ConfigSet:
+) -> irast.Set:
 
     info = _validate_op(expr, ctx=ctx)
     param_val = setgen.ensure_set(
@@ -74,7 +74,7 @@ def compile_ConfigSet(
             context=expr.expr.context
         ) from e
 
-    return irast.ConfigSet(
+    config_set = irast.ConfigSet(
         name=info.param_name,
         cardinality=info.cardinality,
         scope=expr.scope,
@@ -83,13 +83,14 @@ def compile_ConfigSet(
         context=expr.context,
         expr=param_val,
     )
+    return setgen.ensure_set(config_set, ctx=ctx)
 
 
 @dispatch.compile.register
 def compile_ConfigReset(
     expr: qlast.ConfigReset, *,
     ctx: context.ContextLevel,
-) -> irast.ConfigReset:
+) -> irast.Set:
 
     info = _validate_op(expr, ctx=ctx)
     filter_expr = expr.where
@@ -121,7 +122,7 @@ def compile_ConfigReset(
         select_ir = setgen.ensure_set(
             dispatch.compile(select, ctx=ctx), ctx=ctx)
 
-    return irast.ConfigReset(
+    config_reset = irast.ConfigReset(
         name=info.param_name,
         cardinality=info.cardinality,
         scope=expr.scope,
@@ -130,6 +131,7 @@ def compile_ConfigReset(
         context=expr.context,
         selector=select_ir,
     )
+    return setgen.ensure_set(config_reset, ctx=ctx)
 
 
 @dispatch.compile.register

--- a/edb/edgeql/compiler/dispatch.py
+++ b/edb/edgeql/compiler/dispatch.py
@@ -33,6 +33,6 @@ from . import context
 def compile(
     node: qlast.Base, *,
     ctx: context.ContextLevel
-) -> Union[irast.Expr, irast.Set]:
+) -> irast.Set:
     raise NotImplementedError(
         f'no EdgeQL compiler handler for {node.__class__}')

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -216,10 +216,7 @@ def compile_FunctionCall(
             expr=frag,
             type=typegen.type_to_ql_typeref(matched_call.return_type, ctx=ctx),
         )
-        func_initial_value = setgen.ensure_set(
-            dispatch.compile(iv_ql, ctx=ctx),
-            ctx=ctx,
-        )
+        func_initial_value = dispatch.compile(iv_ql, ctx=ctx)
     else:
         func_initial_value = None
 
@@ -308,9 +305,7 @@ def compile_operator(
             if conditional_args and ai in conditional_args:
                 fencectx.in_conditional = qlexpr.context
 
-            arg_ir = setgen.ensure_set(
-                dispatch.compile(qlarg, ctx=fencectx),
-                ctx=fencectx)
+            arg_ir = dispatch.compile(qlarg, ctx=fencectx)
 
             arg_ir = setgen.scoped_set(
                 setgen.ensure_stmt(arg_ir, ctx=fencectx),
@@ -654,13 +649,10 @@ def compile_call_arg(
         # matching.  We will remove it if necessary in `finalize_args()`.
         # Similarly, delay the decision to inject the implicit limit to
         # `finalize_args()`.
-        arg_ql = qlast.SelectQuery(result=arg_ql, implicit=True)
+        arg_ql = qlast.SelectQuery(
+            result=arg_ql, context=arg_ql.context, implicit=True)
         argctx.inhibit_implicit_limit = True
-        return setgen.ensure_set(
-            dispatch.compile(arg_ql, ctx=argctx),
-            srcctx=arg_ql.context,
-            ctx=argctx,
-        ), argctx
+        return dispatch.compile(arg_ql, ctx=argctx), argctx
 
 
 def compile_call_args(
@@ -807,11 +799,8 @@ def finalize_args(
                 and arg.expr.limit is None
                 and not ctx.inhibit_implicit_limit
             ):
-                arg.expr.limit = setgen.ensure_set(
-                    dispatch.compile(
-                        qlast.IntegerConstant(value=str(ctx.implicit_limit)),
-                        ctx=ctx,
-                    ),
+                arg.expr.limit = dispatch.compile(
+                    qlast.IntegerConstant(value=str(ctx.implicit_limit)),
                     ctx=ctx,
                 )
 

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -378,7 +378,8 @@ def __infer_config_reset(
     ir: irast.ConfigReset,
     env: context.Environment,
 ) -> s_types.Type:
-    raise errors.QueryError('no type for ConfigReset')
+    # This is nonsense but we need to return /something/
+    return s_pseudo.PseudoType.get(env.schema, 'anytype')
 
 
 @_infer_type.register

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1099,12 +1099,6 @@ def scoped_set(
     return ir_set
 
 
-def lol_set(
-        expr: irast.Set, *,
-        ctx: context.ContextLevel) -> irast.Set:
-    return expr
-
-
 def ensure_set(
         expr: Union[irast.Set, irast.Expr], *,
         type_override: Optional[s_types.Type]=None,

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -446,8 +446,7 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
             # works right.
             is_subquery = isinstance(step, qlast.Statement)
             with ctx.newscope(fenced=is_subquery) as subctx:
-                path_tip = ensure_set(
-                    dispatch.compile(step, ctx=subctx), ctx=subctx)
+                path_tip = dispatch.compile(step, ctx=subctx)
 
                 # If the head of the path is a direct object
                 # reference, wrap it in an expression set to give it a
@@ -904,14 +903,12 @@ def enum_indirection_set(
         env=ctx.env,
     )
 
-    ptr = casts.compile_cast(
+    return casts.compile_cast(
         irast.StringConstant(value=ptr_name, typeref=strref),
         source,
         srcctx=source_context,
         ctx=ctx,
     )
-
-    return ensure_set(ptr, ctx=ctx)
 
 
 def tuple_indirection_set(
@@ -1100,6 +1097,12 @@ def scoped_set(
             pathctx.assign_set_scope(ir_set, ctx.path_scope, ctx=ctx)
 
     return ir_set
+
+
+def lol_set(
+        expr: irast.Set, *,
+        ctx: context.ContextLevel) -> irast.Set:
+    return expr
 
 
 def ensure_set(
@@ -1321,8 +1324,7 @@ def computable_ptr_set(
                 iterator_target=True,
             )
 
-        comp_ir_set = ensure_set(
-            dispatch.compile(qlexpr, ctx=subctx), ctx=subctx)
+        comp_ir_set = dispatch.compile(qlexpr, ctx=subctx)
 
     comp_ir_set = new_set_from_set(
         comp_ir_set, path_id=result_path_id, rptr=rptr, context=srcctx,

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -209,11 +209,8 @@ def compile_ForQuery(
         # Inject an implicit limit if appropriate
         if ((ctx.expr_exposed or sctx.stmt is ctx.toplevel_stmt)
                 and ctx.implicit_limit):
-            stmt.limit = setgen.ensure_set(
-                dispatch.compile(
-                    qlast.IntegerConstant(value=str(ctx.implicit_limit)),
-                    ctx=sctx,
-                ),
+            stmt.limit = dispatch.compile(
+                qlast.IntegerConstant(value=str(ctx.implicit_limit)),
                 ctx=sctx,
             )
 
@@ -410,8 +407,7 @@ def compile_insert_unless_conflict_on(
 
         # We compile the name here so we can analyze it, but we don't do
         # anything else with it.
-        cspec_res = setgen.ensure_set(dispatch.compile(
-            constraint_spec, ctx=constraint_ctx), ctx=constraint_ctx)
+        cspec_res = dispatch.compile(constraint_spec, ctx=constraint_ctx)
 
     # We accept a property, link, or a list of them in the form of a
     # tuple.
@@ -492,8 +488,8 @@ def compile_insert_unless_conflict_on(
         ctx.path_scope.factoring_allowlist.add(stmt.subject.path_id)
 
         # Compile else
-        else_ir = setgen.ensure_set(dispatch.compile(
-            astutils.ensure_qlstmt(else_branch), ctx=ctx), ctx=ctx)
+        else_ir = dispatch.compile(
+            astutils.ensure_qlstmt(else_branch), ctx=ctx)
         assert isinstance(else_ir, irast.Set)
 
     return irast.OnConflictClause(
@@ -1057,8 +1053,7 @@ def compile_Shape(
 
         with ctx.new() as exposed_ctx:
             exposed_ctx.expr_exposed = False
-            expr = setgen.ensure_set(
-                dispatch.compile(shape_expr, ctx=exposed_ctx), ctx=exposed_ctx)
+            expr = dispatch.compile(shape_expr, ctx=exposed_ctx)
 
         expr_stype = setgen.get_set_type(expr, ctx=ctx)
         if not isinstance(expr_stype, s_objtypes.ObjectType):
@@ -1329,8 +1324,7 @@ def compile_result_clause(
             with sctx.new() as ectx:
                 if shape is not None:
                     ectx.expr_exposed = False
-                expr = setgen.ensure_set(
-                    dispatch.compile(result_expr, ctx=ectx), ctx=ectx)
+                expr = dispatch.compile(result_expr, ctx=ectx)
 
         ctx.partial_path_prefix = expr
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -106,7 +106,7 @@ def init_context(
 
 
 def fini_expression(
-    ir: irast.Base,
+    ir: irast.Set,
     *,
     ctx: context.ContextLevel,
 ) -> irast.Command:
@@ -143,11 +143,10 @@ def fini_expression(
 
     ctx.path_scope.validate_unique_ids()
 
-    if isinstance(ir, irast.Command):
-        if isinstance(ir, irast.ConfigCommand):
-            ir.scope_tree = ctx.path_scope
-        # IR is already a Command
-        return ir
+    # ConfigSet and ConfigReset don't like being part of a Set
+    if isinstance(ir.expr, (irast.ConfigSet, irast.ConfigReset)):
+        ir.expr.scope_tree = ctx.path_scope
+        return ir.expr
 
     volatility = inference.infer_volatility(ir, env=ctx.env)
 
@@ -511,7 +510,7 @@ def compile_anchor(
                 step.show_as_anchor = None
 
     elif isinstance(anchor, qlast.Base):
-        step = setgen.ensure_set(dispatch.compile(anchor, ctx=ctx), ctx=ctx)
+        step = dispatch.compile(anchor, ctx=ctx)
 
     elif isinstance(anchor, irast.Parameter):
         step = setgen.ensure_set(anchor, ctx=ctx)

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -85,8 +85,7 @@ def _ql_typeexpr_to_type(
         with ctx.new() as subctx:
             # Use an empty scope tree, to avoid polluting things pointlessly
             subctx.path_scope = irast.ScopeTreeNode()
-            ir_set = setgen.ensure_set(dispatch.compile(ql_t.expr, ctx=subctx),
-                                       ctx=subctx)
+            ir_set = dispatch.compile(ql_t.expr, ctx=subctx)
             stype = setgen.get_set_type(ir_set, ctx=subctx)
 
         return [stype]

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -336,7 +336,7 @@ def _compile_qlexpr(
     is_linkprop: bool,
 
     ctx: context.ContextLevel,
-) -> Tuple[Union[irast.Expr, irast.Set], context.ViewRPtr]:
+) -> Tuple[irast.Set, context.ViewRPtr]:
 
     is_mutation = is_insert or is_update
 
@@ -849,7 +849,6 @@ def _normalize_view_ptr_expr(
         ctx.env.materialized_sets[ptrcls] = ctx.qlstmt
 
         if not ctx.expr_exposed and irexpr:
-            irexpr = setgen.ensure_set(irexpr, ctx=ctx)
             setgen.maybe_materialize(ptrcls, irexpr, ctx=ctx)
 
     if qlexpr is None and not setgen.is_injected_computable_ptr(


### PR DESCRIPTION
In practice it *did* already do this, except for ConfigSet and
ConfigReset.  Those required a little fiddling.

This lets us drop a lot of calls to `ensure_set`.