### PR TITLE
Ensure a bare collection type is created when creating collection aliases

### DIFF
--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -10358,13 +10358,13 @@ type default::Foo {
             CREATE ALIAS Bar := (<a>"", <b>"");
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 1)
+        self.assertEqual(await self.con.query_one(count_query), orig_count + 2)
 
         await self.con.execute(r"""
             ALTER ALIAS Bar USING ((<b>"", <a>""));
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 1)
+        self.assertEqual(await self.con.query_one(count_query), orig_count + 2)
 
         await self.con.execute(r"""
             DROP ALIAS Bar;


### PR DESCRIPTION
Currently, when an expression alias of a collection type is defined we
don't explicitly create an anonymous collection type corresponding to
the type returned by the alias expression.  This would become
problematic once computed pointers will become defined in terms of an
anonymous expression alias, because queries and backend table
definitions expect naked collection types.

For example, `alias Foo := (1, 2)` will now generate the following
pseudo-delta tree:

    CreateAlias("Foo@alias")
      CreateTupleExprAlias("Foo")
         CreateTuple("tuple<int64, int64>")