### PR TITLE
Turn on AST `__init__` synthesis for edb.pgsql

### DIFF
--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -430,7 +430,7 @@ def _check_annotation(f_type, f_fullname, f_default):
                 f'{f_type!r} is not a type')
 
         if typeutils.is_container_type(f_type):
-            if f_default is not None:
+            if f_default is not None and f_default is not container_factory:
                 raise RuntimeError(
                     f'invalid type annotation on {f_fullname}: '
                     f'default is defined for container type '

--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -60,12 +60,13 @@ def compile_where_clause(
 
 
 def compile_orderby_clause(
-        sortexprs: Optional[Iterable[qlast.SortExpr]], *,
-        ctx: context.ContextLevel) -> List[irast.SortExpr]:
+        sortexprs: Optional[Sequence[qlast.SortExpr]], *,
+        ctx: context.ContextLevel) -> Optional[List[irast.SortExpr]]:
+
+    if not sortexprs:
+        return None
 
     result: List[irast.SortExpr] = []
-    if not sortexprs:
-        return result
 
     if ctx.partial_path_prefix:
         pathctx.register_set_in_scope(ctx.partial_path_prefix, ctx=ctx)

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -217,8 +217,7 @@ def unwrap_set(ir_set: irast.Set) -> irast.Set:
 def get_source_context_as_json(
     expr: irast.Base,
     exctype: Type[errors.EdgeDBError] = errors.InternalServerError,
-) -> Optional[str]:
-    details: Optional[str]
+) -> str:
     if expr.context:
         details = json.dumps({
             # TODO(tailhook) should we add offset, utf16column here?
@@ -229,7 +228,9 @@ def get_source_context_as_json(
         })
 
     else:
-        details = None
+        details = json.dumps({
+            'code': exctype.get_code(),
+        })
 
     return details
 

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -436,7 +436,7 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         if not node.include_inherited:
             self.write(')')
 
-        if node.alias:
+        if node.alias and node.alias.aliasname:
             self.write(' AS ')
             self.visit(node.alias)
 
@@ -446,7 +446,7 @@ class SQLSourceGenerator(codegen.SourceGenerator):
 
         self.visit(node.subquery)
 
-        if node.alias:
+        if node.alias and node.alias.aliasname:
             self.write(' AS ')
             self.visit(node.alias)
 
@@ -465,7 +465,7 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         if node.with_ordinality:
             self.write(' WITH ORDINALITY ')
 
-        if node.alias:
+        if node.alias and node.alias.aliasname:
             self.write(' AS ')
             self.visit(node.alias)
 

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -134,7 +134,7 @@ def compile_ir_to_sql(
         debug.header('SQL Tree')
         debug.dump(qtree)
 
-    if isinstance(qtree, pgast.Query):
+    if isinstance(qtree, pgast.Query) and qtree.argnames:
         argmap = qtree.argnames
     else:
         argmap = {}

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -146,6 +146,7 @@ def get_leftmost_query(query: pgast.Query) -> pgast.Query:
     result = query
     while is_set_op_query(result):
         result = cast(pgast.SelectStmt, result)
+        assert result.larg
         result = result.larg
     return result
 
@@ -156,6 +157,7 @@ def for_each_query_in_set(
 ) -> List[Any]:
     if is_set_op_query(qry):
         qry = cast(pgast.SelectStmt, qry)
+        assert qry.larg and qry.rarg
         result = for_each_query_in_set(qry.larg, cb)
         result.extend(for_each_query_in_set(qry.rarg, cb))
     else:

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -66,7 +66,7 @@ def compile_ConfigSet(
                     )
                 else:
                     val = pgast.TypeCast(
-                        arg=pgast.ArrayExpr(),
+                        arg=pgast.ArrayExpr(elements=[]),
                         type_name=pgast.TypeName(
                             name=('text[]',),
                         ),
@@ -319,6 +319,7 @@ def compile_ConfigReset(
                     name=ctx.env.aliases.get('res'),
                     val=target.val,
                 )
+                assert target.name is not None
 
             rvar = relctx.rvar_for_rel(selector, ctx=ctx)
 
@@ -474,6 +475,7 @@ def top_output_as_config_op(
                 name=env.aliases.get('v'),
                 val=stmt_res.val,
             )
+            assert stmt_res.name is not None
 
         result_row = pgast.RowExpr(
             args=[

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -370,6 +370,7 @@ def compile_operator(
             sql_oper = '!='
 
     elif str_func_name == 'std::EXISTS':
+        assert rexpr
         result = pgast.NullTest(arg=rexpr, negated=True)
 
     elif expr.sql_operator:

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -160,7 +160,8 @@ def array_as_json_object(
         for i, st in enumerate(el_type.subtypes):
             if is_named:
                 colname = st.element_name
-                json_args.append(pgast.StringConstant(val=st.element_name))
+                assert colname
+                json_args.append(pgast.StringConstant(val=colname))
             else:
                 colname = str(i)
 
@@ -329,6 +330,7 @@ def named_tuple_as_json_object(
 
     if irtyputils.is_persistent_tuple(styperef):
         for el_type in styperef.subtypes:
+            assert el_type.element_name
             keyvals.append(pgast.StringConstant(val=el_type.element_name))
             val: pgast.BaseExpr = pgast.Indirection(
                 arg=expr,
@@ -355,6 +357,7 @@ def named_tuple_as_json_object(
         coldeflist = []
 
         for el_type in styperef.subtypes:
+            assert el_type.element_name
             keyvals.append(pgast.StringConstant(val=el_type.element_name))
 
             coldeflist.append(pgast.ColumnDef(
@@ -601,6 +604,7 @@ def aggregate_json_output(
             name=env.aliases.get('v'),
             val=stmt_res.val,
         )
+        assert stmt_res.name is not None
 
     new_val = pgast.CoalesceExpr(
         args=[
@@ -652,6 +656,7 @@ def wrap_script_stmt(
             name=env.aliases.get('v'),
             val=stmt_res.val,
         )
+        assert stmt_res.name is not None
 
     count_val = pgast.FuncCall(
         name=('count',),

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1982,6 +1982,8 @@ def process_set_as_singleton_assertion(
             ),
         )
 
+        if newctx.rel.sort_clause is None:
+            newctx.rel.sort_clause = []
         newctx.rel.sort_clause.append(
             pgast.SortBy(node=pgast.ColumnRef(name=["_sentinel"])),
         )
@@ -2102,6 +2104,8 @@ def process_set_as_std_min_max(
 
         arg_val = output.output_as_value(arg_ref, env=newctx.env)
 
+        if newctx.rel.sort_clause is None:
+            newctx.rel.sort_clause = []
         newctx.rel.sort_clause.append(
             pgast.SortBy(
                 node=arg_val,
@@ -2495,6 +2499,8 @@ def process_set_as_agg_expr_inner(
                 group_rvar = relctx.rvar_for_rel(group_rel, ctx=ctx)
                 relctx.include_rvar(stmt, group_rvar, path_id=path_id, ctx=ctx)
                 ref = pathctx.get_path_identity_var(stmt, path_id, env=ctx.env)
+                if stmt.group_clause is None:
+                    stmt.group_clause = []
                 stmt.group_clause.append(ref)
                 newctx.path_scope[s_path_id] = stmt
 
@@ -2571,7 +2577,7 @@ def process_set_as_agg_expr_inner(
                         query = qrvar.query
                         assert isinstance(query, pgast.SelectStmt)
 
-                        for i, sortref in enumerate(query.sort_clause):
+                        for i, sortref in enumerate(query.sort_clause or ()):
                             alias = argctx.env.aliases.get(f's{i}')
 
                             query.target_list.append(

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -183,7 +183,7 @@ def compile_UpdateStmt(
         assert range_cte is not None
 
         toplevel = ctx.toplevel_stmt
-        toplevel.ctes.append(range_cte)
+        toplevel.append_cte(range_cte)
 
         for typeref, (update_cte, _) in parts.dml_ctes.items():
             # Process UPDATE body.
@@ -211,10 +211,10 @@ def compile_DeleteStmt(
 
         range_cte = parts.range_cte
         assert range_cte is not None
-        ctx.toplevel_stmt.ctes.append(range_cte)
+        ctx.toplevel_stmt.append_cte(range_cte)
 
         for delete_cte, _ in parts.dml_ctes.values():
-            ctx.toplevel_stmt.ctes.append(delete_cte)
+            ctx.toplevel_stmt.append_cte(delete_cte)
 
         # Wrap up.
         return dml.fini_dml_stmt(

--- a/edb/tools/mypy/plugin.py
+++ b/edb/tools/mypy/plugin.py
@@ -469,25 +469,11 @@ class SchemaClassTransformer(BaseStructTransformer):
         return fields
 
 
-INIT_WHITELIST = {
-    'edb.edgeql',
-    'edb.ir',
-}
-
-
 class ASTClassTransformer(BaseTransformer):
 
     def _transform(self) -> List[Field]:
         fields = self._collect_fields()
-
-        # NB: __init__ synthesis below brings up a vast number of
-        #     typing errors which require AST definitions to be
-        #     annotated with defaults properly and the code adjusted
-        #     to handle Optional fields (historically we've been
-        #     initializing container fields with empty lists/tuples).
-
-        if any(self._ctx.cls.fullname.startswith(x) for x in INIT_WHITELIST):
-            self._synthesize_init(fields)
+        self._synthesize_init(fields)
         return fields
 
     def _field_from_field_def(


### PR DESCRIPTION
I tried to make all the fields optional that could be done easily. I
think most of the list/dict fields that still get auto-populated are
basically always written to, though there may be more work that can be
done.