### PR TITLE
Delete some cruft from ast.base

### DIFF
--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -2130,7 +2130,7 @@ def _fix_parent_links(node: qlast.Base) -> qlast.Base:
     # Using AST.parent is an anti-pattern. Instead write code
     # that uses singledispatch and maintains a proper context.
 
-    node._parent = None
+    node._parent = None  # type: ignore
 
     for _field, value in base.iter_fields(node):
         if isinstance(value, dict):

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -860,7 +860,8 @@ def _register_item(
     op = orig_op = copy.copy(decl)
 
     if ctx.depstack:
-        op.sdl_alter_if_exists = True
+        if isinstance(op, qlast.CreateObject):
+            op.sdl_alter_if_exists = True
         top_parent = parent = copy.copy(ctx.depstack[0][0])
         _clear_nonessential_subcommands(parent)
         for entry, _ in ctx.depstack[1:]:
@@ -872,6 +873,7 @@ def _register_item(
         parent.commands.append(op)
         op = top_parent
     else:
+        assert isinstance(op, qlast.Command)
         op.aliases = [qlast.ModuleAliasDecl(alias=None, module=ctx.module)]
 
     assert isinstance(op, qlast.DDLCommand)
@@ -934,10 +936,12 @@ def _register_item(
 
             # indexes need to preserve their "on" expression
             if isinstance(decl, qlast.CreateIndex):
+                assert isinstance(alter_cmd, qlast.IndexCommand)
                 alter_cmd.expr = decl.expr
 
             # constraints need to preserve their "on" expression
             if isinstance(decl, qlast.CreateConcreteConstraint):
+                assert isinstance(alter_cmd, qlast.ConcreteConstraintOp)
                 alter_cmd.subjectexpr = decl.subjectexpr
                 alter_cmd.args = decl.args
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -268,6 +268,7 @@ def gen_dml_cte(
 
         # Auxiliary relations are always joined via the WHERE
         # clause due to the structure of the UPDATE/DELETE SQL statements.
+        assert isinstance(dml_stmt, (pgast.UpdateStmt, pgast.DeleteStmt))
         dml_stmt.where_clause = astutils.new_binop(
             lexpr=pgast.ColumnRef(name=[
                 dml_stmt.relation.alias.aliasname,

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -218,6 +218,8 @@ def get_set_rvar(
                                           rvars=rvars, ctx=subctx)
         elif not is_optional and is_empty_set:
             null_query = rvars.main.rvar.query
+            assert isinstance(
+                null_query, (pgast.SelectStmt, pgast.NullRelation))
             null_query.where_clause = pgast.BooleanConstant(val='FALSE')
 
         result_rvar = _include_rvars(rvars, scope_stmt=scope_stmt, ctx=subctx)

--- a/edb/schema/annos.py
+++ b/edb/schema/annos.py
@@ -324,6 +324,8 @@ class CreateAnnotationValue(
                          op: sd.AlterObjectProperty) -> None:
         if op.property == 'value':
             assert isinstance(op.new_value, str)
+            assert isinstance(node, (
+                qlast.CreateAnnotationValue, qlast.AlterAnnotationValue))
             node.value = qlast.StringConstant.from_python(op.new_value)
         else:
             super()._apply_field_ast(schema, context, node, op)

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -1426,6 +1426,7 @@ class DeleteConstraint(
     ) -> None:
         if op.property == 'args':
             assert isinstance(op.old_value, s_expr.ExpressionList)
+            assert isinstance(node, qlast.DropConcreteConstraint)
             node.args = [arg.qlast for arg in op.old_value]
             return
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2764,6 +2764,7 @@ class CreateObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
     ) -> Optional[qlast.DDLOperation]:
         node = super()._get_ast(schema, context, parent_node=parent_node)
         if node is not None and self.if_not_exists:
+            assert isinstance(node, qlast.CreateObject)
             node.create_if_not_exists = True
         return node
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1097,7 +1097,8 @@ class CreateCallableObject(
     ) -> None:
         super()._apply_fields_ast(schema, context, node)
         params = self._get_params_ast(schema, context, node)
-        node.params = [p[1] for p in params]
+        if isinstance(node, qlast.CallableObjectCommand):
+            node.params = [p[1] for p in params]
 
 
 class DeleteCallableObject(
@@ -1977,6 +1978,7 @@ class DeleteFunction(DeleteCallableObject[Function], FunctionCommand):
 
         params.sort(key=lambda e: e[0])
 
+        assert isinstance(node, qlast.CallableObjectCommand)
         node.params = [p[1] for p in params]
 
 

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -766,10 +766,11 @@ class CreateInheritingObject(
 
             if explicit_bases:
                 if isinstance(node, qlast.CreateObject):
-                    node.bases = [
-                        qlast.TypeName(maintype=utils.name_to_ast_ref(b))
-                        for b in explicit_bases
-                    ]
+                    if isinstance(node, qlast.BasesMixin):
+                        node.bases = [
+                            qlast.TypeName(maintype=utils.name_to_ast_ref(b))
+                            for b in explicit_bases
+                        ]
                 else:
                     node.commands.append(
                         qlast.AlterAddInherit(

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -275,6 +275,7 @@ class LinkCommand(
             assert isinstance(node, (qlast.CreateConcreteLink,
                                      qlast.CreateLink))
             if node.name.name == '__type__':
+                assert isinstance(node, qlast.CreateConcretePointer)
                 node.is_required = True
         return node
 

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -1045,7 +1045,7 @@ class CreateReferencedInheritingObject(
                     referrer_class = refctx.op.get_schema_metaclass()
                     refdict = referrer_class.get_refdict_for_class(objcls)
                     if refdict.requires_explicit_overloaded and implicit_bases:
-                        assert astnode is not None
+                        assert isinstance(astnode, qlast.CreateConcretePointer)
                         astnode.declared_overloaded = True
 
                 return astnode

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -453,6 +453,7 @@ class CreateScalarType(
         elif op.property == 'bases':
             enum_values = self.get_attribute_value('enum_values')
             if enum_values:
+                assert isinstance(node, qlast.BasesMixin)
                 node.bases = [
                     qlast.TypeName(
                         maintype=qlast.ObjectRef(name='enum'),

--- a/tests/common/test_ast.py
+++ b/tests/common/test_ast.py
@@ -34,16 +34,20 @@ class tast:
         pass
 
     class BinOp(Base):
-        __fields = ['op', 'left', 'right']
+        op: typing.Any = None
+        left: typing.Any = None
+        right: typing.Any = None
 
     class UnaryOp(Base):
-        __fields = ['op', 'operand']
+        op: typing.Any = None
+        operand: typing.Any = None
 
     class FunctionCall(Base):
-        __fields = ['name', ('args', list)]
+        name: typing.Any = None
+        args: typing.List[int]
 
     class Constant(Base):
-        __fields = ['value']
+        value: typing.Any = None
 
 
 class tastmatch:
@@ -72,7 +76,7 @@ class ASTBaseTests(unittest.TestCase):
         assert ctree12.left.value == lconst.value
 
         class Dict(tast.Base):
-            __fields = [('node', dict)]
+            node: dict
 
         tree2 = tast.BinOp(
             left=tast.FunctionCall(args=[Dict(node={'lconst': lconst})]))


### PR DESCRIPTION
* Drop all the support for specifying `__fields` directly
 * Don't add a do nothing __setattr__
 * Skip needing to compute a managled attribute name