### PR TITLE
Do some optimizations of AST.__init__

### DIFF
--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -236,8 +236,8 @@ class AST:
         d = self.__dict__
 
         for field_name, factory in self._field_factories:
-            value = factory()
-            d[field_name] = value
+            if field_name not in kwargs:
+                d[field_name] = factory()
 
         d.update(kwargs)
 

--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -232,14 +232,12 @@ class AST:
                 f'cannot instantiate abstract AST node '
                 f'{self.__class__.__name__!r}')
 
-        # Put things directly into __dict__, as an optimization
-        d = self.__dict__
-
+        # Make kwargs directly into our __dict__
         for field_name, factory in self._field_factories:
             if field_name not in kwargs:
-                d[field_name] = factory()
+                kwargs[field_name] = factory()
 
-        d.update(kwargs)
+        self.__dict__ = kwargs
 
         should_check_types = __debug__ and _check_type is _check_type_real
         if should_check_types:

--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -237,12 +237,12 @@ class AST:
             if field_name not in kwargs:
                 kwargs[field_name] = factory()
 
-        self.__dict__ = kwargs
-
         should_check_types = __debug__ and _check_type is _check_type_real
         if should_check_types:
             for k, v in kwargs.items():
                 self.check_field_type(self._fields[k], v)
+
+        self.__dict__ = kwargs
 
     def __copy__(self):
         copied = self.__class__()


### PR DESCRIPTION
The main thing here is not iterating over the full fields list, but
instead iterating over the list of attributes with factory defaults
and the kwargs dict separately.

This gets us benchmark speedups in the 2-5% range, mostly.
(We already picked up 1% from the previous AST changes.)