### PR TITLE
Speed up server startup by caching _get_pickled_init_args

### DIFF
--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -250,6 +250,7 @@ class Pool(amsg.ServerProtocol):
         )
         return init_args
 
+    @functools.lru_cache(maxsize=None)
     def _get_pickled_init_args(self):
         return pickle.dumps(self._get_init_args(), -1)
 

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -248,18 +248,14 @@ class Pool(amsg.ServerProtocol):
             self._dbindex.get_global_schema(),
             self._dbindex.get_compilation_system_config(),
         )
-        return init_args
-
-    @functools.lru_cache(maxsize=None)
-    def _get_pickled_init_args(self):
-        return pickle.dumps(self._get_init_args(), -1)
+        pickled_args = pickle.dumps(init_args, -1)
+        return init_args, pickled_args
 
     def worker_connected(self, pid):
         logger.debug("Worker with PID %s connected, sending init args.", pid)
+        args, pickled_args = self._get_init_args()
         self._loop.create_task(
-            self._attach_worker(
-                pid, self._get_init_args(), self._get_pickled_init_args()
-            )
+            self._attach_worker(pid, args, pickled_args)
         )
 
     def worker_disconnected(self, pid):


### PR DESCRIPTION
On my machine this speeds up startup on my normal collection of test
instances from ~9.5s to ~5.5s.