### PR TITLE
Update terminology in historical changelogs.

### DIFF
--- a/docs/changelog/1_0_a2.rst
+++ b/docs/changelog/1_0_a2.rst
@@ -179,11 +179,11 @@ set of user favorites:
     }
     FILTER .id = <uuid>$id;
 
-This change makes the shape construct consistent with the paths syntax and
-removes potential confusion with the similarly looking computable shape
-expressions.
+This change makes the shape construct consistent with the paths syntax
+and removes potential confusion with the similarly looking computed
+expressions in shapes.
 
-Another change is related to backward link navigation. Starting with Alpha 2
+Another change is related to backlink navigation. Starting with Alpha 2
 it is required to use the :eql:op:`[IS ...] <ISINTERSECT>` operator in order
 to access target objects' properties and links:
 
@@ -296,7 +296,7 @@ specify what data to insert or how to update the existing data:
 Other Fixes and Enhancements
 ----------------------------
 
-* Fix backward links in aliases (:eql:gh:`#990`).
+* Fix backlinks in aliases (:eql:gh:`#990`).
 * Fix covariant types support (:eql:gh:`#709`).
 * Implement explicit handling of 64-bit integers, and arbitrary precision
   integers and decimals (:eql:gh:`#1138`).

--- a/docs/changelog/1_0_a3.rst
+++ b/docs/changelog/1_0_a3.rst
@@ -79,8 +79,8 @@ EdgeQL
 * Fix derivation of link targets in certain cases of multiple
   inheritance (:eql:gh:`52c6b2d4`).
 * Fix handling of ad-hoc tuples (:eql:gh:`#1255`).
-* Fix incorrect implicit limit injection in subqueries in computables
-  (:eql:gh:`#1271`).
+* Fix incorrect implicit limit injection in subqueries in computed
+  expressions (:eql:gh:`#1271`).
 * Computables cardinality must now be declared explicitly as
   ``required``, ``single`` or ``multi``. The expression is validated
   to be within the upper and lower limits implied by the declaration

--- a/docs/changelog/1_0_a4.rst
+++ b/docs/changelog/1_0_a4.rst
@@ -16,14 +16,15 @@ EdgeQL
 * Allow explicit ``OPTIONAL`` qualifier for links and properties in
   DDL and SDL. In particular, use it in :eql:stmt:`DESCRIBE` command
   output. (:eql:gh:`#1342`).
-* Only show link properties on link computables that are aliases.
+* Only show link properties on computed links that are aliases.
 * :eql:stmt:`DESCRIBE` command now shows matches that are potentially
   masked by the user-defined types or functions (:eql:gh:`#1439`).
 * Add ``DESCRIBE ROLES`` and ``DESCRIBE INSTANCE CONFIG`` to the
   :eql:stmt:`DESCRIBE` command.
 * Allow underscore in numeric literals and forbids float and decimal
   constants to end in ``.`` (:eql:gh:`#920`).
-* Validate the ``REQUIRED`` flag on computables (:eql:gh:`#217`).
+* Validate the ``REQUIRED`` flag on computed links and properties
+  (:eql:gh:`#217`).
 * Forbid reference to link properties outside of a path expression
   (:eql:gh:`#1512`).
 * Allow annotations to be renamed (:eql:gh:`#762`).

--- a/docs/changelog/1_0_b1.rst
+++ b/docs/changelog/1_0_b1.rst
@@ -283,7 +283,8 @@ EdgeQL
 * Fix issues with :eql:func:`enumerate` when applied to objects
   (:eql:gh:`#1815`) and results of function calls (:eql:gh:`#1816`).
 * Fix ``DROP PROPERTY`` for ``MULTI`` properties (:eql:gh:`#2059`).
-* Make sure computable pointers don't appear in dump (:eql:gh:`#2057`).
+* Make sure computed links and properties don't appear in dump
+  (:eql:gh:`#2057`).
 * Fix accessing links on objects that come from functions and other
   sources that aren't simple paths (:eql:gh:`#1887`).
 

--- a/docs/changelog/1_0_b2.rst
+++ b/docs/changelog/1_0_b2.rst
@@ -76,7 +76,7 @@ EdgeQL
 * Make :eql:func:`min` and :eql:func:`max` work more consistently
   across all supported types (:eql:gh:`#1920`).
 * Improve cardinality inference (:eql:gh:`#2097`).
-* Disallow use of ``VOLATILE`` functions in schema-defined computable
+* Disallow use of ``VOLATILE`` functions in schema-defined computed
   expressions (:eql:gh:`#2467`).
 * Fix handling of collection types of non-builtin scalars in dumps
   (:eql:gh:`#2349`).
@@ -87,7 +87,7 @@ EdgeQL
   <ref_eql_statements_update>` (:eql:gh:`#2455`).
 * Fix an issue with empty sets (i.e. ``{}``) inside set literals
   (:eql:gh:`#2154`).
-* Fix backward links when multiple types with the same link name exist
+* Fix backlinks when multiple types with the same link name exist
   (:eql:gh:`#2360`).
 * Fix :eql:op:`DISTINCT` on empty and nested tuples (:eql:gh:`#2333`).
 * Fix some serialization issues of shapes inside arrays and tuples

--- a/docs/changelog/1_0_b3.rst
+++ b/docs/changelog/1_0_b3.rst
@@ -14,7 +14,7 @@ We continue working on improving our schema and migration tools:
 * Prohibit mixing computed and regular links or properties
   (:eql:gh:`#2099`).
 * Don't ask for conversion expressions when changing type of
-  computable (:eql:gh:`#2658`).
+  computed link or property (:eql:gh:`#2658`).
 * Fix some migration issues involving rebasing (:eql:gh:`#2536`).
 * Fix backlink processing in SDL schemas (:eql:gh:`#1824`).
 * Improve migration prompts (:eql:gh:`#2547`, :eql:gh:`#2591`).


### PR DESCRIPTION
Use the terms "backlink" and "computed link/property/expression" in the
past changelogs.