### PR TITLE
Be smarter about how and when we materialize

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -220,7 +220,7 @@ class Environment:
 
     materialized_sets: Dict[
         Union[s_types.Type, s_pointers.PointerLike],
-        qlast.Statement,
+        Tuple[qlast.Statement, Sequence[irast.MaterializeReason]],
     ]
     """A mapping of computed sets that must be computed only once."""
 

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1423,73 +1423,93 @@ def maybe_materialize(
     *,
     ctx: context.ContextLevel,
 ) -> None:
-    mat_qlstmt = ctx.env.materialized_sets.get(stype)
-    if mat_qlstmt is not None:
-        materialize_in_stmt = ctx.env.compiled_stmts[mat_qlstmt]
-        if materialize_in_stmt.materialized_sets is None:
-            materialize_in_stmt.materialized_sets = {}
+    if isinstance(stype, s_pointers.PseudoPointer):
+        return
 
-        assert not isinstance(stype, s_pointers.PseudoPointer)
-        if stype.id not in materialize_in_stmt.materialized_sets:
-            saved = (
-                None if isinstance(stype, s_pointers.Pointer) and not ir.rptr
-                else ir
-            )
-            materialize_in_stmt.materialized_sets[stype.id] = (
-                irast.MaterializedSet(materialized=saved, use_sets=[]))
+    # Search for a materialized_sets entry
+    while True:
+        if mat_entry := ctx.env.materialized_sets.get(stype):
+            break
+        # Search up for parent pointers, if applicable
+        if not isinstance(stype, s_pointers.Pointer):
+            return
+        bases = stype.get_bases(ctx.env.schema).objects(ctx.env.schema)
+        if not bases:
+            return
+        stype = bases[0]
 
-        mat_set = materialize_in_stmt.materialized_sets[stype.id]
-        mat_set.use_sets.append(ir)
+    # We've found an entry, populate it.
+    mat_qlstmt, reason = mat_entry
+    materialize_in_stmt = ctx.env.compiled_stmts[mat_qlstmt]
+    if materialize_in_stmt.materialized_sets is None:
+        materialize_in_stmt.materialized_sets = {}
 
+    assert not isinstance(stype, s_pointers.PseudoPointer)
+    if stype.id not in materialize_in_stmt.materialized_sets:
+        saved = (
+            None if isinstance(stype, s_pointers.Pointer) and not ir.rptr
+            else ir
+        )
+        materialize_in_stmt.materialized_sets[stype.id] = (
+            irast.MaterializedSet(
+                materialized=saved, reason=reason, use_sets=[]))
 
-def force_materialized_volatile(
-    ir: irast.Base, *, ctx: context.ContextLevel
-) -> None:
-    vol = inference.infer_volatility(ir, ctx.env)
-    ctx.env.inferred_volatility[ir] = (vol, qltypes.Volatility.Volatile)
+    mat_set = materialize_in_stmt.materialized_sets[stype.id]
+    mat_set.use_sets.append(ir)
 
 
 def should_materialize(
     ir: irast.Base, *,
+    ptrcls: Optional[s_pointers.Pointer]=None,
     binding_pessimism: bool=False,
     skipped_bindings: AbstractSet[irast.PathId]=frozenset(),
     ctx: context.ContextLevel,
-) -> bool:
+) -> Sequence[irast.MaterializeReason]:
     volatility = inference.infer_volatility(
         ir, ctx.env, for_materialization=True)
     if volatility is qltypes.Volatility.Volatile:
-        return True
+        # vol is always good enough, don't need to look harder
+        return (('vol',),)
 
     if not isinstance(ir, irast.Set):
-        return False
+        return ()
 
     typ = get_set_type(ir, ctx=ctx)
 
-    # For shape elements, we need to materialize when they reference bindings
-    # TODO: this is pretty pessimistic, we should be able to detect
-    # cases where it isn't necessary afterwards in stmtctx and clean
-    # them up.
-    if binding_pessimism and irutils.contains_binding(ir, skipped_bindings):
-        return True
+    reasons: List[irast.MaterializeReason] = []
 
-    return should_materialize_type(typ, ctx=ctx)
+    # For shape elements, we need to materialize when they reference
+    # bindings that are visible from that point. This means that doing
+    # WITH/FOR bindings internally is fine, but referring to
+    # externally bound things needs materialization. We can't actually
+    # do this visibility analysis until we are done, though, so
+    # instead we just store the bindings.
+    if (
+        binding_pessimism
+        and (bindings := irutils.find_bindings(ir, skipped_bindings))
+    ):
+        reasons.append(('bindings', bindings))
+
+    if ptrcls and ptrcls in ctx.source_map:
+        reasons += ctx.source_map[ptrcls].should_materialize
+
+    reasons += should_materialize_type(typ, ctx=ctx)
+
+    return reasons
 
 
 def should_materialize_type(
     typ: s_types.Type, *, ctx: context.ContextLevel
-) -> bool:
+) -> List[irast.MaterializeReason]:
     schema = ctx.env.schema
+    reasons: List[irast.MaterializeReason] = []
     if isinstance(
             typ, (s_objtypes.ObjectType, s_pointers.Pointer)):
         for pointer in typ.get_pointers(schema).objects(schema):
-            if (
-                pointer in ctx.source_map
-                and ctx.source_map[pointer].should_materialize
-            ):
-                return True
+            if pointer in ctx.source_map:
+                reasons += ctx.source_map[pointer].should_materialize
     elif isinstance(typ, s_types.Collection):
         for sub in typ.get_subtypes(schema):
-            if should_materialize_type(sub, ctx=ctx):
-                return True
+            reasons += should_materialize_type(sub, ctx=ctx)
 
-    return False
+    return reasons

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1469,7 +1469,7 @@ def should_materialize(
         ir, ctx.env, for_materialization=True)
     if volatility is qltypes.Volatility.Volatile:
         # vol is always good enough, don't need to look harder
-        return (('vol',),)
+        return (irast.MaterializeVolatile(),)
 
     if not isinstance(ir, irast.Set):
         return ()
@@ -1488,7 +1488,7 @@ def should_materialize(
         binding_pessimism
         and (bindings := irutils.find_bindings(ir, skipped_bindings))
     ):
-        reasons.append(('bindings', bindings))
+        reasons.append(irast.MaterializeBindings(bindings))
 
     if ptrcls and ptrcls in ctx.source_map:
         reasons += ctx.source_map[ptrcls].should_materialize

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1233,12 +1233,11 @@ def process_with_block(
                 )
                 results.append(binding)
 
-                if setgen.should_materialize(binding, ctx=ctx):
+                if reason := setgen.should_materialize(binding, ctx=ctx):
                     had_materialized = True
                     typ = setgen.get_set_type(binding, ctx=ctx)
-                    ctx.env.materialized_sets[typ] = edgeql_tree
+                    ctx.env.materialized_sets[typ] = edgeql_tree, reason
                     assert binding.expr
-                    setgen.force_materialized_volatile(binding.expr, ctx=ctx)
                     setgen.maybe_materialize(typ, binding, ctx=ctx)
 
         else:

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -284,15 +284,33 @@ def _fixup_materialized_sets(
                         f"couldn't find the source for {mat_set.uses} on "
                         f"{stmt.result}!")
 
-            # Compile the view shapes in the set
             ir_set = mat_set.materialized
+            assert ir_set.path_scope_id is not None
+            new_scope = ctx.env.scope_tree_nodes[ir_set.path_scope_id]
+            assert new_scope.parent
+            parent = new_scope.parent
+
+            good_reason = False
+            for x in mat_set.reason:
+                if x[0] == 'vol':
+                    good_reason = True
+                elif x[0] == 'bindings':
+                    # If any of the bindings that the set uses are *visible*
+                    # at the binding point, we need to materialize, to make
+                    # sure that things get correlated properly. If it's not
+                    # visible, then it's just being used internally and we
+                    # don't need any special work.
+                    if any(parent.is_visible(b.path_id) for b in x[1]):
+                        good_reason = True
+
+            if not good_reason:
+                del stmt.materialized_sets[key]
+                continue
+
+            # Compile the view shapes in the set
             with ctx.new() as subctx:
                 subctx.implicit_tid_in_shapes = False
                 subctx.implicit_tname_in_shapes = False
-                assert ir_set.path_scope_id is not None
-                new_scope = ctx.env.scope_tree_nodes.get(
-                    ir_set.path_scope_id)
-                assert new_scope
                 subctx.path_scope = new_scope
                 viewgen.compile_view_shapes(ir_set, ctx=subctx)
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -292,15 +292,15 @@ def _fixup_materialized_sets(
 
             good_reason = False
             for x in mat_set.reason:
-                if x[0] == 'vol':
+                if isinstance(x, irast.MaterializeVolatile):
                     good_reason = True
-                elif x[0] == 'bindings':
+                elif isinstance(x, irast.MaterializeBindings):
                     # If any of the bindings that the set uses are *visible*
                     # at the binding point, we need to materialize, to make
                     # sure that things get correlated properly. If it's not
                     # visible, then it's just being used internally and we
                     # don't need any special work.
-                    if any(parent.is_visible(b.path_id) for b in x[1]):
+                    if any(parent.is_visible(b.path_id) for b in x.bindings):
                         good_reason = True
 
             if not good_reason:

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -474,6 +474,9 @@ class Param:
     """IR type reference"""
 
 
+MaterializeReason = typing.Tuple[typing.Any, ...]
+
+
 class ComputableInfo(typing.NamedTuple):
 
     qlexpr: qlast.Expr
@@ -482,7 +485,7 @@ class ComputableInfo(typing.NamedTuple):
     path_id: PathId
     path_id_ns: typing.Optional[Namespace]
     shape_op: qlast.ShapeOp
-    should_materialize: bool
+    should_materialize: typing.Sequence[MaterializeReason]
 
 
 class Statement(Command):
@@ -743,6 +746,8 @@ class MaterializedSet(Base):
     # Hide uses to reduce spew; we produce our own simpler uses
     __ast_hidden__ = {'use_sets'}
     materialized: typing.Optional[Set]
+    reason: typing.Sequence[MaterializeReason]
+
     # We really only want the *paths* of all the places it is used,
     # but we need to store the sets to take advantage of weak
     # namespace rewriting.

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -474,7 +474,15 @@ class Param:
     """IR type reference"""
 
 
-MaterializeReason = typing.Tuple[typing.Any, ...]
+class MaterializeVolatile(typing.NamedTuple):
+    pass
+
+
+class MaterializeBindings(typing.NamedTuple):
+    bindings: typing.Set[Set]
+
+
+MaterializeReason = typing.Union[MaterializeVolatile, MaterializeBindings]
 
 
 class ComputableInfo(typing.NamedTuple):

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -3010,9 +3010,8 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
+    @test.xfail('more than one row returned by a subquery')
     async def test_edgeql_scope_ref_side_02(self):
-        # This works but tbh it is by accident since the SELECT _
-        # triggers a materialization (for the wrong reasons).
         await self.assert_query_result(
             """
                 SELECT (


### PR DESCRIPTION
Instead of always materializing whenever we see a binding in a shape
element, we track the *reasons* we think we might need to
materialize. While finalizing materialization decisions, we look at
the bindings used, and only materialize when a *visible* binding is
referenced.

This means that doing WITH/FOR bindings internally is fine, but
referring to externally bound things needs materialization.

My main motivation for doing this is that the approach I am planning
to take to fix the nesting tests introduced in #2774 involves
materializing those cases, but we obviously can't just materialize
everything that references some unrelated object, so we need machinery
to base it on scope visibility.

A basic example of where this helps is:
```
WITH U := User { asdf := (WITH D := .deck, SELECT D.name) },
SELECT U.asdf;
```
Previously we would do two `array_agg`s, for `asdf` and `U`, and now
we do none.

Another important side effect of this is a WITH bound set of a shape
that has a pointer materialized for binding reasons does not need to
be materialized itself!
(This required having `maybe_materialize` search through the view
pointer hierarchy to find relevant materialized pointers through
multiple views.)

Some queries that this helps with:
```
WITH X := (FOR x in {"!","?"} UNION (User { z := .deck.name ++ x}))
SELECT X {name, z} FILTER .name = "Alice";
```
The `z` multi property is materialized into an array, but `X` does not
have to be.

We can even do:
```
WITH X := (FOR x in {"!","?"} UNION (User { z := .deck.name ++ x}))
SELECT ((SELECT X.z), (SELECT X.z));
```
The whole computation gets duplicated (as is traditional in edgedb)
and the `z` property gets materialized in both.

Unfortunately right now this one still materializes:
```
WITH U := (FOR x in {"!","?"} UNION (User { z := .deck.name ++ x})),
     X := (SELECT U FILTER .name = 'Alice'),
SELECT ((SELECT X.z), (SELECT X.z));
```