### PR TITLE
Sync inittestdb data-dir with that of devmode server (again)

### DIFF
--- a/edb/common/devmode.py
+++ b/edb/common/devmode.py
@@ -18,13 +18,14 @@
 
 
 from __future__ import annotations
+from typing import *
 
 import contextlib
 import json
 import logging
 import os
 import pathlib
-from typing import *
+import sys
 
 
 logger = logging.getLogger('edb.devmode.cache')
@@ -111,7 +112,7 @@ def is_in_dev_mode() -> bool:
     return devmode.lower() not in ('0', '', 'false')
 
 
-def get_dev_mode_cache_dir() -> os.PathLike:
+def get_dev_mode_cache_dir() -> pathlib.Path:
     if is_in_dev_mode():
         root = pathlib.Path(__file__).parent.parent.parent
         cache_dir = (root / 'build' / 'cache')
@@ -119,3 +120,29 @@ def get_dev_mode_cache_dir() -> os.PathLike:
         return cache_dir
     else:
         raise RuntimeError('server is not running in dev mode')
+
+
+def get_dev_mode_data_dir() -> pathlib.Path:
+    data_dir_env = os.environ.get("EDGEDB_SERVER_DEV_DIR")
+    if data_dir_env:
+        data_dir = pathlib.Path(data_dir_env)
+    else:
+        if sys.platform == "darwin":
+            data_dir = (
+                pathlib.Path.home()
+                / "Library"
+                / "Application Support"
+                / "edgedb"
+                / "_localdev"
+            )
+        else:
+            xdg_data_dir = pathlib.Path(
+                os.environ.get("XDG_DATA_HOME", ".")
+            )
+            if not xdg_data_dir.is_absolute():
+                xdg_data_dir = (
+                    pathlib.Path.home() / ".local" / "share"
+                )
+            data_dir = xdg_data_dir / "edgedb" / "_localdev"
+
+    return data_dir

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 from typing import *
 
 import logging
-import os.path
 import pathlib
 import re
 import warnings
@@ -473,27 +472,7 @@ def parse_args(**kwargs: Any):
             if kwargs['postgres_dsn']:
                 pass
             elif devmode.is_in_dev_mode():
-                data_dir_env = os.environ.get("EDGEDB_SERVER_DEV_DIR")
-                if data_dir_env:
-                    data_dir = pathlib.Path(data_dir_env)
-                else:
-                    if sys.platform == "darwin":
-                        data_dir = (
-                            pathlib.Path.home()
-                            / "Library"
-                            / "Application Support"
-                            / "edgedb"
-                            / "_localdev"
-                        )
-                    else:
-                        xdg_data_dir = pathlib.Path(
-                            os.environ.get("XDG_DATA_HOME", ".")
-                        )
-                        if not xdg_data_dir.is_absolute():
-                            xdg_data_dir = (
-                                pathlib.Path.home() / ".local" / "share"
-                            )
-                        data_dir = xdg_data_dir / "edgedb" / "_localdev"
+                data_dir = devmode.get_dev_mode_data_dir()
                 if not data_dir.parent.exists():
                     data_dir.parent.mkdir(exist_ok=True, parents=True)
 

--- a/edb/tools/inittestdb.py
+++ b/edb/tools/inittestdb.py
@@ -27,11 +27,10 @@ import unittest
 
 import click
 
+from edb.common import devmode
 from edb.server import cluster as edgedb_cluster
 from edb.testbase import server as tb
 from edb.tools.edb import edbcommands
-
-from edgedb import platform
 
 
 class TestResult:
@@ -68,12 +67,7 @@ def die(msg):
 @click.option(
     '-D', '--data-dir',
     type=str,
-    default=str(
-        pathlib.Path(os.environ.get(
-            "EDGEDB_SERVER_DEV_DIR",
-            platform.config_dir() / 'data' / '_localdev',
-        ))
-    ),
+    default=str(devmode.get_dev_mode_data_dir()),
     help='database cluster directory',
 )
 @click.option(


### PR DESCRIPTION
The location has been changed in #2771, but `inittestdb` was overlooked
again, so factor out the directory logic into a helper in `devmode` to
make sure this doesn't happen the next time we change the path :-)