### PR TITLE
Stop pinning to an exact version of Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ RUNTIME_DEPS = [
     'edgedb>=0.16.0',
 ]
 
-CYTHON_DEPENDENCY = 'Cython==0.29.23'
+CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
 
 DOCS_DEPS = [
     'lxml~=4.6.2',


### PR DESCRIPTION
Cython 0.29 is in maintenance mode, so the risk of big breakage is low.
On the other hand, this maintenance picks up important fixes, including
support for newer Pythons.  Furthermore, pinning to an exact version
may cause conflicts if something else pins to a slightly different version.