### PR TITLE
Change query_one() usages to query_single()

### DIFF
--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1238,7 +1238,7 @@ class TestConstraintsDDL(tb.DDLTestCase):
             RENAME TO mymax13b;
         """)
 
-        res = await self.con.query_one("""
+        res = await self.con.query_single("""
             DESCRIBE MODULE default
         """)
 

--- a/tests/test_dump03.py
+++ b/tests/test_dump03.py
@@ -57,12 +57,12 @@ class DumpTestCaseMixin:
             ]
         )
 
-        result = await self.con.query_one(
+        result = await self.con.query_single(
             "SELECT sequence_next(INTROSPECT TYPEOF Test.seq)"
         )
         self.assertEqual(result, 2)
 
-        result = await self.con.query_one(
+        result = await self.con.query_single(
             "SELECT sequence_next(INTROSPECT MyPristineSeq)"
         )
         self.assertEqual(result, 1)

--- a/tests/test_dump_basic.py
+++ b/tests/test_dump_basic.py
@@ -70,7 +70,7 @@ class TestDumpBasics(tb.DatabaseTestCase, tb.CLITestCaseMixin):
             hasher.update(data)
             total_len += len(data)
 
-            await self.con.query_one('''
+            await self.con.query_single('''
                 INSERT test::Tmp {
                     idx := <int64>$idx,
                     data := <bytes>$data,
@@ -101,7 +101,7 @@ class TestDumpBasics(tb.DatabaseTestCase, tb.CLITestCaseMixin):
                 # We don't have cursors yet and we also don't want to fetch
                 # a huge data set in one hop; so we fetch row by row.
                 # Not ideal, but isn't too bad either.
-                r = await con2.query_one('''
+                r = await con2.query_single('''
                     WITH
                         MODULE test,
                         A := (SELECT Tmp FILTER Tmp.idx = <int64>$idx)

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -920,7 +920,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
         )
 
         self.assertEqual(
-            await self.con.query_one(
+            await self.con.query_single(
                 r'''SELECT call23(to_json('[{"a":"b"}]'), 0);'''),
             '{"a": "b"}')
         self.assertEqual(

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -550,12 +550,12 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             async with self.assertRaisesRegexTx(
                     edgedb.InvalidValueError,
                     fr"invalid syntax for std::bool: '{variant}'"):
-                await self.con.query_one(f'SELECT <bool>"{variant}"')
+                await self.con.query_single(f'SELECT <bool>"{variant}"')
 
         self.assertTrue(
-            await self.con.query_one('SELECT <bool>"    TruE   "'))
+            await self.con.query_single('SELECT <bool>"    TruE   "'))
         self.assertFalse(
-            await self.con.query_one('SELECT <bool>"    FalsE   "'))
+            await self.con.query_single('SELECT <bool>"    FalsE   "'))
 
     async def test_edgeql_casts_str_03(self):
         # str to json is always lossless
@@ -638,31 +638,31 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <datetime>"2018-05-07;20:01:22.306916+00:00"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <datetime>"2018-05-07T20:01:22.306916"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <datetime>"2018-05-07T20:01:22.306916 1000"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <datetime>"2018-05-07T20:01:22.306916 US/Central"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <datetime>"2018-05-07T20:01:22.306916 +GMT1"')
 
     async def test_edgeql_casts_str_06(self):
@@ -696,13 +696,13 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <cal::local_datetime>"2018-05-07;20:01:22.306916"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 '''
                     SELECT
                         <cal::local_datetime>"2018-05-07T20:01:22.306916+01:00"
@@ -711,13 +711,13 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <cal::local_datetime>"2018-05-07T20:01:22.306916 GMT"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 '''
                     SELECT
                       <cal::local_datetime>"2018-05-07T20:01:22.306916 GMT0"
@@ -726,7 +726,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 '''SELECT <cal::local_datetime>
                     "2018-05-07T20:01:22.306916 US/Central"
                 ''')
@@ -757,25 +757,25 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <cal::local_date>"2018-05-07T20:01:22.306916"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <cal::local_date>"2018/05/07"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <cal::local_date>"2018.05.07"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <cal::local_date>"2018-05-07+01:00"')
 
     async def test_edgeql_casts_str_08(self):
@@ -806,13 +806,13 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 'invalid input syntax for type cal::local_time'):
-            await self.con.query_one(
+            await self.con.query_single(
                 "SELECT <cal::local_time>'2018-05-07 20:01:22'")
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <cal::local_time>"20:01:22.306916+01:00"')
 
     async def test_edgeql_casts_str_09(self):
@@ -1954,25 +1954,25 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <datetime><json>"2018-05-07;20:01:22.306916+00:00"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <datetime><json>"2018-05-07T20:01:22.306916"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <datetime><json>"2018-05-07T20:01:22.306916 1000"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax'):
-            await self.con.query_one(
+            await self.con.query_single(
                 '''SELECT <datetime><json>
                     "2018-05-07T20:01:22.306916 US/Central"
                 ''')
@@ -1980,7 +1980,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <datetime><json>"2018-05-07T20:01:22.306916 +GMT1"')
 
     async def test_edgeql_casts_json_08(self):
@@ -2019,7 +2019,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 '''SELECT
                     <cal::local_datetime><json>"2018-05-07;20:01:22.306916"
                 ''')
@@ -2027,7 +2027,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 '''SELECT <cal::local_datetime><json>
                     "2018-05-07T20:01:22.306916+01:00"
                 ''')
@@ -2035,21 +2035,21 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 '''SELECT <cal::local_datetime><json>
                     "2018-05-07T20:01:22.306916 GMT"''')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 '''SELECT <cal::local_datetime><json>
                     "2018-05-07T20:01:22.306916 GMT0"''')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 '''SELECT <cal::local_datetime><json>
                     "2018-05-07T20:01:22.306916 US/Central"
                 ''')
@@ -2084,25 +2084,25 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <cal::local_date><json>"2018-05-07T20:01:22.306916"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <cal::local_date><json>"2018/05/07"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <cal::local_date><json>"2018.05.07"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <cal::local_date><json>"2018-05-07+01:00"')
 
     async def test_edgeql_casts_json_10(self):
@@ -2138,13 +2138,13 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 'invalid input syntax for type cal::local_time'):
-            await self.con.query_one(
+            await self.con.query_single(
                 "SELECT <cal::local_time><json>'2018-05-07 20:01:22'")
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT <cal::local_time><json>"20:01:22.306916+01:00"')
 
     async def test_edgeql_casts_json_11(self):
@@ -2156,37 +2156,37 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'expected json number or null; got json string'):
-            await self.con.query_one(
+            await self.con.query_single(
                 r"SELECT <array<int64>><json>['asdf']")
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'expected json number or null; got json string'):
-            await self.con.query_one(
+            await self.con.query_single(
                 r"SELECT <array<int64>>to_json('[1, 2, \"asdf\"]')")
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid null value in cast'):
-            await self.con.query_one(
+            await self.con.query_single(
                 r"SELECT <array<int64>>[to_json('1'), to_json('null')]")
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid null value in cast'):
-            await self.con.query_one(
+            await self.con.query_single(
                 r"SELECT <array<int64>>to_json('[1, 2, null]')")
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid null value in cast'):
-            await self.con.query_one(
+            await self.con.query_single(
                 r"SELECT <array<int64>><array<json>>to_json('[1, 2, null]')")
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'cannot extract elements from a scalar'):
-            await self.con.query_one(
+            await self.con.query_single(
                 r"SELECT <array<int64>><json>'asdf'")
 
     async def test_edgeql_casts_json_12(self):
@@ -2247,7 +2247,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         )
 
         self.assertEqual(
-            await self.con.query_one(
+            await self.con.query_single(
                 r"""
                     SELECT <tuple<int64, tuple<a: int64, b: int64>>>
                     to_json('[3000, {"a": 1, "b": 2}]')
@@ -2257,7 +2257,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         )
 
         self.assertEqual(
-            await self.con.query_one(
+            await self.con.query_single(
                 r"""
                     SELECT <tuple<int64, array<tuple<a: int64, b: str>>>>
                     to_json('[3000, [{"a": 1, "b": "foo"},

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -72,7 +72,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             tx = self.con.transaction()
             await tx.start()
             try:
-                res = await self.con.query_one(
+                res = await self.con.query_single(
                     'DESCRIBE CURRENT MIGRATION AS JSON;')
             finally:
                 await tx.rollback()
@@ -110,7 +110,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         try:
             step = 0
             while True:
-                mig = await self.con.query_one(
+                mig = await self.con.query_single(
                     'DESCRIBE CURRENT MIGRATION AS JSON;')
                 mig = json.loads(mig)
                 if mig['proposed'] is None:
@@ -4022,7 +4022,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         # Starting with a small schema migrate to remove its elements.
         # There are non-zero default Objects existing in a fresh blank
         # database because of placeholder objects used for GraphQL.
-        start_objects = await self.con.query_one(r"""
+        start_objects = await self.con.query_single(r"""
             SELECT count(Object);
         """)
 
@@ -8904,7 +8904,7 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             SET MODULE test;
             INSERT User;
         ''')
-        post = await self.con.query_one('''
+        post = await self.con.query_single('''
             INSERT Post {
                 user := (SELECT User LIMIT 1),
             };

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4847,13 +4847,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         ''')
 
         count_query = "SELECT count(schema::CollectionType);"
-        orig_count = await self.con.query_one(count_query)
+        orig_count = await self.con.query_single(count_query)
 
         await self.con.execute('''
             ALTER SCALAR TYPE myint CREATE CONSTRAINT std::one_of(1, 2);
         ''')
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count)
+        self.assertEqual(await self.con.query_single(count_query), orig_count)
 
         async with self.assertRaisesRegexTx(
                 edgedb.ConstraintViolationError,
@@ -6545,7 +6545,7 @@ type default::Foo {
             }]
         )
 
-        role = await self.con.query_one('''
+        role = await self.con.query_single('''
             SELECT sys::Role { password }
             FILTER .name = 'foo2'
         ''')
@@ -6558,7 +6558,7 @@ type default::Foo {
             };
         """)
 
-        role = await self.con.query_one('''
+        role = await self.con.query_single('''
             SELECT sys::Role { password }
             FILTER .name = 'foo2'
         ''')
@@ -6700,7 +6700,7 @@ type default::Foo {
         # This is ensuring that describing std does not cause errors.
         # The test validates only a small sample of entries, though.
 
-        result = await self.con.query_one("""
+        result = await self.con.query_single("""
             DESCRIBE MODULE std
         """)
         # This is essentially a syntax test from this point on.
@@ -9887,7 +9887,7 @@ type default::Foo {
             """)
 
         else:
-            res = await self.con.query_one("""
+            res = await self.con.query_single("""
                 DESCRIBE MODULE default
             """)
 
@@ -9980,7 +9980,7 @@ type default::Foo {
             }
             """)
 
-        res = await self.con.query_one("""
+        res = await self.con.query_single("""
             DESCRIBE MODULE default
         """)
 
@@ -10055,7 +10055,7 @@ type default::Foo {
             }
         """)
 
-        res = await self.con.query_one("""
+        res = await self.con.query_single("""
             DESCRIBE MODULE default
         """)
 
@@ -10154,7 +10154,7 @@ type default::Foo {
 
     async def test_edgeql_ddl_collection_cleanup_01(self):
         count_query = "SELECT count(schema::Array);"
-        orig_count = await self.con.query_one(count_query)
+        orig_count = await self.con.query_single(count_query)
 
         await self.con.execute(r"""
 
@@ -10168,7 +10168,7 @@ type default::Foo {
             };
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 2)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 2)
 
         await self.con.execute(r"""
             ALTER TYPE TestArrays {
@@ -10176,7 +10176,7 @@ type default::Foo {
             };
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 1)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 1)
 
         await self.con.execute(r"""
             ALTER TYPE TestArrays {
@@ -10186,17 +10186,17 @@ type default::Foo {
             };
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 1)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 1)
 
         await self.con.execute(r"""
             DROP TYPE TestArrays;
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count)
+        self.assertEqual(await self.con.query_single(count_query), orig_count)
 
     async def test_edgeql_ddl_collection_cleanup_01b(self):
         count_query = "SELECT count(schema::Array);"
-        orig_count = await self.con.query_one(count_query)
+        orig_count = await self.con.query_single(count_query)
 
         await self.con.execute(r"""
 
@@ -10211,7 +10211,7 @@ type default::Foo {
             };
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 2)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 2)
 
         await self.con.execute(r"""
             ALTER TYPE TestArrays {
@@ -10219,7 +10219,7 @@ type default::Foo {
             };
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 1)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 1)
 
         await self.con.execute(r"""
             ALTER TYPE TestArrays {
@@ -10229,17 +10229,17 @@ type default::Foo {
             };
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 2)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 2)
 
         await self.con.execute(r"""
             DROP TYPE TestArrays;
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count)
+        self.assertEqual(await self.con.query_single(count_query), orig_count)
 
     async def test_edgeql_ddl_collection_cleanup_02(self):
         count_query = "SELECT count(schema::CollectionType);"
-        orig_count = await self.con.query_one(count_query)
+        orig_count = await self.con.query_single(count_query)
 
         await self.con.execute(r"""
 
@@ -10252,19 +10252,19 @@ type default::Foo {
             };
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 2)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 2)
 
         await self.con.execute(r"""
             DROP TYPE TestArrays;
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count)
+        self.assertEqual(await self.con.query_single(count_query), orig_count)
 
     async def test_edgeql_ddl_collection_cleanup_03(self):
         count_query = "SELECT count(schema::CollectionType);"
-        orig_count = await self.con.query_one(count_query)
+        orig_count = await self.con.query_single(count_query)
         elem_count_query = "SELECT count(schema::TupleElement);"
-        orig_elem_count = await self.con.query_one(elem_count_query)
+        orig_elem_count = await self.con.query_single(elem_count_query)
 
         await self.con.execute(r"""
 
@@ -10277,20 +10277,20 @@ type default::Foo {
                  -> array<b> USING (SELECT [<b>""]);
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 4)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 4)
 
         await self.con.execute(r"""
             DROP FUNCTION foo(
                 x: array<a>, z: tuple<b, c>, y: array<tuple<b, c>>);
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count)
+        self.assertEqual(await self.con.query_single(count_query), orig_count)
         self.assertEqual(
-            await self.con.query_one(elem_count_query), orig_elem_count)
+            await self.con.query_single(elem_count_query), orig_elem_count)
 
     async def test_edgeql_ddl_collection_cleanup_04(self):
         count_query = "SELECT count(schema::CollectionType);"
-        orig_count = await self.con.query_one(count_query)
+        orig_count = await self.con.query_single(count_query)
 
         await self.con.execute(r"""
 
@@ -10307,48 +10307,48 @@ type default::Foo {
             CREATE ALIAS Bar := Foo { thing := (.a, .b) };
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 1)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 1)
 
         await self.con.execute(r"""
             ALTER ALIAS Bar USING (Foo { thing := (.a, .b, .c) });
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 1)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 1)
 
         await self.con.execute(r"""
             ALTER ALIAS Bar USING (Foo { thing := (.a, (.b, .c)) });
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 2)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 2)
 
         await self.con.execute(r"""
             ALTER ALIAS Bar USING (Foo { thing := ((.a, .b), .c) });
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 2)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 2)
 
         await self.con.execute(r"""
             ALTER ALIAS Bar USING (Foo { thing := ((.a, .b), .c, "foo") });
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 2)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 2)
 
         # Make a change that doesn't change the types
         await self.con.execute(r"""
             ALTER ALIAS Bar USING (Foo { thing := ((.a, .b), .c, "bar") });
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 2)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 2)
 
         await self.con.execute(r"""
             DROP ALIAS Bar;
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count)
+        self.assertEqual(await self.con.query_single(count_query), orig_count)
 
     async def test_edgeql_ddl_collection_cleanup_05(self):
         count_query = "SELECT count(schema::CollectionType);"
-        orig_count = await self.con.query_one(count_query)
+        orig_count = await self.con.query_single(count_query)
 
         await self.con.execute(r"""
 
@@ -10358,19 +10358,19 @@ type default::Foo {
             CREATE ALIAS Bar := (<a>"", <b>"");
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 2)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 2)
 
         await self.con.execute(r"""
             ALTER ALIAS Bar USING ((<b>"", <a>""));
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count + 2)
+        self.assertEqual(await self.con.query_single(count_query), orig_count + 2)
 
         await self.con.execute(r"""
             DROP ALIAS Bar;
         """)
 
-        self.assertEqual(await self.con.query_one(count_query), orig_count)
+        self.assertEqual(await self.con.query_single(count_query), orig_count)
 
     async def test_edgeql_ddl_drop_field_01(self):
         await self.con.execute(r"""

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -83,13 +83,13 @@ class TestDelete(tb.QueryTestCase):
         )
 
     async def test_edgeql_delete_simple_02(self):
-        id1 = str((await self.con.query_one(r"""
+        id1 = str((await self.con.query_single(r"""
             SELECT(INSERT DeleteTest {
                 name := 'delete-test1'
             }) LIMIT 1;
         """)).id)
 
-        id2 = str((await self.con.query_one(r"""
+        id2 = str((await self.con.query_single(r"""
             SELECT(INSERT DeleteTest {
                 name := 'delete-test2'
             }) LIMIT 1;
@@ -141,7 +141,7 @@ class TestDelete(tb.QueryTestCase):
         )
 
     async def test_edgeql_delete_returning_01(self):
-        id1 = str((await self.con.query_one(r"""
+        id1 = str((await self.con.query_single(r"""
             SELECT (INSERT DeleteTest {
                 name := 'delete-test1'
             }) LIMIT 1;

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -388,40 +388,40 @@ class TestExpressions(tb.QueryTestCase):
         with self.assertRaisesRegex(edgedb.NumericOutOfRangeError,
                                     'std::int16 out of range'):
             async with self.con.transaction():
-                await self.con.query_one(
+                await self.con.query_single(
                     r'''SELECT <int16>36893488147419''',
                 )
 
         with self.assertRaisesRegex(edgedb.NumericOutOfRangeError,
                                     'std::int32 out of range'):
             async with self.con.transaction():
-                await self.con.query_one(
+                await self.con.query_single(
                     r'''SELECT <int32>36893488147419''',
                 )
 
         with self.assertRaisesRegex(edgedb.NumericOutOfRangeError,
                                     'is out of range for type std::int64'):
             async with self.con.transaction():
-                await self.con.query_one(
+                await self.con.query_single(
                     r'''SELECT <int64>'3689348814741900000000000' ''',
                 )
 
         with self.assertRaisesRegex(edgedb.EdgeQLSyntaxError,
                                     'expected digit after dot'):
             async with self.con.transaction():
-                await self.con.query_one('SELECT 0. ')
+                await self.con.query_single('SELECT 0. ')
 
         with self.assertRaisesRegex(edgedb.EdgeQLSyntaxError,
                                     'number is out of range for std::float64'):
             async with self.con.transaction():
-                await self.con.query_one(
+                await self.con.query_single(
                     r'''SELECT 1e999''',
                 )
 
         with self.assertRaisesRegex(edgedb.NumericOutOfRangeError,
                                     'interval field value out of range'):
             async with self.con.transaction():
-                await self.con.query_one(
+                await self.con.query_single(
                     r'''SELECT <duration>'3074457345618258602us' ''',
                 )
 
@@ -832,7 +832,7 @@ class TestExpressions(tb.QueryTestCase):
 
         # overflow is expected for float64, but would not happen for decimal
         with self.assertRaisesRegex(edgedb.NumericOutOfRangeError, 'overflow'):
-            await self.con.query_one(r"""
+            await self.con.query_single(r"""
                 SELECT (10 + math::floor(random()))^309;
             """)
 
@@ -1399,7 +1399,7 @@ class TestExpressions(tb.QueryTestCase):
                                         expected_error_msg,
                                         msg=query):
                 async with self.con.transaction():
-                    await self.con.query_one(query)
+                    await self.con.query_single(query)
 
     # NOTE: Generalized Binop `+` and `-` rules:
     #
@@ -1690,7 +1690,7 @@ class TestExpressions(tb.QueryTestCase):
                 _hint='Consider using the "++" operator for concatenation'
             ):
                 async with self.con.transaction():
-                    await self.con.query_one(query)
+                    await self.con.query_single(query)
 
     async def test_edgeql_expr_valid_setop_01(self):
         # use every scalar with DISTINCT
@@ -2394,7 +2394,7 @@ class TestExpressions(tb.QueryTestCase):
                 edgedb.QueryError,
                 r"operator '\*' cannot .* 'std::str' and 'std::int64'"):
 
-            await self.con.query_one("""
+            await self.con.query_single("""
                 SELECT <std::str>123 * 2;
             """)
 
@@ -2872,7 +2872,7 @@ class TestExpressions(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.QueryError, r'cannot index array by.*str'):
 
-            await self.con.query_one("""
+            await self.con.query_single("""
                 SELECT [1, 2]['1'];
             """)
 
@@ -3208,7 +3208,7 @@ class TestExpressions(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.QueryError, r'cannot index string by.*str'):
 
-            await self.con.query_one("""
+            await self.con.query_single("""
                 SELECT '123'['1'];
             """)
 
@@ -3454,7 +3454,7 @@ aa \
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 r"operator '!=' cannot"):
-            await self.con.query_one(r"""
+            await self.con.query_single(r"""
                 SELECT (a := 1, b := 'foo') != (b := 'foo', a := 1);
             """)
 
@@ -4807,7 +4807,7 @@ aa \
             "name": "He Who Remains",
         }])
 
-        await self.con.query_one("""
+        await self.con.query_single("""
             SELECT assert_single((
                 SELECT User { name } FILTER .name ILIKE "He Who%"
             ))

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -1023,25 +1023,25 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         )
 
     async def test_edgeql_functions_unix_to_datetime_01(self):
-        dt = await self.con.query_one(
+        dt = await self.con.query_single(
             'SELECT <str>to_datetime(1590595184.584);'
         )
         self.assertEqual('2020-05-27T15:59:44.584+00:00', dt)
 
     async def test_edgeql_functions_unix_to_datetime_02(self):
-        dt = await self.con.query_one(
+        dt = await self.con.query_single(
             'SELECT <str>to_datetime(1590595184);'
         )
         self.assertEqual('2020-05-27T15:59:44+00:00', dt)
 
     async def test_edgeql_functions_unix_to_datetime_03(self):
-        dt = await self.con.query_one(
+        dt = await self.con.query_single(
             'SELECT <str>to_datetime(517795200);'
         )
         self.assertEqual('1986-05-30T00:00:00+00:00', dt)
 
     async def test_edgeql_functions_unix_to_datetime_04(self):
-        dt = await self.con.query_one(
+        dt = await self.con.query_single(
             'SELECT <str>to_datetime(517795200.00n);'
         )
         self.assertEqual('1986-05-30T00:00:00+00:00', dt)
@@ -1051,14 +1051,14 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             edgedb.InvalidValueError,
             "'std::datetime' value out of range"
         ):
-            await self.con.query_one(
+            await self.con.query_single(
                 'SELECT to_datetime(999999999999)'
             )
 
     async def test_edgeql_functions_datetime_current_01(self):
         # make sure that datetime as a str gets serialized to a
         # particular format
-        dt = await self.con.query_one('SELECT <str>datetime_current();')
+        dt = await self.con.query_single('SELECT <str>datetime_current();')
         self.assertRegex(dt, r'\d+-\d+-\d+T\d+:\d+:\d+\.\d+.*')
 
     async def test_edgeql_functions_datetime_current_02(self):
@@ -4609,13 +4609,13 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             CREATE SCALAR TYPE my_seq_01 EXTENDING std::sequence;
         ''')
 
-        result = await self.con.query_one('''
+        result = await self.con.query_single('''
             SELECT sequence_next(INTROSPECT my_seq_01)
         ''')
 
         self.assertEqual(result, 1)
 
-        result = await self.con.query_one('''
+        result = await self.con.query_single('''
             SELECT sequence_next(INTROSPECT my_seq_01)
         ''')
 
@@ -4625,7 +4625,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             SELECT sequence_reset(INTROSPECT my_seq_01)
         ''')
 
-        result = await self.con.query_one('''
+        result = await self.con.query_single('''
             SELECT sequence_next(INTROSPECT my_seq_01)
         ''')
 
@@ -4635,7 +4635,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             SELECT sequence_reset(INTROSPECT my_seq_01, 20)
         ''')
 
-        result = await self.con.query_one('''
+        result = await self.con.query_single('''
             SELECT sequence_next(INTROSPECT my_seq_01)
         ''')
 

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -2468,8 +2468,8 @@ class TestInsert(tb.QueryTestCase):
             ) {id, person};
         '''
 
-        res1 = await self.con.query_one(query)
-        res2 = await self.con.query_one(query)
+        res1 = await self.con.query_single(query)
+        res2 = await self.con.query_single(query)
 
         self.assertNotEqual(res1.id, res2.id)
         self.assertEqual(res1.person, res2.person)

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -1052,7 +1052,7 @@ class TestIntrospection(tb.QueryTestCase):
         )
 
     async def test_edgeql_introspection_meta_13(self):
-        res = await self.con.query_one(r"""
+        res = await self.con.query_single(r"""
             SELECT count(schema::Object);
         """)
 
@@ -1350,7 +1350,7 @@ class TestIntrospection(tb.QueryTestCase):
         """)
 
     async def test_edgeql_introspection_database_01(self):
-        res = await self.con.query_one(r"""
+        res = await self.con.query_single(r"""
             WITH MODULE sys
             SELECT count(Database.name);
         """)

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -992,7 +992,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # Make sure that the __type__ attribute gets the same object
         # as a direct schema::ObjectType query. As long as this is true,
         # we can test the schema separately without any other data.
-        res = await self.con.query_one(r'''
+        res = await self.con.query_single(r'''
             SELECT User {
                 __type__: {
                     name,
@@ -6093,7 +6093,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             self.assertEqual(row[0].__tname__, "std::Object")
 
     async def test_edgeql_select_free_shape_01(self):
-        res = await self.con.query_one('SELECT {test := 1}')
+        res = await self.con.query_single('SELECT {test := 1}')
         self.assertEqual(res.test, 1)
 
     async def test_edgeql_select_result_alias_binding_01(self):

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -357,12 +357,12 @@ class TestUpdate(tb.QueryTestCase):
         # manipulated
         try:
             data = []
-            data.append(await self.con.query_one(r"""
+            data.append(await self.con.query_single(r"""
                 INSERT UpdateTest {
                     name := 'ret5.1'
                 };
             """))
-            data.append(await self.con.query_one(r"""
+            data.append(await self.con.query_single(r"""
                 INSERT UpdateTest {
                     name := 'ret5.2'
                 };
@@ -446,7 +446,7 @@ class TestUpdate(tb.QueryTestCase):
             """)
 
     async def test_edgeql_update_generic_01(self):
-        status = await self.con.query_one(r"""
+        status = await self.con.query_single(r"""
             SELECT Status{id}
             FILTER Status.name = 'Open'
             LIMIT 1;

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -46,20 +46,20 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             {(n1, n2) for n1 in ns for n2 in ns},
         )
 
-    def test_loop(self, n=None, *, one=False):
+    def test_loop(self, n=None, *, single=False):
         async def json_query(*args, **kwargs):
-            q = self.con.query_one_json if one else self.con.query_json
+            q = self.con.query_single_json if single else self.con.query_json
             res = await q(*args, **kwargs)
             return json.loads(res)
 
         async def native_query(*args, **kwargs):
-            q = self.con.query_one if one else self.con.query
+            q = self.con.query_single if single else self.con.query
             res = await q(*args, **kwargs)
             return serutils.serialize(res)
 
         async def native_query_typenames(*args, **kwargs):
             res = await self.con._fetchall(*args, **kwargs, __typenames__=True)
-            if one:
+            if single:
                 assert len(res) == 1
                 res = res[0]
             return serutils.serialize(res)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -239,7 +239,7 @@ class TestProtocol(ProtocolTestCase):
 
                 # Let's check what's in the row - if the cancellation didn't
                 # happen, the test will fail with value "inner".
-                val = await con2.query_one('SELECT tclcq.p LIMIT 1')
+                val = await con2.query_single('SELECT tclcq.p LIMIT 1')
                 self.assertEqual(val, 'initial')
 
             finally:

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -424,12 +424,12 @@ class TestServerConfig(tb.QueryTestCase):
             ''')
 
     async def test_server_proto_configure_02(self):
-        conf = await self.con.query_one('''
+        conf = await self.con.query_single('''
             SELECT cfg::Config.__internal_testvalue LIMIT 1
         ''')
         self.assertEqual(conf, 0)
 
-        jsonconf = await self.con.query_one('''
+        jsonconf = await self.con.query_single('''
             SELECT cfg::get_config_json()
         ''')
 
@@ -451,12 +451,12 @@ class TestServerConfig(tb.QueryTestCase):
                 Configure INSTANCE SET __internal_testvalue := 1;
             ''')
 
-            conf = await self.con.query_one('''
+            conf = await self.con.query_single('''
                 SELECT cfg::Config.__internal_testvalue LIMIT 1
             ''')
             self.assertEqual(conf, 1)
 
-            jsonconf = await self.con.query_one('''
+            jsonconf = await self.con.query_single('''
                 SELECT cfg::get_config_json()
             ''')
 
@@ -495,8 +495,8 @@ class TestServerConfig(tb.QueryTestCase):
             };
         ''')
 
-        with self.assertRaisesRegex(edgedb.InterfaceError, r'\bquery_one\('):
-            await self.con.query_one('''
+        with self.assertRaisesRegex(edgedb.InterfaceError, r'\bquery_single\('):
+            await self.con.query_single('''
                 CONFIGURE INSTANCE INSERT cfg::TestInstanceConfig {
                     name := 'test_03_0122222222'
                 };
@@ -928,7 +928,7 @@ class TestServerConfig(tb.QueryTestCase):
             conf3 = "CONFIGURE SESSION SET singleprop := '42';"
             await self.con.execute(conf3)
 
-            res = await self.con.query_one('DESCRIBE INSTANCE CONFIG;')
+            res = await self.con.query_single('DESCRIBE INSTANCE CONFIG;')
             self.assertIn(conf1, res)
             self.assertIn(conf2, res)
             self.assertNotIn(conf3, res)
@@ -953,7 +953,7 @@ class TestServerConfig(tb.QueryTestCase):
             conf2 = "CONFIGURE SESSION SET singleprop := '42';"
             await self.con.execute(conf2)
 
-            res = await self.con.query_one('DESCRIBE CURRENT DATABASE CONFIG;')
+            res = await self.con.query_single('DESCRIBE CURRENT DATABASE CONFIG;')
             self.assertIn(conf1, res)
             self.assertNotIn(conf2, res)
 
@@ -963,7 +963,7 @@ class TestServerConfig(tb.QueryTestCase):
             ''')
 
     async def test_server_version(self):
-        srv_ver = await self.con.query_one(r"""
+        srv_ver = await self.con.query_single(r"""
             SELECT sys::get_version()
         """)
 
@@ -1062,8 +1062,8 @@ class TestServerConfig(tb.QueryTestCase):
 
                 con2 = await sd.connect(host="127.0.0.2")
 
-                self.assertEqual(await con1.query_one("SELECT 1"), 1)
-                self.assertEqual(await con2.query_one("SELECT 2"), 2)
+                self.assertEqual(await con1.query_single("SELECT 1"), 1)
+                self.assertEqual(await con2.query_single("SELECT 2"), 2)
 
             finally:
                 closings = []

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -65,14 +65,14 @@ class TestServerOps(tb.TestCase):
         ) as sd:
 
             con1 = await sd.connect()
-            self.assertEqual(await con1.query_one('SELECT 1'), 1)
+            self.assertEqual(await con1.query_single('SELECT 1'), 1)
 
             con2 = await sd.connect()
-            self.assertEqual(await con2.query_one('SELECT 1'), 1)
+            self.assertEqual(await con2.query_single('SELECT 1'), 1)
 
             await con1.aclose()
 
-            self.assertEqual(await con2.query_one('SELECT 42'), 42)
+            self.assertEqual(await con2.query_single('SELECT 42'), 42)
             await con2.aclose()
 
             with self.assertRaises(
@@ -147,7 +147,7 @@ class TestServerOps(tb.TestCase):
         ) as sd:
             con = await sd.connect(user='test_bootstrap2', password='tbs2')
             try:
-                self.assertEqual(await con.query_one('SELECT 1'), 1)
+                self.assertEqual(await con.query_single('SELECT 1'), 1)
             finally:
                 await con.aclose()
 
@@ -212,7 +212,7 @@ class TestServerOps(tb.TestCase):
         ) as sd:
             con = await sd.connect()
             try:
-                max_connections = await con.query_one(
+                max_connections = await con.query_single(
                     'SELECT cfg::InstanceConfig.__pg_max_connections LIMIT 1'
                 )  # TODO: remove LIMIT 1 after #2402
                 self.assertEqual(int(max_connections), actual + 2)
@@ -232,7 +232,7 @@ class TestServerOps(tb.TestCase):
             ) as sd:
                 con = await sd.connect()
                 try:
-                    max_connections = await con.query_one(
+                    max_connections = await con.query_single(
                         '''
                         SELECT cfg::InstanceConfig.__pg_max_connections
                         LIMIT 1
@@ -307,7 +307,7 @@ class TestServerOps(tb.TestCase):
             ) as sd:
                 con = await sd.connect()
                 try:
-                    val = await con.query_one('SELECT 123')
+                    val = await con.query_single('SELECT 123')
                     self.assertEqual(int(val), 123)
 
                     # stop the postgres
@@ -317,7 +317,7 @@ class TestServerOps(tb.TestCase):
                         errors.EdgeDBError,
                         'Postgres is not available',
                     ):
-                        await con.query_one('SELECT 123+456')
+                        await con.query_single('SELECT 123+456')
 
                     # bring postgres back
                     await self.loop.run_in_executor(None, cluster.start)
@@ -326,7 +326,7 @@ class TestServerOps(tb.TestCase):
                     deadline = time.monotonic() + 5
                     while time.monotonic() < deadline:
                         try:
-                            val = await con.query_one('SELECT 123+456')
+                            val = await con.query_single('SELECT 123+456')
                             break
                         except errors.EdgeDBError:  # TODO: ditto
                             pass

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -84,7 +84,7 @@ class TestServerProto(tb.QueryTestCase):
         except edgedb.InvalidFunctionDefinitionError:
             return False
 
-        return await self.con.query_one('''
+        return await self.con.query_single('''
             SELECT cfg::Config.__internal_testmode LIMIT 1
         ''')
 
@@ -95,7 +95,7 @@ class TestServerProto(tb.QueryTestCase):
         for power in range(10, 20):
             base = 2 ** power
             for i in range(base - 100, base + 100):
-                v = await self.con.query_one(
+                v = await self.con.query_single(
                     'select str_repeat(".", <int64>$i)', i=i)
                 self.assertEqual(len(v), i)
 
@@ -282,15 +282,15 @@ class TestServerProto(tb.QueryTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.InterfaceError,
-                r'cannot be executed with query_one\(\).*'
+                r'cannot be executed with query_single\(\).*'
                 r'not return'):
-            await self.con.query_one('START TRANSACTION')
+            await self.con.query_single('START TRANSACTION')
 
         with self.assertRaisesRegex(
                 edgedb.InterfaceError,
-                r'cannot be executed with query_one_json\(\).*'
+                r'cannot be executed with query_single_json\(\).*'
                 r'not return'):
-            await self.con.query_one_json('START TRANSACTION')
+            await self.con.query_single_json('START TRANSACTION')
 
     async def test_server_proto_fetch_single_command_04(self):
         with self.assertRaisesRegex(edgedb.ProtocolError,
@@ -302,7 +302,7 @@ class TestServerProto(tb.QueryTestCase):
 
         with self.assertRaisesRegex(edgedb.ProtocolError,
                                     'expected one statement'):
-            await self.con.query_one('''
+            await self.con.query_single('''
                 SELECT 1;
                 SET MODULE blah;
             ''')
@@ -461,7 +461,7 @@ class TestServerProto(tb.QueryTestCase):
     async def test_server_proto_basic_datatypes_01(self):
         for _ in range(10):
             self.assertEqual(
-                await self.con.query_one(
+                await self.con.query_single(
                     'select ()'),
                 ())
 
@@ -472,7 +472,7 @@ class TestServerProto(tb.QueryTestCase):
 
             async with self.con.transaction():
                 self.assertEqual(
-                    await self.con.query_one(
+                    await self.con.query_single(
                         'select <array<int64>>[]'),
                     [])
 
@@ -493,11 +493,11 @@ class TestServerProto(tb.QueryTestCase):
 
             with self.assertRaisesRegex(
                     edgedb.InterfaceError,
-                    r'query_one\(\) as it returns a multiset'):
-                await self.con.query_one('SELECT {1, 2}')
+                    r'query_single\(\) as it returns a multiset'):
+                await self.con.query_single('SELECT {1, 2}')
 
-            with self.assertRaisesRegex(edgedb.NoDataError, r'\bquery_one\('):
-                await self.con.query_one('SELECT <int64>{}')
+            with self.assertRaisesRegex(edgedb.NoDataError, r'\bquery_single\('):
+                await self.con.query_single('SELECT <int64>{}')
 
     async def test_server_proto_basic_datatypes_02(self):
         self.assertEqual(
@@ -535,7 +535,7 @@ class TestServerProto(tb.QueryTestCase):
 
             self.assertEqual(
                 json.loads(
-                    await self.con.query_one_json(
+                    await self.con.query_single_json(
                         'select ["a", "b"]')),
                 ["a", "b"])
 
@@ -560,14 +560,14 @@ class TestServerProto(tb.QueryTestCase):
                 [])
 
             with self.assertRaises(edgedb.NoDataError):
-                await self.con.query_one_json('SELECT <int64>{}')
+                await self.con.query_single_json('SELECT <int64>{}')
 
         self.assertEqual(self.con._get_last_status(), 'SELECT')
 
     async def test_server_proto_basic_datatypes_04(self):
         # A regression test for enum typedescs being improperly
         # serialized and screwing up client's decoder.
-        d = await self.con.query_one('''
+        d = await self.con.query_single('''
             SELECT (<RGB>"RED", <RGB>"GREEN", [1], [<RGB>"GREEN"], [2])
         ''')
         self.assertEqual(d[2], [1])
@@ -711,7 +711,7 @@ class TestServerProto(tb.QueryTestCase):
     async def test_server_proto_args_06(self):
         for _ in range(10):
             self.assertEqual(
-                await self.con.query_one(
+                await self.con.query_single(
                     'select <int64>$你好 + 10',
                     你好=32),
                 42)
@@ -719,7 +719,7 @@ class TestServerProto(tb.QueryTestCase):
     async def test_server_proto_args_07(self):
         with self.assertRaisesRegex(edgedb.QueryError,
                                     r'missing a type cast.*parameter'):
-            await self.con.query_one(
+            await self.con.query_single(
                 'select schema::Object {name} filter .id=$id', id='asd')
 
     async def test_server_proto_args_08(self):
@@ -735,14 +735,14 @@ class TestServerProto(tb.QueryTestCase):
             )
 
             self.assertEqual(
-                await self.con.query_one('select ("1", 1, 1.1, 1.1n, 1n)'),
+                await self.con.query_single('select ("1", 1, 1.1, 1.1n, 1n)'),
                 ('1', 1, 1.1, decimal.Decimal('1.1'), 1)
             )
 
     async def test_server_proto_args_09(self):
         async with self._run_and_rollback():
             self.assertEqual(
-                await self.con.query_one(
+                await self.con.query_single(
                     'WITH std AS MODULE math SELECT ("1", 1, 1.1, 1.1n, 1n)'
                 ),
                 ('1', 1, 1.1, decimal.Decimal('1.1'), 1)
@@ -934,7 +934,7 @@ class TestServerProto(tb.QueryTestCase):
 
             with self.assertRaisesRegex(
                     edgedb.TransactionError, "current transaction is aborted"):
-                await self.con.query_one('''
+                await self.con.query_single('''
                     RELEASE SAVEPOINT t1;
                 ''')
 
@@ -999,7 +999,7 @@ class TestServerProto(tb.QueryTestCase):
                 [1])
 
             with self.assertRaises(edgedb.DivisionByZeroError):
-                await self.con.query_one('''
+                await self.con.query_single('''
                     SELECT 1 / 0;
                 ''')
 
@@ -1178,7 +1178,7 @@ class TestServerProto(tb.QueryTestCase):
         with self.assertRaisesRegex(
                 edgedb.InvalidReferenceError,
                 "function 't1::min' does not exist"):
-            await con.query_one('SELECT t1::min({1})')
+            await con.query_single('SELECT t1::min({1})')
 
     async def test_server_proto_tx_savepoint_09(self):
         # Test basic SET ALIAS tracking in transactions/savepoints;
@@ -1247,7 +1247,7 @@ class TestServerProto(tb.QueryTestCase):
             await con.query('ROLLBACK TO SAVEPOINT t2')
 
             self.assertEqual(
-                await con.query_one('SELECT 42+1+1+1+1'),
+                await con.query_single('SELECT 42+1+1+1+1'),
                 46)
         finally:
             await con.query('ROLLBACK')
@@ -1490,7 +1490,7 @@ class TestServerProto(tb.QueryTestCase):
                         await self.con.query('ROLLBACK TO SAVEPOINT _;')
             await self.con.query('RELEASE SAVEPOINT _')
 
-            actual_count = await self.con.query_one(
+            actual_count = await self.con.query_single(
                 '''SELECT count(
                     Tmp11
                     FILTER Tmp11.tmp = "test_server_proto_tx_11")
@@ -1655,7 +1655,7 @@ class TestServerProto(tb.QueryTestCase):
             ''')
 
             self.assertFalse(
-                await self.con.query_one('''
+                await self.con.query_single('''
                     SELECT cfg::Config.__internal_testmode LIMIT 1
                 ''')
             )
@@ -1679,7 +1679,7 @@ class TestServerProto(tb.QueryTestCase):
         await self.con.query('ROLLBACK')
 
         self.assertEqual(
-            await self.con.query_one('SELECT 1;'),
+            await self.con.query_single('SELECT 1;'),
             1)
 
         await self.con.query('START TRANSACTION')
@@ -1688,7 +1688,7 @@ class TestServerProto(tb.QueryTestCase):
         await self.con.query('ROLLBACK')
 
         self.assertEqual(
-            await self.con.query_one('SELECT 1;'),
+            await self.con.query_single('SELECT 1;'),
             1)
 
         await self.con.query('START TRANSACTION')
@@ -1697,7 +1697,7 @@ class TestServerProto(tb.QueryTestCase):
         await self.con.query('ROLLBACK')
 
         self.assertEqual(
-            await self.con.query_one('SELECT 1;'),
+            await self.con.query_single('SELECT 1;'),
             1)
 
     async def test_server_proto_tx_16(self):
@@ -1713,7 +1713,7 @@ class TestServerProto(tb.QueryTestCase):
                     stmt += f' ISOLATION {isol}'
 
                 await self.con.query(stmt)
-                result = await self.con.query_one(
+                result = await self.con.query_single(
                     'SELECT sys::get_transaction_isolation()')
                 # Check that it's an enum and that the value is as
                 # expected without explicitly listing all the possible
@@ -1735,7 +1735,7 @@ class TestServerProto(tb.QueryTestCase):
 
         try:
             async def worker(con, tx, n):
-                await con.query_one(f'''
+                await con.query_single(f'''
                     SELECT count(TransactionTest FILTER .name LIKE 'tx_17_{n}')
                 ''')
 
@@ -1805,12 +1805,12 @@ class TestServerProto(tb.QueryTestCase):
         ''')
 
         for _ in range(10):
-            result = await self.con.query_one(f'''
+            result = await self.con.query_single(f'''
                 SELECT <{typename}>100000
             ''')
             self.assertEqual(result, 100000)
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             ''')
             self.assertEqual(
@@ -1889,7 +1889,7 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
         ''')
 
         self.assertEqual(
-            await self.con.query_one('SELECT Test.foo LIMIT 1'),
+            await self.con.query_single('SELECT Test.foo LIMIT 1'),
             123
         )
 
@@ -1905,7 +1905,7 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
 
             try:
                 self.assertEqual(
-                    await con2.query_one('SELECT Test.foo LIMIT 1'),
+                    await con2.query_single('SELECT Test.foo LIMIT 1'),
                     123
                 )
 
@@ -1918,7 +1918,7 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
                 ''')
 
                 self.assertEqual(
-                    await self.con.query_one('SELECT Test2.foo LIMIT 1'),
+                    await self.con.query_single('SELECT Test2.foo LIMIT 1'),
                     'text'
                 )
 
@@ -1930,7 +1930,7 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
                 ):
                     async with tr:
                         self.assertEqual(
-                            await con2.query_one('SELECT Test2.foo LIMIT 1'),
+                            await con2.query_single('SELECT Test2.foo LIMIT 1'),
                             'text'
                         )
 
@@ -1963,7 +1963,7 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
 
             try:
                 self.assertEqual(
-                    await con3.query_one('SELECT 42'),
+                    await con3.query_single('SELECT 42'),
                     42
                 )
             finally:
@@ -1999,7 +1999,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                 con2 = await self.connect(database=db)
                 try:
                     self.assertEqual(
-                        await con2.query_one('SELECT 1'),
+                        await con2.query_single('SELECT 1'),
                         1
                     )
                 finally:
@@ -2438,7 +2438,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                 CREATE SCALAR TYPE tid_prop_01 EXTENDING str;
             ''')
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT (<array<tid_prop_01>>$input)[1]
             ''', input=['a', 'b'])
 
@@ -2450,7 +2450,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                 CREATE SCALAR TYPE tid_prop_02 EXTENDING str;
             ''')
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT (<array<tid_prop_02>>$input)[1]
             ''', input=['a', 'b'])
 
@@ -2472,7 +2472,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                 COMMIT MIGRATION;
             ''')
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT (<array<tid_prop_03>>$input)[1]
             ''', input=['A', 'B'])
 
@@ -2490,7 +2490,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                 CREATE SCALAR TYPE tid_prop_04 EXTENDING str;
             ''')
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT (<array<tid_prop_04>>$input)[1]
             ''', input=['A', 'B'])
 
@@ -2512,7 +2512,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                 CREATE SCALAR TYPE tid_prop_052 EXTENDING str;
             ''')
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT (<array<tid_prop_052>>$input)[1]
             ''', input=['A', 'C'])
 
@@ -2527,7 +2527,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                 CREATE SCALAR TYPE tid_prop_06 EXTENDING str;
             ''')
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT (<array<tid_prop_06>>$input)[1]
             ''', input=['a', 'b'])
 
@@ -2539,7 +2539,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
                 CREATE SCALAR TYPE tid_prop_07 EXTENDING str;
             ''')
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT (<array<tid_prop_07>>$input)[1]
             ''', input=['a', 'b'])
 
@@ -2565,17 +2565,17 @@ class TestServerProtoDDL(tb.DDLTestCase):
                 CREATE SCALAR TYPE tid_prop_083 EXTENDING str;
             ''')
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT (<array<tid_prop_081>>$input)[0]
             ''', input=['A', 'C'])
             self.assertEqual(result, 'A')
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT (<array<tid_prop_082>>$input)[1]
             ''', input=['A', 'C'])
             self.assertEqual(result, 'C')
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT (<array<tid_prop_083>>$input)[1]
             ''', input=['A', 'Z'])
             self.assertEqual(result, 'Z')
@@ -2604,17 +2604,17 @@ class TestServerProtoDDL(tb.DDLTestCase):
 
             await self.con.query('COMMIT')
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT (<array<tid_prop_091>>$input)[0]
             ''', input=['A', 'C'])
             self.assertEqual(result, 'A')
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT (<array<tid_prop_092>>$input)[1]
             ''', input=['A', 'C'])
             self.assertEqual(result, 'C')
 
-            result = await self.con.query_one('''
+            result = await self.con.query_single('''
                 SELECT (<array<tid_prop_093>>$input)[1]
             ''', input=['A', 'Z'])
             self.assertEqual(result, 'Z')


### PR DESCRIPTION
The python client deprecated query_one() in favor of query_single().