### PR TITLE
Fix a couple of newly reported mypy errors

### DIFF
--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -881,7 +881,9 @@ class FlatSchema(Schema):
                         else:
                             mm[ref_id] = refs.set(key, field_refs)
 
-            return mm.finish()
+            result = mm.finish()
+
+        return result
 
     def add_raw(
         self,
@@ -1922,11 +1924,11 @@ def _get_operators(
 ) -> Optional[Tuple[s_oper.Operator, ...]]:
     objids = schema._shortname_to_id.get((s_oper.Operator, name))
     if objids is None:
-        return
-    return cast(
-        Tuple[s_oper.Operator, ...],
-        tuple(schema.get_by_id(oid) for oid in objids),
-    )
+        return None
+    else:
+        return tuple(
+            schema.get_by_id(oid, type=s_oper.Operator) for oid in objids
+        )
 
 
 @functools.lru_cache()


### PR DESCRIPTION
For bizarre and unknown reasons, mypy suddently became unhappy about two
code locations:

    AssertionError: mypy validation failed:
    edb/schema/schema.py:817:5: error: Missing return statement
    edb/schema/schema.py:1925:9: error: Return value expected

The second is a bare `return`, so fair enough, unclear why it was OK
before, while the first looks like a mypy bug to me.  A `return`
statement in the `with` body should be perfectly valid.  I suspect there
is some weird interaction with new annotations in `immutables`.

@msullivan, you might be interested in diagnosing the latter.