### PR TITLE
Turn assert_single into a no-op when its argument is provably a singleton

### DIFF
--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4857,3 +4857,19 @@ aa \
                     single name := assert_single(.name ++ {"!", "?"})
                 };
             """)
+
+    async def test_edgeql_assert_single_no_op(self):
+        await self.con.query("""
+            SELECT assert_single(1)
+        """)
+
+        await self.con.query("""
+            FOR x IN {User}
+            UNION assert_single(x.name)
+        """)
+
+        await self.con.query("""
+            SELECT User {
+                single foo := assert_single(.name) ++ "!"
+            }
+        """)


### PR DESCRIPTION
This changes the implementation of `assert_single()` to turn it into a
no-op when its argument has been statically proven to be a singleton.
This is beneficial for language query builders, since in lieu of full
cardinality inference on the client side, they'd have to rely heavily on
cardinality assertions, so we want them as cheap as possible.