### PR TITLE
Make find_children search into nested containers

### DIFF
--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -40,15 +40,12 @@ class ASTError(Exception):
 
 class _Field:
     def __init__(
-            self, name, type_, default, factory, traverse, child_traverse=None,
+            self, name, type_, default, factory,
             field_hidden=False, field_meta=False):
         self.name = name
         self.type = type_
         self.default = default
         self.factory = factory
-        self.traverse = traverse
-        self.child_traverse = \
-            child_traverse if child_traverse is not None else traverse
         self.hidden = field_hidden
         self.meta = field_meta
 
@@ -186,8 +183,7 @@ class AST:
                 f_meta = f_name in meta
 
                 fields.append(_Field(
-                    f_name, f_type, f_default, factory,
-                    True, None, f_hidden, f_meta
+                    f_name, f_type, f_default, factory, f_hidden, f_meta
                 ))
 
             cls._direct_fields = fields

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -63,7 +63,7 @@ def get_parameters(ir: irast.Base) -> Set[irast.Parameter]:
 
 def is_const(ir: irast.Base) -> bool:
     """Return True if the given *ir* expression is constant."""
-    flt = lambda n: isinstance(n, irast.Set) and n.expr is None
+    flt = lambda n: isinstance(n, irast.Set) and n.expr is None and n is not ir
     ir_sets = ast.find_children(ir, flt)
     variables = get_parameters(ir)
     return not ir_sets and not variables

--- a/tests/common/test_ast.py
+++ b/tests/common/test_ast.py
@@ -25,6 +25,7 @@ import unittest
 import unittest.mock
 
 from edb.common import ast
+from edb.common.ast import visitor
 from edb.common.ast import match
 
 
@@ -272,3 +273,18 @@ class ASTMatchTests(unittest.TestCase):
         # but the single constant matches just fine
         result = match.match(self.pat4, self.tree4)
         assert result and result.recursive[0].node.value == 'one and only'
+
+
+class ASTFindChildrenTests(unittest.TestCase):
+
+    def test_common_ast_find_children(self):
+        node = tast.UnaryOp(
+            op='NamedTuple',
+            operand=[
+                ('foo', tast.Constant(value=2)),
+                ('bar', [tast.UnaryOp(op='-', operand=tast.Constant(value=3))]),
+            ],
+        )
+        flt = lambda n: isinstance(n, tast.Constant)
+        children = visitor.find_children(node, flt)
+        assert {x.value for x in children} == {2, 3}

--- a/tests/common/test_ast.py
+++ b/tests/common/test_ast.py
@@ -282,7 +282,8 @@ class ASTFindChildrenTests(unittest.TestCase):
             op='NamedTuple',
             operand=[
                 ('foo', tast.Constant(value=2)),
-                ('bar', [tast.UnaryOp(op='-', operand=tast.Constant(value=3))]),
+                ('bar', [
+                    tast.UnaryOp(op='-', operand=tast.Constant(value=3))]),
             ],
         )
         flt = lambda n: isinstance(n, tast.Constant)


### PR DESCRIPTION
This is important because otherwise it misses shapes. This somehow
hasn't caused any visible bugs yet but caused trouble in a pending PR
I have.

While at it, substantially clean up the function and drop support for the unused child_traverse.