### PR TITLE
Change how JSON scalars are reflected into GraphQL.

### DIFF
--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -1210,12 +1210,9 @@ class GraphQLTranslator:
             val = self.visit(node)
 
             if target.is_json:
-                # JSON must use a converter function and not a cast
-
-                return qlast.FunctionCall(
-                    func='to_json',
-                    args=[val]
-                )
+                # JSON can only come as a variable and will already be
+                # converted appropriately.
+                return val
             elif target.edb_base_name != 'std::str':
 
                 # bigint data would require a bigint input, so
@@ -1733,7 +1730,7 @@ def convert_errors(
 
             result.append(err)
             continue
-        if (m.group("used"), m.group("expected")) in _IMPLICIT_CONVERSIONS:
+        elif (m.group("used"), m.group("expected")) in _IMPLICIT_CONVERSIONS:
             # skip the error, we avoid it in the execution code
             continue
         value, line, col = substitutions[m.group("var_name")]

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -2330,8 +2330,6 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         })
 
     def test_graphql_functional_scalars_02(self):
-        # JSON is special since it has to be serialized into its
-        # string representation
         self.assert_graphql_query_result(r"""
             query {
                 ScalarTest {
@@ -2340,7 +2338,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             }
         """, {
             "ScalarTest": [{
-                'p_json': '{"foo": [1, null, "bar"]}',
+                'p_json': {"foo": [1, None, "bar"]},
             }]
         })
 
@@ -2384,8 +2382,6 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             """)
 
     def test_graphql_functional_scalars_06(self):
-        # JSON is special since it has to be serialized into its
-        # string representation
         self.assert_graphql_query_result(r"""
             query {
                 ScalarTest {
@@ -3255,6 +3251,23 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                     "color": "GREEN",
                 }]
             },
+        )
+
+    def test_graphql_functional_variables_46(self):
+        self.assert_graphql_query_result(
+            r"""
+                query($val: JSON) {
+                    ScalarTest(filter: {p_json: {eq: $val}}) {
+                        p_json
+                    }
+                }
+            """, {
+                "ScalarTest": [{
+                    'p_json': {"foo": [1, None, "bar"]},
+                }]
+            },
+            # JSON can only be passed as a variable.
+            variables={"val": {"foo": [1, None, "bar"]}},
         )
 
     def test_graphql_functional_inheritance_01(self):


### PR DESCRIPTION
`std::json` is now reflected into a custom JSON scalar type in Graphql.
This is an escape hatch so the output is rendered as seamless JSON (not
as a string encoding JSON). The input values can only be supplied as a
variable at the moment (because of issues of parsing and validating
GraphQL types otherwise).