### PR TITLE
Fix JSON casts from shapes with `should_materialize` pointers

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -530,6 +530,9 @@ def compile_TypeCast(
                 # JSON wants type shapes and acts as an output sink.
                 subctx.expr_exposed = True
                 subctx.inhibit_implicit_limit = True
+                subctx.implicit_id_in_shapes = False
+                subctx.implicit_tid_in_shapes = False
+                subctx.implicit_tname_in_shapes = False
             ir_expr = dispatch.compile(expr.expr, ctx=subctx)
 
     return casts.compile_cast(

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -1227,6 +1227,17 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             sort=lambda x: x['number'],
         )
 
+    async def test_edgeql_json_cast_object_to_json_06(self):
+        res = await self.con.query("""
+            SELECT to_str(<json>{x := random()});
+        """)
+
+        val = res[0]
+        self.assertIsInstance(val, str)
+        data = json.loads(val)
+
+        self.assertTrue('id' not in data)
+
     async def test_edgeql_json_cast_tuple_to_json_01(self):
         res = await self.con.query("""
             WITH MODULE schema


### PR DESCRIPTION
Currently `id`, `__tname__`, etc might get injected in if
`compile_view_shapes` gets called while compiling the argument.