### PR TITLE
Stop redirecting all Postgres output to /dev/null

### DIFF
--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -484,6 +484,8 @@ class Cluster(BaseCluster):
 
         if os.getenv('EDGEDB_DEBUG_PGSERVER'):
             start_settings['log_statement'] = 'all'
+        else:
+            start_settings['log_min_messages'] = 'warning'
 
         if server_settings:
             start_settings.update(server_settings)
@@ -499,15 +501,10 @@ class Cluster(BaseCluster):
         for k, v in start_settings.items():
             extra_args.extend(['-c', '{}={}'.format(k, v)])
 
-        if os.getenv('EDGEDB_DEBUG_PGSERVER'):
-            stdout = sys.stdout
-        else:
-            stdout = subprocess.DEVNULL
-
         self._daemon_process = \
             subprocess.Popen(
                 [self._postgres, '-D', self._data_dir, *extra_args],
-                stdout=stdout, stderr=subprocess.STDOUT)
+                stdout=sys.stdout, stderr=sys.stderr)
 
         self._daemon_pid = self._daemon_process.pid
 

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -129,11 +129,6 @@ class TestServerOps(tb.TestCase):
                 f'STDERR: {stderr.decode()}',
             )
 
-            if stderr != b'':
-                self.fail(
-                    'Unexpected server error output:\n' + stderr.decode()
-                )
-
     async def test_server_ops_bootstrap_script_server(self):
         # Test that "edgedb-server" works as expected with the
         # following arguments:


### PR DESCRIPTION
We are interested in Postgres' warnings and errors, so stop redirecting
its stdout/stderr to /dev/null in non debug-pgserver mode.  For now this
simply redirects stdout/stderr.  Ideally, we'd want to channel output to
our logger so log redirection via (`--log-to`) continues to work
properly.