### PR TITLE
Turn off Postgres logging when EDGEDB_LOG_LEVEL=silent

### DIFF
--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -483,9 +483,14 @@ class Cluster(BaseCluster):
         }
 
         if os.getenv('EDGEDB_DEBUG_PGSERVER'):
+            start_settings['log_min_messages'] = 'info'
             start_settings['log_statement'] = 'all'
+        elif os.getenv('EDGEDB_LOG_LEVEL') == 'silent':
+            start_settings['log_min_messages'] = 'panic'
+            start_settings['log_statement'] = 'none'
         else:
             start_settings['log_min_messages'] = 'warning'
+            start_settings['log_statement'] = 'none'
 
         if server_settings:
             start_settings.update(server_settings)


### PR DESCRIPTION
In #2793 we enabled Postgres logging in non-debug scenario, which
resulted in a bunch of noise in test runs.  Make sure `EDGEDB_LOG_LEVEL`
is respected.