### PR TITLE
Fix deprecated usages of SSLContext

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1040,7 +1040,7 @@ class Server:
             tls_password_needed = True
             return os.environ.get('EDGEDB_SERVER_TLS_PRIVATE_KEY_PASSWORD', '')
 
-        sslctx = ssl.SSLContext()
+        sslctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         try:
             sslctx.load_cert_chain(
                 tls_cert_file,

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -55,12 +55,11 @@ class BaseHttpTest:
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.tls_context = ssl.SSLContext()
-        cls.tls_context.verify_mode = ssl.CERT_REQUIRED
-        cls.tls_context.check_hostname = False
-        cls.tls_context.load_verify_locations(
-            cafile=cls.get_connect_args()['tls_ca_file']
+        cls.tls_context = ssl.create_default_context(
+            ssl.Purpose.SERVER_AUTH,
+            cafile=cls.get_connect_args()['tls_ca_file'],
         )
+        cls.tls_context.check_hostname = False
 
         cls.http_host, cls.http_port = cls.con.connected_addr()
         api_path = cls.get_api_path()

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -453,10 +453,11 @@ class TestServerOps(tb.TestCase):
             finally:
                 con.close()
 
-            tls_context = ssl.SSLContext()
-            tls_context.verify_mode = ssl.CERT_REQUIRED
+            tls_context = ssl.create_default_context(
+                ssl.Purpose.SERVER_AUTH,
+                cafile=sd.tls_cert_file,
+            )
             tls_context.check_hostname = False
-            tls_context.load_verify_locations(cafile=sd.tls_cert_file)
             con = http.client.HTTPSConnection(
                 sd.host, sd.port, context=tls_context)
             con.connect()


### PR DESCRIPTION
Fix `SSLContext`-related deprecation warnings by setting it up with
explicit protocol/purpose flags.