### PR TITLE
Materialize references to *all* visible sets from inside pointers

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -87,7 +87,6 @@ class ViewRPtr:
 
 @dataclasses.dataclass
 class StatementMetadata:
-    is_unnest_fence: bool = False
     iterator_target: bool = False
 
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -443,7 +443,10 @@ class ContextLevel(compiler.ContextLevel):
     banned_paths: Set[irast.PathId]
     """A set of path ids that are considered invalid in this context."""
 
-    view_map: ChainMap[irast.PathId, Tuple[irast.PathId, irast.Set]]
+    view_map: ChainMap[
+        irast.PathId,
+        Tuple[Tuple[irast.PathId, irast.Set], ...],
+    ]
     """Set translation map.  Used for mapping computable sources..
 
     When compiling a computable, we need to be able to map references to

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -736,7 +736,6 @@ def extend_path(
     direction: PtrDir = PtrDir.Outbound,
     *,
     ignore_computable: bool = False,
-    unnest_fence: bool = False,
     same_computable_scope: bool = False,
     srcctx: Optional[parsing.ParserContext]=None,
     ctx: context.ContextLevel,
@@ -782,7 +781,6 @@ def extend_path(
     if not ignore_computable and is_computable:
         target_set = computable_ptr_set(
             ptr,
-            unnest_fence=unnest_fence,
             same_computable_scope=same_computable_scope,
             srcctx=srcctx,
             ctx=ctx,
@@ -1160,7 +1158,6 @@ def ensure_stmt(
 def computable_ptr_set(
     rptr: irast.Pointer,
     *,
-    unnest_fence: bool=False,
     same_computable_scope: bool=False,
     srcctx: Optional[parsing.ParserContext]=None,
     ctx: context.ContextLevel,
@@ -1315,7 +1312,6 @@ def computable_ptr_set(
 
         if isinstance(qlexpr, qlast.Statement):
             subctx.stmt_metadata[qlexpr] = context.StatementMetadata(
-                is_unnest_fence=unnest_fence,
                 iterator_target=True,
             )
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1128,8 +1128,6 @@ def init_stmt(
 
     metadata = ctx.stmt_metadata.get(qlstmt)
     if metadata is not None:
-        if metadata.is_unnest_fence:
-            ctx.path_scope.unnest_fence = True
         if metadata.iterator_target:
             ctx.iterator_ctx = ctx
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -582,7 +582,7 @@ def _normalize_view_ptr_expr(
                 is_insert=is_insert, is_update=is_update, ctx=ctx)
             materialized = setgen.should_materialize(
                 irexpr, ptrcls=ptrcls,
-                binding_pessimism=True, skipped_bindings={path_id},
+                materialize_visible=True, skipped_bindings={path_id},
                 ctx=ctx)
             ptr_target = inference.infer_type(irexpr, ctx.env)
 
@@ -683,7 +683,7 @@ def _normalize_view_ptr_expr(
             is_insert=is_insert, is_update=is_update, ctx=ctx)
         materialized = setgen.should_materialize(
             irexpr, ptrcls=ptrcls,
-            binding_pessimism=True, skipped_bindings={path_id},
+            materialize_visible=True, skipped_bindings={path_id},
             ctx=ctx)
         ptr_target = inference.infer_type(irexpr, ctx.env)
 
@@ -1313,7 +1313,7 @@ def _compile_view_shapes_in_set(
             element = setgen.extend_path(
                 path_tip,
                 ptr,
-                unnest_fence=True,
+                unnest_fence=False,
                 same_computable_scope=True,
                 srcctx=srcctx,
                 ctx=ctx,

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1313,7 +1313,6 @@ def _compile_view_shapes_in_set(
             element = setgen.extend_path(
                 path_tip,
                 ptr,
-                unnest_fence=False,
                 same_computable_scope=True,
                 srcctx=srcctx,
                 ctx=ctx,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -478,11 +478,11 @@ class MaterializeVolatile(typing.NamedTuple):
     pass
 
 
-class MaterializeBindings(typing.NamedTuple):
-    bindings: typing.Set[Set]
+class MaterializeVisible(typing.NamedTuple):
+    sets: typing.Set[Set]
 
 
-MaterializeReason = typing.Union[MaterializeVolatile, MaterializeBindings]
+MaterializeReason = typing.Union[MaterializeVolatile, MaterializeVisible]
 
 
 class ComputableInfo(typing.NamedTuple):
@@ -761,6 +761,10 @@ class MaterializedSet(Base):
     # namespace rewriting.
     use_sets: typing.List[Set]
     cardinality: qltypes.Cardinality = qltypes.Cardinality.UNKNOWN
+
+    # Whether this has been "finalized" by stmtctx; just for supporting some
+    # assertions
+    finalized: bool = False
 
     @property
     def uses(self) -> typing.List[PathId]:

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -156,6 +156,7 @@ def compile_materialized_exprs(
             if len(mat_set.uses) <= 1:
                 continue
             assert mat_set.materialized
+            assert mat_set.finalized
             if relctx.find_rvar(
                     query, flavor='packed',
                     path_id=mat_set.materialized.path_id, ctx=matctx):


### PR DESCRIPTION
There are still a couple of related-seeming issues, one of which is
pretty scary (test_edgeql_scope_source_rebind_01), so we're not done
yet, but this fixes a bunch.