### PR TITLE
Use `--log-level` instead of `EDGEDB_LOG_LEVEL` to drive Postgres logs

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -252,9 +252,17 @@ _server_options = [
              'exiting with a catalog incompatibility error.'
     ),
     click.option(
-        '-l', '--log-level', default='i',
-        help=('Logging level.  Possible values: (d)ebug, (i)nfo, (w)arn, '
-              '(e)rror, (s)ilent')),
+        '-l', '--log-level',
+        default='i',
+        type=click.Choice(
+            ['debug', 'd', 'info', 'i', 'warn', 'w',
+             'error', 'e', 'silent', 's'],
+            case_sensitive=False,
+        ),
+        help=(
+            'Logging level.  Possible values: (d)ebug, (i)nfo, (w)arn, '
+            '(e)rror, (s)ilent'
+        )),
     click.option(
         '--log-to',
         help=('send logs to DEST, where DEST can be a file name, "syslog", '
@@ -527,6 +535,9 @@ def parse_args(**kwargs: Any):
         and not kwargs['bootstrap_only']
     ):
         abort('Please specify a TLS certificate with --tls-cert-file.')
+
+    if kwargs['log_level']:
+        kwargs['log_level'] = kwargs['log_level'].lower()[0]
 
     bootstrap_script_text: Optional[str]
     if kwargs['bootstrap_script']:

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -60,6 +60,7 @@ class BaseCluster:
         if testmode:
             self._edgedb_cmd.append('--testmode')
 
+        self._log_level = log_level
         self._runstate_dir = runstate_dir
         self._edgedb_cmd.extend(['--runstate-dir', runstate_dir])
         self._pg_cluster = self._get_pg_cluster()
@@ -307,7 +308,10 @@ class Cluster(BaseCluster):
         self._pg_connect_args['database'] = 'template1'
 
     def _get_pg_cluster(self):
-        return pgcluster.get_local_pg_cluster(self._data_dir)
+        return pgcluster.get_local_pg_cluster(
+            self._data_dir,
+            log_level=self._log_level,
+        )
 
     def get_data_dir(self):
         return self._data_dir

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -337,6 +337,7 @@ def run_server(args: srvargs.ServerConfig, *, do_setproctitle: bool=False):
             # Plus two below to account for system connections.
             max_connections=pg_max_connections + 2,
             tenant_id=tenant_id,
+            log_level=args.log_level,
         )
         default_runstate_dir = cluster.get_data_dir()
         cluster.set_connection_params(

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -381,23 +381,18 @@ def _init_cluster(data_dir=None, postgres_dsn=None, *,
             "data_dir and postgres_dsn cannot be set at the same time")
     if init_settings is None:
         init_settings = {}
-    if (not os.environ.get('EDGEDB_DEBUG_SERVER') and
-            not os.environ.get('EDGEDB_LOG_LEVEL')):
-        _env = {'EDGEDB_LOG_LEVEL': 'silent'}
-    else:
-        _env = {}
 
     if postgres_dsn:
         cluster = edgedb_cluster.TempClusterWithRemotePg(
-            postgres_dsn, env=_env, testmode=True, log_level='s')
+            postgres_dsn, testmode=True, log_level='s')
         destroy = True
     elif data_dir is None:
         cluster = edgedb_cluster.TempCluster(
-            env=_env, testmode=True, log_level='s')
+            testmode=True, log_level='s')
         destroy = True
     else:
         cluster = edgedb_cluster.Cluster(
-            data_dir=data_dir, env=_env, log_level='s')
+            data_dir=data_dir, log_level='s')
         destroy = False
 
     if cluster.get_status() == 'not-initialized':
@@ -1509,8 +1504,7 @@ class _EdgeDBServer:
 
         reset_auth = self.reset_auth
 
-        if self.debug:
-            cmd.extend(['--log-level', 'd'])
+        cmd.extend(['--log-level', 'd' if self.debug else 's'])
         if self.max_allowed_connections is not None:
             cmd.extend([
                 '--max-backend-connections', str(self.max_allowed_connections),
@@ -1577,7 +1571,7 @@ class _EdgeDBServer:
 
         self.proc: asyncio.Process = await asyncio.create_subprocess_exec(
             *cmd,
-            stdout=None if self.debug else subprocess.DEVNULL,
+            stdout=None,
             stderr=subprocess.STDOUT,
             pass_fds=(status_w.fileno(),),
         )

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -239,7 +239,7 @@ class TestServerOps(tb.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             cluster = pgcluster.get_local_pg_cluster(
-                td, max_connections=actual)
+                td, max_connections=actual, log_level='s')
             cluster.set_connection_params(
                 pgconnparams.ConnectionParameters(
                     user='postgres',
@@ -279,7 +279,7 @@ class TestServerOps(tb.TestCase):
                 tg.create_task(test(td, 'tenant2'))
 
         with tempfile.TemporaryDirectory() as td:
-            cluster = pgcluster.get_local_pg_cluster(td)
+            cluster = pgcluster.get_local_pg_cluster(td, log_level='s')
             cluster.set_connection_params(
                 pgconnparams.ConnectionParameters(
                     user='postgres',
@@ -330,7 +330,7 @@ class TestServerOps(tb.TestCase):
                     await con.aclose()
 
         with tempfile.TemporaryDirectory() as td:
-            cluster = pgcluster.get_local_pg_cluster(td)
+            cluster = pgcluster.get_local_pg_cluster(td, log_level='s')
             cluster.set_connection_params(
                 pgconnparams.ConnectionParameters(
                     user='postgres',


### PR DESCRIPTION
The `EDGEDB_LOG_LEVEL` variable isn't interpreted by edgedb-server
itself, and passing on `--log-level` is more reasonable anyway.