### PR TITLE
Remove duplicate RUNTIME_DEPS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,6 @@ RUNTIME_DEPS = [
     'uvloop~=0.16.0',
 
     'click~=7.1',
-    'httptools>=0.0.13',
-    'immutables>=0.15',
     'parsing~=1.6.1',
     'psutil~=5.8.0',
     'setproctitle~=1.1.10',


### PR DESCRIPTION
`3b5012f8321a7b51603b10a634fd81e2a0ab66ab` added duplicate dependencies,
which causes `pip` to fall over.