### PR TITLE
Get rid of the double __derived__ in view names

### DIFF
--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -550,23 +550,17 @@ def declare_view(
             view_name = subctx.view_scls.get_name(ctx.env.schema)
             assert isinstance(view_name, s_name.QualName)
         else:
-            if isinstance(alias, s_name.QualName):
-                basename = alias
-            else:
-                basename = s_name.QualName(
-                    module='__derived__', name=alias.name)
-
             if (
                 isinstance(alias, s_name.QualName)
                 and subctx.env.options.schema_view_mode
             ):
-                view_name = basename
+                view_name = alias
                 subctx.recompiling_schema_alias = True
             else:
                 view_name = s_name.QualName(
                     module=ctx.derived_target_module or '__derived__',
                     name=s_name.get_specialized_name(
-                        basename,
+                        alias,
                         ctx.aliases.get('w')
                     )
                 )

--- a/edb/schema/name.py
+++ b/edb/schema/name.py
@@ -213,7 +213,10 @@ def shortname_from_fullname(fullname: Name) -> Name:
     name = fullname.name
     parts = name.split('@', 1)
     if len(parts) == 2:
-        return name_from_string(unmangle_name(parts[0]))
+        res = name_from_string(unmangle_name(parts[0]))
+        if isinstance(fullname, QualName) and isinstance(res, UnqualName):
+            res = QualName(module=fullname.module, name=res.name)
+        return res
     else:
         return fullname
 


### PR DESCRIPTION
A single `__derived__` ought to suffice.