### PR TITLE
Get rid of `new_event_loop` mess in cluster/pgcluster

### DIFF
--- a/edb/server/pgconnparams.py
+++ b/edb/server/pgconnparams.py
@@ -49,7 +49,7 @@ class SSLMode(enum.IntEnum):
 
 @dataclasses.dataclass
 class ConnectionParameters:
-    user: Optional[str] = None
+    user: str
     password: Optional[str] = None
     database: Optional[str] = None
     ssl: Optional[ssl_module.SSLContext] = None

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -37,6 +37,7 @@ import pprint
 import random
 import re
 import secrets
+import shlex
 import socket
 import subprocess
 import sys
@@ -374,8 +375,13 @@ class _TryRunner:
 _default_cluster = None
 
 
-def _init_cluster(data_dir=None, postgres_dsn=None, *,
-                  cleanup_atexit=True, init_settings=None):
+async def init_cluster(
+    data_dir=None,
+    postgres_dsn=None,
+    *,
+    cleanup_atexit=True,
+    init_settings=None,
+) -> edgedb_cluster.BaseCluster:
     if data_dir is not None and postgres_dsn is not None:
         raise ValueError(
             "data_dir and postgres_dsn cannot be set at the same time")
@@ -396,11 +402,11 @@ def _init_cluster(data_dir=None, postgres_dsn=None, *,
             data_dir=data_dir, log_level='s')
         destroy = False
 
-    if cluster.get_status() == 'not-initialized':
-        cluster.init(server_settings=init_settings)
+    if await cluster.get_status() == 'not-initialized':
+        await cluster.init(server_settings=init_settings)
 
-    cluster.start(port=0)
-    cluster.set_superuser_password('test')
+    await cluster.start(port=0)
+    await cluster.set_superuser_password('test')
 
     if cleanup_atexit:
         atexit.register(_shutdown_cluster, cluster, destroy=destroy)
@@ -408,7 +414,7 @@ def _init_cluster(data_dir=None, postgres_dsn=None, *,
     return cluster
 
 
-def _start_cluster(*, cleanup_atexit=True):
+def _start_cluster(*, loop: asyncio.AbstractEventLoop, cleanup_atexit=True):
     global _default_cluster
 
     if _default_cluster is None:
@@ -418,12 +424,16 @@ def _start_cluster(*, cleanup_atexit=True):
             _default_cluster = edgedb_cluster.RunningCluster(**conn_spec)
         else:
             # This branch is not usually used - `edb test` will call
-            # _init_cluster() separately and set EDGEDB_TEST_CLUSTER_ADDR
+            # init_cluster() separately and set EDGEDB_TEST_CLUSTER_ADDR
             data_dir = os.environ.get('EDGEDB_TEST_DATA_DIR')
             postgres_dsn = os.environ.get('EDGEDB_TEST_POSTGRES_DSN')
-            _default_cluster = _init_cluster(
-                data_dir=data_dir, postgres_dsn=postgres_dsn,
-                cleanup_atexit=cleanup_atexit)
+            _default_cluster = loop.run_until_complete(
+                init_cluster(
+                    data_dir=data_dir,
+                    postgres_dsn=postgres_dsn,
+                    cleanup_atexit=cleanup_atexit,
+                )
+            )
 
     return _default_cluster
 
@@ -445,7 +455,7 @@ class ClusterTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.cluster = _start_cluster(cleanup_atexit=True)
+        cls.cluster = _start_cluster(loop=cls.loop, cleanup_atexit=True)
         cls.postgres_dsn = os.environ.get('EDGEDB_TEST_POSTGRES_DSN')
 
     @classmethod
@@ -1301,37 +1311,34 @@ def get_test_cases_setup(
     return result
 
 
-def setup_test_cases(cases, conn, num_jobs, verbose=False):
+async def setup_test_cases(cases, conn, num_jobs, verbose=False):
     setup = get_test_cases_setup(cases)
 
-    async def _run():
-        stats = []
-        if num_jobs == 1:
-            # Special case for --jobs=1
+    stats = []
+    if num_jobs == 1:
+        # Special case for --jobs=1
+        for _case, dbname, setup_script in setup:
+            await _setup_database(dbname, setup_script, conn, stats)
+            if verbose:
+                print(f' -> {dbname}: OK', flush=True)
+    else:
+        async with taskgroup.TaskGroup(name='setup test cases') as g:
+            # Use a semaphore to limit the concurrency of bootstrap
+            # tasks to the number of jobs (bootstrap is heavy, having
+            # more tasks than `--jobs` won't necessarily make
+            # things faster.)
+            sem = asyncio.BoundedSemaphore(num_jobs)
+
+            async def controller(coro, dbname, *args):
+                async with sem:
+                    await coro(dbname, *args)
+                    if verbose:
+                        print(f' -> {dbname}: OK', flush=True)
+
             for _case, dbname, setup_script in setup:
-                await _setup_database(dbname, setup_script, conn, stats)
-                if verbose:
-                    print(f' -> {dbname}: OK', flush=True)
-        else:
-            async with taskgroup.TaskGroup(name='setup test cases') as g:
-                # Use a semaphore to limit the concurrency of bootstrap
-                # tasks to the number of jobs (bootstrap is heavy, having
-                # more tasks than `--jobs` won't necessarily make
-                # things faster.)
-                sem = asyncio.BoundedSemaphore(num_jobs)
-
-                async def controller(coro, dbname, *args):
-                    async with sem:
-                        await coro(dbname, *args)
-                        if verbose:
-                            print(f' -> {dbname}: OK', flush=True)
-
-                for _case, dbname, setup_script in setup:
-                    g.create_task(controller(
-                        _setup_database, dbname, setup_script, conn, stats))
-        return stats
-
-    return asyncio.run(_run())
+                g.create_task(controller(
+                    _setup_database, dbname, setup_script, conn, stats))
+    return stats
 
 
 async def _setup_database(dbname, setup_script, conn_args, stats):
@@ -1566,7 +1573,10 @@ class _EdgeDBServer:
             cmd += ['--allow-insecure-http-clients']
 
         if self.debug:
-            print(f'Starting EdgeDB cluster with the following params: {cmd}')
+            print(
+                f'Starting EdgeDB cluster with the following params:\n'
+                f'{" ".join(shlex.quote(c) for c in cmd)}'
+            )
 
         stat_reader, stat_writer = await asyncio.open_connection(sock=status_r)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,7 +10,7 @@ show_column_numbers = True
 # To enable better type checks on some package, add it to one of the below
 # sections
 
-[mypy-edb.edgeql.compiler.*,edb.edgeql.codegen,edb.graphql.types,edb.edgeql.declarative,edb.edgeql.tracer,edb.pgsql.metaschema,edb.pgsql.compiler.*,edb.schema.reflection.*,edb.common.adapter,edb.ir.*,edb.schema.*,edb.server.config,edb.server.pgconnparams,edb.repl.*,edbperf.*,edb.server.connpool.*]
+[mypy-edb.edgeql.compiler.*,edb.edgeql.codegen,edb.graphql.types,edb.edgeql.declarative,edb.edgeql.tracer,edb.pgsql.metaschema,edb.pgsql.compiler.*,edb.schema.reflection.*,edb.common.adapter,edb.ir.*,edb.schema.*,edb.server.cluster,edb.server.config,edb.server.pgcluster,edb.server.pgconnparams,edb.repl.*,edbperf.*,edb.server.connpool.*]
 # Equivalent of --strict on the command line, but without disallow_untyped_calls:
 disallow_subclassing_any = True
 disallow_any_generics = True


### PR DESCRIPTION
Currently, `edgedb-server` and `postgres` harnesses in `server.cluster`
and `server.pgcluster` expose sync APIs for things like `init()` and
`start()` and then rather unceremoniously create new asyncio event loops
to actually be able to do I/O with the started server reasonably.  This
is obviously a problem if an event loop is already present in the
process, as evidenced by the contortions in some of the `test_server_ops_`
tests.  More importantly, though, sync API in `Cluster` prevents the use
of asyncio subprocesses, which I'd like to use to channel Postgres logs
properly.

In this patch I went over the call stacks that currently do the
`new_event_loop` stuff, made them `async` and threw away a bunch
of hacks in the process.  Also, I had to properly type-annotate the
cluster code, because I can't make myself do refactoring without the
help of a typechecker anymore.