### PR TITLE
Don't force materialization of WITH bindings that use another volatile WITH

### DIFF
--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -43,7 +43,6 @@ VOLATILE = qltypes.Volatility.Volatile
 # A basic one, and one for consumption by materialization.
 #
 # The one for consumption by materialization differs in that it
-# does not consider variable bindings to be Stable and that it
 # (counterintuitively) does not consider DML to be volatile
 # (since DML has its own "materialization" mechanism).
 #
@@ -164,7 +163,7 @@ def __infer_set(
         ])
 
     if ir.is_binding:
-        vol = (STABLE, _normalize_volatility(vol)[1])
+        vol = STABLE
 
     return vol
 


### PR DESCRIPTION
This was needed at some point, but materialization has been improved
enough that it apparently isn't necessary at this point. (Which
semantically it should not be, and I'm not sure totally how I
convinced myself it was.)

(This was sort of stumbled upon by accident, as I wrote some code that
was going to take advantage of the old behavior, but needed to disable
it for FOR in order to have things work, and then realized I can just
disable it always.)