### PR TITLE
Use asyncio subprocess API in PostgreSQL cluster management

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -668,7 +668,7 @@ async def _init_stdlib(
             tpl_pg_db_name = cluster.get_db_name(tpl_db_name)
             tpl_pg_db_name_dyn = (
                 f"edgedb.get_database_backend_name({ql(tpl_db_name)})")
-            tpldbdump = cluster.dump_database(
+            tpldbdump = await cluster.dump_database(
                 tpl_pg_db_name,
                 exclude_schemas=['edgedbinstdata', 'edgedbext'],
                 dump_object_owners=False,

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -90,7 +90,7 @@ class BaseCluster:
 
     async def get_status(self) -> str:
         pg_cluster = await self._get_pg_cluster()
-        pg_status = pg_cluster.get_status()
+        pg_status = await pg_cluster.get_status()
         initially_stopped = pg_status == 'stopped'
 
         if initially_stopped:
@@ -111,7 +111,7 @@ class BaseCluster:
                 await conn.close()
             await asyncio.sleep(0)
             if initially_stopped:
-                pg_cluster.stop()
+                await pg_cluster.stop()
 
         if initially_stopped:
             return 'stopped' if db_exists else 'not-initialized,stopped'
@@ -352,7 +352,7 @@ class Cluster(BaseCluster):
         self._pg_connect_args['database'] = 'template1'
 
     async def _new_pg_cluster(self) -> pgcluster.Cluster:
-        return pgcluster.get_local_pg_cluster(
+        return await pgcluster.get_local_pg_cluster(
             self._data_dir,
             log_level=self._log_level,
         )

--- a/edb/tools/wipe.py
+++ b/edb/tools/wipe.py
@@ -112,7 +112,7 @@ async def do_wipe(
             tenant_id='<unknown>',
         )
     elif data_dir:
-        cluster = pgcluster.get_local_pg_cluster(
+        cluster = await pgcluster.get_local_pg_cluster(
             data_dir,
             tenant_id='<unknown>',
         )
@@ -133,7 +133,7 @@ async def do_wipe(
         click.echo('OK. Not proceeding.')
         return
 
-    status = cluster.get_status()
+    status = await cluster.get_status()
     cluster_started_by_us = False
     if status != 'running':
         if isinstance(cluster, pgcluster.RemoteCluster):
@@ -156,7 +156,7 @@ async def do_wipe(
     finally:
         await conn.close()
         if cluster_started_by_us:
-            cluster.stop()
+            await cluster.stop()
 
 
 def get_database_backend_name(name: str, tenant_id: str) -> str:

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -238,7 +238,7 @@ class TestServerOps(tb.TestCase):
                     await con.aclose()
 
         with tempfile.TemporaryDirectory() as td:
-            cluster = pgcluster.get_local_pg_cluster(
+            cluster = await pgcluster.get_local_pg_cluster(
                 td, max_connections=actual, log_level='s')
             cluster.set_connection_params(
                 pgconnparams.ConnectionParameters(
@@ -246,12 +246,12 @@ class TestServerOps(tb.TestCase):
                     database='template1',
                 ),
             )
-            self.assertTrue(cluster.ensure_initialized())
+            self.assertTrue(await cluster.ensure_initialized())
             await cluster.start()
             try:
                 await test(td)
             finally:
-                cluster.stop()
+                await cluster.stop()
 
     async def test_server_ops_postgres_multitenant(self):
         async def test(pgdata_path, tenant):
@@ -274,14 +274,14 @@ class TestServerOps(tb.TestCase):
                     await con.aclose()
 
         with tempfile.TemporaryDirectory() as td:
-            cluster = pgcluster.get_local_pg_cluster(td, log_level='s')
+            cluster = await pgcluster.get_local_pg_cluster(td, log_level='s')
             cluster.set_connection_params(
                 pgconnparams.ConnectionParameters(
                     user='postgres',
                     database='template1',
                 ),
             )
-            self.assertTrue(cluster.ensure_initialized())
+            self.assertTrue(await cluster.ensure_initialized())
 
             await cluster.start()
             try:
@@ -289,7 +289,7 @@ class TestServerOps(tb.TestCase):
                     tg.create_task(test(td, 'tenant1'))
                     tg.create_task(test(td, 'tenant2'))
             finally:
-                cluster.stop()
+                await cluster.stop()
 
     async def test_server_ops_postgres_recovery(self):
         async def test(pgdata_path):
@@ -304,7 +304,7 @@ class TestServerOps(tb.TestCase):
                     self.assertEqual(int(val), 123)
 
                     # stop the postgres
-                    cluster.stop()
+                    await cluster.stop()
                     # TODO: Use BackendUnavailableError here, same below
                     with self.assertRaisesRegex(
                         errors.EdgeDBError,
@@ -328,19 +328,19 @@ class TestServerOps(tb.TestCase):
                     await con.aclose()
 
         with tempfile.TemporaryDirectory() as td:
-            cluster = pgcluster.get_local_pg_cluster(td, log_level='s')
+            cluster = await pgcluster.get_local_pg_cluster(td, log_level='s')
             cluster.set_connection_params(
                 pgconnparams.ConnectionParameters(
                     user='postgres',
                     database='template1',
                 ),
             )
-            self.assertTrue(cluster.ensure_initialized())
+            self.assertTrue(await cluster.ensure_initialized())
             await cluster.start()
             try:
                 await test(td)
             finally:
-                cluster.stop()
+                await cluster.stop()
 
     async def _test_connection(self, con):
         await con.connect()


### PR DESCRIPTION
This switches all uses of `subprocess` in `pgcluster` to
`asyncio.create_subprocess_exec` and sets up consistent capturing and
logging of subprocess standard streams.

Some slight massaging of log formatting is also here: timestamp is now
formatted as proper ISO date, and logger names are a darker shade of
grey.

Fixes: #2819

![image](https://user-images.githubusercontent.com/347119/129668239-eb6d3e3b-5a24-407d-b6c1-f388b3b3d6dc.png)
