### PR TITLE
Enforce pointer cardinality statically in mutations

### DIFF
--- a/tests/schemas/dump02_setup.edgeql
+++ b/tests/schemas/dump02_setup.edgeql
@@ -40,7 +40,7 @@ INSERT `S p a M` {
 };
 
 INSERT A {
-    `s p A m 🤞` := (SELECT `S p a M` FILTER .`🚀` = 42)
+    `s p A m 🤞` := assert_single((SELECT `S p a M` FILTER .`🚀` = 42))
 };
 
 INSERT Łukasz;

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -3643,3 +3643,15 @@ class TestInsert(tb.QueryTestCase):
                     (INSERT Person { name := 'foo' })
                 )
             ''')
+
+    async def test_edgeql_insert_cardinality_assertion(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                "possibly more than one element returned by an expression "
+                "for a link 'sub' declared as 'single'"):
+            await self.con.query(r'''
+                INSERT InsertTest {
+                    l2 := 10,
+                    sub := Subordinate,
+                }
+            ''')

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -2037,7 +2037,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         ):
             await self.con.execute("""
                 SELECT Issue {
-                    owner := User
+                    owner := (SELECT User LIMIT 1)
                 }
             """)
 

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -2060,7 +2060,7 @@ class TestUpdate(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             "possibly more than one element returned by an expression"
-            " for a computed link 'annotated_status' declared as 'single'",
+            " for a link 'annotated_status' declared as 'single'",
             _position=114,
         ):
             await self.con.execute("""
@@ -3005,4 +3005,16 @@ class TestUpdate(tb.QueryTestCase):
                         flag := 1
                     } FILTER .name = 'Tag'
                 };
+            ''')
+
+    async def test_edgeql_update_cardinality_assertion(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                "possibly more than one element returned by an expression "
+                "for a link 'status' declared as 'single'"):
+            await self.con.query(r'''
+                UPDATE UpdateTest
+                SET {
+                    status := Status,
+                }
             ''')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7209,7 +7209,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                         UPDATE Foo
                         FILTER .val = 1
                         SET {
-                            val += 1
+                            val := .val + 1
                         }
                     )
                 };
@@ -7266,7 +7266,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
                     FILTER
                         (.val = 1)
                     SET {
-                        val += 1
+                        val := (.val + 1)
                     });
                 };
             };

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2352,7 +2352,7 @@ class TestServerProtoDDL(tb.DDLTestCase):
 
                 INSERT {typename} {{
                     link1 := (
-                        SELECT Foo{typename} {{@prop1 := 'aaa'}}
+                        SELECT assert_single(Foo{typename}) {{@prop1 := 'aaa'}}
                     )
                 }};
             ''')


### PR DESCRIPTION
Make sure we actually raise a cardinality assertion error when an
expression to the right of `:=` in mutations violates the declared
pointer cardinality.

Fixes: #2827