### PR TITLE
Fix test instance destruction regression

### DIFF
--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -797,6 +797,7 @@ class ParallelTextTestRunner:
                     )
 
                 async def _setup():
+                    nonlocal cluster
                     nonlocal conn
 
                     cluster = await tb.init_cluster(


### PR DESCRIPTION
This is a regression from #2806 which made test EdgeDB instances linger
after test conclusion.