### PR TITLE
Fix sorting of apparent server package version

### DIFF
--- a/.github/workflows.src/release.tpl.yml
+++ b/.github/workflows.src/release.tpl.yml
@@ -21,10 +21,14 @@ jobs:
           echo ::error::"${branch} is not a release branch."
           exit 1
         fi
+        commitish=$(git rev-parse --verify --quiet "${GITHUB_REF}" | cut -c1-9)
+        date=$(env TZ=UTC git show -s \
+               --format=%cd --date=format-local:%Y%m%d%H "$commitish")
         ver=${branch#releases/}
-        ver+=+g$(git rev-parse --verify --quiet "${GITHUB_REF}" | cut -c1-9)
+        ver+=+d${date}
+        ver+=.g${commitish}
         ver+=.cv$(sed -n -r 's/EDGEDB_CATALOG_VERSION = ([0-9_]+)/\1/p' \
-                   edb/server/defines.py | sed 's/_//g')
+                  edb/server/defines.py | sed 's/_//g')
         echo ::set-output name=version::"${ver}"
         echo ::set-output name=branch::"${branch}"
       id: whichver

--- a/edb/server/buildmeta.py
+++ b/edb/server/buildmeta.py
@@ -20,7 +20,6 @@
 from __future__ import annotations
 from typing import *
 
-import datetime
 import functools
 import hashlib
 import json
@@ -338,12 +337,21 @@ def scm_local_scheme(root, version):
         check=True,
         cwd=root,
     )
-
-    curdate = datetime.datetime.now(tz=datetime.timezone.utc)
-    curdate_str = curdate.strftime(r'%Y%m%d%H')
     commitish = proc.stdout.strip()
+
+    proc = subprocess.run(
+        ['git', 'show', '-s', '--format=%cd',
+         '--date=format-local:%Y%m%d%H', commitish],
+        stdout=subprocess.PIPE,
+        universal_newlines=True,
+        check=True,
+        cwd=root,
+        env={'TZ': 'UTC'},
+    )
+    rev_date = proc.stdout.strip()
+
     catver = defines.EDGEDB_CATALOG_VERSION
-    return f'+d{curdate_str}.g{commitish[:9]}.cv{catver}'
+    return f'+d{rev_date}.g{commitish[:9]}.cv{catver}'
 
 
 def get_cache_src_dirs():


### PR DESCRIPTION
Include the date as the first component of build metadata in release
versions to ensure proper sortability.  This is a regression from #2475.

In addition, switch to using the top commit date instead of current
date, as the latter is encoded in package revision already.

Fixes: edgedb/edgedb-cli#477