### PR TITLE
Fix some backlink cases

### DIFF
--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -179,7 +179,7 @@ class BasePointerRef(ImmutableBase):
     __abstract_node__ = True
 
     # Hide children to reduce noise
-    __ast_hidden__ = {'children'}
+    __ast_hidden__ = {'children', 'outbound_ptr'}
 
     # cardinality fields need to be mutable for lazy cardinality inference.
     # and children because we update pointers with newly derived children
@@ -211,6 +211,11 @@ class BasePointerRef(ImmutableBase):
     dir_cardinality: qltypes.Cardinality
     # Outbound cardinality of the pointer.
     out_cardinality: qltypes.Cardinality
+
+    # For inbound pointers, a pointer to the corresponding outbound pointer.
+    # I think it might be better to drop direction from PointerRef and track it
+    # externally?
+    outbound_ptr: typing.Optional[BasePointerRef] = None
 
     @property
     def dir_target(self) -> TypeRef:

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -636,6 +636,13 @@ def ptrref_from_ptrcls(  # NoQA: F811
     else:
         children = frozenset()
 
+    if direction == s_pointers.PointerDirection.Outbound:
+        outbound_ptr = None
+    else:
+        outbound_ptr = ptrref_from_ptrcls(
+            schema=schema, ptrcls=ptrcls, cache=cache,
+            typeref_cache=typeref_cache)
+
     kwargs.update(dict(
         out_source=out_source,
         out_target=out_target,
@@ -656,6 +663,7 @@ def ptrref_from_ptrcls(  # NoQA: F811
         has_properties=ptrcls.has_user_defined_properties(schema),
         dir_cardinality=dir_cardinality,
         out_cardinality=out_cardinality,
+        outbound_ptr=outbound_ptr,
     ))
 
     ptrref = ircls(**kwargs)


### PR DESCRIPTION
This was prompted by an issue that came up with backlinks in
introspection queries, which was caused by logic errors in the code
that arranges to output the source path of an inline backlink in the
case where the typeref rvar is a subquery pointing to a CTE. While
investigating I also found a handful of issues involving
union/intersection interactions.

To fix this, I deleted all of that code and arranged things to use
`get_path_output` to find the relevant columns. This unfortunately
required adding a `outbound_ptr` to `BasePointerRef` to allow us to
invert a backlink. I think that it might be better if PointerRef didn't
have a direction on it, and that direction was always tracked externally
(which it is also, with Pointer).

Fixes #2599.