### PR TITLE
Fix cardinality inference in "optionality-preserving" functions

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -273,6 +273,12 @@ class CastParamListWrapper(s_func.ParameterLikeList):
     ) -> bool:
         return False
 
+    def has_set_of(
+        self,
+        schema: s_schema.Schema,
+    ) -> bool:
+        return False
+
     def objects(
         self,
         schema: s_schema.Schema,

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -255,6 +255,7 @@ def compile_FunctionCall(
         volatility=func.get_volatility(env.schema),
         sql_func_has_out_params=func.get_sql_func_has_out_params(env.schema),
         error_on_null_result=func.get_error_on_null_result(env.schema),
+        preserves_optionality=func.get_preserves_optionality(env.schema),
         params_typemods=params_typemods,
         context=expr.context,
         typeref=typegen.type_to_typeref(

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -672,32 +672,73 @@ def __infer_func_call(
     scope_tree: irast.ScopeTreeNode,
     ctx: inference_context.InfCtx,
 ) -> qltypes.Cardinality:
-    SetOfType = qltypes.TypeModifier.SetOfType
+    return_card = (
+        MANY if ir.typemod is qltypes.TypeModifier.SetOfType else
+        AT_MOST_ONE if ir.typemod is qltypes.TypeModifier.OptionalType else
+        ONE
+    )
 
-    args = []
-    # process positional args
-    for arg, typemod in zip(ir.args, ir.params_typemods):
-        arg.cardinality = infer_cardinality(
-            arg.expr,
-            scope_tree=scope_tree, ctx=ctx)
-        if typemod is not SetOfType:
-            args.append(arg.expr)
+    ret_lower_bound, ret_upper_bound = _card_to_bounds(return_card)
 
-    # the cardinality of the function call depends on the cardinality
-    # of non-SET_OF arguments AND the cardinality of the function
-    # return value
-    if ir.typemod is SetOfType:
-        return MANY
+    if ir.preserves_optionality:
+        # This is a generic aggregate function which preserves the
+        # optionality of its generic argument.  For simplicity we
+        # are deliberately not checking the parameters here as that
+        # would have been done at the time of declaration.
+        arg_cards = []
+
+        for arg in ir.args:
+            arg.cardinality = infer_cardinality(
+                arg.expr, scope_tree=scope_tree, ctx=ctx)
+            arg_cards.append(arg.cardinality)
+
+        arg_card = zip(*(_card_to_bounds(card) for card in arg_cards))
+        arg_lower, _ = arg_card
+        return _bounds_to_card(min(arg_lower), ret_upper_bound)
+
     else:
-        if args:
-            return _common_cardinality(
-                args, scope_tree=scope_tree, ctx=ctx,
-            )
-        else:
-            if ir.typemod is qltypes.TypeModifier.OptionalType:
-                return AT_MOST_ONE
+        # For regular non-OPTIONAL functions, the general rule of
+        # Cartesian cardinality of arguments applies, although we still
+        # have to account for the declared return cardinality, as the
+        # function might be OPTIONAL or SET OF in its return type.
+        #
+        # If a function is OPTIONAL in its parameters, which includes
+        # aggregate functions, then we compute a Cartesian cardinality
+        # of functions's _non-OPTIONAL_ arguments and its return
+        # cardinality, but only in the upper bound, since we cannot know
+        # how the function behaves in OPTIONAL arguments.
+        non_aggregate_args = []
+        non_aggregate_arg_cards = []
+        singleton_args = []
+        singleton_arg_cards = []
+        all_singletons = True
+
+        for arg, typemod in zip(ir.args, ir.params_typemods):
+            arg.cardinality = infer_cardinality(
+                arg.expr, scope_tree=scope_tree, ctx=ctx)
+            if typemod is not qltypes.TypeModifier.SetOfType:
+                non_aggregate_args.append(arg.expr)
+                non_aggregate_arg_cards.append(arg.cardinality)
+            if typemod is qltypes.TypeModifier.SingletonType:
+                singleton_args.append(arg.expr)
+                singleton_arg_cards.append(arg.cardinality)
             else:
-                return ONE
+                all_singletons = False
+
+        if non_aggregate_args:
+            _check_op_volatility(
+                non_aggregate_args, non_aggregate_arg_cards, ctx=ctx)
+
+        if not singleton_args:
+            # Either no arguments at all, or all arguments are non-singletons,
+            # so the declared return cardinality is as specific as we can get.
+            return return_card
+        else:
+            result = cartesian_cardinality(singleton_arg_cards + [return_card])
+            if not all_singletons:
+                result = _bounds_to_card(
+                    ret_lower_bound, _card_to_bounds(result)[1])
+            return result
 
 
 @_infer_cardinality.register

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -710,6 +710,10 @@ class FunctionCall(Call):
     # Error to raise if the underlying SQL function returns NULL.
     error_on_null_result: typing.Optional[str] = None
 
+    # Whether the generic function preserves optionality of the generic
+    # argument(s).
+    preserves_optionality: bool = False
+
     # Set to the type of the variadic parameter of the bound function
     # (or None, if the function has no variadic parameters.)
     variadic_param_type: typing.Optional[TypeRef] = None

--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -1348,6 +1348,7 @@ std::min(vals: SET OF cal::local_datetime) -> OPTIONAL cal::local_datetime
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1359,6 +1360,7 @@ std::min(vals: SET OF cal::local_date) -> OPTIONAL cal::local_date
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1370,6 +1372,7 @@ std::min(vals: SET OF cal::local_time) -> OPTIONAL cal::local_time
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1381,6 +1384,7 @@ std::min(vals: SET OF array<cal::local_datetime>) -> OPTIONAL array<cal::local_d
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1392,6 +1396,7 @@ std::min(vals: SET OF array<cal::local_date>) -> OPTIONAL array<cal::local_date>
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1403,6 +1408,7 @@ std::min(vals: SET OF array<cal::local_time>) -> OPTIONAL array<cal::local_time>
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1414,6 +1420,7 @@ std::min(vals: SET OF array<cal::relative_duration>) -> OPTIONAL array<cal::rela
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -1425,6 +1432,7 @@ std::max(vals: SET OF cal::local_datetime) -> OPTIONAL cal::local_datetime
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -1436,6 +1444,7 @@ std::max(vals: SET OF cal::local_date) -> OPTIONAL cal::local_date
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -1447,6 +1456,7 @@ std::max(vals: SET OF cal::local_time) -> OPTIONAL cal::local_time
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -1458,6 +1468,7 @@ std::max(vals: SET OF array<cal::local_datetime>) -> OPTIONAL array<cal::local_d
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -1469,6 +1480,7 @@ std::max(vals: SET OF array<cal::local_date>) -> OPTIONAL array<cal::local_date>
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -1480,6 +1492,7 @@ std::max(vals: SET OF array<cal::local_time>) -> OPTIONAL array<cal::local_time>
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -1491,5 +1504,6 @@ std::max(vals: SET OF array<cal::relative_duration>) -> OPTIONAL array<cal::rela
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'max';
 };

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -386,7 +386,7 @@ ALTER TYPE schema::ObjectType {
 CREATE TYPE schema::Function
     EXTENDING schema::CallableObject, schema::VolatilitySubject
 {
-    CREATE PROPERTY fallback -> std::bool {
+    CREATE PROPERTY preserves_optionality -> std::bool {
         SET default := false;
     };
 };

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -23,12 +23,13 @@
 # ---------------------------------------------------
 
 CREATE FUNCTION
-std::assert_single(input: SET OF anytype) -> anytype
+std::assert_single(input: SET OF anytype) -> OPTIONAL anytype
 {
     CREATE ANNOTATION std::description :=
         "Check that the input set contains at most one element, raise
          CardinalityViolationError otherwise.";
     SET volatility := 'Stable';
+    SET preserves_optionality := true;
     USING SQL EXPRESSION;
 };
 
@@ -181,6 +182,7 @@ std::min(vals: SET OF anytype) -> OPTIONAL anytype
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET fallback := true;
+    SET preserves_optionality := true;
     USING SQL EXPRESSION;
 };
 
@@ -202,6 +204,7 @@ std::min(vals: SET OF anyreal) -> OPTIONAL anyreal
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -212,6 +215,7 @@ std::min(vals: SET OF anyenum) -> OPTIONAL anyenum
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -222,6 +226,7 @@ std::min(vals: SET OF str) -> OPTIONAL str
     CREATE ANNOTATION std::description :=
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -233,6 +238,7 @@ std::min(vals: SET OF datetime) -> OPTIONAL datetime
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -244,6 +250,7 @@ std::min(vals: SET OF duration) -> OPTIONAL duration
         'Return the smallest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'min';
 };
 
@@ -258,6 +265,7 @@ std::max(vals: SET OF anytype) -> OPTIONAL anytype
         'Return the greatest value of the input set.';
     SET volatility := 'Immutable';
     SET fallback := true;
+    SET preserves_optionality := true;
     USING SQL EXPRESSION;
 };
 
@@ -279,6 +287,7 @@ std::max(vals: SET OF anyreal) -> OPTIONAL anyreal
     CREATE ANNOTATION std::description :=
         'Return the greatest value of the input set.';
     SET volatility := 'Immutable';
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -289,6 +298,7 @@ std::max(vals: SET OF anyenum) -> OPTIONAL anyenum
     CREATE ANNOTATION std::description :=
         'Return the greatest value of the input set.';
     SET volatility := 'Immutable';
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -299,6 +309,7 @@ std::max(vals: SET OF str) -> OPTIONAL str
     CREATE ANNOTATION std::description :=
         'Return the greatest value of the input set.';
     SET volatility := 'Immutable';
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -310,6 +321,7 @@ std::max(vals: SET OF datetime) -> OPTIONAL datetime
         'Return the greatest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -321,6 +333,7 @@ std::max(vals: SET OF duration) -> OPTIONAL duration
         'Return the greatest value of the input set.';
     SET volatility := 'Immutable';
     SET force_return_cast := true;
+    SET preserves_optionality := true;
     USING SQL FUNCTION 'max';
 };
 
@@ -364,6 +377,7 @@ std::enumerate(
     CREATE ANNOTATION std::description :=
         'Return a set of tuples of the form `(index, element)`.';
     SET volatility := 'Immutable';
+    SET preserves_optionality := true;
     USING SQL EXPRESSION;
 };
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -32,7 +32,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_08_02_00_00
+EDGEDB_CATALOG_VERSION = 2021_08_20_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/schemas/cards_ir_inference.esdl
+++ b/tests/schemas/cards_ir_inference.esdl
@@ -123,3 +123,16 @@ type Person extending BadlyNamed {
     link card -> Card;
     constraint exclusive on ((.p, .card));
 }
+
+
+function taking_opt_returning_non_opt(a: optional str) -> str {
+    using (
+        a
+    );
+};
+
+function taking_non_opt_returning_opt(a: str) -> optional str {
+    using (
+        a
+    );
+};

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -42,6 +42,18 @@ class TestInsert(tb.QueryTestCase):
                 INSERT InsertTest;
             ''')
 
+    async def test_edgeql_insert_fail_2(self):
+        with self.assertRaisesRegex(
+            edgedb.MissingRequiredError,
+            r"missing value for required property"
+            r" 'l2' of object type 'default::InsertTest'",
+        ):
+            await self.con.execute('''
+                INSERT InsertTest {
+                    l2 := assert_single({})
+                };
+            ''')
+
     async def test_edgeql_insert_simple_01(self):
         await self.con.execute(r"""
             INSERT InsertTest {

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -663,3 +663,83 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         AT_LEAST_ONE
         """
+
+    def test_edgeql_ir_card_inference_74(self):
+        """
+        SELECT taking_opt_returning_non_opt("foo")
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_75(self):
+        """
+        SELECT taking_opt_returning_non_opt(<str>{})
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_76(self):
+        """
+        SELECT taking_non_opt_returning_opt("foo")
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_77(self):
+        """
+        SELECT taking_non_opt_returning_opt(<str>{})
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_78(self):
+        """
+        SELECT len("foo")
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_79(self):
+        """
+        SELECT len(<str>{})
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_80(self):
+        """
+        WITH s := {1, 2, 3}
+        SELECT max(s)
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_81(self):
+        """
+        SELECT max(Person.p)
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_82(self):
+        """
+        SELECT assert_single(Person.p)
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_83(self):
+        """
+        SELECT Card {
+            element := assert_single(.element ++ "1")
+        }
+% OK %
+        element: ONE
+        """
+
+    def test_edgeql_ir_card_inference_84(self):
+        """
+        SELECT array_get([1, 2, 3], {0, 2})
+% OK %
+        MANY
+        """


### PR DESCRIPTION
A certain number of standard aggregate functions are guaranteed to
preserve the lower cardinality bound of their argument.  These functions
are `std::assert_single`, `std::enumerate`, `std::min`, and `std::max`.
Unfortunately, there is currently no way to signal that lower
cardinality is preserved, and so we introduce the new std-only
`preserves_cardinality` field, which is also exposed in the public
introspection schema for the benefit of query builders and such.

While doing this, I realised that we also mishandle functions with
non-OPTIONAL arguments that return `OPTIONAL` or `SET OF`, so I fixed
inference of those too.