### PR TITLE
Move a bunch of test setup logic up to `ClusterTestCase`

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -24,6 +24,8 @@ from edb.testbase import server as tb
 
 
 class TestDatabase(tb.ConnectedTestCase):
+    TRANSACTION_ISOLATION = False
+
     async def test_database_create_01(self):
         await self.con.execute('CREATE DATABASE mytestdb;')
 


### PR DESCRIPTION
Currently, `PARALLELISM_GRANULARITY` and `TRANSACTION_ISOLATION` are
defined in `DatabaseTestCase`, which precludes these facilities from
being used in tests that don't setup up a separate database such as
`TestServerAuth`, and `TestDatabase`.  Fix this by moving the
infrastructure up to `ClusterTestCase`.