### PR TITLE
Make properties non-distinct by default

### DIFF
--- a/tests/schemas/constraints.esdl
+++ b/tests/schemas/constraints.esdl
@@ -251,3 +251,9 @@ type BecomingConcreteConstraint {
 }
 
 type BecomingConcreteConstraintChild extending BecomingConcreteConstraint;
+
+type PropertyContainer {
+    multi property tags -> str {
+        constraint exclusive
+    }
+}

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -368,6 +368,33 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     };
                 """)
 
+    async def test_constraints_exclusive_multi_property_distinct(self):
+        await self.con.execute("""
+            INSERT PropertyContainer {
+                tags := {"one", "two"}
+            };
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            "tags violates exclusivity constraint",
+        ):
+            await self.con.execute("""
+                INSERT PropertyContainer {
+                    tags := {"one", "three"}
+                };
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            "tags violates exclusivity constraint",
+        ):
+            await self.con.execute("""
+                INSERT PropertyContainer {
+                    tags := {"four", "four"}
+                };
+            """)
+
     async def test_constraints_objects(self):
         async with self._run_and_rollback():
             with self.assertRaisesRegex(


### PR DESCRIPTION
All values in EdgeQL are considered to be multisets, which are a
generalization of the set concept that allows duplicate elements.  For
brevity we refer to multisets as just "sets", and use "proper set" or
"distinct set" when referring to proper mathematical sets.

In EdgeDB the data is modeled as a directed graph, where objects are
vertices and links are edges.  Query path expressions (`Foo.bar.baz`)
are graph traversal operators and, by definition, always return a
*distinct set*.  This means that there can be no link of the same name
between a pair of objects, and this also means that a set of objects
pointed to by a `multi` link is always distinct.  Computed links must
follow this rule too so as to behave exactly like materialized links
externally.  To illustrate, consider a common case of finding a set of
"friends of friends" of a particular user.  In EdgeQL this is simply
`SELECT User.friends.friends`.  Proper set semantics here allows this
operation to use a more efficient semi-join in place of a regular join
(especially if the latter is later coupled with a use of `DISTINCT`).  A
majority of queries on object paths are like that and so this behavior
is desirable.

Properties are different, because their value is scalar, and scalars
lack true identity, which makes any proper set mechanics on scalar sets
expensive due to explicit elimination of duplicates.  Furthermore,
non-distinct scalar sets are actually *desirable* in many queries,
especially where analytics and tuples are involved.  Finally, we should
enforce consistent multiplicity rules on computed properties, and static
inference of multiplicity on scalars is weak and will effectively force
users to pollute queries with pointless and expensive `DISTINCT`.

Here we change EdgeDB behavior to allow multiplicity greater than one in
`multi` properties.

See edgedb/edgedb#2054 for the discussion.

Fixes: #2622.