### PR TITLE
Stop enforcing `id` uniqueness across tables via triggers

### DIFF
--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -32,7 +32,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_08_20_00_00
+EDGEDB_CATALOG_VERSION = 2021_08_24_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs


### PR DESCRIPTION
Object ids are virtually guaranteed to be unique by the virtue of
them always being generated UUID values.  Hence, make sure we are not
pointlessly generating cross-table id uniqueness checks via triggers.