### PR TITLE
Partially revert "Adjust the precedence of DETACHED to match EXISTS/DISTINCT (#2638)"

### DIFF
--- a/docs/edgeql/lexical.rst
+++ b/docs/edgeql/lexical.rst
@@ -436,14 +436,14 @@ EdgeQL operators listed in order of precedence from lowest to highest:
     * - :eql:op:`*<MULT>`, :eql:op:`/<DIV>`,
         :eql:op:`//<FLOORDIV>`, :eql:op:`%<MOD>`
     * - :eql:op:`??<COALESCE>`
-    * - :eql:op:`DISTINCT`, :eql:op:`EXISTS`,
-	    :ref:`DETACHED <ref_eql_with_detached>`, unary :eql:op:`-<UMINUS>`
+    * - :eql:op:`DISTINCT`, unary :eql:op:`-<UMINUS>`
     * - :eql:op:`^<POW>`
     * - :eql:op:`type cast <CAST>`
     * - :eql:op:`array[] <ARRAYIDX>`,
         :eql:op:`str[] <STRIDX>`,
         :eql:op:`json[] <JSONIDX>`,
         :eql:op:`bytes[] <BYTESIDX>`
+    * - :ref:`DETACHED <ref_eql_with_detached>`
 
 .. |neq| replace:: !=
 .. _neq: ./funcops/generic#operator::NEQ

--- a/edb/edgeql/parser/grammar/precedence.py
+++ b/edb/edgeql/parser/grammar/precedence.py
@@ -123,11 +123,6 @@ class P_DISTINCT(Precedence, assoc='right', tokens=('DISTINCT',),
     pass
 
 
-class P_DETACHED(Precedence, assoc='right', tokens=('DETACHED',),
-                 rel_to_last='='):
-    pass
-
-
 class P_POW_OP(Precedence, assoc='right', tokens=('CIRCUMFLEX',)):
     pass
 
@@ -149,6 +144,10 @@ class P_PAREN(Precedence, assoc='left', tokens=('LPAREN', 'RPAREN')):
 
 
 class P_DOT(Precedence, assoc='left', tokens=('DOT', 'DOTBW')):
+    pass
+
+
+class P_DETACHED(Precedence, assoc='right', tokens=('DETACHED',)):
     pass
 
 

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -1940,7 +1940,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             SELECT User {
                 name,
                 fire_deck := (
-                    SELECT User.deck {name, element}
+                    SELECT .deck {name, element}
                     FILTER .element = 'Fire'
                     ORDER BY .name
                 )
@@ -1955,7 +1955,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 SELECT DETACHED User {
                     name,
                     fire_deck := (
-                        SELECT User.deck {name, element}
+                        SELECT .deck {name, element}
                         FILTER .element = 'Fire'
                         ORDER BY .name
                     )
@@ -1970,7 +1970,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             SELECT User {
                 name,
                 fire_deck := (
-                    SELECT User.deck {name, element}
+                    SELECT .deck {name, element}
                     FILTER .element = 'Fire'
                     ORDER BY .name
                 ).name
@@ -1985,7 +1985,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 SELECT DETACHED User {
                     name,
                     fire_deck := (
-                        SELECT User.deck {name, element}
+                        SELECT .deck {name, element}
                         FILTER .element = 'Fire'
                         ORDER BY .name
                     ).name
@@ -2001,7 +2001,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 SELECT DETACHED User {
                     name,
                     fire_deck := (
-                        SELECT User.deck {name, element}
+                        SELECT .deck {name, element}
                         FILTER .element = 'Fire'
                         ORDER BY .name
                     ).name
@@ -2125,7 +2125,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
     async def test_edgeql_scope_detached_12(self):
         await self.assert_query_result(
             r"""
-            SELECT DETACHED User { name2 := User.name } ORDER BY .name;
+            SELECT DETACHED (User { name2 := User.name }) ORDER BY .name;
             """,
             [
                 {"name2": "Alice"},

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2465,7 +2465,7 @@ aa';
 
 % OK %
 
-        SELECT DETACHED Foo.bar;
+        SELECT (DETACHED Foo).bar;
         """
 
     def test_edgeql_syntax_detached_05(self):
@@ -2474,16 +2474,7 @@ aa';
 
 % OK %
 
-        SELECT DETACHED mod::Foo.bar;
-        """
-
-    def test_edgeql_syntax_detached_06(self):
-        """
-        SELECT (DETACHED Foo).bar;
-
-% OK %
-
-        SELECT (DETACHED Foo).bar;
+        SELECT (DETACHED mod::Foo).bar;
         """
 
     def test_edgeql_syntax_select_01(self):


### PR DESCRIPTION
This partially reverts commit 508a2c417414729159d54927b94bf3fdd007f557.

We keep a compiler fix from that change, but fully revert all of the
parsing precedence changes.