### PR TITLE
Use edgedb-python @ master and fix test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ except ImportError:
 
 
 RUNTIME_DEPS = [
-    'edgedb>=0.17.0',
+    'edgedb@git+https://github.com/edgedb/edgedb-python.git@master',
 
     'asyncpg~=0.24.0',
     'httptools>=0.3.0',

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -766,7 +766,9 @@ class TestServerProto(tb.QueryTestCase):
             async with tg.TaskGroup() as g:
 
                 async def exec_to_fail():
-                    with self.assertRaises(ConnectionResetError):
+                    with self.assertRaises(
+                        edgedb.errors.ClientConnectionClosedError
+                    ):
                         await con2.query(
                             'select sys::_advisory_lock(<int64>$0)', lock_key)
 


### PR DESCRIPTION
We should change the RUNTIME_DEPS back as soon as we relased a new version of edgedb-python.