### PR TITLE
Binary protocol 0.12 improvements

### DIFF
--- a/docs/internals/protocol/typedesc.rst
+++ b/docs/internals/protocol/typedesc.rst
@@ -26,7 +26,8 @@ data types native to the driver.
 There is one special type with *type id* of zero:
 ``00000000-0000-0000-0000-000000000000``. The describe result of this type
 contains zero *blocks*. It's used when a statement returns no meaningful
-results, e.g. the ``CREATE DATABASE example`` statement.
+results, e.g. the ``CREATE DATABASE example`` statement.  It is also used
+to represent the input descriptor when a query does not receive any arguments.
 
 
 Set Descriptor

--- a/edb/api/types.txt
+++ b/edb/api/types.txt
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+# Use `edb gen-types` to regenerate `edb/schema/_types.py` based on this file.
+
 # Base Scalar Types
 
 00000000-0000-0000-0000-000000000001 anytype

--- a/edb/common/uuidgen.py
+++ b/edb/common/uuidgen.py
@@ -47,10 +47,16 @@ def uuid4() -> uuid.UUID:
     return UUID(os.urandom(16))  # type: ignore
 
 
+def uuid5_bytes(namespace: uuid.UUID, name: bytes | bytearray) -> uuid.UUID:
+    """Generate a UUID from the SHA-1 hash of a namespace UUID and a name."""
+    hasher = hashlib.sha1(namespace.bytes)
+    hasher.update(name)
+    return UUID(hasher.digest()[:16])  # type: ignore
+
+
 def uuid5(namespace: uuid.UUID, name: str) -> uuid.UUID:
     """Generate a UUID from the SHA-1 hash of a namespace UUID and a name."""
-    hash = hashlib.sha1(namespace.bytes + bytes(name, "utf-8")).digest()
-    return UUID(hash[:16])  # type: ignore
+    return uuid5_bytes(namespace, name.encode("utf-8"))
 
 
 def from_bytes(data: bytes) -> uuid.UUID:

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -537,73 +537,6 @@ class Compiler:
 
         return sql.decode(), argmap
 
-    def _compile_query_args(
-            self,
-            ctx: CompileContext,
-            schema: s_schema.Schema,
-            subtypes: List[Tuple[str, Any, bool]],
-    ) -> Tuple[bytes, uuid.UUID]:
-        current_tx = ctx.state.current_tx()
-
-        if not subtypes:
-            arg_ast = qlast.SelectQuery(
-                result=qlast.Path(steps=[qlast.ObjectRef(
-                    name='FreeObject',
-                    module='std',
-                )]),
-            )
-        else:
-            elements = []
-            for name, schema_type, required in subtypes:
-                if required:
-                    card = qlast.CardinalityModifier.Required
-                else:
-                    card = qlast.CardinalityModifier.Optional
-
-                elem = qlast.ShapeElement(
-                    expr=qlast.Path(steps=[qlast.Ptr(
-                        ptr=qlast.ObjectRef(name=f'__arg_{name}'),
-                        direction=s_pointers.PointerDirection.Outbound,
-                    )]),
-                    compexpr=qlast.TypeCast(
-                        cardinality_mod=card,
-                        expr=qlast.Parameter(name=name),
-                        type=s_utils.typeref_to_ast(schema, schema_type),
-                    ),
-                    operation=qlast.ShapeOperation(op=qlast.ShapeOp.ASSIGN),
-                )
-
-                elements.append(elem)
-
-            arg_ast = qlast.SelectQuery(
-                result=qlast.Shape(elements=elements),
-            )
-
-        arg_compile_options = qlcompiler.CompilerOptions(
-            modaliases=current_tx.get_modaliases(),
-            implicit_tid_in_shapes=False,
-            implicit_id_in_shapes=False,
-            implicit_tname_in_shapes=False,
-            apply_query_rewrites=False,
-        )
-
-        ir_expr = qlcompiler.compile_ast_to_ir(
-            arg_ast,
-            schema=schema,
-            options=arg_compile_options,
-        )
-
-        in_type_data, in_type_id = sertypes.TypeSerializer.describe(
-            schema=ir_expr.schema,
-            typ=ir_expr.stype,
-            view_shapes=ir_expr.view_shapes,
-            view_shapes_metadata=ir_expr.view_shapes_metadata,
-            protocol_version=ctx.protocol_version,
-            name_filter="__arg_",
-        )
-
-        return in_type_data, in_type_id
-
     def _compile_ql_query(
         self,
         ctx: CompileContext,
@@ -700,11 +633,13 @@ class Compiler:
                 out_type_data, out_type_id = \
                     sertypes.TypeSerializer.describe_json()
 
-            params = []
             in_type_args = None
+            params: list[tuple[str, s_obj.Object, bool]] = []
+            has_named_params = False
+
             if ir.params:
                 first_param = next(iter(ir.params))
-                named = not first_param.name.isdecimal()
+                has_named_params = not first_param.name.isdecimal()
                 if (src := ctx.source) is not None:
                     first_extracted = src.first_extra()
                 else:
@@ -716,7 +651,6 @@ class Compiler:
                     user_params = len(ir.params)
 
                 params = [None] * user_params
-                subtypes = [None] * user_params
                 in_type_args = [None] * user_params
                 for param in ir.params:
                     sql_param = argmap[param.name]
@@ -732,37 +666,49 @@ class Compiler:
                     ):
                         el_type = param.schema_type.get_element_type(ir.schema)
                         array_tid = el_type.id
-                        # array_tid = el_type.get_backend_id(ir.schema)
-                        # if array_tid is None:
-                        #     assert array_tid is not None
 
-                    subtypes[idx] = (param.name, param.schema_type)
+                    if not has_named_params and str(idx) != param.name:
+                        raise RuntimeError(
+                            'positional argument name disagrees '
+                            'with its actual position')
+
                     params[idx] = (
                         param.name,
                         param.schema_type,
                         sql_param.required,
                     )
+
                     in_type_args[idx] = dbstate.Param(
                         name=param.name,
                         required=sql_param.required,
                         array_type_id=array_tid,
                     )
 
-                ir.schema, params_type = s_types.Tuple.create(
-                    ir.schema,
-                    element_types=collections.OrderedDict(subtypes),
-                    named=named)
-
-            else:
-                ir.schema, params_type = s_types.Tuple.create(
-                    ir.schema, element_types={}, named=False)
-
             if ctx.protocol_version >= (0, 12):
-                in_type_data, in_type_id = self._compile_query_args(
-                    ctx, ir.schema, params)
+                in_type_data, in_type_id = \
+                    sertypes.TypeSerializer.describe_params(
+                        schema=ir.schema,
+                        params=params,
+                        protocol_version=ctx.protocol_version,
+                    )
             else:
+                # Legacy protocol support
+                if params:
+                    pschema, params_type = s_types.Tuple.create(
+                        ir.schema,
+                        element_types=collections.OrderedDict(
+                            # keep only param_name/param_type
+                            [param[:2] for param in params]
+                        ),
+                        named=has_named_params)
+                else:
+                    pschema, params_type = s_types.Tuple.create(
+                        ir.schema,
+                        element_types={},
+                        named=has_named_params)
+
                 in_type_data, in_type_id = sertypes.TypeSerializer.describe(
-                    ir.schema, params_type, {}, {},
+                    pschema, params_type, {}, {},
                     protocol_version=ctx.protocol_version)
 
             sql_hash = self._hash_sql(
@@ -1713,7 +1659,7 @@ class Compiler:
         if not len(statements):  # pragma: no cover
             raise errors.ProtocolError('nothing to compile')
 
-        units = []
+        units: list[dbstate.QueryUnit] = []
         unit = None
 
         for stmt in statements:
@@ -1897,7 +1843,13 @@ class Compiler:
                     f'expected 1 compiled unit; got {len(units)}')
 
         for unit in units:  # pragma: no cover
+            if ctx.protocol_version < (0, 12):
+                if unit.in_type_id == sertypes.NULL_TYPE_ID.bytes:
+                    unit.in_type_id = sertypes.EMPTY_TUPLE_ID.bytes
+                    unit.in_type_data = sertypes.EMPTY_TUPLE_DESC
+
             # Sanity checks
+
             na_cardinality = (
                 unit.cardinality is enums.Cardinality.NO_RESULT
             )
@@ -1907,6 +1859,7 @@ class Compiler:
             ):
                 raise errors.InternalServerError(
                     f'QueryUnit {unit!r} is cacheable but has config/aliases')
+
             if not na_cardinality and (
                     len(unit.sql) > 1 or
                     unit.tx_commit or
@@ -1927,7 +1880,7 @@ class Compiler:
     # API
 
     @staticmethod
-    def try_compile_rollback(eql: bytes):
+    def try_compile_rollback(eql: bytes, protocol_version: tuple[int, int]):
         statements = edgeql.parse_block(eql.decode())
 
         stmt = statements[0]
@@ -1949,6 +1902,11 @@ class Compiler:
                 cacheable=False)
 
         if unit is not None:
+            if protocol_version < (0, 12):
+                if unit.in_type_id == sertypes.NULL_TYPE_ID.bytes:
+                    unit.in_type_id = sertypes.EMPTY_TUPLE_ID.bytes
+                    unit.in_type_data = sertypes.EMPTY_TUPLE_DESC
+
             return unit, len(statements) - 1
 
         raise errors.TransactionError(

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -241,9 +241,9 @@ class QueryUnit:
         enums.Cardinality.NO_RESULT
 
     out_type_data: bytes = sertypes.NULL_TYPE_DESC
-    out_type_id: bytes = sertypes.NULL_TYPE_ID
-    in_type_data: bytes = sertypes.EMPTY_TUPLE_DESC
-    in_type_id: bytes = sertypes.EMPTY_TUPLE_ID
+    out_type_id: bytes = sertypes.NULL_TYPE_ID.bytes
+    in_type_data: bytes = sertypes.NULL_TYPE_DESC
+    in_type_id: bytes = sertypes.NULL_TYPE_ID.bytes
     in_type_args: Optional[List[Param]] = None
 
     # Set only when this unit contains a CONFIGURE INSTANCE command.

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -581,12 +581,17 @@ class Pool(amsg.ServerProtocol):
         finally:
             self._release_worker(worker)
 
-    async def try_compile_rollback(self, eql: bytes):
+    async def try_compile_rollback(
+        self,
+        *compile_args,
+        **compile_kwargs,
+    ):
         worker = await self._acquire_worker()
         try:
             return await worker.call(
                 'try_compile_rollback',
-                eql
+                *compile_args,
+                **compile_kwargs,
             )
         finally:
             self._release_worker(worker)

--- a/edb/server/compiler_pool/worker.py
+++ b/edb/server/compiler_pool/worker.py
@@ -234,9 +234,10 @@ def compile_notebook(
 
 
 def try_compile_rollback(
-    eql: bytes
+    *compile_args: Any,
+    **compile_kwargs: Any,
 ):
-    return COMPILER.try_compile_rollback(eql)
+    return COMPILER.try_compile_rollback(*compile_args, **compile_kwargs)
 
 
 def compile_graphql(

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -908,7 +908,10 @@ cdef class EdgeConnection:
         assert self.get_dbview().in_tx_error()
         try:
             compiler_pool = self.server.get_compiler_pool()
-            return await compiler_pool.try_compile_rollback(eql)
+            return await compiler_pool.try_compile_rollback(
+                eql,
+                self.protocol_version
+            )
         except Exception:
             self.get_dbview().raise_in_tx_error()
 


### PR DESCRIPTION
* Implement a faster version of query input type builder.

* Account for the cardinality of arguments in the input type id.

* Use NULL-type-id as input type for queries without arguments.