### PR TITLE
Always use serializable isolation

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1301,8 +1301,8 @@ class Compiler:
             ctx.state.start_tx()
 
             sql = 'START TRANSACTION'
-            if ql.isolation is not None:
-                sql += f' ISOLATION LEVEL {ql.isolation.value}'
+            # N.B: Currently we ignore the isolation level. We should
+            # remove it if we keep it this way.
             if ql.access is not None:
                 sql += f' {ql.access.value}'
             if ql.deferrable is not None:

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -1529,7 +1529,7 @@ cdef class PGConnection:
         buf.write_bytestring(b'UTC')
 
         buf.write_bytestring(b'default_transaction_isolation')
-        buf.write_bytestring(b'repeatable read')
+        buf.write_bytestring(b'serializable')
 
         buf.write_bytestring(b'intervalstyle')
         buf.write_bytestring(b'iso_8601')

--- a/tests/test_server_concurrency.py
+++ b/tests/test_server_concurrency.py
@@ -21,7 +21,6 @@ import asyncio
 import edgedb
 
 from edb.testbase import server as tb
-from edb.tools import test
 
 
 class Barrier:
@@ -92,17 +91,9 @@ class TestServerConcurrentTransactions(tb.QueryTestCase):
         self.assertEqual(set(results), {1, 2})
         self.assertEqual(iterations, 3)
 
-    @test.xfail("""
-        We generate a ConstraintViolationError instead.
-        Issue #2876.
-    """)
     async def test_server_concurrent_conflict_retry_2(self):
         await self.execute_conflict_2('counter4')
 
-    @test.xfail("""
-        We generate a ConstraintViolationError instead.
-        Issue #2876.
-    """)
     async def test_server_concurrent_conflict_no_retry_2(self):
         with self.assertRaises(edgedb.TransactionSerializationError):
             await self.execute_conflict_2(
@@ -143,10 +134,6 @@ class TestServerConcurrentTransactions(tb.QueryTestCase):
             [{'name': 'foo'}],
         )
 
-    @test.xfail("""
-       We *succeed* on both inserts. This is real bad.
-       Issue #2875.
-    """)
     async def test_server_concurrent_inserts_2(self):
         f1 = lambda tx: tx.execute('INSERT Foo { name := "foo" }')
         f2 = lambda tx: tx.execute('INSERT Bar { name := "foo" }')

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -29,6 +29,7 @@ from edb.common import devmode
 from edb.common import taskgroup as tg
 from edb.testbase import server as tb
 from edb.server.compiler import enums
+from edb.tools import test
 
 
 SERVER_HEADER_CAPABILITIES = 0x1001
@@ -1710,6 +1711,7 @@ class TestServerProto(tb.QueryTestCase):
             await self.con.query_single('SELECT 1;'),
             1)
 
+    @test.xfail("... we currently always use serializable")
     async def test_server_proto_tx_16(self):
         try:
             for isol, expected in [


### PR DESCRIPTION
If we stick with this, we'll probably want to yank all of our
isolation mode toggles.

Test suite time doesn't seem affected.

Will fix #2875, #2876.