### PR TITLE
Always allow FINAL for CREATE SCALAR TYPE

### DIFF
--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -24,7 +24,6 @@ from typing import *
 from edb import errors
 
 from edb.common import checked
-from edb.common import verutils
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
@@ -371,17 +370,6 @@ class CreateScalarType(
             create_cmd = cmd
 
         if isinstance(astnode, qlast.CreateScalarType):
-            # We don't support FINAL, but old dumps specify it on all
-            # CREATE SCALAR TYPEs, so we need to permit it in those
-            # cases.
-            if astnode.final and not context.compat_ver_is_before(
-                (1, 0, verutils.VersionStage.BETA, 4)
-            ):
-                raise errors.UnsupportedFeatureError(
-                    f'FINAL is not supported',
-                    context=astnode.context,
-                )
-
             bases = [
                 s_utils.ast_to_type_shell(
                     b,

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4875,12 +4875,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ''')
 
     async def test_edgeql_ddl_scalar_09(self):
-        with self.assertRaisesRegex(
-                edgedb.UnsupportedFeatureError,
-                r'FINAL is not supported'):
-            await self.con.execute('''
-                CREATE FINAL SCALAR TYPE myint EXTENDING std::int64;
-            ''')
+        # We need to support CREATE FINAL SCALAR because it is
+        # written out into old migrations.
+        await self.con.execute('''
+            CREATE FINAL SCALAR TYPE myint EXTENDING std::int64;
+        ''')
 
     async def test_edgeql_ddl_cast_01(self):
         await self.con.execute('''


### PR DESCRIPTION
It's written into migrations that were generated before.