### PR TITLE
Correctly raise exclusive constraints when doing INSERT to related types

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -212,6 +212,11 @@ class Environment:
     functions) that appear in a function body.
     """
 
+    dml_stmts: Set[irast.MutatingStmt]
+    """A list of DML expressions (statements and DML-containing
+    functions) that appear in a function body.
+    """
+
     #: A list of bindings that should be assumed to be singletons.
     singletons: List[irast.PathId]
 
@@ -260,6 +265,7 @@ class Environment:
         self.ptr_ref_cache = PointerRefCache()
         self.type_ref_cache = {}
         self.dml_exprs = []
+        self.dml_stmts = set()
         self.pointer_derivation_map = collections.defaultdict(list)
         self.pointer_specified_info = {}
         self.singletons = []
@@ -528,6 +534,9 @@ class ContextLevel(compiler.ContextLevel):
     path_log: Optional[List[irast.PathId]]
     """An optional list of path ids added to the scope tree in this context."""
 
+    in_temp_scope: bool
+    """Whether we are in a temp scope for view processing."""
+
     def __init__(
         self,
         prevlevel: Optional[ContextLevel],
@@ -590,6 +599,7 @@ class ContextLevel(compiler.ContextLevel):
             self.disable_shadowing = set()
             self.path_log = None
             self.recompiling_schema_alias = False
+            self.in_temp_scope = False
 
         else:
             self.env = prevlevel.env
@@ -637,6 +647,7 @@ class ContextLevel(compiler.ContextLevel):
             self.disable_shadowing = prevlevel.disable_shadowing
             self.path_log = prevlevel.path_log
             self.recompiling_schema_alias = prevlevel.recompiling_schema_alias
+            self.in_temp_scope = prevlevel.in_temp_scope
 
             if mode == ContextSwitchMode.SUBQUERY:
                 self.anchors = prevlevel.anchors.copy()

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -534,9 +534,6 @@ class ContextLevel(compiler.ContextLevel):
     path_log: Optional[List[irast.PathId]]
     """An optional list of path ids added to the scope tree in this context."""
 
-    in_temp_scope: bool
-    """Whether we are in a temp scope for view processing."""
-
     def __init__(
         self,
         prevlevel: Optional[ContextLevel],
@@ -599,7 +596,6 @@ class ContextLevel(compiler.ContextLevel):
             self.disable_shadowing = set()
             self.path_log = None
             self.recompiling_schema_alias = False
-            self.in_temp_scope = False
 
         else:
             self.env = prevlevel.env
@@ -647,7 +643,6 @@ class ContextLevel(compiler.ContextLevel):
             self.disable_shadowing = prevlevel.disable_shadowing
             self.path_log = prevlevel.path_log
             self.recompiling_schema_alias = prevlevel.recompiling_schema_alias
-            self.in_temp_scope = prevlevel.in_temp_scope
 
             if mode == ContextSwitchMode.SUBQUERY:
                 self.anchors = prevlevel.anchors.copy()

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -702,7 +702,7 @@ def compile_inheritance_conflict_checks(
     subject_stype: s_objtypes.ObjectType,
     *, ctx: context.ContextLevel,
 ) -> Optional[List[irast.OnConflictClause]]:
-    if not ctx.env.dml_stmts or ctx.in_temp_scope:
+    if not ctx.env.dml_stmts or ctx.path_scope.in_temp_scope():
         return None
 
     assert isinstance(subject_stype, s_objtypes.ObjectType)
@@ -797,7 +797,7 @@ def compile_InsertQuery(
         stmt.conflict_checks = compile_inheritance_conflict_checks(
             stmt, stmt_subject_stype, ctx=ictx)
 
-        if not ctx.in_temp_scope:
+        if not ctx.path_scope.in_temp_scope():
             ctx.env.dml_stmts.add(stmt)
 
         if expr.unless_conflict is not None:
@@ -916,7 +916,7 @@ def compile_UpdateQuery(
                 ctx=bodyctx)
 
         stmt_subject_stype = setgen.get_set_type(subject, ctx=ictx)
-        if not ctx.in_temp_scope:
+        if not ctx.path_scope.in_temp_scope():
             ctx.env.dml_stmts.add(stmt)
 
         result = setgen.class_set(

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -231,16 +231,17 @@ def compile_GroupQuery(
         context=expr.context)
 
 
-def _compile_insert_unless_conflict_select(
+def _compile_conflict_select(
     stmt: irast.InsertStmt,
     subject_typ: s_objtypes.ObjectType,
     *,
+    for_inheritance: bool,
     obj_constrs: Sequence[s_constr.Constraint],
     constrs: Dict[str, Tuple[s_pointers.Pointer, List[s_constr.Constraint]]],
     parser_context: Optional[pctx.ParserContext],
     ctx: context.ContextLevel,
 ) -> Optional[qlast.Expr]:
-    """Synthesize a select of conflicting objects for UNLESS CONFLICT
+    """Synthesize a select of conflicting objects
 
     ... for a single object type. This gets called once for each ancestor
     type that provides constraints to the type being inserted.
@@ -276,12 +277,20 @@ def _compile_insert_unless_conflict_select(
         name = elem.rptr.ptrref.shortname.name
         if name in needed_ptrs and name not in ptr_anchors:
             assert elem.expr
-
             if inference.infer_volatility(elem.expr, ctx.env).is_volatile():
+                if for_inheritance:
+                    error = (
+                        'INSERT does not support volatile properties with '
+                        'exclusive constraints when another statement in '
+                        'the same query modifies a related type'
+                    )
+                else:
+                    error = (
+                        'INSERT UNLESS CONFLICT ON does not support volatile '
+                        'properties'
+                    )
                 raise errors.UnsupportedFeatureError(
-                    'INSERT UNLESS CONFLICT ON does not support volatile '
-                    'properties',
-                    context=parser_context,
+                    error, context=parser_context
                 )
 
             # FIXME: The wrong thing will definitely happen if there are
@@ -381,18 +390,17 @@ def _constr_matters(
     )
 
 
-ConflictTypeMap = Dict[
-    s_objtypes.ObjectType,
-    Tuple[
-        Dict[str, Tuple[s_pointers.Pointer, List[s_constr.Constraint]]],
-        List[s_constr.Constraint],
-    ],
+PointerConstraintMap = Dict[
+    str,
+    Tuple[s_pointers.Pointer, List[s_constr.Constraint]],
 ]
+ConstraintPair = Tuple[PointerConstraintMap, List[s_constr.Constraint]]
+ConflictTypeMap = Dict[s_objtypes.ObjectType, ConstraintPair]
 
 
 def _split_constraints(
     obj_constrs: Sequence[s_constr.Constraint],
-    constrs: Dict[str, Tuple[s_pointers.Pointer, List[s_constr.Constraint]]],
+    constrs: PointerConstraintMap,
     ctx: context.ContextLevel,
 ) -> ConflictTypeMap:
     schema = ctx.env.schema
@@ -428,16 +436,17 @@ def _split_constraints(
     return type_maps
 
 
-def compile_insert_unless_conflict_select(
+def compile_conflict_select(
     stmt: irast.InsertStmt,
     subject_typ: s_objtypes.ObjectType,
     *,
+    for_inheritance: bool=False,
     obj_constrs: Sequence[s_constr.Constraint],
-    constrs: Dict[str, Tuple[s_pointers.Pointer, List[s_constr.Constraint]]],
+    constrs: PointerConstraintMap,
     parser_context: Optional[pctx.ParserContext],
     ctx: context.ContextLevel,
 ) -> Tuple[irast.Set, bool, bool]:
-    """Synthesize a select of conflicting objects for UNLESS CONFLICT
+    """Synthesize a select of conflicting objects
 
     This teases apart the constraints we care about based on which
     type they originate from, generates a SELECT for each type, and
@@ -446,14 +455,19 @@ def compile_insert_unless_conflict_select(
     `cnstrs` contains the constraints to consider.
     """
     schema = ctx.env.schema
-    type_maps = _split_constraints(obj_constrs, constrs, ctx=ctx)
+
+    if for_inheritance:
+        type_maps = {subject_typ: (constrs, list(obj_constrs))}
+    else:
+        type_maps = _split_constraints(obj_constrs, constrs, ctx=ctx)
 
     # Generate a separate query for each type
     from_parent = False
     frags = []
     for a_obj, (a_constrs, a_obj_constrs) in type_maps.items():
-        frag = _compile_insert_unless_conflict_select(
+        frag = _compile_conflict_select(
             stmt, a_obj, obj_constrs=a_obj_constrs, constrs=a_constrs,
+            for_inheritance=for_inheritance,
             parser_context=parser_context, ctx=ctx,
         )
         if frag:
@@ -477,19 +491,11 @@ def compile_insert_unless_conflict_select(
     return select_ir, always_check, from_parent
 
 
-def compile_insert_unless_conflict(
-    stmt: irast.InsertStmt,
+def _get_exclusive_ptr_constraints(
     typ: s_objtypes.ObjectType,
     *, ctx: context.ContextLevel,
-) -> irast.OnConflictClause:
-    """Compile an UNLESS CONFLICT clause with no ON
-
-    This requires synthesizing a conditional based on all the exclusive
-    constraints on the object.
-    """
-
+) -> Dict[str, Tuple[s_pointers.Pointer, List[s_constr.Constraint]]]:
     schema = ctx.env.schema
-
     pointers = {}
 
     exclusive_constr = schema.get('std::exclusive', type=s_constr.Constraint)
@@ -502,11 +508,23 @@ def compile_insert_unless_conflict(
             if name != 'id':
                 pointers[name] = ptr, ex_cnstrs
 
-    ctx.env.schema = schema
+    return pointers
 
-    obj_constrs = typ.get_constraints(schema).objects(schema)
 
-    select_ir, always_check, _ = compile_insert_unless_conflict_select(
+def compile_insert_unless_conflict(
+    stmt: irast.InsertStmt,
+    typ: s_objtypes.ObjectType,
+    *, ctx: context.ContextLevel,
+) -> irast.OnConflictClause:
+    """Compile an UNLESS CONFLICT clause with no ON
+
+    This requires synthesizing a conditional based on all the exclusive
+    constraints on the object.
+    """
+    pointers = _get_exclusive_ptr_constraints(typ, ctx=ctx)
+    obj_constrs = typ.get_constraints(ctx.env.schema).objects(ctx.env.schema)
+
+    select_ir, always_check, _ = compile_conflict_select(
         stmt, typ,
         constrs=pointers,
         obj_constrs=obj_constrs,
@@ -515,6 +533,56 @@ def compile_insert_unless_conflict(
     return irast.OnConflictClause(
         constraint=None, select_ir=select_ir, always_check=always_check,
         else_ir=None)
+
+
+def compile_inheritance_conflict_selects(
+    stmt: irast.InsertStmt,
+    conflict: irast.MutatingStmt,
+    typ: s_objtypes.ObjectType,
+    *, ctx: context.ContextLevel,
+) -> List[irast.OnConflictClause]:
+    """Compile the selects needed to resolve multiple DML to related types
+
+    Generate a SELECT that finds all objects of type `typ` that conflict with
+    the insert `stmt`. The backend will use this to explicitly check that
+    no conflicts exist, and raise an error if they do.
+
+    This is needed because we mostly use triggers to enforce these
+    cross-type exclusive constraints, and they use a snapshot
+    beginning at the start of the statement.
+    """
+    pointers = _get_exclusive_ptr_constraints(typ, ctx=ctx)
+    obj_constrs = typ.get_constraints(ctx.env.schema).objects(ctx.env.schema)
+
+    # This is a little silly, but for *this* we need to do one per
+    # constraint (so that we can properly identify which constraint
+    # failed in the error messages)
+    entries: List[Tuple[s_constr.Constraint, ConstraintPair]] = []
+    for name, (ptr, ptr_constrs) in pointers.items():
+        for ptr_constr in ptr_constrs:
+            if _constr_matters(ptr_constr, ctx):
+                entries.append((ptr_constr, ({name: (ptr, [ptr_constr])}, [])))
+    for obj_constr in obj_constrs:
+        if _constr_matters(obj_constr, ctx):
+            entries.append((obj_constr, ({}, [obj_constr])))
+
+    clauses = []
+    for cnstr, (p, o) in entries:
+        select_ir, _, _ = compile_conflict_select(
+            stmt, typ,
+            for_inheritance=True,
+            constrs=p,
+            obj_constrs=o,
+            parser_context=stmt.context, ctx=ctx)
+        if isinstance(select_ir, irast.EmptySet):
+            continue
+        cnstr_ref = irast.ConstraintRef(id=cnstr.id)
+        clauses.append(
+            irast.OnConflictClause(
+                constraint=cnstr_ref, select_ir=select_ir, always_check=False,
+                else_ir=None, else_fail=conflict)
+        )
+    return clauses
 
 
 def compile_insert_unless_conflict_on(
@@ -596,7 +664,7 @@ def compile_insert_unless_conflict_on(
 
     ds = {ptr.get_shortname(schema).name: (ptr, field_constrs)
           for ptr in ptrs}
-    select_ir, always_check, from_anc = compile_insert_unless_conflict_select(
+    select_ir, always_check, from_anc = compile_conflict_select(
         stmt, typ, constrs=ds, obj_constrs=obj_constrs,
         parser_context=stmt.context, ctx=ctx)
 
@@ -627,6 +695,45 @@ def compile_insert_unless_conflict_on(
         always_check=always_check,
         else_ir=else_ir
     )
+
+
+def compile_inheritance_conflict_checks(
+    stmt: irast.InsertStmt,
+    subject_stype: s_objtypes.ObjectType,
+    *, ctx: context.ContextLevel,
+) -> Optional[List[irast.OnConflictClause]]:
+    if not ctx.env.dml_stmts or ctx.in_temp_scope:
+        return None
+
+    assert isinstance(subject_stype, s_objtypes.ObjectType)
+    # TODO: support UPDATEs
+    # TODO: when the conflicting statement is an UPDATE, only
+    # look at things it updated
+    modified_ancestors = set()
+    base_object = ctx.env.schema.get(
+        'std::BaseObject', type=s_objtypes.ObjectType)
+    for ir in ctx.env.dml_stmts:
+        typ = setgen.get_set_type(ir.subject, ctx=ctx)
+        assert isinstance(typ, s_objtypes.ObjectType)
+        typ = typ.get_nearest_non_derived_parent(ctx.env.schema)
+
+        # If the earlier DML has a shared ancestor that isn't
+        # BaseObject and isn't (if it's an insert) the same type,
+        # then we need to see if we need a conflict select
+        if subject_stype == typ and not isinstance(ir, irast.UpdateStmt):
+            continue
+        ancs = s_utils.get_class_nearest_common_ancestors(
+            ctx.env.schema, [subject_stype, typ])
+        for anc in ancs:
+            if anc != base_object:
+                modified_ancestors.add((anc, ir))
+
+    conflicters = []
+    for anc_type, ir in modified_ancestors:
+        conflicters.extend(compile_inheritance_conflict_selects(
+            stmt, ir, anc_type, ctx=ctx))
+
+    return conflicters or None
 
 
 @dispatch.compile.register(qlast.InsertQuery)
@@ -686,6 +793,12 @@ def compile_InsertQuery(
 
         stmt_subject_stype = setgen.get_set_type(subject, ctx=ictx)
         assert isinstance(stmt_subject_stype, s_objtypes.ObjectType)
+
+        stmt.conflict_checks = compile_inheritance_conflict_checks(
+            stmt, stmt_subject_stype, ctx=ictx)
+
+        if not ctx.in_temp_scope:
+            ctx.env.dml_stmts.add(stmt)
 
         if expr.unless_conflict is not None:
             constraint_spec, else_branch = expr.unless_conflict
@@ -803,6 +916,8 @@ def compile_UpdateQuery(
                 ctx=bodyctx)
 
         stmt_subject_stype = setgen.get_set_type(subject, ctx=ictx)
+        if not ctx.in_temp_scope:
+            ctx.env.dml_stmts.add(stmt)
 
         result = setgen.class_set(
             schemactx.get_material_type(stmt_subject_stype, ctx=ctx),

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -77,7 +77,6 @@ def process_view(
         return view_scls
 
     with ctx.newscope(fenced=True) as scopectx:
-        scopectx.in_temp_scope = True
         scopectx.path_scope.is_temporary = True
         view_path_id_ns = None
         new_path_id = path_id

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -77,6 +77,7 @@ def process_view(
         return view_scls
 
     with ctx.newscope(fenced=True) as scopectx:
+        scopectx.in_temp_scope = True
         scopectx.path_scope.is_temporary = True
         view_path_id_ns = None
         new_path_id = path_id

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -841,10 +841,14 @@ class OnConflictClause(Base):
     select_ir: Set
     always_check: bool
     else_ir: typing.Optional[Set]
+    else_fail: typing.Optional[MutatingStmt] = None
 
 
 class InsertStmt(MutatingStmt):
     on_conflict: typing.Optional[OnConflictClause] = None
+    # Conflict checks that we should manually raise constraint violations
+    # for.
+    conflict_checks: typing.Optional[typing.List[OnConflictClause]] = None
 
 
 class UpdateStmt(MutatingStmt, FilteredStmt):

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -182,6 +182,9 @@ class ScopeTreeNode:
     def optional(self) -> bool:
         return self.optional_count == 0
 
+    def in_temp_scope(self) -> bool:
+        return any(x.is_temporary for x in self.ancestors)
+
     @property
     def fence_info(self) -> FenceInfo:
         return FenceInfo(

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -331,6 +331,10 @@ def get_constraint_backend_name(
     return convert_name(name, aspect, catenate)
 
 
+def get_constraint_raw_name(id):
+    return f'{id};schemaconstr'
+
+
 def get_index_backend_name(id, module_name, catenate=True, *, aspect=None):
     if aspect is None:
         aspect = 'index'

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -926,13 +926,16 @@ def compile_insert_else_body_failure_check(
     else_fail = on_conflict.else_fail
     if not else_fail:
         return
+
     # Copy the type rels from the possibly conflicting earlier DML
     # into the None overlays so it gets picked up.
     # TODO: Try to *only* get the overlay, not the base type.
     ctx.type_rel_overlays = ctx.type_rel_overlays.copy()
+    ctx.type_rel_overlays[None] = ctx.type_rel_overlays[None].copy()
     ctx.type_rel_overlays[None].update(
         ctx.type_rel_overlays[else_fail])
     ctx.ptr_rel_overlays = ctx.ptr_rel_overlays.copy()
+    ctx.ptr_rel_overlays[None] = ctx.ptr_rel_overlays[None].copy()
     ctx.ptr_rel_overlays[None].update(
         ctx.ptr_rel_overlays[else_fail])
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -600,15 +600,28 @@ def process_insert_body(
             insert_stmt,
             ir_stmt,
             ir_stmt.on_conflict,
+            ctx.enclosing_cte_iterator,
             dml_parts.else_cte,
+            dml_parts,
+            ctx=ctx,
+        )
+
+    iterator = ctx.enclosing_cte_iterator
+    inner_iterator = on_conflict_fake_iterator or iterator
+
+    for extra_conflict in (ir_stmt.conflict_checks or ()):
+        compile_insert_else_body(
+            insert_stmt,
+            ir_stmt,
+            extra_conflict,
+            inner_iterator,
+            None,
+            dml_parts,
             ctx=ctx,
         )
 
     # Compile the shape
     external_inserts = []
-
-    iterator = ctx.enclosing_cte_iterator
-    inner_iterator = on_conflict_fake_iterator or iterator
 
     with ctx.newrel() as subctx:
         subctx.enclosing_cte_iterator = inner_iterator
@@ -715,6 +728,7 @@ def process_insert_body(
 
 def insert_needs_conflict_cte(
     ir_stmt: irast.InsertStmt,
+    on_conflict: irast.OnConflictClause,
     *,
     ctx: context.CompilerContextLevel,
 ) -> bool:
@@ -725,10 +739,13 @@ def insert_needs_conflict_cte(
     # seen already.
     # A more fine-grained scheme would check if there are enclosing
     # iterators or INSERT/UPDATEs to types that could conflict.
+    if on_conflict.else_fail:
+        return False
+
     if ctx.dml_stmts:
         return True
 
-    if ir_stmt.on_conflict and ir_stmt.on_conflict.always_check:
+    if on_conflict.always_check or ir_stmt.conflict_checks:
         return True
 
     for shape_el, _ in ir_stmt.subject.shape:
@@ -752,10 +769,16 @@ def compile_insert_else_body(
         insert_stmt: pgast.InsertStmt,
         ir_stmt: irast.InsertStmt,
         on_conflict: irast.OnConflictClause,
+        enclosing_cte_iterator: Optional[pgast.IteratorCTE],
         else_cte_rvar: Optional[
             Tuple[pgast.CommonTableExpr, pgast.PathRangeVar]],
+        dml_parts: DMLParts,
         *,
         ctx: context.CompilerContextLevel) -> Optional[pgast.IteratorCTE]:
+
+    else_select = on_conflict.select_ir
+    else_branch = on_conflict.else_ir
+    else_fail = on_conflict.else_fail
 
     # We need to generate a "conflict CTE" that filters out
     # objects-to-insert that would conflict with existing objects in
@@ -776,8 +799,9 @@ def compile_insert_else_body(
     #
     # When neither case obtains, we use ON CONFLICT because it ought
     # to be more performant.
-    needs_conflict_cte = insert_needs_conflict_cte(ir_stmt, ctx=ctx)
-    if not needs_conflict_cte:
+    needs_conflict_cte = insert_needs_conflict_cte(
+        ir_stmt, on_conflict, ctx=ctx)
+    if not needs_conflict_cte and not else_fail:
         infer = None
         if on_conflict.constraint:
             constraint_name = f'"{on_conflict.constraint.id};schemaconstr"'
@@ -788,10 +812,7 @@ def compile_insert_else_body(
             infer=infer,
         )
 
-    else_select = on_conflict.select_ir
-    else_branch = on_conflict.else_ir
-
-    if not else_branch and not needs_conflict_cte:
+    if not else_branch and not needs_conflict_cte and not else_fail:
         return None
 
     subject_id = ir_stmt.subject.path_id
@@ -801,8 +822,10 @@ def compile_insert_else_body(
     with ctx.newrel() as ictx:
         ictx.path_scope[subject_id] = ictx.rel
 
-        merge_iterator(ctx.enclosing_cte_iterator, ictx.rel, ctx=ictx)
-        clauses.setup_iterator_volatility(ctx.enclosing_cte_iterator,
+        compile_insert_else_body_failure_check(on_conflict, ctx=ictx)
+
+        merge_iterator(enclosing_cte_iterator, ictx.rel, ctx=ictx)
+        clauses.setup_iterator_volatility(enclosing_cte_iterator,
                                           is_cte=True, ctx=ictx)
 
         dispatch.compile(else_select, ctx=ictx)
@@ -815,6 +838,9 @@ def compile_insert_else_body(
             query=ictx.rel,
             name=ctx.env.aliases.get('else')
         )
+        if else_fail:
+            dml_parts.check_ctes.append(else_select_cte)
+
         ictx.toplevel_stmt.append_cte(else_select_cte)
 
     else_select_rvar = relctx.rvar_for_rel(else_select_cte, ctx=ctx)
@@ -829,7 +855,7 @@ def compile_insert_else_body(
 
             ictx.enclosing_cte_iterator = pgast.IteratorCTE(
                 path_id=else_select.path_id, cte=else_select_cte,
-                parent=ictx.enclosing_cte_iterator)
+                parent=enclosing_cte_iterator)
             ictx.volatility_ref = ()
             dispatch.compile(else_branch, ctx=ictx)
             pathctx.put_path_id_map(ictx.rel, subject_id, else_branch.path_id)
@@ -847,8 +873,8 @@ def compile_insert_else_body(
         # Compile a CTE that matches rows that didn't appear in the
         # ELSE query of conflicting rows.
         with ctx.newrel() as ictx:
-            merge_iterator(ctx.enclosing_cte_iterator, ictx.rel, ctx=ictx)
-            clauses.setup_iterator_volatility(ctx.enclosing_cte_iterator,
+            merge_iterator(enclosing_cte_iterator, ictx.rel, ctx=ictx)
+            clauses.setup_iterator_volatility(enclosing_cte_iterator,
                                               is_cte=True, ctx=ictx)
 
             # Set up a dummy path to represent all of the rows
@@ -874,8 +900,8 @@ def compile_insert_else_body(
 
             # Do the anti-join
             iter_path_id = (
-                ictx.enclosing_cte_iterator.path_id if
-                ictx.enclosing_cte_iterator else None)
+                enclosing_cte_iterator.path_id if
+                enclosing_cte_iterator else None)
             relctx.anti_join(ictx.rel, subrel, iter_path_id, ctx=ctx)
 
             # Package it up as a CTE
@@ -889,6 +915,52 @@ def compile_insert_else_body(
                 parent=ictx.enclosing_cte_iterator)
 
     return anti_cte_iterator
+
+
+def compile_insert_else_body_failure_check(
+        on_conflict: irast.OnConflictClause,
+        *,
+        ctx: context.CompilerContextLevel) -> None:
+    else_fail = on_conflict.else_fail
+    if not else_fail:
+        return
+    # Copy the type rels from the possibly conflicting earlier DML
+    # into the None overlays so it gets picked up.
+    # TODO: Try to *only* get the overlay, not the base type.
+    ctx.type_rel_overlays = ctx.type_rel_overlays.copy()
+    ctx.type_rel_overlays[None].update(
+        ctx.type_rel_overlays[else_fail])
+    ctx.ptr_rel_overlays = ctx.ptr_rel_overlays.copy()
+    ctx.ptr_rel_overlays[None].update(
+        ctx.ptr_rel_overlays[else_fail])
+
+    assert on_conflict.constraint
+    cid = on_conflict.constraint.id
+    maybe_raise = pgast.FuncCall(
+        name=('edgedb', 'raise'),
+        args=[
+            pgast.TypeCast(
+                arg=pgast.NullConstant(),
+                type_name=pgast.TypeName(name=('text',))),
+            pgast.StringConstant(val='exclusion_violation'),
+            pgast.NamedFuncArg(
+                name='msg',
+                val=pgast.StringConstant(
+                    val=(
+                        f'duplicate key value violates unique '
+                        f'constraint "{cid};schemaconstr"'
+                    )
+                ),
+            ),
+            pgast.NamedFuncArg(
+                name='constraint',
+                val=pgast.StringConstant(val=f"{cid};schemaconstr")
+            ),
+        ],
+    )
+    ctx.rel.target_list.append(
+        pgast.ResTarget(name='error', val=maybe_raise)
+    )
 
 
 def compile_insert_shape_element(

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -609,17 +609,6 @@ def process_insert_body(
     iterator = ctx.enclosing_cte_iterator
     inner_iterator = on_conflict_fake_iterator or iterator
 
-    for extra_conflict in (ir_stmt.conflict_checks or ()):
-        compile_insert_else_body(
-            insert_stmt,
-            ir_stmt,
-            extra_conflict,
-            inner_iterator,
-            None,
-            dml_parts,
-            ctx=ctx,
-        )
-
     # Compile the shape
     external_inserts = []
 
@@ -724,6 +713,17 @@ def process_insert_body(
         )
         if check_cte is not None:
             dml_parts.check_ctes.append(check_cte)
+
+    for extra_conflict in (ir_stmt.conflict_checks or ()):
+        compile_insert_else_body(
+            insert_stmt,
+            ir_stmt,
+            extra_conflict,
+            inner_iterator,
+            None,
+            dml_parts,
+            ctx=ctx,
+        )
 
 
 def insert_needs_conflict_cte(

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -60,8 +60,7 @@ class ConstraintCommon:
         return self._schema_constr_name
 
     def raw_constraint_name(self):
-        name = '{};{}'.format(self._constr_id, 'schemaconstr')
-        return name
+        return common.get_constraint_raw_name(self._constr_id)
 
     def generate_extra(self, block):
         text = self.raw_constraint_name()

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -3870,7 +3870,6 @@ class TestInsert(tb.QueryTestCase):
             [2]
         )
 
-    @test.xfail("Issue #2845")
     async def test_edgeql_insert_cross_type_conflict_01(self):
         query = r'''
             WITH name := 'Madeline Hatch',
@@ -3880,11 +3879,267 @@ class TestInsert(tb.QueryTestCase):
         '''
 
         with self.assertRaisesRegex(edgedb.ConstraintViolationError,
-                                    "violates exclusivity constraint"):
+                                    "name violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    async def test_edgeql_insert_cross_type_conflict_02(self):
+        query = r'''
+            WITH name := 'Madeline Hatch',
+                 F := (INSERT DerivedPerson {name := name}),
+                 B := (INSERT Person {name := name}),
+            SELECT (B, F);
+        '''
+
+        with self.assertRaisesRegex(edgedb.ConstraintViolationError,
+                                    "name violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    async def test_edgeql_insert_cross_type_conflict_03(self):
+        await self.con.execute('''
+            INSERT DerivedPerson { name := 'Bar' };
+        ''')
+
+        query = r'''
+            WITH name := 'Madeline Hatch',
+                 B := (UPDATE Person FILTER .name = 'Bar' SET {name := name}),
+                 F := (INSERT Person {name := name})
+            SELECT (B, F);
+        '''
+
+        with self.assertRaisesRegex(edgedb.ConstraintViolationError,
+                                    "name violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    async def test_edgeql_insert_cross_type_conflict_04(self):
+        query = r'''
+        WITH
+             B := (INSERT Person {name := "Foo", case_name := "asdf"}),
+             F := (INSERT DerivedPerson {name := "Bar", case_name := "ASDF"}),
+        SELECT (B, F);
+        '''
+
+        with self.assertRaisesRegex(
+                edgedb.ConstraintViolationError,
+                "case_name violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    async def test_edgeql_insert_cross_type_conflict_05(self):
+        query = r'''
+        WITH
+             B := (INSERT Person {name := "Bar", multi_prop := {"1", "2"}}),
+             F := (INSERT DerivedPerson {
+                      name := "Foo", multi_prop := {"2","3"}}),
+        SELECT (B, F);
+        '''
+
+        with self.assertRaisesRegex(
+                edgedb.ConstraintViolationError,
+                "multi_prop violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    async def test_edgeql_insert_cross_type_conflict_06(self):
+        await self.con.execute('''
+            INSERT DerivedPerson { name := 'Bar' };
+        ''')
+
+        query = r'''
+            WITH name := 'Madeline Hatch',
+                 B := (UPDATE Person FILTER .name = 'Bar'
+                       SET {multi_prop += "a"}),
+                 F := (INSERT Person {name := name, multi_prop := {"a", "b"}})
+            SELECT (B, F);
+        '''
+
+        with self.assertRaisesRegex(
+                edgedb.ConstraintViolationError,
+                "multi_prop violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    async def test_edgeql_insert_cross_type_conflict_07a(self):
+        await self.con.execute('''
+            INSERT Person { name := 'Foo' };
+        ''')
+
+        query = r'''
+            WITH
+                 B := (UPDATE Person FILTER .name = 'Foo'
+                       SET {name := "Bar"}),
+                 F := (INSERT Person {name := "Foo"})
+            SELECT (B, F);
+        '''
+
+        # This is a bummer, but I guess correct?
+        with self.assertRaisesRegex(
+                edgedb.ConstraintViolationError,
+                "name violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    async def test_edgeql_insert_cross_type_conflict_07b(self):
+        await self.con.execute('''
+            INSERT DerivedPerson { name := 'Bar', multi_prop := "a" };
+        ''')
+
+        query = r'''
+            WITH name := 'Madeline Hatch',
+                 B := (UPDATE Person FILTER .name = 'Bar'
+                       SET {multi_prop -= "a"}),
+                 F := (INSERT Person {name := name, multi_prop := {"a", "b"}})
+            SELECT (B, F);
+        '''
+
+        # This is a bummer, but I guess correct?
+        with self.assertRaisesRegex(
+                edgedb.ConstraintViolationError,
+                "multi_prop violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    async def test_edgeql_insert_cross_type_conflict_08(self):
+        # UNLESS CONFLICT doesn't change anything here since inserting
+        # the same thing twice in one query still fails
+        query = r'''
+            WITH name := 'Madeline Hatch',
+                 B := (INSERT Person {name := name}),
+                 F := (INSERT DerivedPerson {name := name} UNLESS CONFLICT),
+            SELECT (B, F);
+        '''
+
+        with self.assertRaisesRegex(edgedb.ConstraintViolationError,
+                                    "name violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    async def test_edgeql_insert_cross_type_conflict_09(self):
+        # UNLESS CONFLICT doesn't change anything here since inserting
+        # the same thing twice in one query still fails
+        query = r'''
+            WITH name := 'Madeline Hatch',
+                 F := (INSERT DerivedPerson {name := name} UNLESS CONFLICT),
+                 B := (INSERT Person {name := name}),
+            SELECT (B, F);
+        '''
+
+        with self.assertRaisesRegex(edgedb.ConstraintViolationError,
+                                    "name violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    async def test_edgeql_insert_cross_type_conflict_10(self):
+        await self.con.execute('''
+            CREATE ABSTRACT TYPE Named {
+                CREATE PROPERTY name -> str {
+                    CREATE CONSTRAINT exclusive;
+                }
+            };
+            CREATE ABSTRACT TYPE Titled {
+                CREATE PROPERTY title -> str {
+                    CREATE CONSTRAINT exclusive;
+                }
+            };
+            CREATE TYPE Foo EXTENDING Named, Titled;
+            CREATE TYPE Bar EXTENDING Named, Titled;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                "name violates exclusivity constraint"):
+            await self.con.execute(r'''
+                WITH name := 'Madeline Hatch',
+                     B := (INSERT Bar {name := name}),
+                     F := (INSERT Foo {name := name}),
+                SELECT (B, F);
+            ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                "title violates exclusivity constraint"):
+            await self.con.execute(r'''
+                WITH name := 'Madeline Hatch',
+                     B := (INSERT Bar {title := name}),
+                     F := (INSERT Foo {title := name}),
+                SELECT (B, F);
+            ''')
+
+    async def test_edgeql_insert_cross_type_conflict_11(self):
+        # Should be fine if it is delegated
+        await self.con.execute('''
+            CREATE ABSTRACT TYPE Named {
+                CREATE PROPERTY name -> str {
+                    CREATE DELEGATED CONSTRAINT exclusive;
+                }
+            };
+            CREATE TYPE Foo EXTENDING Named;
+            CREATE TYPE Bar EXTENDING Named;
+        ''')
+
+        await self.con.execute(r'''
+            WITH name := 'Madeline Hatch',
+                 B := (INSERT Bar {name := name}),
+                 F := (INSERT Foo {name := name}),
+            SELECT (B, F);
+        ''')
+
+    async def test_edgeql_insert_cross_type_conflict_12(self):
+        query = r'''
+        WITH
+             B := (INSERT Person {name := "foo"}),
+             F := (FOR a in {"b", "f"} UNION (
+                   FOR b in {"ar", "oo"} UNION (
+                       INSERT DerivedPerson {name := a ++ b}
+                  ))),
+        SELECT (B, F);
+        '''
+
+        with self.assertRaisesRegex(
+                edgedb.ConstraintViolationError,
+                "name violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    async def test_edgeql_insert_cross_type_conflict_13(self):
+        query = r'''
+        WITH
+             F := (FOR a in {"b", "f"} UNION (
+                   FOR b in {"ar", "oo"} UNION (
+                       INSERT DerivedPerson {name := a ++ b}
+                  ))),
+             B := (INSERT Person {name := "foo"}),
+        SELECT (B, F);
+        '''
+
+        with self.assertRaisesRegex(
+                edgedb.ConstraintViolationError,
+                "name violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    async def test_edgeql_insert_cross_type_conflict_14(self):
+        query = r'''
+            WITH name := 'Madeline Hatch',
+                 B := (INSERT Person {name := name}),
+                 F := (INSERT DerivedPerson {name := <str>random()}),
+            SELECT (B, F);
+        '''
+
+        with self.assertRaisesRegex(
+                edgedb.UnsupportedFeatureError,
+                "does not support volatile properties with exclusive"):
             await self.con.execute(query)
 
     @test.xfail("Issue #2845")
-    async def test_edgeql_insert_cross_type_conflict_02(self):
+    async def test_edgeql_insert_update_cross_type_conflict_01(self):
+        await self.con.execute('''
+            INSERT DerivedPerson { name := 'Bar' };
+        ''')
+
+        query = r'''
+            WITH name := 'Madeline Hatch',
+                 F := (INSERT Person {name := name}),
+                 B := (UPDATE Person FILTER .name = 'Bar' SET {name := name}),
+            SELECT (B, F);
+        '''
+
+        with self.assertRaisesRegex(edgedb.ConstraintViolationError,
+                                    "name violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    @test.xfail("Issue #2845")
+    async def test_edgeql_insert_update_cross_type_conflict_02(self):
         # this isn't really an insert test
         await self.con.execute('''
             INSERT Person { name := 'Foo' };
@@ -3892,14 +4147,14 @@ class TestInsert(tb.QueryTestCase):
         ''')
 
         query = r'''
-            WITH name := 'Madeline hatch',
+            WITH name := 'Madeline Hatch',
                  B := (UPDATE Person FILTER .name = 'Bar' SET {name := name}),
                  F := (UPDATE Person FILTER .name = 'Foo' SET {name := name}),
             SELECT (B, F);
         '''
 
         with self.assertRaisesRegex(edgedb.ConstraintViolationError,
-                                    "violates exclusivity constraint"):
+                                    "name violates exclusivity constraint"):
             await self.con.execute(query)
 
     async def test_edgeql_insert_and_update_01(self):


### PR DESCRIPTION
Since we can't trust triggers to work in this case, we need to do it
ourselves.

This is progress on #2845, but we still need to handle it properly for
UPDATE also.