### PR TITLE
Create source deletion triggers for multi properties

### DIFF
--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -209,7 +209,10 @@ def update_aspect(name, aspect):
 def get_scalar_backend_name(id, module_name, catenate=True, *, aspect=None):
     if aspect is None:
         aspect = 'domain'
-    if aspect not in ('domain', 'sequence', 'enum'):
+    if aspect not in (
+        'domain', 'sequence', 'enum',
+        'source-del-imm-otl-f', 'source-del-imm-otl-t',
+    ):
         raise ValueError(
             f'unexpected aspect for scalar backend name: {aspect!r}')
     name = s_name.QualName(module=module_name, name=str(id))

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3536,6 +3536,20 @@ class PointerMetaCommand(MetaCommand, sd.ObjectCommand,
 
         return (conv_expr, sql_text, alias, expr_is_trivial)
 
+    def schedule_endpoint_delete_action_update(
+            self, link, orig_schema, schema, context):
+        endpoint_delete_actions = context.get(
+            sd.DeltaRootContext).op.update_endpoint_delete_actions
+        link_ops = endpoint_delete_actions.link_ops
+
+        if isinstance(self, sd.DeleteObject):
+            for i, (_, ex_link, _) in enumerate(link_ops):
+                if ex_link == link:
+                    link_ops.pop(i)
+                    break
+
+        link_ops.append((self, link, orig_schema))
+
 
 class LinkMetaCommand(CompositeObjectMetaCommand, PointerMetaCommand):
 
@@ -3608,20 +3622,6 @@ class LinkMetaCommand(CompositeObjectMetaCommand, PointerMetaCommand):
                     create_c.add_command(lc)
 
         return create_c
-
-    def schedule_endpoint_delete_action_update(
-            self, link, orig_schema, schema, context):
-        endpoint_delete_actions = context.get(
-            sd.DeltaRootContext).op.update_endpoint_delete_actions
-        link_ops = endpoint_delete_actions.link_ops
-
-        if isinstance(self, sd.DeleteObject):
-            for i, (_, ex_link, _) in enumerate(link_ops):
-                if ex_link == link:
-                    link_ops.pop(i)
-                    break
-
-        link_ops.append((self, link, orig_schema))
 
 
 class CreateLink(LinkMetaCommand, adapts=s_links.CreateLink):
@@ -4040,6 +4040,7 @@ class CreateProperty(PropertyMetaCommand, adapts=s_props.CreateProperty):
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> s_schema.Schema:
+        orig_schema = schema
         schema = s_props.CreateProperty.apply(self, schema, context)
         prop = self.scls
         propname = prop.get_shortname(schema).name
@@ -4117,6 +4118,10 @@ class CreateProperty(PropertyMetaCommand, adapts=s_props.CreateProperty):
                 self._alter_pointer_optionality(
                     schema, schema, context, fill_expr=None)
 
+            if not prop.is_pure_computable(schema):
+                self.schedule_endpoint_delete_action_update(
+                    prop, orig_schema, schema, context)
+
         return schema
 
 
@@ -4142,6 +4147,10 @@ class RebaseProperty(
         if has_table(source, schema):
             self.update_base_inhviews_on_rebase(
                 schema, orig_schema, context, source)
+
+        if not source.is_pure_computable(schema):
+            self.schedule_endpoint_delete_action_update(
+                source, orig_schema, schema, context)
 
         return schema
 
@@ -4258,6 +4267,14 @@ class AlterProperty(
             ctx.original_schema = orig_schema
             self.provide_table(prop, schema, context)
             self.alter_pointer_default(prop, orig_schema, schema, context)
+            card = self.get_resolved_attribute_value(
+                'cardinality',
+                schema=schema,
+                context=context,
+            )
+            if card and not prop.is_pure_computable(schema):
+                self.schedule_endpoint_delete_action_update(
+                    prop, orig_schema, schema, context)
 
         return schema
 
@@ -4315,6 +4332,8 @@ class DeleteProperty(
             self.pgops.add(dbops.DropTable(name=old_table_name, priority=1))
             self.update_base_inhviews(orig_schema, context, prop)
             self.schedule_inhview_deletion(orig_schema, context, prop)
+            self.schedule_endpoint_delete_action_update(
+                prop, orig_schema, schema, context)
 
         if (
             source is not None
@@ -4741,12 +4760,18 @@ class UpdateEndpointDeleteActions(MetaCommand):
             # the triggers for every schema::Type subtype every time a
             # new object type is created containing a __type__ link.
             eff_schema = (
-                orig_schema if isinstance(link_op, DeleteLink) else schema)
-            action = link.get_on_target_delete(eff_schema)
+                orig_schema
+                if isinstance(link_op, (DeleteProperty, DeleteLink))
+                else schema)
+            if not eff_schema.has_object(link.id):
+                continue
+            action = (
+                link.get_on_target_delete(eff_schema)
+                if isinstance(link, s_links.Link) else None)
             target_is_affected = not (
                 (action is DA.Restrict or action is DA.DeferredRestrict)
                 and link.get_implicit_bases(eff_schema)
-            )
+            ) and isinstance(link, s_links.Link)
 
             if (
                 link.generic(eff_schema)
@@ -4757,10 +4782,13 @@ class UpdateEndpointDeleteActions(MetaCommand):
             source = link.get_source(eff_schema)
             target = link.get_target(eff_schema)
 
-            if not isinstance(link_op, CreateLink):
+            if not isinstance(source, s_objtypes.ObjectType):
+                continue
+
+            if not isinstance(link_op, (CreateProperty, CreateLink)):
                 modifications = True
 
-            if isinstance(link_op, DeleteLink):
+            if isinstance(link_op, (DeleteProperty, DeleteLink)):
                 current_source = orig_schema.get_by_id(source.id, None)
                 if (current_source is not None
                         and not current_source.is_view(orig_schema)):
@@ -4777,7 +4805,7 @@ class UpdateEndpointDeleteActions(MetaCommand):
                 if target_is_affected:
                     affected_targets.add(target)
 
-                if isinstance(link_op, AlterLink):
+                if isinstance(link_op, (AlterProperty, AlterLink)):
                     orig_target = link.get_target(orig_schema)
                     if target != orig_target:
                         current_orig_target = schema.get_by_id(
@@ -4789,8 +4817,7 @@ class UpdateEndpointDeleteActions(MetaCommand):
             links = []
 
             for link in source.get_pointers(src_schema).objects(src_schema):
-                if (not isinstance(link, s_links.Link)
-                        or link.is_pure_computable(src_schema)):
+                if link.is_pure_computable(src_schema):
                     continue
                 ptr_stor_info = types.get_pointer_storage_info(
                     link, schema=src_schema)
@@ -4800,8 +4827,10 @@ class UpdateEndpointDeleteActions(MetaCommand):
                 links.append(link)
 
             links.sort(
-                key=lambda l: (l.get_on_target_delete(src_schema),
-                               l.get_name(src_schema)))
+                key=lambda l: (
+                    (l.get_on_target_delete(src_schema),)
+                    if isinstance(l, s_links.Link) else (),
+                    l.get_name(src_schema)))
 
             if links or modifications:
                 self._update_action_triggers(

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -365,7 +365,7 @@ def get_root_source(
     return obj
 
 
-def _is_view_source(
+def is_view_source(
         source: Optional[so.Object], schema: s_schema.Schema) -> bool:
     source = get_root_source(source, schema)
     return isinstance(source, s_types.Type) and source.is_view(schema)
@@ -1207,7 +1207,7 @@ class PointerCommandOrFragment(
             self.set_attribute_value('required', required, computed=True)
 
         if (
-            not _is_view_source(source, schema)
+            not is_view_source(source, schema)
             and expression.irast.volatility == qltypes.Volatility.Volatile
         ):
             srcctx = self.get_attribute_source_context('target')

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -1528,7 +1528,6 @@ class DeleteReferencedInheritingObject(
 
             cmd = child_ref.init_delta_command(schema, sd.AlterObject)
             cmd.add(rebase_cmd)
-
         else:
             # The ref in child should no longer exist.
             cmd = child_ref.init_delta_command(schema, sd.DeleteObject)

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -3976,3 +3976,16 @@ class TestInsert(tb.QueryTestCase):
             ''',
             [True]
         )
+
+    async def test_edgeql_insert_multi_exclusive_01(self):
+        await self.con.execute('''
+            INSERT Person { name := "asdf", multi_prop := "a" };
+        ''')
+
+        await self.con.execute('''
+            DELETE Person;
+        ''')
+
+        await self.con.execute('''
+            INSERT Person { name := "asdf", multi_prop := "a" };
+        ''')


### PR DESCRIPTION
This fixes a problem where DELETE doesn't remove entries from multi
property link tables.
Fixes #2883.