### PR TITLE
Always allow FINAL for enum CREATE SCALAR TYPEs

### DIFF
--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4875,6 +4875,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ''')
 
     async def test_edgeql_ddl_scalar_09(self):
+        # We need to support CREATE FINAL SCALAR for enums because it
+        # is written out into old migrations.
+        await self.con.execute('''
+            CREATE FINAL SCALAR TYPE my_enum EXTENDING enum<'foo', 'bar'>;
+        ''')
+
         with self.assertRaisesRegex(
                 edgedb.UnsupportedFeatureError,
                 r'FINAL is not supported'):


### PR DESCRIPTION
It's written into migrations and dumps for enums, so we need to
support it somehow.

There is still a potential backward compatability hazard for when we
actually introduce FINAL, which is if anybody actually has a non-enum
scalar that extends an enum. That doesn't really accomplish anything
so maybe we don't care.