### PR TITLE
Fix the flakey test_schema_recursive_05

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1642,9 +1642,6 @@ class TestSchema(tb.BaseSchemaLoadTest):
                 );
             ''')
 
-    @test.xfail('''
-        The cycle is detected, but stragely doesn't mention Foo.
-    ''')
     def test_schema_recursive_05(self):
         schema = self.load_schema(r'''
             type Foo {


### PR DESCRIPTION
This has two components:
 1. Make sort_by_cross_refs prefer reporting non-trivial cycles
    over trivial ones, since anything that has a cycle with a
    computed pointers will also have a trivial cycle, since
    computed pointers get inlined.
 2. Sort the endpoints in the error message so that the output
    there is more deterministic too.

It still won't be totally deterministic which cycle gets reported, if
there are multiple ones, though.