### PR TITLE
Fix handling of function overloads on object type parameters

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -273,6 +273,12 @@ class CastParamListWrapper(s_func.ParameterLikeList):
     ) -> bool:
         return False
 
+    def has_objects(
+        self,
+        schema: s_schema.Schema,
+    ) -> bool:
+        return False
+
     def has_set_of(
         self,
         schema: s_schema.Schema,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -658,6 +658,8 @@ class CallArg(ImmutableBase):
     __ast_mutable_fields__ = frozenset(('cardinality',))
 
     expr: Set
+    """PathId for the __type__ link of object type arguments."""
+    expr_type_path_id: typing.Optional[PathId] = None
     cardinality: qltypes.Cardinality = qltypes.Cardinality.UNKNOWN
 
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2308,6 +2308,19 @@ def _compile_func_args(
         arg_ref = dispatch.compile(ir_arg.expr, ctx=ctx)
         args.append(output.output_as_value(arg_ref, env=ctx.env))
 
+        if ir_arg.expr_type_path_id is not None:
+            # Object type arguments are represented by two
+            # SQL arguments: object id and object type id.
+            # The latter is needed for proper overload
+            # dispatch.
+            type_ref = relctx.get_path_var(
+                ctx.rel,
+                ir_arg.expr_type_path_id,
+                aspect='identity',
+                ctx=ctx,
+            )
+            args.append(type_ref)
+
     if expr.has_empty_variadic and expr.variadic_param_type is not None:
         var = pgast.TypeCast(
             arg=pgast.ArrayExpr(elements=[]),

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -32,7 +32,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_08_25_00_00
+EDGEDB_CATALOG_VERSION = 2021_09_02_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs


### PR DESCRIPTION
Currently, an attempt to declare a function overload with a
difference in an object type parameter crashes with an ISE:

    Error: InternalServerError: function "..." already exists with same argument types

This is because objects are passed to functions by identity and Postgres
is unable to distinguish between the implementations, since all would
have the same `uuid`-typed parameter.

A straightforward solution for this would involve adding a dummy
argument of the composite type corresponding to the object type
relation.  This will only work for compile-time dispatch, i.e.
`SELECT foo(Obj)` would always call the `foo(Obj)` variant, even if more
specific `foo()` implementations exist for subtypes of `Obj`.  This
behavior is very unintuitive and so we must do runtime function dispatch.
Unfortunately, there is no way to do such dispatch in Postgres without
resorting to `EXECUTE` in PL/pgSQL, which would be very slow, so the
solution here is to put all overloaded implementations into a single
function body and switch based on the `__type__` value passed as an
additional shadow argument for the object parameter.

This approach currently places a number of restrictions on overloads of
object type functions: 1) there must be no difference in any but one
parameter type, i.e. this is single dispatch, and 2) the names of
all parameters must match, because all implementations share a single
function definition.  The second restriction is an implementation
caveat, as we can easily normalize the names of positional arguments,
but I decided to keep that out of scope of this patch.