### PR TITLE
Fix volatility inference of functions taking object arguments

### DIFF
--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -27,6 +27,7 @@ from edb import errors
 from edb.edgeql import qltypes
 
 from edb.ir import ast as irast
+from edb.ir import typeutils as irtyputils
 
 from .. import context
 
@@ -209,7 +210,10 @@ def __infer_param(
     ir: irast.Parameter,
     env: context.Environment,
 ) -> InferredVolatility:
-    return IMMUTABLE
+    if irtyputils.contains_object(ir.typeref):
+        return STABLE
+    else:
+        return IMMUTABLE
 
 
 @_infer_volatility_inner.register

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -61,6 +61,16 @@ def is_object(typeref: irast.TypeRef) -> bool:
     )
 
 
+def contains_object(typeref: irast.TypeRef) -> bool:
+    return (
+        is_object(typeref)
+        or (
+            is_collection(typeref)
+            and any(contains_object(st) for st in typeref.subtypes)
+        )
+    )
+
+
 def is_view(typeref: irast.TypeRef) -> bool:
     """Return True if *typeref* describes a view."""
     return typeref.is_view

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -61,16 +61,6 @@ def is_object(typeref: irast.TypeRef) -> bool:
     )
 
 
-def contains_object(typeref: irast.TypeRef) -> bool:
-    return (
-        is_object(typeref)
-        or (
-            is_collection(typeref)
-            and any(contains_object(st) for st in typeref.subtypes)
-        )
-    )
-
-
 def is_view(typeref: irast.TypeRef) -> bool:
     """Return True if *typeref* describes a view."""
     return typeref.is_view

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4338,6 +4338,40 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 ALTER FUNCTION foo() SET volatility := "volatile";
             ''')
 
+    async def test_edgeql_ddl_function_volatility_09(self):
+        await self.con.execute('''
+            CREATE TYPE FuncVol { CREATE PROPERTY i -> int64 };
+            CREATE FUNCTION obj_func(obj: FuncVol) -> int64 {
+                USING (obj.i)
+            };
+            CREATE FUNCTION obj_func_tuple(
+                obj: tuple<array<FuncVol>>
+            ) -> SET OF int64 {
+                USING (array_unpack(obj.0).i)
+            };
+            CREATE FUNCTION obj_func_const(obj: FuncVol) -> int64 {
+                USING (1)
+            };
+        ''')
+
+        await self.assert_query_result(
+            r'''
+            SELECT schema::Function { name, volatility }
+            FILTER .name LIKE 'default::obj_func%'
+            ORDER BY .name;
+            ''',
+            [{
+                "name": "default::obj_func",
+                "volatility": "Stable",
+            }, {
+                "name": "default::obj_func_const",
+                "volatility": "Immutable",
+            }, {
+                "name": "default::obj_func_tuple",
+                "volatility": "Stable",
+            }]
+        )
+
     async def test_edgeql_ddl_function_fallback_01(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidFunctionDefinitionError,

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4349,6 +4349,11 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ) -> SET OF int64 {
                 USING (array_unpack(obj.0).i)
             };
+            CREATE FUNCTION obj_func_tuple_not_referring(
+                arg: tuple<array<FuncVol>, int64>
+            ) -> int64 {
+                USING (arg.1)
+            };
             CREATE FUNCTION obj_func_const(obj: FuncVol) -> int64 {
                 USING (1)
             };
@@ -4369,6 +4374,9 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             }, {
                 "name": "default::obj_func_tuple",
                 "volatility": "Stable",
+            }, {
+                "name": "default::obj_func_tuple_not_referring",
+                "volatility": "Immutable",
             }]
         )
 


### PR DESCRIPTION
A reference to an object `Parameter` is at most `Stable`, because it
triggers a table scan.