### PR TITLE
Handle exclusive violations caused by UPDATEs to related types

### DIFF
--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -166,6 +166,19 @@ class TypeRef(ImmutableBase):
     def __repr__(self) -> str:
         return f'<ir.TypeRef \'{self.name_hint}\' at 0x{id(self):x}>'
 
+    @property
+    def real_material_type(self) -> TypeRef:
+        return self.material_type or self
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+
+        return self.id == other.id
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
 
 class AnyTypeRef(TypeRef):
     pass
@@ -834,6 +847,9 @@ class MutatingStmt(Stmt):
     # the subject later, but making it Optional would cause lots of errors,
     # so we stick a bogus Empty set in.
     subject: Set = EmptySet()  # type: ignore
+    # Conflict checks that we should manually raise constraint violations
+    # for.
+    conflict_checks: typing.Optional[typing.List[OnConflictClause]] = None
 
 
 class OnConflictClause(Base):
@@ -841,14 +857,12 @@ class OnConflictClause(Base):
     select_ir: Set
     always_check: bool
     else_ir: typing.Optional[Set]
+    update_query_set: typing.Optional[Set] = None
     else_fail: typing.Optional[MutatingStmt] = None
 
 
 class InsertStmt(MutatingStmt):
     on_conflict: typing.Optional[OnConflictClause] = None
-    # Conflict checks that we should manually raise constraint violations
-    # for.
-    conflict_checks: typing.Optional[typing.List[OnConflictClause]] = None
 
 
 class UpdateStmt(MutatingStmt, FilteredStmt):

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1706,6 +1706,7 @@ def add_type_rel_overlay(
         typeref: irast.TypeRef,
         op: str,
         rel: Union[pgast.BaseRelation, pgast.CommonTableExpr], *,
+        stop_ref: Optional[irast.TypeRef]=None,
         dml_stmts: Iterable[irast.MutatingStmt] = (),
         path_id: irast.PathId,
         ctx: context.CompilerContextLevel) -> None:
@@ -1715,7 +1716,13 @@ def add_type_rel_overlay(
     objs = [typeref]
     if typeref.ancestors:
         objs.extend(typeref.ancestors)
+
     for obj in objs:
+        if stop_ref and (
+            obj == stop_ref or
+            (stop_ref.ancestors and obj in stop_ref.ancestors)
+        ):
+            continue
         _add_type_rel_overlay(
             obj.id, op, rel,
             dml_stmts=dml_stmts, path_id=path_id, ctx=ctx)

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -81,6 +81,7 @@ type Person2a extending Person2 {
     single link bff -> Person;
     constraint exclusive on ((.first, .bff));
 }
+type DerivedPerson2a extending Person2a;
 
 type Person2b extending Person2 {
     optional single property last -> std::str;
@@ -90,6 +91,7 @@ type Person2b extending Person2 {
         constraint exclusive;
     }
 }
+type DerivedPerson2b extending Person2b;
 
 type PersonWrapper {
     required single link person -> Person;


### PR DESCRIPTION
This expands the infrastructure from #2881 to also cover
UPDATEs. UPDATEs are trickier than inserts for a number of reasons:
 1. Since UPDATE can update child objects as well, it can fail because
    of constraints only present on child types (or even on other
    ancestors of child types).
 2. Because of this, UPDATEs can conflict with themselves, so
    all UPDATEs of types with children and constraints need this
    treatment.
 3. The conflicts can involve data that doesn't appear in the query
    itself.

Handling all the subtypes requires looping over all subtypes on both
sides of a potential conflict, as well as populating overlays for all
subtypes after an update. (The latter turned out to be necessary for
other reasons too, though.)

Handling the data that doesn't appear in the query itself required
arranging to use the CTEs as the source of truth for what is being
updated rather than pulling it from the query.

I also did some optimization of how we look at conflicting data, by
stripping out filters and the base relation from the overlays. This
was necessary to avoid a 25s test suite perf regression on my machine.

Fixes #2845.