### PR TITLE
Fix ISE when an object function is created alongside its object

### DIFF
--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -2245,9 +2245,6 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             },
         })
 
-    @test.xfail('''
-       ISE: relation "<blah>" does not exist
-    ''')
     async def test_edgeql_migration_function_01(self):
         await self.migrate('''
             type Note {


### PR DESCRIPTION
The culprit is the tardiness of type inheritance view creation.  Make it
eager for `CreateObjectType`.

Fixes: #2834.