### PR TITLE
Better error messages on schema type mismatches

### DIFF
--- a/edb/common/english.py
+++ b/edb/common/english.py
@@ -1,0 +1,26 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2009-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+from typing import *
+
+
+def add_a(word):
+    article = 'an' if word[0] in 'aeiou' else 'a'
+    return f'{article} {word}'

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -50,8 +50,10 @@ from edb.schema import constraints as s_constr
 from edb.schema import links as s_links
 from edb.schema import name as s_name
 from edb.schema import objects as s_obj
+from edb.schema import objtypes as s_objtypes
 from edb.schema import properties as s_props
 from edb.schema import pseudo as s_pseudo
+from edb.schema import scalars as s_scalars
 from edb.schema import schema as s_schema
 from edb.schema import sources as s_sources
 from edb.schema import types as s_types
@@ -1200,6 +1202,39 @@ def _resolve_type_expr(
         )
 
 
+TRACER_TO_REAL_TYPE_MAP = {
+    qltracer.ObjectType: s_objtypes.ObjectType,
+    qltracer.ScalarType: s_scalars.ScalarType,
+    qltracer.Constraint: s_constr.Constraint,
+    qltracer.Annotation: s_anno.Annotation,
+    qltracer.Property: s_props.Property,
+    qltracer.Link: s_links.Link,
+}
+
+
+def _get_local_obj(
+    refname: s_name.QualName,
+    tracer_type: Type[qltracer.NamedObject],
+    sourcectx: Optional[parsing.ParserContext],
+    *,
+    ctx: LayoutTraceContext,
+) -> Optional[qltracer.NamedObject]:
+
+    obj = ctx.objects.get(refname)
+
+    if obj is not None and not isinstance(obj, tracer_type):
+        obj_type = TRACER_TO_REAL_TYPE_MAP[type(obj)]
+        real_type = TRACER_TO_REAL_TYPE_MAP[tracer_type]
+        raise errors.InvalidReferenceError(
+            f'{str(refname)!r} exists, but is a '
+            f'{obj_type.get_schema_class_displayname()!r}, '
+            f'not a {real_type.get_schema_class_displayname()!r}',
+            context=sourcectx,
+        )
+
+    return obj
+
+
 def _resolve_type_name(
     ref: qlast.BaseObjectRef,
     *,
@@ -1209,10 +1244,9 @@ def _resolve_type_name(
 ) -> qltracer.ObjectLike:
 
     refname = ctx.get_ref_name(ref)
-    local_obj = ctx.objects.get(refname)
+    local_obj = _get_local_obj(refname, tracer_type, ref.context, ctx=ctx)
     obj: qltracer.ObjectLike
     if local_obj is not None:
-        assert isinstance(local_obj, tracer_type)
         obj = local_obj
     else:
         obj = _resolve_schema_ref(
@@ -1235,26 +1269,23 @@ def _get_tracer_and_real_type(
 
     if isinstance(decl, qlast.CreateObjectType):
         tracer_type = qltracer.ObjectType
-        real_type = s_types.Type
     elif isinstance(decl, qlast.CreateScalarType):
         tracer_type = qltracer.ScalarType
-        real_type = s_types.Type
     elif isinstance(decl, (qlast.CreateConstraint,
                            qlast.CreateConcreteConstraint)):
         tracer_type = qltracer.Constraint
-        real_type = s_constr.Constraint
     elif isinstance(decl, (qlast.CreateAnnotation,
                            qlast.CreateAnnotationValue)):
         tracer_type = qltracer.Annotation
-        real_type = s_anno.Annotation
     elif isinstance(decl, (qlast.CreateProperty,
                            qlast.CreateConcreteProperty)):
         tracer_type = qltracer.Property
-        real_type = s_props.Property
     elif isinstance(decl, (qlast.CreateLink,
                            qlast.CreateConcreteLink)):
         tracer_type = qltracer.Link
-        real_type = s_links.Link
+
+    if tracer_type:
+        real_type = TRACER_TO_REAL_TYPE_MAP[tracer_type]
 
     return tracer_type, real_type
 
@@ -1270,11 +1301,9 @@ def _validate_schema_ref(
         # Bail out and rely on some other validation mechanism
         return
 
-    local_obj = ctx.objects.get(refname)
+    local_obj = _get_local_obj(refname, tracer_type, decl.context, ctx=ctx)
 
-    if local_obj is not None:
-        assert isinstance(local_obj, tracer_type)
-    else:
+    if local_obj is None:
         assert real_type is not None
         _resolve_schema_ref(
             refname,

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -39,6 +39,7 @@ from edb import errors
 
 from edb.common import parsing
 from edb.common import topological
+from edb.common import english
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import codegen as qlcodegen
@@ -1226,9 +1227,9 @@ def _get_local_obj(
         obj_type = TRACER_TO_REAL_TYPE_MAP[type(obj)]
         real_type = TRACER_TO_REAL_TYPE_MAP[tracer_type]
         raise errors.InvalidReferenceError(
-            f'{str(refname)!r} exists, but is a '
-            f'{obj_type.get_schema_class_displayname()!r}, '
-            f'not a {real_type.get_schema_class_displayname()!r}',
+            f'{str(refname)!r} exists, but is '
+            f'{english.add_a(obj_type.get_schema_class_displayname())}, '
+            f'not {english.add_a(real_type.get_schema_class_displayname())}',
             context=sourcectx,
         )
 

--- a/edb/edgeql/parser/parser.py
+++ b/edb/edgeql/parser/parser.py
@@ -20,15 +20,11 @@ from __future__ import annotations
 
 from edb import errors
 from edb.common import debug, parsing
+from edb.common.english import add_a as a
 
 from .grammar import rust_lexer, tokens
 from .grammar import expressions as gr_exprs
 from .grammar import commondl as gr_commondl
-
-
-def a(word):
-    article = 'an' if word[0] in 'aeiou' else 'a'
-    return f'{article} {word}'
 
 
 class EdgeQLParserBase(parsing.Parser):

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -1309,8 +1309,8 @@ class FlatSchema(Schema):
                 got_name = obj.__class__.get_schema_class_displayname()
                 exp_name = type.get_schema_class_displayname()
                 raise errors.InvalidReferenceError(
-                    f'{refname!r} exists, but is '
-                    f'{english.add_a(got_name)}, not {english.add_a(exp_name)}',
+                    f'{refname!r} exists, but is {english.add_a(got_name)}, '
+                    f'not {english.add_a(exp_name)}',
                     context=sourcectx,
                 )
 

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -1248,7 +1248,7 @@ class FlatSchema(Schema):
             if type is not None and not isinstance(obj, type):
                 raise errors.InvalidReferenceError(
                     f'schema object {obj_id!r} exists, but is a '
-                    f'{obj.__class__.get_schema_class_displayname()!r} '
+                    f'{obj.__class__.get_schema_class_displayname()!r}, '
                     f'not a {type.get_schema_class_displayname()!r}'
                 )
 
@@ -1287,7 +1287,7 @@ class FlatSchema(Schema):
             if obj_id is None:
                 return None
 
-            obj = schema.get_by_id(obj_id, type=type, default=None)
+            obj = schema.get_by_id(obj_id, default=None)
             if obj is not None and condition is not None:
                 if not condition(obj):
                     obj = None
@@ -1301,6 +1301,17 @@ class FlatSchema(Schema):
         )
 
         if obj is not so.NoDefault:
+            # We do our own type check, instead of using get_by_id's, so
+            # we can produce a user-facing error message.
+            if obj and type is not None and not isinstance(obj, type):
+                refname = str(name)
+                raise errors.InvalidReferenceError(
+                    f'{refname!r} exists, but is a '
+                    f'{obj.__class__.get_schema_class_displayname()!r}, '
+                    f'not a {type.get_schema_class_displayname()!r}',
+                    context=sourcectx,
+                )
+
             return obj  # type: ignore
         else:
             self._raise_bad_reference(

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -29,6 +29,7 @@ import itertools
 import immutables as immu
 
 from edb import errors
+from edb.common import english
 
 from . import casts as s_casts
 from . import functions as s_func
@@ -1305,10 +1306,11 @@ class FlatSchema(Schema):
             # we can produce a user-facing error message.
             if obj and type is not None and not isinstance(obj, type):
                 refname = str(name)
+                got_name = obj.__class__.get_schema_class_displayname()
+                exp_name = type.get_schema_class_displayname()
                 raise errors.InvalidReferenceError(
-                    f'{refname!r} exists, but is a '
-                    f'{obj.__class__.get_schema_class_displayname()!r}, '
-                    f'not a {type.get_schema_class_displayname()!r}',
+                    f'{refname!r} exists, but is '
+                    f'{english.add_a(got_name)}, not {english.add_a(exp_name)}',
                     context=sourcectx,
                 )
 

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from . import objtypes as s_objtypes
     from . import schema as s_schema
     from . import types as s_types
+    from edb.common import parsing
 
     T = TypeVar('T')
 
@@ -73,6 +74,7 @@ def resolve_name(
     lname: sn.Name,
     *,
     metaclass: Optional[Type[so.Object]] = None,
+    sourcectx: Optional[parsing.ParserContext] = None,
     modaliases: Mapping[Optional[str], str],
     schema: s_schema.Schema,
 ) -> sn.Name:
@@ -81,6 +83,7 @@ def resolve_name(
         type=metaclass,
         module_aliases=modaliases,
         default=None,
+        sourcectx=sourcectx,
     )
     if obj is not None:
         name = obj.get_name(schema)
@@ -116,6 +119,7 @@ def ast_objref_to_object_shell(
         metaclass=metaclass,
         modaliases=modaliases,
         schema=schema,
+        sourcectx=ref.context,
     )
 
     return so.ObjectShell(
@@ -146,6 +150,7 @@ def ast_objref_to_type_shell(
         metaclass=mcls,
         modaliases=modaliases,
         schema=schema,
+        sourcectx=ref.context,
     )
 
     return s_types.TypeShell(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -11514,7 +11514,7 @@ type default::Foo {
     async def test_edgeql_ddl_extending_scalar_wrongly(self):
         async with self.assertRaisesRegexTx(
             edgedb.QueryError,
-            "'str' exists, but is a 'scalar type', not a 'object type'",
+            "'str' exists, but is a scalar type, not an object type",
             _line=1, _col=29
         ):
             await self.con.execute(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -11511,6 +11511,16 @@ type default::Foo {
                 [],
             )
 
+    async def test_edgeql_ddl_extending_scalar_wrongly(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "'str' exists, but is a 'scalar type', not a 'object type'",
+            _line=1, _col=29
+        ):
+            await self.con.execute(
+                r'''CREATE TYPE MyStr EXTENDING str;''',
+            )
+
 
 class TestConsecutiveMigrations(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -608,7 +608,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.InvalidReferenceError,
-        "'test::X' exists, but is a 'scalar type', not a 'object type'",
+        "'test::X' exists, but is a scalar type, not an object type",
         line=3, col=30)
     def test_schema_wrong_type_01(self):
         """
@@ -618,7 +618,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
 
     @tb.must_fail(
         errors.InvalidReferenceError,
-        "'test::X' exists, but is a 'object type', not a 'constraint'",
+        "'test::X' exists, but is an object type, not a constraint",
         line=3, col=22)
     def test_schema_wrong_type_02(self):
         """

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -606,6 +606,26 @@ class TestSchema(tb.BaseSchemaLoadTest):
             }
         """
 
+    @tb.must_fail(
+        errors.InvalidReferenceError,
+        "'test::X' exists, but is a 'scalar type', not a 'object type'",
+        line=3, col=30)
+    def test_schema_wrong_type_01(self):
+        """
+            scalar type X extending enum<TEST>;
+            type Y extending X {}
+        """
+
+    @tb.must_fail(
+        errors.InvalidReferenceError,
+        "'test::X' exists, but is a 'object type', not a 'constraint'",
+        line=3, col=22)
+    def test_schema_wrong_type_02(self):
+        """
+            type X;
+            type Y { constraint X; }
+        """
+
     def test_schema_refs_01(self):
         schema = self.load_schema("""
             type Object1;


### PR DESCRIPTION
Make `Schema.get` produce its own error on a type mismatch instead of
using `get_by_id`, since it has access to the name and so can produce
a better message. Also pass in the sourcectx when resolving names as
part of shell construction, so that the errors will have source
contexts.

In `declarative`, replace some type asserts with type checks and error messages, 
and add some infrastructure for producing the error messages.

Fixes #1016.