### PR TITLE
Always escape newlines when codegening string literals

### DIFF
--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -35,7 +35,7 @@ from . import qltypes
 _module_name_re = re.compile(r'^(?!=\d)\w+(\.(?!=\d)\w+)*$')
 _BYTES_ESCAPE_RE = re.compile(b'[\\\'\x00-\x1f\x7e-\xff]')
 _NON_PRINTABLE_RE = re.compile(
-    r'[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F\u0080-\u009F]')
+    r'[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F\u0080-\u009F\n]')
 _ESCAPES = {
     b'\\': b'\\\\',
     b'\'': b'\\\'',

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -302,6 +302,8 @@ aa';
         r"""
         SELECT 'aa
         aa';
+% OK %
+        SELECT 'aa\naa';
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
@@ -452,8 +454,7 @@ aa';
         r"""
         SELECT "\n";
 % OK %
-        SELECT '
-';
+        SELECT '\n';
         """
 
     def test_edgeql_syntax_constants_39(self):
@@ -3965,6 +3966,24 @@ aa';
         """
         ALTER ABSTRACT ANNOTATION foo::my_annotation
             RENAME TO foo::renamed_annotation;
+        """
+
+    def test_edgeql_syntax_ddl_annotation_05(self):
+        # N.B: The multi line string literal here *must* get turned
+        # into a single line literal with a \n in it, since otherwise
+        # generated DDL migrations with multi-line literals will be
+        # mangled by the cli indenting them.
+        r"""
+        CREATE TYPE Foo {
+            CREATE ANNOTATION description :=
+                "multi
+                 line";
+        };
+% OK %
+        CREATE TYPE Foo {
+            CREATE ANNOTATION description :=
+                'multi\n                 line';
+        };
         """
 
     def test_edgeql_syntax_ddl_constraint_01(self):

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -369,7 +369,7 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         """
 
     def test_eschema_syntax_type_22(self):
-        """
+        r"""
         module test {
             type Foo {
                 property foo -> str {
@@ -403,13 +403,11 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
                 };
                 property bar -> str {
                     # multi-line definition with correct indentation
-                    default := some_func('
-                        1, 2, 3');
+                    default := some_func('\n                        1, 2, 3');
                 };
                 property baz -> str {
                     # multi-line definition with correct indentation
-                    default := 'some_func(
-                        1, 2, 3)';
+                    default := 'some_func(\n                        1, 2, 3)';
                 };
             };
         };


### PR DESCRIPTION
This fixes an issue where multiline string literals in generated
migrations (and actually also ones with escaped newlines in them!)
will get mangled when the CLI indents the migration.

Fixes #2704.