### PR TITLE
Fix handling of the `optional` specifier in shapes

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -517,7 +517,7 @@ class ShapeElement(OffsetLimitMixin, OrderByMixin, FilterMixin, Expr):
     elements: typing.Optional[typing.List[ShapeElement]] = None
     compexpr: typing.Optional[Expr] = None
     cardinality: typing.Optional[qltypes.SchemaCardinality] = None
-    required: bool = False
+    required: typing.Optional[bool] = None
     operation: ShapeOperation = ShapeOperation(op=ShapeOp.ASSIGN)
 
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -525,8 +525,11 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         # and must not be quoted.
 
         quals = []
-        if node.required:
-            quals.append('required')
+        if node.required is not None:
+            if node.required:
+                quals.append('required')
+            else:
+                quals.append('optional')
 
         if node.cardinality:
             quals.append(node.cardinality.as_ptr_qual())

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -185,8 +185,11 @@ class Environment:
 
     pointer_specified_info: Dict[
         s_pointers.Pointer,
-        Tuple[Optional[qltypes.SchemaCardinality], bool,
-              Optional[parsing.ParserContext]],
+        Tuple[
+            Optional[qltypes.SchemaCardinality],
+            Optional[bool],
+            Optional[parsing.ParserContext],
+        ],
     ]
     """Cardinality/source context for pointers with unclear cardinality."""
 

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -743,3 +743,24 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         MANY
         """
+
+    def test_edgeql_ir_card_inference_85(self):
+        """
+        SELECT User { optional multi m := 1 }
+% OK %
+        m: MANY
+        """
+
+    def test_edgeql_ir_card_inference_86(self):
+        """
+        SELECT User { required multi m := 1 }
+% OK %
+        m: AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_87(self):
+        """
+        SELECT User { optional m := 1 }
+% OK %
+        m: AT_MOST_ONE
+        """

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -2041,6 +2041,19 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 }
             """)
 
+    async def test_edgeql_select_tvariant_bad_09(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "cannot redefine link 'status' as optional: it is "
+            "defined as required in the base object type 'default::Issue'",
+            _position=71,
+        ):
+            await self.con.execute("""
+                SELECT Issue {
+                    optional status := (SELECT Status FILTER .name = "Open")
+                }
+            """)
+
     async def test_edgeql_select_instance_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1465,6 +1465,24 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_shape_43a(self):
+        """
+        SELECT Foo {
+            optional multi foo := Foo {
+                name
+            }
+        };
+        """
+
+    def test_edgeql_syntax_shape_43b(self):
+        """
+        SELECT Foo {
+            optional single foo := Foo {
+                name
+            }
+        };
+        """
+
     @tb.must_fail(errors.EdgeQLSyntaxError,
                   r'Unexpected token:.+foo',
                   hint=r"It appears that a ',' is missing in a shape "


### PR DESCRIPTION
Currently, the `optional` specifier in computed pointers in query
shapes is thoroughly ignored, because it is declared as `bool` and not
`Optional[bool]` in the AST making `optional` and absence of optionality
specifier impossible to distinguish.  Fix this.