### PR TITLE
Implement std::assert_exists()

### DIFF
--- a/docs/stdlib/set.rst
+++ b/docs/stdlib/set.rst
@@ -35,6 +35,9 @@ Set
     * - :eql:func:`assert_single`
       - :eql:func-desc:`assert_single`
 
+    * - :eql:func:`assert_exists`
+      - :eql:func-desc:`assert_exists`
+
     * - :eql:func:`count`
       - :eql:func-desc:`count`
 
@@ -299,6 +302,32 @@ Set
         db> SELECT assert_single((SELECT User))
         ERROR: CardinalityViolationError: assert_single violation: more than
                one element returned by an expression
+
+
+----------
+
+
+.. eql:function:: std::assert_exists(s: SET OF anytype) -> SET OF anytype
+
+    :index: cardinality existence empty
+
+    Check that the input set contains at least one element.
+
+    If the input set is empty, ``assert_exists`` raises a
+    ``CardinalityViolationError``.  This function is useful
+    as a runtime existence assertion in queries and computed
+    expressions that should always return sets with at least a single
+    element, but where static cardinality inference is not capable
+    enough or outright impossible.
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT assert_exists((SELECT User FILTER .name = "Administrator"))
+        {default::User {id: ...}}
+
+        db> SELECT assert_exists((SELECT User FILTER .name = "Nonexistent"))
+        ERROR: CardinalityViolationError: assert_exists violation: expression
+               returned an empty set.
 
 
 ----------

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -681,7 +681,19 @@ def __infer_func_call(
 
     ret_lower_bound, ret_upper_bound = _card_to_bounds(return_card)
 
-    if ir.preserves_optionality:
+    if ir.func_shortname == sn.QualName('std', 'assert_exists'):
+        arg_cards = []
+
+        for arg in ir.args:
+            arg.cardinality = infer_cardinality(
+                arg.expr, scope_tree=scope_tree, ctx=ctx)
+            arg_cards.append(arg.cardinality)
+
+        arg_card = zip(*(_card_to_bounds(card) for card in arg_cards))
+        _, arg_upper = arg_card
+        return _bounds_to_card(CardinalityBound.ONE, max(arg_upper))
+
+    elif ir.preserves_optionality:
         # This is a generic aggregate function which preserves the
         # optionality of its generic argument.  For simplicity we
         # are deliberately not checking the parameters here as that

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -19,8 +19,8 @@
 ## Fundamental polymorphic functions
 
 
-# std::assert_single -- runtime cardinality assertion
-# ---------------------------------------------------
+# std::assert_single -- runtime cardinality assertion (upper bound)
+# -----------------------------------------------------------------
 
 CREATE FUNCTION
 std::assert_single(input: SET OF anytype) -> OPTIONAL anytype
@@ -30,6 +30,20 @@ std::assert_single(input: SET OF anytype) -> OPTIONAL anytype
          CardinalityViolationError otherwise.";
     SET volatility := 'Stable';
     SET preserves_optionality := true;
+    USING SQL EXPRESSION;
+};
+
+
+# std::assert_exists -- runtime cardinality assertion (lower bound)
+# -----------------------------------------------------------------
+
+CREATE FUNCTION
+std::assert_exists(input: SET OF anytype) -> SET OF anytype
+{
+    CREATE ANNOTATION std::description :=
+        "Check that the input set contains at least one element, raise
+         CardinalityViolationError otherwise.";
+    SET volatility := 'Stable';
     USING SQL EXPRESSION;
 };
 

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -314,7 +314,10 @@ def static_interpret_backend_error(fields):
 
     elif (
         err_details.code == pgerrors.ERROR_CARDINALITY_VIOLATION
-        and err_details.constraint_name == 'std::assert_single'
+        and (
+            err_details.constraint_name == 'std::assert_single'
+            or err_details.constraint_name == 'std::assert_exists'
+        )
     ):
         return errors.CardinalityViolationError(err_details.message)
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -32,7 +32,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_09_02_00_00
+EDGEDB_CATALOG_VERSION = 2021_09_03_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs


### PR DESCRIPTION
The new `std::assert_exists(input: SET OF anytype) -> SET OF anytype`
function checks the cardinality of the input set, and if it is less
than 1, raises a `CardinalityViolationError`.  This assertion
complements `std::assert_single()` in that it makes it possible to
satisfy lower cardinality bound requirements in computed pointers:

    SELECT Obj {
        required link foo := assert_exists((SELECT Foo))
    }