### PR TITLE
Fix accessing link properties on union types

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -979,18 +979,22 @@ def type_intersection_set(
                 rptr_specialization.append(component)
             elif stype.issubclass(ctx.env.schema, component_endpoint):
                 assert isinstance(stype, s_objtypes.ObjectType)
-                narrow_ptr = stype.getptr(
-                    ctx.env.schema,
-                    component.shortname.get_local_name(),
-                )
-                rptr_specialization.append(
-                    irtyputils.ptrref_from_ptrcls(
-                        schema=ctx.env.schema,
-                        ptrcls=narrow_ptr,
-                        cache=ctx.env.ptr_ref_cache,
-                        typeref_cache=ctx.env.type_ref_cache,
-                    ),
-                )
+                if rptr.direction is s_pointers.PointerDirection.Inbound:
+                    narrow_ptr = stype.getptr(
+                        ctx.env.schema,
+                        component.shortname.get_local_name(),
+                    )
+                    rptr_specialization.append(
+                        irtyputils.ptrref_from_ptrcls(
+                            schema=ctx.env.schema,
+                            ptrcls=narrow_ptr,
+                            cache=ctx.env.ptr_ref_cache,
+                            typeref_cache=ctx.env.type_ref_cache,
+                        ),
+                    )
+                else:
+                    assert isinstance(component, irast.PointerRef)
+                    rptr_specialization.append(component)
 
     ptrcls = irast.TypeIntersectionLink(
         arg_type,

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1484,8 +1484,10 @@ def table_from_ptrref(
 
     # Pseudo pointers (tuple and type intersection) have no schema id.
     sobj_id = ptrref.id if isinstance(ptrref, irast.PointerRef) else None
+    typeref = ptrref.out_source if ptrref else None
     rvar = pgast.RelRangeVar(
         schema_object_id=sobj_id,
+        typeref=typeref,
         relation=relation,
         include_inherited=include_descendants,
         alias=pgast.Alias(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -691,9 +691,10 @@ def process_set_as_link_property_ref(
         assert link_path_id is not None
         orig_link_path_id = link_path_id
 
-        rptr_specialization: Set[irast.PointerRef] = set()
+        rptr_specialization: Optional[Set[irast.PointerRef]] = None
 
         if link_path_id.is_type_intersection_path():
+            rptr_specialization = set()
             link_prefix, ind_ptrs = (
                 irutils.collapse_type_intersection(ir_source))
             for ind_ptr in ind_ptrs:
@@ -716,18 +717,22 @@ def process_set_as_link_property_ref(
                 link_prefix.rptr, src_rvar=src_rvar,
                 link_bias=True, ctx=newctx)
 
-        if rptr_specialization and astutils.is_set_op_query(link_rvar.query):
-            # This is a link property reference to a link union narrowed
-            # by a type intersection.  We already know which union components
+        if astutils.is_set_op_query(link_rvar.query):
+            # If we have an rptr_specialization, then this is a link
+            # property reference to a link union narrowed by a type
+            # intersection.  We already know which union components
             # match the indirection expression, and can route the link
             # property references to correct UNION subqueries.
-            ptr_ids = {spec.id for spec in rptr_specialization}
+            ptr_ids = (
+                {spec.id for spec in rptr_specialization}
+                if rptr_specialization is not None else None
+            )
 
             def cb(subquery: pgast.Query) -> None:
                 if isinstance(subquery, pgast.SelectStmt):
                     rvar = subquery.from_clause[0]
                     assert isinstance(rvar, pgast.PathRangeVar)
-                    if rvar.schema_object_id in ptr_ids:
+                    if ptr_ids is None or rvar.schema_object_id in ptr_ids:
                         pathctx.put_path_source_rvar(
                             subquery, orig_link_path_id, rvar, env=ctx.env
                         )

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -1023,3 +1023,141 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
                 {"name": "Bob", "avatar": None}
             ],
         )
+
+    async def test_edgeql_props_link_union_01(self):
+        await self.con.execute(r'''
+            CREATE TYPE Tgt;
+            CREATE TYPE Tgt2 EXTENDING Tgt;
+            CREATE TYPE Bar {
+                CREATE LINK l -> Tgt {
+                    CREATE PROPERTY x -> str;
+                };
+            };
+            CREATE TYPE Foo {
+                CREATE LINK l -> Tgt {
+                    CREATE PROPERTY x -> str;
+                };
+            };
+            CREATE TYPE Baz {
+                CREATE LINK fubar -> (Bar | Foo);
+            };
+
+            INSERT Baz {
+                fubar := (INSERT Bar {
+                    l := (INSERT Tgt2 { @x := "test" })
+                })
+            };
+        ''')
+
+        await self.assert_query_result(
+            r'''
+                SELECT Baz.fubar.l@x;
+            ''',
+            ["test"],
+        )
+
+        await self.assert_query_result(
+            r'''
+                SELECT Baz.fubar.l[IS Tgt2]@x;
+            ''',
+            ["test"],
+        )
+
+        await self.assert_query_result(
+            r'''
+                SELECT (Foo UNION Bar).l@x;
+            ''',
+            ["test"],
+        )
+
+    async def test_edgeql_props_link_union_02(self):
+        await self.con.execute(r'''
+            CREATE TYPE Tgt;
+            CREATE TYPE Tgt2 EXTENDING Tgt;
+            CREATE TYPE Bar {
+                CREATE MULTI LINK l -> Tgt {
+                    CREATE PROPERTY x -> str;
+                };
+            };
+            CREATE TYPE Foo {
+                CREATE MULTI LINK l -> Tgt {
+                    CREATE PROPERTY x -> str;
+                };
+            };
+            CREATE TYPE Baz {
+                CREATE LINK fubar -> (Bar | Foo);
+            };
+
+            INSERT Baz {
+                fubar := (INSERT Bar {
+                    l := (INSERT Tgt2 { @x := "test" })
+                })
+            };
+        ''')
+
+        await self.assert_query_result(
+            r'''
+                SELECT Baz.fubar.l@x;
+            ''',
+            ["test"],
+        )
+
+        await self.assert_query_result(
+            r'''
+                SELECT Baz.fubar.l[IS Tgt2]@x;
+            ''',
+            ["test"],
+        )
+
+        await self.assert_query_result(
+            r'''
+                SELECT (Foo UNION Bar).l@x;
+            ''',
+            ["test"],
+        )
+
+    async def test_edgeql_props_link_union_03(self):
+        await self.con.execute(r'''
+            CREATE TYPE Tgt;
+            CREATE TYPE Tgt2 EXTENDING Tgt;
+            CREATE TYPE Bar {
+                CREATE LINK l -> Tgt {
+                    CREATE PROPERTY x -> str;
+                };
+            };
+            CREATE TYPE Foo {
+                CREATE MULTI LINK l -> Tgt {
+                    CREATE PROPERTY x -> str;
+                };
+            };
+            CREATE TYPE Baz {
+                CREATE LINK fubar -> (Bar | Foo);
+            };
+
+            INSERT Baz {
+                fubar := (INSERT Bar {
+                    l := (INSERT Tgt2 { @x := "test" })
+                })
+            };
+        ''')
+
+        await self.assert_query_result(
+            r'''
+                SELECT Baz.fubar.l@x;
+            ''',
+            ["test"],
+        )
+
+        await self.assert_query_result(
+            r'''
+                SELECT Baz.fubar.l[IS Tgt2]@x;
+            ''',
+            ["test"],
+        )
+
+        await self.assert_query_result(
+            r'''
+                SELECT (Foo UNION Bar).l@x;
+            ''',
+            ["test"],
+        )


### PR DESCRIPTION
The core thing here is fixing find_actual_ptrref to look at
union_component for link props, with a bit more tweaking needed to get
things lined up for the set op query.

Also fix an issue about type intersections on non-backlinks.

Fixes #2513.