### PR TITLE
Fix bare backlink schema-defined computables

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -493,6 +493,8 @@ def _normalize_view_ptr_expr(
         # Schema computables that point to opaque unions will just have
         # BaseObject as their target, but in order to properly compile
         # it, we need to know the actual type here, so we recompute it.
+        # XXX: This is a hack, though, and hopefully we can fix it once
+        # the computable/alias rework lands.
         is_opaque_schema_computable = (
             ptrcls.is_pure_computable(ctx.env.schema)
             and (t := ptrcls.get_target(ctx.env.schema))

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -490,6 +490,15 @@ def _normalize_view_ptr_expr(
             name=ptrcls.get_shortname(ctx.env.schema).name,
         )
 
+        # Schema computables that point to opaque unions will just have
+        # BaseObject as their target, but in order to properly compile
+        # it, we need to know the actual type here, so we recompute it.
+        is_opaque_schema_computable = (
+            ptrcls.is_pure_computable(ctx.env.schema)
+            and (t := ptrcls.get_target(ctx.env.schema))
+            and t.get_name(ctx.env.schema) == sn.QualName('std', 'BaseObject')
+        )
+
         base_required = base_ptrcls.get_required(ctx.env.schema)
         base_cardinality = _get_base_ptr_cardinality(base_ptrcls, ctx=ctx)
         base_is_singleton = False
@@ -504,6 +513,7 @@ def _normalize_view_ptr_expr(
             or is_polymorphic
             or target_typexpr is not None
             or (ctx.implicit_limit and not base_is_singleton)
+            or is_opaque_schema_computable
         ):
 
             if target_typexpr is None:

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -6162,3 +6162,23 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ''',
             [{"z": [{"name": "Regression."}, {"name": "Release EdgeDB"}]}],
         )
+
+    async def test_edgeql_select_bare_backlink_01(self):
+        await self.con.execute('''
+            CREATE ABSTRACT TYPE Action;
+            CREATE TYPE Post EXTENDING Action;
+            CREATE TYPE Thing;
+            ALTER TYPE Action {
+                CREATE REQUIRED LINK thing -> Thing;
+            };
+            ALTER TYPE Thing {
+                CREATE LINK posts := (.<thing);
+            };
+        ''')
+
+        await self.assert_query_result(
+            r'''
+                 SELECT Thing { posts: {id} };
+            ''',
+            [],
+        )


### PR DESCRIPTION
We need to recompile them in process_view so that we have their
correct full available.
Fixes #2605.