### PR TITLE
Fix a regression when objects from opaque sources to functions

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2379,6 +2379,7 @@ def _compile_func_args(
             # SQL arguments: object id and object type id.
             # The latter is needed for proper overload
             # dispatch.
+            ensure_source_rvar(ir_arg.expr, ctx.rel, ctx=ctx)
             type_ref = relctx.get_path_var(
                 ctx.rel,
                 ir_arg.expr_type_path_id,

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -1475,6 +1475,15 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
             [200.0],
         )
 
+        # Test that opaque object sources work as well.
+        await self.assert_query_result(
+            r"""
+                WITH r := (Rectangle, [Rectangle])
+                SELECT (area(r.0), area(r.1[0]))
+            """,
+            [[200.0, 200.0]],
+        )
+
         # The top parent does _not_ have a definition of area, so
         # calling it on it is still an error (even if there are definitions
         # for all subtypes).


### PR DESCRIPTION
The newly added passing of `__type__` to object functions to support
overloading is missing the requisite `ensure_source_rvar` to make sure
`__type__` is actually available at the call site.

Fixes: #2924