### PR TITLE
Make computed pointers consistent.

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -658,6 +658,7 @@ class ContextLevel(compiler.ContextLevel):
                 self.anchors = prevlevel.anchors.copy()
                 self.modaliases = prevlevel.modaliases.copy()
                 self.aliased_views = collections.ChainMap()
+                self.view_map = collections.ChainMap()
                 self.class_view_overrides = {}
                 self.expr_exposed = prevlevel.expr_exposed
 


### PR DESCRIPTION
Computed links and properties defined in the schema should behave the
same way as the equivalent computed links and properties defined ad-hoc
directly in the query.

Fixes #2558