### PR TITLE
Get rid of setuptools-scm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,8 @@ __pycache__/
 docs/_build
 /AUTHORS
 /ChangeLog
-tests/dumps/**/*_dev*.dump
+/tests/dumps/**/*_dev*.dump
+/edb/_buildmeta.py
 
 /.coverage*
 /htmlcov

--- a/edb/server/.gitignore
+++ b/edb/server/.gitignore
@@ -1,3 +1,2 @@
-/_buildmeta.py
 *.c
 *.html

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -30,10 +30,10 @@ import tempfile
 import click
 import psutil
 
+from edb import buildmeta
 from edb.common import devmode
 from edb.schema import defines as schema_defines
 
-from . import buildmeta
 from . import defines
 
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -29,6 +29,7 @@ import re
 
 import immutables
 
+from edb import buildmeta
 from edb import errors
 
 from edb import edgeql
@@ -51,7 +52,6 @@ from edb.schema import schema as s_schema
 from edb.schema import std as s_std
 
 from edb.server import args as edbargs
-from edb.server import buildmeta
 from edb.server import config
 from edb.server import compiler as edbcompiler
 from edb.server import defines as edbdef

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -33,10 +33,10 @@ import time
 import asyncpg
 import edgedb
 
+from edb import buildmeta
 from edb.common import devmode
 from edb.edgeql import quote
 
-from edb.server import buildmeta
 from edb.server import defines as edgedb_defines
 
 from . import pgcluster

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -19,6 +19,8 @@
 
 from __future__ import annotations
 
+from edb import buildmeta
+
 
 EDGEDB_PORT = 5656
 EDGEDB_SUPERGROUP = 'edgedb_supergroup'
@@ -31,8 +33,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
-# Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_09_03_00_00
+EDGEDB_CATALOG_VERSION = buildmeta.EDGEDB_CATALOG_VERSION
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -42,12 +42,12 @@ import setproctitle
 from . import logsetup
 logsetup.early_setup()
 
+from edb import buildmeta
 from edb.common import devmode
 from edb.common import signalctl
 from edb.common import exceptions
 
 from . import args as srvargs
-from . import buildmeta
 from . import daemon
 from . import defines
 from . import pgconnparams

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -36,10 +36,10 @@ import time
 import asyncpg
 from asyncpg import serverversion
 
+from edb import buildmeta
 from edb.common import supervisor
 from edb.common import uuidgen
 
-from edb.server import buildmeta
 from edb.server import defines
 from edb.pgsql import common as pgcommon
 

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -36,6 +36,7 @@ from libc.stdint cimport int8_t, uint8_t, int16_t, uint16_t, \
                          int32_t, uint32_t, int64_t, uint64_t, \
                          UINT32_MAX
 
+from edb import buildmeta
 from edb import errors
 from edb.edgeql import qltypes
 
@@ -58,7 +59,6 @@ from edb.server.pgproto.pgproto cimport (
     frb_slice_from,
 )
 
-from edb.server import buildmeta
 from edb.server import compiler
 from edb.server import defines
 from edb.server.cache cimport stmt_cache

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -37,6 +37,7 @@ from libc.stdint cimport int8_t, uint8_t, int16_t, uint16_t, \
 
 import immutables
 
+from edb import buildmeta
 from edb import edgeql
 from edb.edgeql import qltypes
 
@@ -57,7 +58,6 @@ from edb.server.dbview cimport dbview
 
 from edb.server import config
 
-from edb.server import buildmeta
 from edb.server import compiler
 from edb.server import defines as edbdef
 from edb.server.compiler import errormech

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -33,12 +33,12 @@ from edb.common import debug
 from edb.common import devmode
 from edb.common import markup
 
+from edb import buildmeta
 from edb import errors
 from edb import edgeql
 from edb.edgeql import ast as qlast
 from edb.edgeql import parser as qlparser
 
-from edb.server import buildmeta
 from edb.server import defines
 from edb.server import compiler as edbcompiler
 

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -24,11 +24,11 @@ import sys
 
 import click
 
+from edb import buildmeta
 from edb.common import debug
 from edb.common import devmode as dm
 from edb.server import args as srv_args
 from edb.server import main as srv_main
-from edb.server import buildmeta
 
 
 @click.group(

--- a/edb/tools/gen_test_dumps.py
+++ b/edb/tools/gen_test_dumps.py
@@ -30,7 +30,7 @@ import unittest
 
 import click
 
-from edb.server import buildmeta
+from edb import buildmeta
 from edb.server import cluster as edgedb_cluster
 from edb.testbase import server as tb
 from edb.tools.edb import edbcommands

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -29,13 +29,13 @@ import immutables
 
 import edgedb
 
+from edb import buildmeta
 from edb import errors
 from edb.edgeql import qltypes
 
 from edb.testbase import server as tb
 from edb.schema import objects as s_obj
 
-from edb.server import buildmeta
 from edb.server import config
 from edb.server.config import ops
 from edb.server.config import spec


### PR DESCRIPTION
We aren't actually benefiting from `setuptools-scm` anymore because we
call `git` and format our version manually anyway, and avoiding the
`setuptools-scm` dependency removes some of it's transivite deps from
the runtime list.

This also moves `edb.server.buildmeta` to `edb.buildmeta`, because it
represents the entire distribution not just the server part and reduces
the possibility of import issues at `setup.py` time.