### PR TITLE
Fix HA test CI

### DIFF
--- a/.github/workflows.src/tests-ha.tpl.yml
+++ b/.github/workflows.src/tests-ha.tpl.yml
@@ -46,4 +46,4 @@ jobs:
         EDGEDB_TEST_STOLON_SENTINEL: build/stolon/bin/stolon-sentinel
         EDGEDB_TEST_STOLON_KEEPER: build/stolon/bin/stolon-keeper
       run: |
-        edb test -j1 -v test_stolon
+        edb test -j1 -v -k test_ha_

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -428,4 +428,4 @@ jobs:
         EDGEDB_TEST_STOLON_SENTINEL: build/stolon/bin/stolon-sentinel
         EDGEDB_TEST_STOLON_KEEPER: build/stolon/bin/stolon-keeper
       run: |
-        edb test -j1 -v test_stolon
+        edb test -j1 -v -k test_ha_

--- a/tests/test_stolon.py
+++ b/tests/test_stolon.py
@@ -347,7 +347,7 @@ class TestStolon(tb.TestCase):
         else:
             self.assertEqual(rv, 1)
 
-    async def test_stolon(self):
+    async def test_ha_stolon(self):
         if not os.environ.get("EDGEDB_TEST_HA"):
             self.skipTest("EDGEDB_TEST_HA is not set")
 


### PR DESCRIPTION
The `workflow_run` trigger is limited to the default branch, so there is for now no way to test it in PRs using this trigger.