### PR TITLE
Add a server option to specify the default authentication method

### DIFF
--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -198,6 +198,7 @@ async def _run_server(
             allow_insecure_binary_clients=args.allow_insecure_binary_clients,
             allow_insecure_http_clients=args.allow_insecure_http_clients,
             backend_adaptive_ha=args.backend_adaptive_ha,
+            default_auth_method=args.default_auth_method,
         )
         await sc.wait_for(ss.init())
 
@@ -315,6 +316,10 @@ async def run_server(
         logger.info(f'EdgeDB server ({info_details}) is starting in DEV mode.')
     else:
         logger.info(f'EdgeDB server ({info_details}) is starting.')
+
+    logger.debug(
+        f"defaulting to the '{args.default_auth_method}' authentication method"
+    )
 
     _init_parsers()
 
@@ -486,7 +491,7 @@ def bump_rlimit_nofile() -> None:
                 logger.warning('could not set RLIMIT_NOFILE')
 
 
-def server_main(*, insecure=False, **kwargs):
+def server_main(**kwargs):
     logsetup.setup_logging(kwargs['log_level'], kwargs['log_to'])
     exceptions.install_excepthook()
 
@@ -497,7 +502,7 @@ def server_main(*, insecure=False, **kwargs):
     if kwargs['devmode'] is not None:
         devmode.enable_dev_mode(kwargs['devmode'])
 
-    server_args = srvargs.parse_args(insecure=insecure, **kwargs)
+    server_args = srvargs.parse_args(**kwargs)
 
     if kwargs['background']:
         daemon_opts = {'detach_process': True}

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -113,6 +113,7 @@ class Server(ha_base.ClusterProtocol):
         status_sink: Optional[Callable[[str], None]] = None,
         startup_script: Optional[srvargs.StartupScript] = None,
         backend_adaptive_ha: bool = False,
+        default_auth_method: str,
     ):
 
         self._loop = asyncio.get_running_loop()
@@ -193,6 +194,7 @@ class Server(ha_base.ClusterProtocol):
         self._tls_cert_file = None
         self._sslctx = None
 
+        self._default_auth_method = default_auth_method
         self._allow_insecure_binary_clients = allow_insecure_binary_clients
         self._allow_insecure_http_clients = allow_insecure_http_clients
         if backend_adaptive_ha:
@@ -1239,7 +1241,9 @@ class Server(ha_base.ClusterProtocol):
                 if match:
                     return auth.method
 
-        return config.get_settings().get_type_by_name('SCRAM')()
+        auth_type = config.get_settings().get_type_by_name(
+            self._default_auth_method)
+        return auth_type()
 
     def get_sys_query(self, key):
         return self._sys_queries[key]

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -51,7 +51,9 @@ def server(version=False, **kwargs):
 
     os.environ['EDGEDB_DEBUG_SERVER'] = '1'
     debug.init_debug_flags()
-    srv_main.server_main(insecure=True, **kwargs)
+    if not kwargs.get('default_auth_method'):
+        kwargs['default_auth_method'] = 'Trust'
+    srv_main.server_main(**kwargs)
 
 
 # Import at the end of the file so that "edb.tools.edb.edbcommands"


### PR DESCRIPTION
The current default authentication method is hardcoded to `SCRAM` and if
one wants a different default, something like this is currently
required:

    CONFIGURE INSTANCE INSERT Auth {
        priority := 0,
        method := (INSERT Trust),
    };

This is problematic because this configuration is persistent, so it's
harder to start an insecure server temporarily.

This patch adds the new `--default-auth-method` argument as well as its
companion `EDGEDB_SERVER_DEFAULT_AUTH_METHOD` environment variable to
set the default authentication method.  `SCRAM` is still the default,
but devmode servers (`edb cli`) now set to `--default-auth-method=Trust`
as before.