### PR TITLE
Fix casting of arrays containing tuples

### DIFF
--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2511,7 +2511,9 @@ def is_type_compatible(
         elif isinstance(t_a, Array) and isinstance(t_b, Array):
             t_as = t_a.get_element_type(schema)
             t_bs = t_b.get_element_type(schema)
-            return not isinstance(t_as, Tuple) and labels_compatible(t_as, t_bs)
+            return (
+                not isinstance(t_as, Tuple) and labels_compatible(t_as, t_bs)
+            )
         else:
             return True
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2509,8 +2509,9 @@ def is_type_compatible(
                        t_b.iter_subtypes(schema))
             )
         elif isinstance(t_a, Array) and isinstance(t_b, Array):
-            return labels_compatible(
-                t_a.get_element_type(schema), t_b.get_element_type(schema))
+            t_as = t_a.get_element_type(schema)
+            t_bs = t_b.get_element_type(schema)
+            return not isinstance(t_as, Tuple) and labels_compatible(t_as, t_bs)
         else:
             return True
 

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -1292,6 +1292,20 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
             ]
         )
 
+    async def test_edgeql_calls_35c(self):
+        # Array return with a tuple forcing a cast
+
+        await self.con.execute('''
+            CREATE SCALAR TYPE Foo extending str;
+            CREATE FUNCTION call35() -> array<tuple<Foo>>
+            USING (SELECT [('1',)] ++ [('2',)]);
+        ''')
+
+        await self.assert_query_result(
+            r'''SELECT call35();''',
+            [[["1"], ["2"]]],
+        )
+
     async def test_edgeql_calls_36(self):
         await self.con.execute('''
             CREATE FUNCTION call36(

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2457,6 +2457,23 @@ class TestExpressions(tb.QueryTestCase):
             [1],
         )
 
+    async def test_edgeql_expr_cast_10(self):
+        await self.assert_query_result(
+            r'''
+                SELECT <array<tuple<EmulatedEnum>>>
+                  (SELECT [('v1',)] ++ [('v2',)])
+            ''',
+            [[["v1"], ["v2"]]],
+        )
+
+        await self.assert_query_result(
+            r'''
+                SELECT <tuple<array<EmulatedEnum>>>
+                  (SELECT (['v1'] ++ ['v2'],))
+            ''',
+            [[["v1", "v2"]]],
+        )
+
     async def test_edgeql_expr_implicit_cast_01(self):
         await self.assert_query_result(
             r'''SELECT (INTROSPECT TYPEOF(<int32>1 + 3)).name;''',


### PR DESCRIPTION
They can not be directly casted, even if the tuple types are compatible.