### PR TITLE
Add `EDGEDB_SERVER_LOG_LEVEL` env var

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -267,6 +267,7 @@ _server_options = [
     ),
     click.option(
         '-l', '--log-level',
+        envvar="EDGEDB_SERVER_LOG_LEVEL",
         default='i',
         type=click.Choice(
             ['debug', 'd', 'info', 'i', 'warn', 'w',


### PR DESCRIPTION
Should make it easier to debug some of the issues when using server though edgedb CLI.

E.g. this one: https://github.com/edgedb/edgedb/issues/2940