### PR TITLE
Do shape compilation in process_view when possible

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -133,7 +133,7 @@ def compile_cast(
                 subctx.implicit_id_in_shapes = False
                 subctx.implicit_tid_in_shapes = False
                 subctx.implicit_tname_in_shapes = False
-                viewgen.compile_view_shapes(ir_set, ctx=subctx)
+                viewgen.late_compile_view_shapes(ir_set, ctx=subctx)
         elif (orig_stype.issubclass(ctx.env.schema, json_t)
               and new_stype.is_enum(ctx.env.schema)):
             # Casts from json to enums need some special handling

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -563,7 +563,7 @@ def compile_inheritance_conflict_checks(
     subject_stype: s_objtypes.ObjectType,
     *, ctx: context.ContextLevel,
 ) -> Optional[List[irast.OnConflictClause]]:
-    if not ctx.env.dml_stmts or ctx.path_scope.in_temp_scope():
+    if not ctx.env.dml_stmts:
         return None
 
     assert isinstance(subject_stype, s_objtypes.ObjectType)

--- a/edb/edgeql/compiler/inference/__init__.py
+++ b/edb/edgeql/compiler/inference/__init__.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 __all__ = (
     'amend_empty_set_type',
-    'infer_toplevel_cardinality',
+    'infer_cardinality',
     'infer_type',
     'infer_volatility',
     'infer_multiplicity',
@@ -29,7 +29,7 @@ __all__ = (
     'make_ctx',
 )
 
-from .cardinality import infer_toplevel_cardinality  # NOQA
+from .cardinality import infer_cardinality  # NOQA
 from .context import InfCtx, make_ctx  # NOQA
 from .multiplicity import infer_multiplicity  # NOQA
 from .types import amend_empty_set_type, infer_type  # NOQA

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -1309,49 +1309,6 @@ def infer_cardinality(
     return result
 
 
-def infer_toplevel_cardinality(
-    ir: irast.Base,
-    *,
-    source_map: Dict[s_pointers.PointerLike, irast.ComputableInfo],
-    scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Cardinality:
-    env = ctx.env
-
-    # We need to infer the pointer cardinality of everything in our
-    # source_map of computable pointers so we can check their
-    # cardinality against their specified cardinality and in order to
-    # populate the ptrcls with the correctly computed cardinality.
-    for ptrcls, cmp_info in source_map.items():
-        if (
-            cmp_info.irexpr is None
-            or not isinstance(ptrcls, s_pointers.Pointer)
-        ):
-            continue
-        specified_card, specified_required, source_ctx = (
-            ctx.env.pointer_specified_info.get(
-                ptrcls, (None, False, None)))
-        root = s_pointers.get_root_source(ptrcls, env.schema)
-        assert isinstance(root, s_objtypes.ObjectType)
-        view_type = root.get_expr_type(env.schema)
-        is_mut_assignment = view_type in (
-            s_types.ExprType.Insert, s_types.ExprType.Update)
-
-        _infer_pointer_cardinality(
-            ptrcls=ptrcls,
-            ptrref=None,
-            irexpr=cmp_info.irexpr,
-            specified_card=specified_card,
-            specified_required=specified_required,
-            is_mut_assignment=is_mut_assignment,
-            scope_tree=scope_tree,
-            source_ctx=source_ctx,
-            ctx=ctx,
-        )
-
-    return infer_cardinality(ir, scope_tree=scope_tree, ctx=ctx)
-
-
 def is_subset_cardinality(
     card0: qltypes.Cardinality,
     card1: qltypes.Cardinality

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -197,7 +197,8 @@ class BasePointerRef(ImmutableBase):
     # cardinality fields need to be mutable for lazy cardinality inference.
     # and children because we update pointers with newly derived children
     __ast_mutable_fields__ = frozenset(
-        ('in_cardinality', 'out_cardinality', 'children')
+        ('in_cardinality', 'out_cardinality', 'children',
+         'is_computable')
     )
 
     # The defaults set here are mostly to try to reduce debug spew output.
@@ -413,6 +414,7 @@ class Pointer(Base):
     target: Set
     ptrref: BasePointerRef
     direction: s_pointers.PointerDirection
+    is_definition: bool
     anchor: typing.Optional[str] = None
     show_as_anchor: typing.Optional[str] = None
 
@@ -429,11 +431,13 @@ class TypeIntersectionPointer(Pointer):
 
     optional: bool
     ptrref: TypeIntersectionPointerRef
+    is_definition: bool = False
 
 
 class TupleIndirectionPointer(Pointer):
 
     ptrref: TupleIndirectionPointerRef
+    is_definition: bool = False
 
 
 class Expr(Base):
@@ -780,7 +784,7 @@ class TypeCast(ImmutableExpr):
 class MaterializedSet(Base):
     # Hide uses to reduce spew; we produce our own simpler uses
     __ast_hidden__ = {'use_sets'}
-    materialized: typing.Optional[Set]
+    materialized: Set
     reason: typing.Sequence[MaterializeReason]
 
     # We really only want the *paths* of all the places it is used,

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -424,7 +424,8 @@ class PathId:
             )
 
             if debug:
-                ptr = f'({ptrspec[0].name})'
+                link_name = str(ptrspec[0].path_id_name or ptrspec[0].name)
+                ptr = f'({link_name})'
             else:
                 ptr = ptrspec[0].shortname.name
             ptrdir = ptrspec[1]

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -60,13 +60,6 @@ class ScopeTreeNode:
     computable_branch: bool
     """Whether this is a branch created to hide heads in a computable path"""
 
-    is_temporary: bool
-    """Whether the branch was created for a view processing.
-
-    Late in the compilation process we prune these nodes to clean up
-    the tree.
-    """
-
     unnest_fence: bool
     """Prevent unnesting in parents."""
 
@@ -112,7 +105,6 @@ class ScopeTreeNode:
         self.path_id = path_id
         self.fenced = fenced
         self.computable_branch = computable_branch
-        self.is_temporary = False
         self.unnest_fence = False
         self.factoring_fence = False
         self.factoring_allowlist = set()
@@ -181,9 +173,6 @@ class ScopeTreeNode:
     @property
     def optional(self) -> bool:
         return self.optional_count == 0
-
-    def in_temp_scope(self) -> bool:
-        return any(x.is_temporary for x in self.ancestors)
 
     @property
     def fence_info(self) -> FenceInfo:

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -155,7 +155,6 @@ def compile_materialized_exprs(
         for mat_set in stmt.materialized_sets.values():
             if len(mat_set.uses) <= 1:
                 continue
-            assert mat_set.materialized
             assert mat_set.finalized
             if relctx.find_rvar(
                     query, flavor='packed',

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -842,6 +842,7 @@ def compile_insert_else_body(
     # Compile the query CTE that selects out the existing rows
     # that we would conflict with
     with ctx.newrel() as ictx:
+        ictx.expr_exposed = False
         ictx.path_scope[subject_id] = ictx.rel
 
         compile_insert_else_body_failure_check(on_conflict, ctx=ictx)

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -2660,8 +2660,11 @@ def get_or_create_union_pointer(
             comp_set.add(c)
     components = list(comp_set)
 
-    if (any(p.is_pure_computable(schema) for p in components) and
-            len(components) > 1):
+    if (
+        any(p.is_pure_computable(schema) for p in components)
+        and len(components) > 1
+        and ptrname.name not in ('__tname__', '__tid__')
+    ):
         p = components[0]
         raise errors.SchemaError(
             f'it is illegal to create a type union that causes '

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2493,9 +2493,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             [27],
         )
 
-    @test.xfail('''
-        We fail to generate a proper shape output
-    ''')
     async def test_edgeql_scope_computables_11c(self):
         # ... make sure we output legit objects in this case
         await self.assert_query_result(
@@ -2897,6 +2894,25 @@ class TestEdgeQLScope(tb.QueryTestCase):
                     cards := .deck {
                         name,
                         multi tag := AliasedFriends.name ++ " - " ++ .name,
+                    }
+                } FILTER .name = 'Alice'),
+                SELECT _ := A.cards.tag ORDER BY _;
+            """,
+            [
+                "Alice - Bog monster",
+                "Alice - Dragon",
+                "Alice - Giant turtle",
+                "Alice - Imp"
+            ]
+        )
+
+        await self.assert_query_result(
+            """
+                WITH A := (SELECT AliasedFriends {
+                    cards := .deck {
+                        name,
+                        multi tag := (
+                            SELECT _ := AliasedFriends.name ++ " - " ++ .name),
                     }
                 } FILTER .name = 'Alice'),
                 SELECT _ := A.cards.tag ORDER BY _;


### PR DESCRIPTION
This eliminates the temporary scope mechanisms, fixes some
materialization issues, and eliminates double-compilation in many
simple cases.

Fixes #2928.