### PR TITLE
edb cli: add `--host` param to `edgedb instance link`

### DIFF
--- a/edb/tools/cli.py
+++ b/edb/tools/cli.py
@@ -53,6 +53,7 @@ def cli(args: list[str]):
             "edb.cli",
             "instance",
             "link",
+            "--host=localhost",
             "--non-interactive",
             "--trust-tls-cert",
             "--overwrite",


### PR DESCRIPTION
This is needed because otherwise CLI tool has unititialized connection
arguments.