### PR TITLE
More fine-grained tracking of pointer overlays

### DIFF
--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -511,6 +511,7 @@ def ptrref_from_ptrcls(  # NoQA: F811
             assert isinstance(source, s_types.Type)
             source_ref = type_to_typeref(schema,
                                          source,
+                                         include_ancestors=True,
                                          cache=typeref_cache)
         else:
             source_ref = source

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -179,7 +179,7 @@ class CompilerContextLevel(compiler.ContextLevel):
     ptr_rel_overlays: DefaultDict[
         Optional[irast.MutatingStmt],
         DefaultDict[
-            str,
+            Tuple[uuid.UUID, str],
             List[
                 Tuple[
                     str,

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1703,7 +1703,7 @@ def process_link_update(
         # context to ensure that references to the link in the result
         # of this DML statement yield the expected results.
         relctx.add_ptr_rel_overlay(
-            ptrref, 'except', delcte, path_id=path_id,
+            mptrref, 'except', delcte, path_id=path_id,
             dml_stmts=ctx.dml_stmt_stack, ctx=ctx)
         toplevel.append_cte(delcte)
     else:
@@ -1875,12 +1875,12 @@ def process_link_update(
         # based filter to filter out links that were already present
         # and have been re-added.
         relctx.add_ptr_rel_overlay(
-            ptrref, 'filter', updcte, dml_stmts=ctx.dml_stmt_stack,
+            mptrref, 'filter', updcte, dml_stmts=ctx.dml_stmt_stack,
             path_id=path_id.ptr_path(),
             ctx=ctx)
 
     relctx.add_ptr_rel_overlay(
-        ptrref, 'union', updcte, dml_stmts=ctx.dml_stmt_stack,
+        mptrref, 'union', updcte, dml_stmts=ctx.dml_stmt_stack,
         path_id=path_id.ptr_path(),
         ctx=ctx)
 


### PR DESCRIPTION
Instead of just tracking them by name, track source/name pairs. This
prevents us from trying to access non-existent columns on overlays.

Fixes #2953.