### PR TITLE
Enable compile-time multiplicity enforcement for computed links

### DIFF
--- a/docs/stdlib/set.rst
+++ b/docs/stdlib/set.rst
@@ -32,6 +32,9 @@ Set
     * - :eql:op:`anytype [IS type] <ISINTERSECT>`
       - :eql:op-desc:`ISINTERSECT`
 
+    * - :eql:func:`assert_distinct`
+      - :eql:func-desc:`assert_distinct`
+
     * - :eql:func:`assert_single`
       - :eql:func-desc:`assert_single`
 
@@ -276,6 +279,39 @@ Set
         # With the use of type intersection it's possible to refer to
         # specific property of Issue now:
         SELECT User.<owner[IS Issue].title;
+
+
+----------
+
+
+.. eql:function:: std::assert_distinct(s: SET OF anytype) -> SET OF anytype
+
+    :index: multiplicity uniqueness
+
+    Check that the input set contains only unique elements, i.e a *proper set*.
+
+    If the input set contains duplicate elements, ``assert_distinct`` raises a
+    ``ConstraintViolationError``.  This function is useful
+    as a runtime distinctness assertion in queries and computed
+    expressions that should always return proper sets, but where static
+    multiplicity inference is not capable enough or outright impossible.
+
+    .. code-block:: edgeql-repl
+
+        db> SELECT assert_distinct(
+        ...   (SELECT User FILTER .groups.name = "Administrators")
+        ...   UNION
+        ...   (SELECT User FILTER .groups.name = "Guests")
+        ... )
+        {default::User {id: ...}}
+
+        db> SELECT assert_distinct(
+        ...   (SELECT User FILTER .groups.name = "Users")
+        ...   UNION
+        ...   (SELECT User FILTER .groups.name = "Guests")
+        ... )
+        ERROR: ConstraintViolationError: assert_distinct violation: expression
+               returned a set with duplicate elements.
 
 
 ----------

--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -38,7 +38,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_09_03_00_00
+EDGEDB_CATALOG_VERSION = 2021_09_22_00_00
 
 
 class MetadataError(Exception):

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -463,7 +463,7 @@ def compile_insert_unless_conflict_on(
     ds = {ptr.get_shortname(schema).name: (ptr, field_constrs)
           for ptr in ptrs}
     select_ir, always_check, from_anc = compile_conflict_select(
-        stmt, typ, constrs=ds, obj_constrs=obj_constrs,
+        stmt, typ, constrs=ds, obj_constrs=list(obj_constrs),
         parser_context=stmt.context, ctx=ctx)
 
     # Compile an else branch

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -161,11 +161,6 @@ class Environment:
         InferredVolatility]
     """A dictionary of expressions and their inferred volatility."""
 
-    inferred_multiplicity: Dict[
-        irast.Base,
-        qltypes.Multiplicity]
-    """A dictionary of expressions and their inferred multiplicity."""
-
     view_shapes: Dict[
         Union[s_types.Type, s_pointers.PointerLike],
         List[Tuple[s_pointers.Pointer, qlast.ShapeOp]]
@@ -253,7 +248,6 @@ class Environment:
         self.type_origins = {}
         self.inferred_types = {}
         self.inferred_volatility = {}
-        self.inferred_multiplicity = {}
         self.view_shapes = collections.defaultdict(list)
         self.view_shapes_metadata = collections.defaultdict(
             irast.ViewShapeMetadata)

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -660,6 +660,16 @@ def __infer_func_call(
         _, arg_upper = arg_card
         return _bounds_to_card(CardinalityBound.ONE, max(arg_upper))
 
+    elif ir.func_shortname == sn.QualName('std', 'assert_distinct'):
+        arg_cards = []
+
+        for arg in ir.args:
+            arg.cardinality = infer_cardinality(
+                arg.expr, scope_tree=scope_tree, ctx=ctx)
+            arg_cards.append(arg.cardinality)
+
+        return max_cardinality(arg_cards)
+
     elif ir.preserves_optionality:
         # This is a generic aggregate function which preserves the
         # optionality of its generic argument.  For simplicity we

--- a/edb/edgeql/compiler/inference/context.py
+++ b/edb/edgeql/compiler/inference/context.py
@@ -20,22 +20,41 @@
 from __future__ import annotations
 from typing import *
 
+import dataclasses
+
 from edb.ir import ast as irast
 from edb.edgeql import qltypes
 
 from .. import context
 
 
+@dataclasses.dataclass(frozen=True, eq=False)
+class MultiplicityInfo:
+    own: qltypes.Multiplicity
+    disjoint_union: bool = False
+
+    def is_one(self) -> bool:
+        return self.own.is_one()
+
+    def is_many(self) -> bool:
+        return self.own.is_many()
+
+    def is_zero(self) -> bool:
+        return self.own.is_zero()
+
+
 class InfCtx(NamedTuple):
     env: context.Environment
     inferred_cardinality: Dict[
         Tuple[irast.Base, irast.ScopeTreeNode],
-        qltypes.Cardinality]
+        qltypes.Cardinality,
+    ]
     inferred_multiplicity: Dict[
         Tuple[irast.Base, irast.ScopeTreeNode],
-        qltypes.Multiplicity]
+        MultiplicityInfo,
+    ]
     singletons: Collection[irast.PathId]
-    bindings: Dict[irast.PathId, irast.ScopeTreeNode]
+    distinct_iterators: Set[irast.PathId]
 
 
 def make_ctx(env: context.Environment) -> InfCtx:
@@ -44,5 +63,5 @@ def make_ctx(env: context.Environment) -> InfCtx:
         inferred_cardinality={},
         inferred_multiplicity={},
         singletons=frozenset(env.singletons),
-        bindings={},
+        distinct_iterators=set(),
     )

--- a/edb/edgeql/compiler/inference/context.py
+++ b/edb/edgeql/compiler/inference/context.py
@@ -30,7 +30,12 @@ from .. import context
 
 @dataclasses.dataclass(frozen=True, eq=False)
 class MultiplicityInfo:
+    """Extended multiplicity descriptor"""
+
+    #: Actual multiplicity number
     own: qltypes.Multiplicity
+    #: Whether this multiplicity descriptor describes
+    #: part of a disjoint set.
     disjoint_union: bool = False
 
     def is_one(self) -> bool:

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -306,17 +306,16 @@ def __infer_func_call(
     scope_tree: irast.ScopeTreeNode,
     ctx: inf_ctx.InfCtx,
 ) -> inf_ctx.MultiplicityInfo:
-    # If the function returns a set (for any reason), all bets are off
-    # and the maximum multiplicity cannot be inferred.
-    card = cardinality.infer_cardinality(
-        ir, scope_tree=scope_tree, ctx=ctx)
+    card = cardinality.infer_cardinality(ir, scope_tree=scope_tree, ctx=ctx)
+    args_mult = []
+    for arg in ir.args:
+        arg_mult = infer_multiplicity(arg.expr, scope_tree=scope_tree, ctx=ctx)
+        args_mult.append(arg_mult)
+        arg.multiplicity = arg_mult.own
 
-    args_mult = tuple(
-        infer_multiplicity(arg.expr, scope_tree=scope_tree, ctx=ctx)
-        for arg in ir.args
-    )
-
-    if card is not None and card.is_single():
+    if card.is_single():
+        return ONE
+    elif str(ir.func_shortname) == 'std::assert_distinct':
         return ONE
     elif str(ir.func_shortname) == 'std::assert_exists':
         return args_mult[0]
@@ -326,9 +325,11 @@ def __infer_func_call(
         # distinct.
         return ContainerMultiplicityInfo(
             own=qltypes.Multiplicity.ONE,
-            elements=(ONE,) + args_mult,
+            elements=(ONE,) + tuple(args_mult),
         )
     else:
+        # If the function returns a set (for any reason), all bets are off
+        # and the maximum multiplicity cannot be inferred.
         return MANY
 
 

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -27,44 +27,61 @@ multiplicity fields and performing multiplicity checks.
 from __future__ import annotations
 from typing import *
 
+import dataclasses
 import functools
+import itertools
 
 from edb import errors
 
 from edb.edgeql import qltypes
 
+from edb.schema import objtypes as s_objtypes
 from edb.schema import pointers as s_pointers
 
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
+from edb.ir import utils as irutils
 
 from . import cardinality
-from . import context as inference_context
+from . import context as inf_ctx
+from . import types as inf_types
+from . import utils as inf_utils
 
 
-ZERO = qltypes.Multiplicity.ZERO
-ONE = qltypes.Multiplicity.ONE
-MANY = qltypes.Multiplicity.MANY
+ZERO = inf_ctx.MultiplicityInfo(own=qltypes.Multiplicity.ZERO)
+ONE = inf_ctx.MultiplicityInfo(own=qltypes.Multiplicity.ONE)
+MANY = inf_ctx.MultiplicityInfo(own=qltypes.Multiplicity.MANY)
+DISTINCT_UNION = inf_ctx.MultiplicityInfo(
+    own=qltypes.Multiplicity.ONE,
+    disjoint_union=True,
+)
+
+
+@dataclasses.dataclass(frozen=True, eq=False)
+class ContainerMultiplicityInfo(inf_ctx.MultiplicityInfo):
+    elements: Tuple[inf_ctx.MultiplicityInfo, ...] = ()
 
 
 def _max_multiplicity(
-    args: Iterable[qltypes.Multiplicity]
-) -> qltypes.Multiplicity:
+    args: Iterable[inf_ctx.MultiplicityInfo]
+) -> inf_ctx.MultiplicityInfo:
     # Coincidentally, the lexical order of multiplicity is opposite of
     # order of multiplicity values.
-    arg_list = list(args)
+    arg_list = [a.own for a in args]
     if not arg_list:
-        return ZERO
+        max_mult = qltypes.Multiplicity.ZERO
     else:
-        return min(arg_list)
+        max_mult = min(arg_list)
+
+    return inf_ctx.MultiplicityInfo(own=max_mult)
 
 
 def _common_multiplicity(
     args: Iterable[irast.Base],
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     return _max_multiplicity(
         infer_multiplicity(a, scope_tree=scope_tree, ctx=ctx) for a in args)
 
@@ -74,8 +91,8 @@ def _infer_multiplicity(
     ir: irast.Expr,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     # return MANY
     raise ValueError(f'infer_multiplicity: cannot handle {ir!r}')
 
@@ -85,8 +102,8 @@ def __infer_none(
     ir: None,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     # Here for debugging purposes.
     raise ValueError('invalid infer_multiplicity(None, schema) call')
 
@@ -96,10 +113,46 @@ def __infer_statement(
     ir: irast.Statement,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     return infer_multiplicity(
         ir.expr, scope_tree=scope_tree, ctx=ctx)
+
+
+@_infer_multiplicity.register
+def __infer_config_insert(
+    ir: irast.ConfigInsert,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
+    return infer_multiplicity(
+        ir.expr, scope_tree=scope_tree, ctx=ctx)
+
+
+@_infer_multiplicity.register
+def __infer_config_set(
+    ir: irast.ConfigSet,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
+    return infer_multiplicity(
+        ir.expr, scope_tree=scope_tree, ctx=ctx)
+
+
+@_infer_multiplicity.register
+def __infer_config_reset(
+    ir: irast.ConfigReset,
+    *,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
+    if ir.selector:
+        return infer_multiplicity(
+            ir.selector, scope_tree=scope_tree, ctx=ctx)
+    else:
+        return ONE
 
 
 @_infer_multiplicity.register
@@ -107,8 +160,8 @@ def __infer_empty_set(
     ir: irast.EmptySet,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     return ZERO
 
 
@@ -117,8 +170,8 @@ def __infer_type_introspection(
     ir: irast.TypeIntrospection,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     # TODO: The result is always ONE, but we still want to actually
     # introspect the expression. Unfortunately, currently the
     # expression is not available at this stage.
@@ -134,10 +187,10 @@ def _infer_shape(
     *,
     is_mutation: bool=False,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
+    ctx: inf_ctx.InfCtx,
 ) -> None:
     for shape_set, _ in ir.shape:
-        new_scope = cardinality._get_set_scope(shape_set, scope_tree, ctx=ctx)
+        new_scope = inf_utils.get_set_scope(shape_set, scope_tree, ctx=ctx)
         if shape_set.expr and shape_set.rptr:
             expr_mult = infer_multiplicity(
                 shape_set.expr, scope_tree=new_scope, ctx=ctx)
@@ -164,8 +217,8 @@ def _infer_set(
     *,
     is_mutation: bool=False,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     result = _infer_set_inner(
         ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx)
     ctx.inferred_multiplicity[ir, scope_tree] = result
@@ -180,31 +233,40 @@ def _infer_set_inner(
     *,
     is_mutation: bool=False,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     rptr = ir.rptr
-    new_scope = cardinality._get_set_scope(ir, scope_tree, ctx=ctx)
+    new_scope = cardinality.inf_utils.get_set_scope(ir, scope_tree, ctx=ctx)
 
-    if rptr is not None:
-        # Validate the source
-        infer_multiplicity(rptr.source, scope_tree=new_scope, ctx=ctx)
-
-    if ir.expr:
+    if ir.expr is None:
+        expr_mult = None
+    else:
         expr_mult = infer_multiplicity(ir.expr, scope_tree=new_scope, ctx=ctx)
 
     if rptr is not None:
         rptrref = rptr.ptrref
+        src_mult = infer_multiplicity(
+            rptr.source, scope_tree=new_scope, ctx=ctx)
 
-        if isinstance(rptr.ptrref, irast.TupleIndirectionPointerRef):
-            # All bets are off for tuple elements.
-            return MANY
+        if isinstance(rptrref, irast.TupleIndirectionPointerRef):
+            if isinstance(src_mult, ContainerMultiplicityInfo):
+                idx = irtyputils.get_tuple_element_index(rptrref)
+                path_mult = src_mult.elements[idx]
+            else:
+                # All bets are off for tuple elements coming from
+                # opaque tuples.
+                path_mult = MANY
         elif not irtyputils.is_object(ir.typeref):
             # This is not an expression and is some kind of scalar, so
             # multiplicity cannot be guaranteed to be ONE (most scalar
             # expressions don't have an implicit requirement to be sets)
             # unless we also have an exclusive constraint.
-
-            if rptr is not None:
+            if (
+                expr_mult is not None
+                and inf_utils.find_visible(rptr.source, new_scope) is not None
+            ):
+                path_mult = expr_mult
+            else:
                 schema = ctx.env.schema
                 # We should only have some kind of path terminating in a
                 # property here.
@@ -212,22 +274,29 @@ def _infer_set_inner(
                 ptr = schema.get_by_id(rptrref.id, type=s_pointers.Pointer)
                 if ptr.is_exclusive(schema):
                     # Got an exclusive constraint
-                    return ONE
-
-            return MANY
-
+                    path_mult = ONE
+                else:
+                    path_mult = MANY
         else:
             # This is some kind of a link at the end of a path.
             # Therefore the target is a proper set.
-            return ONE
+            path_mult = ONE
 
-    elif ir.expr is not None:
-        return expr_mult
+    elif expr_mult is not None:
+        path_mult = expr_mult
 
     else:
         # Evidently this is not a pointer, expression, or a scalar.
         # This is an object type and therefore a proper set.
-        return ONE
+        path_mult = ONE
+
+    if (
+        not path_mult.is_many()
+        and irutils.get_path_root(ir).path_id in ctx.distinct_iterators
+    ):
+        path_mult = dataclasses.replace(path_mult, disjoint_union=True)
+
+    return path_mult
 
 
 @_infer_multiplicity.register
@@ -235,24 +304,30 @@ def __infer_func_call(
     ir: irast.FunctionCall,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     # If the function returns a set (for any reason), all bets are off
     # and the maximum multiplicity cannot be inferred.
     card = cardinality.infer_cardinality(
         ir, scope_tree=scope_tree, ctx=ctx)
 
-    # We still want to validate the multiplicity of the arguments, though.
-    for arg in ir.args:
+    args_mult = tuple(
         infer_multiplicity(arg.expr, scope_tree=scope_tree, ctx=ctx)
+        for arg in ir.args
+    )
 
     if card is not None and card.is_single():
         return ONE
+    elif str(ir.func_shortname) == 'std::assert_exists':
+        return args_mult[0]
     elif str(ir.func_shortname) == 'std::enumerate':
-        # Technically the output of enumerate is always of
-        # multiplicity ONE because it's a set of tuples with first
-        # elements being guaranteed to be distinct.
-        return ONE
+        # The output of enumerate is always of multiplicity ONE because
+        # it's a set of tuples with first elements being guaranteed to be
+        # distinct.
+        return ContainerMultiplicityInfo(
+            own=qltypes.Multiplicity.ONE,
+            elements=(ONE,) + args_mult,
+        )
     else:
         return MANY
 
@@ -262,8 +337,8 @@ def __infer_oper_call(
     ir: irast.OperatorCall,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     mult = []
     cards = []
     for arg in ir.args:
@@ -278,19 +353,50 @@ def __infer_oper_call(
 
     if op_name == 'std::UNION':
         # UNION will produce multiplicity MANY unless most or all of
-        # the elements multiplicity is ZERO (from an empty set).
+        # the elements multiplicity is ZERO (from an empty set), or
+        # all of the elements are sets of unrelated object types of
+        # multiplicity at most ONE, or if all elements have been
+        # proven to be disjoint (e.g. a UNION of INSERTs).
         result = ZERO
+
+        arg_type = inf_types.infer_type(ir.args[0].expr, env=ctx.env)
+        if isinstance(arg_type, s_objtypes.ObjectType):
+            types: List[s_objtypes.ObjectType] = [
+                inf_types.infer_type(arg.expr, env=ctx.env)  # type: ignore
+                for arg in ir.args
+            ]
+
+            lineages = [
+                (t,) + tuple(t.descendants(ctx.env.schema))
+                for t in types
+            ]
+            flattened = tuple(itertools.chain.from_iterable(lineages))
+            types_disjoint = len(flattened) == len(frozenset(flattened))
+        else:
+            types_disjoint = False
+
         for m in mult:
-            if m is ONE and result is ZERO:
-                result = m
-            elif m is ONE and result is not ZERO:
-                return MANY
-            elif m is MANY:
-                return MANY
+            if m.is_one():
+                if (
+                    result.is_zero()
+                    or types_disjoint
+                    or (result.disjoint_union and m.disjoint_union)
+                ):
+                    result = m
+                else:
+                    result = MANY
+                    break
+            elif m.is_many():
+                result = MANY
+                break
+            else:
+                # ZERO
+                pass
+
         return result
 
     elif op_name == 'std::DISTINCT':
-        if mult[0] is ZERO:
+        if mult[0] == ZERO:
             return ZERO
         else:
             return ONE
@@ -303,14 +409,15 @@ def __infer_oper_call(
             return _max_multiplicity((mult[0], mult[2]))
         else:
             return MANY
-
+    elif op_name == 'std::??':
+        return _max_multiplicity((mult[0], mult[1]))
     else:
         # The rest of the operators (other than UNION, DISTINCT, or
         # IF..ELSE). We can ignore the SET OF args because the results
         # are actually proportional to the element-wise args in our
         # operators.
         result = _max_multiplicity(mult)
-        if result is MANY:
+        if result == MANY:
             return result
 
         # Even when arguments are of multiplicity ONE, we cannot
@@ -329,8 +436,8 @@ def __infer_const(
     ir: irast.BaseConstant,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     return ONE
 
 
@@ -339,8 +446,8 @@ def __infer_param(
     ir: irast.Parameter,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     return ONE
 
 
@@ -349,8 +456,8 @@ def __infer_const_set(
     ir: irast.ConstantSet,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     if len(ir.elements) == len({el.value for el in ir.elements}):
         return ONE
     else:
@@ -362,8 +469,8 @@ def __infer_typecheckop(
     ir: irast.TypeCheckOp,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     # Unless this is a singleton, the multiplicity cannot be assumed to be ONE.
     card = cardinality.infer_cardinality(
         ir, scope_tree=scope_tree, ctx=ctx)
@@ -378,8 +485,8 @@ def __infer_typecast(
     ir: irast.TypeCast,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     return infer_multiplicity(
         ir.expr, scope_tree=scope_tree, ctx=ctx,
     )
@@ -389,22 +496,37 @@ def _infer_stmt_multiplicity(
     ir: irast.FilteredStmt,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
+    # WITH block bindings need to be validated, they don't have to
+    # have multiplicity ONE, but their sub-expressions must be valid.
+    for part in (ir.bindings or []):
+        infer_multiplicity(part, scope_tree=scope_tree, ctx=ctx)
+
+    subj = ir.subject if isinstance(ir, irast.MutatingStmt) else ir.result
     result = infer_multiplicity(
-        ir.subject if isinstance(ir, irast.MutatingStmt) else ir.result,
+        subj,
         scope_tree=scope_tree,
         ctx=ctx,
     )
 
-    # WITH block bindings need to be validated, they don't have to
-    # have multiplicity ONE, but their sub-expressions must be valid.
-    #
-    # Inferring how the FILTER clause affects multiplicity is in
-    # general impossible, but we still want to ensure that the FILTER
-    # expression has valid multiplicity.
-    for part in (ir.bindings or []) + ([ir.where] if ir.where else []):
-        infer_multiplicity(part, scope_tree=scope_tree, ctx=ctx)
+    if ir.where:
+        infer_multiplicity(ir.where, scope_tree=scope_tree, ctx=ctx)
+        filtered_ptrs = cardinality.extract_filters(
+            subj, ir.where, scope_tree, ctx)
+        for _, flt_expr in filtered_ptrs:
+            # Check if any of the singleton filter expressions in FILTER
+            # reference enclosing iterators with multiplicity ONE, and
+            # if so, indicate to the enclosing iterator that this UNION
+            # is guaranteed to be disjoint.
+            if (
+                (irutils.get_path_root(flt_expr).path_id
+                 in ctx.distinct_iterators)
+                and not infer_multiplicity(
+                    flt_expr, scope_tree=scope_tree, ctx=ctx
+                ).is_many()
+            ):
+                return DISTINCT_UNION
 
     return result
 
@@ -413,66 +535,28 @@ def _infer_for_multiplicity(
     ir: irast.SelectStmt,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
+    itset = ir.iterator_stmt
+    assert itset is not None
+    itexpr = itset.expr
+    assert itexpr is not None
+    itmult = infer_multiplicity(itset, scope_tree=scope_tree, ctx=ctx)
 
-    assert ir.iterator_stmt is not None
-    itexpr = ir.iterator_stmt.expr
+    if itmult != MANY:
+        ctx.distinct_iterators.add(itset.path_id)
+    result_mult = infer_multiplicity(ir.result, scope_tree=scope_tree, ctx=ctx)
 
-    if isinstance(ir.result.expr, irast.SelectStmt):
-        union = ir.result.expr
-        if (isinstance(union.where, irast.Set) and
-                isinstance(union.where.expr, irast.OperatorCall) and
-                str(union.where.expr.func_shortname) == 'std::='):
-
-            op = union.where.expr
-            left, right = (a.expr for a in op.args)
-
-            # The iterator set may be wrapped in an `enumerate`, this
-            # requires different handling.
-            has_enumerate = (
-                isinstance(itexpr, irast.SelectStmt) and
-                isinstance(itfn := itexpr.result.expr, irast.FunctionCall) and
-                str(itfn.func_shortname) == 'std::enumerate'
-            )
-
-            # First make sure that the cardinality of the FILTER
-            # expression is is no more than 1. Then make sure both
-            # operands are paths.
-            if union.where_card.is_single():
-                it = None
-                if left.rptr is not None:
-                    it = right
-                elif right.rptr is not None:
-                    it = left
-
-                if it is not None:
-                    if has_enumerate:
-                        assert isinstance(itfn, irast.FunctionCall)
-                        enumerate_mult = infer_multiplicity(
-                            itfn.args[0].expr, scope_tree=scope_tree, ctx=ctx,
-                        )
-                        if (
-                            enumerate_mult is ONE
-                            and it.rptr is not None
-                            and isinstance(
-                                it.rptr,
-                                irast.TupleIndirectionPointer
-                            )
-                            # Tuple comes from the iterator set
-                            and it.rptr.source.expr is itexpr
-                            # the indirection is accessing element 1
-                            and str(it.rptr.ptrref.name) == '__tuple__::1'
-                        ):
-                            return ONE
-                    elif (it.is_binding and it.expr is itexpr):
-                        return ONE
-
-    elif isinstance(ir.result.expr, irast.InsertStmt):
+    if isinstance(ir.result.expr, irast.InsertStmt):
         # A union of inserts always has multiplicity ONE
         return ONE
-
-    return MANY
+    elif itmult.is_many():
+        return MANY
+    else:
+        if result_mult.disjoint_union:
+            return result_mult
+        else:
+            return MANY
 
 
 @_infer_multiplicity.register
@@ -480,41 +564,25 @@ def __infer_select_stmt(
     ir: irast.SelectStmt,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
-    result = _infer_stmt_multiplicity(ir, scope_tree=scope_tree, ctx=ctx)
-    itmult = None
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
 
-    if ir.iterator_stmt:
-        # If this is a FOR, then there's a common pattern which can be
-        # detected and the multiplicity of it is ONE. Otherwise it
-        # cannot be reliably inferred.
-        #
-        # The pattern is: FOR x IN {<set of multiplicity ONE>} UNION
-        # (SELECT ... FILTER .prop = x) As long as the FILTER has just
-        # a single .prop = x expression, this is going to be a bunch
-        # of disjoint unions and the final multiplicity will be ONE.
-        itmult = infer_multiplicity(
-            ir.iterator_stmt, scope_tree=scope_tree, ctx=ctx,
+    if ir.iterator_stmt is not None:
+        return _infer_for_multiplicity(ir, scope_tree=scope_tree, ctx=ctx)
+    else:
+        stmt_mult = _infer_stmt_multiplicity(
+            ir, scope_tree=scope_tree, ctx=ctx)
+
+        clauses = (
+            [ir.limit, ir.offset]
+            + [sort.expr for sort in (ir.orderby or ())]
         )
 
-    # OFFSET, LIMIT and ORDER BY have already been validated to be
-    # singletons, but their sub-expressions (if any) still need to be
-    # validated.
-    for part in [ir.limit, ir.offset] + [
-            sort.expr for sort in (ir.orderby or ())]:
-        if part:
-            new_scope = cardinality._get_set_scope(part, scope_tree, ctx=ctx)
-            infer_multiplicity(part, scope_tree=new_scope, ctx=ctx)
+        for clause in filter(None, clauses):
+            new_scope = inf_utils.get_set_scope(clause, scope_tree, ctx=ctx)
+            infer_multiplicity(clause, scope_tree=new_scope, ctx=ctx)
 
-    if itmult is not None:
-        if itmult is ONE:
-            return _infer_for_multiplicity(
-                ir, scope_tree=scope_tree, ctx=ctx)
-
-        return MANY
-    else:
-        return result
+        return stmt_mult
 
 
 @_infer_multiplicity.register
@@ -522,14 +590,14 @@ def __infer_insert_stmt(
     ir: irast.InsertStmt,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     # INSERT will always return a proper set, but we still want to
     # process the sub-expressions.
     infer_multiplicity(
         ir.subject, is_mutation=True, scope_tree=scope_tree, ctx=ctx
     )
-    new_scope = cardinality._get_set_scope(ir.result, scope_tree, ctx=ctx)
+    new_scope = inf_utils.get_set_scope(ir.result, scope_tree, ctx=ctx)
     infer_multiplicity(
         ir.result, is_mutation=True, scope_tree=new_scope, ctx=ctx
     )
@@ -539,7 +607,7 @@ def __infer_insert_stmt(
             if part:
                 infer_multiplicity(part, scope_tree=scope_tree, ctx=ctx)
 
-    return ONE
+    return DISTINCT_UNION
 
 
 @_infer_multiplicity.register
@@ -547,8 +615,8 @@ def __infer_update_stmt(
     ir: irast.UpdateStmt,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     # Presumably UPDATE will always return a proper set, even if it's
     # fed something with higher multiplicity, but we still want to
     # process the expression being updated.
@@ -567,8 +635,8 @@ def __infer_delete_stmt(
     ir: irast.DeleteStmt,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     # Presumably DELETE will always return a proper set, even if it's
     # fed something with higher multiplicity, but we still want to
     # process the expression being deleted.
@@ -587,8 +655,8 @@ def __infer_group_stmt(
     ir: irast.GroupStmt,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     raise NotImplementedError
 
 
@@ -597,8 +665,8 @@ def __infer_slice(
     ir: irast.SliceIndirection,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     # Slice indirection multiplicity is guaranteed to be ONE as long
     # as the cardinality of this expression is at most one, otherwise
     # the results of index indirection can contain values with
@@ -616,8 +684,8 @@ def __infer_index(
     ir: irast.IndexIndirection,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     # Index indirection multiplicity is guaranteed to be ONE as long
     # as the cardinality of this expression is at most one, otherwise
     # the results of index indirection can contain values with
@@ -635,8 +703,8 @@ def __infer_array(
     ir: irast.Array,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
     return _common_multiplicity(ir.elements, scope_tree=scope_tree, ctx=ctx)
 
 
@@ -645,10 +713,15 @@ def __infer_tuple(
     ir: irast.Tuple,
     *,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
-    return _common_multiplicity(
-        [el.val for el in ir.elements], scope_tree=scope_tree, ctx=ctx
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
+    els = tuple(
+        infer_multiplicity(el.val, scope_tree=scope_tree, ctx=ctx)
+        for el in ir.elements
+    )
+    return ContainerMultiplicityInfo(
+        own=_max_multiplicity(els).own,
+        elements=els,
     )
 
 
@@ -657,8 +730,8 @@ def infer_multiplicity(
     *,
     is_mutation: bool=False,
     scope_tree: irast.ScopeTreeNode,
-    ctx: inference_context.InfCtx,
-) -> qltypes.Multiplicity:
+    ctx: inf_ctx.InfCtx,
+) -> inf_ctx.MultiplicityInfo:
 
     result = ctx.inferred_multiplicity.get((ir, scope_tree))
     if result is not None:
@@ -669,19 +742,21 @@ def infer_multiplicity(
     card = cardinality.infer_cardinality(
         ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx)
 
-    if isinstance(ir, irast.Set):
+    if isinstance(ir, irast.EmptySet):
+        result = ZERO
+    elif isinstance(ir, irast.Set):
         result = _infer_set(
             ir, is_mutation=is_mutation, scope_tree=scope_tree, ctx=ctx,
         )
     else:
         result = _infer_multiplicity(ir, scope_tree=scope_tree, ctx=ctx)
 
-    if card is not None and card.is_single():
+    if card is not None and card.is_single() and result.is_many():
         # We've validated multiplicity, so now we can just override it
         # safely.
         result = ONE
 
-    if result not in {ZERO, ONE, MANY}:
+    if not isinstance(result, inf_ctx.MultiplicityInfo):
         raise errors.QueryError(
             'could not determine the multiplicity of '
             'set produced by expression',

--- a/edb/edgeql/compiler/inference/utils.py
+++ b/edb/edgeql/compiler/inference/utils.py
@@ -1,0 +1,63 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2021-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Common utilities used in inferers."""
+
+
+from __future__ import annotations
+from typing import *
+
+from edb import errors
+from edb.ir import ast as irast
+
+from . import context as inf_ctx
+
+
+def get_set_scope(
+    ir_set: irast.Set,
+    scope_tree: irast.ScopeTreeNode,
+    ctx: inf_ctx.InfCtx,
+) -> irast.ScopeTreeNode:
+
+    if ir_set.path_scope_id:
+        new_scope = ctx.env.scope_tree_nodes.get(ir_set.path_scope_id)
+        if new_scope is None:
+            raise errors.InternalServerError(
+                f'dangling scope pointer to node with uid'
+                f':{ir_set.path_scope_id} in {ir_set!r}'
+            )
+    else:
+        new_scope = scope_tree
+
+    return new_scope
+
+
+def find_visible(
+    ir: irast.Set,
+    scope_tree: irast.ScopeTreeNode,
+) -> Optional[irast.ScopeTreeNode]:
+    parent_branch = scope_tree.parent_branch
+    if parent_branch is not None:
+        if scope_tree.namespaces:
+            path_id = ir.path_id.strip_namespace(scope_tree.namespaces)
+        else:
+            path_id = ir.path_id
+
+        return parent_branch.find_visible(path_id)
+    else:
+        return None

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -75,10 +75,6 @@ class GlobalCompilerOptions:
     #: to contain DML in the top-level shape computables.
     allow_top_level_shape_dml: bool = False
 
-    #: This is meant to be a temporary flag, needed while we iron out
-    #: multiplicity issues.
-    validate_multiplicity: bool = False
-
 
 @dataclass
 class CompilerOptions(GlobalCompilerOptions):

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -90,6 +90,10 @@ def compile_SelectQuery(
                 isinstance(expr.result, qlast.UnaryOp)
                 and expr.result.op == 'DISTINCT'
             )
+            or (
+                isinstance(expr.result, qlast.FunctionCall)
+                and expr.result.func == 'assert_distinct'
+            )
         )
 
         if (

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -39,7 +39,6 @@ from edb.schema import sources as s_sources
 from edb.schema import types as s_types
 
 from edb.edgeql import ast as qlast
-from edb.edgeql import qltypes
 from edb.edgeql import parser as qlparser
 
 from edb.common.ast import visitor as ast_visitor
@@ -128,8 +127,9 @@ def fini_expression(
         scope_tree=ctx.path_scope,
         ctx=inf_ctx,
     )
-    multiplicity: Optional[qltypes.Multiplicity] = None
-    if ctx.env.options.validate_multiplicity:
+    if not ctx.env.options.validate_multiplicity:
+        multiplicity = None
+    else:
         multiplicity = inference.infer_multiplicity(
             ir,
             scope_tree=ctx.path_scope,
@@ -229,7 +229,7 @@ def fini_expression(
         scope_tree=ctx.env.path_scope,
         cardinality=cardinality,
         volatility=volatility,
-        multiplicity=multiplicity,
+        multiplicity=multiplicity.own if multiplicity is not None else None,
         stype=expr_type,
         view_shapes={
             src: [ptr for ptr, op in ptrs if op != qlast.ShapeOp.MATERIALIZE]

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -127,14 +127,12 @@ def fini_expression(
         scope_tree=ctx.path_scope,
         ctx=inf_ctx,
     )
-    if not ctx.env.options.validate_multiplicity:
-        multiplicity = None
-    else:
-        multiplicity = inference.infer_multiplicity(
-            ir,
-            scope_tree=ctx.path_scope,
-            ctx=inf_ctx,
-        )
+
+    multiplicity = inference.infer_multiplicity(
+        ir,
+        scope_tree=ctx.path_scope,
+        ctx=inf_ctx,
+    )
 
     # Fix up weak namespaces
     _rewrite_weak_namespaces(ir, ctx)

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -176,6 +176,16 @@ class Multiplicity(s_enum.StrEnum):
     ZERO = 'ZERO'  # This is valid for empty sets
     ONE = 'ONE'
     MANY = 'MANY'
+    UNKNOWN = 'UNKNOWN'
+
+    def is_one(self) -> bool:
+        return self is Multiplicity.ONE
+
+    def is_many(self) -> bool:
+        return self is Multiplicity.MANY
+
+    def is_zero(self) -> bool:
+        return self is Multiplicity.ZERO
 
 
 class DescribeLanguage(s_enum.StrEnum):

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -1474,7 +1474,17 @@ class GQLBaseType(metaclass=GQLTypeMeta):
 
     @property
     def is_array(self) -> bool:
-        return isinstance(self.edb_base, s_types.Array)
+        if self.edb_base is None:
+            return False
+        else:
+            return self.edb_base.is_array()
+
+    @property
+    def is_object_type(self) -> bool:
+        if self.edb_base is None:
+            return False
+        else:
+            return self.edb_base.is_object_type()
 
     @property
     def name(self) -> str:

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -659,12 +659,13 @@ class CallArg(ImmutableBase):
     """Call argument."""
 
     # cardinality fields need to be mutable for lazy cardinality inference.
-    __ast_mutable_fields__ = frozenset(('cardinality',))
+    __ast_mutable_fields__ = frozenset(('cardinality', 'multiplicity'))
 
     expr: Set
     """PathId for the __type__ link of object type arguments."""
     expr_type_path_id: typing.Optional[PathId] = None
     cardinality: qltypes.Cardinality = qltypes.Cardinality.UNKNOWN
+    multiplicity: qltypes.Multiplicity = qltypes.Multiplicity.UNKNOWN
 
 
 class Call(ImmutableExpr):

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -759,6 +759,18 @@ def is_computable_ptrref(ptrref: irast.BasePointerRef) -> bool:
     return ptrref.is_computable
 
 
+def get_tuple_element_index(ptrref: irast.TupleIndirectionPointerRef) -> int:
+    name = ptrref.name.name
+    if name.isdecimal() and name.isascii():
+        return int(name)
+    else:
+        for i, st in enumerate(ptrref.out_source.subtypes):
+            if st.element_name == name:
+                return i
+
+        raise AssertionError(f"element {name} is not found in tuple type")
+
+
 def type_contains(
     parent: irast.TypeRef,
     typeref: irast.TypeRef,

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -214,6 +214,13 @@ def unwrap_set(ir_set: irast.Set) -> irast.Set:
         return ir_set
 
 
+def get_path_root(ir_set: irast.Set) -> irast.Set:
+    result = ir_set
+    while result.rptr is not None:
+        result = result.rptr.source
+    return result
+
+
 def get_source_context_as_json(
     expr: irast.Base,
     exctype: Type[errors.EdgeDBError] = errors.InternalServerError,

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -48,6 +48,21 @@ std::assert_exists(input: SET OF anytype) -> SET OF anytype
 };
 
 
+# std::assert_distinct -- runtime multiplicity assertion
+# ------------------------------------------------------
+
+CREATE FUNCTION
+std::assert_distinct(input: SET OF anytype) -> SET OF anytype
+{
+    CREATE ANNOTATION std::description :=
+        "Check that the input set is a proper set, i.e. all elements
+         are unique";
+    SET volatility := 'Stable';
+    SET preserves_optionality := true;
+    USING SQL EXPRESSION;
+};
+
+
 # std::len
 # --------
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -357,6 +357,11 @@ def _get_set_rvar(
                 rvars = process_set_as_existence_assertion(
                     ir_set, stmt, ctx=ctx)
 
+            elif str(expr.func_shortname) == 'std::assert_distinct':
+                # Multiplicity assertion
+                rvars = process_set_as_multiplicity_assertion(
+                    ir_set, stmt, ctx=ctx)
+
             elif str(expr.func_shortname) == 'std::min' and expr.func_sql_expr:
                 # Generic std::min
                 rvars = process_set_as_std_min_max(ir_set, stmt, ctx=ctx)
@@ -2001,6 +2006,143 @@ def process_set_as_existence_assertion(
         )
 
     return new_stmt_set_rvar(ir_set, stmt, ctx=ctx)
+
+
+def process_set_as_multiplicity_assertion(
+    ir_set: irast.Set,
+    stmt: pgast.SelectStmt,
+    *,
+    ctx: context.CompilerContextLevel,
+) -> SetRVars:
+    """Implementation of std::assert_distinct"""
+    expr = ir_set.expr
+    assert isinstance(expr, irast.FunctionCall)
+
+    ir_arg = expr.args[0]
+    ir_arg_set = ir_arg.expr
+
+    # Generate a distinct set assertion as the following SQL:
+    #
+    #    SELECT
+    #        <target_set>,
+    #        (CASE WHEN
+    #            <target_set>
+    #            IS DISTINCT FROM
+    #            lag(<target_set>) OVER (ORDER BY <target_set>)
+    #        THEN <target_set>
+    #        ELSE edgedb.raise(ConstraintViolationError)) AS check_expr
+    #    FROM
+    #        (SELECT <target_set>, row_number() OVER () AS i) AS q
+    #    ORDER BY
+    #        q.i, check_expr
+    #
+    # NOTE: sorting over original row_number() is necessary to preserve
+    #       order, as assert_distinct() must be completely transparent for
+    #       compliant sets.
+    with ctx.subrel() as newctx:
+        with newctx.subrel() as subctx:
+            dispatch.compile(ir_arg_set, ctx=subctx)
+            arg_ref = pathctx.get_path_value_output(
+                subctx.rel, ir_arg_set.path_id, env=subctx.env)
+            arg_val = output.output_as_value(arg_ref, env=newctx.env)
+            sub_rvar = relctx.new_rel_rvar(ir_arg_set, subctx.rel, ctx=subctx)
+            relctx.include_rvar(
+                newctx.rel, sub_rvar, ir_arg_set.path_id,
+                aspects=('source', 'value'), ctx=subctx,
+            )
+            alias = ctx.env.aliases.get('i')
+            subctx.rel.target_list.append(
+                pgast.ResTarget(
+                    name=alias,
+                    val=pgast.FuncCall(
+                        name=('row_number',),
+                        args=[],
+                        over=pgast.WindowDef(),
+                    )
+                )
+            )
+
+        do_raise = pgast.FuncCall(
+            name=('edgedb', 'raise'),
+            args=[
+                pgast.TypeCast(
+                    arg=pgast.NullConstant(),
+                    type_name=pgast.TypeName(
+                        name=pg_types.pg_type_from_ir_typeref(
+                            ir_arg_set.typeref),
+                    ),
+                ),
+                pgast.StringConstant(val='cardinality_violation'),
+                pgast.NamedFuncArg(
+                    name='msg',
+                    val=pgast.StringConstant(
+                        val='assert_distinct violation: expression returned '
+                            'a set with duplicate elements',
+                    ),
+                ),
+                pgast.NamedFuncArg(
+                    name='constraint',
+                    val=pgast.StringConstant(val='std::assert_distinct'),
+                ),
+            ],
+        )
+
+        check_expr = pgast.CaseExpr(
+            args=[
+                pgast.CaseWhen(
+                    expr=astutils.new_binop(
+                        lexpr=arg_val,
+                        op='IS DISTINCT FROM',
+                        rexpr=pgast.FuncCall(
+                            name=('lag',),
+                            args=[arg_val],
+                            over=pgast.WindowDef(
+                                order_clause=[pgast.SortBy(node=arg_val)],
+                            ),
+                        ),
+                    ),
+                    result=arg_val,
+                ),
+            ],
+            defresult=do_raise,
+        )
+
+        alias2 = ctx.env.aliases.get('v')
+        newctx.rel.target_list.append(
+            pgast.ResTarget(
+                val=check_expr,
+                name=alias2,
+            )
+        )
+
+        pathctx.put_path_var(
+            newctx.rel,
+            ir_set.path_id,
+            check_expr,
+            aspect='value',
+            env=ctx.env,
+        )
+
+        if newctx.rel.sort_clause is None:
+            newctx.rel.sort_clause = []
+        newctx.rel.sort_clause.extend([
+            pgast.SortBy(
+                node=pgast.ColumnRef(name=[sub_rvar.alias.aliasname, alias]),
+            ),
+            pgast.SortBy(
+                node=pgast.ColumnRef(name=[alias2]),
+            ),
+        ])
+
+        pathctx.put_path_id_map(newctx.rel, ir_set.path_id, ir_arg_set.path_id)
+
+    aspects = ('value', 'source')
+
+    func_rvar = relctx.new_rel_rvar(ir_set, newctx.rel, ctx=ctx)
+    relctx.include_rvar(
+        stmt, func_rvar, ir_set.path_id, aspects=aspects, ctx=ctx)
+
+    return new_stmt_set_rvar(ir_set, stmt, aspects=aspects, ctx=ctx)
 
 
 def process_set_as_enumerate(

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -242,7 +242,7 @@ def _build_object_mutation_shape(
             # TODO: replace this hack by a generic implementation of
             # an ObjectKeyDict collection that allow associating objects
             # with arbitrary values (a transposed ObjectDict).
-            target_expr = f'''(
+            target_expr = f"""DISTINCT(
                 FOR v IN {{ json_array_unpack(<json>${var_n}) }}
                 UNION (
                     SELECT {target.get_name(schema)} {{
@@ -250,7 +250,7 @@ def _build_object_mutation_shape(
                     }}
                     FILTER .id = <uuid>v[0]
                 )
-            )'''
+            )"""
             args = props.get('args', [])
             target_value = []
             if v is not None:
@@ -297,7 +297,9 @@ def _build_object_mutation_shape(
                 elif is_ordered:
                     target_expr = f'''(
                         FOR v IN {{
-                            enumerate(<uuid>json_array_unpack(<json>${var_n}))
+                            enumerate(assert_distinct(
+                                <uuid>json_array_unpack(<json>${var_n})
+                            ))
                         }}
                         UNION (
                             SELECT (DETACHED {target.get_name(schema)}) {{

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -321,6 +321,12 @@ def static_interpret_backend_error(fields):
     ):
         return errors.CardinalityViolationError(err_details.message)
 
+    elif (
+        err_details.code == pgerrors.ERROR_CARDINALITY_VIOLATION
+        and err_details.constraint_name == 'std::assert_distinct'
+    ):
+        return errors.ConstraintViolationError(err_details.message)
+
     return errors.InternalServerError(err_details.message)
 
 

--- a/tests/schemas/updates.esdl
+++ b/tests/schemas/updates.esdl
@@ -34,7 +34,9 @@ type Tag {
 }
 
 type UpdateTest {
-    required property name -> str;
+    required property name -> str {
+        constraint exclusive;
+    }
     property comment -> str;
 
     # for testing singleton links

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -920,11 +920,11 @@ class TestInsert(tb.QueryTestCase):
             SELECT
             (INSERT Person {
                 name := "test",
-                notes := {
+                notes := assert_distinct({
                     (SELECT Note FILTER .name = "anote"),
                     (INSERT DerivedNote { name := "new note", note := "hi" }),
                     (UPDATE Note FILTER .name = "dnote" SET { note := "b" }),
-                }
+                })
             })
             { name, notes: {name, note} ORDER BY .name };
             ''',
@@ -953,11 +953,11 @@ class TestInsert(tb.QueryTestCase):
             SELECT
             (INSERT Person {
                 name := "test",
-                notes := {
+                notes := assert_distinct({
                     (SELECT Note FILTER .name = "anote"),
                     (INSERT DerivedNote { name := "new note", note := "hi" }),
                     (UPDATE Note FILTER .name = "dnote" SET { note := "b" }),
-                }
+                })
             })
             {
                 name,
@@ -1776,7 +1776,7 @@ class TestInsert(tb.QueryTestCase):
 
             INSERT InsertTest {
                 l2 := 99,
-                subordinates := (
+                subordinates := DISTINCT(
                     FOR x IN {('a', '1'), ('b', '2'), ('c', '3')} UNION (
                         SELECT Subordinate {@comment := x.0}
                         FILTER .name[-1] = x.1

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -764,3 +764,33 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         m: AT_MOST_ONE
         """
+
+    def test_edgeql_ir_card_inference_88(self):
+        """
+        SELECT User { m := assert_distinct(1) }
+% OK %
+        m: ONE
+        """
+
+    def test_edgeql_ir_card_inference_89(self):
+        """
+        SELECT User { m := assert_distinct(Card) }
+% OK %
+        m: MANY
+        """
+
+    def test_edgeql_ir_card_inference_90(self):
+        """
+        SELECT User { m := assert_distinct(assert_exists(Card)) }
+% OK %
+        m: AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_91(self):
+        """
+        SELECT User {
+            m := assert_distinct(assert_exists(assert_single(Card)))
+        }
+% OK %
+        m: ONE
+        """

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -669,6 +669,14 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         ONE
         """
 
+    def test_edgeql_ir_mult_inference_71(self):
+        """
+        FOR card IN {assert_distinct(Card UNION SpecialCard)}
+        UNION card
+% OK %
+        ONE
+        """
+
     @tb.must_fail(errors.QueryError,
                   r"possibly not a strict set.+computed bad_link",
                   line=3, col=13)

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -40,7 +40,6 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
             qltree,
             self.schema,
             options=compiler.CompilerOptions(
-                validate_multiplicity=True,
                 modaliases={None: 'default'},
             )
         )
@@ -678,7 +677,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         """
 
     @tb.must_fail(errors.QueryError,
-                  r"possibly not a strict set.+computed bad_link",
+                  r"possibly not a distinct set.+computed link 'bad_link'",
                   line=3, col=13)
     def test_edgeql_ir_mult_inference_error_01(self):
         """
@@ -689,7 +688,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         """
 
     @tb.must_fail(errors.QueryError,
-                  r"possibly not a strict set.+computed bad_link",
+                  r"possibly not a distinct set.+computed link 'bad_link'",
                   line=5, col=13)
     def test_edgeql_ir_mult_inference_error_02(self):
         """

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2461,15 +2461,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ],
         )
 
-    async def test_edgeql_scope_computables_10(self):
-        await self.assert_query_result(
-            r"""
-                WITH U := User { cards := (.deck UNION .deck) },
-                SELECT count(U.cards);
-            """,
-            [9],
-        )
-
     async def test_edgeql_scope_computables_11a(self):
         await self.assert_query_result(
             r"""

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -756,6 +756,21 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_select_computable_34(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            r"possibly not a distinct set returned by an expression for "
+            r"a computed link 'foo'",
+            _position=78,
+        ):
+            await self.con.query("""\
+                SELECT Issue{
+                    number,
+                    foo := .owner.todo UNION .owner.todo,
+                }
+                FILTER Issue.number = '1';
+            """)
+
     async def test_edgeql_select_match_01(self):
         await self.assert_query_result(
             r"""

--- a/tests/test_edgeql_tree.py
+++ b/tests/test_edgeql_tree.py
@@ -1015,7 +1015,7 @@ class TestTree(tb.QueryTestCase):
                         UPDATE (SELECT TP.parent)
                         SET {
                             children := (
-                                SELECT _ := {.children, T000}
+                                SELECT _ := assert_distinct({.children, T000})
                                 FILTER _ != TP
                             )
                         }
@@ -1023,7 +1023,7 @@ class TestTree(tb.QueryTestCase):
                 # update node '000'
                 UPDATE (SELECT _ := TPP.children FILTER _ = T000)
                 SET {
-                    children := {.children, TP}
+                    children := assert_distinct({.children, TP})
                 };
             """
         )


### PR DESCRIPTION
A computed link should be indistinguishable from a regular link in queries.
This means that just like regular links, a computed link
_must_ resolve to a distinct set.  After this, it is a compile-time error
to use any expression that could not be proved to have multiplicity of at
most 1.  Queries where static inference is impossible should use
`assert_distinct` or `DISTINCT` depending on whether duplicates are
expected.

Fixes: #117