### PR TITLE
Use an explicit extra dep group to install build deps in CI

### DIFF
--- a/.github/workflows.src/tests.inc.yml
+++ b/.github/workflows.src/tests.inc.yml
@@ -33,7 +33,7 @@
     - name: Install Python dependencies
       if: steps.venv-cache.outputs.cache-hit != 'true'
       run: |
-        _EDGEDB_CI_DOWNLOAD=1 pip download --use-feature=in-tree-build --dest=$VIRTUAL_ENV/deps .[test,docs]
+        pip download --use-feature=in-tree-build --dest=$VIRTUAL_ENV/deps .[test,docs,build]
         pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
 
     # Prepare environment variables and shared artifacts

--- a/.github/workflows/tests-ha.yml
+++ b/.github/workflows/tests-ha.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install Python dependencies
       if: steps.venv-cache.outputs.cache-hit != 'true'
       run: |
-        _EDGEDB_CI_DOWNLOAD=1 pip download --use-feature=in-tree-build --dest=$VIRTUAL_ENV/deps .[test,docs]
+        pip download --use-feature=in-tree-build --dest=$VIRTUAL_ENV/deps .[test,docs,build]
         pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
 
     # Prepare environment variables and shared artifacts

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install Python dependencies
       if: steps.venv-cache.outputs.cache-hit != 'true'
       run: |
-        _EDGEDB_CI_DOWNLOAD=1 pip download --use-feature=in-tree-build --dest=$VIRTUAL_ENV/deps .[test,docs]
+        pip download --use-feature=in-tree-build --dest=$VIRTUAL_ENV/deps .[test,docs,build]
         pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
 
     # Prepare environment variables and shared artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install Python dependencies
       if: steps.venv-cache.outputs.cache-hit != 'true'
       run: |
-        _EDGEDB_CI_DOWNLOAD=1 pip download --use-feature=in-tree-build --dest=$VIRTUAL_ENV/deps .[test,docs]
+        pip download --use-feature=in-tree-build --dest=$VIRTUAL_ENV/deps .[test,docs,build]
         pip install -U --no-index --find-links=$VIRTUAL_ENV/deps $VIRTUAL_ENV/deps/*
 
     # Prepare environment variables and shared artifacts

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ EDGEDBCLI_REPO = 'https://github.com/edgedb/edgedb-cli'
 EXTRA_DEPS = {
     'test': TEST_DEPS,
     'docs': DOCS_DEPS,
+    'build': BUILD_DEPS,
 }
 
 EXT_CFLAGS = ['-O2']
@@ -800,9 +801,6 @@ setuptools.setup(
             extra_link_args=EXT_LDFLAGS),
     ],
     rust_extensions=rust_extensions,
-    install_requires=(
-        # BUILD_DEPS are needed until pypa/pip#5865 is fixed
-        RUNTIME_DEPS + BUILD_DEPS if os.getenv('_EDGEDB_CI_DOWNLOAD') else []
-    ),
+    install_requires=RUNTIME_DEPS,
     extras_require=EXTRA_DEPS,
 )


### PR DESCRIPTION
Changes in #2956 broke package builds, mostly because of missing
parentheses in `install_requires`, but I also think putting build deps
into an extra group would be a cleaner workaround.