### PR TITLE
Shorten Unix socket paths

### DIFF
--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -354,6 +354,7 @@ class Cluster(BaseCluster):
     async def _new_pg_cluster(self) -> pgcluster.Cluster:
         return await pgcluster.get_local_pg_cluster(
             self._data_dir,
+            runstate_dir=self._runstate_dir,
             log_level=self._log_level,
         )
 

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -180,8 +180,7 @@ class Pool(amsg.ServerProtocol):
 
         self._runstate_dir = runstate_dir
 
-        self._poolsock_name = os.path.join(
-            self._runstate_dir, 'compilers.socket')
+        self._poolsock_name = os.path.join(self._runstate_dir, 'ipc')
 
         assert pool_size >= 1
         self._pool_size = pool_size

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -299,6 +299,7 @@ def _generate_cert(
 
 async def _get_local_pgcluster(
     args: srvargs.ServerConfig,
+    runstate_dir: pathlib.Path,
     tenant_id: str,
 ) -> Tuple[pgcluster.Cluster, srvargs.ServerConfig]:
     pg_max_connections = args.max_backend_connections
@@ -315,6 +316,7 @@ async def _get_local_pgcluster(
 
     cluster = await pgcluster.get_local_pg_cluster(
         args.data_dir,
+        runstate_dir=runstate_dir,
         # Plus two below to account for system connections.
         max_connections=pg_max_connections + 2,
         tenant_id=tenant_id,
@@ -418,7 +420,8 @@ async def run_server(
 
     with runstate_dir_mgr as runstate_dir:
         if args.data_dir:
-            cluster, args = await _get_local_pgcluster(args, tenant_id)
+            cluster, args = await _get_local_pgcluster(
+                args, runstate_dir, tenant_id)
         elif args.backend_dsn:
             cluster, args = await _get_remote_pgcluster(args, tenant_id)
         else:

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -127,8 +127,7 @@ def _ensure_runstate_dir(
 @contextlib.contextmanager
 def _internal_state_dir(runstate_dir):
     try:
-        with tempfile.TemporaryDirectory(prefix='edgedb-internal-',
-                                         dir=runstate_dir) as td:
+        with tempfile.TemporaryDirectory(prefix="", dir=runstate_dir) as td:
             yield td
     except PermissionError as ex:
         abort(f'cannot write to the runstate directory: '
@@ -410,16 +409,17 @@ async def run_server(
             specified_runstate_dir,
         )
 
-        with runstate_dir_mgr as runstate_dir, \
-                _internal_state_dir(runstate_dir) as internal_runstate_dir:
+        with (
+            runstate_dir_mgr as runstate_dir,
+            _internal_state_dir(runstate_dir) as internal_runstate_dir,
+        ):
 
             if cluster_status == 'stopped':
                 await cluster.start()
                 pg_cluster_started_by_us = True
 
             elif cluster_status != 'running':
-                abort('Could not start database cluster in %s',
-                      args.data_dir)
+                abort('Could not start database cluster in %s', args.data_dir)
 
             need_cluster_restart = await _init_cluster(cluster, args)
 

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -406,6 +406,7 @@ class Cluster(BaseCluster):
         data_dir: pathlib.Path,
         *,
         pg_config_path: str,
+        runstate_dir: Optional[pathlib.Path] = None,
         instance_params: Optional[BackendInstanceParams] = None,
         log_level: str = 'i',
     ):
@@ -414,6 +415,8 @@ class Cluster(BaseCluster):
             instance_params=instance_params,
         )
         self._data_dir = data_dir
+        self._runstate_dir = (
+            runstate_dir if runstate_dir is not None else data_dir)
         self._daemon_pid: Optional[int] = None
         self._daemon_process: Optional[asyncio.subprocess.Process] = None
         self._daemon_supervisor: Optional[supervisor.Supervisor] = None
@@ -530,7 +533,7 @@ class Cluster(BaseCluster):
         start_settings = {
             'listen_addresses': '',  # we use Unix sockets
             'unix_socket_permissions': '0700',
-            'unix_socket_directories': str(self._data_dir),
+            'unix_socket_directories': str(self._runstate_dir),
             # here we are not setting superuser_reserved_connections because
             # we're using superuser only now (so all connections available),
             # and we don't support reserving connections for now
@@ -876,6 +879,7 @@ class RemoteCluster(BaseCluster):
 async def get_local_pg_cluster(
     data_dir: pathlib.Path,
     *,
+    runstate_dir: Optional[pathlib.Path] = None,
     max_connections: Optional[int] = None,
     tenant_id: Optional[str] = None,
     log_level: Optional[str] = None,
@@ -893,6 +897,7 @@ async def get_local_pg_cluster(
         ).instance_params
     cluster = Cluster(
         data_dir=data_dir,
+        runstate_dir=runstate_dir,
         pg_config_path=str(pg_config),
         instance_params=instance_params,
         log_level=log_level,


### PR DESCRIPTION
* Place PostgreSQL socket in the runstate directory instead of data dir
* Save 29 bytes in compiler pool IPC socket path name