### PR TITLE
Always use bundled Postgres client binaries

### DIFF
--- a/tests/test_backend_connect.py
+++ b/tests/test_backend_connect.py
@@ -38,7 +38,6 @@ import urllib.parse
 import click
 from click.testing import CliRunner
 
-from edb import buildmeta
 from edb.server import args as edb_args
 from edb.server import bootstrap
 from edb.server import pgcluster
@@ -109,11 +108,11 @@ def get_default_args(version, **kwargs):
 class TempCluster(pgcluster.Cluster):
     def __init__(self, *,
                  data_dir_suffix=None, data_dir_prefix=None,
-                 data_dir_parent=None, pg_config_path=None):
+                 data_dir_parent=None):
         self._data_dir = tempfile.mkdtemp(suffix=data_dir_suffix,
                                           prefix=data_dir_prefix,
                                           dir=data_dir_parent)
-        super().__init__(self._data_dir, pg_config_path=pg_config_path)
+        super().__init__(self._data_dir)
 
 
 class ClusterTestCase(tb.TestCase):
@@ -134,8 +133,7 @@ class ClusterTestCase(tb.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        pg_config_path = buildmeta.get_pg_config_path()
-        cluster = cls.cluster = TempCluster(pg_config_path=str(pg_config_path))
+        cluster = cls.cluster = TempCluster()
         cls.loop.run_until_complete(cluster.lookup_postgres())
         cluster.set_connection_params(
             pgconnparams.ConnectionParameters(

--- a/tests/test_backend_ha.py
+++ b/tests/test_backend_ha.py
@@ -31,7 +31,6 @@ import urllib.parse
 import edgedb
 import httptools
 
-from edb import buildmeta
 from edb.testbase import server as tb
 from edb.server import pgcluster
 from edb.server.ha import base as ha_base
@@ -323,7 +322,7 @@ class StolonKeeper(ServerContext):
             "--pg-port",
             str(self.port),
             "--pg-bin-path",
-            self.pg_bin_dir,
+            str(self.pg_bin_dir),
         )
         try:
             await self.wait_for_healthy()
@@ -448,10 +447,7 @@ class AdaptiveHAProxy(ha_base.ClusterProtocol):
 
 @contextlib.asynccontextmanager
 async def stolon_setup(*, debug=False):
-    pg_config_path = str(buildmeta.get_pg_config_path())
-    pg_config = pgcluster.BaseCluster.find_pg_config(pg_config_path)
-    pg_config_data = await pgcluster.BaseCluster.run_pg_config(pg_config)
-    pg_bin_dir = pgcluster.BaseCluster.get_pg_bin_dir(pg_config_data)
+    pg_bin_dir = await pgcluster.get_pg_bin_dir()
 
     async with ConsulAgent() as consul:
         async with StolonSentinel(consul, debug=debug):


### PR DESCRIPTION
The internal pgcluster code is currently set up to allow using arbitrary
Postgres installations for client binaries (`pg_config`, `psql`, etc),
which isn't particularly useful because we always ship Postgres binaries
as part of EdgeDB even when a remote cluster is used.