### PR TITLE
Fix handling of `??` in schema singleton expressions

### DIFF
--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -331,8 +331,17 @@ def compile_OperatorCall(
                     result=dispatch.compile(if_expr, ctx=ctx))
             ],
             defresult=dispatch.compile(else_expr, ctx=ctx))
-
-    if expr.typemod is ql_ft.TypeModifier.SetOfType:
+    elif (str(expr.func_shortname) == 'std::??'
+            and expr.args[0].cardinality.is_single()
+            and expr.args[1].cardinality.is_single()):
+        l_expr, r_expr = (a.expr for a in expr.args)
+        return pgast.CoalesceExpr(
+            args=[
+                dispatch.compile(l_expr, ctx=ctx),
+                dispatch.compile(r_expr, ctx=ctx),
+            ],
+        )
+    elif expr.typemod is ql_ft.TypeModifier.SetOfType:
         raise RuntimeError(
             f'set returning operator {expr.func_shortname!r} is not supported '
             f'in simple expressions')

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -144,3 +144,11 @@ class TestIndexes(tb.DDLTestCase):
             await self.con.execute("""
                 ALTER TYPE User DROP INDEX ON (.name)
             """)
+
+    async def test_index_04(self):
+        await self.con.execute(r"""
+            CREATE TYPE User {
+                CREATE PROPERTY title -> str;
+                CREATE INDEX ON (.title ?? "N/A");
+            }
+        """)


### PR DESCRIPTION
`std::??` was overlooked in the singleton schema expression code path.

Fixes: #2975