### PR TITLE
Fix handling of release versions in `get_version_from_scm()`

### DIFF
--- a/.github/workflows.src/release.tpl.yml
+++ b/.github/workflows.src/release.tpl.yml
@@ -8,7 +8,6 @@ jobs:
   prep:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.whichver.outputs.version }}
       branch: ${{ steps.whichver.outputs.branch }}
     steps:
     - uses: actions/checkout@v2
@@ -17,19 +16,6 @@ jobs:
       shell: bash
       run: |
         branch=${GITHUB_REF#refs/heads/}
-        if [[ $branch != releases/* ]]; then
-          echo ::error::"${branch} is not a release branch."
-          exit 1
-        fi
-        commitish=$(git rev-parse --verify --quiet "${GITHUB_REF}" | cut -c1-9)
-        date=$(env TZ=UTC git show -s \
-               --format=%cd --date=format-local:%Y%m%d%H "$commitish")
-        ver=${branch#releases/}
-        ver+=+d${date}
-        ver+=.g${commitish}
-        ver+=.cv$(sed -n -r 's/EDGEDB_CATALOG_VERSION = ([0-9_]+)/\1/p' \
-                  edb/server/defines.py | sed 's/_//g')
-        echo ::set-output name=version::"${ver}"
         echo ::set-output name=branch::"${branch}"
       id: whichver
 
@@ -43,11 +29,11 @@ jobs:
       uses: edgedb/edgedb-pkg/integration/linux/build/<< tgt.name >>@master
       env:
         SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "<< tgt.platform >>"
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
 
     - uses: actions/upload-artifact@v2
       with:
@@ -106,7 +92,7 @@ jobs:
     - name: Build
       env:
         SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_VERSION: "${{ needs.prep.outputs.version }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "<< tgt.platform >>"
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ jobs:
   prep:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.whichver.outputs.version }}
       branch: ${{ steps.whichver.outputs.branch }}
     steps:
     - uses: actions/checkout@v2
@@ -17,15 +16,6 @@ jobs:
       shell: bash
       run: |
         branch=${GITHUB_REF#refs/heads/}
-        if [[ $branch != releases/* ]]; then
-          echo ::error::"${branch} is not a release branch."
-          exit 1
-        fi
-        ver=${branch#releases/}
-        ver+=+g$(git rev-parse --verify --quiet "${GITHUB_REF}" | cut -c1-9)
-        ver+=.cv$(sed -n -r 's/EDGEDB_CATALOG_VERSION = ([0-9_]+)/\1/p' \
-                   edb/server/defines.py | sed 's/_//g')
-        echo ::set-output name=version::"${ver}"
         echo ::set-output name=branch::"${branch}"
       id: whichver
 
@@ -39,11 +29,11 @@ jobs:
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-stretch@master
       env:
         SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "stretch"
         EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
 
     - uses: actions/upload-artifact@v2
       with:
@@ -59,11 +49,11 @@ jobs:
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-buster@master
       env:
         SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "buster"
         EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
 
     - uses: actions/upload-artifact@v2
       with:
@@ -79,11 +69,11 @@ jobs:
       uses: edgedb/edgedb-pkg/integration/linux/build/debian-bullseye@master
       env:
         SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "bullseye"
         EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
 
     - uses: actions/upload-artifact@v2
       with:
@@ -99,11 +89,11 @@ jobs:
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-xenial@master
       env:
         SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "xenial"
         EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
 
     - uses: actions/upload-artifact@v2
       with:
@@ -119,11 +109,11 @@ jobs:
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-bionic@master
       env:
         SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "bionic"
         EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
 
     - uses: actions/upload-artifact@v2
       with:
@@ -139,11 +129,11 @@ jobs:
       uses: edgedb/edgedb-pkg/integration/linux/build/ubuntu-focal@master
       env:
         SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "focal"
         EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
 
     - uses: actions/upload-artifact@v2
       with:
@@ -159,11 +149,11 @@ jobs:
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-7@master
       env:
         SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "centos"
         PKG_PLATFORM_VERSION: "7"
         EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
 
     - uses: actions/upload-artifact@v2
       with:
@@ -179,11 +169,11 @@ jobs:
       uses: edgedb/edgedb-pkg/integration/linux/build/centos-8@master
       env:
         SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_VERSION: "${{ needs.prep.outputs.version }}"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "centos"
         PKG_PLATFORM_VERSION: "8"
         EXTRA_OPTIMIZATIONS: "true"
+        BUILD_IS_RELEASE: "true"
 
     - uses: actions/upload-artifact@v2
       with:
@@ -242,7 +232,7 @@ jobs:
     - name: Build
       env:
         SRC_REF: "${{ needs.prep.outputs.branch }}"
-        PKG_VERSION: "${{ needs.prep.outputs.version }}"
+        BUILD_IS_RELEASE: "true"
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "macos"
         PKG_PLATFORM_VERSION: "x86_64"


### PR DESCRIPTION
Always generate a dev version unless the `EDGEDB_BUILD_IS_RELEASE`
environment variable is set and make sure release versions contain build
metadata.  This lets us have only one copy of the version generation
code and simplifies the release action.