### PR TITLE
backend pool: fix hanging concurrent acquire due to discard

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -411,7 +411,8 @@ class Server(ha_base.ClusterProtocol):
 
     def release_pgcon(self, dbname, conn, *, discard=False):
         if not conn.is_healthy():
-            logger.warning('Released an unhealthy pgcon; discard now.')
+            if not discard:
+                logger.warning('Released an unhealthy pgcon; discard now.')
             discard = True
         self._pg_pool.release(dbname, conn, discard=discard)
 

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -1417,7 +1417,7 @@ class _EdgeDBServerData(NamedTuple):
     server_data: Any
     tls_cert_file: str
 
-    async def connect(self, **kwargs: Any) -> edgedb.AsyncIOConnection:
+    def get_connect_args(self, **kwargs):
         conn_args = dict(
             user='edgedb',
             password=self.password,
@@ -1427,7 +1427,10 @@ class _EdgeDBServerData(NamedTuple):
         )
 
         conn_args.update(kwargs)
+        return conn_args
 
+    async def connect(self, **kwargs: Any) -> edgedb.AsyncIOConnection:
+        conn_args = self.get_connect_args(**kwargs)
         return await edgedb.async_connect(**conn_args)
 
 


### PR DESCRIPTION
When a frontend connection is broken, the server may cancel the pending
backend query and discard the pgcon. When at the same time the backend
pool is being acquired, we should create a new pgcon after discarding.

This fixes the unstable test_proto_connection_lost_cancel_query, and
also refines the warning of releasing an unhealthy pgcon.