### PR TITLE
Fix creation of required computed links

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3849,6 +3849,7 @@ class CreateLink(LinkMetaCommand, adapts=s_links.CreateLink):
             if (
                 link.get_cardinality(schema).is_multi()
                 and link.get_required(schema)
+                and not link.is_pure_computable(schema)
                 and not sets_required
             ):
                 self._alter_pointer_optionality(

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3956,6 +3956,7 @@ class AlterLinkLowerCardinality(
             if (
                 not pop.maybe_get_object_aux_data('from_alias')
                 and not self.scls.is_endpoint_pointer(schema)
+                and not self.scls.is_pure_computable(schema)
                 and orig_required != new_required
             ):
                 self._alter_pointer_optionality(
@@ -4218,6 +4219,7 @@ class CreateProperty(PropertyMetaCommand, adapts=s_props.CreateProperty):
             if (
                 prop.get_cardinality(schema).is_multi()
                 and prop.get_required(schema)
+                and not prop.is_pure_computable(schema)
                 and not sets_required
             ):
                 self._alter_pointer_optionality(
@@ -4320,6 +4322,7 @@ class AlterPropertyLowerCardinality(
             if (
                 not pop.maybe_get_object_aux_data('from_alias')
                 and not self.scls.is_endpoint_pointer(schema)
+                and not self.scls.is_pure_computable(schema)
                 and orig_required != new_required
             ):
                 self._alter_pointer_optionality(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -11765,6 +11765,20 @@ type default::Foo {
                     .<profile[IS User]
                 )));
             };
+            ALTER TYPE Profile {
+                ALTER LINK user SET OPTIONAL;
+            };
+        ''')
+
+    async def test_edgeql_ddl_required_computed_02(self):
+        await self.con.execute(r'''
+            CREATE TYPE Foo;
+            ALTER TYPE Foo {
+                CREATE PROPERTY z := {1, 2};
+            };
+            ALTER TYPE Foo {
+                ALTER PROPERTY z SET OPTIONAL;
+            };
         ''')
 
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -11751,6 +11751,22 @@ type default::Foo {
                 r'''CREATE TYPE MyStr EXTENDING str;''',
             )
 
+    async def test_edgeql_ddl_required_computed_01(self):
+        await self.con.execute(r'''
+            CREATE TYPE Profile;
+            CREATE TYPE User {
+                CREATE REQUIRED SINGLE LINK profile -> Profile;
+            };
+        ''')
+
+        await self.con.execute(r'''
+            ALTER TYPE Profile {
+                CREATE REQUIRED LINK user := (std::assert_exists((SELECT
+                    .<profile[IS User]
+                )));
+            };
+        ''')
+
 
 class TestConsecutiveMigrations(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
Don't generate actual data migration code for required computed links.