### PR TITLE
Fix determination of lower cardinality on union pointers

### DIFF
--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -2687,6 +2687,7 @@ def get_or_create_union_pointer(
             cardinality = qltypes.SchemaCardinality.Many
             break
 
+    required = all(component.get_required(schema) for component in components)
     metacls = type(components[0])
     default_base_name = metacls.get_default_base_name()
     assert default_base_name is not None
@@ -2706,6 +2707,7 @@ def get_or_create_union_pointer(
         attrs={
             'union_of': so.ObjectSet.create(schema, components),
             'cardinality': cardinality,
+            'required': required,
         },
     )
 

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -794,3 +794,14 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         m: ONE
         """
+
+    def test_edgeql_ir_card_inference_92(self):
+        """
+        WITH
+            inserted := (INSERT Award { name := <str>$0 }),
+            all := (inserted UNION (SELECT Award)),
+        SELECT DISTINCT (all { name })
+        ORDER BY .name ASC
+% OK %
+        name: ONE
+        """


### PR DESCRIPTION
Union pointers currently forget to properly sum up the lower cardinality
of the constituents leading to incorrect downstream inference.