### PR TITLE
Fix assert_distinct on tuples

### DIFF
--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -73,7 +73,7 @@ def _max_multiplicity(
     # order of multiplicity values.
     arg_list = [a.own for a in args]
     if not arg_list:
-        max_mult = qltypes.Multiplicity.ZERO
+        max_mult = qltypes.Multiplicity.ONE
     else:
         max_mult = min(arg_list)
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2095,8 +2095,8 @@ def process_set_as_multiplicity_assertion(
     with ctx.subrel() as newctx:
         with newctx.subrel() as subctx:
             dispatch.compile(ir_arg_set, ctx=subctx)
-            arg_ref = pathctx.get_path_value_output(
-                subctx.rel, ir_arg_set.path_id, env=subctx.env)
+            arg_ref = pathctx.get_path_output_and_fix_tuple(
+                subctx.rel, ir_arg_set.path_id, aspect='value', env=subctx.env)
             arg_val = output.output_as_value(arg_ref, env=newctx.env)
             sub_rvar = relctx.new_rel_rvar(ir_arg_set, subctx.rel, ctx=subctx)
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -5097,6 +5097,33 @@ aa \
                 );
             """)
 
+        await self.assert_query_result(
+            r"""
+                SELECT assert_distinct(
+                    {(0,), (1,)}
+                );
+            """,
+            {(0,), (1,)},
+        )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            "assert_distinct violation",
+        ):
+            await self.con.query("""
+                SELECT assert_distinct(
+                    {(0, 1, (0,)), (0, 1, (0,))}
+                );
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            "assert_distinct violation",
+        ):
+            await self.con.query("""
+                SELECT assert_distinct({(), ()});
+            """)
+
     async def test_edgeql_assert_distinct_no_op(self):
         await self.con.query("""
             SELECT assert_distinct(<int64>{})

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -699,3 +699,31 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
             name,
         }
         """
+
+    def test_edgeql_ir_mult_inference_72(self):
+        """
+        SELECT ()
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_73(self):
+        """
+        SELECT {(), ()}
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_mult_inference_74(self):
+        """
+        SELECT <array<str>>[]
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_mult_inference_75(self):
+        """
+        SELECT <str>{}
+% OK %
+        ZERO
+        """


### PR DESCRIPTION
We need to "fix" any tuples to be TupleVar instead of TupleVarBase.

Additionally, making it work for empty tuples requires fixing
multiplicity inference to infer ONE for the empty tuple instead of
ZERO.