### PR TITLE
Fix Managed Postgres CI

### DIFF
--- a/.github/aws-rds/main.tf
+++ b/.github/aws-rds/main.tf
@@ -1,9 +1,8 @@
 resource "aws_db_instance" "default" {
   allocated_storage = 10
   engine = "postgres"
-  engine_version = "12.5"
-  instance_class = "db.t3.small"
-//  instance_class = "db.m6g.large"
+  engine_version = "12.8"
+  instance_class = "db.m6g.large"
   name = "edbtest"
   username = "edbtest"
   password = var.password

--- a/.github/do-database/main.tf
+++ b/.github/do-database/main.tf
@@ -18,7 +18,7 @@ resource "digitalocean_database_cluster" "default" {
   name = "edbtest"
   engine     = "pg"
   version    = "12"
-  size       = "db-s-1vcpu-2gb"
+  size       = "db-s-4vcpu-8gb"
   region     = "nyc1"
   node_count = 1
 }

--- a/.github/do-database/outputs.tf
+++ b/.github/do-database/outputs.tf
@@ -12,6 +12,7 @@ output "db_instance_user" {
 
 output "db_instance_password" {
   value = digitalocean_database_cluster.default.password
+  sensitive = true
 }
 
 output "db_instance_database" {

--- a/.github/gcp-cloud-sql/main.tf
+++ b/.github/gcp-cloud-sql/main.tf
@@ -9,7 +9,7 @@ resource "google_sql_database_instance" "default" {
   deletion_protection = false
 
   settings {
-    tier = "db-g1-small"
+    tier = "db-custom-1-3840"
 
     ip_configuration {
       authorized_networks {

--- a/.github/workflows.src/tests-managed-pg.tpl.yml
+++ b/.github/workflows.src/tests-managed-pg.tpl.yml
@@ -84,7 +84,7 @@ jobs:
       env:
         EDGEDB_TEST_BACKEND_DSN: postgres://edbtest:${{ secrets.AWS_RDS_PASSWORD }}@${{ needs.setup-aws-rds.outputs.pghost }}/postgres
       run: |
-        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         edb test -j2 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
 
   teardown-aws-rds:
@@ -196,7 +196,7 @@ jobs:
       env:
         EDGEDB_TEST_BACKEND_DSN: postgres://${{ steps.pguser.outputs.stdout }}:${{ steps.pgpass.outputs.stdout }}@${{ steps.pghost.outputs.stdout }}:${{ steps.pgport.outputs.stdout }}/${{ steps.pgdatabase.outputs.stdout }}
       run: |
-        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         edb test -j2 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
 
   teardown-do-database:
@@ -271,7 +271,7 @@ jobs:
       env:
         EDGEDB_TEST_BACKEND_DSN: postgres://postgres:${{ secrets.AWS_RDS_PASSWORD }}@${{ needs.setup-gcp-cloud-sql.outputs.pghost }}/postgres
       run: |
-        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         edb test -j2 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
 
   teardown-gcp-cloud-sql:

--- a/.github/workflows.src/tests-managed-pg.tpl.yml
+++ b/.github/workflows.src/tests-managed-pg.tpl.yml
@@ -21,7 +21,7 @@ name: Tests on Managed PostgreSQL
 
 on:
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 3 * * 6"
   workflow_dispatch:
     inputs: {}
   push:

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -2,7 +2,7 @@ name: Tests on Managed PostgreSQL
 
 on:
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 3 * * 6"
   workflow_dispatch:
     inputs: {}
   push:

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -462,7 +462,7 @@ jobs:
       env:
         EDGEDB_TEST_BACKEND_DSN: postgres://edbtest:${{ secrets.AWS_RDS_PASSWORD }}@${{ needs.setup-aws-rds.outputs.pghost }}/postgres
       run: |
-        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         edb test -j2 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
 
   teardown-aws-rds:
@@ -706,7 +706,7 @@ jobs:
       env:
         EDGEDB_TEST_BACKEND_DSN: postgres://${{ steps.pguser.outputs.stdout }}:${{ steps.pgpass.outputs.stdout }}@${{ steps.pghost.outputs.stdout }}:${{ steps.pgport.outputs.stdout }}/${{ steps.pgdatabase.outputs.stdout }}
       run: |
-        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         edb test -j2 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
 
   teardown-do-database:
@@ -912,7 +912,7 @@ jobs:
       env:
         EDGEDB_TEST_BACKEND_DSN: postgres://postgres:${{ secrets.AWS_RDS_PASSWORD }}@${{ needs.setup-gcp-cloud-sql.outputs.pghost }}/postgres
       run: |
-        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         edb test -j2 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
 
   teardown-gcp-cloud-sql:


### PR DESCRIPTION
* Upgraded the instance type, because the Postgres processes keep getting killed on AWS and DO, and it was very slow on GCP.
* For the cost, the frequency is reduced to once a week.
* Also added `--testmode` in bootstrap to fix failing tests `test_server_proto_configure_describe_database_config` and `test_server_proto_configure_describe_system_config`.

Fixes #2291