### PR TITLE
Documentation: Replace computed property `name` with `full_name`

### DIFF
--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -608,7 +608,7 @@ Then create and run another migration:
 .. code-block:: bash
 
     $ edgedb migration create
-    did you create property 'name' of object type
+    did you create property 'full_name' of object type
     'default::Person'? [y,n,l,c,b,s,q,?]
     > y
     Created ./dbschema/migrations/00003.edgeql, id:

--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -590,7 +590,7 @@ properties of ``Person``. Let's update ``dbschema/default.esdl``:
             property last_name -> str;
 
             # add computable property "name"
-            property name :=
+            property full_name :=
                 .first_name ++ ' ' ++ .last_name
                 IF EXISTS .last_name
                 ELSE .first_name;


### PR DESCRIPTION
This fixes an error in the quick start documentation.

The computed property `name`  is referenced in the following queries by the name `full_name` which doesn't exist. This PR fixes this by renaming the computed property `name` to `full_name`.