### PR TITLE
Fix OPTIONAL interaction with shape subqueries

### DIFF
--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -529,7 +529,11 @@ class ScopeTreeNode:
 
                 # This path is already present in the tree, discard,
                 # but merge its OPTIONAL status, if any.
-                desc_fenced = descendant.fence is not node.fence or was_fenced
+                desc_fenced = (
+                    descendant.fence is not node.fence
+                    or was_fenced
+                    or visible.fence not in {self, self.parent_fence}
+                )
                 descendant.remove()
                 descendant._gravestone = visible
                 keep_optional = desc_optional or desc_fenced

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -273,8 +273,12 @@ def get_column(
     if nullable is None:
         if isinstance(rvar, pgast.RelRangeVar):
             # Range over a relation, we cannot infer nullability in
-            # this context, so assume it's true.
-            nullable = True
+            # this context, so assume it's true, unless we are looking
+            # at a colspec that says it is false
+            if isinstance(colspec, pgast.ColumnRef):
+                nullable = colspec.nullable
+            else:
+                nullable = True
 
         elif isinstance(rvar, pgast.RangeSubselect):
             col_idx = find_column_in_subselect_rvar(rvar, colname)

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -415,10 +415,20 @@ def _rewrite_config_insert(
         ir_set: irast.Set, *,
         ctx: context.CompilerContextLevel) -> irast.Set:
 
+    overwrite_query = pgast.SelectStmt()
+    id_expr = pgast.FuncCall(
+        name=('edgedbext', 'uuid_generate_v1mc',),
+        args=[],
+    )
+    pathctx.put_path_identity_var(
+        overwrite_query, ir_set.path_id, id_expr, force=True, env=ctx.env)
+    pathctx.put_path_value_var(
+        overwrite_query, ir_set.path_id, id_expr, force=True, env=ctx.env)
+
     relctx.add_type_rel_overlay(
         ir_set.typeref,
         'replace',
-        pgast.NullRelation(path_id=ir_set.path_id),
+        overwrite_query,
         path_id=ir_set.path_id,
         ctx=ctx,
     )

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1221,13 +1221,7 @@ def range_for_material_objtype(
         set_ops.append(('union', qry))
 
         for op, cte, cte_path_id in overlays:
-            rvar = pgast.RelRangeVar(
-                relation=cte,
-                typeref=typeref,
-                alias=pgast.Alias(
-                    aliasname=env.aliases.get(hint=cte.name or '')
-                )
-            )
+            rvar = rvar_for_rel(cte, typeref=typeref, ctx=ctx)
 
             qry = pgast.SelectStmt(
                 from_clause=[rvar],
@@ -1585,12 +1579,7 @@ def range_for_ptrref(
                     qry, path_id, table, env=ctx.env)
 
             for op, cte, cte_path_id in overlays:
-                rvar = pgast.RelRangeVar(
-                    relation=cte,
-                    alias=pgast.Alias(
-                        aliasname=ctx.env.aliases.get(cte.name or '')
-                    )
-                )
+                rvar = rvar_for_rel(cte, ctx=ctx)
 
                 qry = pgast.SelectStmt(
                     target_list=[

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -3088,3 +3088,36 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 {"name": "Dwarf", "user": "Dave"},
             ]
         )
+
+    async def test_edgeql_scope_tuple_correlate_01(self):
+        await self.assert_query_result(
+            """
+            SELECT _ := (User {friends: {name}}, User.friends.name ?? 'n/a')
+            ORDER BY _.1;
+            """,
+            [
+                [{"friends": [{"name": "Bob"}]}, "Bob"],
+                [{"friends": [{"name": "Bob"}]}, "Bob"],
+                [{"friends": [{"name": "Carol"}]}, "Carol"],
+                [{"friends": [{"name": "Dave"}]}, "Dave"],
+                [{"friends": []}, "n/a"],
+                [{"friends": []}, "n/a"]
+            ]
+        )
+
+    async def test_edgeql_scope_tuple_correlate_02(self):
+        await self.assert_query_result(
+            """
+            SELECT _ := (User {z := .friends {name}},
+                         User.friends.name ?? 'n/a')
+            ORDER BY _.1;
+            """,
+            [
+                [{"z": {"name": "Bob"}}, "Bob"],
+                [{"z": {"name": "Bob"}}, "Bob"],
+                [{"z": {"name": "Carol"}}, "Carol"],
+                [{"z": {"name": "Dave"}}, "Dave"],
+                [{"z": None}, "n/a"],
+                [{"z": None}, "n/a"]
+            ]
+        )


### PR DESCRIPTION
This requires adding an extra null test when compiling shapes, to
prevent emitting shapes containing null for each field, so I also
slightly improved the "nullable" logic to avoid inserting that test
pointlessly all the time.

Adding this check also meant that CONFIGURE INSERT needed to be
modified to not claim that NULL was its id, so I updated it to use a
real UUID, which also meant needing to tweak the overlay processing
to not use RelRangeVar directly.