### PR TITLE
Fix cardinality inference of shape subqueries correlated with optionals

### DIFF
--- a/edb/edgeql/compiler/inference/context.py
+++ b/edb/edgeql/compiler/inference/context.py
@@ -51,14 +51,14 @@ class MultiplicityInfo:
 class InfCtx(NamedTuple):
     env: context.Environment
     inferred_cardinality: Dict[
-        Tuple[irast.Base, irast.ScopeTreeNode],
+        Tuple[irast.Base, irast.ScopeTreeNode, FrozenSet[irast.PathId]],
         qltypes.Cardinality,
     ]
     inferred_multiplicity: Dict[
         Tuple[irast.Base, irast.ScopeTreeNode],
         MultiplicityInfo,
     ]
-    singletons: Collection[irast.PathId]
+    singletons: FrozenSet[irast.PathId]
     distinct_iterators: Set[irast.PathId]
 
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1213,6 +1213,7 @@ def _inline_type_computable(
     ptr_set = None
     if ptr is None:
         ql = qlast.ShapeElement(
+            required=True,
             expr=qlast.Path(
                 steps=[qlast.Ptr(
                     ptr=qlast.ObjectRef(name=compname),

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -805,3 +805,11 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         name: ONE
         """
+
+    def test_edgeql_ir_card_inference_93(self):
+        """
+        SELECT (User { friends: { required bs := .name } },
+                User.friends.name ?? 'a')
+% OK %
+        MANY
+        """


### PR DESCRIPTION
The main thing downstream of this is that it impacts how the values are
materialized, which was causing trouble with materialized shapes with
injected `__type__` after some further pending changes.