### PR TITLE
Add a preserves_upper_cardinality flag and make enumerate use it

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -38,7 +38,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_10_04_00_00
+EDGEDB_CATALOG_VERSION = 2021_10_07_00_00
 
 
 class MetadataError(Exception):

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -256,6 +256,8 @@ def compile_FunctionCall(
         sql_func_has_out_params=func.get_sql_func_has_out_params(env.schema),
         error_on_null_result=func.get_error_on_null_result(env.schema),
         preserves_optionality=func.get_preserves_optionality(env.schema),
+        preserves_upper_cardinality=func.get_preserves_upper_cardinality(
+            env.schema),
         params_typemods=params_typemods,
         context=expr.context,
         typeref=typegen.type_to_typeref(

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -734,6 +734,10 @@ class FunctionCall(Call):
     # argument(s).
     preserves_optionality: bool = False
 
+    # Whether the generic function preserves upper cardinality of the generic
+    # argument(s).
+    preserves_upper_cardinality: bool = False
+
     # Set to the type of the variadic parameter of the bound function
     # (or None, if the function has no variadic parameters.)
     variadic_param_type: typing.Optional[TypeRef] = None

--- a/edb/lib/std/20-genericfuncs.edgeql
+++ b/edb/lib/std/20-genericfuncs.edgeql
@@ -44,6 +44,7 @@ std::assert_exists(input: SET OF anytype) -> SET OF anytype
         "Check that the input set contains at least one element, raise
          CardinalityViolationError otherwise.";
     SET volatility := 'Stable';
+    SET preserves_upper_cardinality := true;
     USING SQL EXPRESSION;
 };
 
@@ -59,6 +60,7 @@ std::assert_distinct(input: SET OF anytype) -> SET OF anytype
          are unique";
     SET volatility := 'Stable';
     SET preserves_optionality := true;
+    SET preserves_upper_cardinality := true;
     USING SQL EXPRESSION;
 };
 
@@ -407,6 +409,7 @@ std::enumerate(
         'Return a set of tuples of the form `(index, element)`.';
     SET volatility := 'Immutable';
     SET preserves_optionality := true;
+    SET preserves_upper_cardinality := true;
     USING SQL EXPRESSION;
 };
 

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -813,3 +813,10 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         MANY
         """
+
+    def test_edgeql_ir_card_inference_94(self):
+        """
+        SELECT User { foo := enumerate(.name) }
+% OK %
+        foo: ONE
+        """


### PR DESCRIPTION
assert_distinct and assert_exists also pick it up, though they
already behaved that way.