### PR TITLE
Remove an incorrect and unnecessary materialization scope tree hack

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -931,19 +931,6 @@ def fini_stmt(
         result = setgen.new_set_from_set(
             result, context=irstmt.context, ctx=ctx)
 
-    if isinstance(irstmt, irast.Stmt) and irstmt.bindings:
-        # If a binding is in a branched-but-not-fenced subnode, we
-        # want to hoist it up to the current scope. This is important
-        # for materialization-related cases where WITH+tuple is being
-        # used like FOR.
-        # See test_edgeql_volatility_hack_0{3,4}b
-        # XXX: To be honest I do not 100% remember why this makes sense.
-        for binding in irstmt.bindings:
-            if node := ctx.path_scope.find_child(
-                    binding.path_id, in_branches=True):
-                node.remove()
-                ctx.path_scope.attach_subtree(node)
-
     if view is not None:
         parent_ctx.view_sets[view] = result
 

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -820,3 +820,14 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         foo: ONE
         """
+
+    def test_edgeql_ir_card_inference_95(self):
+        """
+        WITH x := User
+        SELECT (
+            WITH y := x
+            SELECT (y,).0
+        )
+% OK %
+        MANY
+        """


### PR DESCRIPTION
As part of the materialization work, I added a hack where we would
hoist a binding up out of a branched-but-not-fenced subnode. This
apparently fixed some materialization cases where WITH+tuple is being
used like FOR, but it also pretty clearly breaks cardinality inference
for other cases using WITH+tuple like FOR!

This hack doesn't seem to be needed anymore, though. Hopefully because
the *real* underlying cause was fixed.