### PR TITLE
Fix issues with binding and tuple correlations

### DIFF
--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -407,12 +407,8 @@ class FindPotentiallyVisibleVisitor(FindPathScopes):
         if node.path_id in self.to_skip:
             return set()
 
-        results = []
+        results = [{node}]
         results.append(self.visit(node.rptr))
-        # If the root of a path is potentially visible,
-        # say that the whole path is
-        if self.combine_field_results(results):
-            results.append({node})
         results.append(self.visit(node.shape))
         if not node.rptr:
             results.append(self.visit(node.expr))

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -199,7 +199,8 @@ def compile_materialized_exprs(
             for mat_id in mat_ids:
                 relctx.include_rvar(
                     query, mat_rvar, path_id=mat_id,
-                    flavor='packed', pull_namespace=False, ctx=matctx,
+                    flavor='packed', update_mask=False, pull_namespace=False,
+                    ctx=matctx,
                 )
 
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -181,6 +181,7 @@ def include_rvar(
         path_id: irast.PathId, *,
         overwrite_path_rvar: bool=False,
         pull_namespace: bool=True,
+        update_mask: bool=True,
         flavor: str='normal',
         aspects: Optional[Tuple[str, ...] | AbstractSet[str]]=None,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
@@ -214,6 +215,7 @@ def include_rvar(
         stmt, rvar=rvar, path_id=path_id,
         overwrite_path_rvar=overwrite_path_rvar,
         pull_namespace=pull_namespace,
+        update_mask=update_mask,
         flavor=flavor,
         aspects=aspects,
         ctx=ctx)
@@ -225,6 +227,7 @@ def include_specific_rvar(
         path_id: irast.PathId, *,
         overwrite_path_rvar: bool=False,
         pull_namespace: bool=True,
+        update_mask: bool=True,
         flavor: str='normal',
         aspects: Iterable[str]=('value',),
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
@@ -268,9 +271,7 @@ def include_specific_rvar(
             pathctx.put_path_rvar_if_not_exists(
                 stmt, path_id, rvar, flavor=flavor, aspect=aspect, env=ctx.env)
 
-    # Packed rvars don't necessarily have anything to do with the
-    # current scope, so we don't set up path_id_mask based on them.
-    if flavor != 'packed':
+    if update_mask:
         scopes = [ctx.scope_tree]
         parent_scope = ctx.scope_tree.parent
         if parent_scope is not None:


### PR DESCRIPTION
Place tuple elements in separate subrels so they have seperate path
remapping, and adjust materialization path finding to not skip
extensions of the ignored path.

Fixes #3001.