### PR TITLE
Add some utilities to make edgeql generation in the compiler easier

### DIFF
--- a/edb/edgeql/compiler/astutils.py
+++ b/edb/edgeql/compiler/astutils.py
@@ -96,3 +96,12 @@ def is_nontrivial_shape_element(shape_el: qlast.ShapeElement) -> bool:
             any(is_nontrivial_shape_element(el) for el in shape_el.elements)
         )
     )
+
+
+def extend_path(expr: qlast.Expr, field: str) -> qlast.Path:
+    return qlast.Path(
+        steps=[
+            expr,
+            qlast.Ptr(ptr=qlast.ObjectRef(name=field)),
+        ],
+    )

--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -39,6 +39,7 @@ from edb.schema import types as s_types
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes as ft
 
+from . import astutils
 from . import context
 from . import dispatch
 from . import pathctx
@@ -399,8 +400,7 @@ def _cast_json_to_tuple(
 
     with ctx.new() as subctx:
         subctx.anchors = subctx.anchors.copy()
-        source_alias = subctx.aliases.get('a')
-        subctx.anchors[source_alias] = ir_set
+        source_path = subctx.create_anchor(ir_set, 'a')
 
         # TODO: try using jsonb_to_record instead of a bunch of
         # json_get calls and see if that is faster.
@@ -409,7 +409,7 @@ def _cast_json_to_tuple(
             val_e = qlast.FunctionCall(
                 func=('__std__', 'json_get'),
                 args=[
-                    qlast.Path(steps=[qlast.ObjectRef(name=source_alias)]),
+                    source_path,
                     qlast.StringConstant(value=new_el_name),
                 ],
             )
@@ -550,16 +550,11 @@ def _cast_array(
 
         with ctx.new() as subctx:
             subctx.anchors = subctx.anchors.copy()
-            source_alias = subctx.aliases.get('a')
-            subctx.anchors[source_alias] = ir_set
+            source_path = subctx.create_anchor(ir_set, 'a')
 
             unpacked = qlast.FunctionCall(
                 func=('__std__', 'array_unpack'),
-                args=[
-                    qlast.Path(
-                        steps=[qlast.ObjectRef(name=source_alias)],
-                    ),
-                ],
+                args=[source_path],
             )
 
             enumerated = dispatch.compile(
@@ -570,27 +565,14 @@ def _cast_array(
                 ctx=subctx,
             )
 
-            enumerated_alias = subctx.aliases.get('e')
-            subctx.anchors[enumerated_alias] = enumerated
-            enumerated_ref = qlast.Path(
-                steps=[qlast.ObjectRef(name=enumerated_alias)],
-            )
+            enumerated_ref = subctx.create_anchor(enumerated, 'e')
 
             elements = qlast.FunctionCall(
                 func=('__std__', 'array_agg'),
                 args=[
                     qlast.SelectQuery(
                         result=qlast.TypeCast(
-                            expr=qlast.Path(
-                                steps=[
-                                    enumerated_ref,
-                                    qlast.Ptr(
-                                        ptr=qlast.ObjectRef(
-                                            name='1',
-                                        ),
-                                    ),
-                                ],
-                            ),
+                            expr=astutils.extend_path(enumerated_ref, '1'),
                             type=typegen.type_to_ql_typeref(
                                 el_type,
                                 ctx=subctx,
@@ -599,16 +581,7 @@ def _cast_array(
                         ),
                         orderby=[
                             qlast.SortExpr(
-                                path=qlast.Path(
-                                    steps=[
-                                        enumerated_ref,
-                                        qlast.Ptr(
-                                            ptr=qlast.ObjectRef(
-                                                name='0',
-                                            ),
-                                        ),
-                                    ],
-                                ),
+                                path=astutils.extend_path(enumerated_ref, '0'),
                                 direction=qlast.SortOrder.Asc,
                             ),
                         ],

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -93,10 +93,7 @@ def _compile_conflict_select(
             ptr = subject_typ.getptr(ctx.env.schema, s_name.UnqualName(p))
             val = setgen.extend_path(fake_dml_set, ptr, ctx=ctx)
 
-            source_alias = ctx.aliases.get(p)
-            ctx.anchors[source_alias] = val
-            ptr_anchors[p] = (
-                qlast.Path(steps=[qlast.ObjectRef(name=source_alias)]))
+            ptr_anchors[p] = ctx.create_anchor(val, p)
 
     # Find the IR corresponding to the fields we care about and
     # produce anchors for them
@@ -125,10 +122,8 @@ def _compile_conflict_select(
 
             # FIXME: The wrong thing will definitely happen if there are
             # volatile entries here
-            source_alias = ctx.aliases.get(name)
-            ctx.anchors[source_alias] = setgen.ensure_set(elem.expr, ctx=ctx)
-            ptr_anchors[name] = (
-                qlast.Path(steps=[qlast.ObjectRef(name=source_alias)]))
+            ptr_anchors[name] = ctx.create_anchor(
+                setgen.ensure_set(elem.expr, ctx=ctx), name)
 
     if for_inheritance and not ptrs_in_shape:
         return None

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -712,6 +712,13 @@ class ContextLevel(compiler.ContextLevel):
     def detached(self) -> compiler.CompilerContextManager[ContextLevel]:
         return self.new(ContextSwitchMode.DETACHED)
 
+    def create_anchor(self, ir: irast.Set, name: str='v') -> qlast.Path:
+        alias = self.aliases.get(name)
+        self.anchors[alias] = ir
+        return qlast.Path(
+            steps=[qlast.ObjectRef(name=alias)],
+        )
+
 
 class CompilerContext(compiler.CompilerContext[ContextLevel]):
     ContextLevelClass = ContextLevel

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -788,17 +788,15 @@ def _normalize_view_ptr_expr(
                         expr=compexpr,
                     ))
                     ptr_target = base_target
-
                     # We also need to compile the cast to IR.
-                    source_alias = ctx.aliases.get('a')
-                    cast_qlexpr = astutils.ensure_qlstmt(qlast.TypeCast(
-                        type=typegen.type_to_ql_typeref(base_target, ctx=ctx),
-                        expr=qlast.Path(
-                            steps=[qlast.ObjectRef(name=source_alias)]),
-                    ))
                     with ctx.new() as subctx:
                         subctx.anchors = subctx.anchors.copy()
-                        subctx.anchors[source_alias] = irexpr
+                        source_path = subctx.create_anchor(irexpr, 'a')
+                        cast_qlexpr = astutils.ensure_qlstmt(qlast.TypeCast(
+                            type=typegen.type_to_ql_typeref(
+                                base_target, ctx=ctx),
+                            expr=source_path,
+                        ))
 
                         old_rptr = irexpr.rptr
                         irexpr.rptr = None


### PR DESCRIPTION
Abstract away the common pattern of create anchors, and add
a helper function for creating simple paths.