### PR TITLE
Fix/update to the build guide

### DIFF
--- a/docs/internals/dev.rst
+++ b/docs/internals/dev.rst
@@ -44,8 +44,8 @@ Python "venv" with all dependencies and commands installed into it.
       $ mkdir ~/dev
       $ cd ~/dev
 
-#. Clone the edgedb repository using `--recursive`
-   so it clones all submodules as well:
+#. Clone the edgedb repository using ``--recursive``
+   to clone all submodules:
 
    .. code-block:: bash
 


### PR DESCRIPTION
Hi, I am part of a security researcher group.

While trying to build the project for testing we noticed some issues with the build guide.

Hope this patch helps.
@pwnCTRL


Fix/update to the build guide
----------------------------------------
The build guide previously failed do to numerous errors.

1. Cloning sub-modules.
It was not stated in the build guide (or anywhere else) that you need to clone all the sub-modules of the repository. This lead to failed builds with nonsensical error messages.

2. Small issue with paths.
Probably a typo but the line `cd ../edgedb` should be only `cd edgedb`.
