### PR TITLE
Unbreak `make build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ casts:
 
 
 build:
-	pip install -Ue .[docs,test]
+	pip install --no-use-pep517 -Ue .[docs,test]
 
 
 clean:


### PR DESCRIPTION
Recent versions of pip seem to have broken editable `pip install` by
in PEP 517 mode.