### PR TITLE
Get rid of get_class_nearest_common_ancestor

### DIFF
--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -111,10 +111,12 @@ def _infer_common_type(
             if common_type is None:
                 break
     else:
-        common_type = s_utils.get_class_nearest_common_ancestor(
+        common_types = s_utils.get_class_nearest_common_ancestors(
             env.schema,
             cast(Sequence[s_types.InheritingType], types),
         )
+        # We arbitrarily select the first nearest common ancestor
+        common_type = common_types[0] if common_types else None
 
     if common_type is None:
         return None

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -141,9 +141,6 @@ class TypeRef(ImmutableBase):
     # If this is an intersection type, this would be a set of
     # intersection elements.
     intersection: typing.Optional[typing.FrozenSet[TypeRef]] = None
-    # If this is a union type, this would be the nearest common
-    # ancestor of the union members.
-    common_parent: typing.Optional[TypeRef] = None
     # If this node is an element of a collection, and the
     # collection elements are named, this would be then
     # name of the element.

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -240,17 +240,6 @@ def type_to_typeref(
         else:
             name = tname
 
-        common_parent_ref: Optional[irast.TypeRef]
-        if union_of:
-            common_parent = s_utils.get_class_nearest_common_ancestor(
-                schema, union_of.objects(schema))
-            assert isinstance(common_parent, s_types.Type)
-            common_parent_ref = type_to_typeref(
-                schema, common_parent, cache=cache
-            )
-        else:
-            common_parent_ref = None
-
         descendants: Optional[FrozenSet[irast.TypeRef]]
 
         if material_typeref is None and include_descendants:
@@ -293,7 +282,6 @@ def type_to_typeref(
             union=union,
             union_is_concrete=union_is_concrete,
             intersection=intersection,
-            common_parent=common_parent_ref,
             element_name=_name,
             is_scalar=t.is_scalar(),
             is_abstract=t.get_abstract(schema),

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -126,6 +126,8 @@ def init_dml_stmt(
     dml_map = {}
 
     for typeref in typerefs:
+        if typeref.union:
+            continue
         dml_cte, dml_rvar = gen_dml_cte(
             ir_stmt,
             range_rvar=range_rvar,
@@ -241,7 +243,6 @@ def gen_dml_cte(
         typeref,
         target_path_id,
         for_mutation=True,
-        common_parent=True,
         ctx=ctx,
     )
     pathctx.put_path_value_rvar(

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1302,21 +1302,10 @@ def range_for_typeref(
     for_mutation: bool=False,
     include_descendants: bool=True,
     dml_source: Optional[irast.MutatingStmt]=None,
-    common_parent: bool=False,
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
 
-    if typeref.common_parent is not None and common_parent:
-        rvar = range_for_material_objtype(
-            typeref.common_parent,
-            path_id,
-            include_descendants=include_descendants,
-            for_mutation=for_mutation,
-            dml_source=dml_source,
-            ctx=ctx,
-        )
-
-    elif typeref.union:
+    if typeref.union:
         # Union object types are represented as a UNION of selects
         # from their children, which is, for most purposes, equivalent
         # to SELECTing from a parent table.

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -197,9 +197,13 @@ class ObjectType(
         if not isinstance(other, ObjectType):
             return schema, None
 
-        nearest_common_ancestor = utils.get_class_nearest_common_ancestor(
+        nearest_common_ancestors = utils.get_class_nearest_common_ancestors(
             schema, [self, other]
         )
+        # We arbitrarily select the first nearest common ancestor
+        nearest_common_ancestor = (
+            nearest_common_ancestors[0] if nearest_common_ancestors else None)
+
         if nearest_common_ancestor is not None:
             assert isinstance(nearest_common_ancestor, ObjectType)
         return (

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -475,16 +475,17 @@ class InheritingType(so.DerivableInheritingObject, QualifiedType):
         if self == other:
             return 0
 
-        ancestor = utils.get_class_nearest_common_ancestor(
+        ancestors = utils.get_class_nearest_common_ancestors(
             schema, [self, other])
 
-        if ancestor is None:
+        if not ancestors:
             return -1
-        elif ancestor == self:
+        elif self in ancestors:
             return 0
         else:
-            ancestors = list(self.get_ancestors(schema).objects(schema))
-            return ancestors.index(ancestor) + 1
+            all_ancestors = list(self.get_ancestors(schema).objects(schema))
+            return min(
+                all_ancestors.index(ancestor) + 1 for ancestor in ancestors)
 
 
 class TypeShell(so.ObjectShell[TypeT_co]):

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -641,18 +641,6 @@ def get_class_nearest_common_ancestors(
     return nearests
 
 
-def get_class_nearest_common_ancestor(
-    schema: s_schema.Schema,
-    classes: Iterable[so.InheritingObjectT]
-) -> Optional[so.InheritingObjectT]:
-    common_list = get_class_nearest_common_ancestors(schema, classes)
-    # FIXME: This is arbitrary and probably not meaningful
-    if common_list:
-        return common_list[0]
-    else:
-        return None
-
-
 def minimize_class_set_by_most_generic(
     schema: s_schema.Schema,
     classes: Iterable[so.InheritingObjectT]


### PR DESCRIPTION
It makes a mostly arbitrary selection among multiple possible nearest
common ancestors. Get rid of that arbitrary selection explicit in some
places and make it explicit in the rest.

(This is going up now mostly as local branch cleanup)