### PR TITLE
Default to data directory in portable builds

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -90,7 +90,11 @@ def get_runstate_path(data_dir: pathlib.Path) -> pathlib.Path:
     if devmode.is_in_dev_mode():
         return data_dir
     else:
-        return pathlib.Path(get_build_metadata_value('RUNSTATE_DIR'))
+        runstate_dir = get_build_metadata_value('RUNSTATE_DIR')
+        if runstate_dir is not None:
+            return pathlib.Path(runstate_dir)
+        else:
+            return data_dir
 
 
 def get_shared_data_dir_path() -> pathlib.Path:

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -131,10 +131,17 @@ class PortType(click.ParamType):
 
 
 def _get_runstate_dir_default() -> str:
+    runstate_dir: Optional[str]
+
     try:
-        return buildmeta.get_build_metadata_value("RUNSTATE_DIR")
+        runstate_dir = buildmeta.get_build_metadata_value("RUNSTATE_DIR")
     except buildmeta.MetadataError:
-        return '<data-dir>'
+        runstate_dir = None
+
+    if runstate_dir is None:
+        runstate_dir = '<data-dir>'
+
+    return runstate_dir
 
 
 def _validate_max_backend_connections(ctx, param, value):

--- a/setup.py
+++ b/setup.py
@@ -163,11 +163,14 @@ def _compile_build_meta(build_lib, version, pg_config, runstate_dir,
     else:
         pg_config_path = repr(str(pg_config_path))
 
-    runstate_dir_path = pathlib.Path(runstate_dir)
-    if not runstate_dir_path.is_absolute():
-        runstate_dir_path = f"_ROOT / {str(runstate_dir_path)!r}"
+    if runstate_dir:
+        runstate_dir_path = pathlib.Path(runstate_dir)
+        if not runstate_dir_path.is_absolute():
+            runstate_dir_path = f"_ROOT / {str(runstate_dir_path)!r}"
+        else:
+            runstate_dir_path = repr(str(runstate_dir_path))
     else:
-        runstate_dir_path = repr(str(runstate_dir_path))
+        runstate_dir_path = "None  # default to <data-dir>"
 
     shared_dir_path = pathlib.Path(shared_dir)
     if not shared_dir_path.is_absolute():


### PR DESCRIPTION
It makes no sense to hardcode an absolute path for runstate in portable
builds, so use the data directory as the default instead.