### PR TITLE
Explicitly check for the byte length of runstate dir

### DIFF
--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -33,6 +33,7 @@ import time
 
 import immutables
 
+from edb.server import defines
 from edb.server import pgcluster
 from edb.server import metrics
 
@@ -182,6 +183,11 @@ class Pool(amsg.ServerProtocol):
         self._runstate_dir = runstate_dir
 
         self._poolsock_name = os.path.join(self._runstate_dir, 'ipc')
+        assert len(self._poolsock_name) <= (
+            defines.MAX_RUNSTATE_DIR_PATH
+            + defines.MAX_UNIX_SOCKET_PATH_LENGTH
+            + 1
+        ), "pool IPC socket length exceeds maximum allowed"
 
         assert pool_size >= 1
         self._pool_size = pool_size

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -51,6 +51,14 @@ _QUERIES_ROLLING_AVG_LEN = 300
 
 DEFAULT_MODULE_ALIAS = 'default'
 
+# The maximum length of a Unix socket relative to runstate dir.
+# 21 is the length of the longest socket we might use, which
+# is the admin socket (.s.EDGEDB.admin.xxxxx).
+MAX_UNIX_SOCKET_PATH_LENGTH = 21
+
+# 104 is the maximum Unix socket path length on BSD/Darwin, whereas
+# Linux is constrained to 108.
+MAX_RUNSTATE_DIR_PATH = 104 - MAX_UNIX_SOCKET_PATH_LENGTH - 1
 
 HTTP_PORT_QUERY_CACHE_SIZE = 1000
 HTTP_PORT_MAX_CONCURRENCY = 250  # XXX

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -420,6 +420,20 @@ async def run_server(
     )
 
     with runstate_dir_mgr as runstate_dir:
+        runstate_dir_str = str(runstate_dir)
+        runstate_dir_str_len = len(
+            runstate_dir_str.encode(
+                sys.getfilesystemencoding(),
+                errors=sys.getfilesystemencodeerrors(),
+            ),
+        )
+        if runstate_dir_str_len > defines.MAX_RUNSTATE_DIR_PATH:
+            abort(
+                f'the length of the specified path for server run state '
+                f'exceeds the maximum of {defines.MAX_RUNSTATE_DIR_PATH} '
+                f'bytes: {runstate_dir_str!r} ({runstate_dir_str_len} bytes)'
+            )
+
         if args.data_dir:
             cluster, args = await _get_local_pgcluster(
                 args, runstate_dir, tenant_id)

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1254,6 +1254,11 @@ class Server(ha_base.ClusterProtocol):
     async def _start_admin_server(self, port: int) -> asyncio.AbstractServer:
         admin_unix_sock_path = os.path.join(
             self._runstate_dir, f'.s.EDGEDB.admin.{port}')
+        assert len(admin_unix_sock_path) <= (
+            defines.MAX_RUNSTATE_DIR_PATH
+            + defines.MAX_UNIX_SOCKET_PATH_LENGTH
+            + 1
+        ), "admin Unix socket length exceeds maximum allowed"
         admin_unix_srv = await self._loop.create_unix_server(
             lambda: binary.EdgeConnection(self, external_auth=True),
             admin_unix_sock_path


### PR DESCRIPTION
Most systems have a fairly low limit for the total length of a Unix
socket path, e.g. on macOS its 104 bytes, and on Linux it's 108.  Rather
than failing with an obscure error and a traceback, validate the
specified or implied runstate path directory with an assumption for the
maximum Unix socket name we use.