### PR TITLE
Do not include CLI proxy entrypoint in release builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -467,10 +467,10 @@ class develop(setuptools_develop.develop):
         scripts = self.distribution.entry_points['console_scripts']
         patched_scripts = []
         for s in scripts:
-            if 'rustcli' not in s:
-                s = f'{s}_dev'
+            s = f'{s}_dev'
             patched_scripts.append(s)
         patched_scripts.append('edb = edb.tools.edb:edbcommands')
+        patched_scripts.append('edgedb = edb.cli:rustcli')
         self.distribution.entry_points['console_scripts'] = patched_scripts
 
         super().run(*args, **kwargs)
@@ -811,7 +811,6 @@ setuptools.setup(
     entry_points={
         'console_scripts': [
             'edgedb-server = edb.server.main:main',
-            'edgedb = edb.cli:rustcli',
         ],
     },
     ext_modules=[


### PR DESCRIPTION
The CLI is not built in non-dev builds, so make sure the `edgedb`
wrapper does not make it into venv `bin/`