### PR TITLE
Makefile: Revert to PEP 517 mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ casts:
 
 
 build:
-	pip install --no-use-pep517 -Ue .[docs,test]
+	pip install -Ue .[docs,test]
 
 
 clean:
-	git clean -Xf -e "!/*.code-workspace" -e "!/*.vscode"
+	git clean -Xfd -e "!/*.code-workspace" -e "!/*.vscode"


### PR DESCRIPTION
This is a revert of 740b4944439998981701e3782039ffa75da018d3.  It seems
like `--no-use-pep517` breaks too and I can no longer reproduce the
original issue with pip 21.3.1.

Also, adjust the `make clean` target to explicitly remove the ignored
directories too.