### PR TITLE
Produce better error messages for DDL creating existing objects

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2813,8 +2813,7 @@ class CreateObject(ObjectCommand[so.Object_T], Generic[so.Object_T]):
             funcs = schema.get_functions(fn, tuple())
             if funcs:
                 raise errors.SchemaError(
-                    f'{funcs[0].get_verbosename(schema)} is already present '
-                    f'in the schema {schema!r}')
+                    f'{funcs[0].get_verbosename(schema)} already exists')
 
     def _create_begin(
         self,

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1626,8 +1626,7 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
         if other := schema.get(
                 sn.QualName(fullname.module, shortname.name), None):
             raise errors.SchemaError(
-                f'{other.get_verbosename(schema)} is already present '
-                f'in the schema {schema!r}')
+                f'{other.get_verbosename(schema)} already exists')
 
         schema = super()._create_begin(schema, context)
 

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -587,7 +587,7 @@ class FlatSchema(Schema):
                         globalname_to_id[key], type=so.Object)
                     vn = other_obj.get_verbosename(self, with_parent=True)
                     raise errors.SchemaError(
-                        f'{vn} is already present in the schema')
+                        f'{vn} already exists')
                 globalname_to_id = globalname_to_id.set(key, obj_id)
             else:
                 assert isinstance(new_name, sn.QualName)
@@ -603,7 +603,7 @@ class FlatSchema(Schema):
                         name_to_id[new_name], type=so.Object)
                     vn = other_obj.get_verbosename(self, with_parent=True)
                     raise errors.SchemaError(
-                        f'{vn} is already present in the schema')
+                        f'{vn} already exists')
                 name_to_id = name_to_id.set(new_name, obj_id)
 
             if has_sn_cache:
@@ -905,7 +905,7 @@ class FlatSchema(Schema):
                 self._name_to_id[name], type=so.Object)
             vn = other_obj.get_verbosename(self, with_parent=True)
             raise errors.SchemaError(
-                f'{vn} is already present in the schema')
+                f'{vn} already exists')
 
         if id in self._id_to_data:
             raise errors.SchemaError(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3984,7 +3984,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_function_28(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r"'default::foo' is already present in the schema"):
+                r"'default::foo' already exists"):
 
             await self.con.execute('''\
                 CREATE TYPE foo;
@@ -3994,7 +3994,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_function_29(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r"'default::foo\(\)' is already present in the schema"):
+                r"'default::foo\(\)' already exists"):
 
             await self.con.execute('''\
                 CREATE FUNCTION foo() -> str USING ('a');
@@ -4708,7 +4708,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
     async def test_edgeql_ddl_module_01(self):
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r"'spam' is already present in the schema"):
+                r"'spam' already exists"):
 
             await self.con.execute('''\
                 CREATE MODULE spam;
@@ -6812,7 +6812,7 @@ type default::Foo {
 
         async with self.assertRaisesRegexTx(
             edgedb.SchemaError,
-            "extension 'MyExtension' is already present in the schema",
+            "extension 'MyExtension' already exists",
         ):
             await self.con.execute(r"""
                 CREATE EXTENSION MyExtension VERSION '2.0';
@@ -8093,7 +8093,7 @@ type default::Foo {
         with self.assertRaisesRegex(
                 edgedb.errors.SchemaError,
                 r"constraint 'std::max_len_value' of property 'firstname' "
-                r"of object type 'default::Base' is already present"):
+                r"of object type 'default::Base' already exists"):
             await self.con.execute(r"""
                 CREATE TYPE Base {
                     CREATE PROPERTY firstname -> str {
@@ -8380,7 +8380,7 @@ type default::Foo {
         with self.assertRaisesRegex(
                 edgedb.errors.SchemaError,
                 r"constraint 'std::max_len_value' of property 'firstname' "
-                r"of object type 'default::Base' is already present"):
+                r"of object type 'default::Base' already exists"):
             await self.con.execute(r"""
                 ALTER TYPE Base {
                     ALTER PROPERTY firstname {
@@ -11886,7 +11886,7 @@ type default::Foo {
 
         with self.assertRaisesRegex(
                 edgedb.errors.SchemaError,
-                r"object type 'default::Foo' is already present"):
+                r"object type 'default::Foo' already exists"):
             await self.con.execute(r"""
                 CREATE TYPE Foo;
             """)
@@ -11901,7 +11901,7 @@ type default::Foo {
         with self.assertRaisesRegex(
                 edgedb.errors.SchemaError,
                 r"property 'foo' of "
-                r"object type 'default::Foo' is already present"):
+                r"object type 'default::Foo' already exists"):
             await self.con.execute(r"""
                 ALTER TYPE Foo {
                     CREATE PROPERTY foo -> str;
@@ -11916,7 +11916,7 @@ type default::Foo {
 
         with self.assertRaisesRegex(
                 edgedb.errors.SchemaError,
-                r"object type 'default::Foo' is already present"):
+                r"object type 'default::Foo' already exists"):
             await self.con.execute(r"""
                 ALTER TYPE Bar RENAME TO Foo;
             """)
@@ -11932,7 +11932,7 @@ type default::Foo {
         with self.assertRaisesRegex(
                 edgedb.errors.SchemaError,
                 r"property 'foo' of "
-                r"object type 'default::Foo' is already present"):
+                r"object type 'default::Foo' already exists"):
             await self.con.execute(r"""
                 ALTER TYPE Foo {
                     ALTER PROPERTY bar RENAME TO foo;

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2642,7 +2642,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         with self.assertRaisesRegex(
                 errors.SchemaError,
-                r'Constraint .+ is already present in the schema'):
+                r'constraint .+ already exists'):
             self._assert_migration_consistency(schema)
 
     def test_schema_get_migration_42(self):


### PR DESCRIPTION
Currently we produce messages like:
  ObjectType <QualName default::Foo> is already
  present in the schema <FlatSchema gen:2 at 0x7fd21a263040>
and
  Constraint <QualName default::std|max_len_value@default|__||firstname&default||Base@b1d5781111d84f7b3fe45a0852e59758cd7a87e5>
  is already present in the schema <FlatSchema gen:2 at 0x7f96836e59a0>

Instead produce:
  object type 'default::Foo' is already present in the schema
and
  constraint 'std::max_len_value' of property 'firstname' of
  object type 'default::Base' is already present in the schema