### PR TITLE
drop savepoints created after the requested one in rollback query

### DIFF
--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -424,14 +424,17 @@ class Transaction:
             raise errors.TransactionError(
                 'savepoints can only be used in transaction blocks')
 
+        sp_ids_to_erase = []
         for sp in reversed(self._savepoints.values()):
+            sp_ids_to_erase.append(sp.id)
+
             if sp.name == name:
-                sp_id = sp.id
                 break
         else:
             raise errors.TransactionError(f'there is no {name!r} savepoint')
 
-        self._savepoints.pop(sp_id)
+        for sp_id in sp_ids_to_erase:
+            self._savepoints.pop(sp_id)
 
     def get_schema(self, std_schema: s_schema.FlatSchema) -> s_schema.Schema:
         assert isinstance(std_schema, s_schema.FlatSchema)

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -404,12 +404,20 @@ class Transaction:
             raise errors.TransactionError(
                 'savepoints can only be used in transaction blocks')
 
+        sp_to_erase = []
         for sp in reversed(self._savepoints.values()):
             if sp.name == name:
                 self._current = sp
-                return sp
+                break
 
-        raise errors.TransactionError(f'there is no {name!r} savepoint')
+            sp_to_erase.append(sp)
+        else:
+            raise errors.TransactionError(f'there is no {name!r} savepoint')
+
+        for sp in sp_to_erase:
+            self._savepoints.pop(sp.id)
+
+        return sp
 
     def release_savepoint(self, name: str):
         if self.is_implicit():

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -404,18 +404,18 @@ class Transaction:
             raise errors.TransactionError(
                 'savepoints can only be used in transaction blocks')
 
-        sp_to_erase = []
+        sp_ids_to_erase = []
         for sp in reversed(self._savepoints.values()):
             if sp.name == name:
                 self._current = sp
                 break
 
-            sp_to_erase.append(sp)
+            sp_ids_to_erase.append(sp.id)
         else:
             raise errors.TransactionError(f'there is no {name!r} savepoint')
 
-        for sp in sp_to_erase:
-            self._savepoints.pop(sp.id)
+        for sp_id in sp_ids_to_erase:
+            self._savepoints.pop(sp_id)
 
         return sp
 

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1277,6 +1277,20 @@ class TestServerProto(tb.QueryTestCase):
         finally:
             await con.query('ROLLBACK')
 
+    async def test_server_proto_tx_savepoint_13(self):
+        con = self.con
+
+        await con.query('START TRANSACTION')
+        await con.query('DECLARE SAVEPOINT p1')
+        await con.query('DECLARE SAVEPOINT p2')
+        await con.query('RELEASE SAVEPOINT p1')
+
+        try:
+            with self.assertRaises(edgedb.TransactionError):
+                await con.query('ROLLBACK TO SAVEPOINT p2')
+        finally:
+            await con.query('ROLLBACK')
+
     async def test_server_proto_tx_01(self):
         await self.con.query('START TRANSACTION')
 

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1263,6 +1263,20 @@ class TestServerProto(tb.QueryTestCase):
         finally:
             await con.query('ROLLBACK')
 
+    async def test_server_proto_tx_savepoint_12(self):
+        con = self.con
+
+        await con.query('START TRANSACTION')
+        await con.query('DECLARE SAVEPOINT p1')
+        await con.query('DECLARE SAVEPOINT p2')
+        await con.query('ROLLBACK TO SAVEPOINT p1')
+
+        try:
+            with self.assertRaises(edgedb.TransactionError):
+                await con.query('ROLLBACK TO SAVEPOINT p2')
+        finally:
+            await con.query('ROLLBACK')
+
     async def test_server_proto_tx_01(self):
         await self.con.query('START TRANSACTION')
 


### PR DESCRIPTION
Fix ISE in the `ROLLBACK TO SAVEPOINT ...` query by removing from the transaction savepoint storage all savepoints that were created after the one requested in the query.

Fixes #2420.