### PR TITLE
Don't add duplicate pointer overlays

### DIFF
--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1795,13 +1795,16 @@ def _add_ptr_rel_overlay(
         path_id: irast.PathId,
         ctx: context.CompilerContextLevel) -> None:
 
+    entry = (op, rel, path_id)
     if dml_stmts:
         for dml_stmt in dml_stmts:
             overlays = ctx.ptr_rel_overlays[dml_stmt][typeid, ptrref_name]
-            overlays.append((op, rel, path_id))
+            if entry not in overlays:
+                overlays.append(entry)
     else:
         overlays = ctx.ptr_rel_overlays[None][typeid, ptrref_name]
-        overlays.append((op, rel, path_id))
+        if entry not in overlays:
+            overlays.append(entry)
 
 
 def add_ptr_rel_overlay(

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -4817,3 +4817,37 @@ class TestInsert(tb.QueryTestCase):
                 [0, {}, {}],
             ]
         )
+
+    async def test_edgeql_insert_nested_and_with_01(self):
+        await self.assert_query_result(
+            r"""
+                WITH
+                    New := (
+                        INSERT Person {
+                            name := "test",
+                            notes := (INSERT Note { name := "test" })
+                         }
+                    ),
+                SELECT (
+                    INSERT Person2a {
+                        first := New.name, last := "!", bff := New,
+                    }
+                ) {
+                    first,
+                    bff: {
+                        name,
+                        notes: { name }
+                    }
+                };
+            """,
+            [
+                {
+                    "first": "test",
+                    "bff": {
+                        "name": "test",
+                        "notes": [{"name": "test"}]
+                    },
+                }
+            ]
+
+        )


### PR DESCRIPTION
This is needed since otherwise reuse_type_rel_overlays will
add duplicate overlays if a WITH-bound DML is reused multiple times
inside another DML statement.
We already do this check for type overlays.

Fixes #2916.