### PR TITLE
Fix interruptable task warning in failover

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1131,6 +1131,8 @@ class Server(ha_base.ClusterProtocol):
             raise
 
     def _on_sys_pgcon_failover_signal(self):
+        if not self._serving:
+            return
         try:
             if self._backend_adaptive_ha is not None:
                 # Switch to FAILOVER if adaptive HA is enabled


### PR DESCRIPTION
As mentioned in the previous PR, I'll check all the other tasks to make sure:

1. Tasks should exit properly when server stops
2. Tasks should not be created if server is already stopping