### PR TITLE
Prohibit DML on computed pointers

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -680,6 +680,12 @@ def _normalize_view_ptr_expr(
             # If this is a mutation, the pointer must exist.
             ptrcls = setgen.resolve_ptr(
                 ptrsource, ptrname, track_ref=lexpr, ctx=ctx)
+            if ptrcls.is_pure_computable(ctx.env.schema):
+                ptr_vn = ptrcls.get_verbosename(ctx.env.schema,
+                                                with_parent=True)
+                raise errors.QueryError(
+                    f'modification of computed {ptr_vn} is prohibited',
+                    context=shape_el.context)
 
             base_ptrcls = ptrcls.get_bases(
                 ctx.env.schema).first(ctx.env.schema)

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -54,6 +54,20 @@ class TestInsert(tb.QueryTestCase):
                 };
             ''')
 
+    async def test_edgeql_insert_fail_3(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            r"modification of computed property"
+            r" 'name' of object type 'default::Person2b' is prohibited",
+        ):
+            await self.con.execute('''
+                INSERT Person2b {
+                    first := "foo",
+                    last := "bar",
+                    name := "something else",
+                };
+            ''')
+
     async def test_edgeql_insert_simple_01(self):
         await self.con.execute(r"""
             INSERT InsertTest {


### PR DESCRIPTION
(The current behavior is to generate bogus SQL)