### PR TITLE
reserve "never" keyword for future usage

### DIFF
--- a/edb/edgeql-parser/src/keywords.rs
+++ b/edb/edgeql-parser/src/keywords.rs
@@ -125,6 +125,7 @@ pub const FUTURE_RESERVED_KEYWORDS: &[&str] = &[
     "single",
     "when",
     "window",
+    "never",
     // Keep in sync with `tokenizer::is_keyword`
 ];
 

--- a/edb/edgeql-parser/src/tokenizer.rs
+++ b/edb/edgeql-parser/src/tokenizer.rs
@@ -930,6 +930,7 @@ pub fn is_keyword(s: &str) -> bool {
         | "over"
         | "when"
         | "window"
+        | "never"
           // Keep in sync with keywords::FUTURE_RESERVED_KEYWORDS
         => true,
         _ => false,


### PR DESCRIPTION
I'm not quite sure if this is enough for the fix, but the parser now raises an error when using `never` in expressions without backticks.

Fixes #3078.