### PR TITLE
Add a note about date ranges to the docs.

### DIFF
--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -105,6 +105,16 @@ date/time values.
 
 EdgeDB stores and outputs timezone-aware values in UTC.
 
+.. note::
+
+    All the date/time types are restricted to years between 1 and
+    9999, including the end points.
+
+    Although many systems support ISO 8601 date formatting in theory,
+    in practice the formatting before year 1 and after 9999 tends to
+    be inconsistent. As such dates outside that range are not reliably
+    portable.
+
 
 ----------
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -145,7 +145,7 @@ class TimestampTzDomain(dbops.Domain):
     """Timestamptz clamped to years 0001-9999.
 
     The default timestamp range of (4713 BC - 294276 AD) has problems:
-    Postgres isn't ISO compliant with years out of the 0-9999 range and
+    Postgres isn't ISO compliant with years out of the 1-9999 range and
     language compatibility is questionable.
     """
     def __init__(self) -> None:
@@ -165,7 +165,7 @@ class TimestampDomain(dbops.Domain):
     """Timestamp clamped to years 0001-9999.
 
     The default timestamp range of (4713 BC - 294276 AD) has problems:
-    Postgres isn't ISO compliant with years out of the 0-9999 range and
+    Postgres isn't ISO compliant with years out of the 1-9999 range and
     language compatibility is questionable.
     """
     def __init__(self) -> None:
@@ -185,7 +185,7 @@ class DateDomain(dbops.Domain):
     """Date clamped to years 0001-9999.
 
     The default timestamp range of (4713 BC - 294276 AD) has problems:
-    Postgres isn't ISO compliant with years out of the 0-9999 range and
+    Postgres isn't ISO compliant with years out of the 1-9999 range and
     language compatibility is questionable.
     """
     def __init__(self) -> None:

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -429,6 +429,77 @@ class TestEdgeQLDT(tb.QueryTestCase):
                 """
             )
 
+    async def test_edgeql_dt_duration_10_datetime_range(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.execute(
+                """
+                SELECT <datetime>'9999-12-31T00:00:00Z' +
+                    <cal::relative_duration>'1 week'
+                """
+            )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.execute(
+                """
+                SELECT <datetime>'0001-01-01T00:00:00Z' -
+                    <cal::relative_duration>'1 week'
+                """
+            )
+
+    async def test_edgeql_dt_duration_11_local_datetime_range(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.execute(
+                """
+                SELECT <cal::local_datetime>'9999-12-31T00:00:00' +
+                    <cal::relative_duration>'1 week'
+                """
+            )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.execute(
+                """
+                SELECT <cal::local_datetime>'0001-01-01T00:00:00' -
+                    <cal::relative_duration>'1 week'
+                """
+            )
+
+    async def test_edgeql_dt_duration_12_local_date_range(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.execute(
+                """
+                SELECT
+                    <cal::local_date>'9999-12-31'
+                    + <cal::relative_duration>'30 hours'
+                """
+            )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.execute(
+                """
+                SELECT
+                    <cal::local_date>'0001-01-01'
+                    - <cal::relative_duration>'30 hours'
+                """
+            )
+
     async def test_edgeql_dt_local_datetime_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -1814,15 +1814,6 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                         cal::to_local_datetime('00:00:00 0715');
                 ''')
 
-    async def test_edgeql_functions_to_local_time_05(self):
-        async with self.assertRaisesRegexTx(
-            edgedb.InvalidValueError,
-            'value out of range',
-        ):
-            await self.con.query(r'''
-                SELECT cal::to_local_datetime(10000, 1, 1, 1, 1, 1);
-            ''')
-
     async def test_edgeql_functions_to_duration_01(self):
         await self.assert_query_result(
             r'''SELECT <str>to_duration(hours:=20);''',


### PR DESCRIPTION
Explicitly state that our dates are limited to the range between 1 and
9999 years.

Add range tests involving `relative_duration`.

Remove a redundant range test.

Closes #1768