### PR TITLE
discussion: handle new tasks on server shutdown

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1153,7 +1153,7 @@ cdef class EdgeConnection:
     def signal_side_effects(self, side_effects):
         if side_effects & dbview.SideEffects.SchemaChanges:
             self.server.create_task(
-                self.server._signal_sysevent(
+                lambda: self.server._signal_sysevent(
                     'schema-changes',
                     dbname=self.get_dbview().dbname,
                 ),
@@ -1161,14 +1161,14 @@ cdef class EdgeConnection:
             )
         if side_effects & dbview.SideEffects.GlobalSchemaChanges:
             self.server.create_task(
-                self.server._signal_sysevent(
+                lambda: self.server._signal_sysevent(
                     'global-schema-changes',
                 ),
                 interruptable=False,
             )
         if side_effects & dbview.SideEffects.DatabaseConfigChanges:
             self.server.create_task(
-                self.server._signal_sysevent(
+                lambda: self.server._signal_sysevent(
                     'database-config-changes',
                     dbname=self.get_dbview().dbname,
                 ),
@@ -1176,7 +1176,7 @@ cdef class EdgeConnection:
             )
         if side_effects & dbview.SideEffects.InstanceConfigChanges:
             self.server.create_task(
-                self.server._signal_sysevent(
+                lambda: self.server._signal_sysevent(
                     'system-config-changes',
                 ),
                 interruptable=False,
@@ -2197,7 +2197,7 @@ cdef class EdgeConnection:
                 'invalid connection status while establishing the connection')
         self._transport = transport
         self._main_task = self.server.create_task(
-            self.main(), interruptable=False
+            self.main, interruptable=False
         )
         self.server.on_binary_client_connected(self)
 
@@ -2265,7 +2265,7 @@ cdef class EdgeConnection:
                     # _next_ query that is unlucky enough to pick up this
                     # Postgres backend from the connection pool.
                     self.server.create_task(
-                        self.server._cancel_and_discard_pgcon(
+                        lambda: self.server._cancel_and_discard_pgcon(
                             self._pinned_pgcon,
                             self.get_dbview().dbname,
                         ),

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -126,9 +126,11 @@ cdef class HttpProtocol:
                 # Most clients should arrive here to continue with TLS
                 self.transport.pause_reading()
                 self.server.create_task(
-                    self._forward_first_data(data), interruptable=True
+                    lambda: self._forward_first_data(data), interruptable=True
                 )
-                self.server.create_task(self._start_tls(), interruptable=True)
+                self.server.create_task(
+                    lambda: self._start_tls(), interruptable=True
+                )
                 return
 
             # In case when we're talking to a non-TLS client, keep using the
@@ -191,7 +193,7 @@ cdef class HttpProtocol:
         else:
             self.in_response = True
             self.server.create_task(
-                self._handle_request(req), interruptable=False
+                lambda: self._handle_request(req), interruptable=False
             )
 
         self.server._http_last_minute_requests += 1
@@ -222,7 +224,7 @@ cdef class HttpProtocol:
         if self.unprocessed:
             req = self.unprocessed.popleft()
             self.server.create_task(
-                self._handle_request(req), interruptable=False
+                lambda: self._handle_request(req), interruptable=False
             )
         else:
             self.transport.resume_reading()


### PR DESCRIPTION
For new tasks created after the server is requessted to shutdown and before the loop actually stops, we have 3 options to handle them:

1. Don't even create the `coroutine` object to avoid the `RuntimeWarning` (this PR). The downside is the inconsistent `server.create_task()` API that takes a coroutine factory rather than a coroutine object.
2. Don't call `create_task()` when `server._accept_new_tasks == False`. This adds a lot of duplicate checks before calling `server.create_task()`.
3. Create the tasks anyways, and carefully check every task and modify them to honor the shutdown event. We don't even need the "interruptable" tasks in this case. The risk is, the server may freeze at exit if in the future someone adds new tasks that cannot clean themselves at server exit.
  * We could use `SignalController().wait_for(coro, cancel_on=SIGxxx)` in most tasks, but this also means we'll have a lot of signal-triggered cancellation.
  * At the same time, certain server-exit sanity checks in the tasks are unavoidable. Even if we choose other options, these checks are also necessary for "un-interruptable" tasks to stop, because those tasks may have already started before the server is requested to stop.
