### PR TITLE
Fix a collection of migration issues

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -185,6 +185,7 @@ def delta_objects(
             y_alter_variants[y] += 1
 
     alters = []
+    alter_pairs = []
 
     if comparison_map:
         if issubclass(sclass, so.InheritingObject):
@@ -215,6 +216,8 @@ def delta_objects(
                 )
                 or x_name in renames_x
             ):
+                alter_pairs.append((x, y))
+
                 alter = y.as_alter_delta(
                     other=x,
                     context=context,
@@ -240,8 +243,10 @@ def delta_objects(
 
                 alter.set_annotation('confidence', confidence)
                 alters.append(alter)
+            elif confidence == 1.0:
+                alter_pairs.append((x, y))
 
-    created = new - {x for x, (s, _) in comparison_map.items() if s > 0.6}
+    created = new - {x for x, _ in alter_pairs}
 
     for x in created:
         x_name = x.get_name(new_schema)
@@ -257,7 +262,7 @@ def delta_objects(
     delta.update(alters)
 
     deleted_order: Iterable[so.Object_T]
-    deleted = old - {y for _, (s, y) in comparison_map.items() if s > 0.6}
+    deleted = old - {y for _, y in alter_pairs}
 
     if issubclass(sclass, so.InheritingObject):
         deleted_order = _sort_by_inheritance(  # type: ignore

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -30,6 +30,7 @@ import uuid
 
 from edb import errors
 from edb.edgeql import qltypes
+from edb.common.typeutils import not_none
 
 from edb.common import checked
 from edb.common import markup
@@ -3043,6 +3044,10 @@ class InheritingObject(SubclassableObject):
                 'ancestors',
                 other.get_ancestors(other_schema).as_shell(other_schema),
             )
+            # Trim these from the base alter since they are redundant
+            # and clog up debug output.
+            delta.discard(not_none(delta._get_attribute_set_cmd('bases')))
+            delta.discard(not_none(delta._get_attribute_set_cmd('ancestors')))
 
             delta.add(rebase_cmd)
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1969,8 +1969,8 @@ class SetPointerType(
             #    in the new schema; there is no way for us to infer
             #    castability and we assume a cast expression is needed.
             if isinstance(old_type_shell, s_types.CollectionTypeShell):
-                create = old_type_shell.as_create_delta(schema)
                 try:
+                    create = old_type_shell.as_create_delta(schema)
                     schema = sd.apply(create, schema=schema)
                 except errors.InvalidReferenceError:
                     # A removed type is part of the collection,

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -904,8 +904,7 @@ class FlatSchema(Schema):
             other_obj = self.get_by_id(
                 self._name_to_id[name], type=so.Object)
             vn = other_obj.get_verbosename(self, with_parent=True)
-            raise errors.SchemaError(
-                f'{vn} already exists')
+            raise errors.SchemaError(f'{vn} already exists')
 
         if id in self._id_to_data:
             raise errors.SchemaError(

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -3244,6 +3244,31 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
         ])
         await self.fast_forward_describe_migration()
 
+    @test.xfail('Fails to rebase because the type is mismatched')
+    async def test_edgeql_migration_reject_prop_05(self):
+        await self.migrate('''
+            scalar type Slug extending str;
+            abstract type Named {
+                required property name -> Slug;
+            };
+            type User {
+                required property name -> str;
+            };
+        ''')
+
+        await self.start_migration('''
+            scalar type Slug extending str;
+            abstract type Named {
+                required property name -> Slug;
+            };
+            type User extending Named;
+        ''')
+
+        await self.interact([
+            ("did you drop property 'name' of object type 'test::User'?", "n"),
+        ], check_complete=False)
+        await self.fast_forward_describe_migration()
+
     async def test_edgeql_migration_eq_01(self):
         await self.migrate("""
             type Base;

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1900,6 +1900,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                         {state}
                     }}
                 }};
+                DESCRIBE CURRENT MIGRATION AS JSON;
                 POPULATE MIGRATION;
                 COMMIT MIGRATION;
             '''
@@ -4220,6 +4221,55 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             abstract type Owned;
             type Comment extending Text, Owned;
         """, r"""
+        """])
+
+    def test_schema_migrations_equivalence_52(self):
+        self._assert_migration_equivalence([r"""
+            scalar type Slug extending str;
+            type User {
+                required property name -> str;
+            };
+        """, r"""
+            scalar type Slug extending str;
+            abstract type Named {
+                required property name -> Slug;
+            };
+            type User extending Named;
+        """])
+
+    def test_schema_migrations_equivalence_53(self):
+        self._assert_migration_equivalence([r"""
+            scalar type Slug extending str;
+            abstract type Named {
+                required property name -> Slug;
+            };
+            type User {
+                required property name -> str;
+            };
+        """, r"""
+            scalar type Slug extending str;
+            abstract type Named {
+                required property name -> Slug;
+            };
+            type User extending Named {
+                property foo -> str;
+            }
+        """])
+
+    @test.xfail('Fails to delete the index first')
+    def test_schema_migrations_equivalence_54(self):
+        self._assert_migration_equivalence([r"""
+            type User {
+                  required property name -> str;
+                  index on (__subject__.name);
+            };
+        """, r"""
+            scalar type Slug extending str;
+            abstract type Named {
+                required property name -> Slug;
+                index on (__subject__.name);
+            };
+            type User extending Named;
         """])
 
     def test_schema_migrations_equivalence_compound_01(self):


### PR DESCRIPTION
* Track alters explicitly so we the proposals of create/delete delete
   happen only when an alter did not get created.
 * Move collection type shell creation in SetPointerType into the try
   block, since it too can fail.
 * Run a DESCRIBE AS JSON during the test_schema equivalence tests,
   which shook out a bug.
 * Renames must occur before a creation of a new object with the same
   name.
 * Some finer distinctions for rebase ordering

This fixes about half of the issues that come up in Issue #2399.