### PR TITLE
Make sure `False AND {}` is `{}`

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -38,7 +38,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_10_26_00_00
+EDGEDB_CATALOG_VERSION = 2021_11_02_00_00
 
 
 class MetadataError(Exception):

--- a/edb/lib/std/25-booloperators.edgeql
+++ b/edb/lib/std/25-booloperators.edgeql
@@ -44,14 +44,16 @@ std::`OR` (a: std::bool, b: std::bool) -> std::bool {
 };
 
 
-# `USING SQL EXPRESSION` means that the operator is translated
-# by the compiler into some SQL expression.
+# For the same reasons as OR above, we need to make sure
+# False AND {} is {}.
 CREATE INFIX OPERATOR
 std::`AND` (a: std::bool, b: std::bool) -> std::bool {
     CREATE ANNOTATION std::identifier := 'and';
     CREATE ANNOTATION std::description := 'Logical conjunction.';
     SET volatility := 'Immutable';
-    USING SQL EXPRESSION;
+    USING SQL $$
+    SELECT ("a" AND "b") OR ("a"::int & "b"::int)::bool
+    $$;
 };
 
 

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -257,7 +257,6 @@ def get_pointer_backend_name(id, module_name, *, catenate=False, aspect=None):
 
 
 _operator_map = {
-    s_name.name_from_string('std::AND'): 'AND',
     s_name.name_from_string('std::NOT'): 'NOT',
     s_name.name_from_string('std::?='): 'IS NOT DISTINCT FROM',
     s_name.name_from_string('std::?!='): 'IS DISTINCT FROM',
@@ -287,6 +286,8 @@ def get_operator_backend_name(name, catenate=False, *, aspect=None):
             # table.
             if oper_name == 'OR':
                 oper_name = '|||'
+            elif oper_name == 'AND':
+                oper_name = '&&&'
             else:
                 raise ValueError(
                     f'cannot represent operator {oper_name} in Postgres')

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -719,6 +719,9 @@ async def _init_stdlib(
     else:
         logger.info('Initializing the standard library...')
         await metaschema._execute_sql_script(conn, tpldbdump.decode('utf-8'))
+        # Restore the search_path as the dump might have altered it.
+        await conn.execute(
+            "SELECT pg_catalog.set_config('search_path', 'edgedb', false)")
 
     if not in_dev_mode and testmode:
         # Running tests on a production build.

--- a/tests/schemas/issues.esdl
+++ b/tests/schemas/issues.esdl
@@ -106,6 +106,15 @@ type Issue extending Named, Owned, Text {
     property tags -> array<str>;
 }
 
+# This is used to test correct behavior of boolean operators: NOT,
+# AND, OR. It targets especially interactions of properties and {}.
+#
+# Issue can be used to test similar interaction for links.
+type BooleanTest extending Named {
+    property val -> int64;
+    multi property tags -> str;
+}
+
 type File extending Named;
 
 type URL extending Named {

--- a/tests/schemas/issues_setup.edgeql
+++ b/tests/schemas/issues_setup.edgeql
@@ -142,3 +142,29 @@ FILTER User.name = 'Yury'
 SET {
     todo := (SELECT Issue FILTER Issue.number IN {'3', '4'})
 };
+
+INSERT BooleanTest {
+    name := 'circle',
+    val := 2,
+    tags := {'red', 'black'},
+};
+
+INSERT BooleanTest {
+    name := 'triangle',
+    val := 10,
+    tags := {'red', 'green'},
+};
+
+INSERT BooleanTest {
+    name := 'square',
+    tags := {'red'},
+};
+
+INSERT BooleanTest {
+    name := 'pentagon',
+};
+
+INSERT BooleanTest {
+    name := 'hexagon',
+    val := 4,
+};

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -7083,7 +7083,9 @@ type default::Foo {
                     SET volatility := 'Immutable';
                     CREATE ANNOTATION std::description :=
                         'Logical conjunction.';
-                    USING SQL EXPRESSION;
+                    USING SQL $$
+                        SELECT ("a" AND "b") OR ("a"::int & "b"::int)::bool
+                    $$;
                 };
                 ''',
                 '''

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -59,6 +59,7 @@ class TestIntrospection(tb.QueryTestCase):
                     .name;
             """,
             [
+                {'name': 'default::BooleanTest'},
                 {'name': 'default::Comment'},
                 {'name': 'default::Dictionary'},
                 {'name': 'default::File'},
@@ -1328,6 +1329,7 @@ class TestIntrospection(tb.QueryTestCase):
                     .name;
             """,
             [
+                {'name': 'default::BooleanTest', 'count': 0},
                 {'name': 'default::Comment', 'count': 0},
                 {'name': 'default::Dictionary', 'count': 0},
                 {'name': 'default::File', 'count': 0},

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -3408,6 +3408,111 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'number': '2'}, {'number': '3'}],
         )
 
+    async def test_edgeql_select_and_09(self):
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                val,
+                x := .val < 5 and .name like '%on'
+            } order by .name;
+            ''',
+            [
+                {'name': 'circle', 'val': 2, 'x': False},
+                {'name': 'hexagon', 'val': 4, 'x': True},
+                {'name': 'pentagon', 'val': {}, 'x': {}},
+                {'name': 'square', 'val': {}, 'x': {}},
+                {'name': 'triangle', 'val': 10, 'x': False},
+            ],
+        )
+
+    async def test_edgeql_select_and_10(self):
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                val,
+                x := not (.val < 5 and .name like '%on')
+            } order by .name;
+            ''',
+            [
+                {'name': 'circle', 'val': 2, 'x': True},
+                {'name': 'hexagon', 'val': 4, 'x': False},
+                {'name': 'pentagon', 'val': {}, 'x': {}},
+                {'name': 'square', 'val': {}, 'x': {}},
+                {'name': 'triangle', 'val': 10, 'x': True},
+            ],
+        )
+
+    async def test_edgeql_select_and_11(self):
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                tags,
+                x := (
+                    select _ := .tags = 'red' and .name like '%a%' order by _
+                )
+            } order by .name;
+            ''',
+            [{
+                'name': 'circle',
+                'tags': {'red', 'black'},
+                'x': [False, False],
+            }, {
+                'name': 'hexagon',
+                'tags': {},
+                'x': [],
+            }, {
+                'name': 'pentagon',
+                'tags': {},
+                'x': [],
+            }, {
+                'name': 'square',
+                'tags': {'red'},
+                'x': [True],
+            }, {
+                'name': 'triangle',
+                'tags': {'red', 'green'},
+                'x': [False, True],
+            }],
+        )
+
+    async def test_edgeql_select_and_12(self):
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                tags,
+                x := (
+                    select _ := not (.tags = 'red' and .name like '%a%')
+                    order by _
+                )
+            } order by .name;
+            ''',
+            [{
+                'name': 'circle',
+                'tags': {'red', 'black'},
+                'x': [True, True],
+            }, {
+                'name': 'hexagon',
+                'tags': {},
+                'x': [],
+            }, {
+                'name': 'pentagon',
+                'tags': {},
+                'x': [],
+            }, {
+                'name': 'square',
+                'tags': {'red'},
+                'x': [False],
+            }, {
+                'name': 'triangle',
+                'tags': {'red', 'green'},
+                'x': [False, True],
+            }],
+        )
+
     async def test_edgeql_select_or_01(self):
         issues_h = await self.con.query(r'''
             SELECT Issue{number}
@@ -3649,6 +3754,111 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'number': '2'}, {'number': '3'}],
         )
 
+    async def test_edgeql_select_or_16(self):
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                val,
+                x := .val < 5 or .name like '%on'
+            } order by .name;
+            ''',
+            [
+                {'name': 'circle', 'val': 2, 'x': True},
+                {'name': 'hexagon', 'val': 4, 'x': True},
+                {'name': 'pentagon', 'val': {}, 'x': {}},
+                {'name': 'square', 'val': {}, 'x': {}},
+                {'name': 'triangle', 'val': 10, 'x': False},
+            ],
+        )
+
+    async def test_edgeql_select_or_17(self):
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                val,
+                x := not (.val < 5 or .name like '%on')
+            } order by .name;
+            ''',
+            [
+                {'name': 'circle', 'val': 2, 'x': False},
+                {'name': 'hexagon', 'val': 4, 'x': False},
+                {'name': 'pentagon', 'val': {}, 'x': {}},
+                {'name': 'square', 'val': {}, 'x': {}},
+                {'name': 'triangle', 'val': 10, 'x': True},
+            ],
+        )
+
+    async def test_edgeql_select_or_18(self):
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                tags,
+                x := (
+                    select _ := .tags = 'red' or .name like '%t%a%' order by _
+                )
+            } order by .name;
+            ''',
+            [{
+                'name': 'circle',
+                'tags': {'red', 'black'},
+                'x': [False, True],
+            }, {
+                'name': 'hexagon',
+                'tags': {},
+                'x': [],
+            }, {
+                'name': 'pentagon',
+                'tags': {},
+                'x': [],
+            }, {
+                'name': 'square',
+                'tags': {'red'},
+                'x': [True],
+            }, {
+                'name': 'triangle',
+                'tags': {'red', 'green'},
+                'x': [True, True],
+            }],
+        )
+
+    async def test_edgeql_select_or_19(self):
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                tags,
+                x := (
+                    select _ := not (.tags = 'red' or .name like '%t%a%')
+                    order by _
+                )
+            } order by .name;
+            ''',
+            [{
+                'name': 'circle',
+                'tags': {'red', 'black'},
+                'x': [False, True],
+            }, {
+                'name': 'hexagon',
+                'tags': {},
+                'x': [],
+            }, {
+                'name': 'pentagon',
+                'tags': {},
+                'x': [],
+            }, {
+                'name': 'square',
+                'tags': {'red'},
+                'x': [False],
+            }, {
+                'name': 'triangle',
+                'tags': {'red', 'green'},
+                'x': [False, False],
+            }],
+        )
+
     async def test_edgeql_select_not_01(self):
         await self.assert_query_result(
             r'''
@@ -3704,6 +3914,106 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # this is the result from or04
             #
             [{'number': '2'}, {'number': '3'}],
+        )
+
+    async def test_edgeql_select_not_04(self):
+        # testing double negation
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                val,
+                x := not (.val < 5)
+            } order by .name;
+            ''',
+            [
+                {'name': 'circle', 'val': 2, 'x': False},
+                {'name': 'hexagon', 'val': 4, 'x': False},
+                {'name': 'pentagon', 'val': {}, 'x': {}},
+                {'name': 'square', 'val': {}, 'x': {}},
+                {'name': 'triangle', 'val': 10, 'x': True},
+            ],
+        )
+
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                val,
+                x := not not (.val < 5)
+            } order by .name;
+            ''',
+            [
+                {'name': 'circle', 'val': 2, 'x': True},
+                {'name': 'hexagon', 'val': 4, 'x': True},
+                {'name': 'pentagon', 'val': {}, 'x': {}},
+                {'name': 'square', 'val': {}, 'x': {}},
+                {'name': 'triangle', 'val': 10, 'x': False},
+            ],
+        )
+
+    async def test_edgeql_select_not_05(self):
+        # testing double negation
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                tags,
+                x := (select _ := not (.tags = 'red') order by _)
+            } order by .name;
+            ''',
+            [{
+                'name': 'circle',
+                'tags': {'red', 'black'},
+                'x': [False, True],
+            }, {
+                'name': 'hexagon',
+                'tags': {},
+                'x': [],
+            }, {
+                'name': 'pentagon',
+                'tags': {},
+                'x': [],
+            }, {
+                'name': 'square',
+                'tags': {'red'},
+                'x': [False],
+            }, {
+                'name': 'triangle',
+                'tags': {'red', 'green'},
+                'x': [False, True],
+            }],
+        )
+
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                tags,
+                x := (select _ := not not (.tags = 'red') order by _)
+            } order by .name;
+            ''',
+            [{
+                'name': 'circle',
+                'tags': {'red', 'black'},
+                'x': [False, True],
+            }, {
+                'name': 'hexagon',
+                'tags': {},
+                'x': [],
+            }, {
+                'name': 'pentagon',
+                'tags': {},
+                'x': [],
+            }, {
+                'name': 'square',
+                'tags': {'red'},
+                'x': [True],
+            }, {
+                'name': 'triangle',
+                'tags': {'red', 'green'},
+                'x': [False, True],
+            }],
         )
 
     async def test_edgeql_select_empty_01(self):


### PR DESCRIPTION
The `std::AND` operator is not `OPTIONAL`, so we cannot safely fall back
to SQL `AND`.  Use the same technique as we do for `OR`.  Technically,
we could formulate this to only use the altered implementation if any of
the operands is optional, but that is left as a future optimization.