### PR TITLE
Force delete/recreate when referenced object deleted/recreated

### DIFF
--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -271,13 +271,12 @@ def delta_schemas(
     ]
 
     assert not context.renames
-    # We retry performing the diff until we stop finding new
-    # renames. This allows us to be agnostic to the order that we
-    # process schemaclasses.
-    old_count = -1
-    while old_count != len(context.renames):
-        old_count = len(context.renames)
-        context.deletions.clear()
+    # We retry performing the diff until we stop finding new renames
+    # and deletions. This allows us to be agnostic to the order that
+    # we process schemaclasses.
+    old_count = -1, -1
+    while old_count != (len(context.renames), len(context.deletions)):
+        old_count = len(context.renames), len(context.deletions)
 
         objects = sd.DeltaRoot(canonical=True)
 

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -34,6 +34,7 @@ from edb.edgeql import qltypes
 
 from . import abc as s_abc
 from . import objects as so
+from . import name as sn
 
 
 if TYPE_CHECKING:
@@ -88,6 +89,13 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
     def is_compiled(self) -> bool:
         return self.refs is not None
 
+    def _refs_keys(self, schema: s_schema.Schema) -> Set[
+            Tuple[Type[so.Object], sn.Name]]:
+        return {
+            (type(x), x.get_name(schema))
+            for x in (self.refs.objects(schema) if self.refs else ())
+        }
+
     @classmethod
     def compare_values(cls: Type[Expression],
                        ours: Expression,
@@ -101,7 +109,15 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
             return 1.0
         elif not ours or not theirs:
             return compcoef
-        elif ours.text == theirs.text:
+
+        # If the new and old versions share a reference to an object
+        # that is being deleted, then we must delete this object as well.
+        our_refs = ours._refs_keys(our_schema)
+        their_refs = theirs._refs_keys(their_schema)
+        if (our_refs & their_refs) & context.deletions.keys():
+            return 0.0
+
+        if ours.text == theirs.text:
             return 1.0
         else:
             return compcoef

--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -116,7 +116,7 @@ class Property(
                 context=context,
                 compcoef=field.compcoef)
             if target_coef < 1:
-                similarity /= target_coef
+                similarity *= target_coef
         return similarity
 
     def should_propagate(self, schema: s_schema.Schema) -> bool:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4256,7 +4256,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
-    @test.xfail('Fails to delete the index first')
     def test_schema_migrations_equivalence_54(self):
         self._assert_migration_equivalence([r"""
             type User {
@@ -4270,6 +4269,23 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                 index on (__subject__.name);
             };
             type User extending Named;
+        """])
+
+    def test_schema_migrations_equivalence_55(self):
+        self._assert_migration_equivalence([r"""
+            type User {
+                  required property name -> str;
+                  property asdf := .name ++ "!";
+            };
+        """, r"""
+            scalar type Slug extending str;
+            abstract type Named {
+                required property name -> Slug;
+                index on (__subject__.name);
+            };
+            type User extending Named {
+                  property asdf := .name ++ "!";
+            }
         """])
 
     def test_schema_migrations_equivalence_compound_01(self):
@@ -4320,10 +4336,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             function foo() -> str USING ('bar');
         """])
 
-    @test.xfail('''
-        cannot drop function 'default::hello06(a: std::int64)'
-        because other objects in the schema depend on it
-    ''')
     def test_schema_migrations_equivalence_function_06(self):
         self._assert_migration_equivalence([r"""
             function hello06(a: int64) -> str
@@ -4351,10 +4363,6 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
-    @test.xfail('''
-        cannot drop function 'default::hello10(a: std::int64)'
-        because other objects in the schema depend on it
-    ''')
     def test_schema_migrations_equivalence_function_10(self):
         self._assert_migration_equivalence([r"""
             function hello10(a: int64) -> str


### PR DESCRIPTION
If an object that a referring object depends on is deleted and then
recreated, we currently don't have anything we can do except also do
that for the referring object as well.

Fixes #3118.