### PR TITLE
Make "and" and "or" in GraphQL conform to Postgres truthtable.

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -38,7 +38,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_11_02_00_00
+EDGEDB_CATALOG_VERSION = 2021_11_03_00_00
 
 
 class MetadataError(Exception):

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -161,6 +161,7 @@ sys::get_current_database() -> str
     USING SQL FUNCTION 'edgedb.get_current_database';
 };
 
+
 CREATE FUNCTION
 sys::_describe_roles_as_ddl() -> str
 {
@@ -168,4 +169,26 @@ sys::_describe_roles_as_ddl() -> str
     SET volatility := 'Stable';
     SET internal := true;
     USING SQL FUNCTION 'edgedb._describe_roles_as_ddl';
+};
+
+
+CREATE FUNCTION
+sys::__pg_and(a: OPTIONAL std::bool, b: OPTIONAL std::bool) -> std::bool
+{
+    SET volatility := 'Immutable';
+    SET internal := true;
+    USING SQL $$
+        SELECT a AND b;
+    $$;
+};
+
+
+CREATE FUNCTION
+sys::__pg_or(a: OPTIONAL std::bool, b: OPTIONAL std::bool) -> std::bool
+{
+    SET volatility := 'Immutable';
+    SET internal := true;
+    USING SQL $$
+        SELECT a OR b;
+    $$;
 };

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -1365,6 +1365,98 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             }]
         })
 
+    def test_graphql_functional_arguments_24(self):
+        # Test boolean AND handling {} like Postgres
+        self.assert_graphql_query_result(r"""
+            query {
+                other__Foo(
+                    filter: {
+                        not: {
+                            color: {eq: GREEN},
+                            after: {neq: "b"},
+                        },
+                    },
+                    order: {color: {dir: ASC}}
+                ) {
+                    select
+                    after
+                    color
+                }
+            }
+        """, {
+            "other__Foo": [{
+                "select": "a",
+                "after": None,
+                "color": "RED",
+            }, {
+                "select": None,
+                "after": "q",
+                "color": "BLUE",
+            }]
+        })
+
+    def test_graphql_functional_arguments_25(self):
+        # Test boolean AND handling {} like Postgres
+        self.assert_graphql_query_result(r"""
+            query {
+                other__Foo(
+                    filter: {
+                        not: {
+                          and: [
+                            {color: {eq: GREEN}},
+                            {after: {neq: "b"}},
+                          ]
+                        },
+                    },
+                    order: {color: {dir: ASC}}
+                ) {
+                    select
+                    after
+                    color
+                }
+            }
+        """, {
+            "other__Foo": [{
+                "select": "a",
+                "after": None,
+                "color": "RED",
+            }, {
+                "select": None,
+                "after": "q",
+                "color": "BLUE",
+            }]
+        })
+
+    def test_graphql_functional_arguments_26(self):
+        # Test boolean OR handling {} like Postgres
+        self.assert_graphql_query_result(r"""
+            query {
+                other__Foo(
+                    filter: {
+                      or: [
+                        {color: {neq: GREEN}},
+                        {after: {eq: "b"}},
+                      ]
+                    },
+                    order: {color: {dir: ASC}}
+                ) {
+                    select
+                    after
+                    color
+                }
+            }
+        """, {
+            "other__Foo": [{
+                "select": "a",
+                "after": None,
+                "color": "RED",
+            }, {
+                "select": None,
+                "after": "q",
+                "color": "BLUE",
+            }]
+        })
+
     def test_graphql_functional_enums_01(self):
         self.assert_graphql_query_result(r"""
             query {
@@ -3268,6 +3360,107 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             },
             # JSON can only be passed as a variable.
             variables={"val": {"foo": [1, None, "bar"]}},
+        )
+
+    def test_graphql_functional_variables_47(self):
+        # Test boolean AND handling {} like Postgres
+        self.assert_graphql_query_result(
+            r"""
+                query($color: other__ColorEnum!, $after: String!) {
+                    other__Foo(
+                        filter: {
+                            not: {
+                                color: {eq: $color},
+                                after: {neq: $after},
+                            },
+                        },
+                        order: {color: {dir: ASC}}
+                    ) {
+                        select
+                        after
+                        color
+                    }
+                }
+            """, {
+                "other__Foo": [{
+                    "select": "a",
+                    "after": None,
+                    "color": "RED",
+                }, {
+                    "select": None,
+                    "after": "q",
+                    "color": "BLUE",
+                }]
+            },
+            variables={'color': 'GREEN', 'after': 'b'},
+        )
+
+    def test_graphql_functional_variables_48(self):
+        # Test boolean AND handling {} like Postgres
+        self.assert_graphql_query_result(
+            r"""
+                query($color: other__ColorEnum!, $after: String!) {
+                    other__Foo(
+                        filter: {
+                            not: {
+                              and: [
+                                {color: {eq: $color}},
+                                {after: {neq: $after}},
+                              ]
+                            },
+                        },
+                        order: {color: {dir: ASC}}
+                    ) {
+                        select
+                        after
+                        color
+                    }
+                }
+            """, {
+                "other__Foo": [{
+                    "select": "a",
+                    "after": None,
+                    "color": "RED",
+                }, {
+                    "select": None,
+                    "after": "q",
+                    "color": "BLUE",
+                }]
+            },
+            variables={'color': 'GREEN', 'after': 'b'},
+        )
+
+    def test_graphql_functional_variables_49(self):
+        # Test boolean OR handling {} like Postgres
+        self.assert_graphql_query_result(
+            r"""
+                query($color: other__ColorEnum!, $after: String!) {
+                    other__Foo(
+                        filter: {
+                          or: [
+                            {color: {neq: $color}},
+                            {after: {eq: $after}},
+                          ]
+                        },
+                        order: {color: {dir: ASC}}
+                    ) {
+                        select
+                        after
+                        color
+                    }
+                }
+            """, {
+                "other__Foo": [{
+                    "select": "a",
+                    "after": None,
+                    "color": "RED",
+                }, {
+                    "select": None,
+                    "after": "q",
+                    "color": "BLUE",
+                }]
+            },
+            variables={'color': 'GREEN', 'after': 'b'},
         )
 
     def test_graphql_functional_inheritance_01(self):


### PR DESCRIPTION
In EdgeQL all operators handle {} the same way. If the operands are
required, then the result is {} if any of the inputs are {}. This
applies to boolean operators as well, so that `not`, `and`, `or` will
all produce {} as the result if any of the operands are {}. This case
can then be explicitly handled by adding `??` to the operands or the the
result.

In Postgres `False AND NULL` is `False` and `True OR NULL` is `True`.
In the general case this inconsistency can cause hard to debug subtle
issues.

In GraphQL we don't have arbitrary expressions, but rather a very
restricted subset of them appearing as "filter". In that particular
subset of usage it makes sense to use "short-circuiting" definition of
"and" and "or" operators because that best conforms to the expectations
in this use-case.