### PR TITLE
Restrict `|` operator to object types only.

### DIFF
--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -92,8 +92,27 @@ def _ql_typeexpr_to_type(
 
     elif isinstance(ql_t, qlast.TypeOp):
         if ql_t.op == '|':
-            return (_ql_typeexpr_to_type(ql_t.left, ctx=ctx) +
-                    _ql_typeexpr_to_type(ql_t.right, ctx=ctx))
+            # We need to validate that type ops are applied only to
+            # object types. So we check the base case here, when the
+            # left or right operand is a single type, because if it's
+            # a longer list, then we know that it was already composed
+            # of "|" or "&", or it is the result of inference by
+            # "typeof" and is a list of object types anyway.
+            left = _ql_typeexpr_to_type(ql_t.left, ctx=ctx)
+            right = _ql_typeexpr_to_type(ql_t.right, ctx=ctx)
+
+            if len(left) == 1 and not left[0].is_object_type():
+                raise errors.UnsupportedFeatureError(
+                    f'cannot use type operator {ql_t.op!r} with non-object '
+                    f'type {left[0].get_displayname(ctx.env.schema)}',
+                    context=ql_t.left.context)
+            if len(right) == 1 and not right[0].is_object_type():
+                raise errors.UnsupportedFeatureError(
+                    f'cannot use type operator {ql_t.op!r} with non-object '
+                    f'type {right[0].get_displayname(ctx.env.schema)}',
+                    context=ql_t.right.context)
+
+            return left + right
 
         raise errors.UnsupportedFeatureError(
             f'type operator {ql_t.op!r} is not implemented',

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4805,11 +4805,74 @@ aa \
             [],
         )
 
-    async def test_edgeql_normalization_missmatch_01(self):
+    async def test_edgeql_normalization_mismatch_01(self):
         with self.assertRaisesRegex(
                 edgedb.EdgeQLSyntaxError, "Unexpected type expression"):
 
             await self.con.query('SELECT <tuple<"">>1;')
+
+    async def test_edgeql_typeop_01(self):
+        with self.assertRaisesRegex(
+                edgedb.UnsupportedFeatureError,
+                "type operator '&' is not implemented",
+        ):
+            await self.con.query('select <Named & Owned>{};')
+
+    async def test_edgeql_typeop_02(self):
+        with self.assertRaisesRegex(
+                edgedb.UnsupportedFeatureError,
+                "cannot use type operator '|' with non-object type",
+        ):
+            await self.con.query('select 1 is (int64 | float64);')
+
+    async def test_edgeql_typeop_03(self):
+        with self.assertRaisesRegex(
+                edgedb.UnsupportedFeatureError,
+                "cannot use type operator '|' with non-object type",
+        ):
+            await self.con.query('select 1 is (Object | float64);')
+
+    async def test_edgeql_typeop_04(self):
+        with self.assertRaisesRegex(
+                edgedb.UnsupportedFeatureError,
+                "cannot use type operator '|' with non-object type",
+        ):
+            await self.con.query(
+                'select [1] is (array<int64> | array<float64>);')
+
+    async def test_edgeql_typeop_05(self):
+        with self.assertRaisesRegex(
+                edgedb.UnsupportedFeatureError,
+                "cannot use type operator '|' with non-object type",
+        ):
+            await self.con.query(
+                'select (1,) is (tuple<int64> | tuple<float64>);')
+
+    async def test_edgeql_typeop_06(self):
+        with self.assertRaisesRegex(
+                edgedb.UnsupportedFeatureError,
+                "cannot use type operator '|' with non-object type",
+        ):
+            await self.con.query(
+                'select [1] is (typeof [2] | typeof [2.2]);')
+
+    async def test_edgeql_typeop_07(self):
+        with self.assertRaisesRegex(
+                edgedb.UnsupportedFeatureError,
+                "cannot use type operator '|' with non-object type",
+        ):
+            await self.con.query(
+                'select (1,) is (typeof (2,) | typeof (2.2,));')
+
+    async def test_edgeql_typeop_08(self):
+        await self.assert_query_result(
+            'select {x := 1} is (typeof Issue.references | Object);',
+            {False}
+        )
+        await self.assert_query_result(
+            'select {x := 1} is (typeof Issue.references | BaseObject);',
+            {True}
+        )
 
     async def test_edgeql_assert_single_01(self):
         await self.con.execute("""


### PR DESCRIPTION
The type union is less useful for non-object types and may potentially
be needed for discriminated unions for scalars.

Closes #3116