### PR TITLE
Disallow referencing aliases from inside computables

### DIFF
--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -9952,6 +9952,10 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             ],
         )
 
+    @test.xfail('''
+       Referring to alias unsupported from computable
+       This is the only test that broke when we disallowed that!
+    ''')
     async def test_edgeql_migration_alias_02(self):
         await self.migrate(r'''
             type Foo {


### PR DESCRIPTION
It is broken on a lot of axes, so it's best for now to disallow it so
the error messages are consistent.

Only one previously passing test broke.