### PR TITLE
Do not emit `ALTER SYSTEM` when it's not supported by the backend

### DIFF
--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -145,6 +145,13 @@
 
 ####
 
+0x_09_00_00_00   BackendError
+
+0x_09_00_01_00   UnsupportedBackendFeatureError
+
+
+####
+
 0x_F0_00_00_00   LogMessage
 
 0x_F0_01_00_00   WarningMessage

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -83,6 +83,8 @@ __all__ = base.__all__ + (  # type: ignore
     'AuthenticationError',
     'AvailabilityError',
     'BackendUnavailableError',
+    'BackendError',
+    'UnsupportedBackendFeatureError',
     'LogMessage',
     'WarningMessage',
 )
@@ -382,6 +384,14 @@ class AvailabilityError(EdgeDBError):
 
 class BackendUnavailableError(AvailabilityError):
     _code = 0x_08_00_00_01
+
+
+class BackendError(EdgeDBError):
+    _code = 0x_09_00_00_00
+
+
+class UnsupportedBackendFeatureError(BackendError):
+    _code = 0x_09_00_01_00
 
 
 class LogMessage(EdgeDBMessage):

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -103,6 +103,12 @@ ALTER TYPE cfg::AbstractConfig {
         SET default := <cfg::memory>'0';
     };
 
+    CREATE PROPERTY durprop -> std::duration {
+        CREATE ANNOTATION cfg::internal := 'true';
+        SET default := <std::duration>'0 seconds';
+    };
+
+
     CREATE PROPERTY __pg_max_connections -> std::int64 {
         CREATE ANNOTATION cfg::internal := 'true';
         CREATE ANNOTATION cfg::backend_setting := '"max_connections"';

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -53,6 +53,7 @@ def compile_ir_to_sql_tree(
     external_rvars: Optional[
         Mapping[Tuple[irast.PathId, str], pgast.PathRangeVar]
     ] = None,
+
 ) -> pgast.Base:
     try:
         # Transform to sql tree

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -31,6 +31,7 @@ import uuid
 from edb.common import compiler
 
 from edb.pgsql import ast as pgast
+from edb.pgsql import params as pgparams
 
 from . import aliases
 
@@ -376,6 +377,7 @@ class Environment:
     scope_tree_nodes: Dict[int, irast.ScopeTreeNode]
     external_rvars: Mapping[Tuple[irast.PathId, str], pgast.PathRangeVar]
     materialized_views: Dict[uuid.UUID, irast.Set]
+    backend_runtime_params: pgparams.BackendRuntimeParams
 
     #: A list of CTEs that implement constraint validation at the
     #: query level.
@@ -396,6 +398,7 @@ class Environment:
         external_rvars: Optional[
             Mapping[Tuple[irast.PathId, str], pgast.PathRangeVar]
         ] = None,
+        backend_runtime_params: pgparams.BackendRuntimeParams,
     ) -> None:
         self.aliases = aliases.AliasGenerator()
         self.output_format = output_format
@@ -411,6 +414,7 @@ class Environment:
         self.external_rvars = external_rvars or {}
         self.materialized_views = {}
         self.check_ctes = []
+        self.backend_runtime_params = backend_runtime_params
 
 
 # XXX: this context hack is necessary until pathctx is converted

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -69,9 +69,9 @@ from edb.ir import utils as irutils
 
 from edb.pgsql import common
 from edb.pgsql import dbops
+from edb.pgsql import params
 
 from edb.server import defines as edbdef
-from edb.server import pgcluster
 
 from . import ast as pg_ast
 from .common import qname as q
@@ -187,21 +187,21 @@ class MetaCommand(sd.Command, metaclass=CommandMeta):
     def _get_backend_params(
         self,
         context: sd.CommandContext,
-    ) -> pgcluster.BackendRuntimeParams:
+    ) -> params.BackendRuntimeParams:
 
         ctx_backend_params = context.backend_runtime_params
         if ctx_backend_params is not None:
             backend_params = cast(
-                pgcluster.BackendRuntimeParams, ctx_backend_params)
+                params.BackendRuntimeParams, ctx_backend_params)
         else:
-            backend_params = pgcluster.get_default_runtime_params()
+            backend_params = params.get_default_runtime_params()
 
         return backend_params
 
     def _get_instance_params(
         self,
         context: sd.CommandContext,
-    ) -> pgcluster.BackendInstanceParams:
+    ) -> params.BackendInstanceParams:
         return self._get_backend_params(context).instance_params
 
     def _get_tenant_id(self, context: sd.CommandContext) -> str:
@@ -366,9 +366,9 @@ class AlterGlobalSchemaVersion(
         ctx_backend_params = context.backend_runtime_params
         if ctx_backend_params is not None:
             backend_params = cast(
-                pgcluster.BackendRuntimeParams, ctx_backend_params)
+                params.BackendRuntimeParams, ctx_backend_params)
         else:
-            backend_params = pgcluster.get_default_runtime_params()
+            backend_params = params.get_default_runtime_params()
 
         instance_params = backend_params.instance_params
         capabilities = instance_params.capabilities
@@ -377,7 +377,7 @@ class AlterGlobalSchemaVersion(
         tpl_db_name = common.get_database_backend_name(
             edbdef.EDGEDB_TEMPLATE_DB, tenant_id=tenant_id)
 
-        if capabilities & pgcluster.BackendCapabilities.SUPERUSER_ACCESS:
+        if capabilities & params.BackendCapabilities.SUPERUSER_ACCESS:
             # Only superusers are generally allowed to make an UPDATE
             # lock on shared catalogs.
             lock = dbops.Query(
@@ -5310,7 +5310,7 @@ class CreateRole(MetaCommand, adapts=s_roles.CreateRole):
             if not backend_params.instance_params.base_superuser:
                 superuser_flag = (
                     capabilities
-                    & pgcluster.BackendCapabilities.SUPERUSER_ACCESS
+                    & params.BackendCapabilities.SUPERUSER_ACCESS
                 )
 
         if backend_params.session_authorization_role is not None:
@@ -5390,7 +5390,7 @@ class AlterRole(MetaCommand, adapts=s_roles.AlterRole):
             if not instance_params.base_superuser:
                 superuser_flag = (
                     capabilities
-                    & pgcluster.BackendCapabilities.SUPERUSER_ACCESS
+                    & params.BackendCapabilities.SUPERUSER_ACCESS
                 )
 
             kwargs['superuser'] = superuser_flag

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -244,6 +244,7 @@ class Query(MetaCommand, adapts=sd.Query):
                 schema,
                 schema.get('std::str'),
             ),
+            backend_runtime_params=context.backend_runtime_params,
         )
 
         sql_text = codegen.generate_source(sql_tree)
@@ -3689,6 +3690,7 @@ class PointerMetaCommand(MetaCommand):
             output_format=compiler.OutputFormat.NATIVE_INTERNAL,
             singleton_mode=expr_is_trivial,
             external_rvars=external_rvars,
+            backend_runtime_params=context.backend_runtime_params,
         )
 
         sql_text = codegen.generate_source(sql_tree)

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -54,11 +54,11 @@ from edb.server import defines
 from edb.server import compiler as edbcompiler
 from edb.server import config as edbconfig
 from edb.server import bootstrap as edbbootstrap
-from edb.server import pgcluster
 
 from . import common
 from . import dbops
 from . import types
+from . import params
 
 if TYPE_CHECKING:
     import asyncpg
@@ -3388,7 +3388,7 @@ class SysConfigFunction(dbops.Function):
 
     backend_caps := edgedb.get_backend_capabilities();
     IF (backend_caps
-        & {int(pgcluster.BackendCapabilities.CONFIGFILE_ACCESS)}) != 0
+        & {int(params.BackendCapabilities.CONFIGFILE_ACCESS)}) != 0
     THEN
         RETURN QUERY
         SELECT *

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -3288,6 +3288,8 @@ class SysConfigFullFunction(dbops.Function):
                         SELECT * FROM pg_auto_conf_settings UNION ALL
                         SELECT * FROM pg_config
                     ) AS q
+                WHERE
+                    q.is_backend
             )
         $$;
     ELSE
@@ -3297,9 +3299,15 @@ class SysConfigFullFunction(dbops.Function):
                     q.*
                 FROM
                     (
+                        -- config_sys is here, because there
+                        -- is no other way to read instance-level
+                        -- configuration overrides.
+                        SELECT * FROM config_sys UNION ALL
                         SELECT * FROM pg_db_setting UNION ALL
                         SELECT * FROM pg_config
                     ) AS q
+                WHERE
+                    q.is_backend
             )
         $$;
     END IF;

--- a/edb/pgsql/params.py
+++ b/edb/pgsql/params.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+from typing import *
+
+import enum
+import functools
+import locale
+
+from edb import buildmeta
+
+
+class BackendCapabilities(enum.IntFlag):
+
+    NONE = 0
+    #: Whether CREATE ROLE .. SUPERUSER is allowed
+    SUPERUSER_ACCESS = 1 << 0
+    #: Whether reading PostgreSQL configuration files
+    #: via pg_file_settings is allowed
+    CONFIGFILE_ACCESS = 1 << 1
+    #: Whether the PostgreSQL server supports the C.UTF-8 locale
+    C_UTF8_LOCALE = 1 << 2
+
+
+ALL_BACKEND_CAPABILITIES = (
+    BackendCapabilities.SUPERUSER_ACCESS
+    | BackendCapabilities.CONFIGFILE_ACCESS
+    | BackendCapabilities.C_UTF8_LOCALE
+)
+
+
+class BackendInstanceParams(NamedTuple):
+
+    capabilities: BackendCapabilities
+    tenant_id: str
+    base_superuser: Optional[str] = None
+    max_connections: int = 500
+    reserved_connections: int = 0
+
+
+class BackendRuntimeParams(NamedTuple):
+
+    instance_params: BackendInstanceParams
+    session_authorization_role: Optional[str] = None
+
+
+@functools.lru_cache
+def get_default_runtime_params(
+    **instance_params: Any,
+) -> BackendRuntimeParams:
+    capabilities = ALL_BACKEND_CAPABILITIES
+    if not _is_c_utf8_locale_present():
+        capabilities &= ~BackendCapabilities.C_UTF8_LOCALE
+    instance_params.setdefault('capabilities', capabilities)
+    if 'tenant_id' not in instance_params:
+        instance_params = dict(
+            tenant_id=buildmeta.get_default_tenant_id(),
+            **instance_params,
+        )
+
+    return BackendRuntimeParams(
+        instance_params=BackendInstanceParams(**instance_params),
+    )
+
+
+def _is_c_utf8_locale_present() -> bool:
+    try:
+        locale.setlocale(locale.LC_CTYPE, 'C.UTF-8')
+    except Exception:
+        return False
+    else:
+        # We specifically don't use locale.getlocale(), because
+        # it can lie and return a non-existent locale due to PEP 538.
+        locale.setlocale(locale.LC_CTYPE, '')
+        return True

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -60,6 +60,7 @@ from edb.pgsql import common as pg_common
 from edb.pgsql import dbops
 from edb.pgsql import delta as delta_cmds
 from edb.pgsql import metaschema
+from edb.pgsql import params as pgparams
 from edb.pgsql.common import quote_ident as qi
 from edb.pgsql.common import quote_literal as ql
 
@@ -135,7 +136,7 @@ async def _ensure_edgedb_supergroup(
         name=pg_role_name,
         superuser=bool(
             instance_params.capabilities
-            & pgcluster.BackendCapabilities.SUPERUSER_ACCESS
+            & pgparams.BackendCapabilities.SUPERUSER_ACCESS
         ),
         allow_login=False,
         allow_createdb=True,
@@ -184,7 +185,7 @@ async def _ensure_edgedb_role(
             superuser
             and bool(
                 instance_params.capabilities
-                & pgcluster.BackendCapabilities.SUPERUSER_ACCESS
+                & pgparams.BackendCapabilities.SUPERUSER_ACCESS
             )
         ),
         allow_login=True,
@@ -255,7 +256,7 @@ async def _create_edgedb_template_database(
     instance_params = ctx.cluster.get_runtime_params().instance_params
     capabilities = instance_params.capabilities
     have_c_utf8 = (
-        capabilities & pgcluster.BackendCapabilities.C_UTF8_LOCALE)
+        capabilities & pgparams.BackendCapabilities.C_UTF8_LOCALE)
 
     logger.info('Creating template database...')
     block = dbops.SQLBlock()

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -108,7 +108,7 @@ class CompileContext:
     inline_objectids: bool = True
     schema_object_ids: Optional[Mapping[s_name.Name, uuid.UUID]] = None
     source: Optional[edgeql.Source] = None
-    backend_runtime_params: Any = (
+    backend_runtime_params: pg_params.BackendRuntimeParams = (
         pg_params.get_default_runtime_params())
     compat_ver: Optional[verutils.Version] = None
     bootstrap_mode: bool = False
@@ -607,6 +607,7 @@ class Compiler:
             ),
             expected_cardinality_one=ctx.expected_cardinality_one,
             output_format=_convert_format(ctx.output_format),
+            backend_runtime_params=ctx.backend_runtime_params,
         )
 
         if (
@@ -1513,6 +1514,7 @@ class Compiler:
             ir,
             pretty=(debug.flags.edgeql_compile
                     or debug.flags.edgeql_compile_sql_text),
+            backend_runtime_params=ctx.backend_runtime_params,
         )
 
         sql = (sql_text.encode(),)

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -67,13 +67,13 @@ from edb.schema import schema as s_schema
 from edb.schema import types as s_types
 from edb.schema import utils as s_utils
 
+from edb.pgsql import common as pg_common
 from edb.pgsql import delta as pg_delta
 from edb.pgsql import dbops as pg_dbops
-from edb.pgsql import common as pg_common
+from edb.pgsql import params as pg_params
 from edb.pgsql import types as pg_types
 
 from edb.server import config
-from edb.server import pgcluster
 
 from . import dbstate
 from . import enums
@@ -109,7 +109,7 @@ class CompileContext:
     schema_object_ids: Optional[Mapping[s_name.Name, uuid.UUID]] = None
     source: Optional[edgeql.Source] = None
     backend_runtime_params: Any = (
-        pgcluster.get_default_runtime_params())
+        pg_params.get_default_runtime_params())
     compat_ver: Optional[verutils.Version] = None
     bootstrap_mode: bool = False
     internal_schema_mode: bool = False
@@ -253,8 +253,8 @@ class Compiler:
     def __init__(
         self,
         *,
-        backend_runtime_params: pgcluster.BackendRuntimeParams=
-            pgcluster.get_default_runtime_params(),
+        backend_runtime_params: pg_params.BackendRuntimeParams=
+            pg_params.get_default_runtime_params(),
     ):
         self._dbname = None
         self._cached_db = None

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -33,11 +33,12 @@ import time
 
 import immutables
 
-from edb.server import defines
-from edb.server import pgcluster
-from edb.server import metrics
-
 from edb.common import debug
+
+from edb.pgsql import params as pgparams
+
+from edb.server import defines
+from edb.server import metrics
 
 from . import amsg
 from . import queue
@@ -72,7 +73,7 @@ class Worker:
         self,
         manager,
         dbs: state.DatabasesState,
-        backend_runtime_params: pgcluster.BackendRuntimeParams,
+        backend_runtime_params: pgparams.BackendRuntimeParams,
         std_schema,
         refl_schema,
         schema_class_layout,
@@ -166,7 +167,7 @@ class Pool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
         loop,
         runstate_dir,
         dbindex,
-        backend_runtime_params: pgcluster.BackendRuntimeParams,
+        backend_runtime_params: pgparams.BackendRuntimeParams,
         std_schema,
         refl_schema,
         schema_class_layout,
@@ -733,7 +734,7 @@ async def create_compiler_pool(
     runstate_dir: str,
     pool_size: int,
     dbindex,
-    backend_runtime_params: pgcluster.BackendRuntimeParams,
+    backend_runtime_params: pgparams.BackendRuntimeParams,
     std_schema,
     refl_schema,
     schema_class_layout,

--- a/edb/server/compiler_pool/worker.py
+++ b/edb/server/compiler_pool/worker.py
@@ -32,17 +32,18 @@ import immutables
 
 from edb import graphql
 
+from edb.common import debug
+from edb.common import devmode
+from edb.common import markup
+
 from edb.edgeql import parser as ql_parser
+
+from edb.pgsql import params as pgparams
 
 from edb.schema import schema as s_schema
 
 from edb.server import compiler
 from edb.server import config
-from edb.server import pgcluster
-
-from edb.common import debug
-from edb.common import devmode
-from edb.common import markup
 
 from . import amsg
 from . import state
@@ -50,8 +51,8 @@ from . import state
 
 INITED: bool = False
 DBS: state.DatabasesState = immutables.Map()
-BACKEND_RUNTIME_PARAMS: pgcluster.BackendRuntimeParams = \
-    pgcluster.get_default_runtime_params()
+BACKEND_RUNTIME_PARAMS: pgparams.BackendRuntimeParams = \
+    pgparams.get_default_runtime_params()
 COMPILER: compiler.Compiler
 LAST_STATE: Optional[compiler.dbstate.CompilerConnectionState] = None
 STD_SCHEMA: s_schema.FlatSchema

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -20,9 +20,6 @@ from __future__ import annotations
 from typing import *
 
 import asyncio
-import enum
-import functools
-import locale
 import logging
 import os
 import os.path
@@ -43,6 +40,7 @@ from edb.common import uuidgen
 from edb.server import defines
 from edb.server.ha import base as ha_base
 from edb.pgsql import common as pgcommon
+from edb.pgsql import params as pgparams
 
 from . import pgconnparams
 
@@ -58,18 +56,6 @@ get_database_backend_name = pgcommon.get_database_backend_name
 get_role_backend_name = pgcommon.get_role_backend_name
 
 
-def _is_c_utf8_locale_present() -> bool:
-    try:
-        locale.setlocale(locale.LC_CTYPE, 'C.UTF-8')
-    except Exception:
-        return False
-    else:
-        # We specifically don't use locale.getlocale(), because
-        # it can lie and return a non-existent locale due to PEP 538.
-        locale.setlocale(locale.LC_CTYPE, '')
-        return True
-
-
 class ClusterError(Exception):
     pass
 
@@ -78,63 +64,12 @@ class PostgresPidFileNotReadyError(Exception):
     """Raised on an attempt to read non-existent or bad Postgres PID file"""
 
 
-class BackendCapabilities(enum.IntFlag):
-
-    NONE = 0
-    #: Whether CREATE ROLE .. SUPERUSER is allowed
-    SUPERUSER_ACCESS = 1 << 0
-    #: Whether reading PostgreSQL configuration files
-    #: via pg_file_settings is allowed
-    CONFIGFILE_ACCESS = 1 << 1
-    #: Whether the PostgreSQL server supports the C.UTF-8 locale
-    C_UTF8_LOCALE = 1 << 2
-
-
-ALL_BACKEND_CAPABILITIES = (
-    BackendCapabilities.SUPERUSER_ACCESS
-    | BackendCapabilities.CONFIGFILE_ACCESS
-    | BackendCapabilities.C_UTF8_LOCALE
-)
-
-
-class BackendInstanceParams(NamedTuple):
-
-    capabilities: BackendCapabilities
-    tenant_id: str
-    base_superuser: Optional[str] = None
-    max_connections: int = 500
-    reserved_connections: int = 0
-
-
-class BackendRuntimeParams(NamedTuple):
-
-    instance_params: BackendInstanceParams
-    session_authorization_role: Optional[str] = None
-
-
-@functools.lru_cache
-def get_default_runtime_params(**instance_params: Any) -> BackendRuntimeParams:
-    capabilities = ALL_BACKEND_CAPABILITIES
-    if not _is_c_utf8_locale_present():
-        capabilities &= ~BackendCapabilities.C_UTF8_LOCALE
-    instance_params.setdefault('capabilities', capabilities)
-    if 'tenant_id' not in instance_params:
-        instance_params = dict(
-            tenant_id=buildmeta.get_default_tenant_id(),
-            **instance_params,
-        )
-
-    return BackendRuntimeParams(
-        instance_params=BackendInstanceParams(**instance_params),
-    )
-
-
 class BaseCluster:
 
     def __init__(
         self,
         *,
-        instance_params: Optional[BackendInstanceParams] = None,
+        instance_params: Optional[pgparams.BackendInstanceParams] = None,
     ) -> None:
         self._connection_addr: Optional[Tuple[str, int]] = None
         self._connection_params: Optional[
@@ -145,7 +80,7 @@ class BaseCluster:
         self._pg_bin_dir: Optional[pathlib.Path] = None
         if instance_params is None:
             self._instance_params = (
-                get_default_runtime_params().instance_params)
+                pgparams.get_default_runtime_params().instance_params)
         else:
             self._instance_params = instance_params
 
@@ -203,11 +138,11 @@ class BaseCluster:
     def stop_watching(self) -> None:
         pass
 
-    def get_runtime_params(self) -> BackendRuntimeParams:
+    def get_runtime_params(self) -> pgparams.BackendRuntimeParams:
         params = self.get_connection_params()
         login_role: Optional[str] = params.user
         sup_role = self.get_role_name(defines.EDGEDB_SUPERUSER)
-        return BackendRuntimeParams(
+        return pgparams.BackendRuntimeParams(
             instance_params=self._instance_params,
             session_authorization_role=(
                 None if login_role == sup_role else login_role
@@ -354,7 +289,7 @@ class Cluster(BaseCluster):
         data_dir: pathlib.Path,
         *,
         runstate_dir: Optional[pathlib.Path] = None,
-        instance_params: Optional[BackendInstanceParams] = None,
+        instance_params: Optional[pgparams.BackendInstanceParams] = None,
         log_level: str = 'i',
     ):
         super().__init__(instance_params=instance_params)
@@ -416,7 +351,7 @@ class Cluster(BaseCluster):
             instance_params = self.get_runtime_params().instance_params
             capabilities = instance_params.capabilities
             have_c_utf8 = (
-                capabilities & BackendCapabilities.C_UTF8_LOCALE)
+                capabilities & pgparams.BackendCapabilities.C_UTF8_LOCALE)
             await self.init(
                 username='postgres',
                 locale='C.UTF-8' if have_c_utf8 else 'en_US.UTF-8',
@@ -747,7 +682,7 @@ class RemoteCluster(BaseCluster):
         addr: Tuple[str, int],
         params: pgconnparams.ConnectionParameters,
         *,
-        instance_params: Optional[BackendInstanceParams] = None,
+        instance_params: Optional[pgparams.BackendInstanceParams] = None,
         ha_backend: Optional[ha_base.HABackend] = None,
     ):
         super().__init__(instance_params=instance_params)
@@ -851,7 +786,7 @@ async def get_local_pg_cluster(
         tenant_id = buildmeta.get_default_tenant_id()
     instance_params = None
     if max_connections is not None:
-        instance_params = get_default_runtime_params(
+        instance_params = pgparams.get_default_runtime_params(
             max_connections=max_connections,
             tenant_id=tenant_id,
         ).instance_params
@@ -922,8 +857,8 @@ async def get_remote_pg_cluster(
 
     async def _detect_capabilities(
         conn: asyncpg.Connection,
-    ) -> BackendCapabilities:
-        caps = BackendCapabilities.NONE
+    ) -> pgparams.BackendCapabilities:
+        caps = pgparams.BackendCapabilities.NONE
 
         try:
             await conn.execute(f'ALTER SYSTEM SET foo = 10')
@@ -935,7 +870,7 @@ async def get_remote_pg_cluster(
             configfile_access = True
 
         if configfile_access:
-            caps |= BackendCapabilities.CONFIGFILE_ACCESS
+            caps |= pgparams.BackendCapabilities.CONFIGFILE_ACCESS
 
         tx = conn.transaction()
         await tx.start()
@@ -951,7 +886,7 @@ async def get_remote_pg_cluster(
             await tx.rollback()
 
         if can_make_superusers:
-            caps |= BackendCapabilities.SUPERUSER_ACCESS
+            caps |= pgparams.BackendCapabilities.SUPERUSER_ACCESS
 
         coll = await conn.fetchval('''
             SELECT collname FROM pg_collation
@@ -959,7 +894,7 @@ async def get_remote_pg_cluster(
         ''')
 
         if coll is not None:
-            caps |= BackendCapabilities.C_UTF8_LOCALE
+            caps |= pgparams.BackendCapabilities.C_UTF8_LOCALE
 
         return caps
 
@@ -989,7 +924,7 @@ async def get_remote_pg_cluster(
     try:
         cluster_type, superuser_name = await _get_cluster_type(conn)
         max_connections = await _get_pg_settings(conn, 'max_connections')
-        instance_params = BackendInstanceParams(
+        instance_params = pgparams.BackendInstanceParams(
             capabilities=await _detect_capabilities(conn),
             base_superuser=superuser_name,
             max_connections=int(max_connections),

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -999,16 +999,16 @@ class TestServerConfig(tb.QueryTestCase):
                 "unable to parse '12mse'"):
             await self.con.execute('''
                 configure session set
-                    query_execution_timeout := <duration>'12mse'
+                    durprop := <duration>'12mse'
             ''')
 
         with self.assertRaisesRegex(
                 edgedb.ConfigurationError,
-                r"invalid setting value type for session_idle_timeout: "
+                r"invalid setting value type for durprop: "
                 r"'std::str' \(expecting 'std::duration"):
             await self.con.execute('''
                 configure instance set
-                    session_idle_timeout := '12 seconds'
+                    durprop := '12 seconds'
             ''')
 
     async def test_server_proto_configure_compilation(self):


### PR DESCRIPTION
Currently, we unconditionally compile `CONFIGURE INSTANCE` to `ALTER 
SYSTEM`, even if the latter is not supported by the backend, which is 
common for cloud Postgres.  When unsupported, emit a config op JSON record
and let `dbview.apply_system_config_op()` deal with it.