### PR TITLE
Fix emission of values in DESCRIBE CONFIG for types without literals

### DIFF
--- a/edb/ir/statypes.py
+++ b/edb/ir/statypes.py
@@ -304,35 +304,42 @@ class ConfigMemory:
 
     def __init__(
         self,
-        text: str,
+        val: str | int,
         /,
     ) -> None:
-        if text == '0':
-            self._value = 0
-            return
+        if isinstance(val, int):
+            self._value = val
+        elif isinstance(val, str):
+            text = val
+            if text == '0':
+                self._value = 0
+                return
 
-        m = self._parser.match(text)
-        if m is None:
-            raise errors.InvalidValueError(
-                f'unable to parse memory size: {text!r}')
+            m = self._parser.match(text)
+            if m is None:
+                raise errors.InvalidValueError(
+                    f'unable to parse memory size: {text!r}')
 
-        num = int(m.group('num'))
-        unit = m.group('unit')
+            num = int(m.group('num'))
+            unit = m.group('unit')
 
-        if unit == 'B':
-            self._value = num
-        elif unit == 'KiB':
-            self._value = num * self.KiB
-        elif unit == 'MiB':
-            self._value = num * self.MiB
-        elif unit == 'GiB':
-            self._value = num * self.GiB
-        elif unit == 'TiB':
-            self._value = num * self.TiB
-        elif unit == 'PiB':
-            self._value = num * self.PiB
+            if unit == 'B':
+                self._value = num
+            elif unit == 'KiB':
+                self._value = num * self.KiB
+            elif unit == 'MiB':
+                self._value = num * self.MiB
+            elif unit == 'GiB':
+                self._value = num * self.GiB
+            elif unit == 'TiB':
+                self._value = num * self.TiB
+            elif unit == 'PiB':
+                self._value = num * self.PiB
+            else:
+                raise AssertionError('unexpected unit')
         else:
-            raise AssertionError('unexpected unit')
+            raise ValueError(
+                f"invalid ConfigMemory value: {type(val)}, expected int | str")
 
     def to_nbytes(self) -> int:
         return self._value

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -98,6 +98,11 @@ ALTER TYPE cfg::AbstractConfig {
         SET default := '';
     };
 
+    CREATE PROPERTY memprop -> cfg::memory {
+        CREATE ANNOTATION cfg::internal := 'true';
+        SET default := <cfg::memory>'0';
+    };
+
     CREATE PROPERTY __pg_max_connections -> std::int64 {
         CREATE ANNOTATION cfg::internal := 'true';
         CREATE ANNOTATION cfg::backend_setting := '"max_connections"';

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -4677,12 +4677,12 @@ def _render_config_value(
         schema,
         schema.get('std::duration', type=s_scalars.ScalarType),
     ):
-        val = f'cfg::_quote(<str>{value_expr})'
+        val = f'"<std::duration>" ++ cfg::_quote(<str>{value_expr})'
     elif valtype.issubclass(
         schema,
         schema.get('cfg::memory', type=s_scalars.ScalarType),
     ):
-        val = f'cfg::_quote(<str>{value_expr})'
+        val = f'"<cfg::memory>" ++ cfg::_quote(<str>{value_expr})'
     elif valtype.issubclass(
         schema,
         schema.get('std::str', type=s_scalars.ScalarType),

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -105,7 +105,7 @@ class Operation(NamedTuple):
             elif (isinstance(self.value, str) and
                     issubclass(setting.type, statypes.Duration)):
                 return statypes.Duration(self.value)
-            elif (isinstance(self.value, str) and
+            elif (isinstance(self.value, (str, int)) and
                     issubclass(setting.type, statypes.ConfigMemory)):
                 return statypes.ConfigMemory(self.value)
             elif self.value is None and allow_missing:

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -936,10 +936,14 @@ class TestServerConfig(tb.QueryTestCase):
             conf3 = "CONFIGURE SESSION SET singleprop := '42';"
             await self.con.execute(conf3)
 
+            conf4 = "CONFIGURE INSTANCE SET memprop := <cfg::memory>'100MiB';"
+            await self.con.execute(conf4)
+
             res = await self.con.query_single('DESCRIBE INSTANCE CONFIG;')
             self.assertIn(conf1, res)
             self.assertIn(conf2, res)
             self.assertNotIn(conf3, res)
+            self.assertIn(conf4, res)
 
         finally:
             await self.con.execute('''
@@ -948,6 +952,9 @@ class TestServerConfig(tb.QueryTestCase):
             ''')
             await self.con.execute('''
                 CONFIGURE INSTANCE RESET singleprop;
+            ''')
+            await self.con.execute('''
+                CONFIGURE INSTANCE RESET memprop;
             ''')
 
     async def test_server_proto_configure_describe_database_config(self):


### PR DESCRIPTION
Configuration data types without native literals, like `std::duration`
and `std::memory` should be rendered with an explicit cast.

Fixes: #3139