### PR TITLE
Reflect more native types to GraphQL.

### DIFF
--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -37,6 +37,10 @@ type Profile extending NamedObject {
     required property value -> str;
     property tags -> array<str>;
     multi property odd -> array<int64>;
+
+    # computed link and property test
+    link owner_user := .<profile[IS User];
+    property owner_name := .<profile[IS User].name;
 }
 
 type User extending NamedObject {
@@ -95,6 +99,9 @@ type ScalarTest {
     property p_array_int64 -> array<int64>;
     property p_array_json -> array<json>;
     property p_array_bytes -> array<bytes>;
+
+    property p_tuple -> tuple<int64, str>;
+    property p_array_tuple -> array<tuple<str, bool>>;
 }
 type BigIntTest {
     property value -> bigint;

--- a/tests/schemas/graphql_schema.esdl
+++ b/tests/schemas/graphql_schema.esdl
@@ -39,7 +39,7 @@ type Profile extending NamedObject {
     multi property odd -> array<int64>;
 
     # computed link and property test
-    link owner := .<profile[IS User];
+    link owner_user := .<profile[IS User];
     property owner_name := .<profile[IS User].name;
 }
 

--- a/tests/schemas/graphql_setup.edgeql
+++ b/tests/schemas/graphql_setup.edgeql
@@ -128,6 +128,9 @@ INSERT ScalarTest {
     p_array_str := ['hello', 'world'],
     p_array_json := [<json>'hello', <json>'world'],
     p_array_bytes := [b'hello', b'world'],
+
+    p_tuple := (123, 'test'),
+    p_array_tuple := [('hello', true), ('world', false)],
 };
 
 # Inheritance tests

--- a/tests/test_http_graphql_mutation.py
+++ b/tests/test_http_graphql_mutation.py
@@ -2154,6 +2154,120 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
             }]
         })
 
+    def test_graphql_mutation_update_scalars_07(self):
+        # This tests array of JSON mutations. JSON can only be
+        # mutated via a variable.
+        data = {
+            'el0': {"foo": [1, None, "aardvark"]},
+            'el1': False,
+        }
+
+        self.assert_graphql_query_result(
+            r"""
+                mutation insert_ScalarTest($el0: JSON!, $el1: JSON!) {
+                    insert_ScalarTest(
+                        data: [{
+                            p_str: "Update ScalarTest07",
+                            p_array_json: [$el0, $el1],
+                        }]
+                    ) {
+                        p_str
+                        p_array_json
+                    }
+                }
+            """, {
+                "insert_ScalarTest": [{
+                    'p_str': 'Update ScalarTest07',
+                    'p_array_json': [data['el0'], data['el1']],
+                }]
+            },
+            variables=data,
+        )
+
+        self.assert_graphql_query_result(
+            r"""
+                mutation update_ScalarTest($el: JSON!) {
+                    update_ScalarTest(
+                        filter: {p_str: {eq: "Update ScalarTest07"}}
+                        data: {
+                            p_array_json: {prepend: [$el]},
+                        }
+                    ) {
+                        p_str
+                        p_array_json
+                    }
+                }
+            """, {
+                "update_ScalarTest": [{
+                    'p_str': 'Update ScalarTest07',
+                    'p_array_json': ["first", data['el0'], data['el1']],
+                }]
+            },
+            variables={"el": "first"}
+        )
+
+        self.assert_graphql_query_result(
+            r"""
+                mutation update_ScalarTest($el: JSON!) {
+                    update_ScalarTest(
+                        filter: {p_str: {eq: "Update ScalarTest07"}}
+                        data: {
+                            p_array_json: {append: [$el]},
+                        }
+                    ) {
+                        p_str
+                        p_array_json
+                    }
+                }
+            """, {
+                "update_ScalarTest": [{
+                    'p_str': 'Update ScalarTest07',
+                    'p_array_json': ["first", data['el0'], data['el1'], 9999],
+                }]
+            },
+            variables={"el": 9999}
+        )
+
+        self.assert_graphql_query_result(
+            r"""
+                mutation update_ScalarTest {
+                    update_ScalarTest(
+                        filter: {p_str: {eq: "Update ScalarTest07"}}
+                        data: {
+                            p_array_json: {slice: [1, 3]},
+                        }
+                    ) {
+                        p_str
+                        p_array_json
+                    }
+                }
+            """, {
+                "update_ScalarTest": [{
+                    'p_str': 'Update ScalarTest07',
+                    'p_array_json': [data['el0'], data['el1']],
+                }]
+            }
+        )
+
+        # clean up
+        self.assert_graphql_query_result(
+            r"""
+                mutation delete_ScalarTest {
+                    delete_ScalarTest(
+                        filter: {p_str: {eq: "Update ScalarTest07"}}
+                    ) {
+                        p_str
+                        p_array_json
+                    }
+                }
+            """, {
+                "delete_ScalarTest": [{
+                    'p_str': 'Update ScalarTest07',
+                    'p_array_json': [data['el0'], data['el1']],
+                }]
+            }
+        )
+
     def test_graphql_mutation_update_enum_01(self):
         # This tests enum values in updates.
 

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -2448,17 +2448,17 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             """)
 
     def test_graphql_functional_scalars_04(self):
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r"Cannot query field 'p_array_json' on type 'ScalarTest'",
-                _line=4, _col=25):
-            self.graphql_query(r"""
-                query {
-                    ScalarTest {
-                        p_array_json
-                    }
+        self.assert_graphql_query_result(r"""
+            query {
+                ScalarTest {
+                    p_array_json
                 }
-            """)
+            }
+        """, {
+            "ScalarTest": [{
+                'p_array_json': ["hello", "world"],
+            }]
+        })
 
     def test_graphql_functional_scalars_05(self):
         with self.assertRaisesRegex(
@@ -2496,6 +2496,32 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         """, {
             "ScalarTest": [{
                 'p_array_str': ['hello', 'world'],
+            }]
+        })
+
+    def test_graphql_functional_scalars_08(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                ScalarTest {
+                    p_tuple
+                }
+            }
+        """, {
+            "ScalarTest": [{
+                'p_tuple': [123, "test"],
+            }]
+        })
+
+    def test_graphql_functional_scalars_09(self):
+        self.assert_graphql_query_result(r"""
+            query {
+                ScalarTest {
+                    p_array_tuple
+                }
+            }
+        """, {
+            "ScalarTest": [{
+                'p_array_tuple': [["hello", True], ["world", False]],
             }]
         })
 

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -767,29 +767,6 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     },
                     {
                         "__typename": "__Field",
-                        "name": "owner",
-                        "description": None,
-                        "type": {
-                            "__typename": "__Type",
-                            "name": None,
-                            "kind": "LIST",
-                            "ofType": {
-                                "__typename": "__Type",
-                                "name": None,
-                                "kind": "NON_NULL",
-                                "ofType": {
-                                    "__typename": "__Type",
-                                    "name": "User",
-                                    "kind": "INTERFACE",
-                                    "ofType": None
-                                }
-                            }
-                        },
-                        "isDeprecated": False,
-                        "deprecationReason": None
-                    },
-                    {
-                        "__typename": "__Field",
                         "name": "owner_name",
                         "description": None,
                         "type": {
@@ -804,6 +781,29 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                                     "__typename": "__Type",
                                     "name": "String",
                                     "kind": "SCALAR",
+                                    "ofType": None
+                                }
+                            }
+                        },
+                        "isDeprecated": False,
+                        "deprecationReason": None
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "owner_user",
+                        "description": None,
+                        "type": {
+                            "__typename": "__Type",
+                            "name": None,
+                            "kind": "LIST",
+                            "ofType": {
+                                "__typename": "__Type",
+                                "name": None,
+                                "kind": "NON_NULL",
+                                "ofType": {
+                                    "__typename": "__Type",
+                                    "name": "User",
+                                    "kind": "INTERFACE",
                                     "ofType": None
                                 }
                             }
@@ -1186,7 +1186,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                             },
                             {
                                 "__typename": "__Field",
-                                "name": "owner",
+                                "name": "owner_name",
                                 "description": None,
                                 "type": {
                                     "__typename": "__Type",
@@ -1203,7 +1203,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                             },
                             {
                                 "__typename": "__Field",
-                                "name": "owner_name",
+                                "name": "owner_user",
                                 "description": None,
                                 "type": {
                                     "__typename": "__Type",
@@ -2536,7 +2536,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
         )
 
     def test_graphql_reflection_02(self):
-        # Make sure that "id", as well as computed "owner" and
+        # Make sure that "id", as well as computed "owner_user" and
         # "owner_name" are not reflected into insert or update
         result = self.graphql_query(r"""
             query {
@@ -2553,7 +2553,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
             }
         """)
 
-        for bad in ['id', 'owner', 'owner_name']:
+        for bad in ['id', 'owner_user', 'owner_name']:
             self.assertNotIn(
                 bad,
                 [t['name'] for t in result['in']['inputFields']]


### PR DESCRIPTION
Reflect EdgeDB tuples as JSON to GraphQL.

Reflect `array<json>` as List[JSON!] to GraphQL. There's no reason for
this restriction anymore as JSON van now be reflected.

Reflect `array<tuple<...>>` as List[JSON!]` to GraphQL, but make it
read-only because it involves a tuple.

Issue #1252.