### PR TITLE
release: Build using the latest SDK on macOS

### DIFF
--- a/.github/workflows.src/nightly.tpl.yml
+++ b/.github/workflows.src/nightly.tpl.yml
@@ -39,6 +39,12 @@ jobs:
         PKG_PLATFORM: "<< tgt.platform >>"
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         EXTRA_OPTIMIZATIONS: "true"
+<% if tgt.family == "generic" %>
+        BUILD_GENERIC: true
+<% endif %>
+<% if tgt.platform_libc %>
+        PKG_PLATFORM_LIBC: "<< tgt.platform_libc >>"
+<% endif %>
 
     - uses: actions/upload-artifact@v2
       with:
@@ -57,42 +63,15 @@ jobs:
         ref: master
         path: edgedb-pkg
 
-    - uses: actions/cache@v2
-      id: sdk1010cache
-      with:
-        path: ~/.cache/MacOSX10.10.sdk/
-        key: MacOSX10.10.sdk
-
-    - name: Install Xcode
-      if: steps.sdk1010cache.outputs.cache-hit != 'true'
-      env:
-        XCODE_INSTALL_USER: github-ci@edgedb.com
-        XCODE_INSTALL_PASSWORD: ${{ secrets.BOT_APPLE_ID_PASSWORD }}
-        SPACESHIP_SKIP_2FA_UPGRADE: 1
-      run: |
-        xcversion install 6.4
-
-    - name: Cache 10.10 SDK
-      if: steps.sdk1010cache.outputs.cache-hit != 'true'
-      run: |
-        mkdir -p ~/.cache
-        cp -a \
-          /Applications/Xcode-6.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/ \
-          ~/.cache/MacOSX10.10.sdk/
-
-    - name: Select macOS SDK
-      run: |
-        sudo cp -a \
-          ~/.cache/MacOSX10.10.sdk/ \
-          /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
-        sudo xcode-select -s /Library/Developer/CommandLineTools
-
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: stable
         default: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
 
     - name: Build
       env:
@@ -101,7 +80,6 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "<< tgt.platform >>"
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
-        SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
       run: |
         edgedb-pkg/integration/macos/build.sh
 

--- a/.github/workflows.src/release.tpl.yml
+++ b/.github/workflows.src/release.tpl.yml
@@ -34,6 +34,12 @@ jobs:
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
         EXTRA_OPTIMIZATIONS: "true"
         BUILD_IS_RELEASE: "true"
+<% if tgt.family == "generic" %>
+        BUILD_GENERIC: true
+<% endif %>
+<% if tgt.platform_libc %>
+        PKG_PLATFORM_LIBC: "<< tgt.platform_libc >>"
+<% endif %>
 
     - uses: actions/upload-artifact@v2
       with:
@@ -52,42 +58,15 @@ jobs:
         ref: master
         path: edgedb-pkg
 
-    - uses: actions/cache@v2
-      id: sdk1010cache
-      with:
-        path: ~/.cache/MacOSX10.10.sdk/
-        key: MacOSX10.10.sdk
-
-    - name: Install Xcode
-      if: steps.sdk1010cache.outputs.cache-hit != 'true'
-      env:
-        XCODE_INSTALL_USER: github-ci@edgedb.com
-        XCODE_INSTALL_PASSWORD: ${{ secrets.BOT_APPLE_ID_PASSWORD }}
-        SPACESHIP_SKIP_2FA_UPGRADE: 1
-      run: |
-        xcversion install 6.4
-
-    - name: Cache 10.10 SDK
-      if: steps.sdk1010cache.outputs.cache-hit != 'true'
-      run: |
-        mkdir -p ~/.cache
-        cp -a \
-          /Applications/Xcode-6.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/ \
-          ~/.cache/MacOSX10.10.sdk/
-
-    - name: Select macOS SDK
-      run: |
-        sudo cp -a \
-          ~/.cache/MacOSX10.10.sdk/ \
-          /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
-        sudo xcode-select -s /Library/Developer/CommandLineTools
-
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: stable
         default: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
 
     - name: Build
       env:
@@ -96,7 +75,6 @@ jobs:
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "<< tgt.platform >>"
         PKG_PLATFORM_VERSION: "<< tgt.platform_version >>"
-        SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
       run: |
         edgedb-pkg/integration/macos/build.sh
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,6 +40,8 @@ jobs:
         PKG_PLATFORM_VERSION: "stretch"
         EXTRA_OPTIMIZATIONS: "true"
 
+
+
     - uses: actions/upload-artifact@v2
       with:
         name: builds-debian-stretch
@@ -59,6 +61,8 @@ jobs:
         PKG_PLATFORM: "debian"
         PKG_PLATFORM_VERSION: "buster"
         EXTRA_OPTIMIZATIONS: "true"
+
+
 
     - uses: actions/upload-artifact@v2
       with:
@@ -80,6 +84,8 @@ jobs:
         PKG_PLATFORM_VERSION: "bullseye"
         EXTRA_OPTIMIZATIONS: "true"
 
+
+
     - uses: actions/upload-artifact@v2
       with:
         name: builds-debian-bullseye
@@ -99,6 +105,8 @@ jobs:
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "xenial"
         EXTRA_OPTIMIZATIONS: "true"
+
+
 
     - uses: actions/upload-artifact@v2
       with:
@@ -120,6 +128,8 @@ jobs:
         PKG_PLATFORM_VERSION: "bionic"
         EXTRA_OPTIMIZATIONS: "true"
 
+
+
     - uses: actions/upload-artifact@v2
       with:
         name: builds-ubuntu-bionic
@@ -139,6 +149,8 @@ jobs:
         PKG_PLATFORM: "ubuntu"
         PKG_PLATFORM_VERSION: "focal"
         EXTRA_OPTIMIZATIONS: "true"
+
+
 
     - uses: actions/upload-artifact@v2
       with:
@@ -160,6 +172,8 @@ jobs:
         PKG_PLATFORM_VERSION: "7"
         EXTRA_OPTIMIZATIONS: "true"
 
+
+
     - uses: actions/upload-artifact@v2
       with:
         name: builds-centos-7
@@ -180,6 +194,8 @@ jobs:
         PKG_PLATFORM_VERSION: "8"
         EXTRA_OPTIMIZATIONS: "true"
 
+
+
     - uses: actions/upload-artifact@v2
       with:
         name: builds-centos-8
@@ -197,42 +213,15 @@ jobs:
         ref: master
         path: edgedb-pkg
 
-    - uses: actions/cache@v2
-      id: sdk1010cache
-      with:
-        path: ~/.cache/MacOSX10.10.sdk/
-        key: MacOSX10.10.sdk
-
-    - name: Install Xcode
-      if: steps.sdk1010cache.outputs.cache-hit != 'true'
-      env:
-        XCODE_INSTALL_USER: github-ci@edgedb.com
-        XCODE_INSTALL_PASSWORD: ${{ secrets.BOT_APPLE_ID_PASSWORD }}
-        SPACESHIP_SKIP_2FA_UPGRADE: 1
-      run: |
-        xcversion install 6.4
-
-    - name: Cache 10.10 SDK
-      if: steps.sdk1010cache.outputs.cache-hit != 'true'
-      run: |
-        mkdir -p ~/.cache
-        cp -a \
-          /Applications/Xcode-6.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/ \
-          ~/.cache/MacOSX10.10.sdk/
-
-    - name: Select macOS SDK
-      run: |
-        sudo cp -a \
-          ~/.cache/MacOSX10.10.sdk/ \
-          /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
-        sudo xcode-select -s /Library/Developer/CommandLineTools
-
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: stable
         default: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
 
     - name: Build
       env:
@@ -241,7 +230,6 @@ jobs:
         PKG_SUBDIST: "nightly"
         PKG_PLATFORM: "macos"
         PKG_PLATFORM_VERSION: "x86_64"
-        SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
       run: |
         edgedb-pkg/integration/macos/build.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         BUILD_IS_RELEASE: "true"
 
+
+
     - uses: actions/upload-artifact@v2
       with:
         name: builds-debian-stretch
@@ -54,6 +56,8 @@ jobs:
         PKG_PLATFORM_VERSION: "buster"
         EXTRA_OPTIMIZATIONS: "true"
         BUILD_IS_RELEASE: "true"
+
+
 
     - uses: actions/upload-artifact@v2
       with:
@@ -75,6 +79,8 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         BUILD_IS_RELEASE: "true"
 
+
+
     - uses: actions/upload-artifact@v2
       with:
         name: builds-debian-bullseye
@@ -94,6 +100,8 @@ jobs:
         PKG_PLATFORM_VERSION: "xenial"
         EXTRA_OPTIMIZATIONS: "true"
         BUILD_IS_RELEASE: "true"
+
+
 
     - uses: actions/upload-artifact@v2
       with:
@@ -115,6 +123,8 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         BUILD_IS_RELEASE: "true"
 
+
+
     - uses: actions/upload-artifact@v2
       with:
         name: builds-ubuntu-bionic
@@ -134,6 +144,8 @@ jobs:
         PKG_PLATFORM_VERSION: "focal"
         EXTRA_OPTIMIZATIONS: "true"
         BUILD_IS_RELEASE: "true"
+
+
 
     - uses: actions/upload-artifact@v2
       with:
@@ -155,6 +167,8 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         BUILD_IS_RELEASE: "true"
 
+
+
     - uses: actions/upload-artifact@v2
       with:
         name: builds-centos-7
@@ -175,6 +189,8 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         BUILD_IS_RELEASE: "true"
 
+
+
     - uses: actions/upload-artifact@v2
       with:
         name: builds-centos-8
@@ -192,42 +208,15 @@ jobs:
         ref: master
         path: edgedb-pkg
 
-    - uses: actions/cache@v2
-      id: sdk1010cache
-      with:
-        path: ~/.cache/MacOSX10.10.sdk/
-        key: MacOSX10.10.sdk
-
-    - name: Install Xcode
-      if: steps.sdk1010cache.outputs.cache-hit != 'true'
-      env:
-        XCODE_INSTALL_USER: github-ci@edgedb.com
-        XCODE_INSTALL_PASSWORD: ${{ secrets.BOT_APPLE_ID_PASSWORD }}
-        SPACESHIP_SKIP_2FA_UPGRADE: 1
-      run: |
-        xcversion install 6.4
-
-    - name: Cache 10.10 SDK
-      if: steps.sdk1010cache.outputs.cache-hit != 'true'
-      run: |
-        mkdir -p ~/.cache
-        cp -a \
-          /Applications/Xcode-6.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/ \
-          ~/.cache/MacOSX10.10.sdk/
-
-    - name: Select macOS SDK
-      run: |
-        sudo cp -a \
-          ~/.cache/MacOSX10.10.sdk/ \
-          /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
-        sudo xcode-select -s /Library/Developer/CommandLineTools
-
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: stable
         default: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
 
     - name: Build
       env:
@@ -236,7 +225,6 @@ jobs:
         PKG_REVISION: "<current-date>"
         PKG_PLATFORM: "macos"
         PKG_PLATFORM_VERSION: "x86_64"
-        SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX10.10.sdk/
       run: |
         edgedb-pkg/integration/macos/build.sh
 


### PR DESCRIPTION
The packaging infra now uses proper macOS targeting at build time, so
there is no need to use the old SDK version to build anymore.