### PR TITLE
Fix __typenames__ injection in queries like `[Object]`

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1426,7 +1426,6 @@ def _get_computable_ctx(
             if source_scls.is_view(ctx.env.schema):
                 scls_name = source_stype.get_name(ctx.env.schema)
                 subctx.aliased_views[scls_name] = None
-            subctx.source_map = qlctx.source_map.copy()
             subctx.view_nodes = qlctx.view_nodes.copy()
             subctx.view_map = ctx.view_map.new_child()
 

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -85,6 +85,7 @@ def _ql_typeexpr_to_type(
         with ctx.new() as subctx:
             # Use an empty scope tree, to avoid polluting things pointlessly
             subctx.path_scope = irast.ScopeTreeNode()
+            subctx.expr_exposed = False
             ir_set = dispatch.compile(ql_t.expr, ctx=subctx)
             stype = setgen.get_set_type(ir_set, ctx=subctx)
 

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -6493,17 +6493,12 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             self.assertEqual(row[0].__tname__, "default::User")
             self.assertEqual(row[1].__tname__, "default::Issue")
 
-    @test.xfail("""
-        SchemaDefinitionError: cannot alter object type 'std::Object':
-        module std is read-only
-    """)
     async def test_edgeql_select_array_common_type_02(self):
-        # Issue #2387
         res = await self.con._fetchall("""
             SELECT [Object];
         """, __typenames__=True)
         for row in res:
-            self.assertEqual(row[0].__tname__, "std::Object")
+            self.assertTrue(row[0].__tname__.startswith("default::"))
 
     async def test_edgeql_select_free_shape_01(self):
         res = await self.con.query_single('SELECT {test := 1}')


### PR DESCRIPTION
Do this by invoking compile_query_result when compiling paths.