### PR TITLE
Make schema::Link.target point to ObjectType instead of Type

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -38,7 +38,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_11_08_16_00
+EDGEDB_CATALOG_VERSION = 2021_11_09_20_00
 
 
 class MetadataError(Exception):

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -104,7 +104,10 @@ CREATE ABSTRACT LINK schema::ordered {
 CREATE TYPE schema::Module EXTENDING schema::Object;
 
 
-CREATE ABSTRACT TYPE schema::CollectionType EXTENDING schema::Type;
+CREATE ABSTRACT TYPE schema::PrimitiveType EXTENDING schema::Type;
+
+
+CREATE ABSTRACT TYPE schema::CollectionType EXTENDING schema::PrimitiveType;
 
 
 CREATE TYPE schema::Array EXTENDING schema::CollectionType {
@@ -145,7 +148,7 @@ CREATE ABSTRACT TYPE schema::AnnotationSubject EXTENDING schema::Object {
     CREATE MULTI LINK annotations EXTENDING schema::reference
     -> schema::Annotation {
         CREATE PROPERTY value -> std::str;
-	ON TARGET DELETE ALLOW;
+        ON TARGET DELETE ALLOW;
     };
 };
 
@@ -212,7 +215,7 @@ CREATE ABSTRACT TYPE schema::ConsistencySubject EXTENDING schema::Object {
     CREATE MULTI LINK constraints EXTENDING schema::reference
     -> schema::Constraint {
         CREATE CONSTRAINT std::exclusive;
-	ON TARGET DELETE ALLOW;
+        ON TARGET DELETE ALLOW;
     };
 };
 
@@ -230,7 +233,7 @@ CREATE TYPE schema::Index EXTENDING schema::AnnotationSubject {
 CREATE ABSTRACT TYPE schema::Source EXTENDING schema::Object {
     CREATE MULTI LINK indexes -> schema::Index {
         CREATE CONSTRAINT std::exclusive;
-	ON TARGET DELETE ALLOW;
+        ON TARGET DELETE ALLOW;
     };
 };
 
@@ -251,7 +254,7 @@ CREATE ABSTRACT TYPE schema::Pointer
 ALTER TYPE schema::Source {
     CREATE MULTI LINK pointers EXTENDING schema::reference -> schema::Pointer {
         CREATE CONSTRAINT std::exclusive;
-	ON TARGET DELETE ALLOW;
+        ON TARGET DELETE ALLOW;
     };
 };
 
@@ -268,7 +271,7 @@ CREATE TYPE schema::Alias EXTENDING schema::AnnotationSubject
 CREATE TYPE schema::ScalarType
     EXTENDING
         schema::InheritingObject, schema::ConsistencySubject,
-        schema::AnnotationSubject, schema::Type
+        schema::AnnotationSubject, schema::PrimitiveType
 {
     CREATE PROPERTY default -> std::str;
     CREATE PROPERTY enum_values -> array<std::str>;
@@ -371,7 +374,10 @@ ALTER TYPE schema::Pointer {
 
 
 ALTER TYPE schema::Link {
-    CREATE MULTI LINK properties := .pointers;
+    ALTER LINK target
+        SET TYPE schema::ObjectType
+        USING (.target[IS schema::ObjectType]);
+    CREATE MULTI LINK properties := .pointers[IS schema::Property];
     CREATE PROPERTY on_target_delete -> schema::TargetDeleteAction;
 };
 

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -194,7 +194,8 @@ class TestIntrospection(tb.QueryTestCase):
                         name,
                         cardinality,
                         target: {
-                            name
+                            name,
+                            compound_type,
                         }
                     } ORDER BY .name
                 }
@@ -204,19 +205,31 @@ class TestIntrospection(tb.QueryTestCase):
                 'name': 'default::Comment',
                 'links': [{
                     'name': '__type__',
-                    'target': {'name': 'schema::Type'},
+                    'target': {
+                        'name': 'schema::Type',
+                        'compound_type': False,
+                    },
                     'cardinality': 'One',
                 }, {
                     'name': 'issue',
-                    'target': {'name': 'default::Issue'},
+                    'target': {
+                        'name': 'default::Issue',
+                        'compound_type': False,
+                    },
                     'cardinality': 'One',
                 }, {
                     'name': 'owner',
-                    'target': {'name': 'default::User'},
+                    'target': {
+                        'name': 'default::User',
+                        'compound_type': False,
+                    },
                     'cardinality': 'One',
                 }, {
                     'name': 'parent',
-                    'target': {'name': 'default::Comment'},
+                    'target': {
+                        'name': 'default::Comment',
+                        'compound_type': False,
+                    },
                     'cardinality': 'One',
                 }]
             }]


### PR DESCRIPTION
Links always target ObjectType instances, so use a more specific target
declaration in the introspection schema.

Fixes: #1787