### PR TITLE
Fix typename injection on introspection output

### DIFF
--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -49,6 +49,7 @@ from . import pathctx
 from . import polyres
 from . import schemactx
 from . import setgen
+from . import stmt
 from . import typegen
 
 if TYPE_CHECKING:
@@ -270,7 +271,8 @@ def compile_FunctionCall(
         tuple_path_ids=tuple_path_ids,
     )
 
-    return setgen.ensure_set(fcall, typehint=rtype, path_id=path_id, ctx=ctx)
+    ir_set = setgen.ensure_set(fcall, typehint=rtype, path_id=path_id, ctx=ctx)
+    return stmt.maybe_add_view(ir_set, ctx=ctx)
 
 
 #: A dictionary of conditional callables and the indices

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -1659,3 +1659,18 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
                     fight(Scorpion, SubZero);SELECT area(Shape)
                 """,
             )
+
+    async def test_edgeql_call_builtin_obj(self):
+        await self.con.execute(
+            r"""
+                CREATE FUNCTION get_obj(name: str) ->
+                  SET OF schema::Object USING (
+                    SELECT schema::Object FILTER .name = name);
+            """,
+        )
+
+        res = await self.con._fetchall("""
+            SELECT get_obj('std::BaseObject')
+        """, __typenames__=True)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0].__tname__, "schema::ObjectType")

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -5202,3 +5202,18 @@ aa \
                 single foo := assert_distinct(.name)
             }
         """)
+
+    async def test_edgeql_introspect_without_shape(self):
+        await self.assert_query_result(
+            """
+                SELECT (INTROSPECT TYPEOF BaseObject)
+            """,
+            [
+                {"id": {}}
+            ]
+        )
+        res = await self.con._fetchall("""
+            SELECT (INTROSPECT TYPEOF BaseObject)
+        """, __typenames__=True)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0].__tname__, "schema::ObjectType")


### PR DESCRIPTION
Also fix injection on functions that return std objects. There are
still issues involving with bound stuff, but I think it's worth
getting this fix in.

Fixes #3160.