### PR TITLE
Fix inheritance issues with cfg::*Config objects

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -38,7 +38,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_11_09_20_00
+EDGEDB_CATALOG_VERSION = 2021_11_09_21_04
 
 
 class MetadataError(Exception):

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -373,6 +373,38 @@ class TestServerConfig(tb.QueryTestCase):
     PARALLELISM_GRANULARITY = 'system'
     TRANSACTION_ISOLATION = False
 
+    async def test_server_proto_config_objects(self):
+        await self.assert_query_result(
+            """SELECT cfg::InstanceConfig IS cfg::AbstractConfig""",
+            [True],
+        )
+
+        await self.assert_query_result(
+            """SELECT cfg::InstanceConfig IS cfg::DatabaseConfig""",
+            [False],
+        )
+
+        await self.assert_query_result(
+            """SELECT cfg::InstanceConfig IS cfg::InstanceConfig""",
+            [True],
+        )
+
+        await self.assert_query_result(
+            """
+            SELECT cfg::AbstractConfig {
+                tname := .__type__.name
+            }
+            ORDER BY .__type__.name
+            """,
+            [{
+                "tname": "cfg::Config",
+            }, {
+                "tname": "cfg::DatabaseConfig",
+            }, {
+                "tname": "cfg::InstanceConfig",
+            }]
+        )
+
     async def test_server_proto_configure_01(self):
         with self.assertRaisesRegex(
                 edgedb.ConfigurationError,


### PR DESCRIPTION
The views underpinning `cfg::Config`, `cfg::DatabaseConfig` and
`cfg::InstanceConfig` all erroneously point to `cfg::Config` in
`__type__`.  Also, `cfg::AbstractConfig` inheritance view is missing.
Fix both issues.

Fixes: #2575