### PR TITLE
Fix false positive cycle detections in functions

### DIFF
--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -310,20 +310,20 @@ class TracerContext:
         self, ref: qlast.ObjectRef
     ) -> Set[sn.QualName]:
         refs = set()
-        prefixes = []
+        prefixes = set()
 
         if ref.module:
             # replace the module alias with the real name
             module = self.modaliases.get(ref.module, ref.module)
-            prefixes.append(f'{module}::{ref.name}')
+            prefixes.add(f'{module}::{ref.name}')
         else:
-            prefixes.append(f'{self.module}::{ref.name}')
-            prefixes.append(f'std::{ref.name}')
+            prefixes.add(f'{self.module}::{ref.name}')
+            prefixes.add(f'std::{ref.name}')
 
         for objname in self.objects.keys():
-            for prefix in prefixes:
-                if str(objname).startswith(prefix):
-                    refs.add(objname)
+            short_name = str(objname).split('@@', 1)[0]
+            if short_name in prefixes:
+                refs.add(objname)
 
         return refs
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1634,6 +1634,14 @@ class TestSchema(tb.BaseSchemaLoadTest):
                 );
             ''')
 
+        # Make sure unrelated functions with similar prefix
+        # aren't matched erroneously (#3115)
+        schema = self.load_schema(r'''
+            function len_strings(words: str) -> int64 using (
+                len(words)
+            );
+        ''', modname='default')
+
     @test.xfail('''
         RecursionError: maximum recursion depth exceeded in comparison
 


### PR DESCRIPTION
The function body tracer is checking for references to functions and
then uses the name prefix to look for all overloaded function
definitions to include in the dependency list.  Unfortunately, the
prefix checking code simply uses `startswith`, which could grab
completely unrelated functions if they happen to have a name with
a given prefix.

Fixes: #3115