### PR TITLE
Fix more issues with injecting typenames into std:: objects

### DIFF
--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -51,6 +51,7 @@ def compile_where_clause(
         pathctx.register_set_in_scope(ctx.partial_path_prefix, ctx=ctx)
 
     with ctx.newscope(fenced=True) as subctx:
+        subctx.expr_exposed = context.Exposure.UNEXPOSED
         subctx.path_scope.unnest_fence = True
         ir_expr = dispatch.compile(where, ctx=subctx)
         bool_t = ctx.env.get_track_schema_type(sn.QualName('std', 'bool'))
@@ -72,6 +73,7 @@ def compile_orderby_clause(
         pathctx.register_set_in_scope(ctx.partial_path_prefix, ctx=ctx)
 
     with ctx.new() as subctx:
+        subctx.expr_exposed = context.Exposure.UNEXPOSED
         for sortexpr in sortexprs:
             with subctx.newscope(fenced=True) as exprctx:
                 exprctx.path_scope.unnest_fence = True
@@ -134,6 +136,7 @@ def compile_limit_offset_clause(
         ir_set = None
     else:
         with ctx.newscope(fenced=True) as subctx:
+            subctx.expr_exposed = context.Exposure.UNEXPOSED
             # Clear out the partial_path_prefix, since we aren't in
             # the scope of the select subject
             subctx.partial_path_prefix = None

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -180,7 +180,7 @@ def compile_ConfigInsert(
             _inject_tname(el.compexpr, ctx=ctx)
 
     with ctx.newscope(fenced=False) as subctx:
-        subctx.expr_exposed = True
+        subctx.expr_exposed = context.Exposure.EXPOSED
         subctx.modaliases = ctx.modaliases.copy()
         subctx.modaliases[None] = 'cfg'
         subctx.special_computables_in_mutation_shape |= {'_tname'}

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -52,6 +52,15 @@ if TYPE_CHECKING:
     from edb.schema import sources as s_sources
 
 
+class Exposure(enum.IntEnum):
+    UNEXPOSED = 0
+    BINDING = 1
+    EXPOSED = 2
+
+    def __bool__(self) -> bool:
+        return self == self.EXPOSED
+
+
 class ContextSwitchMode(enum.Enum):
     NEW = enum.auto()
     SUBQUERY = enum.auto()
@@ -564,7 +573,7 @@ class ContextLevel(compiler.ContextLevel):
             self.iterator_path_ids = frozenset()
             self.scope_id_ctr = compiler.SimpleCounter()
             self.view_scls = None
-            self.expr_exposed = False
+            self.expr_exposed = Exposure.UNEXPOSED
 
             self.partial_path_prefix = None
 

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -529,16 +529,17 @@ def compile_TypeCast(
         with ctx.new() as subctx:
             if target_stype.contains_json(subctx.env.schema):
                 # JSON wants type shapes and acts as an output sink.
-                subctx.expr_exposed = True
+                subctx.expr_exposed = context.Exposure.EXPOSED
                 subctx.inhibit_implicit_limit = True
                 subctx.implicit_id_in_shapes = False
                 subctx.implicit_tid_in_shapes = False
                 subctx.implicit_tname_in_shapes = False
             ir_expr = dispatch.compile(expr.expr, ctx=subctx)
 
-    return casts.compile_cast(
+    res = casts.compile_cast(
         ir_expr, target_stype, cardinality_mod=expr.cardinality_mod,
         ctx=ctx, srcctx=expr.expr.context)
+    return stmt.maybe_add_view(res, ctx=ctx)
 
 
 @dispatch.compile.register(qlast.Introspect)

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -587,7 +587,9 @@ def compile_operator(
 
     _check_free_shape_op(node, ctx=ctx)
 
-    return setgen.ensure_set(node, typehint=rtype, ctx=ctx)
+    return stmt.maybe_add_view(
+        setgen.ensure_set(node, typehint=rtype, ctx=ctx),
+        ctx=ctx)
 
 
 # These ops are all footguns when used with free shapes,

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -95,7 +95,7 @@ def new_set(
             qry.where = astutils.extend_binop(qry.where, f.qlast)
 
         with ctx.detached() as subctx:
-            subctx.expr_exposed = False
+            subctx.expr_exposed = context.Exposure.UNEXPOSED
             subctx.path_scope = subctx.env.path_scope.root
             # Put a placeholder to prevent recursion.
             subctx.type_rewrites[stype] = irast.Set()  # type: ignore
@@ -1342,7 +1342,7 @@ def computable_ptr_set(
         # a similar check on is_mutation in _normalize_view_ptr_expr.
         if (source_scls.get_expr_type(ctx.env.schema)
                 != s_types.ExprType.Select):
-            subctx.expr_exposed = True
+            subctx.expr_exposed = context.Exposure.EXPOSED
 
         comp_ir_set = dispatch.compile(qlexpr, ctx=subctx)
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -152,14 +152,18 @@ def compile_ForQuery(
         # we aren't willing to tackle.
         if contains_dml:
             sctx.path_scope.factoring_allowlist.update(ctx.iterator_path_ids)
-        iterator_view = stmtctx.declare_view(
-            iterator,
-            s_name.UnqualName(qlstmt.iterator_alias),
-            factoring_fence=contains_dml,
-            path_id_namespace=sctx.path_id_namespace,
-            binding_kind=irast.BindingKind.For,
-            ctx=sctx,
-        )
+
+        with sctx.new() as ectx:
+            if ectx.expr_exposed:
+                ectx.expr_exposed = context.Exposure.BINDING
+            iterator_view = stmtctx.declare_view(
+                iterator,
+                s_name.UnqualName(qlstmt.iterator_alias),
+                factoring_fence=contains_dml,
+                path_id_namespace=sctx.path_id_namespace,
+                binding_kind=irast.BindingKind.For,
+                ctx=ectx,
+            )
 
         iterator_stmt = setgen.new_set_from_set(
             iterator_view, preserve_scope_ns=True, ctx=sctx)
@@ -260,7 +264,7 @@ def compile_InsertQuery(
         init_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 
         with ictx.new() as ectx:
-            ectx.expr_exposed = False
+            ectx.expr_exposed = context.Exposure.UNEXPOSED
             subject = dispatch.compile(expr.subject, ctx=ectx)
         assert isinstance(subject, irast.Set)
 
@@ -323,9 +327,6 @@ def compile_InsertQuery(
         )
 
         with ictx.new() as resultctx:
-            if ictx.stmt is ctx.toplevel_stmt:
-                resultctx.expr_exposed = True
-
             stmt.result = compile_query_subject(
                 result,
                 view_scls=ctx.view_scls,
@@ -348,7 +349,7 @@ def compile_InsertQuery(
             and ictx.stmt is ctx.toplevel_stmt
         ):
             with ictx.new() as resultctx:
-                resultctx.expr_exposed = True
+                resultctx.expr_exposed = context.Exposure.EXPOSED
                 result = compile_query_subject(
                     result,
                     view_name=ctx.toplevel_result_view_name,
@@ -390,7 +391,7 @@ def compile_UpdateQuery(
         init_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 
         with ictx.new() as ectx:
-            ectx.expr_exposed = False
+            ectx.expr_exposed = context.Exposure.UNEXPOSED
             subject = dispatch.compile(expr.subject, ctx=ectx)
         assert isinstance(subject, irast.Set)
 
@@ -434,9 +435,6 @@ def compile_UpdateQuery(
         )
 
         with ictx.new() as resultctx:
-            if ictx.stmt is ctx.toplevel_stmt:
-                resultctx.expr_exposed = True
-
             stmt.result = compile_query_subject(
                 result,
                 view_scls=ctx.view_scls,
@@ -507,7 +505,7 @@ def compile_DeleteQuery(
         # DELETE Expr is a delete(SET OF X), so we need a scope fence.
         with ictx.newscope(fenced=True) as scopectx:
             scopectx.implicit_limit = 0
-            scopectx.expr_exposed = False
+            scopectx.expr_exposed = context.Exposure.UNEXPOSED
             subject = setgen.scoped_set(
                 dispatch.compile(expr.subject, ctx=scopectx), ctx=scopectx)
 
@@ -537,9 +535,6 @@ def compile_DeleteQuery(
         )
 
         with ictx.new() as resultctx:
-            if ictx.stmt is ctx.toplevel_stmt:
-                resultctx.expr_exposed = True
-
             stmt.result = compile_query_subject(
                 result,
                 view_scls=ctx.view_scls,
@@ -811,7 +806,7 @@ def compile_Shape(
         subctx.class_view_overrides = subctx.class_view_overrides.copy()
 
         with ctx.new() as exposed_ctx:
-            exposed_ctx.expr_exposed = False
+            exposed_ctx.expr_exposed = context.Exposure.UNEXPOSED
             expr = dispatch.compile(shape_expr, ctx=exposed_ctx)
 
         expr_stype = setgen.get_set_type(expr, ctx=ctx)
@@ -956,7 +951,8 @@ def process_with_block(
 
         elif isinstance(with_entry, qlast.AliasedExpr):
             with ctx.new() as scopectx:
-                scopectx.expr_exposed = False
+                if scopectx.expr_exposed:
+                    scopectx.expr_exposed = context.Exposure.BINDING
                 binding = stmtctx.declare_view(
                     with_entry.expr,
                     s_name.UnqualName(with_entry.alias),
@@ -997,9 +993,6 @@ def compile_result_clause(
         forward_rptr: bool=False,
         ctx: context.ContextLevel) -> irast.Set:
     with ctx.new() as sctx:
-        if sctx.stmt is ctx.toplevel_stmt:
-            sctx.expr_exposed = True
-
         if forward_rptr:
             sctx.view_rptr = view_rptr
             # sctx.view_scls = view_scls
@@ -1058,7 +1051,7 @@ def compile_result_clause(
         else:
             with sctx.new() as ectx:
                 if shape is not None:
-                    ectx.expr_exposed = False
+                    ectx.expr_exposed = context.Exposure.UNEXPOSED
                 expr = dispatch.compile(result_expr, ctx=ectx)
 
         ctx.partial_path_prefix = expr
@@ -1068,6 +1061,7 @@ def compile_result_clause(
             forward_rptr=forward_rptr,
             result_alias=result_alias,
             view_scls=view_scls,
+            allow_select_shape_inject=False,
             compile_views=ctx.stmt is ctx.toplevel_stmt,
             ctx=sctx,
             parser_context=result.context)
@@ -1088,7 +1082,7 @@ def compile_query_subject(
         is_insert: bool=False,
         is_update: bool=False,
         is_delete: bool=False,
-        allow_select_shape_inject: bool=False,
+        allow_select_shape_inject: bool=True,
         forward_rptr: bool=False,
         parser_context: Optional[pctx.ParserContext]=None,
         ctx: context.ContextLevel) -> irast.Set:
@@ -1133,27 +1127,29 @@ def compile_query_subject(
     if (
         (
             (
-                ctx.expr_exposed
+                ctx.expr_exposed >= context.Exposure.BINDING
                 and expr_stype.is_object_type()
                 and allow_select_shape_inject
 
                 and not forward_rptr
                 and (
-                    viewgen.has_implicit_type_computables(
-                        expr_stype,
-                        is_mutation=is_mutation,
-                        ctx=ctx,
+                    (
+                        viewgen.has_implicit_type_computables(
+                            expr_stype,
+                            is_mutation=is_mutation,
+                            ctx=ctx,
+                        )
+                        and not expr_stype.is_view(ctx.env.schema)
+                    ) or (
+                        expr_stype in ctx.env.materialized_sets
+                        # ahhhhhh
+                        and ctx.expr_exposed
                     )
-                    or expr_stype in ctx.env.materialized_sets
                 )
             )
             or is_mutation
         )
         and shape is None
-        and (
-            expr_stype not in ctx.env.view_shapes
-            or expr_stype in ctx.env.materialized_sets
-        )
     ):
         # Force the subject to be compiled as a view in these cases:
         # a) a __tid__ insertion is anticipated (the actual
@@ -1162,6 +1158,12 @@ def compile_query_subject(
         #    we also skip doing this when forward_rptr is true, because
         #    generating an extra type in those cases can cause issues,
         #    and we can just do the insertion on whatever the inner thing is
+        #
+        #    Note that we do this when exposed or when potentially exposed
+        #    because we are in a binding. This is because types that
+        #    appear in bindings might get put into the output
+        #    and need a __tid__ injection without having a chance to have
+        #    a shape put on them.
         # b) this is a mutation without an explicit shape,
         #    such as a DELETE, because mutation subjects are
         #    always expected to be derived types.
@@ -1170,7 +1172,8 @@ def compile_query_subject(
         #    test_edgeql_volatility_select_hard_objects_09 where we
         #    can't rely on the serialization done at an inner location.
         #    (This is a hack, because I don't think it can generalize
-        #     to tuples/arrays containing objects)
+        #     to tuples/arrays containing objects. It is also fragile,
+        #     and performing it in with bindings breaks things...)
         shape = []
 
     if shape is not None and view_scls is None:
@@ -1227,7 +1230,10 @@ def maybe_add_view(ir: irast.Set, *, ctx: context.ContextLevel) -> irast.Set:
     # should make sure expr_exposed is false.
     #
     # The checks here are microoptimizations.
-    if ctx.expr_exposed and ir.path_id.is_objtype_path():
+    if (
+        ctx.expr_exposed >= context.Exposure.BINDING
+        and ir.path_id.is_objtype_path()
+    ):
         return compile_query_subject(
             ir, allow_select_shape_inject=True, compile_views=False, ctx=ctx)
     else:

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -101,6 +101,7 @@ def init_context(
     ctx.implicit_tid_in_shapes = options.implicit_tid_in_shapes
     ctx.implicit_tname_in_shapes = options.implicit_tname_in_shapes
     ctx.implicit_limit = options.implicit_limit
+    ctx.expr_exposed = context.Exposure.EXPOSED
 
     return ctx
 
@@ -580,7 +581,7 @@ def declare_view_from_schema(
         return vc
 
     with ctx.detached() as subctx:
-        subctx.expr_exposed = False
+        subctx.expr_exposed = context.Exposure.UNEXPOSED
         view_expr = viewcls.get_expr(ctx.env.schema)
         assert view_expr is not None
         view_ql = qlparser.parse(view_expr.text)

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -85,7 +85,7 @@ def _ql_typeexpr_to_type(
         with ctx.new() as subctx:
             # Use an empty scope tree, to avoid polluting things pointlessly
             subctx.path_scope = irast.ScopeTreeNode()
-            subctx.expr_exposed = False
+            subctx.expr_exposed = context.Exposure.UNEXPOSED
             ir_set = dispatch.compile(ql_t.expr, ctx=subctx)
             stype = setgen.get_set_type(ir_set, ctx=subctx)
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -5217,3 +5217,16 @@ aa \
         """, __typenames__=True)
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0].__tname__, "schema::ObjectType")
+
+    async def test_edgeql_object_injections(self):
+        await self.con._fetchall("""
+            SELECT <Object>{}
+        """, __typenames__=True)
+
+        await self.con._fetchall("""
+            WITH Z := (Object,), SELECT Z;
+        """, __typenames__=True)
+
+        await self.con._fetchall("""
+            FOR Z IN {(Object,)} UNION Z;
+        """, __typenames__=True)


### PR DESCRIPTION
We need to be able to insert views for injection inside of WITH/FOR
bindings, so we generalize expr_exposed to have an intermediate
exposure level corresponding to bindings.

To make problems like this less obscure, we make them *worse* by
adding an assert that prevents injecting into non-view shapes in
general.