### PR TITLE
Produce better error on bad arguments to set constructors

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -281,6 +281,10 @@ class BinOp(Expr):
     right: Expr
 
 
+class SetConstructorOp(BinOp):
+    op: str = 'UNION'
+
+
 class WindowSpec(Clause, OrderByMixin):
     orderby: typing.List[SortExpr]
     partition: typing.List[Expr]

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -486,9 +486,18 @@ def compile_operator(
                 ):
                     hint = 'Consider using the "++" operator for concatenation'
 
-            raise errors.QueryError(
-                f'operator {str(op_name)!r} cannot be applied to '
-                f'operands of type {types}',
+            if isinstance(qlexpr, qlast.SetConstructorOp):
+                msg = (
+                    f'set constructor has arguments of incompatible types '
+                    f'{types}'
+                )
+            else:
+                msg = (
+                    f'operator {str(op_name)!r} cannot be applied to '
+                    f'operands of type {types}'
+                )
+            raise errors.InvalidTypeError(
+                msg,
                 hint=hint,
                 context=qlexpr.context)
         elif len(matched) > 1:

--- a/tests/test_http_notebook.py
+++ b/tests/test_http_notebook.py
@@ -108,7 +108,7 @@ class TestHttpNotebook(tb.BaseHttpExtensionTest, tb.server.QueryTestCase):
                     {
                         'kind': 'error',
                         'error': [
-                            'QueryError',
+                            'InvalidTypeError',
                             "operator '*' cannot be applied to operands "
                             "of type 'std::str' and 'std::int64'",
                             {


### PR DESCRIPTION
Currently a query like "SELECT {1, 2, '3'}" produces a hard to
interpret error:

   operator 'UNION' cannot be applied to operands
   of type 'std::int64' and 'std::str'

Fix the error message to a more comprehensible:

   set constructor has arguments of incompatible types
   'std::int64' and 'std::str'

While there also fix the source context of the generated error
to point to the location of the error.

Fixes: https://github.com/edgedb/edgedb/issues/2333