### PR TITLE
Set session_idle_timeout and session_idle_transaction_timeout

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -38,7 +38,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_11_09_21_04
+EDGEDB_CATALOG_VERSION = 2021_11_10_00_00
 
 
 class MetadataError(Exception):

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -59,13 +59,13 @@ CREATE ABSTRACT TYPE cfg::AbstractConfig extending cfg::ConfigObject {
     CREATE REQUIRED PROPERTY session_idle_timeout -> std::duration {
         CREATE ANNOTATION cfg::system := 'true';
         CREATE ANNOTATION cfg::report := 'true';
-        SET default := <std::duration>'0 seconds';
+        SET default := <std::duration>'60 seconds';
     };
 
     CREATE REQUIRED PROPERTY session_idle_transaction_timeout -> std::duration {
         CREATE ANNOTATION cfg::backend_setting :=
             '"idle_in_transaction_session_timeout"';
-        SET default := <std::duration>'0 seconds';
+        SET default := <std::duration>'10 seconds';
     };
 
     CREATE REQUIRED PROPERTY query_execution_timeout -> std::duration {

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1317,7 +1317,7 @@ class TestSeparateCluster(tb.TestCase):
 
                 # check that the default was set correctly
                 await assert_conf(
-                    c1, 'session_idle_transaction_timeout', 0)
+                    c1, 'session_idle_transaction_timeout', 10000)
 
                 ####
 


### PR DESCRIPTION
Now that our REPL reads the session_idle_timeout setting and sends
periodic SYNC messages to avoid disconnects, we're ready to flip
the timeouts back to what was planned: 60 and 10 seconds
correspondingly.