### PR TITLE
Some cleanup to recent type computable inlining changes

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1202,15 +1202,15 @@ def _inline_type_computable(
     stype: s_objtypes.ObjectType,
     compname: str,
     propname: str,
-    is_mutation: bool,
     *,
     shape_ptrs: List[ShapePtr],
     ctx: context.ContextLevel,
 ) -> None:
     assert isinstance(stype, s_objtypes.ObjectType)
-    # Injecting into non-view objects /usually/ works, but it fails if the
-    # object is in the std library. Prevent it in general to find bugs faster.
-    assert is_mutation or stype.is_view(ctx.env.schema)
+    # Injecting into non-view objects /almost/ works, but it fails if the
+    # object is in the std library, and is dodgy always.
+    # Prevent it in general to find bugs faster.
+    assert stype.is_view(ctx.env.schema)
 
     ptr: Optional[s_pointers.Pointer]
     try:
@@ -1321,8 +1321,7 @@ def _get_shape_configuration_inner(
     ):
         assert isinstance(stype, s_objtypes.ObjectType)
         _inline_type_computable(
-            ir_set, stype, '__tid__', 'id', is_mutation,
-            ctx=ctx, shape_ptrs=shape_ptrs)
+            ir_set, stype, '__tid__', 'id', ctx=ctx, shape_ptrs=shape_ptrs)
 
     if (
         stype is not None
@@ -1330,8 +1329,7 @@ def _get_shape_configuration_inner(
     ):
         assert isinstance(stype, s_objtypes.ObjectType)
         _inline_type_computable(
-            ir_set, stype, '__tname__', 'name', is_mutation,
-            ctx=ctx, shape_ptrs=shape_ptrs)
+            ir_set, stype, '__tname__', 'name', ctx=ctx, shape_ptrs=shape_ptrs)
 
 
 def _get_early_shape_configuration(


### PR DESCRIPTION
PR #3165 added an assert that the stype was a view, but exempted
mutations from that check. Exempting mutations is spurious and
unnecessary (though it seemed necessary at one point during
development).