### PR TITLE
Fix type filtering on computed pointers

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -781,6 +781,7 @@ def process_set_as_path_type_intersection(
     if (not source_is_visible
             and ir_source.rptr is not None
             and not ir_source.path_id.is_type_intersection_path()
+            and not ir_source.rptr.ptrref.is_computable
             and (
                 ptrref.is_subtype
                 or pg_types.get_ptrref_storage_info(

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2847,6 +2847,18 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ],
         )
 
+    async def test_edgeql_scope_link_narrow_computable_01(self):
+        await self.assert_query_result(
+            """
+                SELECT Card {
+                    owners[IS Bot]: {name}
+                } FILTER .name = 'Sprite'
+            """,
+            [
+                {"owners": [{"name": "Dave"}]},
+            ],
+        )
+
     async def test_edgeql_scope_branch_01(self):
         await self.assert_query_result(
             """


### PR DESCRIPTION
An optimization was incorrectly failing to exclude computed pointers.
Fixes #2323.