### PR TITLE
Drop materialization special case in compile_query_subject view insertion

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1132,20 +1132,12 @@ def compile_query_subject(
                 and allow_select_shape_inject
 
                 and not forward_rptr
-                and (
-                    (
-                        viewgen.has_implicit_type_computables(
-                            expr_stype,
-                            is_mutation=is_mutation,
-                            ctx=ctx,
-                        )
-                        and not expr_stype.is_view(ctx.env.schema)
-                    ) or (
-                        expr_stype in ctx.env.materialized_sets
-                        # ahhhhhh
-                        and ctx.expr_exposed
-                    )
+                and viewgen.has_implicit_type_computables(
+                    expr_stype,
+                    is_mutation=is_mutation,
+                    ctx=ctx,
                 )
+                and not expr_stype.is_view(ctx.env.schema)
             )
             or is_mutation
         )
@@ -1167,13 +1159,6 @@ def compile_query_subject(
         # b) this is a mutation without an explicit shape,
         #    such as a DELETE, because mutation subjects are
         #    always expected to be derived types.
-        # c) this is a use of a type we think we are materializing,
-        #    which hacks around issues like
-        #    test_edgeql_volatility_select_hard_objects_09 where we
-        #    can't rely on the serialization done at an inner location.
-        #    (This is a hack, because I don't think it can generalize
-        #     to tuples/arrays containing objects. It is also fragile,
-        #     and performing it in with bindings breaks things...)
         shape = []
 
     if shape is not None and view_scls is None:

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -337,7 +337,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ]
         )
 
-    @test.xfail('says that .letter could be multi')
     async def test_edgeql_for_in_computable_02b(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
It is hacky, and not really needed anymore. Removing it fixed a test.

Removing it also caused test_edgeql_insert_enumerate_01 to fail when
doing type injection since it exposed an issue that allowed id and
`__tname__` to be injected twice in some queries that inserted twice
to the same object. I decided that the real root cause of that issue
was that schemactx copied view_shapes to child views without updating
the pointers to point to the child, so I changed that.

There wound up being a lot of churn on that side, as I had to commit
some violence to get mypy to not lose track of things because of type
intersections.