### PR TITLE
Pin edgedb-python to 0.18.0a2 for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ except ImportError:
 
 
 RUNTIME_DEPS = [
-    'edgedb>=0.18.0a2',
+    'edgedb==0.18.0a2',
 
     'asyncpg~=0.24.0',
     'httptools>=0.3.0',


### PR DESCRIPTION
The test harness isn't prepared for the API changes yet.