### PR TITLE
Fix edgedb-server to be able to run with `-I ::1`.

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1351,7 +1351,7 @@ class Server(ha_base.ClusterProtocol):
             else:
                 addr_str = f"{{{', '.join('%s:%d' % addr for addr in addrs)}}}"
         elif addrs:
-            addr_str = "%s:%d" % addrs[0]
+            addr_str = f'{addrs[0][0]}:{addrs[0][1]}'
             port = addrs[0][1]
         else:
             addr_str = None


### PR DESCRIPTION
The current code incorrectly assumes that the `addrs` tuple
will always have two elements that isn't correct for IPv6 addresses.