### PR TITLE
Fix generated SET TYPE in migration when a create is split into an alter

### DIFF
--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -362,12 +362,38 @@ class CreateLink(
                         assert isinstance(t, (so.Object, so.ObjectShell))
                         node.target = utils.typeref_to_ast(schema, t)
             else:
+                old_type = pointers.merge_target(
+                    self.scls,
+                    list(self.scls.get_bases(schema).objects(schema)),
+                    'target',
+                    ignore_local=True,
+                    schema=schema,
+                )
                 assert isinstance(op.new_value, (so.Object, so.ObjectShell))
+                new_type = (
+                    op.new_value.resolve(schema)
+                    if isinstance(op.new_value, so.ObjectShell)
+                    else op.new_value)
+
+                new_type_ast = utils.typeref_to_ast(schema, op.new_value)
+                cast_expr = None
+                # If the type isn't assignment castable, generate a
+                # USING with a nonsense cast. It shouldn't matter,
+                # since there should be no data to cast, but the DDL side
+                # of things doesn't know that since the command is split up.
+                if old_type and not old_type.assignment_castable_to(
+                        new_type, schema):
+                    cast_expr = qlast.TypeCast(
+                        type=new_type_ast,
+                        expr=qlast.Set(elements=[]),
+                    )
                 node.commands.append(
                     qlast.SetPointerType(
-                        value=utils.typeref_to_ast(schema, op.new_value),
+                        value=new_type_ast,
+                        cast_expr=cast_expr,
                     )
                 )
+
         elif op.property == 'on_target_delete':
             node.commands.append(qlast.OnTargetDelete(cascade=op.new_value))
         else:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2840,6 +2840,26 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_schema_get_migration_51(self):
+        schema = r'''
+        abstract type Version {
+            required link entity -> Versioned;
+        }
+
+        abstract type Barks;
+        abstract type Versioned;
+
+        type DogVersion extending Version, Barks {
+            overloaded required link entity -> Dog;
+        }
+
+        type Dog extending Versioned {
+            multi link versions := (SELECT Dog.<entity[IS DogVersion]);
+        }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_schema_get_migration_multi_module_01(self):
         schema = r'''
             # The two declared types declared are from different


### PR DESCRIPTION
When an ALTER LINK that changes type gets split off from a CREATE TYPE
into an ALTER TYPE, we may need to include a USING statement. The body
of the USING statement doesn't actually matter---it's only needed because
the DDL side can't figure out that the cast expr isn't needed.

Fixes #3183.