### PR TITLE
Don't have {} act as a wildcard in assert_query_result

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -833,6 +833,13 @@ class ConnectedTestCaseMixin:
                         f'{_format_path(path)}')
 
         def _assert_dict_shape(path, data, shape):
+            if not isinstance(data, dict):
+                self.fail(
+                    f'{message}: expected dict '
+                    f'{_format_path(path)}')
+
+            # TODO: should we also check that there aren't *extra* keys
+            # (other than id, __tname__?)
             for sk, sv in shape.items():
                 if not data or sk not in data:
                     self.fail(

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -561,22 +561,22 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''SELECT call13('aaa');''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
             r'''SELECT call13(b'aaaa');''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
             r'''SELECT call13([1, 2, 3, 4, 5]);''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
             r'''SELECT call13(['a', 'b']);''',
-            [{}],
+            [1],
         )
 
         await self.con.execute('''
@@ -773,7 +773,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''SELECT call18(2);''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
@@ -987,7 +987,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''SELECT call26(['aaa']);''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
@@ -1131,7 +1131,7 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''SELECT call31([1, 2])[0];''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
@@ -1161,17 +1161,17 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
 
         await self.assert_query_result(
             r'''SELECT call31((a:=[(x:=1)])).a[0].x;''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
             r'''SELECT call31((a:=[(x:=1)])).0[0].x;''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
             r'''SELECT call31((a:=[(x:=1)])).0[0].0;''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -1319,37 +1319,37 @@ class TestEdgeQLCasts(tb.QueryTestCase):
     async def test_edgeql_casts_numeric_06(self):
         await self.assert_query_result(
             r'''SELECT <int16>1;''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
             r'''SELECT <int32>1;''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
             r'''SELECT <int64>1;''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
             r'''SELECT <float32>1;''',
-            [{}],
+            [1.0],
         )
 
         await self.assert_query_result(
             r'''SELECT <float64>1;''',
-            [{}],
+            [1.0],
         )
 
         await self.assert_query_result(
             r'''SELECT <bigint>1;''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
             r'''SELECT <decimal>1;''',
-            [{}],
+            [1],
         )
 
     async def test_edgeql_casts_numeric_07(self):
@@ -1361,7 +1361,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 f'''
                     SELECT <{t1}><{t2}>1;
                 ''',
-                [{}],
+                [1],
             )
 
     async def test_edgeql_casts_collections_01(self):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -591,7 +591,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 } ORDER BY TestSelfLink2.foo2;
             """,
             [
-                {'bar2': {}, 'foo2': 'Alice'},
+                {'bar2': [], 'foo2': 'Alice'},
                 {'bar2': {'Alice'}, 'foo2': 'Bob'},
                 {'bar2': {'Alice', 'Bob'}, 'foo2': 'Carol'}
             ],
@@ -3519,7 +3519,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             r"""
                 SELECT int_func_1();
             """,
-            [{}],
+            [1],
         )
 
     async def test_edgeql_ddl_function_07(self):
@@ -6445,9 +6445,14 @@ type default::Foo {
                     (SELECT ggc.properties FILTER .name = 'a')
                         .annotations@value;
             """,
-            {}
+            []
         )
 
+    @test.xfail('''
+        Default value ought to get reset back to non-existent, since it
+        was inherited? (Or actually maybe not, since the prop is owned
+        by then?)
+    ''')
     async def test_edgeql_ddl_extending_05(self):
         # Check that field alters are propagated.
         await self.con.execute(r"""
@@ -6518,7 +6523,7 @@ type default::Foo {
 
         await self.con.execute(r"""
             ALTER TYPE ExtC5 ALTER PROPERTY a SET REQUIRED;
-            ALTER TYPE ExtC5 DROP EXTENDING ExtA5;
+            ALTER TYPE ExtC5 DROP EXTENDING ExtB5;
         """)
 
         await self.assert_query_result(
@@ -6532,7 +6537,7 @@ type default::Foo {
                     (SELECT C5.properties FILTER .name = 'a')
                         .default;
             """,
-            {}
+            []
         )
 
     async def test_edgeql_ddl_modules_01(self):
@@ -8188,7 +8193,7 @@ type default::Foo {
                 'name': 'default::ConTest01',
                 'properties': [{
                     'name': 'con_test',
-                    'constraints': {},
+                    'constraints': [],
                 }]
             }
         ])

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -3684,7 +3684,7 @@ aa \
     async def test_edgeql_expr_tuple_indirection_06(self):
         await self.assert_query_result(
             r'''SELECT (1, ('a', 'b', (0.1, 0.2)), 2, 3).0;''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
@@ -3705,7 +3705,7 @@ aa \
     async def test_edgeql_expr_tuple_indirection_07(self):
         await self.assert_query_result(
             r'''WITH A := (1, ('a', 'b', (0.1, 0.2)), 2, 3) SELECT A.0;''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
@@ -4480,7 +4480,7 @@ aa \
     async def test_edgeql_expr_aggregate_01(self):
         await self.assert_query_result(
             r'''SELECT count(DISTINCT {1, 1, 1});''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
@@ -5258,7 +5258,7 @@ aa \
                 SELECT (INTROSPECT TYPEOF BaseObject)
             """,
             [
-                {"id": {}}
+                {"id": str}
             ]
         )
         res = await self.con._fetchall("""

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -100,7 +100,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_array_agg_02(self):
         await self.assert_query_result(
             r'''SELECT array_agg({1, 2, 3})[0];''',
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
@@ -2836,7 +2836,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             r'''
                 SELECT min(<int64>Issue.number);
             ''',
-            [{}],
+            [1],
         )
 
     async def test_edgeql_functions_min_03(self):
@@ -3435,17 +3435,17 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_contains_03(self):
         await self.assert_query_result(
             r'''SELECT contains(<str>{}, <str>{});''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
             r'''SELECT contains(<str>{}, 'a');''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
             r'''SELECT contains('qwerty', <str>{});''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
@@ -3486,17 +3486,17 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_contains_04(self):
         await self.assert_query_result(
             r'''SELECT contains(<bytes>{}, <bytes>{});''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
             r'''SELECT contains(<bytes>{}, b'a');''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
             r'''SELECT contains(b'qwerty', <bytes>{});''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
@@ -3517,17 +3517,17 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_find_01(self):
         await self.assert_query_result(
             r'''SELECT find(<str>{}, <str>{});''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
             r'''SELECT find(<str>{}, 'a');''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
             r'''SELECT find('qwerty', <str>{});''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
@@ -3568,7 +3568,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_find_02(self):
         await self.assert_query_result(
             r'''SELECT find(<bytes>{}, <bytes>{});''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
@@ -3589,17 +3589,17 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
     async def test_edgeql_functions_find_03(self):
         await self.assert_query_result(
             r'''SELECT find(<array<str>>{}, <str>{});''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
             r'''SELECT find(<array<str>>{}, 'the');''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
             r'''SELECT find(['the', 'quick', 'brown', 'fox'], <str>{});''',
-            {},
+            [],
         )
 
         await self.assert_query_result(

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -870,7 +870,7 @@ class TestInsert(tb.QueryTestCase):
             ''',
             [{
                 'name': 'test',
-                'subject': {'id': {}},
+                'subject': {'id': str},
             }],
         )
 
@@ -1893,7 +1893,7 @@ class TestInsert(tb.QueryTestCase):
             """,
             [{
                 'l2': 99,
-                'subordinates': {},
+                'subordinates': [],
             }],
         )
 
@@ -3900,7 +3900,7 @@ class TestInsert(tb.QueryTestCase):
                 }
                 UNLESS CONFLICT ON .name ELSE (SELECT Obj);
             ''',
-            [{"id": {}}]
+            [{"id": str}]
         )
 
         await self.assert_query_result(

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -601,7 +601,7 @@ class TestIntrospection(tb.QueryTestCase):
                             {
                                 'name': 'std::max_len_value',
                                 'expr': '(__subject__ <= max)',
-                                'annotations': {},
+                                'annotations': [],
                                 'subject': {'name': 'body'},
                                 'params': [
                                     {
@@ -624,9 +624,9 @@ class TestIntrospection(tb.QueryTestCase):
                             {
                                 'name': 'std::exclusive',
                                 'expr': 'std::_is_exclusive(__subject__)',
-                                'annotations': {},
+                                'annotations': [],
                                 'subject': {'name': 'id'},
-                                'params': {},
+                                'params': [],
                                 'return_typemod': 'SingletonType',
                                 'return_type': {'name': 'std::bool'},
                                 'errmessage':
@@ -671,7 +671,7 @@ class TestIntrospection(tb.QueryTestCase):
                     {
                         'name': 'std::one_of',
                         'expr': 'std::contains(vals, __subject__)',
-                        'annotations': {},
+                        'annotations': [],
                         'subject': {'name': 'default::EmulatedEnum'},
                         'params': [
                             {

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -824,7 +824,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             WITH JT3 := (SELECT JSONTest FILTER .number = 3)
             SELECT json_get(JT3.data, '100');
             ''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
@@ -832,7 +832,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             WITH JT3 := (SELECT JSONTest FILTER .number = 3)
             SELECT json_get(JT3.data, 'foo');
             ''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
@@ -840,7 +840,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             WITH JT3 := (SELECT JSONTest FILTER .number = 3)
             SELECT json_get(JT3.data, '0', 'b', 'bar', '2', 'bingo');
             ''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
@@ -848,7 +848,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             WITH JT3 := (SELECT JSONTest FILTER .number = 3)
             SELECT json_get(JT3.data, '1', 'b', 'bar', '2', 'bingo');
             ''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
@@ -856,7 +856,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             WITH JT3 := (SELECT JSONTest FILTER .number = 3)
             SELECT json_get(JT3.data, '2', 'b', 'bar', '2', 'bingo');
             ''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
@@ -864,7 +864,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             WITH JT3 := (SELECT JSONTest FILTER .number = 3)
             SELECT json_get(JT3.data, '3', 'b', 'bar', '2', 'bingo');
             ''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
@@ -883,7 +883,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             WITH JT3 := (SELECT JSONTest FILTER .number = 3)
             SELECT json_get(JT3.data, '4', 'b', 'foo', '2', 'bingo');
             ''',
-            {}
+            []
         )
 
     async def test_edgeql_json_get_02(self):
@@ -904,40 +904,40 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''SELECT json_get(JSONTest.data, '100');''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
             r'''SELECT json_get(JSONTest.data, 'foo');''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
             r'''
                 SELECT json_get(JSONTest.data, '0', 'b', 'bar', '2', 'bingo');
             ''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
             r'''
                 SELECT json_get(JSONTest.data, '1', 'b', 'bar', '2', 'bingo');
             ''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
             r'''
                 SELECT json_get(JSONTest.data, '2', 'b', 'bar', '2', 'bingo');
             ''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
             r'''
                 SELECT json_get(JSONTest.data, '3', 'b', 'bar', '2', 'bingo');
             ''',
-            {},
+            [],
         )
 
         await self.assert_query_result(
@@ -952,7 +952,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             r'''
                 SELECT json_get(JSONTest.data, '4', 'b', 'foo', '2', 'bingo');
             ''',
-            {}
+            []
         )
 
     async def test_edgeql_json_get_03(self):

--- a/tests/test_edgeql_linkatoms.py
+++ b/tests/test_edgeql_linkatoms.py
@@ -50,12 +50,12 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
                 }, {
                     'name': 'chair',
                     'tag_set1': {'wood', 'rectangle'},
-                    'tag_set2': {},
+                    'tag_set2': [],
                     'tag_array': ['wood', 'rectangle'],
                 }, {
                     'name': 'ectoplasm',
-                    'tag_set1': {},
-                    'tag_set2': {},
+                    'tag_set1': [],
+                    'tag_set2': [],
                     'tag_array': None,
                 }, {
                     'name': 'floor lamp',
@@ -64,8 +64,8 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
                     'tag_array': ['metal', 'plastic'],
                 }, {
                     'name': 'mystery toy',
-                    'tag_set1': {},
-                    'tag_set2': {},
+                    'tag_set1': [],
+                    'tag_set2': [],
                     'tag_array': None,
                 }, {
                     'name': 'table',
@@ -74,12 +74,12 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
                     'tag_array': ['wood', 'rectangle'],
                 }, {
                     'name': 'teapot',
-                    'tag_set1': {},
-                    'tag_set2': {},
+                    'tag_set1': [],
+                    'tag_set2': [],
                     'tag_array': ['ceramic', 'round'],
                 }, {
                     'name': 'tv',
-                    'tag_set1': {},
+                    'tag_set1': [],
                     'tag_set2': {'plastic', 'rectangle'},
                     'tag_array': ['plastic', 'rectangle'],
                 },
@@ -103,30 +103,30 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
                 }, {
                     'name': 'chair',
                     'tag_set1': ['wood', 'rectangle'],
-                    'tag_set2': {},
+                    'tag_set2': [],
                 }, {
                     'name': 'ectoplasm',
-                    'tag_set1': {},
-                    'tag_set2': {},
+                    'tag_set1': [],
+                    'tag_set2': [],
                 }, {
                     'name': 'floor lamp',
                     'tag_set1': ['plastic', 'metal'],
                     'tag_set2': ['metal', 'plastic'],
                 }, {
                     'name': 'mystery toy',
-                    'tag_set1': {},
-                    'tag_set2': {},
+                    'tag_set1': [],
+                    'tag_set2': [],
                 }, {
                     'name': 'table',
                     'tag_set1': ['wood', 'rectangle'],
                     'tag_set2': ['rectangle', 'wood'],
                 }, {
                     'name': 'teapot',
-                    'tag_set1': {},
-                    'tag_set2': {},
+                    'tag_set1': [],
+                    'tag_set2': [],
                 }, {
                     'name': 'tv',
-                    'tag_set1': {},
+                    'tag_set1': [],
                     'tag_set2': ['plastic', 'rectangle'],
                 },
             ]
@@ -149,30 +149,30 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
                 }, {
                     'name': 'chair',
                     'tag_set1': ['wood'],
-                    'tag_set2': {},
+                    'tag_set2': [],
                 }, {
                     'name': 'ectoplasm',
-                    'tag_set1': {},
-                    'tag_set2': {},
+                    'tag_set1': [],
+                    'tag_set2': [],
                 }, {
                     'name': 'floor lamp',
                     'tag_set1': ['plastic'],
                     'tag_set2': ['plastic'],
                 }, {
                     'name': 'mystery toy',
-                    'tag_set1': {},
-                    'tag_set2': {},
+                    'tag_set1': [],
+                    'tag_set2': [],
                 }, {
                     'name': 'table',
                     'tag_set1': ['wood'],
                     'tag_set2': ['wood'],
                 }, {
                     'name': 'teapot',
-                    'tag_set1': {},
-                    'tag_set2': {},
+                    'tag_set1': [],
+                    'tag_set2': [],
                 }, {
                     'name': 'tv',
-                    'tag_set1': {},
+                    'tag_set1': [],
                     'tag_set2': ['rectangle'],
                 },
             ]
@@ -195,30 +195,30 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
                 }, {
                     'name': 'chair',
                     'tag_set1': {'wood', 'rectangle'},
-                    'tag_set2': {},
+                    'tag_set2': [],
                 }, {
                     'name': 'ectoplasm',
-                    'tag_set1': {},
-                    'tag_set2': {},
+                    'tag_set1': [],
+                    'tag_set2': [],
                 }, {
                     'name': 'floor lamp',
                     'tag_set1': {'plastic'},
                     'tag_set2': {'metal', 'plastic'},
                 }, {
                     'name': 'mystery toy',
-                    'tag_set1': {},
-                    'tag_set2': {},
+                    'tag_set1': [],
+                    'tag_set2': [],
                 }, {
                     'name': 'table',
                     'tag_set1': {'wood', 'rectangle'},
                     'tag_set2': {'rectangle'},
                 }, {
                     'name': 'teapot',
-                    'tag_set1': {},
-                    'tag_set2': {},
+                    'tag_set1': [],
+                    'tag_set2': [],
                 }, {
                     'name': 'tv',
-                    'tag_set1': {},
+                    'tag_set1': [],
                     'tag_set2': {'plastic', 'rectangle'},
                 },
             ]
@@ -377,35 +377,35 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             [
                 {
                     'name': 'ball',
-                    'foo': {},
-                    'bar': {},
+                    'foo': [],
+                    'bar': [],
                 }, {
                     'name': 'chair',
                     'foo': {'wood', 'rectangle'},
-                    'bar': {},
+                    'bar': [],
                 }, {
                     'name': 'ectoplasm',
-                    'foo': {},
-                    'bar': {},
+                    'foo': [],
+                    'bar': [],
                 }, {
                     'name': 'floor lamp',
-                    'foo': {},
-                    'bar': {},
+                    'foo': [],
+                    'bar': [],
                 }, {
                     'name': 'mystery toy',
-                    'foo': {},
-                    'bar': {},
+                    'foo': [],
+                    'bar': [],
                 }, {
                     'name': 'table',
                     'foo': {'wood', 'rectangle'},
                     'bar': {'wood', 'rectangle'},
                 }, {
                     'name': 'teapot',
-                    'foo': {},
-                    'bar': {},
+                    'foo': [],
+                    'bar': [],
                 }, {
                     'name': 'tv',
-                    'foo': {},
+                    'foo': [],
                     'bar': {'rectangle'},
                 },
             ],
@@ -677,19 +677,19 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             [
                 {
                     'name': 'ball',
-                    'unpack': {}
+                    'unpack': []
                 }, {
                     'name': 'chair',
                     'unpack': {'rectangle', 'wood'}
                 }, {
                     'name': 'ectoplasm',
-                    'unpack': {}
+                    'unpack': []
                 }, {
                     'name': 'floor lamp',
                     'unpack': {'metal', 'plastic'}
                 }, {
                     'name': 'mystery toy',
-                    'unpack': {}
+                    'unpack': []
                 }, {
                     'name': 'table',
                     'unpack': {'rectangle', 'wood'}
@@ -716,19 +716,19 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             [
                 {
                     'name': 'ball',
-                    'unpack': {}
+                    'unpack': []
                 }, {
                     'name': 'chair',
                     'unpack': {'rectangle', 'wood'}
                 }, {
                     'name': 'ectoplasm',
-                    'unpack': {}
+                    'unpack': []
                 }, {
                     'name': 'floor lamp',
                     'unpack': {'metal', 'plastic'}
                 }, {
                     'name': 'mystery toy',
-                    'unpack': {}
+                    'unpack': []
                 }, {
                     'name': 'table',
                     'unpack': {'rectangle', 'wood'}
@@ -847,28 +847,28 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             [
                 {
                     'name': 'ball',
-                    'unique': {}
+                    'unique': []
                 }, {
                     'name': 'chair',
-                    'unique': {}
+                    'unique': []
                 }, {
                     'name': 'ectoplasm',
-                    'unique': {}
+                    'unique': []
                 }, {
                     'name': 'floor lamp',
                     'unique': {'metal'}
                 }, {
                     'name': 'mystery toy',
-                    'unique': {}
+                    'unique': []
                 }, {
                     'name': 'table',
-                    'unique': {}
+                    'unique': []
                 }, {
                     'name': 'teapot',
                     'unique': {'ceramic', 'round'}
                 }, {
                     'name': 'tv',
-                    'unique': {}
+                    'unique': []
                 },
             ],
         )

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2654,7 +2654,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 SELECT (U.cards.a.name, U.cards.a.id, U.cards) LIMIT 1;
             """,
             [
-                [{}, {}, {"id": {}}],
+                [str, str, {"id": str}],
             ],
         )
 

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -741,7 +741,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             SELECT User {name, todo_ids := .todo.id} FILTER .name = 'Elvis';
             """,
             [
-                {'name': 'Elvis', 'todo_ids': [{}, {}]},
+                {'name': 'Elvis', 'todo_ids': [str, str]},
             ]
         )
 
@@ -752,7 +752,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             SELECT Z {name, asdf_id := .asdf.id} FILTER .name = 'Elvis';
             """,
             [
-                {'name': 'Elvis', 'asdf_id': {}},
+                {'name': 'Elvis', 'asdf_id': str},
             ]
         )
 
@@ -3420,8 +3420,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [
                 {'name': 'circle', 'val': 2, 'x': False},
                 {'name': 'hexagon', 'val': 4, 'x': True},
-                {'name': 'pentagon', 'val': {}, 'x': {}},
-                {'name': 'square', 'val': {}, 'x': {}},
+                {'name': 'pentagon', 'val': None, 'x': None},
+                {'name': 'square', 'val': None, 'x': None},
                 {'name': 'triangle', 'val': 10, 'x': False},
             ],
         )
@@ -3438,8 +3438,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [
                 {'name': 'circle', 'val': 2, 'x': True},
                 {'name': 'hexagon', 'val': 4, 'x': False},
-                {'name': 'pentagon', 'val': {}, 'x': {}},
-                {'name': 'square', 'val': {}, 'x': {}},
+                {'name': 'pentagon', 'val': None, 'x': None},
+                {'name': 'square', 'val': None, 'x': None},
                 {'name': 'triangle', 'val': 10, 'x': True},
             ],
         )
@@ -3461,11 +3461,11 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 'x': [False, False],
             }, {
                 'name': 'hexagon',
-                'tags': {},
+                'tags': [],
                 'x': [],
             }, {
                 'name': 'pentagon',
-                'tags': {},
+                'tags': [],
                 'x': [],
             }, {
                 'name': 'square',
@@ -3496,11 +3496,11 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 'x': [True, True],
             }, {
                 'name': 'hexagon',
-                'tags': {},
+                'tags': [],
                 'x': [],
             }, {
                 'name': 'pentagon',
-                'tags': {},
+                'tags': [],
                 'x': [],
             }, {
                 'name': 'square',
@@ -3766,8 +3766,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [
                 {'name': 'circle', 'val': 2, 'x': True},
                 {'name': 'hexagon', 'val': 4, 'x': True},
-                {'name': 'pentagon', 'val': {}, 'x': {}},
-                {'name': 'square', 'val': {}, 'x': {}},
+                {'name': 'pentagon', 'val': None, 'x': None},
+                {'name': 'square', 'val': None, 'x': None},
                 {'name': 'triangle', 'val': 10, 'x': False},
             ],
         )
@@ -3784,8 +3784,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [
                 {'name': 'circle', 'val': 2, 'x': False},
                 {'name': 'hexagon', 'val': 4, 'x': False},
-                {'name': 'pentagon', 'val': {}, 'x': {}},
-                {'name': 'square', 'val': {}, 'x': {}},
+                {'name': 'pentagon', 'val': None, 'x': None},
+                {'name': 'square', 'val': None, 'x': None},
                 {'name': 'triangle', 'val': 10, 'x': True},
             ],
         )
@@ -3807,11 +3807,11 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 'x': [False, True],
             }, {
                 'name': 'hexagon',
-                'tags': {},
+                'tags': [],
                 'x': [],
             }, {
                 'name': 'pentagon',
-                'tags': {},
+                'tags': [],
                 'x': [],
             }, {
                 'name': 'square',
@@ -3842,11 +3842,11 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 'x': [False, True],
             }, {
                 'name': 'hexagon',
-                'tags': {},
+                'tags': [],
                 'x': [],
             }, {
                 'name': 'pentagon',
-                'tags': {},
+                'tags': [],
                 'x': [],
             }, {
                 'name': 'square',
@@ -3929,8 +3929,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [
                 {'name': 'circle', 'val': 2, 'x': False},
                 {'name': 'hexagon', 'val': 4, 'x': False},
-                {'name': 'pentagon', 'val': {}, 'x': {}},
-                {'name': 'square', 'val': {}, 'x': {}},
+                {'name': 'pentagon', 'val': None, 'x': None},
+                {'name': 'square', 'val': None, 'x': None},
                 {'name': 'triangle', 'val': 10, 'x': True},
             ],
         )
@@ -3946,8 +3946,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [
                 {'name': 'circle', 'val': 2, 'x': True},
                 {'name': 'hexagon', 'val': 4, 'x': True},
-                {'name': 'pentagon', 'val': {}, 'x': {}},
-                {'name': 'square', 'val': {}, 'x': {}},
+                {'name': 'pentagon', 'val': None, 'x': None},
+                {'name': 'square', 'val': None, 'x': None},
                 {'name': 'triangle', 'val': 10, 'x': False},
             ],
         )
@@ -3968,11 +3968,11 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 'x': [False, True],
             }, {
                 'name': 'hexagon',
-                'tags': {},
+                'tags': [],
                 'x': [],
             }, {
                 'name': 'pentagon',
-                'tags': {},
+                'tags': [],
                 'x': [],
             }, {
                 'name': 'square',
@@ -3999,11 +3999,11 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 'x': [False, True],
             }, {
                 'name': 'hexagon',
-                'tags': {},
+                'tags': [],
                 'x': [],
             }, {
                 'name': 'pentagon',
-                'tags': {},
+                'tags': [],
                 'x': [],
             }, {
                 'name': 'square',
@@ -4281,15 +4281,15 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 <str>Issue.time_estimate
             );
             """,
-            [{}],
+            [1],
         )
 
     async def test_edgeql_select_cross_13(self):
         await self.assert_query_result(
             r"""
-            SELECT count(count( Issue.watchers));
+            SELECT count(count(Issue.watchers));
             """,
-            [{}],
+            [1],
         )
 
         await self.assert_query_result(
@@ -6719,28 +6719,28 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r'''
                 SELECT <array<User>>{} UNION [User]
             ''',
-            [[{"id": {}}], [{"id": {}}]],
+            [[{"id": str}], [{"id": str}]],
         )
 
         await self.assert_query_result(
             r'''
                 SELECT <array<User>>{} ?? [User]
             ''',
-            [[{"id": {}}], [{"id": {}}]],
+            [[{"id": str}], [{"id": str}]],
         )
 
         await self.assert_query_result(
             r'''
                 SELECT <array<User>>{} IF false ELSE [User]
             ''',
-            [[{"id": {}}], [{"id": {}}]],
+            [[{"id": str}], [{"id": str}]],
         )
 
         await self.assert_query_result(
             r'''
                 SELECT assert_exists([User])
             ''',
-            [[{"id": {}}], [{"id": {}}]],
+            [[{"id": str}], [{"id": str}]],
         )
 
     async def test_edgeql_collection_shape_02(self):
@@ -6748,28 +6748,28 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r'''
                 SELECT <array<User>>{} UNION array_agg(User)
             ''',
-            [[{"id": {}}, {"id": {}}]],
+            [[{"id": str}, {"id": str}]],
         )
 
         await self.assert_query_result(
             r'''
                 SELECT <array<User>>{} ?? array_agg(User)
             ''',
-            [[{"id": {}}, {"id": {}}]],
+            [[{"id": str}, {"id": str}]],
         )
 
         await self.assert_query_result(
             r'''
                 SELECT <array<User>>{} IF false ELSE array_agg(User)
             ''',
-            [[{"id": {}}, {"id": {}}]],
+            [[{"id": str}, {"id": str}]],
         )
 
         await self.assert_query_result(
             r'''
                 SELECT assert_exists(array_agg(User))
             ''',
-            [[{"id": {}}, {"id": {}}]],
+            [[{"id": str}, {"id": str}]],
         )
 
     async def test_edgeql_collection_shape_03(self):
@@ -6777,28 +6777,28 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r'''
                 SELECT <tuple<User, int64>>{} UNION (User, 2)
             ''',
-            [[{"id": {}}, 2], [{"id": {}}, 2]],
+            [[{"id": str}, 2], [{"id": str}, 2]],
         )
 
         await self.assert_query_result(
             r'''
                 SELECT <tuple<User, int64>>{} ?? (User, 2)
             ''',
-            [[{"id": {}}, 2], [{"id": {}}, 2]],
+            [[{"id": str}, 2], [{"id": str}, 2]],
         )
 
         await self.assert_query_result(
             r'''
                 SELECT <tuple<User, int64>>{} IF false ELSE (User, 2)
             ''',
-            [[{"id": {}}, 2], [{"id": {}}, 2]],
+            [[{"id": str}, 2], [{"id": str}, 2]],
         )
 
         await self.assert_query_result(
             r'''
                 SELECT assert_exists((User, 2))
             ''',
-            [[{"id": {}}, 2], [{"id": {}}, 2]],
+            [[{"id": str}, 2], [{"id": str}, 2]],
         )
 
     async def test_edgeql_collection_shape_04(self):
@@ -6806,7 +6806,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r'''
                 SELECT [(User,)][0]
             ''',
-            [[{"id": {}}], [{"id": {}}]]
+            [[{"id": str}], [{"id": str}]]
         )
 
         await self.assert_query_result(
@@ -6821,7 +6821,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r'''
                 SELECT ([User],).0
             ''',
-            [[{"id": {}}], [{"id": {}}]]
+            [[{"id": str}], [{"id": str}]]
         )
 
         await self.assert_query_result(
@@ -6837,7 +6837,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 SELECT { z := ([User],).0 }
             ''',
             [
-                {"z": [[{"id": {}}], [{"id": {}}]]}
+                {"z": [[{"id": str}], [{"id": str}]]}
             ]
         )
 
@@ -6847,7 +6847,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 WITH Z := (<array<User>>{} IF false ELSE [User]),
                 SELECT (Z, array_agg(array_unpack(Z))).1;
             ''',
-            [[{"id": {}}], [{"id": {}}]]
+            [[{"id": str}], [{"id": str}]]
         )
 
         await self.assert_query_result(
@@ -6855,7 +6855,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 WITH Z := (SELECT assert_exists([User]))
                 SELECT (Z, array_agg(array_unpack(Z))).1;
             ''',
-            [[{"id": {}}], [{"id": {}}]]
+            [[{"id": str}], [{"id": str}]]
         )
 
     async def test_edgeql_assert_fail_object_computed_01(self):

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -1871,7 +1871,7 @@ class TestUpdate(tb.QueryTestCase):
             r"""
                 SELECT UpdateTest.comment;
             """,
-            {},
+            [],
         )
 
     async def test_edgeql_update_empty_02(self):
@@ -1914,7 +1914,7 @@ class TestUpdate(tb.QueryTestCase):
             r"""
                 SELECT UpdateTest.status;
             """,
-            {},
+            [],
         )
 
     async def test_edgeql_update_empty_05(self):

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -889,8 +889,8 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             };
         ''', [
             {
-                'foo': [{"id": {}}, {"id": {}}, {"id": {}}],
-                'bar': [{"id": {}}, {"id": {}}, {"id": {}}],
+                'foo': [{"id": str}, {"id": str}, {"id": str}],
+                'bar': [{"id": str}, {"id": str}, {"id": str}],
             }
         ])
 


### PR DESCRIPTION
For assert_query_result, the empty dict `{}` acts as a "wild card",
that will match anything (because it checks each element in the dict,
and so if the dict is empty, it doesn't look at the returned data at all).

In addition to tests intentionally using it as a wildcard, there are
lots of tests that wanted it to mean "null or empty set".

For the former, I put in the actual value or put in the type,
which acts as a wildcard but in a slight more typed way.

The latter I fixed.

Fixes #3196.