### PR TITLE
Filter NULL arguments out when calling non-strict functions/operators

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -38,7 +38,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_11_10_00_00
+EDGEDB_CATALOG_VERSION = 2021_11_17_00_00
 
 
 class MetadataError(Exception):

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -245,11 +245,6 @@ def compile_FunctionCall(
     else:
         tuple_path_ids = []
 
-    impl_is_strict = (
-        func.get_impl_is_strict(env.schema)
-        and func.get_language(env.schema) != qlast.Language.EdgeQL
-    )
-
     fcall = irast.FunctionCall(
         args=final_args,
         func_shortname=func_name,
@@ -274,7 +269,7 @@ def compile_FunctionCall(
         variadic_param_type=variadic_param_type,
         func_initial_value=func_initial_value,
         tuple_path_ids=tuple_path_ids,
-        impl_is_strict=impl_is_strict,
+        impl_is_strict=func.get_impl_is_strict(env.schema),
     )
 
     ir_set = setgen.ensure_set(fcall, typehint=rtype, path_id=path_id, ctx=ctx)

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -245,6 +245,11 @@ def compile_FunctionCall(
     else:
         tuple_path_ids = []
 
+    impl_is_strict = (
+        func.get_impl_is_strict(env.schema)
+        and func.get_language(env.schema) != qlast.Language.EdgeQL
+    )
+
     fcall = irast.FunctionCall(
         args=final_args,
         func_shortname=func_name,
@@ -269,6 +274,7 @@ def compile_FunctionCall(
         variadic_param_type=variadic_param_type,
         func_initial_value=func_initial_value,
         tuple_path_ids=tuple_path_ids,
+        impl_is_strict=impl_is_strict,
     )
 
     ir_set = setgen.ensure_set(fcall, typehint=rtype, path_id=path_id, ctx=ctx)
@@ -592,6 +598,7 @@ def compile_operator(
         typeref=typegen.type_to_typeref(rtype, env=env),
         typemod=oper.get_return_typemod(env.schema),
         tuple_path_ids=[],
+        impl_is_strict=oper.get_impl_is_strict(env.schema),
     )
 
     _check_free_shape_op(node, ctx=ctx)
@@ -860,7 +867,8 @@ def finalize_args(
                 arg, paramtype, srcctx=None, ctx=ctx)
 
         args.append(
-            irast.CallArg(expr=arg, expr_type_path_id=arg_type_path_id))
+            irast.CallArg(expr=arg, expr_type_path_id=arg_type_path_id,
+                          is_default=barg.is_default))
 
         # If we have any logged paths left over and our enclosing
         # context is logging paths, propagate them up.

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -48,6 +48,7 @@ class BoundArg(NamedTuple):
     val: irast.Set
     valtype: s_types.Type
     cast_distance: int
+    is_default: bool = False
 
 
 class MissingArg(NamedTuple):
@@ -428,6 +429,7 @@ def try_bind_call_args(
                         default,
                         param_type,
                         0,
+                        True,
                     )
                 )
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -668,6 +668,7 @@ class CallArg(ImmutableBase):
     expr_type_path_id: typing.Optional[PathId] = None
     cardinality: qltypes.Cardinality = qltypes.Cardinality.UNKNOWN
     multiplicity: qltypes.Multiplicity = qltypes.Multiplicity.UNKNOWN
+    is_default: bool = False
 
 
 class Call(ImmutableExpr):
@@ -707,6 +708,11 @@ class Call(ImmutableExpr):
 
     # Volatility of the function or operator.
     volatility: qltypes.Volatility
+
+    # Whether the underlying implementation is strict in all its required
+    # arguments (NULL inputs lead to NULL results). If not, we need to
+    # filter at the call site.
+    impl_is_strict: bool = False
 
 
 class FunctionCall(Call):

--- a/edb/lib/std/30-arrayfuncs.edgeql
+++ b/edb/lib/std/30-arrayfuncs.edgeql
@@ -173,6 +173,7 @@ std::`++` (l: array<anytype>, r: array<anytype>) -> array<anytype> {
     CREATE ANNOTATION std::identifier := 'concat';
     CREATE ANNOTATION std::description := 'Array concatenation.';
     SET volatility := 'Immutable';
+    SET impl_is_strict := false;
     USING SQL FUNCTION 'array_cat';
 };
 

--- a/edb/pgsql/common.py
+++ b/edb/pgsql/common.py
@@ -257,6 +257,8 @@ def get_pointer_backend_name(id, module_name, *, catenate=False, aspect=None):
 
 
 _operator_map = {
+    s_name.name_from_string('std::AND'): 'AND',
+    s_name.name_from_string('std::OR'): 'OR',
     s_name.name_from_string('std::NOT'): 'NOT',
     s_name.name_from_string('std::?='): 'IS NOT DISTINCT FROM',
     s_name.name_from_string('std::?!='): 'IS DISTINCT FROM',

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -238,7 +238,7 @@ def compile_TypeCast(
         )
 
     else:
-        raise RuntimeError('cast not supported')
+        raise errors.UnsupportedFeatureError('cast not supported')
 
     if expr.cardinality_mod is qlast.CardinalityModifier.Required:
         res = pgast.FuncCall(
@@ -327,7 +327,7 @@ def _compile_call_args(
             and ref.nullable
             and typemod == ql_ft.TypeModifier.SingletonType
         ):
-            raise RuntimeError(
+            raise errors.UnsupportedFeatureError(
                 'operations on potentially empty arguments not supported in '
                 'simple expressions')
     return args
@@ -360,7 +360,7 @@ def compile_OperatorCall(
             ],
         )
     elif expr.typemod is ql_ft.TypeModifier.SetOfType:
-        raise RuntimeError(
+        raise errors.UnsupportedFeatureError(
             f'set returning operator {expr.func_shortname!r} is not supported '
             f'in simple expressions')
 
@@ -594,7 +594,7 @@ def compile_FunctionCall(
         ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
 
     if expr.typemod is ql_ft.TypeModifier.SetOfType:
-        raise RuntimeError(
+        raise errors.UnsupportedFeatureError(
             'set returning functions are not supported in simple expressions')
 
     args = _compile_call_args(expr, ctx=ctx)
@@ -725,7 +725,7 @@ def _compile_set_in_singleton_mode(
                 return set_expr
 
             if ptrref.source_ptr is None and source.rptr is not None:
-                raise RuntimeError(
+                raise errors.UnsupportedFeatureError(
                     'unexpectedly long path in simple expr')
 
             ptr_stor_info = pg_types.get_ptrref_storage_info(

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -740,6 +740,9 @@ class CallableObject(
     abstract = so.SchemaField(
         bool, default=False, inheritable=False, compcoef=0.909)
 
+    impl_is_strict = so.SchemaField(
+        bool, default=True, compcoef=0.4)
+
     def as_create_delta(
         self: CallableObjectT,
         schema: s_schema.Schema,

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -312,6 +312,17 @@ class ParameterDesc(ParameterLike):
         return cmd
 
 
+def _params_are_all_required_singletons(
+    params: Sequence[ParameterLike], schema: s_schema.Schema,
+) -> bool:
+    return all(
+        param.get_kind(schema) is not ft.ParameterKind.VariadicParam
+        and param.get_typemod(schema) is ft.TypeModifier.SingletonType
+        and param.get_default(schema) is None
+        for param in params
+    )
+
+
 class Parameter(
     so.ObjectFragment,
     ParameterLike,
@@ -612,9 +623,12 @@ class FuncParameterList(so.ObjectList[Parameter], ParameterLikeList):
         return any(p.get_type(schema).is_polymorphic(schema)
                    for p in self.objects(schema))
 
+    def has_type_mod(
+            self, schema: s_schema.Schema, mod: ft.TypeModifier) -> bool:
+        return any(p.get_typemod(schema) is mod for p in self.objects(schema))
+
     def has_set_of(self, schema: s_schema.Schema) -> bool:
-        return any(p.get_typemod(schema) is ft.TypeModifier.SetOfType
-                   for p in self.objects(schema))
+        return self.has_type_mod(schema, ft.TypeModifier.SetOfType)
 
     def has_objects(self, schema: s_schema.Schema) -> bool:
         return any(p.get_type(schema).is_object_type()
@@ -1623,6 +1637,15 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
             else:
                 backend_name = uuidgen.uuid1mc()
             self.set_attribute_value('backend_name', backend_name)
+
+            if (
+                self.has_attribute_value("code")
+                or self.has_attribute_value("nativecode")
+            ):
+                self.set_attribute_value(
+                    'impl_is_strict',
+                    _params_are_all_required_singletons(cp, schema),
+                )
 
         # Check if other schema objects with the same name (ignoring
         # signature, of course) exist.

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -310,6 +310,10 @@ class CreateOperator(
                     astnode.code.from_function,
                 )
             if astnode.code.code is not None:
+                # TODO: Make operators from code strict when we can?
+                cmd.set_attribute_value(
+                    'impl_is_strict', False
+                )
                 cmd.set_attribute_value(
                     'code',
                     astnode.code.code,

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -260,6 +260,7 @@ def generate_structure(schema: s_schema.Schema) -> SchemaReflectionParts:
             ) -> std::int64 {
                 USING SQL FUNCTION 'edgedb.get_pg_type_for_edgedb_type';
                 SET volatility := 'STABLE';
+                SET impl_is_strict := false;
             };
 
             CREATE FUNCTION sys::_expr_from_json(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -8896,10 +8896,7 @@ type default::Foo {
                  CREATE CONSTRAINT expression ON (
                      <str>.num != asdf2()
                  );
-                 # FIXME: An index on asdf(.color) isn't supported currently
-                 # because passing nullable arguments requires filtering.
-                 # CREATE INDEX ON (asdf(.color));
-                 CREATE INDEX ON (.color);
+                 CREATE INDEX ON (asdf(.color));
                  CREATE PROPERTY lol -> str {
                      SET default := asdf2();
                  }

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -7088,9 +7088,7 @@ type default::Foo {
                     SET volatility := 'Immutable';
                     CREATE ANNOTATION std::description :=
                         'Logical conjunction.';
-                    USING SQL $$
-                        SELECT ("a" AND "b") OR ("a"::int & "b"::int)::bool
-                    $$;
+                    USING SQL EXPRESSION;
                 };
                 ''',
                 '''
@@ -8898,7 +8896,10 @@ type default::Foo {
                  CREATE CONSTRAINT expression ON (
                      <str>.num != asdf2()
                  );
-                 CREATE INDEX ON (asdf(.color));
+                 # FIXME: An index on asdf(.color) isn't supported currently
+                 # because passing nullable arguments requires filtering.
+                 # CREATE INDEX ON (asdf(.color));
+                 CREATE INDEX ON (.color);
                  CREATE PROPERTY lol -> str {
                      SET default := asdf2();
                  }

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -2787,8 +2787,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_func_06(self):
         await self.con.execute(r'''
-            CREATE FUNCTION concat2(VARIADIC s: std::str) -> std::str
+            CREATE FUNCTION concat2(VARIADIC s: std::str) -> std::str {
+                SET impl_is_strict := false;
                 USING SQL FUNCTION 'concat';
+            }
         ''')
 
         with self.assertRaisesRegex(
@@ -6921,5 +6923,49 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 {'name': 'pentagon', 'val': None, 'x': None},
                 {'name': 'square', 'val': None, 'x': None},
                 {'name': 'triangle', 'val': 10, 'x': 'triangle'},
+            ],
+        )
+
+    async def test_edgeql_select_call_null_02(self):
+        # testing calls with null args to a function that we can't mark
+        # as strict
+        await self.con.execute('''
+            create function foo(x: OPTIONAL str, y: int64) -> str USING (
+                x ?? "test"
+            );
+        ''')
+
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                val,
+                x := foo(.name, .val)
+            } order by .name;
+            ''',
+            [
+                {'name': 'circle', 'val': 2, 'x': 'circle'},
+                {'name': 'hexagon', 'val': 4, 'x': 'hexagon'},
+                {'name': 'pentagon', 'val': None, 'x': None},
+                {'name': 'square', 'val': None, 'x': None},
+                {'name': 'triangle', 'val': 10, 'x': 'triangle'},
+            ],
+        )
+
+    async def test_edgeql_select_concat_null_01(self):
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                val,
+                x := [.val] ++ [0]
+            } order by .name;
+            ''',
+            [
+                {'name': 'circle', 'val': 2, 'x': [2, 0]},
+                {'name': 'hexagon', 'val': 4, 'x': [4, 0]},
+                {'name': 'pentagon', 'val': None, 'x': None},
+                {'name': 'square', 'val': None, 'x': None},
+                {'name': 'triangle', 'val': 10, 'x': [10, 0]},
             ],
         )

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -6900,3 +6900,26 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             await self.con.query("""
                 SELECT array_agg((SELECT User {m := Publication}))[{1000}].m;
             """)
+
+    async def test_edgeql_select_call_null_01(self):
+        # testing calls with null args
+        await self.con.execute('''
+            create function foo(x: str, y: int64) -> str USING (x);
+        ''')
+
+        await self.assert_query_result(
+            r'''
+            select BooleanTest {
+                name,
+                val,
+                x := foo(.name, .val)
+            } order by .name;
+            ''',
+            [
+                {'name': 'circle', 'val': 2, 'x': 'circle'},
+                {'name': 'hexagon', 'val': 4, 'x': 'hexagon'},
+                {'name': 'pentagon', 'val': None, 'x': None},
+                {'name': 'square', 'val': None, 'x': None},
+                {'name': 'triangle', 'val': 10, 'x': 'triangle'},
+            ],
+        )


### PR DESCRIPTION
We have two related problems with a related solution:
 - Our implementation of the AND operator, which carefully
   ensures that we return NULL if either input is NULL,
   is a huge performance problem that prevents the use of indexes
 - User defined functions with implementations that aren't strict in
   their arguments can end up producing values when they shouldn't.

To fix this, we add NOT NULL filters when calling functions/operators
with potentially NULL values. To avoid doing this *too* much (and to
make it work more often in singleton mode), we add a notion of
function/operators having a strict implementation, which allows
the check to be skipped. Currently all built-in functions and operators
except for AND and OR are marked as being strict.

Fixes some #3185 related issues.
Fixes #3195.