### PR TITLE
Support path prefix in link indexes

### DIFF
--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -574,6 +574,8 @@ def trace_Path(
                 # Abbreviated path.
                 if ctx.path_prefix in ctx.objects:
                     tip = ctx.objects[ctx.path_prefix]
+                    if isinstance(tip, Pointer):
+                        ptr = tip
                 else:
                     # We can't reason about this path.
                     return None

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2636,12 +2636,8 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
     def create_index(cls, index, schema, context):
         subject = index.get_subject(schema)
 
-        if not isinstance(subject, s_pointers.Pointer):
-            singletons = [subject]
-            path_prefix_anchor = ql_ast.Subject().name
-        else:
-            singletons = []
-            path_prefix_anchor = None
+        singletons = [subject]
+        path_prefix_anchor = ql_ast.Subject().name
 
         index_expr = index.get_expr(schema)
         ir = index_expr.irast

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -284,11 +284,7 @@ class IndexCommand(
             assert parent_ctx is not None
             assert isinstance(parent_ctx.op, sd.ObjectCommand)
             subject = parent_ctx.op.get_object(schema, context)
-
-            if isinstance(subject, s_abc.Pointer):
-                path_prefix_anchor = None
-            else:
-                path_prefix_anchor = qlast.Subject().name
+            path_prefix_anchor = qlast.Subject().name
 
             expr = type(value).compiled(
                 value,

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -28,7 +28,6 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import qltypes
 
-from . import abc as s_abc
 from . import annos as s_anno
 from . import delta as sd
 from . import expr as s_expr

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2860,6 +2860,16 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
 
         self._assert_migration_consistency(schema)
 
+    def test_schema_get_migration_52(self):
+        schema = r'''
+        abstract link friendship {
+            property strength -> float64;
+            index on (@strength);
+        }
+        '''
+
+        self._assert_migration_consistency(schema)
+
     def test_schema_get_migration_multi_module_01(self):
         schema = r'''
             # The two declared types declared are from different


### PR DESCRIPTION
The straightforward solution was blocked by a bug in tracer that
wouldn't properly pick up pointers when they were the path_prefix.