### PR TITLE
Implement index and slicing of json strings.

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -38,7 +38,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_11_17_00_00
+EDGEDB_CATALOG_VERSION = 2021_11_18_00_00
 
 
 class MetadataError(Exception):

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -399,7 +399,7 @@ def __infer_slice(
     if node_type.issubclass(env.schema, str_t):
         base_name = 'string'
     elif node_type.issubclass(env.schema, json_t):
-        base_name = 'json array'
+        base_name = 'JSON array'
     elif node_type.issubclass(env.schema, bytes_t):
         base_name = 'bytes'
     elif isinstance(node_type, s_abc.Array):

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -326,9 +326,14 @@ def _static_interpret_wrong_object_type(_code, err_details):
     if err_details.column_name:
         return SchemaRequired
 
+    hint = None
+    if err_details.detail_json:
+        hint = err_details.detail_json.get('hint')
+
     return errors.InvalidValueError(
         err_details.message,
-        details=err_details.detail if err_details.detail else None
+        details=err_details.detail if err_details.detail else None,
+        hint=hint,
     )
 
 

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -81,7 +81,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
     async def test_edgeql_casts_bytes_04(self):
         async with self.assertRaisesRegexTx(
-                edgedb.InvalidValueError, r'expected json string or null'):
+                edgedb.InvalidValueError, r'expected JSON string or null'):
             await self.con.query_single("""SELECT <bytes>to_json('1');"""),
 
         self.assertEqual(
@@ -2172,13 +2172,13 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'expected json number or null; got json string'):
+                r'expected JSON number or null; got JSON string'):
             await self.con.query_single(
                 r"SELECT <array<int64>><json>['asdf']")
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'expected json number or null; got json string'):
+                r'expected JSON number or null; got JSON string'):
             await self.con.query_single(
                 r"SELECT <array<int64>>to_json('[1, 2, \"asdf\"]')")
 
@@ -2288,7 +2288,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'expected json number or null; got json string'):
+                r'expected JSON number or null; got JSON string'):
             await self.con.query(
                 r"""
                     SELECT <tuple<a: int64, b: int64>>

--- a/tests/test_edgeql_enums.py
+++ b/tests/test_edgeql_enums.py
@@ -282,5 +282,5 @@ class TestEdgeQLEnums(tb.QueryTestCase):
     async def test_edgeql_enums_json_cast_03(self):
         with self.assertRaisesRegex(
                 edgedb.InvalidValueError,
-                r'expected json string or null; got json number'):
+                r'expected JSON string or null; got JSON number'):
             await self.con.execute("SELECT <color_enum_t><json>12")

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -268,7 +268,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_04(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'json index 10 is out of bounds'):
+                r'JSON index 10 is out of bounds'):
             await self.con.query(r"""
                 SELECT (to_json('[1, "a", 3]'))[10];
             """)
@@ -276,7 +276,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_05(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'json index -10 is out of bounds'):
+                r'JSON index -10 is out of bounds'):
             await self.con.query(r"""
                 SELECT (to_json('[1, "a", 3]'))[-10];
             """)
@@ -284,7 +284,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_06(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'cannot index json array by text'):
+                r'cannot index JSON array by text'):
             await self.con.query(r"""
                 SELECT (to_json('[1, "a", 3]'))['1'];
             """)
@@ -292,7 +292,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_07(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r"json index 'c' is out of bounds"):
+                r"JSON index 'c' is out of bounds"):
             await self.con.query(r"""
                 SELECT (to_json('{"a": 1, "b": null}'))["c"];
             """)
@@ -300,7 +300,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_08(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'cannot index json object by bigint'):
+                r'cannot index JSON object by bigint'):
             await self.con.execute(r"""
                 SELECT (to_json('{"a": 1, "b": null}'))[0];
             """)
@@ -308,7 +308,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_09(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'cannot index json null'):
+                r'cannot index JSON null'):
             await self.con.query(r"""
                 SELECT (to_json('null'))[0];
             """)
@@ -316,7 +316,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_10(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'cannot index json boolean'):
+                r'cannot index JSON boolean'):
             await self.con.execute(r"""
                 SELECT (to_json('true'))[0];
             """)
@@ -324,17 +324,9 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_11(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'cannot index json number'):
+                r'cannot index JSON number'):
             await self.con.execute(r"""
                 SELECT (to_json('123'))[0];
-            """)
-
-    async def test_edgeql_json_accessor_12(self):
-        async with self.assertRaisesRegexTx(
-                edgedb.InvalidValueError,
-                r'cannot index json string'):
-            await self.con.execute(r"""
-                SELECT (to_json('"qwerty"'))[0];
             """)
 
     async def test_edgeql_json_accessor_13(self):
@@ -360,7 +352,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_14(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'json index 10 is out of bounds'):
+                r'JSON index 10 is out of bounds'):
             await self.con.query(r"""
                 WITH
                     JT3 := (SELECT JSONTest FILTER .number = 3)
@@ -370,7 +362,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_15(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'json index -10 is out of bounds'):
+                r'JSON index -10 is out of bounds'):
             await self.con.query(r"""
                 WITH
                     JT3 := (SELECT JSONTest FILTER .number = 3)
@@ -380,7 +372,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_16(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'cannot index json array by text'):
+                r'cannot index JSON array by text'):
             await self.con.query(r"""
                 WITH
                     JT3 := (SELECT JSONTest FILTER .number = 3)
@@ -390,7 +382,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_17(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r"json index 'c' is out of bounds"):
+                r"JSON index 'c' is out of bounds"):
             await self.con.execute(r"""
                 WITH
                     JT3 := (SELECT JSONTest FILTER .number = 3)
@@ -400,7 +392,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_18(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'cannot index json object by bigint'):
+                r'cannot index JSON object by bigint'):
             await self.con.query(r"""
                 WITH
                     JT3 := (SELECT JSONTest FILTER .number = 3)
@@ -410,7 +402,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_19(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'cannot index json null'):
+                r'cannot index JSON null'):
             await self.con.execute(r"""
                 WITH
                     JT3 := (SELECT JSONTest FILTER .number = 3)
@@ -420,7 +412,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_20(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'cannot index json boolean'):
+                r'cannot index JSON boolean'):
             await self.con.execute(r"""
                 WITH
                     JT3 := (SELECT JSONTest FILTER .number = 3)
@@ -430,7 +422,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_21(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'cannot index json number'):
+                r'cannot index JSON number'):
             await self.con.query(r"""
                 WITH
                     JT3 := (SELECT JSONTest FILTER .number = 3)
@@ -440,11 +432,55 @@ class TestEdgeQLJSON(tb.QueryTestCase):
     async def test_edgeql_json_accessor_22(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'cannot index json string'):
+                r'cannot index JSON string'):
             await self.con.execute(r"""
                 WITH
                     JT3 := (SELECT JSONTest FILTER .number = 3)
                 SELECT JT3.data[2]['b']['bar'][2]['bingo'];
+            """)
+
+    async def test_edgeql_json_accessor_23(self):
+        await self.assert_query_result(
+            r'''select to_json('"hello"')[0] = <json>'h';''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''select to_json('"hello"')[-2] = <json>'l';''',
+            [True],
+        )
+
+    async def test_edgeql_json_accessor_24(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError,
+                r'JSON index 10 is out of bounds'):
+            await self.con.query(r"""
+                select to_json('"hello"')[10];
+            """)
+
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError,
+                r'JSON index -10 is out of bounds'):
+            await self.con.query(r"""
+                select to_json('"hello"')[-10];
+            """)
+
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError,
+                r'JSON index 10 is out of bounds'):
+            await self.con.query(r"""
+                WITH
+                    JT3 := (SELECT JSONTest FILTER .number = 3)
+                SELECT JT3.data[4]['c'][10];
+            """)
+
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError,
+                r'JSON index -10 is out of bounds'):
+            await self.con.query(r"""
+                WITH
+                    JT3 := (SELECT JSONTest FILTER .number = 3)
+                SELECT JT3.data[4]['c'][-10];
             """)
 
     async def test_edgeql_json_null_01(self):
@@ -1314,6 +1350,18 @@ class TestEdgeQLJSON(tb.QueryTestCase):
             ['[]'],
         )
 
+        await self.assert_query_result(
+            r'''SELECT to_json('[1, "a", 3, null]')[100:];''',
+            [[]],
+            ['[]'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT to_json('[1, "a", 3, null]')[:-100];''',
+            [[]],
+            ['[]'],
+        )
+
     async def test_edgeql_json_slice_02(self):
 
         await self.assert_query_result(
@@ -1372,10 +1420,91 @@ class TestEdgeQLJSON(tb.QueryTestCase):
 
     async def test_edgeql_json_slice_03(self):
         async with self.assertRaisesRegexTx(
-                edgedb.QueryError, r'cannot slice json array by.*str'):
+                edgedb.QueryError, r'cannot slice JSON array by.*str'):
 
             await self.con.execute(r"""
                 SELECT to_json('[1, "a", 3, null]')[:'1'];
+            """)
+
+    async def test_edgeql_json_slice_04(self):
+        await self.assert_query_result(
+            r'''SELECT to_json('"hello"')[:1];''',
+            ['h'],
+            ['"h"'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT to_json('"hello"')[:-1];''',
+            ['hell'],
+            ['"hell"'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT to_json('"hello"')[1:-1];''',
+            ['ell'],
+            ['"ell"'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT to_json('"hello"')[-1:1];''',
+            [''],
+            ['""'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT to_json('"hello"')[-100:100];''',
+            ['hello'],
+            ['"hello"'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT to_json('"hello"')[100:-100];''',
+            [''],
+            ['""'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT to_json('"hello"')[:-100];''',
+            [''],
+            ['""'],
+        )
+
+        await self.assert_query_result(
+            r'''SELECT to_json('"hello"')[100:];''',
+            [''],
+            ['""'],
+        )
+
+    async def test_edgeql_json_slice_05(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError, r'cannot slice JSON number'):
+
+            await self.con.execute(r"""
+                select to_json('123')[0:1];
+            """)
+
+    async def test_edgeql_json_slice_06(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError, r'cannot slice JSON object'):
+
+            await self.con.execute(r"""
+                select to_json('{"a":123}')[0:1];
+            """)
+
+    async def test_edgeql_json_slice_07(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError, r'cannot slice JSON boolean'):
+
+            await self.con.execute(r"""
+                select to_json('true')[0:1];
+            """)
+
+    async def test_edgeql_json_slice_08(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError, r'cannot slice JSON null'):
+
+            await self.con.execute(r"""
+                select to_json('null')[0:1];
             """)
 
     async def test_edgeql_json_bytes_cast_01(self):

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -3128,7 +3128,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_33(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'expected json string'):
+                r'expected JSON string'):
 
             self.graphql_query(
                 r"""
@@ -3267,7 +3267,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_39(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                r'expected json number.+got json string'):
+                r'expected JSON number.+got JSON string'):
             self.graphql_query(
                 r"""
                     query($limit: Int!) {


### PR DESCRIPTION
Even though Postgres doesn't have support for index or slicing
operations on a json string, we can implement it similarly to how we
implemented `++` for json strings.