### PR TITLE
Allow multiple `--emit-server-status` arguments

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1272,8 +1272,8 @@ async def _check_catalog_compatibility(
         )
 
         if datadir_major != expected_ver.major:
-            if ctx.args.status_sink is not None:
-                ctx.args.status_sink(f'INCOMPATIBLE={json.dumps(status)}')
+            for status_sink in ctx.args.status_sinks:
+                status_sink(f'INCOMPATIBLE={json.dumps(status)}')
             raise errors.ConfigurationError(
                 'database instance incompatible with this version of EdgeDB',
                 details=(
@@ -1289,8 +1289,8 @@ async def _check_catalog_compatibility(
             )
 
         if datadir_catver != expected_catver:
-            if ctx.args.status_sink is not None:
-                ctx.args.status_sink(f'INCOMPATIBLE={json.dumps(status)}')
+            for status_sink in ctx.args.status_sinks:
+                status_sink(f'INCOMPATIBLE={json.dumps(status)}')
             raise errors.ConfigurationError(
                 'database instance incompatible with this version of EdgeDB',
                 details=(

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -192,7 +192,7 @@ async def _run_server(
             netport=args.port,
             auto_shutdown_after=args.auto_shutdown_after,
             echo_runtime_info=args.echo_runtime_info,
-            status_sink=args.status_sink,
+            status_sinks=args.status_sinks,
             startup_script=args.startup_script,
             binary_endpoint_security=args.binary_endpoint_security,
             http_endpoint_security=args.http_endpoint_security,

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -132,7 +132,7 @@ class Server(ha_base.ClusterProtocol):
             srvargs.ServerEndpointSecurityMode.Tls),
         auto_shutdown_after: float = -1,
         echo_runtime_info: bool = False,
-        status_sink: Optional[Callable[[str], None]] = None,
+        status_sinks: Sequence[Callable[[str], None]] = (),
         startup_script: Optional[srvargs.StartupScript] = None,
         backend_adaptive_ha: bool = False,
         default_auth_method: str,
@@ -190,7 +190,7 @@ class Server(ha_base.ClusterProtocol):
         self._auto_shutdown_handler = None
 
         self._echo_runtime_info = echo_runtime_info
-        self._status_sink = status_sink
+        self._status_sinks = status_sinks
 
         self._startup_script = startup_script
 
@@ -1470,7 +1470,7 @@ class Server(ha_base.ClusterProtocol):
             }
             print(f'\nEDGEDB_SERVER_DATA:{json.dumps(ri)}\n', flush=True)
 
-        if self._status_sink is not None:
+        for status_sink in self._status_sinks:
             status = {
                 "listen_addrs": listen_addrs,
                 "port": self._listen_port,
@@ -1479,7 +1479,7 @@ class Server(ha_base.ClusterProtocol):
                 "tenant_id": self._tenant_id,
                 "tls_cert_file": self._tls_cert_file,
             }
-            self._status_sink(f'READY={json.dumps(status)}')
+            status_sink(f'READY={json.dumps(status)}')
 
     async def stop(self):
         try:


### PR DESCRIPTION
It is possible to be wanting to specify multiple server status sinks.
One such use case is the server docker image entrypoint, which uses
`--emit-server-status` to monitor and report auto-generated TLS
certificates, but this functionality is disabled if
`--emit-server-status` was already specified.