### PR TITLE
server: Be tolerant toward failures to bind server sockets

### DIFF
--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -272,8 +272,10 @@ def _generate_cert(
         )
         .add_extension(
             x509.SubjectAlternativeName(
-                [x509.DNSName(name) for name in listen_hosts
-                 if name != '0.0.0.0']
+                [
+                    x509.DNSName(name) for name in listen_hosts
+                    if name not in {'0.0.0.0', '::'}
+                ]
             ),
             critical=False,
         )

--- a/tests/test_server_unit.py
+++ b/tests/test_server_unit.py
@@ -24,8 +24,12 @@ from edb.server import server
 
 class TestServerUnittests(unittest.TestCase):
 
-    def test_server_unittest_fix_wildcard_host(self):
+    def test_server_unittest_fix_wildcard_addrs(self):
         CASES = [
+            (
+                ['*'],
+                (['0.0.0.0', '::'], [])
+            ),
             (
                 ['0.0.0.0', '::0'],
                 (['0.0.0.0', '::'], [])
@@ -80,7 +84,7 @@ class TestServerUnittests(unittest.TestCase):
         ]
 
         for hosts, expected in CASES:
-            new_hosts, rej_hosts = server._cleanup_wildcard_hosts(hosts)
+            new_hosts, rej_hosts = server._cleanup_wildcard_addrs(hosts)
             self.assertEqual(
                 (set(new_hosts), set(rej_hosts)),
                 (set(expected[0]), set(expected[1]))


### PR DESCRIPTION
This makes it so that failures to resolve or bind to some of the
specified `listen_addresses` (and `-I` on command line) are not fatal
and are instead logged as warnings.  This is needed because of the
unfortunate reality of bad DNS and network stack configurations in the
wild, where even `localhost` might not be a reliable listen interface
specification.  A good example of this is Github actions where,
`localhost` resolves to `::1`, but IPv6 does not actually work.

This effectively restores pre-176dcd5a04493 behavior and goes further to
tolerate binding failures as long as at least one socket binds.  This
matches PostgreSQL behavior.