### PR TITLE
Replace `--generate-self-signed-cert` with `--tls-cert-mode`

### DIFF
--- a/docs/changelog/1_0_rc2.rst
+++ b/docs/changelog/1_0_rc2.rst
@@ -301,8 +301,13 @@ Server configuration
     - ``never``
 
 ``EDGEDB_SERVER_TLS_CERT_MODE``
-    - ``file == default``
-    - ``self_signed`` — generate self-signed on bootstrap and when expired
+    - ``require_file`` — requires a valid TLS certificate and key to be
+      specified
+    - ``generate_self_signed`` generate self-signed certificate and private
+      key on bootstrap if certificate or key are not specified or missing
+    - ``default`` (equals to ``require_file`` if ``EDGEDB_SERVER_SECURITY``
+      is set to ``strict``, equals to ``generate_self_signed`` if
+      ``EDGEDB_SERVER_SECURITY`` is set to ``insecure_dev_mode``)
 
 ``EDGEDB_DOCKER_SHOW_GENERATED_CERT``
     - ``always == default``

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -56,22 +56,31 @@ class BaseCluster:
         env: Optional[Mapping[str, str]] = None,
         testmode: bool = False,
         log_level: Optional[str] = None,
+        security: Optional[
+            edgedb_args.ServerSecurityMode
+        ] = None,
         http_endpoint_security: Optional[
             edgedb_args.ServerEndpointSecurityMode
         ] = None
     ):
         self._edgedb_cmd = [sys.executable, '-m', 'edb.server.main']
 
+        self._edgedb_cmd.append('--tls-cert-mode=generate_self_signed')
+
         if log_level:
             self._edgedb_cmd.extend(['--log-level', log_level])
 
         if devmode.is_in_dev_mode():
             self._edgedb_cmd.append('--devmode')
-        else:
-            self._edgedb_cmd.append('--generate-self-signed-cert')
 
         if testmode:
             self._edgedb_cmd.append('--testmode')
+
+        if security:
+            self._edgedb_cmd.extend((
+                '--security',
+                str(security),
+            ))
 
         if http_endpoint_security:
             self._edgedb_cmd.extend((
@@ -347,6 +356,9 @@ class Cluster(BaseCluster):
         env: Optional[Mapping[str, str]] = None,
         testmode: bool = False,
         log_level: Optional[str] = None,
+        security: Optional[
+            edgedb_args.ServerSecurityMode
+        ] = None,
         http_endpoint_security: Optional[
             edgedb_args.ServerEndpointSecurityMode
         ] = None
@@ -360,6 +372,7 @@ class Cluster(BaseCluster):
             env=env,
             testmode=testmode,
             log_level=log_level,
+            security=security,
             http_endpoint_security=http_endpoint_security,
         )
         self._edgedb_cmd.extend(['-D', str(self._data_dir)])
@@ -401,6 +414,9 @@ class TempCluster(Cluster):
         env: Optional[Mapping[str, str]] = None,
         testmode: bool = False,
         log_level: Optional[str] = None,
+        security: Optional[
+            edgedb_args.ServerSecurityMode
+        ] = None,
         http_endpoint_security: Optional[
             edgedb_args.ServerEndpointSecurityMode
         ] = None
@@ -418,6 +434,7 @@ class TempCluster(Cluster):
             env=env,
             testmode=testmode,
             log_level=log_level,
+            security=security,
             http_endpoint_security=http_endpoint_security,
         )
 
@@ -472,9 +489,12 @@ class TempClusterWithRemotePg(BaseCluster):
         env: Optional[Mapping[str, str]] = None,
         testmode: bool = False,
         log_level: Optional[str] = None,
+        security: Optional[
+            edgedb_args.ServerSecurityMode
+        ] = None,
         http_endpoint_security: Optional[
             edgedb_args.ServerEndpointSecurityMode
-        ] = None
+        ] = None,
     ) -> None:
         runstate_dir = pathlib.Path(
             tempfile.mkdtemp(
@@ -486,7 +506,7 @@ class TempClusterWithRemotePg(BaseCluster):
         self._backend_dsn = backend_dsn
         super().__init__(
             runstate_dir, env=env, testmode=testmode, log_level=log_level,
-            http_endpoint_security=http_endpoint_security)
+            security=security, http_endpoint_security=http_endpoint_security)
         self._edgedb_cmd.extend(['--backend-dsn', backend_dsn])
 
     async def _new_pg_cluster(self) -> pgcluster.BaseCluster:

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -394,6 +394,7 @@ async def init_cluster(
     *,
     cleanup_atexit=True,
     init_settings=None,
+    security=edgedb_args.ServerSecurityMode.Strict,
     http_endpoint_security=edgedb_args.ServerEndpointSecurityMode.Optional,
 ) -> edgedb_cluster.BaseCluster:
     if data_dir is not None and backend_dsn is not None:
@@ -406,16 +407,19 @@ async def init_cluster(
         cluster = edgedb_cluster.TempClusterWithRemotePg(
             backend_dsn, testmode=True, log_level='s',
             data_dir_prefix='edb-test-',
+            security=security,
             http_endpoint_security=http_endpoint_security)
         destroy = True
     elif data_dir is None:
         cluster = edgedb_cluster.TempCluster(
             testmode=True, log_level='s', data_dir_prefix='edb-test-',
+            security=security,
             http_endpoint_security=http_endpoint_security)
         destroy = True
     else:
         cluster = edgedb_cluster.Cluster(
             data_dir=data_dir, log_level='s',
+            security=security,
             http_endpoint_security=http_endpoint_security)
         destroy = False
 
@@ -1642,7 +1646,7 @@ class _EdgeDBServer:
             '--testmode',
             '--emit-server-status', f'fd://{status_w.fileno()}',
             '--compiler-pool-size', str(self.compiler_pool_size),
-            '--generate-self-signed-cert',
+            '--tls-cert-mode=generate_self_signed',
         ]
 
         for addr in self.bind_addrs:

--- a/tests/test_backend_connect.py
+++ b/tests/test_backend_connect.py
@@ -152,7 +152,7 @@ class ClusterTestCase(tb.TestCase):
         result = CliRunner().invoke(get_default_args, [])
         arg_input = pickle.loads(result.stdout_bytes)
         arg_input["data_dir"] = pathlib.Path(cluster.get_data_dir())
-        arg_input["generate_self_signed_cert"] = True
+        arg_input["tls_cert_mode"] = "generate_self_signed"
         cls.tenant_id = cluster.get_runtime_params().instance_params.tenant_id
         cls.dbname = cluster.get_db_name('edgedb')
         args = edb_args.parse_args(**arg_input)


### PR DESCRIPTION
The `--generate-self-signed-cert` option and the corresponding
`EDGEDB_SERVER_GENERATE_SELF_SIGNED_CERT` are deprecated are replaced
with the `--tls-cert-mode` (`EDGEDB_SERVER_TLS_MODE`) enum with the
following values:

* `require_file` -- requires TLS certificate and key to be specified
  and to be valid files;
* `generate_self_signed` -- permits the server to auto-generate
  a self-signed certificate, possibly storing the result in
  `--tls-cert-file` and `--tls-key-file` if those are set, but
  point to non-existent files.

The default is determined by `--security` as before.