### PR TITLE
Require both TLS certificate and key to be explicitly specified

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -692,27 +692,28 @@ def parse_args(**kwargs: Any):
     if kwargs['tls_key_file'] and not kwargs['tls_cert_file']:
         abort('When --tls-key-file is set, --tls-cert-file must also be set.')
 
+    if kwargs['tls_cert_file'] and not kwargs['tls_key_file']:
+        abort('When --tls-cert-file is set, --tls-key-file must also be set.')
+
     self_signing = kwargs['tls_cert_mode'] is ServerTlsCertMode.SelfSigned
 
     if tls_cert_file := kwargs['tls_cert_file']:
-        tls_cert_file = tls_cert_file.resolve()
         if not tls_cert_file.exists() and not self_signing:
             abort(f"File doesn't exist: --tls-cert-file={tls_cert_file}")
         kwargs['tls_cert_file'] = tls_cert_file
     elif self_signing:
         if kwargs['data_dir']:
             tls_cert_file = kwargs['data_dir'] / TLS_CERT_FILE_NAME
+            tls_key_file = kwargs['data_dir'] / TLS_KEY_FILE_NAME
         else:
             tls_cert_file = pathlib.Path('<runstate>') / TLS_CERT_FILE_NAME
+            tls_key_file = pathlib.Path('<runstate>') / TLS_KEY_FILE_NAME
         kwargs['tls_cert_file'] = tls_cert_file
+        kwargs['tls_key_file'] = tls_key_file
 
     if tls_key_file := kwargs['tls_key_file']:
-        tls_key_file = tls_key_file.resolve()
         if not tls_key_file.exists() and not self_signing:
             abort(f"File doesn't exist: --tls-key-file={tls_key_file}")
-        kwargs['tls_key_file'] = tls_key_file
-    elif self_signing:
-        tls_key_file = tls_cert_file.parent / TLS_KEY_FILE_NAME
         kwargs['tls_key_file'] = tls_key_file
 
     if not kwargs['bootstrap_only'] and not self_signing:

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -205,8 +205,8 @@ async def _run_server(
         tls_cert_newly_generated = False
         if args.tls_cert_mode is srvargs.ServerTlsCertMode.SelfSigned:
             assert args.tls_cert_file is not None
-            assert args.tls_key_file is not None
             if not args.tls_cert_file.exists():
+                assert args.tls_key_file is not None
                 _generate_cert(
                     args.tls_cert_file,
                     args.tls_key_file,


### PR DESCRIPTION
Whenever either `--tls-cert-file` or `--tls-key-file` are specified, the other must be also.