### PR TITLE
Prevent mutation of free objects

### DIFF
--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -55,6 +55,9 @@ class GlobalCompilerOptions:
     #: Use material types for pointer targets in schema views.
     schema_view_mode: bool = False
 
+    #: True in compile_bootstrap_script().
+    bootstrap_mode: bool = False
+
     #: Whether to track which subexpressions reference each schema object.
     track_schema_ref_exprs: bool = False
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -275,6 +275,14 @@ def compile_InsertQuery(
                 f'{subject_stype.get_verbosename(ctx.env.schema)}',
                 context=expr.subject.context)
 
+        if (
+            subject_stype.is_free_object_type(ctx.env.schema)
+            and not ctx.env.options.bootstrap_mode
+        ):
+            raise errors.QueryError(
+                f'free objects cannot be inserted',
+                context=expr.subject.context)
+
         if subject_stype.is_view(ctx.env.schema):
             raise errors.QueryError(
                 f'cannot insert into expression alias '
@@ -402,6 +410,11 @@ def compile_UpdateQuery(
                 context=expr.subject.context
             )
 
+        if subj_type.is_free_object_type(ctx.env.schema):
+            raise errors.QueryError(
+                f'free objects cannot be updated',
+                context=expr.subject.context)
+
         ictx.partial_path_prefix = subject
 
         clauses.compile_where_clause(
@@ -515,6 +528,11 @@ def compile_DeleteQuery(
                 f'cannot delete non-ObjectType objects',
                 context=expr.subject.context
             )
+
+        if subj_type.is_free_object_type(ctx.env.schema):
+            raise errors.QueryError(
+                f'free objects cannot be deleted',
+                context=expr.subject.context)
 
         with ictx.new() as bodyctx:
             bodyctx.implicit_id_in_shapes = False

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -99,6 +99,12 @@ class ObjectType(
     def is_object_type(self) -> bool:
         return True
 
+    def is_free_object_type(self, schema: s_schema.Schema) -> bool:
+        return self.issubclass(
+            schema,
+            schema.get('std::FreeObject', type=ObjectType),
+        )
+
     def is_union_type(self, schema: s_schema.Schema) -> bool:
         return bool(self.get_union_of(schema))
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -190,6 +190,9 @@ class Type(
     def is_object_type(self) -> bool:
         return False
 
+    def is_free_object_type(self, schema: s_schema.Schema) -> bool:
+        return False
+
     def is_union_type(self, schema: s_schema.Schema) -> bool:
         return False
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -582,6 +582,7 @@ class Compiler:
                 json_parameters=ctx.json_parameters,
                 implicit_limit=ctx.implicit_limit,
                 allow_writing_protected_pointers=ctx.schema_reflection_mode,
+                bootstrap_mode=ctx.bootstrap_mode,
                 apply_query_rewrites=(
                     not ctx.bootstrap_mode
                     and not ctx.schema_reflection_mode

--- a/tests/test_edgeql_delete.py
+++ b/tests/test_edgeql_delete.py
@@ -50,7 +50,24 @@ class TestDelete(tb.QueryTestCase):
             await self.con.execute('''\
                 DELETE 42;
             ''')
-        pass
+
+    async def test_edgeql_delete_bad_02(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            r'free objects cannot be deleted',
+        ):
+            await self.con.execute('''\
+                WITH foo := {bar := 1}
+                DELETE foo
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            r'free objects cannot be deleted',
+        ):
+            await self.con.execute('''\
+                DELETE std::FreeObject
+            ''')
 
     async def test_edgeql_delete_simple_01(self):
         # ensure a clean slate, not part of functionality testing

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1931,6 +1931,16 @@ class TestInsert(tb.QueryTestCase):
                 INSERT Foo;
             """)
 
+    async def test_edgeql_insert_free_obj(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            r"free objects cannot be inserted",
+            _position=23,
+        ):
+            await self.con.execute("""\
+                INSERT std::FreeObject;
+            """)
+
     async def test_edgeql_insert_selfref_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -487,6 +487,16 @@ class TestUpdate(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_update_bad_01(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            r'free objects cannot be updated',
+        ):
+            await self.con.execute('''\
+                WITH foo := {bar := 1}
+                UPDATE foo SET { bar := 2 };
+            ''')
+
     async def test_edgeql_update_filter_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
Free objects are immutable, so any attempt at DML on them is an error.