### PR TITLE
Prohibit using FreeObject as a base or linking to it

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -1020,7 +1020,7 @@ class CreateConstraint(
         schema: s_schema.Schema,
         context: sd.CommandContext,
         astnode: qlast.ObjectDDL,
-        bases: Any,
+        bases: List[Constraint],
         referrer: so.Object,
     ) -> sd.ObjectCommand[Constraint]:
         cmd = super().as_inherited_ref_cmd(

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2348,6 +2348,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         *,
         name: Optional[sn.Name] = None,
         default: Union[so.Object_T, so.NoDefaultT] = so.NoDefault,
+        sourcectx: Optional[parsing.ParserContext] = None,
     ) -> so.Object_T:
         ...
 
@@ -2359,6 +2360,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         *,
         name: Optional[sn.Name] = None,
         default: None = None,
+        sourcectx: Optional[parsing.ParserContext] = None,
     ) -> Optional[so.Object_T]:
         ...
 
@@ -2369,6 +2371,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         *,
         name: Optional[sn.Name] = None,
         default: Union[so.Object_T, so.NoDefaultT, None] = so.NoDefault,
+        sourcectx: Optional[parsing.ParserContext] = None,
     ) -> Optional[so.Object_T]:
         metaclass = self.get_schema_metaclass()
         if name is None:
@@ -2700,6 +2703,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
         *,
         name: Optional[sn.Name] = None,
         default: Union[so.QualifiedObject_T, so.NoDefaultT] = so.NoDefault,
+        sourcectx: Optional[parsing.ParserContext] = None,
     ) -> so.QualifiedObject_T:
         ...
 
@@ -2711,6 +2715,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
         *,
         name: Optional[sn.Name] = None,
         default: None = None,
+        sourcectx: Optional[parsing.ParserContext] = None,
     ) -> Optional[so.QualifiedObject_T]:
         ...
 
@@ -2722,6 +2727,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
         name: Optional[sn.Name] = None,
         default: Union[
             so.QualifiedObject_T, so.NoDefaultT, None] = so.NoDefault,
+        sourcectx: Optional[parsing.ParserContext] = None,
     ) -> Optional[so.QualifiedObject_T]:
         if name is None:
             name = self.classname
@@ -2729,11 +2735,10 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
             if rename is not None:
                 name = rename
         metaclass = self.get_schema_metaclass()
-        return cast(
-            Optional[so.QualifiedObject_T],
-            schema.get(name, type=metaclass, default=default,
-                       sourcectx=self.source_context),
-        )
+        if sourcectx is None:
+            sourcectx = self.source_context
+        return schema.get(
+            name, type=metaclass, default=default, sourcectx=sourcectx)
 
 
 class GlobalObjectCommand(ObjectCommand[so.GlobalObject_T]):

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -23,6 +23,7 @@ from typing import *
 from edb import edgeql
 from edb import errors
 from edb.common import ast
+from edb.common import parsing
 from edb.common import verutils
 from edb.edgeql import ast as qlast
 from edb.edgeql import compiler as qlcompiler
@@ -201,6 +202,7 @@ class IndexCommand(
         *,
         name: Optional[sn.Name] = None,
         default: Union[Index, so.NoDefaultT] = so.NoDefault,
+        sourcectx: Optional[parsing.ParserContext] = None,
     ) -> Index:
         ...
 
@@ -212,6 +214,7 @@ class IndexCommand(
         *,
         name: Optional[sn.Name] = None,
         default: None = None,
+        sourcectx: Optional[parsing.ParserContext] = None,
     ) -> Optional[Index]:
         ...
 
@@ -222,10 +225,12 @@ class IndexCommand(
         *,
         name: Optional[sn.Name] = None,
         default: Union[Index, so.NoDefaultT, None] = so.NoDefault,
+        sourcectx: Optional[parsing.ParserContext] = None,
     ) -> Optional[Index]:
         try:
             return super().get_object(
-                schema, context, name=name, default=default
+                schema, context, name=name,
+                default=default, sourcectx=sourcectx,
             )
         except errors.InvalidReferenceError:
             referrer_ctx = self.get_referrer_context_or_die(context)

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -242,8 +242,15 @@ class LinkCommand(
         if not target.is_object_type():
             srcctx = self.get_attribute_source_context('target')
             raise errors.InvalidLinkTargetError(
-                f'invalid link target, expected object type, got '
-                f'{target.get_schema_class_displayname()}',
+                f'invalid link target type, expected object type, got '
+                f'{target.get_verbosename(schema)}',
+                context=srcctx,
+            )
+
+        if target.is_free_object_type(schema):
+            srcctx = self.get_attribute_source_context('target')
+            raise errors.InvalidLinkTargetError(
+                f'{target.get_verbosename(schema)} is not a valid link target',
                 context=srcctx,
             )
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -2412,6 +2412,9 @@ class ObjectCollectionShell(Shell, Generic[Object_T]):
         self.items = items
         self.collection_type = collection_type
 
+    def __iter__(self) -> Iterator[ObjectShell[Object_T]]:
+        return iter(self.items)
+
     def resolve(self, schema: s_schema.Schema) -> ObjectCollection[Object_T]:
         return self.collection_type.create(
             schema,

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -100,10 +100,16 @@ class ObjectType(
         return True
 
     def is_free_object_type(self, schema: s_schema.Schema) -> bool:
-        return self.issubclass(
-            schema,
-            schema.get('std::FreeObject', type=ObjectType),
-        )
+        if self.get_name(schema) == sn.QualName('std', 'FreeObject'):
+            return True
+
+        FreeObject = schema.get(
+            'std::FreeObject', type=ObjectType, default=None)
+        if FreeObject is None:
+            # Possible in bootstrap before FreeObject is declared
+            return False
+        else:
+            return self.issubclass(schema, FreeObject)
 
     def is_union_type(self, schema: s_schema.Schema) -> bool:
         return bool(self.get_union_of(schema))
@@ -481,8 +487,10 @@ class RenameObjectType(
     pass
 
 
-class RebaseObjectType(ObjectTypeCommand,
-                       inheriting.RebaseInheritingObject[ObjectType]):
+class RebaseObjectType(
+    ObjectTypeCommand,
+    s_types.RebaseInheritingType[ObjectType],
+):
     pass
 
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1752,7 +1752,7 @@ class CreatePointer(
         schema: s_schema.Schema,
         context: sd.CommandContext,
         astnode: qlast.ObjectDDL,
-        bases: Any,
+        bases: List[Pointer_T],
         referrer: so.Object,
     ) -> sd.ObjectCommand[Pointer_T]:
         cmd = super().as_inherited_ref_cmd(

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import *
 
 from edb import errors
+from edb.common import parsing
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
@@ -150,8 +151,14 @@ class PseudoType(
 
 class PseudoTypeShell(s_types.TypeShell[PseudoType]):
 
-    def __init__(self, *, name: sn.Name) -> None:
-        super().__init__(name=name, schemaclass=PseudoType)
+    def __init__(
+        self,
+        *,
+        name: sn.Name,
+        sourcectx: Optional[parsing.ParserContext] = None,
+    ) -> None:
+        super().__init__(
+            name=name, schemaclass=PseudoType, sourcectx=sourcectx)
 
     def is_polymorphic(self, schema: s_schema.Schema) -> bool:
         return True

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -610,12 +610,13 @@ class CreateReferencedObject(
         schema: s_schema.Schema,
         context: sd.CommandContext,
         astnode: qlast.ObjectDDL,
-        bases: Any,
+        bases: List[ReferencedT],
         referrer: so.Object,
     ) -> sd.ObjectCommand[ReferencedT]:
         cmd = cls(classname=cls._classname_from_ast(schema, astnode, context))
         cmd.set_attribute_value('name', cmd.classname)
-        cmd.set_attribute_value('bases', so.ObjectList.create(schema, bases))
+        cmd.set_attribute_value(
+            'bases', so.ObjectList.create(schema, bases).as_shell(schema))
         return cmd
 
     @classmethod
@@ -1079,7 +1080,7 @@ class CreateReferencedInheritingObject(
                             implicit_bases,
                         )
 
-                    self.set_attribute_value('bases', bases)
+                    self.set_attribute_value('bases', bases.as_shell(schema))
 
                 if referrer.get_is_derived(schema):
                     self.set_attribute_value('is_derived', True)

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -416,16 +416,20 @@ class CreateScalarType(
                         context=astnode.bases[0].context,
                     )
                 create_cmd.set_attribute_value('enum_values', shell.elements)
-                create_cmd.set_attribute_value('bases', [
-                    s_utils.ast_objref_to_object_shell(
-                        s_utils.name_to_ast_ref(
-                            s_name.QualName('std', 'anyenum'),
-                        ),
-                        schema=schema,
-                        metaclass=ScalarType,
-                        modaliases={},
+                create_cmd.set_attribute_value(
+                    'bases',
+                    so.ObjectCollectionShell(
+                        [s_utils.ast_objref_to_object_shell(
+                            s_utils.name_to_ast_ref(
+                                s_name.QualName('std', 'anyenum'),
+                            ),
+                            schema=schema,
+                            metaclass=ScalarType,
+                            modaliases={},
+                        )],
+                        collection_type=so.ObjectList,
                     )
-                ])
+                )
 
         return cmd
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2201,33 +2201,82 @@ class InheritingTypeCommand(
     TypeCommand[InheritingTypeT],
     inheriting.InheritingObjectCommand[InheritingTypeT],
 ):
-    pass
+    def _validate_bases(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        bases: so.ObjectList[InheritingTypeT],
+        shells: Mapping[s_name.QualName, TypeShell[InheritingTypeT]],
+        is_derived: bool,
+    ) -> None:
+        for base in bases.objects(schema):
+            if (
+                base.contains_any(schema)
+                or (base.is_free_object_type(schema) and not is_derived)
+            ):
+                base_type_name = base.get_displayname(schema)
+                shell = shells.get(base.get_name(schema))
+                raise errors.SchemaError(
+                    f"{base_type_name!r} cannot be a parent type",
+                    context=shell.sourcectx if shell is not None else None,
+                )
 
 
 class CreateInheritingType(
     InheritingTypeCommand[InheritingTypeT],
     inheriting.CreateInheritingObject[InheritingTypeT],
 ):
-
     def validate_create(
         self,
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> None:
-
         super().validate_create(schema, context)
 
+        shells = self.get_attribute_value('bases')
+        if isinstance(shells, so.ObjectList):
+            # XXX: fix set_attribute_value shell hygiene
+            shells = shells.as_shell(schema)
+        shell_map = {s.get_name(schema): s for s in shells}
         bases = self.get_resolved_attribute_value(
             'bases',
             schema=schema,
             context=context,
         )
-        if bases:
-            for base in bases.objects(schema):
-                if base.contains_any(schema):
-                    base_type_name = base.get_displayname(schema)
-                    raise errors.SchemaError(
-                        f"{base_type_name!r} cannot be a parent type")
+        self._validate_bases(
+            schema,
+            context,
+            bases,
+            shell_map,
+            is_derived=self.get_attribute_value('is_derived') or False,
+        )
+
+
+class RebaseInheritingType(
+    InheritingTypeCommand[InheritingTypeT],
+    inheriting.RebaseInheritingObject[InheritingTypeT],
+):
+    def validate_alter(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> None:
+        super().validate_alter(schema, context)
+        shell_map = {}
+        for base_shells, _ in self.added_bases:
+            shell_map.update({s.get_name(schema): s for s in base_shells})
+        bases = self.get_resolved_attribute_value(
+            'bases',
+            schema=schema,
+            context=context,
+        )
+        self._validate_bases(
+            schema,
+            context,
+            bases,
+            shell_map,
+            is_derived=self.scls.get_is_derived(schema),
+        )
 
 
 class CollectionTypeCommandContext(sd.ObjectCommandContext[Collection]):

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -303,12 +303,16 @@ def ast_to_type_shell(
     elif isinstance(node.maintype, qlast.AnyType):
         from . import pseudo as s_pseudo
         return s_pseudo.PseudoTypeShell(
-            name=sn.UnqualName('anytype'))  # type: ignore
+            name=sn.UnqualName('anytype'),
+            sourcectx=node.maintype.context,
+        )  # type: ignore
 
     elif isinstance(node.maintype, qlast.AnyTuple):
         from . import pseudo as s_pseudo
         return s_pseudo.PseudoTypeShell(
-            name=sn.UnqualName('anytuple'))  # type: ignore
+            name=sn.UnqualName('anytuple'),
+            sourcectx=node.maintype.context,
+        )  # type: ignore
 
     assert isinstance(node.maintype, qlast.ObjectRef)
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6540,6 +6540,24 @@ type default::Foo {
             []
         )
 
+    async def test_edgeql_ddl_extending_06(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaError,
+            r"'std::FreeObject' cannot be a parent type",
+        ):
+            await self.con.execute("""
+                CREATE TYPE SomeObject6 EXTENDING FreeObject;
+            """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.SchemaError,
+            r"'std::FreeObject' cannot be a parent type",
+        ):
+            await self.con.execute("""
+                CREATE TYPE SomeObject6;
+                ALTER TYPE SomeObject6 EXTENDING FreeObject;
+            """)
+
     async def test_edgeql_ddl_modules_01(self):
         try:
             await self.con.execute(r"""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -275,9 +275,12 @@ class TestSchema(tb.BaseSchemaLoadTest):
             type UniqueName_3 extending UniqueName, UniqueName_2;
         """
 
-    @tb.must_fail(errors.InvalidLinkTargetError,
-                  'invalid link target, expected object type, got scalar type',
-                  position=69)
+    @tb.must_fail(
+        errors.InvalidLinkTargetError,
+        "invalid link target type, expected object type, "
+        "got scalar type 'std::str'",
+        position=69,
+    )
     def test_schema_bad_link_01(self):
         """
             type Object {
@@ -285,13 +288,28 @@ class TestSchema(tb.BaseSchemaLoadTest):
             };
         """
 
-    @tb.must_fail(errors.InvalidLinkTargetError,
-                  'invalid link target, expected object type, got scalar type',
-                  position=69)
+    @tb.must_fail(
+        errors.InvalidLinkTargetError,
+        "invalid link target type, expected object type, "
+        "got scalar type 'std::int64'",
+        position=69,
+    )
     def test_schema_bad_link_02(self):
         """
             type Object {
                 link foo := 1 + 1
+            };
+        """
+
+    @tb.must_fail(
+        errors.InvalidLinkTargetError,
+        "object type 'std::FreeObject' is not a valid link target",
+        position=69,
+    )
+    def test_schema_bad_link_03(self):
+        """
+            type Object {
+                link foo -> FreeObject
             };
         """
 


### PR DESCRIPTION
Neither makes sense semantically.