### PR TITLE
Restore default TLS cert location in data-dir regardless of `tls-cert-mode`

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -697,35 +697,26 @@ def parse_args(**kwargs: Any):
 
     self_signing = kwargs['tls_cert_mode'] is ServerTlsCertMode.SelfSigned
 
-    if tls_cert_file := kwargs['tls_cert_file']:
-        if not tls_cert_file.exists() and not self_signing:
-            abort(f"File doesn't exist: --tls-cert-file={tls_cert_file}")
-        kwargs['tls_cert_file'] = tls_cert_file
-    elif self_signing:
+    if not kwargs['tls_cert_file']:
         if kwargs['data_dir']:
             tls_cert_file = kwargs['data_dir'] / TLS_CERT_FILE_NAME
             tls_key_file = kwargs['data_dir'] / TLS_KEY_FILE_NAME
-        else:
+        elif self_signing:
             tls_cert_file = pathlib.Path('<runstate>') / TLS_CERT_FILE_NAME
             tls_key_file = pathlib.Path('<runstate>') / TLS_KEY_FILE_NAME
-        kwargs['tls_cert_file'] = tls_cert_file
-        kwargs['tls_key_file'] = tls_key_file
-
-    if tls_key_file := kwargs['tls_key_file']:
-        if not tls_key_file.exists() and not self_signing:
-            abort(f"File doesn't exist: --tls-key-file={tls_key_file}")
-        kwargs['tls_key_file'] = tls_key_file
-
-    if not kwargs['bootstrap_only'] and not self_signing:
-        if not kwargs['tls_cert_file']:
+        else:
             abort(
                 "no TLS certificate specified and certificate auto-generation"
                 " has not been requested; see help for --tls-cert-mode",
                 exit_code=10,
             )
-        elif not kwargs['tls_cert_file'].exists():
+        kwargs['tls_cert_file'] = tls_cert_file
+        kwargs['tls_key_file'] = tls_key_file
+
+    if not kwargs['bootstrap_only'] and not self_signing:
+        if not kwargs['tls_cert_file'].exists():
             abort(
-                f"specified TLS certificate file \"{kwargs['tls_cert_file']}\""
+                f"TLS certificate file \"{kwargs['tls_cert_file']}\""
                 " does not exist and certificate auto-generation has not been"
                 " requested; see help for --tls-cert-mode",
                 exit_code=10,
@@ -737,7 +728,7 @@ def parse_args(**kwargs: Any):
         and not kwargs['tls_cert_file'].is_file()
     ):
         abort(
-            f"specified TLS certificate file \"{kwargs['tls_cert_file']}\""
+            f"TLS certificate file \"{kwargs['tls_cert_file']}\""
             " is not a regular file"
         )
 
@@ -747,7 +738,7 @@ def parse_args(**kwargs: Any):
         and not kwargs['tls_key_file'].is_file()
     ):
         abort(
-            f"specified TLS private key file \"{kwargs['tls_key_file']}\""
+            f"TLS private key file \"{kwargs['tls_key_file']}\""
             " is not a regular file"
         )
 

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -250,6 +250,28 @@ class TestServerOps(tb.TestCase):
             os.unlink(key_file)
             os.unlink(cert_file)
 
+    async def test_server_ops_generates_cert_to_default_location(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            async with tb.start_edgedb_server(
+                data_dir=temp_dir,
+            ) as sd:
+                con = await sd.connect()
+                try:
+                    await con.query_single("SELECT 1")
+                finally:
+                    await con.aclose()
+
+            # Check that the server works with the generated cert/key
+            async with tb.start_edgedb_server(
+                data_dir=temp_dir,
+                tls_cert_mode=args.ServerTlsCertMode.RequireFile,
+            ) as sd:
+                con = await sd.connect()
+                try:
+                    await con.query_single("SELECT 1")
+                finally:
+                    await con.aclose()
+
     async def test_server_ops_bogus_bind_addr_in_mix(self):
         async with tb.start_edgedb_server(
             bind_addrs=('host.invalid', '127.0.0.1',),


### PR DESCRIPTION
Look TLS cert/key in `<data-dir>` even if `--tls-cert-mode` is not
`generate_self_signed`.  This restores pre-#3213 behavior.