### PR TITLE
Mute coroutine warning at shutdown by immediate cancellation

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1194,7 +1194,7 @@ cdef class EdgeConnection:
         return query_unit
 
     def signal_side_effects(self, side_effects):
-        if not self.server._accept_new_tasks:
+        if self.server.is_shutting_down():
             return
         if side_effects & dbview.SideEffects.SchemaChanges:
             self.server.create_task(
@@ -2234,8 +2234,8 @@ cdef class EdgeConnection:
 
     def connection_made(self, transport):
         if (
-            not self.server._accepting_connections
-            or not self.server._accept_new_tasks
+            not self.server.is_accepting_connections()
+            or self.server.is_shutting_down()
         ):
             transport.abort()
             return

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -2233,10 +2233,7 @@ cdef class EdgeConnection:
         return out_buf
 
     def connection_made(self, transport):
-        if (
-            not self.server.is_accepting_connections()
-            or self.server.is_shutting_down()
-        ):
+        if not self.server.is_serving():
             transport.abort()
             return
 


### PR DESCRIPTION
After revisiting #3112, I found a more reliable option 4 to address the "coroutine ... was never awaited" warning - cancel the late tasks immediately after creating them.

Closes #3112