### PR TITLE
Avoid generating EXISTS where clauses for type filters

### DIFF
--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -136,11 +136,20 @@ def fini_expression(
         scope_tree=ctx.path_scope,
         ctx=inf_ctx,
     )
+    cardinality = inference.infer_cardinality(
+        ir,
+        scope_tree=ctx.path_scope,
+        ctx=inf_ctx,
+    )
 
     # Fix up weak namespaces
     _rewrite_weak_namespaces(ir, ctx)
 
     ctx.path_scope.validate_unique_ids()
+
+    # Infer cardinalities of type rewrites
+    for rw in ctx.type_rewrites.values():
+        inference.infer_cardinality(rw, scope_tree=ctx.path_scope, ctx=inf_ctx)
 
     # ConfigSet and ConfigReset don't like being part of a Set
     if isinstance(ir.expr, (irast.ConfigSet, irast.ConfigReset)):

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -136,11 +136,6 @@ def fini_expression(
         scope_tree=ctx.path_scope,
         ctx=inf_ctx,
     )
-    cardinality = inference.infer_cardinality(
-        ir,
-        scope_tree=ctx.path_scope,
-        ctx=inf_ctx,
-    )
 
     # Fix up weak namespaces
     _rewrite_weak_namespaces(ir, ctx)

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -275,10 +275,7 @@ def compile_filter_clause(
     with ctx.new() as ctx1:
         ctx1.expr_exposed = False
 
-        if (
-            cardinality is qltypes.Cardinality.ONE
-            or cardinality is qltypes.Cardinality.AT_MOST_ONE
-        ):
+        if cardinality.is_single():
             where_clause = dispatch.compile(ir_set, ctx=ctx)
         else:
             # In WHERE we compile ir.Set as a boolean disjunction:


### PR DESCRIPTION
Since we don't run card inference on type rewrites, the where clause
cardinality always gets compiled as if it is multi, which it isn't.

Run card inference on type rewrites, and tweak compilation of FILTER
to be both more natural reading and to crash on this sort of bug
instead.