### PR TITLE
Fix some problems involving toplevel statements in schema queries

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -329,6 +329,7 @@ def compile_ast_fragment_to_ir(
         scope_tree=ctx.path_scope,
         source_map={},
         type_rewrites={},
+        singletons=[],
     )
 
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -248,6 +248,7 @@ def fini_expression(
         ),
         type_rewrites={s.typeref.id: s for s in ctx.type_rewrites.values()},
         dml_exprs=ctx.env.dml_exprs,
+        singletons=ctx.env.singletons,
     )
     return result
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -543,6 +543,7 @@ class Statement(Command):
     source_map: typing.Dict[s_pointers.Pointer, ComputableInfo]
     dml_exprs: typing.List[qlast.Base]
     type_rewrites: typing.Dict[uuid.UUID, Set]
+    singletons: typing.List[PathId]
 
 
 class TypeIntrospection(ImmutableExpr):

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -30,7 +30,6 @@ from edb.pgsql import ast as pgast
 from edb.pgsql import params as pgparams
 
 from . import astutils
-from . import clauses
 from . import context
 from . import dispatch
 from . import pathctx
@@ -380,7 +379,6 @@ def compile_ConfigInsert(
             subctx.expr_exposed = True
             rewritten = _rewrite_config_insert(stmt.expr, ctx=subctx)
             dispatch.compile(rewritten, ctx=subctx)
-            clauses.fini_stmt(ctx.rel, ctx=subctx, parent_ctx=ctx)
 
             return pathctx.get_path_serialized_output(
                 ctx.rel, stmt.expr.path_id, env=ctx.env)

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -87,8 +87,6 @@ def init_dml_stmt(
         A ``DMLParts`` tuple containing a map of DML CTEs as well as the
         common range CTE for UPDATE/DELETE statements.
     """
-    clauses.init_stmt(ir_stmt, ctx, parent_ctx)
-
     range_cte: Optional[pgast.CommonTableExpr]
     range_rvar: Optional[pgast.RelRangeVar]
 
@@ -426,7 +424,6 @@ def fini_dml_stmt(
             dml_stmts=dml_stack, path_id=ir_stmt.subject.path_id, ctx=ctx)
 
     clauses.compile_output(ir_stmt.result, ctx=ctx)
-    clauses.fini_stmt(wrapper, ctx, parent_ctx)
 
     ctx.dml_stmt_stack.pop()
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -52,7 +52,7 @@ def init_toplevel_query(
         ir_set: irast.Set, *,
         ctx: context.CompilerContextLevel) -> None:
 
-    ctx.toplevel_stmt = ctx.stmt = ctx.rel = pgast.SelectStmt()
+    ctx.toplevel_stmt = ctx.stmt = ctx.rel
     update_scope(ir_set, ctx.rel, ctx=ctx)
     ctx.pending_query = ctx.rel
 

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -45,8 +45,6 @@ def compile_SelectStmt(
     parent_ctx = ctx
     with parent_ctx.substmt() as ctx:
         # Common setup.
-        clauses.init_stmt(stmt, ctx=ctx, parent_ctx=parent_ctx)
-
         for binding in (stmt.bindings or ()):
             # If something we are WITH binding contains DML, we want to
             # compile it *now*, in the context of its initial appearance
@@ -136,8 +134,6 @@ def compile_SelectStmt(
         # The LIMIT clause
         query.limit_count = clauses.compile_limit_offset_clause(
             stmt.limit, ctx=ctx)
-
-        clauses.fini_stmt(query, ctx, parent_ctx)
 
     return query
 

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -1660,6 +1660,19 @@ class TestEdgeQLFuncCalls(tb.DDLTestCase):
                 """,
             )
 
+    async def test_edgeql_calls_obj_04(self):
+        await self.con.execute("""
+            CREATE FUNCTION thing(s: schema::Constraint) -> str
+                USING (s.name ++ s.expr);
+
+            CREATE FUNCTION frob(s: schema::Object) -> str
+                USING ("ahhhh");
+            CREATE FUNCTION frob(s: schema::Constraint) -> str
+                USING (s.name ++ s.expr);
+            CREATE FUNCTION frob(s: schema::Pointer) -> str
+                USING (s.name ++ <str>s.required);
+        """)
+
     async def test_edgeql_call_builtin_obj(self):
         await self.con.execute(
             r"""

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2356,6 +2356,14 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 ],
             )
 
+        async with self._run_and_rollback():
+            # This had trouble if there was a SELECT, at one point.
+            await self.con.execute("""
+                ALTER TYPE Foo ALTER PROPERTY m_p {
+                    SET TYPE int64 USING (SELECT <int64>.m_p + <int64>.r_p)
+                }
+            """)
+
         # Conversion expression that reduces cardinality...
         async with self._run_and_rollback():
             await self.con.execute("""
@@ -2497,6 +2505,14 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     {'l': {'@lp': 3}},
                 ],
             )
+
+        async with self._run_and_rollback():
+            # Also once had SELECT trouble
+            await self.con.execute("""
+                ALTER TYPE Foo ALTER LINK l ALTER PROPERTY lp {
+                    SET TYPE int64 USING (SELECT <int64>@lp)
+                }
+            """)
 
     async def test_edgeql_ddl_ptr_set_type_using_02(self):
         await self.con.execute(r"""


### PR DESCRIPTION
Queries that are specified in the schema for various reasons could
be bare expressions, without a SELECT statement or similar.

Some functions that operated on schema objects and did not have a SELECT
in their definition would fail to include the rewrite CTEs in the function
body, since that code only triggered from fini_stmt.

An initial attempt to fix this by *always* including a SELECT revealed
bugs in that direction, also! (And was an unsatisfying solution.)

We fix these issues in two parts:
 1. Make less things driven by detecting the toplevel_stmt.
    Explicitly finalize the toplevel.
 2. Register the top level as the path_scope for any singletons
    in a schema expression, which prevents extra scope levels
    from causing trouble in SET TYPE USING queries and the like.

I'm hoping to do some more followup cleanups to tear out more
`is_toplevel` code.