### PR TITLE
Swap the default behavior of sorting by emptys sets

### DIFF
--- a/docs/reference/edgeql/select.rst
+++ b/docs/reference/edgeql/select.rst
@@ -66,8 +66,8 @@ SELECT
     an empty set when evaluating an *expression* are sorted *after*
     all other values; if ``EMPTY FIRST`` is specified, then they
     are sorted *before* all other values.  If neither is specified,
-    ``EMPTY FIRST`` is assumed when ``ASC`` is specified or implied,
-    and ``EMPTY LAST`` when ``DESC`` is specified.
+    ``EMPTY LAST`` is assumed when ``ASC`` is specified or implied,
+    and ``EMPTY FIRST`` when ``DESC`` is specified.
 
 :eql:synopsis:`OFFSET <offset-expr>`
     The optional ``OFFSET`` clause, where

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -1527,18 +1527,18 @@ class GraphQLTranslator:
         if direction == 'ASC':
             direction = qlast.SortAsc
             # nulls are optional, but are 'SMALLEST' by default
-            if nulls == 'BIGGEST':
-                nulls = qlast.NonesLast
-            else:
+            if nulls == 'SMALLEST':
                 nulls = qlast.NonesFirst
+            else:
+                nulls = qlast.NonesLast
 
         else:  # DESC
             direction = qlast.SortDesc
             # nulls are optional, but are 'SMALLEST' by default
-            if nulls == 'BIGGEST':
-                nulls = qlast.NonesFirst
-            else:
+            if nulls == 'SMALLEST':
                 nulls = qlast.NonesLast
+            else:
+                nulls = qlast.NonesFirst
 
         return [Ordering(names=[], direction=direction, nulls=nulls)]
 

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -655,9 +655,9 @@ class SQLSourceGenerator(codegen.SourceGenerator):
 
             if node.nulls is None:
                 if node.dir == pgast.SortDesc:
-                    self.write(' NULLS LAST')
-                else:
                     self.write(' NULLS FIRST')
+                else:
+                    self.write(' NULLS LAST')
             elif node.nulls == pgast.NullsFirst:
                 self.write(' NULLS FIRST')
             elif node.nulls == pgast.NullsLast:

--- a/edb/tools/toy_eval_model.py
+++ b/edb/tools/toy_eval_model.py
@@ -429,8 +429,8 @@ def eval_orderby(
     # it in one go...)
     for sort in reversed(orderby):
         nones_bigger = (
-            (sort.direction == 'ASC' and sort.nones_order == 'last')
-            or (sort.direction == 'DESC' and sort.nones_order == 'first')
+            (sort.direction == 'ASC' and sort.nones_order != 'first')
+            or (sort.direction == 'DESC' and sort.nones_order != 'last')
         )
 
         # Decorate

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -2681,6 +2681,35 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 ORDER BY User.<owner[IS Issue].number;
             """)
 
+    async def test_edgeql_select_order_05(self):
+        # test the defaults with nones
+        # ascending implies nones last, descending implies nones first
+        await self.assert_query_result(
+            r'''
+            SELECT Issue {name, time_estimate}
+            FILTER .name LIKE '%EdgeDB%'
+            ORDER BY .time_estimate;
+            ''',
+            [
+                {"name": "Release EdgeDB", "time_estimate": 3000},
+                {"name": "Improve EdgeDB repl output rendering.",
+                 "time_estimate": None},
+            ]
+        )
+
+        await self.assert_query_result(
+            r'''
+            SELECT Issue {name, time_estimate}
+            FILTER .name LIKE '%EdgeDB%'
+            ORDER BY .time_estimate DESC;
+            ''',
+            [
+                {"name": "Improve EdgeDB repl output rendering.",
+                 "time_estimate": None},
+                {"name": "Release EdgeDB", "time_estimate": 3000},
+            ]
+        )
+
     async def test_edgeql_select_where_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -3684,14 +3684,6 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         """, {
             "User": [
                 {
-                    "name": "John",
-                    "profile": None,
-                },
-                {
-                    "name": "Jane",
-                    "profile": None,
-                },
-                {
                     "name": "Bob",
                     "profile": {
                         "name": "Bob profile",
@@ -3704,7 +3696,15 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                         "name": "Alice profile",
                         "value": "special",
                     },
-                }
+                },
+                {
+                    "name": "John",
+                    "profile": None,
+                },
+                {
+                    "name": "Jane",
+                    "profile": None,
+                },
             ]
         })
 


### PR DESCRIPTION
That is, make `EMPTY LAST` the default for `ASC` and `EMPTY FIRST` the
default for `DESC`. This seems like worse behavior, but it is pretty
marginal, and it is what SQL can do quickly.

It turns out we had zero tests for this behavior.

Partial fix to #3234.