### PR TITLE
Avoid putting subqueries in SQL ORDER BY clauses

### DIFF
--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -390,3 +390,19 @@ def strip_output_var(
         raise AssertionError(f'unexpected OutputVar subclass: {var!r}')
 
     return result
+
+
+def select_is_simple(stmt: pgast.SelectStmt) -> bool:
+    return (
+        not stmt.distinct_clause
+        and not stmt.where_clause
+        and not stmt.group_clause
+        and not stmt.having
+        and not stmt.window_clause
+        and not stmt.values
+        and not stmt.sort_clause
+        and not stmt.limit_offset
+        and not stmt.limit_count
+        and not stmt.locking_clause
+        and not stmt.op
+    )

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -244,6 +244,69 @@ def compile_filter_clause(
     return where_clause
 
 
+def _get_target_from_range(
+    target: pgast.BaseExpr, rvar: pgast.BaseRangeVar
+) -> Optional[pgast.BaseExpr]:
+    """Try to read a target out of a very simple rvar.
+
+    The goal here is to allow collapsing trivial pass-through subqueries.
+    In particular, given a target `foo.bar` and an rvar
+    `(SELECT <expr> as "bar") AS "foo"`, we produce <expr>.
+
+    We can also recursively handle the nested case.
+    """
+    if (
+        not isinstance(rvar, pgast.RangeSubselect)
+
+        # Check that the relation name matches the rvar
+        or not isinstance(target, pgast.ColumnRef)
+        or not target.name
+        or target.name[0] != rvar.alias.aliasname
+
+        # And that the rvar is a simple subquery with one target
+        # and at most one from clause
+        or not (subq := rvar.subquery)
+        or len(subq.target_list) != 1
+        or not isinstance(subq, pgast.SelectStmt)
+        or not astutils.select_is_simple(subq)
+        or len(subq.from_clause) > 1
+
+        # And that the one target matches
+        or not (inner_tgt := rvar.subquery.target_list[0])
+        or inner_tgt.name != target.name[1]
+    ):
+        return None
+
+    if subq.from_clause:
+        return _get_target_from_range(inner_tgt.val, subq.from_clause[0])
+    else:
+        return inner_tgt.val
+
+
+def collapse_query(query: pgast.Query) -> pgast.BaseExpr:
+    """Try to collapse trivial queries into simple expressions.
+
+    In particular, we want to transform
+    `(SELECT foo.bar FROM LATERAL (SELECT <expr> as "bar") AS "foo")`
+    into simply `<expr>`.
+    """
+    if not isinstance(query, pgast.SelectStmt):
+        return query
+
+    if (
+        not isinstance(query, pgast.SelectStmt)
+        or len(query.target_list) != 1
+        or len(query.from_clause) != 1
+    ):
+        return query
+
+    val = _get_target_from_range(
+        query.target_list[0].val, query.from_clause[0])
+    if val:
+        return val
+    return query
+
+
 def compile_orderby_clause(
         ir_exprs: Sequence[irast.SortExpr], *,
         ctx: context.CompilerContextLevel) -> List[pgast.SortBy]:
@@ -256,8 +319,12 @@ def compile_orderby_clause(
 
             # In OPDER BY we compile ir.Set as a subquery:
             #    SELECT SetRel.value FROM SetRel)
-            value = relgen.set_as_subquery(
+            subq = relgen.set_as_subquery(
                 expr.expr, as_value=True, ctx=orderctx)
+            # pg apparently can't use indexes for ordering if the body
+            # of an ORDER BY is a subquery, so try to collapse the query
+            # into a simple expression.
+            value = collapse_query(subq)
 
             sortexpr = pgast.SortBy(
                 node=value,

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -317,7 +317,7 @@ def compile_orderby_clause(
         with ctx.new() as orderctx:
             orderctx.expr_exposed = False
 
-            # In OPDER BY we compile ir.Set as a subquery:
+            # In ORDER BY we compile ir.Set as a subquery:
             #    SELECT SetRel.value FROM SetRel)
             subq = relgen.set_as_subquery(
                 expr.expr, as_value=True, ctx=orderctx)

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -304,7 +304,8 @@ def collapse_query(query: pgast.Query) -> pgast.BaseExpr:
         query.target_list[0].val, query.from_clause[0])
     if val:
         return val
-    return query
+    else:
+        return query
 
 
 def compile_orderby_clause(


### PR DESCRIPTION
pg does a bad job understanding how to use indexes if the body of an
ORDER BY is a subquery. We need, in general, for it to be a subquery,
but most common cases do not, so try to collapse it in a simple expression.

Fixes related issue to #3234.