### PR TITLE
Specify NULLS FIRST when creating indexes.

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -42,7 +42,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_11_18_00_00
+EDGEDB_CATALOG_VERSION = 2021_12_02_00_00
 
 
 class MetadataError(Exception):


### PR DESCRIPTION
This makes the index correspond with our default ORDER BY behavior,
which makes the default behavior fast.

Fixes #3234, though a competing fix with #3238.