### PR TITLE
Support single-role and single-database mode

### DIFF
--- a/.github/workflows.src/tests-pg-versions.tpl.yml
+++ b/.github/workflows.src/tests-pg-versions.tpl.yml
@@ -28,7 +28,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres-version: [ 12, 13, 14 ]
+        postgres-version: [ 13 ]
+        single-mode:
+         - ''
+         - 'NOCREATEDB NOCREATEROLE'
+         - 'CREATEDB NOCREATEROLE'
+        include:
+          - postgres-version: 12
+            single-mode: ''
+          - postgres-version: 14
+            single-mode: ''
     services:
       postgres:
         image: postgres:${{ matrix.postgres-version }}-alpine
@@ -47,10 +56,39 @@ jobs:
 
     # Run the test
 
+    - name: Setup single mode role and database
+      if: ${{ matrix.single-mode }}
+      shell: python
+      run: |
+        import asyncio, asyncpg
+        async def main():
+            conn = await asyncpg.connect("postgres://postgres:postgres@localhost/postgres")
+            await conn.execute("""\
+                CREATE ROLE singles;
+                ALTER ROLE singles WITH LOGIN PASSWORD 'test' NOSUPERUSER ${{ matrix.single-mode }};
+            """)
+            await conn.execute(""" \
+                CREATE DATABASE singles OWNER singles;
+            """)
+            await conn.execute(""" \
+                REVOKE ALL ON DATABASE singles FROM PUBLIC;
+                GRANT CONNECT ON DATABASE singles TO singles;
+                GRANT ALL ON DATABASE singles TO singles;
+            """)
+        asyncio.run(main())
+
     - name: Test
       env:
-        EDGEDB_TEST_BACKEND_DSN: postgres://postgres:postgres@localhost/postgres
         EDGEDB_TEST_POSTGRES_VERSION: ${{ matrix.postgres-version }}
       run: |
+        if [[ "${{ matrix.single-mode }}" ]]; then
+          export EDGEDB_TEST_BACKEND_DSN=postgres://singles:test@localhost/singles
+        else
+          export EDGEDB_TEST_BACKEND_DSN=postgres://postgres:postgres@localhost/postgres
+        fi
         edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
-        edb test -j2 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+        if [[ "${{ matrix.single-mode }}" == *"NOCREATEDB"* ]]; then
+          edb test -j1 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+        else
+          edb test -j2 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+        fi

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -304,7 +304,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres-version: [ 12, 13, 14 ]
+        postgres-version: [ 13 ]
+        single-mode:
+         - ''
+         - 'NOCREATEDB NOCREATEROLE'
+         - 'CREATEDB NOCREATEROLE'
+        include:
+          - postgres-version: 12
+            single-mode: ''
+          - postgres-version: 14
+            single-mode: ''
     services:
       postgres:
         image: postgres:${{ matrix.postgres-version }}-alpine
@@ -433,10 +442,39 @@ jobs:
 
     # Run the test
 
+    - name: Setup single mode role and database
+      if: ${{ matrix.single-mode }}
+      shell: python
+      run: |
+        import asyncio, asyncpg
+        async def main():
+            conn = await asyncpg.connect("postgres://postgres:postgres@localhost/postgres")
+            await conn.execute("""\
+                CREATE ROLE singles;
+                ALTER ROLE singles WITH LOGIN PASSWORD 'test' NOSUPERUSER ${{ matrix.single-mode }};
+            """)
+            await conn.execute(""" \
+                CREATE DATABASE singles OWNER singles;
+            """)
+            await conn.execute(""" \
+                REVOKE ALL ON DATABASE singles FROM PUBLIC;
+                GRANT CONNECT ON DATABASE singles TO singles;
+                GRANT ALL ON DATABASE singles TO singles;
+            """)
+        asyncio.run(main())
+
     - name: Test
       env:
-        EDGEDB_TEST_BACKEND_DSN: postgres://postgres:postgres@localhost/postgres
         EDGEDB_TEST_POSTGRES_VERSION: ${{ matrix.postgres-version }}
       run: |
+        if [[ "${{ matrix.single-mode }}" ]]; then
+          export EDGEDB_TEST_BACKEND_DSN=postgres://singles:test@localhost/singles
+        else
+          export EDGEDB_TEST_BACKEND_DSN=postgres://postgres:postgres@localhost/postgres
+        fi
         edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
-        edb test -j2 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+        if [[ "${{ matrix.single-mode }}" == *"NOCREATEDB"* ]]; then
+          edb test -j1 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+        else
+          edb test -j2 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+        fi

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -2532,6 +2532,9 @@ class MigrationStmt(Nonterm):
     def reduce_CommitMigrationStmt(self, *kids):
         self.val = kids[0].val
 
+    def reduce_DropMigrationStmt(self, *kids):
+        self.val = kids[0].val
+
 
 class MigrationBody(typing.NamedTuple):
 

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -27,7 +27,6 @@ from edb.schema import objects as s_obj
 from edb.edgeql import qltypes
 
 from edb.pgsql import ast as pgast
-from edb.pgsql import params as pgparams
 
 from . import astutils
 from . import context
@@ -48,10 +47,7 @@ def compile_ConfigSet(
     result: pgast.BaseExpr
 
     if op.scope is qltypes.ConfigScope.INSTANCE and op.backend_setting:
-        if not (
-            ctx.env.backend_runtime_params.instance_params.capabilities
-            & pgparams.BackendCapabilities.CONFIGFILE_ACCESS
-        ):
+        if not ctx.env.backend_runtime_params.has_configfile_access:
             raise errors.UnsupportedBackendFeatureError(
                 "configuring backend parameters via CONFIGURE INSTANCE"
                 " is not supported by the current backend"

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -5364,7 +5364,8 @@ class DatabaseMixin:
                     SELECT
                         edgedb.raise(
                             NULL::uuid,
-                            msg => 'operation is not supported by the backend'
+                            msg => 'operation is not supported by the backend',
+                            exc => 'feature_not_supported'
                         )
                     INTO _dummy_text
                     '''
@@ -5431,7 +5432,8 @@ class RoleMixin:
                     SELECT
                         edgedb.raise(
                             NULL::uuid,
-                            msg => 'operation is not supported by the backend'
+                            msg => 'operation is not supported by the backend',
+                            exc => 'feature_not_supported'
                         )
                     INTO _dummy_text
                     '''

--- a/edb/pgsql/params.py
+++ b/edb/pgsql/params.py
@@ -33,12 +33,18 @@ class BackendCapabilities(enum.IntFlag):
     CONFIGFILE_ACCESS = 1 << 1
     #: Whether the PostgreSQL server supports the C.UTF-8 locale
     C_UTF8_LOCALE = 1 << 2
+    #: Whether CREATE ROLE is allowed
+    CREATE_ROLE = 1 << 3
+    #: Whether CREATE DATABASE is allowed
+    CREATE_DATABASE = 1 << 4
 
 
 ALL_BACKEND_CAPABILITIES = (
     BackendCapabilities.SUPERUSER_ACCESS
     | BackendCapabilities.CONFIGFILE_ACCESS
     | BackendCapabilities.C_UTF8_LOCALE
+    | BackendCapabilities.CREATE_ROLE
+    | BackendCapabilities.CREATE_DATABASE
 )
 
 

--- a/edb/pgsql/params.py
+++ b/edb/pgsql/params.py
@@ -62,6 +62,45 @@ class BackendRuntimeParams(NamedTuple):
     instance_params: BackendInstanceParams
     session_authorization_role: Optional[str] = None
 
+    @property
+    def tenant_id(self) -> str:
+        return self.instance_params.tenant_id
+
+    @property
+    def has_superuser_access(self) -> bool:
+        return bool(
+            self.instance_params.capabilities
+            & BackendCapabilities.SUPERUSER_ACCESS
+        )
+
+    @property
+    def has_configfile_access(self) -> bool:
+        return bool(
+            self.instance_params.capabilities
+            & BackendCapabilities.CONFIGFILE_ACCESS
+        )
+
+    @property
+    def has_c_utf8_locale(self) -> bool:
+        return bool(
+            self.instance_params.capabilities
+            & BackendCapabilities.C_UTF8_LOCALE
+        )
+
+    @property
+    def has_create_role(self) -> bool:
+        return bool(
+            self.instance_params.capabilities
+            & BackendCapabilities.CREATE_ROLE
+        )
+
+    @property
+    def has_create_database(self) -> bool:
+        return bool(
+            self.instance_params.capabilities
+            & BackendCapabilities.CREATE_DATABASE
+        )
+
 
 @functools.lru_cache
 def get_default_runtime_params(

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -344,6 +344,12 @@ class BaseCluster:
             }
         ''')
 
+    def has_create_database(self) -> bool:
+        return True
+
+    def has_create_role(self) -> bool:
+        return True
+
 
 class Cluster(BaseCluster):
     def __init__(
@@ -477,6 +483,12 @@ class RunningCluster(BaseCluster):
     def destroy(self) -> None:
         pass
 
+    def has_create_database(self) -> bool:
+        return os.environ.get('EDGEDB_TEST_CASES_SET_UP') != 'inplace'
+
+    def has_create_role(self) -> bool:
+        return os.environ.get('EDGEDB_TEST_HAS_CREATE_ROLE') == 'True'
+
 
 class TempClusterWithRemotePg(BaseCluster):
     def __init__(
@@ -511,3 +523,15 @@ class TempClusterWithRemotePg(BaseCluster):
 
     async def _new_pg_cluster(self) -> pgcluster.BaseCluster:
         return await pgcluster.get_remote_pg_cluster(self._backend_dsn)
+
+    def has_create_database(self) -> bool:
+        if self._pg_cluster:
+            return self._pg_cluster.get_runtime_params().has_create_database
+        else:
+            return super().has_create_database()
+
+    def has_create_role(self) -> bool:
+        if self._pg_cluster:
+            return self._pg_cluster.get_runtime_params().has_create_role
+        else:
+            return super().has_create_role()

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -760,7 +760,11 @@ class Compiler:
             and ctx.log_ddl_as_migrations
             and not isinstance(
                 stmt,
-                (qlast.CreateMigration, qlast.GlobalObjectCommand),
+                (
+                    qlast.CreateMigration,
+                    qlast.GlobalObjectCommand,
+                    qlast.DropMigration,
+                ),
             )
         ):
             cm = qlast.CreateMigration(
@@ -1285,6 +1289,11 @@ class Compiler:
 
             current_tx.update_migration_state(None)
             query = self._compile_ql_transaction(ctx, tx_cmd)
+
+        elif isinstance(ql, qlast.DropMigration):
+            self._assert_not_in_migration_block(ctx, ql)
+
+            query = self._compile_and_apply_ddl_stmt(ctx, ql)
 
         else:
             raise AssertionError(f'unexpected migration command: {ql}')

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -555,14 +555,14 @@ class Pool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
                 system_config,
             )
 
-            units, state = await worker.call(
+            units, state_ = await worker.call(
                 'compile',
                 *preargs,
                 *compile_args,
                 sync_state=sync_state
             )
-            worker._last_pickled_state = state
-            return units, state
+            worker._last_pickled_state = state_
+            return units, state_
 
         finally:
             self._release_worker(worker)

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -456,16 +456,19 @@ async def run_server(
                 f'bytes: {runstate_dir_str!r} ({runstate_dir_str_len} bytes)'
             )
 
-        if args.data_dir:
-            cluster, args = await _get_local_pgcluster(
-                args, runstate_dir, tenant_id)
-        elif args.backend_dsn:
-            cluster, args = await _get_remote_pgcluster(args, tenant_id)
-        else:
-            # This should have been checked by main() already,
-            # but be extra careful.
-            abort('neither the data directory nor the remote Postgres DSN '
-                  'have been specified')
+        try:
+            if args.data_dir:
+                cluster, args = await _get_local_pgcluster(
+                    args, runstate_dir, tenant_id)
+            elif args.backend_dsn:
+                cluster, args = await _get_remote_pgcluster(args, tenant_id)
+            else:
+                # This should have been checked by main() already,
+                # but be extra careful.
+                abort('neither the data directory nor the remote Postgres DSN '
+                      'have been specified')
+        except pgcluster.ClusterError as e:
+            abort(str(e))
 
         try:
             pg_cluster_init_by_us = await cluster.ensure_initialized()

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -91,6 +91,15 @@ class BaseCluster:
         )
 
     def get_role_name(self, role_name: str) -> str:
+        if (
+            not self._instance_params.capabilities
+            & pgparams.BackendCapabilities.CREATE_ROLE
+        ):
+            assert (
+                role_name == defines.EDGEDB_SUPERUSER
+            ), f"role_name={role_name} is not allowed"
+            return self.get_connection_params().user
+
         return get_database_backend_name(
             role_name,
             tenant_id=self._instance_params.tenant_id,

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -348,10 +348,7 @@ class Cluster(BaseCluster):
             logger.info(
                 'Initializing database cluster in %s', self._data_dir)
 
-            instance_params = self.get_runtime_params().instance_params
-            capabilities = instance_params.capabilities
-            have_c_utf8 = (
-                capabilities & pgparams.BackendCapabilities.C_UTF8_LOCALE)
+            have_c_utf8 = self.get_runtime_params().has_c_utf8_locale
             await self.init(
                 username='postgres',
                 locale='C.UTF-8' if have_c_utf8 else 'en_US.UTF-8',

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -931,6 +931,16 @@ async def get_remote_pg_cluster(
         if coll is not None:
             caps |= pgparams.BackendCapabilities.C_UTF8_LOCALE
 
+        roles = await conn.fetchrow('''
+            SELECT rolcreaterole, rolcreatedb FROM pg_roles
+            WHERE rolname = (SELECT current_user);
+        ''')
+
+        if roles['rolcreaterole']:
+            caps |= pgparams.BackendCapabilities.CREATE_ROLE
+        if roles['rolcreatedb']:
+            caps |= pgparams.BackendCapabilities.CREATE_DATABASE
+
         return caps
 
     async def _get_pg_settings(

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -168,6 +168,13 @@ class BaseCluster:
             ),
         )
 
+    def overwrite_capabilities(
+        self, capabilities: pgparams.BackendCapabilities
+    ):
+        self._instance_params = self._instance_params._replace(
+            capabilities=capabilities
+        )
+
     def get_connection_addr(self) -> Optional[Tuple[str, int]]:
         return self._get_connection_addr()
 

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -168,13 +168,6 @@ class BaseCluster:
             ),
         )
 
-    def overwrite_capabilities(
-        self, capabilities: pgparams.BackendCapabilities
-    ):
-        self._instance_params = self._instance_params._replace(
-            capabilities=capabilities
-        )
-
     def get_connection_addr(self) -> Optional[Tuple[str, int]]:
         return self._get_connection_addr()
 

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -300,7 +300,7 @@ async def _connect(connargs, dbname, ssl):
     return pgcon
 
 
-async def connect(connargs, dbname, tenant_id):
+async def connect(connargs, dbname, backend_params):
     global INIT_CON_SCRIPT
 
     # This is different than parsing DSN and use the default sslmode=prefer,
@@ -321,17 +321,19 @@ async def connect(connargs, dbname, tenant_id):
     else:
         pgcon = await _connect(connargs, dbname, ssl=ssl)
 
-    sup_role = pgcommon.get_role_backend_name(
-        defines.EDGEDB_SUPERUSER, tenant_id=tenant_id)
-    if connargs['user'] != sup_role:
-        # We used to use SET SESSION AUTHORIZATION here, there're some security
-        # differences over SET ROLE, but as we don't allow accessing Postgres
-        # directly through EdgeDB, SET ROLE is mostly fine here. (Also hosted
-        # backends like Postgres on DigitalOcean support only SET ROLE)
-        await pgcon.simple_query(
-            f'SET ROLE {pg_qi(sup_role)}'.encode(),
-            ignore_data=True,
-        )
+    if backend_params.has_create_role:
+        sup_role = pgcommon.get_role_backend_name(
+            defines.EDGEDB_SUPERUSER, tenant_id=backend_params.tenant_id)
+        if connargs['user'] != sup_role:
+            # We used to use SET SESSION AUTHORIZATION here, there're some
+            # security differences over SET ROLE, but as we don't allow
+            # accessing Postgres directly through EdgeDB, SET ROLE is mostly
+            # fine here. (Also hosted backends like Postgres on DigitalOcean
+            # support only SET ROLE)
+            await pgcon.simple_query(
+                f'SET ROLE {pg_qi(sup_role)}'.encode(),
+                ignore_data=True,
+            )
 
     if 'in_hot_standby' in pgcon.parameter_status:
         # in_hot_standby is always present in Postgres 14 and above

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -513,12 +513,14 @@ cdef class PGConnection:
         self.server = server
 
     def mark_as_system_db(self):
-        assert defines.EDGEDB_SYSTEM_DB in self.dbname
+        if self.server.get_backend_runtime_params().has_create_database:
+            assert defines.EDGEDB_SYSTEM_DB in self.dbname
         self.is_system_db = True
 
     async def listen_for_sysevent(self):
         try:
-            assert defines.EDGEDB_SYSTEM_DB in self.dbname
+            if self.server.get_backend_runtime_params().has_create_database:
+                assert defines.EDGEDB_SYSTEM_DB in self.dbname
             await self.simple_query(
                 b'LISTEN __edgedb_sysevent__;',
                 ignore_data=True
@@ -530,7 +532,8 @@ cdef class PGConnection:
                 raise
 
     async def signal_sysevent(self, event, **kwargs):
-        assert defines.EDGEDB_SYSTEM_DB in self.dbname
+        if self.server.get_backend_runtime_params().has_create_database:
+            assert defines.EDGEDB_SYSTEM_DB in self.dbname
         event = json.dumps({
             'event': event,
             'server_id': self.server._server_id,

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -319,7 +319,10 @@ class Server(ha_base.ClusterProtocol):
         started_at = time.monotonic()
         try:
             rv = await pgcon.connect(
-                self._get_pgaddr(), pg_dbname, self._tenant_id)
+                self._get_pgaddr(),
+                pg_dbname,
+                self.get_backend_runtime_params(),
+            )
         except Exception:
             metrics.backend_connection_establishment_errors.inc()
             raise

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -18,6 +18,8 @@
 
 
 from __future__ import annotations
+
+import functools
 from typing import *
 
 import asyncio
@@ -315,7 +317,10 @@ class Server(ha_base.ClusterProtocol):
 
     async def _pg_connect(self, dbname):
         ha_serial = self._ha_master_serial
-        pg_dbname = self.get_pg_dbname(dbname)
+        if self.get_backend_runtime_params().has_create_database:
+            pg_dbname = self.get_pg_dbname(dbname)
+        else:
+            pg_dbname = self.get_pg_dbname(defines.EDGEDB_SUPERUSER_DB)
         started_at = time.monotonic()
         try:
             rv = await pgcon.connect(
@@ -1604,6 +1609,7 @@ class Server(ha_base.ClusterProtocol):
     def get_instance_data(self, key):
         return self._instance_data[key]
 
+    @functools.lru_cache
     def get_backend_runtime_params(self) -> Any:
         return self._cluster.get_runtime_params()
 

--- a/tests/test_backend_connect.py
+++ b/tests/test_backend_connect.py
@@ -116,7 +116,6 @@ class TempCluster(pgcluster.Cluster):
 
 class ClusterTestCase(tb.TestCase):
     cluster: Optional[TempCluster]
-    tenant_id: Optional[str]
     loop: asyncio.AbstractEventLoop
 
     @classmethod
@@ -153,7 +152,6 @@ class ClusterTestCase(tb.TestCase):
         arg_input = pickle.loads(result.stdout_bytes)
         arg_input["data_dir"] = pathlib.Path(cluster.get_data_dir())
         arg_input["tls_cert_mode"] = "generate_self_signed"
-        cls.tenant_id = cluster.get_runtime_params().instance_params.tenant_id
         cls.dbname = cluster.get_db_name('edgedb')
         args = edb_args.parse_args(**arg_input)
         await bootstrap.ensure_bootstrapped(cluster, args)
@@ -200,7 +198,9 @@ class ClusterTestCase(tb.TestCase):
     @classmethod
     def connect(cls, **kwargs):
         conn_spec = cls.get_connection_spec(kwargs)
-        return pgcon.connect(conn_spec, cls.dbname, cls.tenant_id)
+        return pgcon.connect(
+            conn_spec, cls.dbname, cls.cluster.get_runtime_params()
+        )
 
     def setUp(self):
         super().setUp()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -27,6 +27,9 @@ class TestDatabase(tb.ConnectedTestCase):
     TRANSACTION_ISOLATION = False
 
     async def test_database_create_01(self):
+        if not self.has_create_database:
+            self.skipTest("create database is not supported by the backend")
+
         await self.con.execute('CREATE DATABASE mytestdb;')
 
         try:

--- a/tests/test_dump02.py
+++ b/tests/test_dump02.py
@@ -234,6 +234,10 @@ class TestDump02(tb.StableDumpTestCase, DumpTestCaseMixin):
     SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
                          'dump02_setup.edgeql')
 
+    TEARDOWN = '''
+        CONFIGURE CURRENT DATABASE RESET allow_dml_in_functions;
+    '''
+
     @classmethod
     def get_setup_script(cls):
         script = (
@@ -252,4 +256,11 @@ class TestDump02Compat(
     dump_subdir='dump02',
     check_method=DumpTestCaseMixin.ensure_schema_data_integrity,
 ):
-    pass
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.loop.run_until_complete(cls.con.execute('''
+                CONFIGURE CURRENT DATABASE RESET allow_dml_in_functions;
+            '''))
+        finally:
+            super().tearDownClass()

--- a/tests/test_dump_basic.py
+++ b/tests/test_dump_basic.py
@@ -50,6 +50,9 @@ class TestDumpBasics(tb.DatabaseTestCase, tb.CLITestCaseMixin):
         return buf
 
     async def test_dump_fuzz_01(self):
+        if not self.has_create_database:
+            self.skipTest('create database is not supported by the backend')
+
         # This test creates a simple `DBSIZE` DB filled with semi-random
         # byte strings. While the DB is populated a hash of all byte
         # strings is computed. The DB is then dumped and restored.

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6930,6 +6930,9 @@ type default::Foo {
             """)
 
     async def test_edgeql_ddl_role_01(self):
+        if not self.has_create_role:
+            self.skipTest("create role is not supported by the backend")
+
         await self.con.execute(r"""
             CREATE ROLE foo_01;
         """)
@@ -6950,6 +6953,9 @@ type default::Foo {
         )
 
     async def test_edgeql_ddl_role_02(self):
+        if not self.has_create_role:
+            self.skipTest("create role is not supported by the backend")
+
         await self.con.execute(r"""
             CREATE SUPERUSER ROLE foo2 {
                 SET password := 'secret';
@@ -6990,6 +6996,9 @@ type default::Foo {
         self.assertIsNone(role.password)
 
     async def test_edgeql_ddl_role_03(self):
+        if not self.has_create_role:
+            self.skipTest("create role is not supported by the backend")
+
         await self.con.execute(r"""
             CREATE SUPERUSER ROLE foo3 {
                 SET password := 'secret';
@@ -7062,6 +7071,9 @@ type default::Foo {
         )
 
     async def test_edgeql_ddl_role_04(self):
+        if not self.has_create_role:
+            self.skipTest("create role is not supported by the backend")
+
         await self.con.execute(r"""
             CREATE SUPERUSER ROLE foo5 IF NOT EXISTS {
                 SET password := 'secret';
@@ -7099,6 +7111,9 @@ type default::Foo {
         )
 
     async def test_edgeql_ddl_describe_roles(self):
+        if not self.has_create_role:
+            self.skipTest("create role is not supported by the backend")
+
         await self.con.execute("""
             CREATE SUPERUSER ROLE base1;
             CREATE SUPERUSER ROLE `base 2`;

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -28,6 +28,9 @@ class TestServerAuth(tb.ConnectedTestCase):
     TRANSACTION_ISOLATION = False
 
     async def test_server_auth_01(self):
+        if not self.has_create_role:
+            self.skipTest('create role is not supported by the backend')
+
         await self.con.query('''
             CREATE SUPERUSER ROLE foo {
                 SET password := 'foo-pass';
@@ -159,6 +162,9 @@ class TestServerAuth(tb.ConnectedTestCase):
             await self.con.query("DROP ROLE bar")
 
     async def test_server_auth_02(self):
+        if not self.has_create_role:
+            self.skipTest('create role is not supported by the backend')
+
         try:
             await self.con.query('''
                 CREATE SUPERUSER ROLE foo {

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -1918,6 +1918,9 @@ class TestServerProtoDdlPropagation(tb.QueryTestCase):
     @unittest.skipUnless(devmode.is_in_dev_mode(),
                          'the test requires devmode')
     async def test_server_proto_ddlprop_01(self):
+        if not self.has_create_role:
+            self.skipTest('create role is not supported by the backend')
+
         conargs = self.get_connect_args()
 
         await self.con.execute('''
@@ -2029,6 +2032,9 @@ class TestServerProtoDDL(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False
 
     async def test_server_proto_create_db_01(self):
+        if not self.has_create_database:
+            self.skipTest('create database is not supported by the backend')
+
         db = 'test_server_proto_create_db_01'
 
         con1 = self.con
@@ -2874,6 +2880,9 @@ class TestServerProtoConcurrentGlobalDDL(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False
 
     async def test_server_proto_concurrent_global_ddl(self):
+        if not self.has_create_role:
+            self.skipTest('create role is not supported by the backend')
+
         ntasks = 5
 
         async with tg.TaskGroup() as g:


### PR DESCRIPTION
This PR is a WIP to support backends that doesn't allow `CREATE ROLE` or `CREATE DATABASE` like Heroku Postgres.

If `CREATE ROLE` is not allowed:

* The same backend user will be used for everything.
* Bootstrap only one EdgeDB user `edgedb`, mapped to the same backend user.
* `--tenant-id` is disallowed, EdgeQL `CREATE ROLE`, `DROP ROLE` will raise an error.
* Because we cannot `COMMENT ON` the role, the `pg_authid` metadata is stored in `edgedbinstdata.instdata['single_role_metadata']`
* `sys::Role` is shadowed by a completely different set of views.
* The template_db and system_db are still created as usual.

If `CREATE DATABASE` is not allowed:
* Assumes `CREATE ROLE` is not allowed - or else you could just create a new role with `CREATE DATABASE` permission
* No template database will be created
* Data which is usually found in a system database is stored in the same database
* Metadata of the "template database" and "system database" is stored as `edgedbinstdata.instdata['__edgedbtpl__metadata']` and `edgedbinstdata.instdata['__edgedbsys__metadata']`

TODO:

- [x] Drop `test-heroku.yml`, and add it to `test-pg-versions.yml`
- [ ] Add Terraform scripts to run tests on real Heroku Postgres
- [x] `test_server_proto_configure_compilation` is failing (but not local?)
- [x] I think the concurrent schema change is broken in this branch, like `edb test -j2 tests/test_edgeql_expressions.py` will fail.