### PR TITLE
Disallow optional inline alias for DML statements

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -470,7 +470,6 @@ class Statement(Command, Expr):
 class SubjectMixin(Base):
     __abstract_node__ = True
     subject: Expr
-    subject_alias: typing.Optional[str] = None
 
 
 class ReturningMixin(Base):
@@ -524,6 +523,7 @@ class SelectQuery(Query, ReturningMixin, SelectClauseMixin):
 
 
 class GroupQuery(SelectQuery, SubjectMixin):
+    subject_alias: typing.Optional[str] = None
     using: typing.List[AliasedExpr]
     by: typing.List[Expr]
     into: str

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -271,8 +271,6 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
         self._write_keywords('DELETE')
         self._block_ws(1)
-        if node.subject_alias:
-            self.write(node.subject_alias, ' := ')
         self.visit(node.subject)
         self._block_ws(-1)
         self._visit_filter(node)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -304,7 +304,6 @@ def compile_InsertQuery(
                 shape=expr.shape,
                 view_rptr=ctx.view_rptr,
                 compile_views=True,
-                result_alias=expr.subject_alias,
                 is_insert=True,
                 ctx=bodyctx)
 
@@ -431,7 +430,6 @@ def compile_UpdateQuery(
                 shape=expr.shape,
                 view_rptr=ctx.view_rptr,
                 compile_views=True,
-                result_alias=expr.subject_alias,
                 is_update=True,
                 ctx=bodyctx)
 
@@ -485,7 +483,6 @@ def compile_DeleteQuery(
                 subjql = qlast.SelectQuery(
                     result=qlast.SelectQuery(
                         result=expr.subject,
-                        result_alias=expr.subject_alias,
                         where=expr.where,
                         orderby=expr.orderby,
                         context=expr.context,
@@ -498,7 +495,6 @@ def compile_DeleteQuery(
             else:
                 subjql = qlast.SelectQuery(
                     result=expr.subject,
-                    result_alias=expr.subject_alias,
                     where=expr.where,
                     orderby=expr.orderby,
                     offset=expr.offset,

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -176,10 +176,9 @@ class SimpleGroup(Nonterm):
 
 class SimpleInsert(Nonterm):
     def reduce_Insert(self, *kids):
-        r'%reduce INSERT OptionallyAliasedExpr OptUnlessConflictClause'
+        r'%reduce INSERT Expr OptUnlessConflictClause'
 
-        subj = kids[1].val.expr
-        subj_alias = kids[1].val.alias
+        subj = kids[1].val
 
         # check that the insert subject is either a path or a shape
         if isinstance(subj, qlast.Shape):
@@ -198,7 +197,6 @@ class SimpleInsert(Nonterm):
 
         self.val = qlast.InsertQuery(
             subject=objtype,
-            subject_alias=subj_alias,
             shape=shape,
             unless_conflict=unless_conflict,
         )
@@ -206,10 +204,9 @@ class SimpleInsert(Nonterm):
 
 class SimpleUpdate(Nonterm):
     def reduce_Update(self, *kids):
-        "%reduce UPDATE OptionallyAliasedExpr OptFilterClause SET Shape"
+        "%reduce UPDATE Expr OptFilterClause SET Shape"
         self.val = qlast.UpdateQuery(
-            subject=kids[1].val.expr,
-            subject_alias=kids[1].val.alias,
+            subject=kids[1].val,
             where=kids[2].val,
             shape=kids[4].val,
         )
@@ -217,11 +214,10 @@ class SimpleUpdate(Nonterm):
 
 class SimpleDelete(Nonterm):
     def reduce_Delete(self, *kids):
-        r"%reduce DELETE OptionallyAliasedExpr \
+        r"%reduce DELETE Expr \
                   OptFilterClause OptSortClause OptSelectLimit"
         self.val = qlast.DeleteQuery(
-            subject=kids[1].val.expr,
-            subject_alias=kids[1].val.alias,
+            subject=kids[1].val,
             where=kids[2].val,
             orderby=kids[3].val,
             offset=kids[4].val[0],

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -390,7 +390,7 @@ def result_alias_context(
     alias: Optional[str] = None
     if isinstance(node, qlast.SelectQuery):
         alias = node.result_alias
-    elif isinstance(node, qlast.SubjectMixin):
+    elif isinstance(node, qlast.GroupQuery):
         alias = node.subject_alias
 
     # potentially SELECT uses an alias for the main result

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -656,7 +656,7 @@ class TestInsert(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    I := (INSERT _ := InsertTest {
+                    I := (INSERT InsertTest {
                         name := 'IT returning 4',
                         l2 := 9999,
                     })
@@ -670,7 +670,7 @@ class TestInsert(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 WITH
-                    I := (INSERT _ := InsertTest {
+                    I := (INSERT InsertTest {
                         name := 'IT returning 4',
                         l2 := 9,
                     })

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2741,8 +2741,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                 property comp := count((
                     # Use an alias in WITH block in a computable
                     WITH x := .val
-                    # Use an alias in UPDATE in a computable
-                    UPDATE y := Bar FILTER x = y.val
+                    UPDATE Bar FILTER x = Bar.val
                     SET {
                         val := 'foo'
                     }
@@ -2769,8 +2768,7 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
                 property comp := count((
                     # Use an alias in WITH block in a computable
                     WITH x := .val
-                    # Use an alias in DELETE in a computable
-                    DELETE y := Bar FILTER x = y.val
+                    DELETE Bar FILTER x = Bar.val
                 ))
             }
 


### PR DESCRIPTION
It is undocumented, untested, and broken.
Fixes #3247.