### PR TITLE
Don't alter ancestor views if the ancestor is being deleted

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2576,7 +2576,7 @@ class CompositeMetaCommand(MetaCommand):
         exclude_children: FrozenSet[s_sources.Source] = frozenset(),
     ) -> None:
         for base in obj.get_ancestors(schema).objects(schema):
-            if has_table(base, schema):
+            if has_table(base, schema) and not context.is_deleting(base):
                 self.alter_inhview(
                     schema,
                     context,

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -12276,6 +12276,21 @@ type default::Foo {
             };
         """)
 
+    async def test_edgeql_ddl_drop_parent_multi_link(self):
+        await self.con.execute(r"""
+            CREATE TYPE C;
+            CREATE TYPE D {
+                CREATE MULTI LINK multi_link -> C;
+            };
+            CREATE TYPE E EXTENDING D
+        """)
+
+        await self.con.execute(r"""
+            ALTER TYPE D {
+                DROP LINK multi_link;
+            };
+        """)
+
 
 class TestConsecutiveMigrations(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
The ancestor view will already have been deleted by the time
children are being processed.

Fixes #3276.