### PR TITLE
Fix the 'current_client_connections' metric

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -277,11 +277,11 @@ class Server(ha_base.ClusterProtocol):
 
     def on_binary_client_connected(self, conn):
         self._binary_conns[conn] = True
+        metrics.current_client_connections.inc()
 
     def on_binary_client_authed(self, conn):
         self._report_connections(event='opened')
         metrics.total_client_connections.inc()
-        metrics.current_client_connections.inc()
 
     def on_binary_client_after_idling(self, conn):
         try:


### PR DESCRIPTION
It should be inc'ed on establishing a connection, not when a connection
is authed. Not all established connections pass auth, some are bouncing
before that.