### PR TITLE
Have ordering produce properly sub-nested hierarchies

### DIFF
--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -10326,6 +10326,106 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         await self.migrate('')
 
+    async def test_edgeql_migration_inheritance_to_empty_02(self):
+        await self.migrate(r'''
+            abstract type Named {
+                required property name -> str {
+                    delegated constraint exclusive;
+                }
+            }
+
+            type User {
+                link avatar -> Card {
+                    property text -> str;
+                    property tag := .name ++ (("-" ++ @text) ?? "");
+                }
+            }
+
+            type Card extending Named;
+
+            type SpecialCard extending Card;
+        ''')
+
+        await self.migrate('')
+
+    async def test_edgeql_migration_drop_constraint_01(self):
+        await self.migrate(r'''
+            abstract type Named {
+                required property name -> str {
+                    delegated constraint exclusive;
+                }
+            }
+
+            type User {
+                link avatar -> Card {
+                    property text -> str;
+                    property tag := .name ++ (("-" ++ @text) ?? "");
+                }
+            }
+
+            type Card extending Named;
+
+            type SpecialCard extending Card;
+        ''')
+
+        await self.migrate(r'''
+            abstract type Named {
+                required property name -> str;
+            }
+
+            type User {
+                link avatar -> Card {
+                    property text -> str;
+                    property tag := .name ++ (("-" ++ @text) ?? "");
+                }
+            }
+
+            type Card extending Named;
+
+            type SpecialCard extending Card;
+        ''')
+
+    async def test_edgeql_migration_drop_constraint_02(self):
+        await self.migrate(r'''
+            abstract type Named {
+                required property name -> str {
+                    delegated constraint exclusive;
+                }
+            }
+
+            type User {
+                link avatar -> Card {
+                    property text -> str;
+                    property tag := .name ++ (("-" ++ @text) ?? "");
+                }
+            }
+
+            type Card extending Named;
+
+            type SpecialCard extending Card;
+            type SpecialCard2 extending Card;
+            type VerySpecialCard extending SpecialCard, SpecialCard2;
+        ''')
+
+        await self.migrate(r'''
+            abstract type Named {
+                required property name -> str;
+            }
+
+            type User {
+                link avatar -> Card {
+                    property text -> str;
+                    property tag := .name ++ (("-" ++ @text) ?? "");
+                }
+            }
+
+            type Card extending Named;
+
+            type SpecialCard extending Card;
+            type SpecialCard2 extending Card;
+            type VerySpecialCard extending SpecialCard, SpecialCard2;
+        ''')
+
 
 class TestEdgeQLDataMigrationNonisolated(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
Currently when an inherited parent object (like a pointer or
constraint) is deleted, all of its descendants have their implicit
delete op attached directly to the parent delete.

This causes problems when the object is a constraint and the property
is referenced by some other computed prop, since that computed prop
will be rechecked in the inconsistent state of constraint being
half-deleted.

Fix this by making a sub-sub-object delete properly get attached to
the sub-object delete.

Fixes #3280.