### PR TITLE
Make schema expressions depend on constraints that affect their cardinality

### DIFF
--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -27,6 +27,7 @@ from edb.common import ordered
 from edb.common import topological
 
 from . import delta as sd
+from . import expraliases as s_expraliases
 from . import functions as s_func
 from . import inheriting
 from . import name as sn
@@ -693,6 +694,11 @@ def _trace_op(
                 # Otherwise, things must be deleted _after_ their referrers
                 # have been deleted or altered.
                 deps.add(('delete', ref_name_str))
+                # (except for aliases, which in the collection case
+                # specifically need the old target deleted before the
+                # new one is created)
+                if not isinstance(ref, s_expraliases.Alias):
+                    deps.add(('alter', ref_name_str))
                 if type(ref) == type(obj):
                     deps.add(('rebase', ref_name_str))
 

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -664,7 +664,8 @@ class Pointer(referencing.ReferencedInheritingObject,
     def get_referrer(self, schema: s_schema.Schema) -> Optional[so.Object]:
         return self.get_source(schema)
 
-    def is_exclusive(self, schema: s_schema.Schema) -> bool:
+    def get_exclusive_constraints(
+            self, schema: s_schema.Schema) -> Sequence[constraints.Constraint]:
         if self.generic(schema):
             raise ValueError(f'{self!r} is generic')
 
@@ -672,13 +673,17 @@ class Pointer(referencing.ReferencedInheritingObject,
 
         ptr = self.get_nearest_non_derived_parent(schema)
 
+        constrs = []
         for constr in ptr.get_constraints(schema).objects(schema):
             if (constr.issubclass(schema, exclusive) and
                     not constr.get_subjectexpr(schema)):
 
-                return True
+                constrs.append(constr)
 
-        return False
+        return constrs
+
+    def is_exclusive(self, schema: s_schema.Schema) -> bool:
+        return bool(self.get_exclusive_constraints(schema))
 
     def singular(
         self,

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -10426,6 +10426,82 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             type VerySpecialCard extending SpecialCard, SpecialCard2;
         ''')
 
+    async def test_edgeql_migration_drop_constraint_03(self):
+        await self.migrate(r'''
+            type C {
+                required property val -> str {
+                    constraint exclusive;
+                }
+            }
+
+            type Foo {
+                required link foo -> C {
+                    default := (SELECT C FILTER .val = 'D00');
+                }
+            }
+        ''')
+
+        await self.migrate('')
+
+    async def test_edgeql_migration_drop_constraint_04(self):
+        await self.migrate(r'''
+            type C {
+                required property val -> str {
+                    constraint exclusive;
+                }
+            }
+
+            type Foo {
+                required link foo -> C {
+                    default := (SELECT C FILTER .val = 'D00');
+                }
+            }
+        ''')
+
+        await self.migrate(r'''
+            type C {
+                required property val -> str;
+            }
+
+            type Foo {
+                required multi link foo -> C {
+                    default := (SELECT C FILTER .val = 'D00');
+                }
+            }
+        ''')
+
+    async def test_edgeql_migration_drop_constraint_05(self):
+        await self.migrate(r'''
+            type C {
+                required property val -> str {
+                    constraint exclusive;
+                }
+                required property val2 -> str {
+                    constraint exclusive;
+                }
+            }
+
+            type Foo {
+                required link foo -> C {
+                    default := (SELECT C FILTER .val = 'D00');
+                }
+            }
+        ''')
+
+        await self.migrate(r'''
+            type C {
+                required property val2 -> str {
+                    constraint exclusive;
+                }
+            }
+
+            type Foo {
+                required link foo -> C {
+                    default := (SELECT C FILTER .val2 = 'D00');
+                }
+            }
+        ''')
+
 
 class TestEdgeQLDataMigrationNonisolated(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
This fixes problems where a constraint will be deleted before deleting
schema expressions that reference it and that need to be single.

Fixes #3275.