### PR TITLE
Don't alter ancestor views if the ancestor is being deleted, multiple inheritance

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2562,7 +2562,9 @@ class CompositeMetaCommand(MetaCommand):
                 self.alter_inhview(schema, context, new_base)
 
         for old_base in orig_bases - bases:
-            if has_table(old_base, schema):
+            if has_table(old_base, schema) and not context.is_deleting(
+                old_base
+            ):
                 self.alter_inhview(
                     schema, context, old_base,
                     exclude_children=frozenset((obj,)))

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -12291,6 +12291,24 @@ type default::Foo {
             };
         """)
 
+    async def test_edgeql_ddl_drop_multi_parent_multi_link(self):
+        await self.con.execute(r"""
+            CREATE TYPE C;
+            CREATE TYPE D {
+                CREATE MULTI LINK multi_link -> C;
+            };
+            CREATE TYPE E {
+                CREATE MULTI LINK multi_link -> C;
+            };
+            CREATE TYPE F EXTENDING D, E;
+        """)
+
+        await self.con.execute(r"""
+            ALTER TYPE D {
+                DROP LINK multi_link;
+            };
+        """)
+
 
 class TestConsecutiveMigrations(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
This is the same as #3279 but suits the case of multiple inheritance:

Schema:

```
module default {
    type A;
    type S {
        multi link l_a -> default::A;
    };
    type T {
        multi link l_a -> default::A;
    };
    type V extending default::S, default::T;
};
```

Then

```
edgedb> start migration to {}; populate migration; DESCRIBE CURRENT MIGRATION; commit migration;
OK: START MIGRATION
OK: POPULATE MIGRATION
{
  'ALTER TYPE default::S {
    DROP LINK l_a;
};
ALTER TYPE default::T {
    DROP LINK l_a;
};
DROP TYPE default::A;
DROP TYPE default::V;
DROP TYPE default::S;
DROP TYPE default::T;',
}
Error: InternalServerError: relation "edgedbpub.d31023e8-61ca-11ec-bacd-19e9ae0388bb" does not exist
  Hint: This is most likely a bug in EdgeDB. Please consider opening an issue ticket at https://github.com/edgedb/edgedb/issues/new?template=bug_report.md
```
