### PR TITLE
Exit with status 11 on longer-than-supported runstate dir path

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -47,14 +47,14 @@ TLS_KEY_FILE_NAME = "edbprivkey.pem"
 logger = logging.getLogger('edb.server')
 
 
-class FatalConfigurationError(Exception):
+class InvalidUsageError(Exception):
 
-    def __init__(self, msg: str, exit_code: int = 1) -> None:
+    def __init__(self, msg: str, exit_code: int = 2) -> None:
         super().__init__(msg, exit_code)
 
 
-def abort(msg: str, *, exit_code: int = 1) -> NoReturn:
-    raise FatalConfigurationError(msg, exit_code)
+def abort(msg: str, *, exit_code: int = 2) -> NoReturn:
+    raise InvalidUsageError(msg, exit_code)
 
 
 class StartupScript(NamedTuple):

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -453,7 +453,8 @@ async def run_server(
             abort(
                 f'the length of the specified path for server run state '
                 f'exceeds the maximum of {defines.MAX_RUNSTATE_DIR_PATH} '
-                f'bytes: {runstate_dir_str!r} ({runstate_dir_str_len} bytes)'
+                f'bytes: {runstate_dir_str!r} ({runstate_dir_str_len} bytes)',
+                exit_code=11,
             )
 
         if args.data_dir:
@@ -581,7 +582,7 @@ def server_main(**kwargs):
 
     try:
         server_args = srvargs.parse_args(**kwargs)
-    except srvargs.FatalConfigurationError as e:
+    except srvargs.InvalidUsageError as e:
         abort(e.args[0], exit_code=e.args[1])
 
     if kwargs['background']:


### PR DESCRIPTION
This needs to be a specific exit code for the CLI to be able to identify
the condition better and present a better error message.

While at it, change the default "invalid usage" exit code to `2`, which
is what seems to be commonly used to indicate usage errors.