### PR TITLE
Refactor the contains_* foo methods in the schema

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -455,8 +455,7 @@ def compile_TypeCast(
             )
 
         if (
-            isinstance(pt, s_types.Collection)
-            and pt.contains_array_of_tuples(ctx.env.schema)
+            pt.contains_array_of_tuples(ctx.env.schema)
             and not ctx.env.options.func_params
         ):
             raise errors.QueryError(

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -800,7 +800,7 @@ class GQLCoreSchema:
                 fields[name] = GraphQLInputField(intype)
 
             elif (
-                isinstance(edb_target, s_types.Collection) and
+                edb_target and
                 edb_target.contains_array_of_tuples(self.edb_schema)
             ):
                 # Can't insert array<tuple<...>>
@@ -898,7 +898,7 @@ class GQLCoreSchema:
                 fields[name] = GraphQLInputField(intype)
 
             elif (
-                isinstance(edb_target, s_types.Collection) and
+                edb_target and
                 edb_target.contains_array_of_tuples(self.edb_schema)
             ):
                 # Can't update array<tuple<...>>

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -76,7 +76,7 @@ class ScalarType(
     def is_polymorphic(self, schema: s_schema.Schema) -> bool:
         return self.get_abstract(schema)
 
-    def contains_json(self, schema: s_schema.Schema) -> bool:
+    def is_json(self, schema: s_schema.Schema) -> bool:
         return self.issubclass(
             schema,
             schema.get(s_name.QualName('std', 'json'), type=ScalarType),


### PR DESCRIPTION
Add a generalized find_predicate that searches through subtypes.  This
means we can add more such searches without having to modify multiple
classes.