### PR TITLE
Add Heroku Postgres test

### DIFF
--- a/.github/heroku-postgres/.gitignore
+++ b/.github/heroku-postgres/.gitignore
@@ -1,0 +1,4 @@
+/.terraform/
+/terraform.tfstate*
+/.terraform.lock.hcl
+/.terraform.tfstate.lock.info

--- a/.github/heroku-postgres/main.tf
+++ b/.github/heroku-postgres/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    heroku = {
+      source = "heroku/heroku"
+      version = "~> 4.0"
+    }
+  }
+}
+
+//resource "heroku_app" "default" {
+//  name = "edgedb-heroku-ci"
+//  region = "us"
+//
+//  organization {
+//    name = "edgedb"
+//  }
+//}
+
+resource "heroku_addon" "database" {
+//  app = heroku_app.default.name
+  app = "edgedb-heroku-ci"
+  plan = "heroku-postgresql:hobby-basic"
+  config = {}
+}
+
+output "heroku_postgres_dsn" {
+  value = heroku_addon.database.config_var_values.DATABASE_URL
+  sensitive = true
+}

--- a/.github/workflows.src/tests-managed-pg.tpl.yml
+++ b/.github/workflows.src/tests-managed-pg.tpl.yml
@@ -384,3 +384,109 @@ jobs:
           name: aws-aurora-tfstate
           path: .github/aws-aurora/terraform.tfstate
           retention-days: 1
+
+
+  setup-heroku-postgres:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .github/heroku-postgres
+    steps:
+      << setup_terraform()|indent(2) >>
+
+      - name: Setup Heroku Postgres
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
+        run: |
+          terraform apply -auto-approve
+
+      - name: Store Terraform state
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: heroku-postgres-tfstate
+          path: .github/heroku-postgres/terraform.tfstate
+          retention-days: 1
+
+  test-heroku-postgres:
+    runs-on: ubuntu-latest
+    needs: [setup-heroku-postgres, build]
+    steps:
+    <<- restore_cache() >>
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+
+    - name: Initialize Terraform
+      working-directory: .github/heroku-postgres
+      run: terraform init
+
+    - name: Restore Terraform state
+      uses: actions/download-artifact@v2
+      with:
+        name: heroku-postgres-tfstate
+        path: .github/heroku-postgres
+
+    - name: Get Heroku Postgres DSN
+      id: pgdsn
+      working-directory: .github/heroku-postgres
+      run: |
+        terraform output -raw heroku_postgres_dsn
+
+    # Run the test
+
+    - name: Change Heroku Postgres password
+      shell: python
+      id: passwd
+      run: |
+        import asyncio, asyncpg, urllib.parse
+        async def main():
+            dsn = "${{ steps.pgdsn.outputs.stdout }}"
+            p = urllib.parse.urlparse(dsn)
+            conn = await asyncpg.connect(dsn)
+            await conn.execute(f"""\
+                ALTER ROLE {p.username} PASSWORD 'test';
+            """)
+            p = p._replace(netloc=f'{p.username}:test@{p.hostname}')
+            print(f'::set-output name=pgdsn::{p.geturl()}')
+        asyncio.run(main())
+
+    - name: Test
+      env:
+        EDGEDB_TEST_BACKEND_VENDOR: heroku-postgres
+        EDGEDB_TEST_BACKEND_DSN: ${{ steps.passwd.outputs.pgdsn }}
+      run: |
+        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
+        edb test -j1 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+
+  teardown-heroku-postgres:
+    runs-on: ubuntu-latest
+    needs: test-heroku-postgres
+    if: ${{ always() }}
+    defaults:
+      run:
+        working-directory: .github/heroku-postgres
+    steps:
+      << setup_terraform()|indent(2) >>
+
+      << setup_aws_creds()|indent(2) >>
+
+      - name: Restore Terraform state
+        uses: actions/download-artifact@v2
+        with:
+          name: heroku-postgres-tfstate
+          path: .github/heroku-postgres
+
+      - name: Destroy Heroku Postgres
+        run: terraform destroy -auto-approve
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
+
+      - name: Overwrite Terraform state
+        uses: actions/upload-artifact@v2
+        with:
+          name: heroku-postgres-tfstate
+          path: .github/heroku-postgres/terraform.tfstate
+          retention-days: 1

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -1183,3 +1183,242 @@ jobs:
           name: aws-aurora-tfstate
           path: .github/aws-aurora/terraform.tfstate
           retention-days: 1
+
+
+  setup-heroku-postgres:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .github/heroku-postgres
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Initialize Terraform
+        run: terraform init
+
+      - name: Setup Heroku Postgres
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
+        run: |
+          terraform apply -auto-approve
+
+      - name: Store Terraform state
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: heroku-postgres-tfstate
+          path: .github/heroku-postgres/terraform.tfstate
+          retention-days: 1
+
+  test-heroku-postgres:
+    runs-on: ubuntu-latest
+    needs: [setup-heroku-postgres, build]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: false
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+        submodules: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10.0'
+
+    - name: Handle virtualenv
+      uses: syphar/restore-virtualenv@v1.2
+      id: venv-cache
+      with:
+        requirement_files: setup.py
+        custom_cache_key_element: v2
+
+    # Restore the artifacts and environment variables
+
+    - name: Download shared artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: shared-artifacts
+        path: .tmp
+
+    - name: Set environment variables
+      run: |
+        echo EDGEDBCLI_GIT_REV=$(cat .tmp/edgedbcli_git_rev.txt) >> $GITHUB_ENV
+        echo POSTGRES_GIT_REV=$(cat .tmp/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat .tmp/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
+        echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
+
+    # Restore build cache
+
+    - name: Restore cached EdgeDB CLI binaries
+      uses: actions/cache@v2
+      id: cli-cache
+      with:
+        path: build/cli
+        key: edb-cli-v3-${{ env.EDGEDBCLI_GIT_REV }}
+
+    - name: Restore cached Rust extensions
+      uses: actions/cache@v2
+      id: rust-cache
+      with:
+        path: build/rust_extensions
+        key: edb-rust-v3-${{ hashFiles('.tmp/rust_cache_key.txt') }}
+
+    - name: Restore cached Cython extensions
+      uses: actions/cache@v2
+      id: ext-cache
+      with:
+        path: build/extensions
+        key: edb-ext-v4-${{ hashFiles('.tmp/ext_cache_key.txt') }}
+
+    - name: Restore compiled parsers cache
+      uses: actions/cache@v2
+      id: parsers-cache
+      with:
+        path: build/lib
+        key: edb-parsers-v2-${{ hashFiles('.tmp/parsers_cache_key.txt') }}
+
+    - name: Restore cached PostgreSQL build
+      uses: actions/cache@v2
+      id: postgres-cache
+      with:
+        path: build/postgres/install
+        key: edb-postgres-v2-${{ env.POSTGRES_GIT_REV }}
+
+    - name: Restore cached Stolon build
+      uses: actions/cache@v2
+      id: stolon-cache
+      with:
+        path: build/stolon/bin
+        key: edb-stolon-v2-${{ env.STOLON_GIT_REV }}
+
+    - name: Restore bootstrap cache
+      uses: actions/cache@v2
+      id: bootstrap-cache
+      with:
+        path: build/cache
+        key: edb-bootstrap-v2-${{ hashFiles('.tmp/bootstrap_cache_key.txt') }}
+
+    - name: Stop if we cannot retrieve the cache
+      if: |
+        steps.venv-cache.outputs.cache-hit != 'true' ||
+        steps.cli-cache.outputs.cache-hit != 'true' ||
+        steps.rust-cache.outputs.cache-hit != 'true' ||
+        steps.ext-cache.outputs.cache-hit != 'true' ||
+        steps.parsers-cache.outputs.cache-hit != 'true' ||
+        steps.postgres-cache.outputs.cache-hit != 'true' ||
+        steps.stolon-cache.outputs.cache-hit != 'true' ||
+        steps.bootstrap-cache.outputs.cache-hit != 'true'
+      run: |
+        echo ::error::Cannot retrieve build cache.
+        exit 1
+
+    - name: Restore cache into the source tree
+      run: |
+        cp -v build/cli/bin/edgedb edb/cli/edgedb
+        rsync -av ./build/rust_extensions/edb/ ./edb/
+        rsync -av ./build/extensions/edb/ ./edb/
+        rsync -av ./build/lib/edb/ ./edb/
+        cp build/postgres/install/stamp build/postgres/
+        rsync -av $VIRTUAL_ENV/edgedb_server.egg-info/ ./edgedb_server.egg-info/
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+
+    - name: Initialize Terraform
+      working-directory: .github/heroku-postgres
+      run: terraform init
+
+    - name: Restore Terraform state
+      uses: actions/download-artifact@v2
+      with:
+        name: heroku-postgres-tfstate
+        path: .github/heroku-postgres
+
+    - name: Get Heroku Postgres DSN
+      id: pgdsn
+      working-directory: .github/heroku-postgres
+      run: |
+        terraform output -raw heroku_postgres_dsn
+
+    # Run the test
+
+    - name: Change Heroku Postgres password
+      shell: python
+      id: passwd
+      run: |
+        import asyncio, asyncpg, urllib.parse
+        async def main():
+            dsn = "${{ steps.pgdsn.outputs.stdout }}"
+            p = urllib.parse.urlparse(dsn)
+            conn = await asyncpg.connect(dsn)
+            await conn.execute(f"""\
+                ALTER ROLE {p.username} PASSWORD 'test';
+            """)
+            p = p._replace(netloc=f'{p.username}:test@{p.hostname}')
+            print(f'::set-output name=pgdsn::{p.geturl()}')
+        asyncio.run(main())
+
+    - name: Test
+      env:
+        EDGEDB_TEST_BACKEND_VENDOR: heroku-postgres
+        EDGEDB_TEST_BACKEND_DSN: ${{ steps.passwd.outputs.pgdsn }}
+      run: |
+        edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
+        edb test -j1 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN
+
+  teardown-heroku-postgres:
+    runs-on: ubuntu-latest
+    needs: test-heroku-postgres
+    if: ${{ always() }}
+    defaults:
+      run:
+        working-directory: .github/heroku-postgres
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Initialize Terraform
+        run: terraform init
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Restore Terraform state
+        uses: actions/download-artifact@v2
+        with:
+          name: heroku-postgres-tfstate
+          path: .github/heroku-postgres
+
+      - name: Destroy Heroku Postgres
+        run: terraform destroy -auto-approve
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
+
+      - name: Overwrite Terraform state
+        uses: actions/upload-artifact@v2
+        with:
+          name: heroku-postgres-tfstate
+          path: .github/heroku-postgres/terraform.tfstate
+          retention-days: 1

--- a/tests/test_dump01.py
+++ b/tests/test_dump01.py
@@ -1201,9 +1201,9 @@ class DumpTestCaseMixin:
             r'''
             WITH w := {'Lorem', 'ipsum', 'dolor', 'sit', 'amet'}
             SELECT w
-            ORDER BY w;
+            ORDER BY str_lower(w);
             ''',
-            ['Lorem', 'amet', 'dolor', 'ipsum', 'sit'],
+            ['amet', 'dolor', 'ipsum', 'Lorem', 'sit'],
         )
 
         await self.assert_query_result(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -17,6 +17,7 @@
 #
 
 import decimal
+import os
 import re
 import textwrap
 import uuid
@@ -306,6 +307,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             }]
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_ddl_rename_type_and_add_01(self):
         await self.con.execute("""
 
@@ -354,6 +359,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             };
         """)
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_ddl_rename_type_and_add_02(self):
         await self.con.execute("""
 

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -21,6 +21,7 @@ import json
 import os.path
 
 from edb.testbase import server as tb
+from edb.tools import test
 
 import edgedb
 
@@ -527,6 +528,10 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             ['no', 'no', 'no', 'no', 'no', 'no', 'no', 'no', 'yes'],
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_aliases_if_else_02(self):
         await self.assert_query_result(
             r"""

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -24,6 +24,7 @@ import os.path
 import edgedb
 
 from edb.testbase import server as tb
+from edb.tools import test
 
 
 class TestEdgeQLFunctions(tb.QueryTestCase):
@@ -729,6 +730,10 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [2],
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_functions_re_match_01(self):
         await self.assert_query_result(
             r'''SELECT re_match('ab', 'AbabaB');''',
@@ -794,6 +799,10 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [['schema', 'Link'], ['schema', 'Property']],
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_functions_re_match_all_01(self):
         await self.assert_query_result(
             r'''SELECT re_match_all('ab', 'AbabaB');''',
@@ -2706,6 +2715,10 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             {1, 2},
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_functions_min_01(self):
         await self.assert_query_result(
             r'''SELECT min(<int64>{});''',

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -76,6 +76,10 @@ class TestIntrospection(tb.QueryTestCase):
             ]
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_introspection_objtype_02(self):
         await self.assert_query_result(
             r"""
@@ -104,6 +108,10 @@ class TestIntrospection(tb.QueryTestCase):
             }]
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_introspection_objtype_03(self):
         await self.assert_query_result(
             r"""
@@ -130,6 +138,10 @@ class TestIntrospection(tb.QueryTestCase):
             }]
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_introspection_objtype_04(self):
         await self.assert_query_result(
             r"""
@@ -183,6 +195,10 @@ class TestIntrospection(tb.QueryTestCase):
             }]
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_introspection_objtype_06(self):
         await self.assert_query_result(
             r"""
@@ -1087,6 +1103,10 @@ class TestIntrospection(tb.QueryTestCase):
             [True] * res
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_introspection_meta_14(self):
         await self.assert_query_result(
             r"""
@@ -1213,6 +1233,10 @@ class TestIntrospection(tb.QueryTestCase):
             ],
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_introspection_meta_default_03(self):
         await self.assert_query_result(
             r'''
@@ -1256,6 +1280,10 @@ class TestIntrospection(tb.QueryTestCase):
             ],
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_introspection_meta_default_04(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1509,6 +1509,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ],
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_select_polymorphic_09(self):
         # Test simultaneous type intersection on source and target
         # of a shape element.
@@ -6347,6 +6351,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ["Elvis", "Yury"],
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_select_expr_objects_04(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_tutorial.py
+++ b/tests/test_edgeql_tutorial.py
@@ -17,13 +17,19 @@
 #
 
 
+import os
 import unittest  # NOQA
 
 from edb.testbase import server as tb
+from edb.tools import test
 
 
 class TestEdgeQLTutorial(tb.QueryTestCase):
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_tutorial(self):
         await self.con.execute(r'''
             START MIGRATION TO {

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -3054,6 +3054,10 @@ class TestUpdate(tb.QueryTestCase):
             }]
         )
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     async def test_edgeql_update_add_dupes_01b(self):
         await self.con.execute("""
             INSERT UpdateTestSubSubType {

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -1923,6 +1923,10 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             ]
         }, sort=lambda x: x['name'])
 
+    @test.xfail(
+        "Known collation issue on Heroku Postgres",
+        unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"
+    )
     def test_graphql_functional_fragment_type_12(self):
         self.assert_graphql_query_result(r"""
             query {


### PR DESCRIPTION
Run tests on real Heroku Postgres weekly. Sample run: https://github.com/edgedb/edgedb/actions/runs/1616127940

Some tests are failing because Heroku Postgres has `COLLATE="en_US.UTF-8"` while EdgeDB assumes `COLLATE="C"`. These tests are marked as "xfail" for now until EdgeDB supports single-db mode on backend that doesn't have `COLLATE="C"`. Before that, string ordering would follow the local collation inconsistently on backends like Heroku Postgres.