### PR TITLE
Add a `bag` type that tells assert_query_result to ignore order

### DIFF
--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -270,15 +270,12 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ''',
             [
                 {
-                    'select_deck': [
+                    'select_deck': tb.bag([
                         {'name': 'Bog monster', '@letter': 'B'},
                         {'name': 'Imp', '@letter': 'I'},
-                    ]
+                    ])
                 }
             ],
-            sort={
-                'select_deck': lambda x: x['name'],
-            }
         )
 
     async def test_edgeql_for_in_computable_02(self):
@@ -586,10 +583,7 @@ class TestEdgeQLFor(tb.QueryTestCase):
                 } FILTER .name = 'Alice';
             ''',
             [{"select_deck":
-              ["Bog monster", "Dragon", "Giant turtle", "Imp"]}],
-            sort={
-                'select_deck': lambda x: x,
-            }
+              tb.bag(["Bog monster", "Dragon", "Giant turtle", "Imp"])}],
         )
 
         # This one caused a totally nonsense type error.
@@ -605,10 +599,7 @@ class TestEdgeQLFor(tb.QueryTestCase):
                 } FILTER .name = 'Alice';
             ''',
             [{"select_deck":
-              ["Bog monster", "Dragon", "Giant turtle", "Imp"]}],
-            sort={
-                'select_deck': lambda x: x,
-            }
+              tb.bag(["Bog monster", "Dragon", "Giant turtle", "Imp"])}],
         )
 
     async def test_edgeql_for_in_computable_06(self):
@@ -630,15 +621,12 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ''',
             [
                 {
-                    "select_deck": [
+                    "select_deck": tb.bag([
                         {"letter": {"B!!", "B!?"}, "name": "Bog monster"},
                         {"letter": {"I!!", "I!?"}, "name": "Imp"},
-                    ]
+                    ])
                 }
             ],
-            sort={
-                'select_deck': lambda x: x["name"],
-            }
         )
 
     async def test_edgeql_for_in_computable_07(self):
@@ -661,15 +649,12 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ''',
             [
                 {
-                    "select_deck": [
+                    "select_deck": tb.bag([
                         {"letter": ["B!!", "B!?"], "name": "Bog monster"},
                         {"letter": ["I!!", "I!?"], "name": "Imp"},
-                    ]
+                    ])
                 }
             ],
-            sort={
-                'select_deck': lambda x: x["name"],
-            }
         )
 
     async def test_edgeql_for_in_computable_08(self):
@@ -693,7 +678,7 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ''',
             [
                 {
-                    "select_deck": [
+                    "select_deck": tb.bag([
                         {
                             "name": "Bog monster",
                             "letter": {"B!!", "B!?"},
@@ -708,12 +693,9 @@ class TestEdgeQLFor(tb.QueryTestCase):
                             "uncorrelated": {("!", "!"), ("!", "?"),
                                              ("?", "!"), ("?", "?")}
                         },
-                    ]
+                    ])
                 }
             ],
-            sort={
-                'select_deck': lambda x: x["name"],
-            }
         )
 
     @test.xfail("'letter' does not exist")
@@ -742,15 +724,12 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ''',
             [
                 {
-                    'select_deck': [
+                    'select_deck': tb.bag([
                         {'name': 'Bog monster', '@letter': 'B'},
                         {'name': 'Imp', '@letter': 'I'},
-                    ]
+                    ])
                 }
             ],
-            sort={
-                'select_deck': lambda x: x['name'],
-            }
         )
 
     @test.xfail("""
@@ -785,15 +764,12 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ''',
             [
                 {
-                    'select_deck': [
+                    'select_deck': tb.bag([
                         {'name': 'Bog monster', 'letter': 'B'},
                         {'name': 'Imp', 'letter': 'I'},
-                    ]
+                    ])
                 }
             ],
-            sort={
-                'select_deck': lambda x: x['name'],
-            }
         )
 
     async def test_edgeql_for_in_computable_11(self):
@@ -839,15 +815,12 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ''',
             [
                 {
-                    'select_deck': [
+                    'select_deck': tb.bag([
                         [{'name': 'Bog monster', 'letter': 'B'}],
                         [{'name': 'Imp', 'letter': 'I'}],
-                    ]
+                    ])
                 }
             ],
-            sort={
-                'select_deck': lambda x: x[0]['name'],
-            }
         )
 
     async def test_edgeql_for_in_computable_13(self):
@@ -893,15 +866,12 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ''',
             [
                 {
-                    'select_deck': [
+                    'select_deck': tb.bag([
                         {'name': 'Bog monster', 'letter': 'B'},
                         {'name': 'Imp', 'letter': 'I'},
-                    ]
+                    ])
                 }
             ],
-            sort={
-                'select_deck': lambda x: x['name'],
-            }
         )
 
     async def test_edgeql_for_in_computable_15(self):
@@ -922,15 +892,12 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ''',
             [
                 {
-                    'select_deck': [
+                    'select_deck': tb.bag([
                         {'name': 'Bog monster', 'letter': 'B'},
                         {'name': 'Imp', 'letter': 'I'},
-                    ]
+                    ])
                 }
             ],
-            sort={
-                'select_deck': lambda x: x['name'],
-            }
         )
 
     async def test_edgeql_for_in_computable_16(self):
@@ -951,15 +918,12 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ''',
             [
                 {
-                    'select_deck': [
+                    'select_deck': tb.bag([
                         {'name': 'Bog monster', 'letter': 'B'},
                         {'name': 'Imp', 'letter': 'I'},
-                    ]
+                    ])
                 }
             ],
-            sort={
-                'select_deck': lambda x: x['name'],
-            }
         )
 
     @test.xfail("""

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1749,11 +1749,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             '''
                 SELECT (SELECT (SELECT Issue { watchers: {name} }).watchers);
             ''',
-            [
+            tb.bag([
                 {'name': 'Elvis'},
                 {'name': 'Yury'},
-            ],
-            sort=lambda x: x['name'],
+            ]),
         )
 
     async def test_edgeql_select_tvariant_01(self):
@@ -2142,7 +2141,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                     body  # body should appear in the duck type
                 };
             """,
-            [
+            tb.bag([
                 {'body': 'EdgeDB needs to happen soon.'},
                 {'body': 'Fix regression introduced by lexer tweak.',
                  'name': 'Regression.'},
@@ -2153,8 +2152,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 {'body': 'We need to be able to render data '
                          'in tabular format.',
                  'name': 'Improve EdgeDB repl output rendering.'}
-            ],
-            sort=lambda x: x['body']
+            ]),
         )
 
     async def test_edgeql_select_setops_02(self):
@@ -2167,15 +2165,14 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 [IS Text].body
             };
             ''',
-            [
+            tb.bag([
                 {'body': 'EdgeDB needs to happen soon.'},
                 {'body': 'Fix regression introduced by lexer tweak.'},
                 {'body': 'Initial public release of EdgeDB.'},
                 {'body': 'Minor lexer tweaks.'},
                 {'body': 'We need to be able to render '
                          'data in tabular format.'}
-            ],
-            sort=lambda x: x['body']
+            ]),
         )
 
         await self.assert_query_result(
@@ -2530,8 +2527,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             # Named doesn't have a property number.
             SELECT Issue[IS Named].number;
             """,
-            ['1', '2', '3', '4'],
-            sort=True,
+            {'1', '2', '3', '4'},
         )
 
     async def test_edgeql_select_setops_17(self):
@@ -4473,8 +4469,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             r"""
             SELECT Issue.number ++ (SELECT Issue.number);
             """,
-            ['11', '22', '33', '44'],
-            sort=True
+            {'11', '22', '33', '44'},
         )
 
     async def test_edgeql_select_subqueries_10(self):
@@ -4485,9 +4480,8 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             SELECT
                 Issue.number ++ sub;
             """,
-            ['11', '12', '13', '14', '21', '22', '23', '24',
-             '31', '32', '33', '34', '41', '42', '43', '44'],
-            sort=True
+            {'11', '12', '13', '14', '21', '22', '23', '24',
+             '31', '32', '33', '34', '41', '42', '43', '44'},
         )
 
     async def test_edgeql_select_subqueries_11(self):
@@ -5778,7 +5772,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 LIMIT 2
             );
             ''',
-            [
+            tb.bag([
                 {
                     'name': 'Improve EdgeDB repl output rendering.',
                     'number': '2'
@@ -5791,8 +5785,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                     'name': 'Regression.',
                     'number': '4'
                 },
-            ],
-            sort=lambda x: x['number'],
+            ]),
         )
 
     async def test_edgeql_select_for_04(self):


### PR DESCRIPTION
assert_query_result currently supports using sets to ignore order,
but that doesn't work for objects, which can't be hashed or sorted.

There is a system for specifying a sort key for internal data, but it
is way clunkier than just saying we don't care about the order.

I converted some places that were using sort= to use this.