### PR TITLE
Minor docs update regarding FOR.

### DIFF
--- a/docs/edgeql/insert.rst
+++ b/docs/edgeql/insert.rst
@@ -311,8 +311,7 @@ using a :ref:`for loop <ref_eql_for>` to insert the objects.
 
   db> with
   ...   raw_data := <json>$data,
-  ...   items := json_array_unpack(raw_data)
-  ... for item in { items } union (
+  ... for item in json_array_unpack(raw_data) union (
   ...   insert Hero { name := <str>item['name'] }
   ... );
   Parameter <json>$data: [{"name":"Sersi"},{"name":"Ikaris"},{"name":"Thena"}]

--- a/docs/reference/edgeql/for.rst
+++ b/docs/reference/edgeql/for.rst
@@ -19,7 +19,7 @@ FOR
 
     UNION <output-expr> ;
 
-:eql:synopsis:`FOR <variable> IN "{" <iterator-set> [, ...]  "}"`
+:eql:synopsis:`FOR <variable> IN <iterator-expr>`
     The ``FOR`` clause has this general form:
 
     .. TODO: rewrite this
@@ -177,11 +177,13 @@ an intuitive manner.
         UPDATE User
         FILTER .name = x.name
         SET {
-            friends := (
-                FOR f in {array_unpack(x.friends)}
-                UNION (
-                    SELECT U2 {@nickname := f.1}
-                    FILTER U2.name = f.0
+            friends := assert_distinct(
+                (
+                    FOR f in array_unpack(x.friends)
+                    UNION (
+                        SELECT U2 {@nickname := f.1}
+                        FILTER U2.name = f.0
+                    )
                 )
             )
         }

--- a/docs/reference/edgeql/insert.rst
+++ b/docs/reference/edgeql/insert.rst
@@ -177,7 +177,7 @@ clause.
         Elvis := (SELECT User FILTER .name = 'Elvis'),
         Open := (SELECT Status FILTER .name = 'Open')
 
-    FOR Q IN {(SELECT User FILTER .name ILIKE 'A%')}
+    FOR Q IN (SELECT User FILTER .name ILIKE 'A%')
 
     UNION (INSERT Issue {
         name := Q.name + ' access problem',


### PR DESCRIPTION
Omit the `{...}` in `FOR` whenever possible.

Simplify cheatsheet examples for booleans and coalescing that involve
`FOR`.