### PR TITLE
Fix performance of queries containing references to multi-links from DML

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -178,7 +178,7 @@ class EdgeQLPathInfo(Base):
 class BaseRangeVar(ImmutableBaseExpr):
     """Range variable, used in FROM clauses."""
 
-    __ast_meta__ = {'schema_object_id'}
+    __ast_meta__ = {'schema_object_id', 'tag'}
 
     # This is a hack, since there is some code that relies on not
     # having an alias on a range var (to refer to a CTE directly, for
@@ -189,6 +189,9 @@ class BaseRangeVar(ImmutableBaseExpr):
 
     #: The id of the schema object this rvar represents
     schema_object_id: typing.Optional[uuid.UUID] = None
+
+    #: Optional identification piece to describe what's inside the rvar
+    tag: typing.Optional[str] = None
 
     def __repr__(self) -> str:
         return (

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -21,9 +21,9 @@
 
 
 from __future__ import annotations
+from typing import *
 
 import contextlib
-from typing import *
 
 from edb import errors
 
@@ -441,7 +441,7 @@ def ensure_source_rvar(
         scope_stmt = relctx.maybe_get_scope_stmt(ir_set.path_id, ctx=ctx)
         if scope_stmt is None:
             scope_stmt = ctx.rel
-        rvar = relctx.new_root_rvar(ir_set, ctx=ctx)
+        rvar = relctx.new_root_rvar(ir_set, lateral=True, ctx=ctx)
         relctx.include_rvar(scope_stmt, rvar, path_id=ir_set.path_id, ctx=ctx)
         pathctx.put_path_rvar(
             stmt, ir_set.path_id, rvar, aspect='source', env=ctx.env)
@@ -827,6 +827,7 @@ def process_set_as_path_type_intersection(
         poly_rvar = relctx.range_for_typeref(
             target_typeref,
             path_id=ir_set.path_id,
+            lateral=True,
             ctx=ctx,
         )
 
@@ -1041,7 +1042,7 @@ def process_set_as_path(
 
         # Target set range.
         if irtyputils.is_object(ir_set.typeref):
-            target_rvar = relctx.new_root_rvar(ir_set, ctx=ctx)
+            target_rvar = relctx.new_root_rvar(ir_set, lateral=True, ctx=ctx)
 
             main_rvar = SetRVar(
                 target_rvar,


### PR DESCRIPTION
When compiling link references that have a DML statement as a source,
we normally produce an "overlay" UNION containing the existing link
relation as well as the effects of the mutation.  Unfortunately,
Postgres seems to cope badly with JOINs containing UNIONs which are
composed of a mix of RelRange and RangeSubselect, producing horrible
HashJoin plans scanning the entire UNION.  Luckily, there's a
straightforward workaround: push the JOIN condition into UNION operands
and simply CROSS JOIN the UNION laterally.  While this is theoretically
beneficial for all kinds of UNIONs, we restrict this optimization to overlay
UNIONs only to limit the possibility of breakage as not all  UNIONs are
guaranteed to have correct path namespace and translation maps set up.