### PR TITLE
Improve performance of `IN`

### DIFF
--- a/edb/lib/std/25-setoperators.edgeql
+++ b/edb/lib/std/25-setoperators.edgeql
@@ -44,7 +44,7 @@ std::`NOT IN` (e: anytype, s: SET OF anytype) -> std::bool
         'Test the membership of an element in a set.';
     USING SQL EXPRESSION;
     SET volatility := 'Immutable';
-    SET derivative_of := 'std::=';
+    SET derivative_of := 'std::!=';
 };
 
 

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -406,3 +406,13 @@ def select_is_simple(stmt: pgast.SelectStmt) -> bool:
         and not stmt.locking_clause
         and not stmt.op
     )
+
+
+def is_row_expr(expr: pgast.BaseExpr) -> bool:
+    while True:
+        if isinstance(expr, (pgast.RowExpr, pgast.ImplicitRowExpr)):
+            return True
+        elif isinstance(expr, pgast.TypeCast):
+            expr = expr.arg
+        else:
+            return False

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2169,6 +2169,9 @@ class TestExpressions(tb.QueryTestCase):
             [True]
         )
 
+    @test.xfail(
+        "Postgres crashes with 'could not identify a hash function for "
+        "type record'")
     async def test_edgeql_expr_valid_collection_15(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -494,6 +494,13 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [True],
         )
 
+        await self.assert_query_result(
+            r"""
+            SELECT ("foo", 1) IN array_unpack([("foo", 1), ("bar", 2)]);
+            """,
+            [True],
+        )
+
     async def test_edgeql_functions_enumerate_01(self):
         await self.assert_query_result(
             r'''SELECT [10, 20];''',


### PR DESCRIPTION
A fix in #2329 changed the implementation of `IN` from an `ALL`/`ANY`
sublink to a `[NOT] EXISTS` sublink, which is slower in the trivial
cases like `foo in array_unpack(array)`.  The original fix was motivated
by tuple property breakage, and fortunately there is a simpler syntactic
fix for opaque tuples that allows keeping `ALL`/`ANY` sublinks in all
cases.

This does regress one test with a deeply nested ad-hoc tuple, which
crashes Postgres with an arcane "could not identify a hash function for
type record"