### PR TITLE
Always include the definition context namespace in computable contexts

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1219,7 +1219,6 @@ def computable_ptr_set(
     ptrcls_to_shadow = None
 
     qlctx: Optional[context.ContextLevel]
-    inner_source_path_id: Optional[irast.PathId]
 
     try:
         comp_info = ctx.source_map[ptrcls]
@@ -1286,7 +1285,6 @@ def computable_ptr_set(
             )
         qlexpr = astutils.ensure_qlstmt(schema_qlexpr)
         qlctx = None
-        inner_source_path_id = None
         path_id_ns = None
 
     newctx: Callable[[], ContextManager[context.ContextLevel]]
@@ -1449,7 +1447,7 @@ def _get_computable_ctx(
     rptr: irast.Pointer,
     source: irast.Set,
     source_scls: s_types.Type,
-    inner_source_path_id: Optional[irast.PathId],
+    inner_source_path_id: irast.PathId,
     path_id_ns: Optional[irast.Namespace],
     same_scope: bool,
     qlctx: context.ContextLevel,
@@ -1495,15 +1493,9 @@ def _get_computable_ctx(
             # lines up.
             subns |= qlctx.path_id_namespace
 
-            if inner_source_path_id is not None:
-                inner_path_id = inner_source_path_id
-            else:
-                inner_path_id = pathctx.get_path_id(source_stype, ctx=subctx)
-
-            inner_path_id = inner_path_id.merge_namespace(subns)
-
             subctx.pending_stmt_full_path_id_namespace = frozenset(subns)
 
+            inner_path_id = inner_source_path_id.merge_namespace(subns)
             with subctx.new() as remapctx:
                 remapctx.path_id_namespace |= subns
                 # We need to run the inner_path_id through the same

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -3521,7 +3521,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             )
             select props {
               name,
-              namelen # <- adding this property causes cartesian product
+              namelen
             };
             ''',
             tb.bag([

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -3063,7 +3063,7 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
-    async def test_edgeql_scope_ref_outer_02(self):
+    async def test_edgeql_scope_ref_outer_02a(self):
         await self.assert_query_result(
             """
                 SELECT User {
@@ -3071,6 +3071,25 @@ class TestEdgeQLScope(tb.QueryTestCase):
                         multi tag := User.name,
                     })
                 } FILTER .name = 'Alice' AND EXISTS .cards;
+            """,
+            [{
+                "cards": [
+                    {"tag": ["Alice"]},
+                    {"tag": ["Alice"]},
+                    {"tag": ["Alice"]},
+                    {"tag": ["Alice"]}
+                ]
+            }],
+        )
+
+    async def test_edgeql_scope_ref_outer_02b(self):
+        await self.assert_query_result(
+            """
+                SELECT (for u IN User UNION u {
+                    cards := (SELECT _ := .deck {
+                        multi tag := u.name,
+                    })
+                }) FILTER .name = 'Alice' AND EXISTS .cards;
             """,
             [{
                 "cards": [
@@ -3490,4 +3509,46 @@ class TestEdgeQLScope(tb.QueryTestCase):
                 {"avatar": {
                     "name": "Djinn", "retag": "Djinn-Wow", "t2": "Wow"}}
             ]
+        )
+
+    async def test_edgeql_scope_for_with_computable_01(self):
+        await self.assert_query_result(
+            r'''
+            with props := (
+              for h in User union (
+                select h {namelen := len(h.name)}
+              )
+            )
+            select props {
+              name,
+              namelen # <- adding this property causes cartesian product
+            };
+            ''',
+            tb.bag([
+                {"name": "Alice", "namelen": 5},
+                {"name": "Bob", "namelen": 3},
+                {"name": "Carol", "namelen": 5},
+                {"name": "Dave", "namelen": 4}
+            ])
+        )
+
+    async def test_edgeql_scope_for_with_computable_02(self):
+        await self.assert_query_result(
+            r'''
+            with props := (
+              for h in User union (
+                with g := h, select g {namelen := len(g.name)}
+              )
+            )
+            select props {
+              name,
+              namelen
+            };
+            ''',
+            tb.bag([
+                {"name": "Alice", "namelen": 5},
+                {"name": "Bob", "namelen": 3},
+                {"name": "Carol", "namelen": 5},
+                {"name": "Dave", "namelen": 4}
+            ])
         )


### PR DESCRIPTION
We need to include the *original* source namespace in our ctx
namespace when compiling computables. The current mechanism of trying
to look up in view_sets or failing that using the source namespace
from the computable use, but this was failing to find it in some cases
with FOR.

Fix this by instead directly pulling in the namespace from qlctx. The
inclusion of qlctx's namespace nicely allows us to ditch so later
logic as well.

Additionally we need to merge the namespace into *both* sides in
get_view_map_remapping, to handle cases like referencing a `FOR`
variable where the current ns doesn't get merged in.

Fixes #3323.