### PR TITLE
Require PostgreSQL version 13.0 or higher

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -35,6 +35,7 @@ import subprocess
 import sys
 import tempfile
 
+from asyncpg import serverversion
 
 from edb.common import debug
 from edb.common import devmode
@@ -70,32 +71,68 @@ def get_build_metadata_value(prop: str) -> str:
             f'could not find {prop} in EdgeDB distribution metadata') from None
 
 
-def get_pg_config_path() -> pathlib.Path:
-    if devmode.is_in_dev_mode():
-        root = pathlib.Path(__file__).parent.parent
-        pg_config = (root / 'build' / 'postgres' /
-                     'install' / 'bin' / 'pg_config').resolve()
-        if not pg_config.is_file():
-            try:
-                pg_config = pathlib.Path(
-                    get_build_metadata_value('PG_CONFIG_PATH'))
-            except MetadataError:
-                pass
+def _get_devmode_pg_config_path() -> pathlib.Path:
+    root = pathlib.Path(__file__).parent.parent.resolve()
+    pg_config = root / 'build' / 'postgres' / 'install' / 'bin' / 'pg_config'
+    if not pg_config.is_file():
+        try:
+            pg_config = pathlib.Path(
+                get_build_metadata_value('PG_CONFIG_PATH'))
+        except MetadataError:
+            pass
 
-        if not pg_config.is_file():
-            raise MetadataError('DEV mode: Could not find PostgreSQL build, '
-                                'run `pip install -e .`')
-
-    else:
-        pg_config = pathlib.Path(
-            get_build_metadata_value('PG_CONFIG_PATH'))
-
-        if not pg_config.is_file():
-            raise MetadataError(
-                f'invalid pg_config path: {pg_config!r}: file does not exist '
-                f'or is not a regular file')
+    if not pg_config.is_file():
+        raise MetadataError('DEV mode: Could not find PostgreSQL build, '
+                            'run `pip install -e .`')
 
     return pg_config
+
+
+def get_pg_config_path() -> pathlib.Path:
+    if devmode.is_in_dev_mode():
+        pg_config = _get_devmode_pg_config_path()
+    else:
+        try:
+            pg_config = pathlib.Path(
+                get_build_metadata_value('PG_CONFIG_PATH'))
+        except MetadataError:
+            pg_config = _get_devmode_pg_config_path()
+        else:
+            if not pg_config.is_file():
+                raise MetadataError(
+                    f'invalid pg_config path: {pg_config!r}: file does not '
+                    f'exist or is not a regular file')
+
+    return pg_config
+
+
+_bundled_pg_version = None
+
+
+def get_pg_version() -> Tuple[serverversion.ServerVersion, str]:
+    global _bundled_pg_version
+    if _bundled_pg_version is not None:
+        return _bundled_pg_version
+
+    pg_config = subprocess.run(
+        [get_pg_config_path()],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    for line in pg_config.stdout.splitlines():
+        k, eq, v = line.partition('=')
+        if eq and k.strip().lower() == 'version':
+            v = v.strip()
+            _bundled_pg_version = (
+                serverversion.split_server_version_string(v),
+                v,
+            )
+            return _bundled_pg_version
+    else:
+        raise MetadataError(
+            "could not find version information in pg_config output")
 
 
 def get_runstate_path(data_dir: pathlib.Path) -> pathlib.Path:

--- a/edb/pgsql/params.py
+++ b/edb/pgsql/params.py
@@ -48,9 +48,20 @@ ALL_BACKEND_CAPABILITIES = (
 )
 
 
+class BackendVersion(NamedTuple):
+
+    major: int
+    minor: int
+    micro: int
+    releaselevel: str
+    serial: int
+    string: str
+
+
 class BackendInstanceParams(NamedTuple):
 
     capabilities: BackendCapabilities
+    version: BackendVersion
     tenant_id: str
     base_superuser: Optional[str] = None
     max_connections: int = 500
@@ -113,6 +124,19 @@ def get_default_runtime_params(
     if 'tenant_id' not in instance_params:
         instance_params = dict(
             tenant_id=buildmeta.get_default_tenant_id(),
+            **instance_params,
+        )
+    if 'version' not in instance_params:
+        parsed_ver, ver_string = buildmeta.get_pg_version()
+        instance_params = dict(
+            version=BackendVersion(
+                major=parsed_ver.major,
+                minor=parsed_ver.minor,
+                micro=parsed_ver.micro,
+                releaselevel=parsed_ver.releaselevel,
+                serial=parsed_ver.serial,
+                string=ver_string,
+            ),
             **instance_params,
         )
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,6 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 EDGEDB_CATALOG_VERSION = buildmeta.EDGEDB_CATALOG_VERSION
+MIN_POSTGRES_VERSION = (13, 0)
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -553,7 +553,8 @@ async def run_server(
                 cluster.destroy()
 
             elif pg_cluster_started_by_us:
-                await cluster.stop()
+                if await cluster.get_status() == 'running':
+                    await cluster.stop()
 
 
 def bump_rlimit_nofile() -> None:

--- a/edb/server/pgcluster.py
+++ b/edb/server/pgcluster.py
@@ -1011,8 +1011,19 @@ async def get_remote_pg_cluster(
                     "The remote backend doesn't support CREATE DATABASE; "
                     "multi-tenancy is disabled."
                 )
+
+        parsed_ver = conn.get_server_version()
+        ver_string = conn.get_settings().server_version
         instance_params = pgparams.BackendInstanceParams(
             capabilities=capabilities,
+            version=pgparams.BackendVersion(
+                major=parsed_ver.major,
+                minor=parsed_ver.minor,
+                micro=parsed_ver.micro,
+                releaselevel=parsed_ver.releaselevel,
+                serial=parsed_ver.serial,
+                string=ver_string,
+            ),
             base_superuser=superuser_name,
             max_connections=int(max_connections),
             reserved_connections=await _get_reserved_connections(conn),


### PR DESCRIPTION
Formally establish PostgreSQL 13 as the minimum required version to run
EdgeDB.  While version 12 mostly works, there are numerous issues with
tuple types in that version.  EdgeDB will now refuse to start if the
PostgreSQL cluster specified by `--remote-dsn` is older than 13.0.