### PR TITLE
workflows: Remove Postgres 12 from the test matrix

### DIFF
--- a/.github/workflows.src/tests-pg-versions.tpl.yml
+++ b/.github/workflows.src/tests-pg-versions.tpl.yml
@@ -34,8 +34,6 @@ jobs:
          - 'NOCREATEDB NOCREATEROLE'
          - 'CREATEDB NOCREATEROLE'
         include:
-          - postgres-version: 12
-            single-mode: ''
           - postgres-version: 14
             single-mode: ''
     services:

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -310,8 +310,6 @@ jobs:
          - 'NOCREATEDB NOCREATEROLE'
          - 'CREATEDB NOCREATEROLE'
         include:
-          - postgres-version: 12
-            single-mode: ''
           - postgres-version: 14
             single-mode: ''
     services:


### PR DESCRIPTION
Now that the minimum requirement has been bumped to 13, remove 12 from
the test matrix.