### PR TITLE
Decouple Postgres password in single-user mode

### DIFF
--- a/.github/workflows.src/tests-managed-pg.tpl.yml
+++ b/.github/workflows.src/tests-managed-pg.tpl.yml
@@ -436,26 +436,10 @@ jobs:
 
     # Run the test
 
-    - name: Change Heroku Postgres password
-      shell: python
-      id: passwd
-      run: |
-        import asyncio, asyncpg, urllib.parse
-        async def main():
-            dsn = "${{ steps.pgdsn.outputs.stdout }}"
-            p = urllib.parse.urlparse(dsn)
-            conn = await asyncpg.connect(dsn)
-            await conn.execute(f"""\
-                ALTER ROLE {p.username} PASSWORD 'test';
-            """)
-            p = p._replace(netloc=f'{p.username}:test@{p.hostname}')
-            print(f'::set-output name=pgdsn::{p.geturl()}')
-        asyncio.run(main())
-
     - name: Test
       env:
         EDGEDB_TEST_BACKEND_VENDOR: heroku-postgres
-        EDGEDB_TEST_BACKEND_DSN: ${{ steps.passwd.outputs.pgdsn }}
+        EDGEDB_TEST_BACKEND_DSN: ${{ steps.pgdsn.outputs.stdout }}
       run: |
         edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         edb test -j1 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN

--- a/.github/workflows/tests-managed-pg.yml
+++ b/.github/workflows/tests-managed-pg.yml
@@ -1354,26 +1354,10 @@ jobs:
 
     # Run the test
 
-    - name: Change Heroku Postgres password
-      shell: python
-      id: passwd
-      run: |
-        import asyncio, asyncpg, urllib.parse
-        async def main():
-            dsn = "${{ steps.pgdsn.outputs.stdout }}"
-            p = urllib.parse.urlparse(dsn)
-            conn = await asyncpg.connect(dsn)
-            await conn.execute(f"""\
-                ALTER ROLE {p.username} PASSWORD 'test';
-            """)
-            p = p._replace(netloc=f'{p.username}:test@{p.hostname}')
-            print(f'::set-output name=pgdsn::{p.geturl()}')
-        asyncio.run(main())
-
     - name: Test
       env:
         EDGEDB_TEST_BACKEND_VENDOR: heroku-postgres
-        EDGEDB_TEST_BACKEND_DSN: ${{ steps.passwd.outputs.pgdsn }}
+        EDGEDB_TEST_BACKEND_DSN: ${{ steps.pgdsn.outputs.stdout }}
       run: |
         edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         edb test -j1 -v --backend-dsn=$EDGEDB_TEST_BACKEND_DSN

--- a/edb/pgsql/dbops/roles.py
+++ b/edb/pgsql/dbops/roles.py
@@ -92,7 +92,10 @@ class RoleExists(base.Condition):
 
 class RoleCommand:
 
-    def _render(self):
+    def _role(self):
+        return f'ROLE {self.object.get_id()}'
+
+    def _attrs(self):
         attrs = []
 
         attrmap = {
@@ -116,7 +119,7 @@ class RoleCommand:
         elif self.object.password is not base.NotSpecified:
             attrs.append(f'PASSWORD {ql(self.object.password)}')
 
-        return f'ROLE {self.object.get_id()} {" ".join(attrs)}'
+        return " ".join(attrs)
 
 
 class CreateRole(ddl.CreateObject, RoleCommand):
@@ -132,13 +135,17 @@ class CreateRole(ddl.CreateObject, RoleCommand):
             members = f'ROLE {roles}'
         else:
             members = ''
-        return f'CREATE {self._render()} {membership} {members}'
+        return f'CREATE {self._role()} {self._attrs()} {membership} {members}'
 
 
 class AlterRole(ddl.AlterObject, RoleCommand):
 
     def code(self, block: base.PLBlock) -> str:
-        return f'ALTER {self._render()}'
+        attrs = self._attrs()
+        if attrs:
+            return f'ALTER {self._role()} {attrs}'
+        else:
+            return ''
 
     def generate_extra(self, block: base.PLBlock) -> None:
         super().generate_extra(block)

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -5516,7 +5516,9 @@ class AlterRole(MetaCommand, RoleMixin, adapts=s_roles.AlterRole):
         kwargs = {}
         if self.has_attribute_value('password'):
             passwd = self.get_attribute_value('password')
-            kwargs['password'] = passwd
+            if backend_params.has_create_role:
+                # Only modify Postgres password of roles managed by EdgeDB
+                kwargs['password'] = passwd
             kwargs['metadata'] = dict(
                 id=str(role.id),
                 name=role_name,

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -7119,6 +7119,35 @@ type default::Foo {
             }]
         )
 
+    async def test_edgeql_ddl_role_05(self):
+        if self.has_create_role:
+            self.skipTest("create role is supported by the backend")
+        con = await self.connect()
+        try:
+            await con.execute("""
+                ALTER ROLE edgedb SET password := 'test_role_05'
+            """)
+            if self.has_create_database:
+                await con.execute("""CREATE DATABASE test_role_05""")
+        finally:
+            await con.aclose()
+        args = {'password': "test_role_05"}
+        if self.has_create_database:
+            args['database'] = "test_role_05"
+        con = await self.connect(**args)
+        try:
+            await con.execute("""
+                ALTER ROLE edgedb SET password := 'test'
+            """)
+        finally:
+            await con.aclose()
+        con = await self.connect()
+        try:
+            if self.has_create_database:
+                await con.execute("""DROP DATABASE test_role_05""")
+        finally:
+            await con.aclose()
+
     async def test_edgeql_ddl_describe_roles(self):
         if not self.has_create_role:
             self.skipTest("create role is not supported by the backend")


### PR DESCRIPTION
Changing the password of `edgedb` in single-user mode will now affect
only the global metadata. The password of the actual backend Postgres
user is not affected.

Closes #3341