### PR TITLE
Hang on to definition site remappings in _get_computable_ctx

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1495,6 +1495,13 @@ def _get_computable_ctx(
 
             subctx.pending_stmt_full_path_id_namespace = frozenset(subns)
 
+            # If one of the sources present at the definition site is still
+            # visible, make sure to hang on to the remapping.
+            for entry in qlctx.view_map.values():
+                for map_path_id, remapped in entry:
+                    if subctx.path_scope.is_visible(map_path_id):
+                        update_view_map(map_path_id, remapped, ctx=subctx)
+
             inner_path_id = inner_source_path_id.merge_namespace(subns)
             with subctx.new() as remapctx:
                 remapctx.path_id_namespace |= subns

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -1046,11 +1046,13 @@ class ScopeTreeNode:
     def dump(self) -> None:
         print(self.pdebugformat())
 
-    def dump_full(self) -> None:
+    def dump_full(self, others: Collection[ScopeTreeNode]=()) -> None:
         """Do a debug dump of the root but hilight the current node."""
         styles = {}
         if term.supports_colors(sys.stdout.fileno()):
             styles[self] = term.Style16(color='magenta', bold=True)
+            for other in others:
+                styles[other] = term.Style16(color='blue', bold=True)
         print(self.root.pdebugformat(styles=styles))
 
     def _set_parent(self, parent: Optional[ScopeTreeNode]) -> None:

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -3273,6 +3273,35 @@ class TestEdgeQLScope(tb.QueryTestCase):
         self.assertEqual(len(res), 9)
         self.assertTrue(set(res).issubset(baseline))
 
+    async def test_edgeql_scope_ref_outer_08(self):
+        await self.assert_query_result(
+            """
+            SELECT User { avatar := .avatar {
+                tag := User.name ++ ' - ' ++ .name
+            } }
+            ORDER BY .avatar.tag
+            """,
+            [
+                {"avatar": None},
+                {"avatar": None},
+                {"avatar": {"tag": "Alice - Dragon"}},
+                {"avatar": {"tag": "Dave - Djinn"}}
+            ]
+        )
+
+    async def test_edgeql_scope_ref_outer_09(self):
+        await self.assert_query_result(
+            """
+            SELECT User { avatar := .avatar {
+                tag := User.name ++ ' - ' ++ .name
+            } }
+            FILTER .avatar.tag != 'Dave - Djinn'
+            """,
+            [
+                {"avatar": {"tag": "Alice - Dragon"}},
+            ]
+        )
+
     async def test_edgeql_scope_ref_side_01(self):
         await self.assert_query_result(
             """


### PR DESCRIPTION
This fixes a regression introduced by #3305, which (correctly, sort
of) made some cases not materialize, except that the
non-materialization case didn't work.