### PR TITLE
Fix incorrect context in reserialize_object

### DIFF
--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -1104,7 +1104,7 @@ def reserialize_object(
     tref = pgast.ColumnRef(name=[el.colname], is_packed_multi=el.multi)
 
     with ctx.subrel() as subctx:
-        sub_rvar = unpack_var(subctx.rel, tel.path_id, ref=tref, ctx=ctx)
+        sub_rvar = unpack_var(subctx.rel, tel.path_id, ref=tref, ctx=subctx)
     reqry = sub_rvar.query
     assert isinstance(reqry, pgast.Query)
     rptr = tel.path_id.rptr()

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -544,7 +544,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
-    @test.xfail("Eta-expansion breaks somehow with link properties")
     async def test_edgeql_scope_tuple_05b(self):
         # Similar to above tests, but forcing use of eta-expansion
         await self.assert_query_result(


### PR DESCRIPTION
This was breaking things for me in my in-progress GROUP work,
but it looks like it also fixes an xfailed test.