### PR TITLE
Turn some pgsql.context sets into frozensets

### DIFF
--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -135,11 +135,11 @@ class CompilerContextLevel(compiler.ContextLevel):
     current_insert_path_id: Optional[irast.PathId]
 
     #: Paths, for which semi-join is banned in this context.
-    disable_semi_join: Set[irast.PathId]
+    disable_semi_join: FrozenSet[irast.PathId]
 
     #: Paths, which need to be explicitly wrapped into SQL
     #: optionality scaffolding.
-    force_optional: Set[irast.PathId]
+    force_optional: FrozenSet[irast.PathId]
 
     #: Specifies that references to a specific Set must be narrowed
     #: by only selecting instances of type specified by the mapping value.
@@ -229,8 +229,8 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.volatility_ref = ()
             self.current_insert_path_id = None
 
-            self.disable_semi_join = set()
-            self.force_optional = set()
+            self.disable_semi_join = frozenset()
+            self.force_optional = frozenset()
             self.intersection_narrowing = {}
 
             self.path_scope = collections.ChainMap()
@@ -265,8 +265,8 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.volatility_ref = prevlevel.volatility_ref
             self.current_insert_path_id = prevlevel.current_insert_path_id
 
-            self.disable_semi_join = prevlevel.disable_semi_join.copy()
-            self.force_optional = prevlevel.force_optional.copy()
+            self.disable_semi_join = prevlevel.disable_semi_join
+            self.force_optional = prevlevel.force_optional
             self.intersection_narrowing = prevlevel.intersection_narrowing
 
             self.path_scope = prevlevel.path_scope
@@ -310,8 +310,8 @@ class CompilerContextLevel(compiler.ContextLevel):
                 self.rel_hierarchy = {}
                 self.scope_tree = prevlevel.scope_tree.root
 
-                self.disable_semi_join = set()
-                self.force_optional = set()
+                self.disable_semi_join = frozenset()
+                self.force_optional = frozenset()
                 self.intersection_narrowing = {}
                 self.pending_type_ctes = set(prevlevel.pending_type_ctes)
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -986,7 +986,7 @@ def compile_insert_shape_element(
         assert shape_el.rptr is not None
         if (shape_el.rptr.dir_cardinality
                 is qltypes.Cardinality.AT_MOST_ONE):
-            insvalctx.force_optional.add(shape_el.path_id)
+            insvalctx.force_optional |= {shape_el.path_id}
 
         if iterator_id is not None:
             id = iterator_id
@@ -1955,7 +1955,7 @@ def process_link_values(
             input_rel_ctx.shapes_needed_by_dml.add(shape_expr)
 
             if ptr_is_required and enforce_cardinality:
-                input_rel_ctx.force_optional.add(ir_expr.path_id)
+                input_rel_ctx.force_optional |= {ir_expr.path_id}
 
             dispatch.visit(ir_expr, ctx=input_rel_ctx)
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -907,12 +907,14 @@ def process_set_as_path(
 
     if is_linkprop:
         backtrack_src = ir_source
-        ctx.disable_semi_join.add(backtrack_src.path_id)
+        new_paths = {backtrack_src.path_id}
 
         assert backtrack_src.rptr
         while backtrack_src.path_id.is_type_intersection_path():
             backtrack_src = backtrack_src.rptr.source
-            ctx.disable_semi_join.add(backtrack_src.path_id)
+            new_paths.add(backtrack_src.path_id)
+
+        ctx.disable_semi_join |= new_paths
 
     semi_join = (
         not source_is_visible and
@@ -2089,7 +2091,7 @@ def process_set_as_existence_assertion(
         # The solution to assert_exists() is as simple as
         # calling raise_on_null().
         newctx.expr_exposed = False
-        newctx.force_optional.add(ir_arg_set.path_id)
+        newctx.force_optional |= {ir_arg_set.path_id}
         pathctx.put_path_id_map(newctx.rel, ir_set.path_id, ir_arg_set.path_id)
         arg_ref = dispatch.compile(ir_arg_set, ctx=newctx)
         arg_val = output.output_as_value(arg_ref, env=newctx.env)

--- a/edb/pgsql/compiler/shapecomp.py
+++ b/edb/pgsql/compiler/shapecomp.py
@@ -56,7 +56,7 @@ def compile_shape(
             pgast.NullTest(arg=var, negated=True))
 
     with ctx.newscope() as shapectx:
-        shapectx.disable_semi_join.add(ir_set.path_id)
+        shapectx.disable_semi_join |= {ir_set.path_id}
 
         if isinstance(ir_set.expr, irast.Stmt):
             # The source set for this shape is a FOR statement,


### PR DESCRIPTION
disable_semi_join and force_optional were being copied on every new
context. Make them frozensets and use `|=` to add elements so that we
only copy when things are actually added.