### PR TITLE
Reflect more complex aliases.

### DIFF
--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -1258,13 +1258,6 @@ class GQLCoreSchema:
                 # The aliased types actually only reflect as an object
                 # type, but the rest of the processing is identical to
                 # interfaces.
-                if '~' in gql_name:
-                    # These are internal aliases, but they define the
-                    # actual shapes we need to reflect.
-                    gql_name = '_edb' + gql_name.replace('|', '_') \
-                                                .replace('@', '_') \
-                                                .replace('~', '_')
-
                 self._gql_objtypes_from_alias[t_name] = GraphQLObjectType(
                     name=gql_name,
                     fields=partial(self.get_fields, t_name),

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -1258,6 +1258,13 @@ class GQLCoreSchema:
                 # The aliased types actually only reflect as an object
                 # type, but the rest of the processing is identical to
                 # interfaces.
+                if '~' in gql_name:
+                    # These are internal aliases, but they define the
+                    # actual shapes we need to reflect.
+                    gql_name = '_edb' + gql_name.replace('|', '_') \
+                                                .replace('@', '_') \
+                                                .replace('~', '_')
+
                 self._gql_objtypes_from_alias[t_name] = GraphQLObjectType(
                     name=gql_name,
                     fields=partial(self.get_fields, t_name),

--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -74,6 +74,12 @@ alias ProfileAlias := Profile {
     owner := .<profile
 };
 
+alias TwoUsers := (
+    select User {
+        initial := .name[0],
+    } order by .name limit 2
+);
+
 type Person extending User;
 
 scalar type positive_int_t extending int64 {

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -906,6 +906,52 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             },
         )
 
+    def test_graphql_functional_alias_07(self):
+        self.assert_graphql_query_result(
+            r"""
+                {
+                    TwoUsers {
+                        name
+                        initial
+                    }
+                }
+            """,
+            {
+                "TwoUsers": [
+                    {
+                        "name": "Alice",
+                        "initial": "A",
+                    },
+                    {
+                        "name": "Bob",
+                        "initial": "B",
+                    },
+                ],
+            },
+        )
+
+    def test_graphql_functional_alias_08(self):
+        self.assert_graphql_query_result(
+            r"""
+                {
+                    TwoUsers(
+                        filter: {initial: {eq: "A"}}
+                    ) {
+                        name
+                        initial
+                    }
+                }
+            """,
+            {
+                "TwoUsers": [
+                    {
+                        "name": "Alice",
+                        "initial": "A",
+                    },
+                ],
+            },
+        )
+
     def test_graphql_functional_arguments_01(self):
         result = self.graphql_query(r"""
             query {


### PR DESCRIPTION
Aliases using objects, filters and other clauses should be reflected
into GraphQL.

Issue #3347