### PR TITLE
Update quickstart docs to use correct query

### DIFF
--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -409,7 +409,7 @@ at the end, anything after ``blade runner`` will match: "Blade Runner",
   .......     title,
   .......     year
   ....... }
-  ....... filter .title = "Blade Runner 2049";
+  ....... filter .title ILIKE 'blade runner%';
   {default::Movie {title: 'Blade Runner 2049', year: 2017}}
 
 Let's get more details about the ``Movie``:


### PR DESCRIPTION
Update `docs > guides > quickstart.rst > 5. Run some queries`.

Fix the filter to use `ILIKE`, like the paragraph above the code sample explains.