### PR TITLE
Optimize optional compilation of simple paths

### DIFF
--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -21,6 +21,8 @@
 
 from __future__ import annotations
 from typing import *
+if TYPE_CHECKING:
+    from typing_extensions import TypeGuard
 
 import json
 
@@ -188,7 +190,7 @@ def is_implicit_wrapper(ir_expr: irast.Base) -> bool:
     )
 
 
-def is_trivial_select(ir_expr: irast.Base) -> bool:
+def is_trivial_select(ir_expr: irast.Base) -> TypeGuard[irast.SelectStmt]:
     """Return True if the given *ir_expr* expression is a trivial
        SELECT expression, i.e `SELECT <expr>`.
     """

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -504,7 +504,7 @@ def can_omit_optional_wrapper(
     is visible and bar is a single non-computed property, which we know
     will be stored as NULL in the database.
     """
-    if (
+    return (
         ir_set.expr is None
         and not ir_set.path_id.is_objtype_path()
         and ir_set.rptr
@@ -512,10 +512,7 @@ def can_omit_optional_wrapper(
         and not ir_set.rptr.is_inbound
         and ir_set.rptr.ptrref.out_cardinality.is_single()
         and not ir_set.rptr.ptrref.is_computable
-    ):
-        return True
-
-    return False
+    )
 
 
 def prepare_optional_rel(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -504,7 +504,7 @@ def can_omit_optional_wrapper(
     is visible and bar is a single non-computed property, which we know
     will be stored as NULL in the database.
     """
-    return (
+    return bool(
         ir_set.expr is None
         and not ir_set.path_id.is_objtype_path()
         and ir_set.rptr

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -500,10 +500,19 @@ def can_omit_optional_wrapper(
     Doing so is safe when the expression is guarenteed to result in
     a NULL and not an empty set.
 
-    Currently the only such case implement is a path `foo.bar` where foo
+    The main such case implemented is a path `foo.bar` where foo
     is visible and bar is a single non-computed property, which we know
     will be stored as NULL in the database.
+
+    We also handle trivial SELECTs wrapping such an expression.
     """
+    if ir_set.expr and irutils.is_trivial_select(ir_set.expr):
+        return can_omit_optional_wrapper(
+            ir_set.expr.result,
+            relctx.get_scope(ir_set.expr.result, ctx=ctx) or new_scope,
+            ctx=ctx,
+        )
+
     return bool(
         ir_set.expr is None
         and not ir_set.path_id.is_objtype_path()


### PR DESCRIPTION
Currently we put an optional wrapper around optional arguments in all
cases, include ones such as
`SELECT Issue { te :=  .time_estimate ?? -1 }` in which it would be sound
to simply rely on time_estimate being stored as NULL in the database
and omit the optional wrapper.

We can omit the optional wrapper when the argument is a path in which
the LHS is visible and the pointer is a single non-computed property.