### PR TITLE
Fix non-singleton arrays inside materialized objects

### DIFF
--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -946,7 +946,10 @@ def unpack_var(
                 ctr += 1
 
                 typ = pg_types.pg_type_from_ir_typeref(el_id.target)
-                if el_id.target.id in ctx.env.materialized_views:
+                if (
+                    el_id.target.id in ctx.env.materialized_views
+                    or el_id.is_array_path()
+                ):
                     typ = ('record',)
                     must_pack = True
 

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -946,14 +946,16 @@ def unpack_var(
                 ctr += 1
 
                 typ = pg_types.pg_type_from_ir_typeref(el_id.target)
-                if (
-                    el_id.target.id in ctx.env.materialized_views
-                    or el_id.is_array_path()
-                ):
+                if el_id.target.id in ctx.env.materialized_views:
                     typ = ('record',)
                     must_pack = True
 
                 if not is_singleton:
+                    # Arrays get wrapped in a record before they can be put
+                    # in another array
+                    if el_id.is_array_path():
+                        typ = ('record',)
+                        must_pack = True
                     typ = pg_types.pg_type_array(typ)
 
                 coldeflist.append(

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -1637,6 +1637,17 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
                 for tgt in obj['tgt']:
                     self.assertEqual(tgt['x'], -tgt['y'])
 
+    async def test_edgeql_volatility_shape_array_01(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH X := { multi x := [next()] },
+                SELECT ((SELECT X.x), (SELECT X.x));
+            """)
+
+            self.assertEqual(len(res), 1)
+            for obj in res:
+                self.assertEqual(obj[0], obj[1])
+
     async def test_edgeql_volatility_errors_01(self):
         async with self._run_and_rollback():
             with self.assertRaisesRegex(

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -1648,6 +1648,17 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             for obj in res:
                 self.assertEqual(obj[0], obj[1])
 
+    async def test_edgeql_volatility_shape_array_02(self):
+        for query in self.test_loop():
+            res = await query("""
+                WITH X := { x := [next()] },
+                SELECT ((SELECT X.x), (SELECT X.x));
+            """)
+
+            self.assertEqual(len(res), 1)
+            for obj in res:
+                self.assertEqual(obj[0], obj[1])
+
     async def test_edgeql_volatility_errors_01(self):
         async with self._run_and_rollback():
             with self.assertRaisesRegex(


### PR DESCRIPTION
Non-singleton pointers get wrapped in an array, we wrap arrays in a
record before putting them in another array. We need to handle that at
the unpack site also.