### PR TITLE
docs: Fix an incorrect statement about inheritance

### DIFF
--- a/docs/datamodel/objects.rst
+++ b/docs/datamodel/objects.rst
@@ -102,8 +102,8 @@ types out of combinations of more basic types.
     property profession -> str;
   }
 
-Name conflicts are not allowed; supertypes cannot share any link or property
-names.
+If multiple supertypes share links or properties, those properties must be
+of the same type and cardinality.
 
 
 .. note::


### PR DESCRIPTION
Pointer name overlap in supertypes is, in fact, allowed if those
pointers have the same type and cardinality.