### PR TITLE
Add an assertion that materialized references are not duplicated

### DIFF
--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -323,6 +323,10 @@ def _fixup_materialized_sets(
                 subctx.path_scope = new_scope
                 viewgen.late_compile_view_shapes(ir_set, ctx=subctx)
 
+            for use_set in mat_set.use_sets:
+                if use_set != mat_set.materialized:
+                    use_set.is_materialized_ref = True
+
             assert (
                 not any(use.src_path() for use in mat_set.uses)
                 or mat_set.materialized.rptr

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -476,6 +476,8 @@ class Set(Base):
     shape_source: typing.Optional[Set] = None
     is_binding: typing.Optional[BindingKind] = None
 
+    is_materialized_ref: bool = False
+
     def __repr__(self) -> str:
         return f'<ir.Set \'{self.path_id}\' at 0x{id(self):x}>'
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1226,6 +1226,9 @@ def process_set_as_subquery(
 
             return _new_subquery_stmt_set_rvar(ir_set, stmt, ctx=ctx)
 
+        # materialized refs should always get picked up by now
+        assert not ir_set.is_materialized_ref
+
         if inner_id != outer_id:
             pathctx.put_path_id_map(ctx.rel, outer_id, inner_id)
 

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -1155,6 +1155,16 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
 
             self.assertEqual(len(res), 4)
 
+    @test.xfail('''
+        Fails the `not ir_set.is_materialized_ref` assertion
+
+        Before that assertion the test was passing, though it was
+        also calling next() too many times.
+    ''')
+    async def test_edgeql_volatility_select_nested_06e(self):
+        # here we want some deduplicating to happen
+        # same as above but with an extra select
+        for query in self.test_loop():
             res = await query("""
                 WITH O := (SELECT (SELECT Obj {
                          friends := (SELECT Tgt { x := next() })


### PR DESCRIPTION
This turns some cases that are currently miscompiled into ones
that trigger an ISE, which is an improvement.