### PR TITLE
Reduce the number of calls to delta_schema in the migration happy path

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -810,7 +810,6 @@ class Compiler:
             )
 
             context = self._new_delta_context(ctx)
-            orig_schema = schema
             schema = delta.apply(schema, context=context)
 
             if mstate.last_proposed:
@@ -1160,8 +1159,10 @@ class Compiler:
                         if mstate.parent_migration is not None
                         else 'initial'
                     ),
-                    'complete': not proposed_desc and s_ddl.schemas_are_equal(
-                        schema, mstate.target_schema),
+                    'complete': (
+                        proposed_desc is None
+                        and s_ddl.schemas_are_equal(
+                            schema, mstate.target_schema)),
                     'confirmed': confirmed,
                     'proposed': proposed_desc,
                 }).encode('unicode_escape').decode('utf-8')

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -315,7 +315,7 @@ class MigrationState(NamedTuple):
     target_schema: s_schema.Schema
     guidance: s_obj.DeltaGuidance
     accepted_cmds: Tuple[qlast.Command, ...]
-    last_proposed: Tuple[ProposedMigrationStep, ...]
+    last_proposed: Optional[Tuple[ProposedMigrationStep, ...]]
 
 
 class TransactionState(NamedTuple):


### PR DESCRIPTION
Get rid of all calls to schemas_are_equal except to check if a migration
is complete once we already think it should be. Also, distinguish between
the "we have nothing proposed" case and the "we have consumed all proposed
advice" case, which saves one schema diff at the end.

This brings the time to migrate to constraints.esdl down on my machine
from 78s to 12s.