### PR TITLE
add `SHOULD_RETRY` tag to `TransactionConflictError` inheritors

### DIFF
--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -120,8 +120,8 @@
 
 0x_05_03_00_00   TransactionError
 0x_05_03_01_00   TransactionConflictError  #SHOULD_RETRY
-0x_05_03_01_01   TransactionSerializationError
-0x_05_03_01_02   TransactionDeadlockError
+0x_05_03_01_01   TransactionSerializationError  #SHOULD_RETRY
+0x_05_03_01_02   TransactionDeadlockError  #SHOULD_RETRY
 
 
 ####

--- a/edb/tools/gen_errors.py
+++ b/edb/tools/gen_errors.py
@@ -181,6 +181,9 @@ class ErrorsTree:
 
             self.add(desc)
 
+    def get_errors(self):
+        return self._tree
+
     def get_parent(self, code):
         b1, b2, b3, b4 = code
 

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -17,9 +17,12 @@
 #
 
 
+import pathlib
 import unittest
 
+import edb
 from edb import errors
+from edb.tools import gen_errors
 
 
 class TestErrorsClasses(unittest.TestCase):
@@ -59,3 +62,20 @@ class TestErrorsClasses(unittest.TestCase):
         # intended for client libraries.
 
         self.assertFalse(hasattr(errors, 'ClientError'))
+
+
+class TestErrorsTags(unittest.TestCase):
+    errors_path = pathlib.Path(edb.__path__[0]) / 'api' / 'errors.txt'
+
+    def test_api_errors_tags_01(self):
+        tree = gen_errors.ErrorsTree()
+        tree.load(self.errors_path)
+
+        for (code, desc) in tree.get_errors().items():
+            parent = tree.get_parent(code)
+            if parent is None:
+                continue
+
+            self.assertTrue(
+                all(tag in desc.tags for tag in parent.tags),
+                f"{desc.name} error doesn't inherit all {parent.name} tags")


### PR DESCRIPTION
This is a small change, but I think it might be useful. I needed it for my driver so that I didn't have to invent a tag inheritance mechanism when generating errors.

`ClientConnectionFailedTemporarilyError` and its inheritors have tag duplication for this case:
https://github.com/edgedb/edgedb/blob/master/edb/api/errors.txt#L165-L167

Similar to the `TransactionConflictError` exception and its inheritors in the python driver:
https://github.com/edgedb/edgedb-python/blob/master/edgedb/errors/__init__.py#L375-L387