### PR TITLE
Fix incorrect .esdl file name in projects docs

### DIFF
--- a/docs/guides/projects.rst
+++ b/docs/guides/projects.rst
@@ -43,7 +43,7 @@ Let's unpack that.
    <ref_cli_edgedb_paths>`—feel free to peek inside to see how it's stored.
 5. Then it creates an ``edgedb.toml`` file, which marks this directory as an
    EdgeDB project.
-6. Finally, it creates a ``dbschema`` directory and a ``dbschema/schema.esdl``
+6. Finally, it creates a ``dbschema`` directory and a ``dbschema/default.esdl``
    schema file (if they don't already exist).
 
 


### PR DESCRIPTION
In the Quickstart guide [here](https://www.edgedb.com/docs/guides/quickstart#initialize-a-project) it's mentioned that the default esdl file will be created as `default.esdl`.

In the Projects docs here mentions the file `schema.esdl` will be created.

This PR fixes the Project docs default esdl file name.