### PR TITLE
Fix typo in abstract type name in docs

### DIFF
--- a/docs/datamodel/objects.rst
+++ b/docs/datamodel/objects.rst
@@ -94,7 +94,7 @@ types out of combinations of more basic types.
     property last_name -> str;
   }
 
-  abstract type Email {
+  abstract type HasEmail {
     property email -> str;
   }
 


### PR DESCRIPTION
The extended abstracted type was used as `HasEmail` but was delcared as `Email`