### PR TITLE
Bump bundled Postgres to 14.2

### DIFF
--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2169,11 +2169,6 @@ class TestExpressions(tb.QueryTestCase):
             [True]
         )
 
-    @test.xfail(
-        "Postgres 14 crashes with 'could not identify a hash function for "
-        "type record'",
-        unless=int(os.getenv("EDGEDB_TEST_POSTGRES_VERSION", "13")) < 14,
-    )
     async def test_edgeql_expr_valid_collection_15(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -4431,10 +4431,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [{'number': '1'}, {'number': '4'}],
         )
 
-    @test.xfail(
-        "Known issue in Postgres 14",
-        unless=int(os.getenv("EDGEDB_TEST_POSTGRES_VERSION", "13")) < 14
-    )
     async def test_edgeql_select_subqueries_07(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
The Memoize and record hashing regressions were fixed in 14.2, so we can
upgrade now.