### PR TITLE
Fix backlink documentation

### DIFF
--- a/docs/datamodel/computeds.rst
+++ b/docs/datamodel/computeds.rst
@@ -110,7 +110,7 @@ to traverse a link in the *reverse* direction.
 
   type User {
     property name -> str;
-    blog_posts := .<author[is BlogPost]
+    multi link blog_posts := .<author[is BlogPost]
   }
 
 The ``User.blog_posts`` expression above uses the *backlink operator* ``.<`` in


### PR DESCRIPTION
In the example the link keyword is omitted and the example as presented here errors on migration