### PR TITLE
Fix crash when filtering on a composite exclusive constraint

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -940,14 +940,15 @@ def extract_exclusive_filters(
 
     results: List[Tuple[Tuple[s_pointers.Pointer, irast.Set], ...]] = []
     if filtered_ptrs:
-        filtered_ptrs_map = dict(filtered_ptrs)
         schema = ctx.env.schema
-        ptr_set = set()
+        filtered_ptrs_map = {
+            ptr.get_nearest_non_derived_parent(schema): expr
+            for ptr, expr in filtered_ptrs
+        }
+        ptr_set = set(filtered_ptrs_map)
         # First look at each referenced pointer and see if it has
         # an exclusive constraint.
-        for ptr, expr in filtered_ptrs:
-            ptr = ptr.get_nearest_non_derived_parent(schema)
-            ptr_set.add(ptr)
+        for ptr, expr in filtered_ptrs_map.items():
             for constr in ptr.get_exclusive_constraints(schema):
                 # Bingo, got an equality filter on a pointer with a
                 # unique constraint

--- a/tests/schemas/constraints.esdl
+++ b/tests/schemas/constraints.esdl
@@ -257,3 +257,9 @@ type PropertyContainer {
         constraint exclusive
     }
 }
+
+type Pair {
+    required property x -> str;
+    required property y -> str;
+    constraint exclusive on (( .x, .y ));
+}

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -368,6 +368,19 @@ class TestConstraintsSchema(tb.QueryTestCase):
                     };
                 """)
 
+    async def test_constraints_exclusive_pair(self):
+        await self.assert_query_result(
+            r'''
+                select {
+                    single z := (
+                        select Pair {x, y} filter .x = 'a' and .y = 'b')
+                }
+            ''',
+            [
+                {"z": None}
+            ],
+        )
+
     async def test_constraints_exclusive_multi_property_distinct(self):
         await self.con.execute("""
             INSERT PropertyContainer {

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -543,7 +543,7 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 
     def test_edgeql_ir_card_inference_57(self):
         """
-        SELECT Person FILTER .p = 7 AND .q = 3
+        SELECT Person { first } FILTER .p = 7 AND .q = 3
 % OK %
         AT_MOST_ONE
         """


### PR DESCRIPTION
card inference crashes because of inconsistent use of view pointers.
This means the crash occurs whenever there is a shape on the object
(either explicitly or because of type insertion or similar).

Fixes #3502.