### PR TITLE
Only run bootstrap command/script on bootstrap

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1638,7 +1638,8 @@ async def ensure_bootstrapped(
 ) -> bool:
     """Bootstraps EdgeDB instance if it hasn't been bootstrapped already.
 
-    Returns True if bootstrap happened and False if the instance was already bootstrapped.
+    Returns True if bootstrap happened and False if the instance was already
+    bootstrapped.
     """
     pgconn = await cluster.connect()
     pgconn.add_log_listener(_pg_log_listener)

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1636,6 +1636,10 @@ async def ensure_bootstrapped(
     cluster: pgcluster.BaseCluster,
     args: edbargs.ServerConfig,
 ) -> bool:
+    """Bootstraps postgres if it hasn't been bootstrapped already.
+
+    Returns True if the current invocation bootstrapped postgres.
+    """
     pgconn = await cluster.connect()
     pgconn.add_log_listener(_pg_log_listener)
 

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1636,9 +1636,9 @@ async def ensure_bootstrapped(
     cluster: pgcluster.BaseCluster,
     args: edbargs.ServerConfig,
 ) -> bool:
-    """Bootstraps postgres if it hasn't been bootstrapped already.
+    """Bootstraps EdgeDB instance if it hasn't been bootstrapped already.
 
-    Returns True if the current invocation bootstrapped postgres.
+    Returns True if bootstrap happened and False if the instance was already bootstrapped.
     """
     pgconn = await cluster.connect()
     pgconn.add_log_listener(_pg_log_listener)

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -128,7 +128,7 @@ class Server(ha_base.ClusterProtocol):
         compiler_pool_size,
         nethosts,
         netport,
-        bootstrapped_by_us: bool,
+        new_instance: bool,
         testmode: bool = False,
         binary_endpoint_security: srvargs.ServerEndpointSecurityMode = (
             srvargs.ServerEndpointSecurityMode.Tls),
@@ -197,7 +197,7 @@ class Server(ha_base.ClusterProtocol):
         self._status_sinks = status_sinks
 
         self._startup_script = startup_script
-        self._bootstrapped_by_us = bootstrapped_by_us
+        self._new_instance = new_instance
 
         # Never use `self.__sys_pgcon` directly; get it via
         # `await self._acquire_sys_pgcon()`.
@@ -1519,7 +1519,7 @@ class Server(ha_base.ClusterProtocol):
         await self._cluster.start_watching(self)
         await self._create_compiler_pool()
 
-        if self._startup_script and self._bootstrapped_by_us:
+        if self._startup_script and self._new_instance:
             await binary.EdgeConnection.run_script(
                 server=self,
                 database=self._startup_script.database,

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -128,6 +128,7 @@ class Server(ha_base.ClusterProtocol):
         compiler_pool_size,
         nethosts,
         netport,
+        bootstrapped_by_us: bool,
         testmode: bool = False,
         binary_endpoint_security: srvargs.ServerEndpointSecurityMode = (
             srvargs.ServerEndpointSecurityMode.Tls),
@@ -196,6 +197,7 @@ class Server(ha_base.ClusterProtocol):
         self._status_sinks = status_sinks
 
         self._startup_script = startup_script
+        self._bootstrapped_by_us = bootstrapped_by_us
 
         # Never use `self.__sys_pgcon` directly; get it via
         # `await self._acquire_sys_pgcon()`.
@@ -1517,7 +1519,7 @@ class Server(ha_base.ClusterProtocol):
         await self._cluster.start_watching(self)
         await self._create_compiler_pool()
 
-        if self._startup_script:
+        if self._startup_script and self._bootstrapped_by_us:
             await binary.EdgeConnection.run_script(
                 server=self,
                 database=self._startup_script.database,


### PR DESCRIPTION
Previously `--bootstrap-command` and `--bootstrap-script` would run every time `edgedb-server` started. This change makes these options no-ops if the postgres server has already been bootstrapped.