### PR TITLE
fix candidate for #2567: We generate a pointless self join

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -441,10 +441,13 @@ def ensure_source_rvar(
         scope_stmt = relctx.maybe_get_scope_stmt(ir_set.path_id, ctx=ctx)
         if scope_stmt is None:
             scope_stmt = ctx.rel
-        rvar = relctx.new_root_rvar(ir_set, lateral=True, ctx=ctx)
-        relctx.include_rvar(scope_stmt, rvar, path_id=ir_set.path_id, ctx=ctx)
-        pathctx.put_path_rvar(
-            stmt, ir_set.path_id, rvar, aspect='source', env=ctx.env)
+        rvar = relctx.maybe_get_path_rvar(
+            scope_stmt, ir_set.path_id, aspect='source', ctx=ctx)
+        if rvar is None:
+            rvar = relctx.new_root_rvar(ir_set, lateral=True, ctx=ctx)
+            relctx.include_rvar(scope_stmt, rvar, path_id=ir_set.path_id, ctx=ctx)
+            pathctx.put_path_rvar(
+                stmt, ir_set.path_id, rvar, aspect='source', env=ctx.env)
 
     return rvar
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -445,7 +445,8 @@ def ensure_source_rvar(
             scope_stmt, ir_set.path_id, aspect='source', ctx=ctx)
         if rvar is None:
             rvar = relctx.new_root_rvar(ir_set, lateral=True, ctx=ctx)
-            relctx.include_rvar(scope_stmt, rvar, path_id=ir_set.path_id, ctx=ctx)
+            relctx.include_rvar(
+                scope_stmt, rvar, path_id=ir_set.path_id, ctx=ctx)
             pathctx.put_path_rvar(
                 stmt, ir_set.path_id, rvar, aspect='source', env=ctx.env)
 

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -20,7 +20,6 @@
 import os.path
 
 from edb.testbase import lang as tb
-from edb.tools import test
 
 from edb.common.ast import visitor as ast_visitor
 
@@ -69,16 +68,18 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
 
         # Make sure that User is only selected from *once* in the query
         user_obj = self.schema.get('default::User')
-        user_id_str = str(user_obj.id)
         self.assertEqual(
-            sql.count(user_id_str), 1, "User table referenced more than once: " + sql
+            sql.count(str(user_obj.id)),
+            1,
+            "User table referenced more than once: " + sql
         )
 
         # Make sure that Profile is only selected from *once* in the query
         profile_obj = self.schema.get('default::Profile')
-        profile_id_str = str(profile_obj.id)
         self.assertEqual(
-            sql.count(profile_id_str), 1, "Profile table referenced more than once: " + sql
+            sql.count(str(profile_obj.id)),
+            1,
+            "Profile table referenced more than once: " + sql
         )
 
     def test_codegen_elide_optional_wrapper(self):


### PR DESCRIPTION
Fixes #2567 and hopefully doesn't break anything else.

@elprans says "Indeed, we need to check if path_rvar is in scope_stmt before re-including it."

@msullivan this is in your court I believe.