### PR TITLE
Fix typo in parameters docs (examples)

### DIFF
--- a/docs/edgeql/parameters.rst
+++ b/docs/edgeql/parameters.rst
@@ -51,7 +51,7 @@ JavaScript
 
 .. code-block:: javascript
 
-  await client.query("select 'I ❤️ ' ++ <str>$var ++ '!';", {
+  await client.query("select 'I ❤️ ' ++ <str>$name ++ '!';", {
     name: "rock and roll"
   });
 


### PR DESCRIPTION
I may be missing something, but shouldn't the parameter name in the EdgeQL query match the property name in the JS substitutions arg?