### PR TITLE
Raise a proper error on TypeIntrospection in simple expressions

### DIFF
--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -315,6 +315,14 @@ def compile_SliceIndirection(
     return result
 
 
+@dispatch.compile.register(irast.TypeIntrospection)
+def compile_TypeIntrospection(
+        expr: irast.TypeIntrospection, *,
+        ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
+    raise errors.UnsupportedFeatureError(
+        'type introspection not supported in simple expressions')
+
+
 def _compile_call_args(
     expr: irast.Call, *,
     ctx: context.CompilerContextLevel

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -12523,6 +12523,19 @@ type default::Foo {
                 alter type Foo set abstract;
             """)
 
+    async def test_edgeql_ddl_no_type_intro_in_default(self):
+        with self.assertRaisesRegex(
+                edgedb.UnsupportedFeatureError,
+                r"type introspection not supported in simple expressions"):
+            await self.con.execute(r"""
+                create scalar type Foo extending sequence;
+                create type Project {
+                    create required property number -> Foo {
+                        set default := sequence_next(introspect Foo);
+                    }
+                };
+            """)
+
 
 class TestConsecutiveMigrations(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
Fixes #3494.

At least kind of. We could also probably support this. The main problem
is just that sequence_next wants the type as an extra argument.