### PR TITLE
Disable rebasing scalar types

### DIFF
--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -2939,10 +2939,10 @@ class InheritingObject(SubclassableObject):
     def get_base_names(self, schema: s_schema.Schema) -> Collection[sn.Name]:
         return self.get_bases(schema).names(schema)
 
-    def get_topmost_concrete_base(
+    def maybe_get_topmost_concrete_base(
         self: InheritingObjectT,
         schema: s_schema.Schema
-    ) -> InheritingObjectT:
+    ) -> Optional[InheritingObjectT]:
         """Get the topmost non-abstract base."""
         lineage = self.get_ancestors(schema).objects(schema)
         for ancestor in reversed(lineage):
@@ -2952,8 +2952,19 @@ class InheritingObject(SubclassableObject):
         if not self.get_abstract(schema):
             return self
 
-        raise errors.SchemaError(
-            f'{self.get_verbosename(schema)} has no non-abstract ancestors')
+        return None
+
+    def get_topmost_concrete_base(
+        self: InheritingObjectT,
+        schema: s_schema.Schema
+    ) -> InheritingObjectT:
+        """Get the topmost non-abstract base."""
+        base = self.maybe_get_topmost_concrete_base(schema)
+        if not base:
+            raise errors.SchemaError(
+                f'{self.get_verbosename(schema)} has no non-abstract ancestors'
+            )
+        return base
 
     def get_base_for_cast(self, schema: s_schema.Schema) -> Object:
         return self.get_topmost_concrete_base(schema)

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -573,18 +573,16 @@ class RebaseScalarType(
             self.validate_scalar_bases(schema, context)
 
         else:
-            if not self.scls.get_abstract(schema):
-                old_concrete = self.scls.get_topmost_concrete_base(schema)
+            old_concrete = self.scls.maybe_get_topmost_concrete_base(schema)
 
             schema = super().apply(schema, context)
 
             self.validate_scalar_bases(schema, context)
 
-            if not self.scls.get_abstract(schema):
-                new_concrete = self.scls.get_topmost_concrete_base(schema)
-                if old_concrete != new_concrete:
-                    raise errors.SchemaError(
-                        f'cannot change concrete base of a scalar type')
+            new_concrete = self.scls.maybe_get_topmost_concrete_base(schema)
+            if old_concrete != new_concrete:
+                raise errors.SchemaError(
+                    f'cannot change concrete base of a scalar type')
 
         return schema
 
@@ -602,7 +600,6 @@ class RebaseScalarType(
             # For each descendant, compute its new ancestors and check
             # that they are valid for a scalar type.
             new_schema = obj.set_field_value(schema, 'bases', bases)
-
             for desc in obj.descendants(schema):
                 ancestors = so.compute_ancestors(new_schema, desc)
                 self.validate_scalar_ancestors(ancestors, schema, context)

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -570,12 +570,22 @@ class RebaseScalarType(
             schema = self._validate_enum_change(
                 scls, cur_labels, new_labels, schema, context)
 
-        else:
-            schema = super().apply(schema, context)
-            # raise errors.SchemaError(
-            #     f'cannot change supertypes of scalar type')
+            self.validate_scalar_bases(schema, context)
 
-        self.validate_scalar_bases(schema, context)
+        else:
+            if not self.scls.get_abstract(schema):
+                old_concrete = self.scls.get_topmost_concrete_base(schema)
+
+            schema = super().apply(schema, context)
+
+            self.validate_scalar_bases(schema, context)
+
+            if not self.scls.get_abstract(schema):
+                new_concrete = self.scls.get_topmost_concrete_base(schema)
+                if old_concrete != new_concrete:
+                    raise errors.SchemaError(
+                        f'cannot change concrete base of a scalar type')
+
         return schema
 
     def validate_scalar_bases(
@@ -592,6 +602,7 @@ class RebaseScalarType(
             # For each descendant, compute its new ancestors and check
             # that they are valid for a scalar type.
             new_schema = obj.set_field_value(schema, 'bases', bases)
+
             for desc in obj.descendants(schema):
                 ancestors = so.compute_ancestors(new_schema, desc)
                 self.validate_scalar_ancestors(ancestors, schema, context)

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -571,7 +571,8 @@ class RebaseScalarType(
                 scls, cur_labels, new_labels, schema, context)
 
         else:
-            schema = super().apply(schema, context)
+            raise errors.SchemaError(
+                f'cannot change supertypes of scalar type')
 
         self.validate_scalar_bases(schema, context)
         return schema

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -571,8 +571,9 @@ class RebaseScalarType(
                 scls, cur_labels, new_labels, schema, context)
 
         else:
-            raise errors.SchemaError(
-                f'cannot change supertypes of scalar type')
+            schema = super().apply(schema, context)
+            # raise errors.SchemaError(
+            #     f'cannot change supertypes of scalar type')
 
         self.validate_scalar_bases(schema, context)
         return schema

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5173,7 +5173,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r'cannot change supertypes of scalar type'):
+                r'scalar type may not have more than one concrete base type'):
             await self.con.execute('''
                 ALTER SCALAR TYPE myint EXTENDING b;
             ''')
@@ -5186,7 +5186,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r'cannot change supertypes of scalar type'):
+                r'scalar type may not have more than one concrete base type'):
             await self.con.execute('''
                 ALTER SCALAR TYPE a EXTENDING str;
             ''')
@@ -5298,9 +5298,23 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         ''')
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r'cannot change supertypes of scalar type'):
+                r'scalar type must have a concrete base type'):
             await self.con.execute('''
-                alter scalar type Foo drop extending int64;
+                alter scalar type Foo drop extending str;
+            ''')
+
+    async def test_edgeql_ddl_scalar_12(self):
+        await self.con.execute('''
+            create scalar type Foo extending str;
+        ''')
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                r'cannot change concrete base of a scalar type'):
+            await self.con.execute('''
+                alter scalar type Foo {
+                    drop extending str;
+                    extending int64 LAST;
+                };
             ''')
 
     async def test_edgeql_ddl_cast_01(self):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5173,7 +5173,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r'cannot change supertype of scalar type'):
+                r'cannot change supertypes of scalar type'):
             await self.con.execute('''
                 ALTER SCALAR TYPE myint EXTENDING b;
             ''')
@@ -5186,7 +5186,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r'cannot change supertype of scalar type'):
+                r'cannot change supertypes of scalar type'):
             await self.con.execute('''
                 ALTER SCALAR TYPE a EXTENDING str;
             ''')
@@ -5298,7 +5298,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         ''')
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r'cannot change supertype of scalar type'):
+                r'cannot change supertypes of scalar type'):
             await self.con.execute('''
                 alter scalar type Foo drop extending int64;
             ''')

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5173,7 +5173,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r'may not have more than one concrete base type'):
+                r'cannot change supertype of scalar type'):
             await self.con.execute('''
                 ALTER SCALAR TYPE myint EXTENDING b;
             ''')
@@ -5186,7 +5186,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
         with self.assertRaisesRegex(
                 edgedb.SchemaError,
-                r'may not have more than one concrete base type'):
+                r'cannot change supertype of scalar type'):
             await self.con.execute('''
                 ALTER SCALAR TYPE a EXTENDING str;
             ''')
@@ -5290,6 +5290,17 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 r'scalar type must have a concrete base type'):
             await self.con.execute('''
                 create scalar type Foo;
+            ''')
+
+    async def test_edgeql_ddl_scalar_11(self):
+        await self.con.execute('''
+            create scalar type Foo extending str;
+        ''')
+        with self.assertRaisesRegex(
+                edgedb.SchemaError,
+                r'cannot change supertype of scalar type'):
+            await self.con.execute('''
+                alter scalar type Foo drop extending int64;
             ''')
 
     async def test_edgeql_ddl_cast_01(self):


### PR DESCRIPTION
Currently doing this can allow pg and edgedb to disagree about a column's type!