### PR TITLE
Loosen up the assertion that all generated DROP subcommands are DROPs

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2233,7 +2233,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                 self._append_subcmd_ast(schema, node, op, context)
 
         if isinstance(node, qlast.DropObject):
-            def _is_drop(ddl: qlast.ObjectDDL) -> bool:
+            def _is_drop(ddl: qlast.DDLOperation) -> bool:
                 return (
                     isinstance(ddl, (qlast.DropObject, qlast.AlterObject))
                     and all(_is_drop(sub) for sub in ddl.commands)

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -10506,6 +10506,58 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
             }
         ''')
 
+    async def test_edgeql_migration_fiddly_delete_01(self):
+        await self.migrate(r'''
+            type Document {
+              multi link entries -> Entry {
+                constraint exclusive;
+              }
+              multi link fields := .entries.field;
+              required link form -> Form;
+            }
+
+            type Entry {
+              required link field -> Field;
+              required property value -> str;
+              link form := .field.form;
+            }
+
+            type Field {
+              required property name -> str;
+
+              link form := .<fields[IS Form];
+            }
+
+            type Form {
+              required property name -> str {
+                constraint exclusive;
+              }
+
+              multi link fields -> Field;
+            }
+        ''')
+        await self.migrate(r'''
+            type Entry {
+              required link field -> Field;
+              required property value -> str;
+              link form := .field.form;
+            }
+
+            type Field {
+              required property name -> str;
+
+              link form := .<fields[IS Form];
+            }
+
+            type Form {
+              required property name -> str {
+                constraint exclusive;
+              }
+
+              multi link fields -> Field;
+            }
+        ''')
+
 
 class TestEdgeQLDataMigrationNonisolated(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
Alters containing only drops are OK also.

Fixes #3521.