### PR TITLE
Provide a more detailed message in constraint error details field

### DIFF
--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -194,11 +194,10 @@ class Constraint(
             self.get_field_value(schema, 'subject'),
         )
 
-    def format_error_message(
+    def format_error(
         self,
         schema: s_schema.Schema,
     ) -> str:
-        errmsg = self.get_errmessage(schema)
         subject = self.get_subject(schema)
         titleattr = subject.get_annotation(schema, sn.QualName('std', 'title'))
 
@@ -208,6 +207,14 @@ class Constraint(
         else:
             subjtitle = titleattr
 
+        return self.format_error_message(schema, subjtitle)
+
+    def format_error_message(
+        self,
+        schema: s_schema.Schema,
+        subjtitle: str,
+    ) -> str:
+        errmsg = self.get_errmessage(schema)
         args = self.get_args(schema)
         if args:
             args_ql: List[qlast.Base] = [

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -434,8 +434,12 @@ def _interpret_constraint_errors(code, schema, err_details, hint):
 
         constraint = schema.get_by_id(constraint_id)
 
-        return errors.ConstraintViolationError(
-            constraint.format_error_message(schema))
+        msg = constraint.format_error(schema)
+        subject = constraint.get_subject(schema)
+        vname = subject.get_verbosename(schema, with_parent=True)
+        subjtitle = f"value of {vname}"
+        details = constraint.format_error_message(schema, subjtitle)
+        return errors.ConstraintViolationError(msg, details=details)
     elif error_type == 'newconstraint':
         # If we're here, it means that we already validated that
         # schema_name, table_name and column_name all exist.


### PR DESCRIPTION
Currently, constraint violation errors include a nicely-formatted
message that is intended to be displayed to application end user, and
so don't include any extra technical details, such as the type on which
the constraint is defined.  This makes life harder on developers, so
include a more elaborate message in the `details` field:

    edgedb> insert City2 { name := 'sesh' };
    edgedb error: ConstraintViolationError: name violates exclusivity constraint
      Detail: value of property 'name' of object type 'default::City2' violates exclusivity constraint

It would also be nice to include the constraint definition and the
offending value, but that requires a more elaborate fix.

Fixes: #3522