### PR TITLE
preparser: fix backslash at the end of raw string

### DIFF
--- a/docs/edgeql/literals.rst
+++ b/docs/edgeql/literals.rst
@@ -452,6 +452,16 @@ The ``bytes`` type represents raw binary data.
   db> select b'bina\\x01ry';
   {b'bina\\x01ry'}
 
+There is a special syntax for declaring "raw byte strings". Raw byte strings
+treat the backslash ``\`` as a literal character instead of an escape
+character.
+
+.. code-block:: edgeql-repl
+
+  db> select rb'hello\nthere';
+  {b'hello\\nthere'}
+  db> select br'\';
+  {b'\\'}
 
 
 .. _ref_eql_literal_array:

--- a/edb/edgeql-parser/tests/preparser.rs
+++ b/edb/edgeql-parser/tests/preparser.rs
@@ -29,6 +29,17 @@ fn test_quoted_semicolon() {
 }
 
 #[test]
+fn test_raw_string() {
+    test_statement(br#"select r"\"; some trailer"#, 12);
+}
+
+#[test]
+fn test_raw_byte_string() {
+    test_statement(br#"select rb"\"; some trailer"#, 13);
+    test_statement(br#"select br'hello\'; some trailer"#, 18);
+}
+
+#[test]
 fn test_single_quoted_semicolon() {
     test_statement(b"select 'a;'; some trailer", 12);
 }


### PR DESCRIPTION
Fixes edgedb/edgedb-cli#676

Also adds examples of binary raw strings to docs