### PR TITLE
Fix collection of migration issues with inherited props

### DIFF
--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -92,7 +92,8 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
         deferred_complex_ops = []
 
         for field_name in field_names:
-            ignore_local_field = ignore_local or field_name in inherited_fields
+            was_inherited = field_name in inherited_fields
+            ignore_local_field = ignore_local or was_inherited
             field = mcls.get_field(field_name)
 
             try:
@@ -118,8 +119,9 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
 
             if (
                 (
-                    (result is not None or ours is not None)
-                    and (result != ours or inherited)
+                    result != ours
+                    or inherited
+                    or (was_inherited and not scls.get_owned(schema))
                 ) or (
                     result is None and ours is None and ignore_local
                 )

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -78,8 +78,15 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
         fields: Optional[Iterable[str]] = None,
         ignore_local: bool = False,
     ) -> s_schema.Schema:
+        from . import referencing as s_referencing
+
         mcls = self.get_schema_metaclass()
         scls = self.scls
+
+        is_owned = (
+            isinstance(scls, s_referencing.ReferencedObject)
+            and scls.get_owned(schema)
+        )
 
         field_names: Iterable[str]
         if fields is not None:
@@ -121,7 +128,7 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
                 (
                     result != ours
                     or inherited
-                    or (was_inherited and not scls.get_owned(schema))
+                    or (was_inherited and not is_owned)
                 ) or (
                     result is None and ours is None and ignore_local
                 )

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -72,6 +72,8 @@ def linearize_delta(
         commands.
     """
 
+    # delta.dump()
+
     # We take the scatter-sort-gather approach here, where the original
     # tree is broken up into linear branches, which are then sorted
     # and reassembled back into a tree.
@@ -843,7 +845,12 @@ def _trace_op(
                     for ref in refs:
                         write_ref_deps(ref, referrer, this_name_str)
 
-                if isinstance(obj, referencing.ReferencedInheritingObject):
+                if (
+                    isinstance(obj, referencing.ReferencedInheritingObject)
+                    # Changes to owned objects can't necessarily be merged
+                    # in with parents, so we make sure not to.
+                    and not obj.get_owned(new_schema)  # XXX ???
+                ):
                     implicit_ancestors = [
                         b.get_name(new_schema)
                         for b in obj.get_implicit_ancestors(new_schema)

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -72,8 +72,6 @@ def linearize_delta(
         commands.
     """
 
-    # delta.dump()
-
     # We take the scatter-sort-gather approach here, where the original
     # tree is broken up into linear branches, which are then sorted
     # and reassembled back into a tree.
@@ -849,7 +847,7 @@ def _trace_op(
                     isinstance(obj, referencing.ReferencedInheritingObject)
                     # Changes to owned objects can't necessarily be merged
                     # in with parents, so we make sure not to.
-                    and not obj.get_owned(new_schema)  # XXX ???
+                    and not obj.get_owned(new_schema)
                 ):
                     implicit_ancestors = [
                         b.get_name(new_schema)


### PR DESCRIPTION
* Propagate RESETs to non-owned children
 * Don't merge modifications to owned children when ordering migrations.
   The modification to the parent won't apply to the child, so we have
   to explicitly do the child.
 * Prune required_user_input whose placeholders have been elided from the
   actual DDL generated.

Fixes #3542.