### PR TITLE
Make sure _propagate_if_expr_refs preserves inherited/computed state

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2012,7 +2012,12 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                                     schema, cmd_create, fn, context, value)
 
                         cmd_drop.set_attribute_value(fn, dummy)
-                        cmd_create.set_attribute_value(fn, value)
+                        cmd_create.set_attribute_value(
+                            fn,
+                            value,
+                            inherited=ref.field_is_inherited(schema, fn),
+                            computed=ref.field_is_computed(schema, fn),
+                        )
 
                     context.affected_finalization[self].append(
                         (delta_create, cmd_create, this_ref_desc)

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1462,6 +1462,20 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
 
         return schema
 
+    def field_is_computed(
+        self,
+        schema: s_schema.Schema,
+        field_name: str,
+    ) -> bool:
+        return field_name in self.get_computed_fields(schema)
+
+    def field_is_inherited(
+        self,
+        schema: s_schema.Schema,
+        field_name: str,
+    ) -> bool:
+        return False
+
     def del_classref(
         self,
         schema: s_schema.Schema,

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -8899,6 +8899,55 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
                 POPULATE MIGRATION;
             """)
 
+    async def test_edgeql_migration_inherited_default_01(self):
+        await self.migrate(r"""
+            abstract type Foo {
+                multi link link -> Obj {
+                    default := ( select Obj filter .name = 'X' )
+                };
+            }
+
+            type Bar extending Foo {}
+
+            type Obj {
+                required property name -> str {
+                    constraint exclusive;
+                }
+            }
+        """)
+
+    async def test_edgeql_migration_inherited_default_02(self):
+        await self.migrate(r"""
+            abstract type Foo {
+                multi link link -> Obj {
+                };
+            }
+
+            type Bar extending Foo {}
+
+            type Obj {
+                required property name -> str {
+                    constraint exclusive;
+                }
+            }
+        """)
+
+        await self.migrate(r"""
+            abstract type Foo {
+                multi link link -> Obj {
+                    default := ( select Obj filter .name = 'X' )
+                };
+            }
+
+            type Bar extending Foo {}
+
+            type Obj {
+                required property name -> str {
+                    constraint exclusive;
+                }
+            }
+        """)
+
     async def test_edgeql_migration_scalar_array_01(self):
         await self.migrate(r"""
             type User {


### PR DESCRIPTION
Otherwise the inherited/computed state of attributes can get corrupted
by semi-related schema operations, since _propagate_if_expr_refs just
totally ignores any notion of the inheritance tree.

Fixes #3544.