### PR TITLE
Add on-demand compiler pool scaling

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -94,6 +94,41 @@ class BackendCapabilitySets(NamedTuple):
     must_be_absent: List[pgsql_params.BackendCapabilities]
 
 
+class CompilerPoolScalingMode(enum.StrEnum):
+    Fixed = "fixed"
+    OnDemand = "on_demand"
+
+    def __init__(self, name):
+        self.pool_class = None
+
+    def set_class(self, cls):
+        self.pool_class = cls
+        return cls
+
+    def compute_default_pool_size(self):
+        if self.value == self.Fixed:
+            return compute_default_compiler_pool_size()
+        else:
+            return 1
+
+
+class OptionWithDynamicHelp(click.Option):
+    def __init__(self, *args, help_func, **kwargs):
+        self._help = None
+        self._help_func = help_func
+        super().__init__(*args, **kwargs)
+
+    @property
+    def help(self):
+        if self._help:
+            return self._help
+        return self._help_func()
+
+    @help.setter
+    def help(self, value):
+        self._help = value
+
+
 class ServerConfig(NamedTuple):
 
     data_dir: pathlib.Path
@@ -119,6 +154,7 @@ class ServerConfig(NamedTuple):
     runstate_dir: pathlib.Path
     max_backend_connections: Optional[int]
     compiler_pool_size: int
+    compiler_pool_scaling_mode: CompilerPoolScalingMode
     echo_runtime_info: bool
     emit_server_status: str
     temp_dir: bool
@@ -254,7 +290,7 @@ def adjust_testmode_max_connections(max_conns):
 
 
 def _validate_compiler_pool_size(ctx, param, value):
-    if value < defines.BACKEND_COMPILER_POOL_SIZE_MIN:
+    if value is not None and value < defines.BACKEND_COMPILER_POOL_SIZE_MIN:
         raise click.BadParameter(
             f'the minimum value for the compiler pool size option '
             f'is {defines.BACKEND_COMPILER_POOL_SIZE_MIN}')
@@ -432,8 +468,29 @@ _server_options = [
         callback=_validate_max_backend_connections),
     click.option(
         '--compiler-pool-size', type=int,
-        default=compute_default_compiler_pool_size(),
-        callback=_validate_compiler_pool_size),
+        callback=_validate_compiler_pool_size,
+        cls=OptionWithDynamicHelp,
+        help_func=lambda:
+            'Specify the size of the compiler pool. Defaults to ' +
+             ', or '.join(
+                 f'{mode.compute_default_pool_size()} for "{mode.value}" '
+                 f'scaling mode'
+                 for mode in CompilerPoolScalingMode.__members__.values()
+             ) + '.',
+    ),
+    click.option(
+        '--compiler-pool-scaling-mode',
+        type=click.Choice(
+            list(CompilerPoolScalingMode.__members__.values()),
+            case_sensitive=True,
+        ),
+        default=CompilerPoolScalingMode.Fixed.value,
+        help='Choose a mode for the compiler pool to scale. "fixed" means the '
+             'pool will not scale and sticks to --compiler-pool-size, while '
+             '"on_demand" means the pool will maintain at least '
+             '--compiler-pool-size workers and automatically scales up and '
+             'down to the demand. Default to "fixed".',
+    ),
     click.option(
         '--echo-runtime-info', type=bool, default=False, is_flag=True,
         help='[DEPREATED, use --emit-server-status] '
@@ -731,6 +788,13 @@ def parse_args(**kwargs: Any):
     kwargs['tls_cert_mode'] = ServerTlsCertMode(kwargs['tls_cert_mode'])
     kwargs['default_auth_method'] = ServerAuthMethod(
         kwargs['default_auth_method'])
+    kwargs['compiler_pool_scaling_mode'] = CompilerPoolScalingMode(
+        kwargs['compiler_pool_scaling_mode']
+    )
+    if not kwargs['compiler_pool_size']:
+        kwargs['compiler_pool_size'] = kwargs[
+            'compiler_pool_scaling_mode'
+        ].compute_default_pool_size()
 
     if kwargs['temp_dir']:
         if kwargs['data_dir']:

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -94,7 +94,7 @@ class BackendCapabilitySets(NamedTuple):
     must_be_absent: List[pgsql_params.BackendCapabilities]
 
 
-class CompilerPoolScalingMode(enum.StrEnum):
+class CompilerPoolMode(enum.StrEnum):
     Fixed = "fixed"
     OnDemand = "on_demand"
 
@@ -155,7 +155,7 @@ class ServerConfig(NamedTuple):
     runstate_dir: pathlib.Path
     max_backend_connections: Optional[int]
     compiler_pool_size: int
-    compiler_pool_scaling_mode: CompilerPoolScalingMode
+    compiler_pool_mode: CompilerPoolMode
     echo_runtime_info: bool
     emit_server_status: str
     temp_dir: bool
@@ -475,17 +475,17 @@ _server_options = [
             'Specify the size of the compiler pool. Defaults to ' +
             ', or '.join(
                 f'{mode.compute_default_pool_size()} for "{mode.value}" '
-                f'scaling mode'
-                for mode in CompilerPoolScalingMode.__members__.values()
+                f'mode'
+                for mode in CompilerPoolMode.__members__.values()
             ) + '.',
     ),
     click.option(
-        '--compiler-pool-scaling-mode',
+        '--compiler-pool-mode',
         type=click.Choice(
-            list(CompilerPoolScalingMode.__members__.values()),
+            list(CompilerPoolMode.__members__.values()),
             case_sensitive=True,
         ),
-        default=CompilerPoolScalingMode.Fixed.value,
+        default=CompilerPoolMode.Fixed.value,
         help='Choose a mode for the compiler pool to scale. "fixed" means the '
              'pool will not scale and sticks to --compiler-pool-size, while '
              '"on_demand" means the pool will maintain at least '
@@ -789,12 +789,12 @@ def parse_args(**kwargs: Any):
     kwargs['tls_cert_mode'] = ServerTlsCertMode(kwargs['tls_cert_mode'])
     kwargs['default_auth_method'] = ServerAuthMethod(
         kwargs['default_auth_method'])
-    kwargs['compiler_pool_scaling_mode'] = CompilerPoolScalingMode(
-        kwargs['compiler_pool_scaling_mode']
+    kwargs['compiler_pool_mode'] = CompilerPoolMode(
+        kwargs['compiler_pool_mode']
     )
     if not kwargs['compiler_pool_size']:
         kwargs['compiler_pool_size'] = kwargs[
-            'compiler_pool_scaling_mode'
+            'compiler_pool_mode'
         ].compute_default_pool_size()
 
     if kwargs['temp_dir']:

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -101,7 +101,8 @@ class CompilerPoolScalingMode(enum.StrEnum):
     def __init__(self, name):
         self.pool_class = None
 
-    def set_class(self, cls):
+    def assign_implementation(self, cls):
+        # decorator function to link this enum with the actual implementation
         self.pool_class = cls
         return cls
 
@@ -118,15 +119,15 @@ class OptionWithDynamicHelp(click.Option):
         self._help_func = help_func
         super().__init__(*args, **kwargs)
 
-    @property
-    def help(self):
+    def _get_help(self):
         if self._help:
             return self._help
         return self._help_func()
 
-    @help.setter
-    def help(self, value):
+    def _set_help(self, value):
         self._help = value
+
+    help = property(_get_help, _set_help)  # type: ignore
 
 
 class ServerConfig(NamedTuple):
@@ -472,11 +473,11 @@ _server_options = [
         cls=OptionWithDynamicHelp,
         help_func=lambda:
             'Specify the size of the compiler pool. Defaults to ' +
-             ', or '.join(
-                 f'{mode.compute_default_pool_size()} for "{mode.value}" '
-                 f'scaling mode'
-                 for mode in CompilerPoolScalingMode.__members__.values()
-             ) + '.',
+            ', or '.join(
+                f'{mode.compute_default_pool_size()} for "{mode.value}" '
+                f'scaling mode'
+                for mode in CompilerPoolScalingMode.__members__.values()
+            ) + '.',
     ),
     click.option(
         '--compiler-pool-scaling-mode',

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -34,9 +34,11 @@ import time
 import immutables
 
 from edb.common import debug
+from edb.common import taskgroup
 
 from edb.pgsql import params as pgparams
 
+from edb.server import args as srvargs
 from edb.server import defines
 from edb.server import metrics
 
@@ -47,6 +49,8 @@ from . import state
 
 PROCESS_INITIAL_RESPONSE_TIMEOUT: float = 60.0
 KILL_TIMEOUT: float = 10.0
+ADAPTIVE_SCALE_UP_WAIT_TIME: float = 3.0
+ADAPTIVE_SCALE_DOWN_WAIT_TIME: float = 60.0
 WORKER_MOD: str = __name__.rpartition('.')[0] + '.worker'
 
 
@@ -156,7 +160,7 @@ class Worker:
             pass
 
 
-class Pool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
+class BasePool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
 
     _workers_queue: queue.WorkerQueue[Worker]
     _workers: Dict[int, Worker]
@@ -195,9 +199,6 @@ class Pool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
         self._workers = {}
 
         self._server = amsg.Server(self._poolsock_name, loop, self)
-        self._template_transport = None
-        self._template_proc_scheduled = False
-        self._template_proc_version = 0
         self._ready_evt = asyncio.Event()
 
         self._running = None
@@ -222,8 +223,7 @@ class Pool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
 
         self._workers[pid] = worker
         self._workers_queue.release(worker)
-        if len(self._workers) > self._pool_size:
-            self._server.kill_outdated_worker(self._template_proc_version)
+        self._worker_attached()
 
         logger.debug("started compiler worker process (PID %s)", pid)
         if (
@@ -237,6 +237,9 @@ class Pool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
             self._ready_evt.set()
 
         return worker
+
+    def _worker_attached(self):
+        pass
 
     @functools.lru_cache(maxsize=None)
     def _get_init_args(self):
@@ -265,14 +268,6 @@ class Pool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
         return init_args, pickled_args
 
     def worker_connected(self, pid, version):
-        if version < self._template_proc_version:
-            logger.debug(
-                "Outdated worker with PID %s connected; discard now.", pid
-            )
-            self._server.get_by_pid(pid).abort()
-            metrics.compiler_process_spawns.inc()
-            return
-
         logger.debug("Worker with PID %s connected, sending init args.", pid)
         args, pickled_args = self._get_init_args()
         self._loop.create_task(
@@ -286,18 +281,8 @@ class Pool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
         self._workers.pop(pid, None)
         metrics.current_compiler_processes.dec()
 
-    def process_exited(self):
-        # Template process exited
-        self._template_transport = None
-        if self._running:
-            logger.error("Template compiler process exited; recreating now.")
-            self._schedule_template_proc(0)
-
     def get_template_pid(self):
-        if self._template_transport is None:
-            return None
-        else:
-            return self._template_transport.get_pid()
+        return None
 
     async def start(self):
         if self._running is not None:
@@ -309,62 +294,44 @@ class Pool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
         await self._server.start()
         self._running = True
 
-        await self._create_template_proc(retry=False)
+        await self._start()
 
         await asyncio.wait_for(
             self._ready_evt.wait(),
             PROCESS_INITIAL_RESPONSE_TIMEOUT
         )
 
-    async def _create_template_proc(self, retry=True):
-        self._template_proc_scheduled = False
-        if not self._running:
-            return
-        self._template_proc_version += 1
-        version = str(self._template_proc_version)
-        try:
-            env = _ENV
-            if debug.flags.server:
-                env = {'EDGEDB_DEBUG_SERVER': '1', **_ENV}
+    async def _create_worker_process(self, numproc=None, version=0):
+        env = _ENV
+        if debug.flags.server:
+            env = {'EDGEDB_DEBUG_SERVER': '1', **_ENV}
 
-            cmdline = [sys.executable]
-            if sys.flags.isolated:
-                cmdline.append('-I')
+        cmdline = [sys.executable]
+        if sys.flags.isolated:
+            cmdline.append('-I')
 
+        cmdline.extend([
+            '-m', WORKER_MOD,
+            '--sockname', self._poolsock_name,
+            '--version-serial', str(version),
+        ])
+        if numproc:
             cmdline.extend([
-                '-m', WORKER_MOD,
-                '--sockname', self._poolsock_name,
-                '--numproc', str(self._pool_size),
-                '--version-serial', version,
+                '--numproc', str(numproc),
             ])
 
-            self._template_transport, _ = await self._loop.subprocess_exec(
-                lambda: self,
-                *cmdline,
-                env=env,
-                stdin=subprocess.DEVNULL,
-                stdout=None,
-                stderr=None,
-            )
-        except Exception:
-            if retry:
-                if self._running:
-                    t = defines.BACKEND_COMPILER_TEMPLATE_PROC_RESTART_INTERVAL
-                    logger.exception(
-                        f"Unexpected error occurred creating template compiler"
-                        f" process; retry in {t} second{'s' if t > 1 else ''}."
-                    )
-                    self._schedule_template_proc(t)
-            else:
-                raise
-
-    def _schedule_template_proc(self, sleep):
-        if self._template_proc_scheduled:
-            return
-        self._template_proc_scheduled = True
-        self._loop.call_later(
-            sleep, self._loop.create_task, self._create_template_proc()
+        transport, _ = await self._loop.subprocess_exec(
+            lambda: self,
+            *cmdline,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=None,
+            stderr=None,
         )
+        return transport
+
+    async def _start(self):
+        raise NotImplementedError
 
     async def stop(self):
         if not self._running:
@@ -377,10 +344,10 @@ class Pool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
         self._workers_queue = queue.WorkerQueue(self._loop)
         self._workers.clear()
 
-        trans, self._template_transport = self._template_transport, None
-        if trans is not None:
-            trans.terminate()
-            await trans._wait()
+        await self._stop()
+
+    async def _stop(self):
+        raise NotImplementedError
 
     def _report_worker(self, worker: Worker, *, action: str = "spawn"):
         action = action.capitalize()
@@ -736,6 +703,201 @@ class Pool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
             self._release_worker(worker)
 
 
+@srvargs.CompilerPoolScalingMode.Fixed.set_class
+class FixedPool(BasePool):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._template_transport = None
+        self._template_proc_scheduled = False
+        self._template_proc_version = 0
+
+    def _worker_attached(self):
+        if len(self._workers) > self._pool_size:
+            self._server.kill_outdated_worker(self._template_proc_version)
+
+    def worker_connected(self, pid, version):
+        if version < self._template_proc_version:
+            logger.debug(
+                "Outdated worker with PID %s connected; discard now.", pid
+            )
+            self._server.get_by_pid(pid).abort()
+            metrics.compiler_process_spawns.inc()
+        else:
+            super().worker_connected(pid, version)
+
+    def process_exited(self):
+        # Template process exited
+        self._template_transport = None
+        if self._running:
+            logger.error("Template compiler process exited; recreating now.")
+            self._schedule_template_proc(0)
+
+    def get_template_pid(self):
+        if self._template_transport is None:
+            return None
+        else:
+            return self._template_transport.get_pid()
+
+    async def _start(self):
+        await self._create_template_proc(retry=False)
+
+    async def _create_template_proc(self, retry=True):
+        self._template_proc_scheduled = False
+        if not self._running:
+            return
+        self._template_proc_version += 1
+        try:
+            self._template_transport = await self._create_worker_process(
+                numproc=self._pool_size,
+                version=self._template_proc_version,
+            )
+        except Exception:
+            if retry:
+                if self._running:
+                    t = defines.BACKEND_COMPILER_TEMPLATE_PROC_RESTART_INTERVAL
+                    logger.exception(
+                        f"Unexpected error occurred creating template compiler"
+                        f" process; retry in {t} second{'s' if t > 1 else ''}."
+                    )
+                    self._schedule_template_proc(t)
+            else:
+                raise
+
+    def _schedule_template_proc(self, sleep):
+        if self._template_proc_scheduled:
+            return
+        self._template_proc_scheduled = True
+        self._loop.call_later(
+            sleep, self._loop.create_task, self._create_template_proc()
+        )
+
+    async def _stop(self):
+        trans, self._template_transport = self._template_transport, None
+        if trans is not None:
+            trans.terminate()
+            await trans._wait()
+
+
+@srvargs.CompilerPoolScalingMode.OnDemand.set_class
+class SimpleAdaptivePool(BasePool):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._worker_transports = {}
+        self._expected_num_workers = 0
+        self._scale_up_handle = None
+        self._scale_down_handle = None
+        self._max_num_workers = srvargs.compute_default_compiler_pool_size()
+
+    async def _start(self):
+        async with taskgroup.TaskGroup() as g:
+            for i in range(self._pool_size):
+                g.create_task(self._create_worker())
+
+    async def _stop(self):
+        self._expected_num_workers = 0
+        transports, self._worker_transports = self._worker_transports, {}
+        for transport in transports.values():
+            await transport._wait()
+
+    async def _acquire_worker(self, *, condition=None):
+        if (
+            self._running and
+            self._scale_up_handle is None
+            and self._workers_queue.qsize() == 0
+            and (
+                len(self._workers)
+                == self._expected_num_workers
+                < self._max_num_workers
+            )
+        ):
+            self._scale_up_handle = self._loop.call_later(
+                ADAPTIVE_SCALE_UP_WAIT_TIME,
+                self._maybe_scale_up,
+                self._workers_queue.count_waiters() + 1,
+            )
+        if self._scale_down_handle is not None:
+            self._scale_down_handle.cancel()
+            self._scale_down_handle = None
+        return await super()._acquire_worker(condition=condition)
+
+    def _release_worker(self, worker):
+        if self._scale_down_handle is not None:
+            self._scale_down_handle.cancel()
+            self._scale_down_handle = None
+        super()._release_worker(worker)
+        if (
+            self._running and
+            self._workers_queue.count_waiters() == 0 and
+            len(self._workers) > self._pool_size
+        ):
+            self._scale_down_handle = self._loop.call_later(
+                ADAPTIVE_SCALE_DOWN_WAIT_TIME,
+                self._scale_down,
+            )
+
+    def worker_disconnected(self, pid):
+        num_workers_before = len(self._workers)
+        super().worker_disconnected(pid)
+        self._worker_transports.pop(pid, None)
+        if not self._running:
+            return
+        if len(self._workers) < self._pool_size:
+            # The auto-scaler will not scale down below the pool_size, so we
+            # should restart the unexpectedly-exited worker process.
+            logger.warning(
+                "Compiler worker process[%d] exited unexpectedly; "
+                "start a new one now.", pid
+            )
+            self._loop.create_task(self._create_worker())
+            self._expected_num_workers = len(self._workers)
+        elif num_workers_before == self._expected_num_workers:
+            # This is likely the case when a worker died unexpectedly, and we
+            # don't want to restart the worker because the auto-scaler will
+            # start a new one again if necessary.
+            self._expected_num_workers = len(self._workers)
+
+    def process_exited(self):
+        if self._running:
+            for pid, transport in list(self._worker_transports.items()):
+                if transport.is_closing():
+                    self._worker_transports.pop(pid, None)
+
+    async def _create_worker(self):
+        try:
+            transport = await self._create_worker_process()
+            self._worker_transports[transport.get_pid()] = transport
+            self._expected_num_workers += 1
+        finally:
+            self._scale_up_handle = None
+
+    def _maybe_scale_up(self, starting_num_waiters):
+        if not self._running:
+            return
+        if self._workers_queue.count_waiters() > starting_num_waiters:
+            logger.info(
+                "Compile requests are queuing up in the past %d seconds, "
+                "spawn a new compiler worker process now.",
+                ADAPTIVE_SCALE_UP_WAIT_TIME,
+            )
+            self._loop.create_task(self._create_worker())
+        else:
+            self._scale_up_handle = None
+
+    def _scale_down(self):
+        self._scale_down_handle = None
+        if not self._running or len(self._workers) <= self._pool_size:
+            return
+        logger.info(
+            "The compiler pool is not used in %d seconds, scaling down to %d.",
+            ADAPTIVE_SCALE_DOWN_WAIT_TIME, self._pool_size,
+        )
+        self._expected_num_workers = self._pool_size
+        for worker in sorted(
+            self._workers.values(), key=lambda w: w._last_used
+        )[:-self._pool_size]:
+            worker.close()
+
+
 async def create_compiler_pool(
     *,
     runstate_dir: str,
@@ -745,10 +907,11 @@ async def create_compiler_pool(
     std_schema,
     refl_schema,
     schema_class_layout,
-
-) -> Pool:
+    pool_class=FixedPool,
+) -> BasePool:
+    assert issubclass(pool_class, BasePool)
     loop = asyncio.get_running_loop()
-    pool = Pool(
+    pool = pool_class(
         loop=loop,
         pool_size=pool_size,
         runstate_dir=runstate_dir,

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -708,7 +708,7 @@ class BasePool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
             self._release_worker(worker)
 
 
-@srvargs.CompilerPoolScalingMode.Fixed.assign_implementation
+@srvargs.CompilerPoolMode.Fixed.assign_implementation
 class FixedPool(BasePool):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -786,7 +786,7 @@ class FixedPool(BasePool):
             await trans._wait()
 
 
-@srvargs.CompilerPoolScalingMode.OnDemand.assign_implementation
+@srvargs.CompilerPoolMode.OnDemand.assign_implementation
 class SimpleAdaptivePool(BasePool):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/edb/server/compiler_pool/queue.py
+++ b/edb/server/compiler_pool/queue.py
@@ -104,6 +104,12 @@ class WorkerQueue(typing.Generic[W]):
             self._queue.append(worker)
         self._wakeup_next_waiter()
 
+    def qsize(self) -> int:
+        return len(self._queue)
+
+    def count_waiters(self) -> int:
+        return len(self._waiters)
+
     def _wakeup_next_waiter(self) -> None:
         while self._waiters:
             waiter = self._waiters.popleft()

--- a/edb/server/compiler_pool/worker.py
+++ b/edb/server/compiler_pool/worker.py
@@ -368,6 +368,14 @@ def main():
     parser.add_argument('--version-serial', type=int)
     args = parser.parse_args()
 
+    ql_parser.preload(allow_rebuild=False)
+    gc.freeze()
+
+    if args.numproc is None:
+        # Run a single worker process
+        run_worker(args.sockname, args.version_serial)
+        return
+
     numproc = int(args.numproc)
     assert numproc >= 1
 
@@ -375,9 +383,6 @@ def main():
     # new workers are created continuously - it probably means the
     # worker cannot start correctly.
     max_worker_spawns = numproc * 2
-
-    ql_parser.preload(allow_rebuild=False)
-    gc.freeze()
 
     children = set()
     continuous_num_spawns = 0

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -192,7 +192,7 @@ async def _run_server(
             internal_runstate_dir=internal_runstate_dir,
             max_backend_connections=args.max_backend_connections,
             compiler_pool_size=args.compiler_pool_size,
-            compiler_pool_scaling_mode=args.compiler_pool_scaling_mode,
+            compiler_pool_mode=args.compiler_pool_mode,
             nethosts=args.bind_addresses,
             netport=args.port,
             auto_shutdown_after=args.auto_shutdown_after,

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -192,6 +192,7 @@ async def _run_server(
             internal_runstate_dir=internal_runstate_dir,
             max_backend_connections=args.max_backend_connections,
             compiler_pool_size=args.compiler_pool_size,
+            compiler_pool_scaling_mode=args.compiler_pool_scaling_mode,
             nethosts=args.bind_addresses,
             netport=args.port,
             auto_shutdown_after=args.auto_shutdown_after,

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -126,7 +126,7 @@ class Server(ha_base.ClusterProtocol):
         internal_runstate_dir,
         max_backend_connections,
         compiler_pool_size,
-        compiler_pool_scaling_mode: srvargs.CompilerPoolScalingMode,
+        compiler_pool_mode: srvargs.CompilerPoolMode,
         nethosts,
         netport,
         new_instance: bool,
@@ -177,7 +177,7 @@ class Server(ha_base.ClusterProtocol):
         self._max_backend_connections = max_backend_connections
         self._compiler_pool = None
         self._compiler_pool_size = compiler_pool_size
-        self._compiler_pool_scaling_mode = compiler_pool_scaling_mode
+        self._compiler_pool_mode = compiler_pool_mode
         self._suggested_client_pool_size = max(
             min(max_backend_connections,
                 defines.MAX_SUGGESTED_CLIENT_POOL_SIZE),
@@ -461,7 +461,7 @@ class Server(ha_base.ClusterProtocol):
     async def _create_compiler_pool(self):
         self._compiler_pool = await compiler_pool.create_compiler_pool(
             pool_size=self._compiler_pool_size,
-            pool_class=self._compiler_pool_scaling_mode.pool_class,
+            pool_class=self._compiler_pool_mode.pool_class,
             dbindex=self._dbindex,
             runstate_dir=self._internal_runstate_dir,
             backend_runtime_params=self.get_backend_runtime_params(),

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -126,6 +126,7 @@ class Server(ha_base.ClusterProtocol):
         internal_runstate_dir,
         max_backend_connections,
         compiler_pool_size,
+        compiler_pool_scaling_mode: srvargs.CompilerPoolScalingMode,
         nethosts,
         netport,
         new_instance: bool,
@@ -176,6 +177,7 @@ class Server(ha_base.ClusterProtocol):
         self._max_backend_connections = max_backend_connections
         self._compiler_pool = None
         self._compiler_pool_size = compiler_pool_size
+        self._compiler_pool_scaling_mode = compiler_pool_scaling_mode
         self._suggested_client_pool_size = max(
             min(max_backend_connections,
                 defines.MAX_SUGGESTED_CLIENT_POOL_SIZE),
@@ -459,6 +461,7 @@ class Server(ha_base.ClusterProtocol):
     async def _create_compiler_pool(self):
         self._compiler_pool = await compiler_pool.create_compiler_pool(
             pool_size=self._compiler_pool_size,
+            pool_class=self._compiler_pool_scaling_mode.pool_class,
             dbindex=self._dbindex,
             runstate_dir=self._internal_runstate_dir,
             backend_runtime_params=self.get_backend_runtime_params(),


### PR DESCRIPTION
Use --compiler-pool-scaling-mode=on_demand to switch to the new mode,
which will a spawn new compiler worker process every 3 seconds if the
compiling requests keep queueing up, up to num of CPUs; after 60 seconds
without compiling requests, the compiler pool will scale down to
--compiler-pool-size with a default of 1 under on-demand mode.