### PR TITLE
Remote compiler

### DIFF
--- a/.github/workflows.src/tests-pg-versions.tpl.yml
+++ b/.github/workflows.src/tests-pg-versions.tpl.yml
@@ -33,9 +33,14 @@ jobs:
          - ''
          - 'NOCREATEDB NOCREATEROLE'
          - 'CREATEDB NOCREATEROLE'
+        remote-compiler: [ '' ]
         include:
           - postgres-version: 14
             single-mode: ''
+            remote-compiler: ''
+          - postgres-version: 14
+            single-mode: ''
+            remote-compiler: 'remote-compiler'
     services:
       postgres:
         image: postgres:${{ matrix.postgres-version }}-alpine
@@ -83,6 +88,10 @@ jobs:
           export EDGEDB_TEST_BACKEND_DSN=postgres://singles:test@localhost/singles
         else
           export EDGEDB_TEST_BACKEND_DSN=postgres://postgres:postgres@localhost/postgres
+        fi
+        if [[ "${{ matrix.remote-compiler }}" ]]; then
+          edgedb-server compiler /tmp/edb-compiler --pool-size 2 &
+          export EDGEDB_TEST_REMOTE_COMPILER=/tmp/edb-compiler
         fi
         edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         if [[ "${{ matrix.single-mode }}" == *"NOCREATEDB"* ]]; then

--- a/.github/workflows/tests-pg-versions.yml
+++ b/.github/workflows/tests-pg-versions.yml
@@ -309,9 +309,14 @@ jobs:
          - ''
          - 'NOCREATEDB NOCREATEROLE'
          - 'CREATEDB NOCREATEROLE'
+        remote-compiler: [ '' ]
         include:
           - postgres-version: 14
             single-mode: ''
+            remote-compiler: ''
+          - postgres-version: 14
+            single-mode: ''
+            remote-compiler: 'remote-compiler'
     services:
       postgres:
         image: postgres:${{ matrix.postgres-version }}-alpine
@@ -469,6 +474,10 @@ jobs:
           export EDGEDB_TEST_BACKEND_DSN=postgres://singles:test@localhost/singles
         else
           export EDGEDB_TEST_BACKEND_DSN=postgres://postgres:postgres@localhost/postgres
+        fi
+        if [[ "${{ matrix.remote-compiler }}" ]]; then
+          edgedb-server compiler /tmp/edb-compiler --pool-size 2 &
+          export EDGEDB_TEST_REMOTE_COMPILER=/tmp/edb-compiler
         fi
         edb server --bootstrap-only --backend-dsn=$EDGEDB_TEST_BACKEND_DSN --testmode
         if [[ "${{ matrix.single-mode }}" == *"NOCREATEDB"* ]]; then

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -493,6 +493,23 @@ class FlatSchema(Schema):
         self._refs_to = immu.Map()
         self._generation = 0
 
+    def eq(self, other: FlatSchema) -> bool:
+        if self._id_to_data != other._id_to_data:
+            return False
+        if self._id_to_type != other._id_to_type:
+            return False
+        if self._shortname_to_id != other._shortname_to_id:
+            return False
+        if self._name_to_id != other._name_to_id:
+            return False
+        if self._globalname_to_id != other._globalname_to_id:
+            return False
+        if self._refs_to != other._refs_to:
+            return False
+        if self._generation != other._generation:
+            return False
+        return True
+
     def _replace(
         self,
         *,

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -493,23 +493,6 @@ class FlatSchema(Schema):
         self._refs_to = immu.Map()
         self._generation = 0
 
-    def eq(self, other: FlatSchema) -> bool:
-        if self._id_to_data != other._id_to_data:
-            return False
-        if self._id_to_type != other._id_to_type:
-            return False
-        if self._shortname_to_id != other._shortname_to_id:
-            return False
-        if self._name_to_id != other._name_to_id:
-            return False
-        if self._globalname_to_id != other._globalname_to_id:
-            return False
-        if self._refs_to != other._refs_to:
-            return False
-        if self._generation != other._generation:
-            return False
-        return True
-
     def _replace(
         self,
         *,

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -630,11 +630,16 @@ _compiler_options = [
         type=int,
         callback=_validate_compiler_pool_size,
         default=compute_default_compiler_pool_size(),
+        help=f"Number of compiler worker processes. Defaults to "
+             f"{compute_default_compiler_pool_size()}.",
     ),
     click.option(
-        "--cache-size",
+        "--client-schema-cache-size",
         type=int,
         default=100,
+        help="Number of client schemas each worker could cache at most. The "
+             "compiler server is not affected by this setting, it keeps a "
+             "pickled copy of the client schema of all active clients."
     ),
     click.argument("socket_path"),
 ]
@@ -800,6 +805,9 @@ def parse_args(**kwargs: Any):
     )
     if kwargs['compiler_pool_size'] is None:
         if kwargs['compiler_pool_mode'] == CompilerPoolMode.Remote:
+            # this reflects to a local semaphore to control concurrency,
+            # 2 means this is a small EdgeDB instance that could only issue
+            # at max 2 concurrent compile requests at a time.
             kwargs['compiler_pool_size'] = 2
         else:
             kwargs['compiler_pool_size'] = compute_default_compiler_pool_size()

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -641,7 +641,10 @@ _compiler_options = [
              "compiler server is not affected by this setting, it keeps a "
              "pickled copy of the client schema of all active clients."
     ),
-    click.argument("socket_path"),
+    click.option(
+        "--socket-path",
+        required=True,
+    ),
 ]
 
 

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -69,6 +69,17 @@ class BaseCluster:
         if log_level:
             self._edgedb_cmd.extend(['--log-level', log_level])
 
+        compiler_addr = os.getenv('EDGEDB_TEST_REMOTE_COMPILER')
+        if compiler_addr:
+            self._edgedb_cmd.extend(
+                [
+                    '--compiler-pool-mode',
+                    'remote',
+                    '--compiler-pool-addr',
+                    compiler_addr,
+                ]
+            )
+
         if devmode.is_in_dev_mode():
             self._edgedb_cmd.append('--devmode')
 

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -22,6 +22,7 @@ from typing import *  # NoQA
 
 import asyncio
 import functools
+import hashlib
 import logging
 import os
 import os.path
@@ -51,7 +52,7 @@ PROCESS_INITIAL_RESPONSE_TIMEOUT: float = 60.0
 KILL_TIMEOUT: float = 10.0
 ADAPTIVE_SCALE_UP_WAIT_TIME: float = 3.0
 ADAPTIVE_SCALE_DOWN_WAIT_TIME: float = 60.0
-WORKER_MOD: str = __name__.rpartition('.')[0] + '.worker'
+WORKER_PKG: str = __name__.rpartition('.')[0] + '.'
 
 
 logger = logging.getLogger("edb.server")
@@ -69,13 +70,12 @@ def _pickle_memoized(schema):
     return pickle.dumps(schema, -1)
 
 
-class Worker:
+class BaseWorker:
 
     _dbs: state.DatabasesState
 
     def __init__(
         self,
-        manager,
         dbs: state.DatabasesState,
         backend_runtime_params: pgparams.BackendRuntimeParams,
         std_schema,
@@ -83,12 +83,8 @@ class Worker:
         schema_class_layout,
         global_schema,
         system_config,
-        server,
-        pid
     ):
         self._dbs = dbs
-        self._pid = pid
-
         self._backend_runtime_params = backend_runtime_params
         self._std_schema = std_schema
         self._refl_schema = refl_schema
@@ -97,24 +93,9 @@ class Worker:
         self._system_config = system_config
         self._last_pickled_state = None
 
-        self._manager = manager
-        self._server = server
         self._con = None
         self._last_used = time.monotonic()
         self._closed = False
-
-    async def _attach(self, init_args_pickled: bytes):
-        self._manager._stats_spawned += 1
-
-        self._con = self._server.get_by_pid(self._pid)
-
-        await self.call(
-            '__init_worker__',
-            init_args_pickled,
-        )
-
-    def get_pid(self):
-        return self._pid
 
     async def call(self, method_name, *args, sync_state=None):
         assert not self._closed
@@ -147,6 +128,29 @@ class Worker:
             exc.__formatted_error__ = data[0]
             raise exc
 
+
+class Worker(BaseWorker):
+    def __init__(self, manager, server, pid, *args):
+        super().__init__(*args)
+
+        self._pid = pid
+        self._last_pickled_state = None
+        self._manager = manager
+        self._server = server
+
+    async def _attach(self, init_args_pickled: bytes):
+        self._manager._stats_spawned += 1
+
+        self._con = self._server.get_by_pid(self._pid)
+
+        await self.call(
+            '__init_worker__',
+            init_args_pickled,
+        )
+
+    def get_pid(self):
+        return self._pid
+
     def close(self):
         if self._closed:
             return
@@ -160,22 +164,17 @@ class Worker:
             pass
 
 
-class BasePool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
-
-    _workers_queue: queue.WorkerQueue[Worker]
-    _workers: Dict[int, Worker]
-
+class AbstractPool:
     def __init__(
         self,
         *,
         loop,
-        runstate_dir,
         dbindex,
         backend_runtime_params: pgparams.BackendRuntimeParams,
         std_schema,
         refl_schema,
         schema_class_layout,
-        pool_size,
+        **kwargs,
     ):
         self._loop = loop
         self._dbindex = dbindex
@@ -184,62 +183,6 @@ class BasePool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
         self._std_schema = std_schema
         self._refl_schema = refl_schema
         self._schema_class_layout = schema_class_layout
-
-        self._runstate_dir = runstate_dir
-
-        self._poolsock_name = os.path.join(self._runstate_dir, 'ipc')
-        assert len(self._poolsock_name) <= (
-            defines.MAX_RUNSTATE_DIR_PATH
-            + defines.MAX_UNIX_SOCKET_PATH_LENGTH
-            + 1
-        ), "pool IPC socket length exceeds maximum allowed"
-
-        assert pool_size >= 1
-        self._pool_size = pool_size
-        self._workers = {}
-
-        self._server = amsg.Server(self._poolsock_name, loop, self)
-        self._ready_evt = asyncio.Event()
-
-        self._running = None
-
-        self._stats_spawned = 0
-        self._stats_killed = 0
-
-    def is_running(self):
-        return bool(self._running)
-
-    async def _attach_worker(self, pid: int, init_args, init_args_pickled):
-        if not self._running:
-            return
-        worker = Worker(  # type: ignore
-            self,
-            *init_args,
-            self._server,
-            pid,
-        )
-        await worker._attach(init_args_pickled)
-        self._report_worker(worker)
-
-        self._workers[pid] = worker
-        self._workers_queue.release(worker)
-        self._worker_attached()
-
-        logger.debug("started compiler worker process (PID %s)", pid)
-        if (
-            not self._ready_evt.is_set()
-            and len(self._workers) == self._pool_size
-        ):
-            logger.info(
-                f"started {self._pool_size} compiler worker "
-                f"process{'es' if self._pool_size > 1 else ''}",
-            )
-            self._ready_evt.set()
-
-        return worker
-
-    def _worker_attached(self):
-        pass
 
     @functools.lru_cache(maxsize=None)
     def _get_init_args(self):
@@ -267,109 +210,16 @@ class BasePool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
         pickled_args = pickle.dumps(init_args, -1)
         return init_args, pickled_args
 
-    def worker_connected(self, pid, version):
-        logger.debug("Worker with PID %s connected, sending init args.", pid)
-        args, pickled_args = self._get_init_args()
-        self._loop.create_task(
-            self._attach_worker(pid, args, pickled_args)
-        )
-        metrics.compiler_process_spawns.inc()
-        metrics.current_compiler_processes.inc()
+    async def start(self):
+        raise NotImplementedError
 
-    def worker_disconnected(self, pid):
-        logger.debug("Worker with PID %s disconnected.", pid)
-        self._workers.pop(pid, None)
-        metrics.current_compiler_processes.dec()
+    async def stop(self):
+        raise NotImplementedError
 
     def get_template_pid(self):
         return None
 
-    async def start(self):
-        if self._running is not None:
-            raise RuntimeError(
-                'the compiler pool has already been started once')
-
-        self._workers_queue = queue.WorkerQueue(self._loop)
-
-        await self._server.start()
-        self._running = True
-
-        await self._start()
-
-        await asyncio.wait_for(
-            self._ready_evt.wait(),
-            PROCESS_INITIAL_RESPONSE_TIMEOUT
-        )
-
-    async def _create_compiler_process(self, numproc=None, version=0):
-        # Create a new compiler process. When numproc is None, a single
-        # standalone compiler worker process is started; if numproc is an int,
-        # a compiler template process will be created, which will then fork
-        # itself into `numproc` actual worker processes and run as a supervisor
-
-        env = _ENV
-        if debug.flags.server:
-            env = {'EDGEDB_DEBUG_SERVER': '1', **_ENV}
-
-        cmdline = [sys.executable]
-        if sys.flags.isolated:
-            cmdline.append('-I')
-
-        cmdline.extend([
-            '-m', WORKER_MOD,
-            '--sockname', self._poolsock_name,
-            '--version-serial', str(version),
-        ])
-        if numproc:
-            cmdline.extend([
-                '--numproc', str(numproc),
-            ])
-
-        transport, _ = await self._loop.subprocess_exec(
-            lambda: self,
-            *cmdline,
-            env=env,
-            stdin=subprocess.DEVNULL,
-            stdout=None,
-            stderr=None,
-        )
-        return transport
-
-    async def _start(self):
-        raise NotImplementedError
-
-    async def stop(self):
-        if not self._running:
-            return
-        self._running = False
-
-        await self._server.stop()
-        self._server = None
-
-        self._workers_queue = queue.WorkerQueue(self._loop)
-        self._workers.clear()
-
-        await self._stop()
-
-    async def _stop(self):
-        raise NotImplementedError
-
-    def _report_worker(self, worker: Worker, *, action: str = "spawn"):
-        action = action.capitalize()
-        if not action.endswith("e"):
-            action += "e"
-        action += "d"
-        log_metrics.info(
-            "%s a compiler worker with PID %d; pool=%d;"
-            + " spawned=%d; killed=%d",
-            action,
-            worker.get_pid(),
-            len(self._workers),
-            self._stats_spawned,
-            self._stats_killed,
-        )
-
-    def _compute_compile_preargs(
+    async def _compute_compile_preargs(
         self,
         worker,
         dbname,
@@ -499,18 +349,11 @@ class BasePool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
 
         return preargs, callback
 
-    async def _acquire_worker(self, *, condition=None):
-        while (
-            worker := await self._workers_queue.acquire(condition=condition)
-        ).get_pid() not in self._workers:
-            # The worker was disconnected; skip to the next one.
-            pass
-        return worker
+    async def _acquire_worker(self, *, condition=None, weighter=None):
+        raise NotImplementedError
 
-    def _release_worker(self, worker):
-        # Skip disconnected workers
-        if worker.get_pid() in self._workers:
-            self._workers_queue.release(worker)
+    def _release_worker(self, worker, *, put_in_front: bool = True):
+        raise NotImplementedError
 
     async def compile(
         self,
@@ -524,7 +367,7 @@ class BasePool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
     ):
         worker = await self._acquire_worker()
         try:
-            preargs, sync_state = self._compute_compile_preargs(
+            preargs, sync_state = await self._compute_compile_preargs(
                 worker,
                 dbname,
                 user_schema,
@@ -594,7 +437,7 @@ class BasePool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
             # of reusing it later (and maximising the chance of
             # the w._last_pickled_state is pickled_state` check returning
             # `True` is higher.
-            self._workers_queue.release(worker, put_in_front=False)
+            self._release_worker(worker, put_in_front=False)
 
     async def compile_notebook(
         self,
@@ -608,7 +451,7 @@ class BasePool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
     ):
         worker = await self._acquire_worker()
         try:
-            preargs, sync_state = self._compute_compile_preargs(
+            preargs, sync_state = await self._compute_compile_preargs(
                 worker,
                 dbname,
                 user_schema,
@@ -655,7 +498,7 @@ class BasePool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
     ):
         worker = await self._acquire_worker()
         try:
-            preargs, sync_state = self._compute_compile_preargs(
+            preargs, sync_state = await self._compute_compile_preargs(
                 worker,
                 dbname,
                 user_schema,
@@ -708,8 +551,199 @@ class BasePool(amsg.ServerProtocol, asyncio.SubprocessProtocol):
             self._release_worker(worker)
 
 
+class BaseLocalPool(
+    AbstractPool, amsg.ServerProtocol, asyncio.SubprocessProtocol
+):
+
+    _worker_class = Worker
+    _worker_mod = "worker"
+    _workers_queue: queue.WorkerQueue[Worker]
+    _workers: Dict[int, Worker]
+
+    def __init__(
+        self,
+        *,
+        runstate_dir,
+        pool_size,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self._runstate_dir = runstate_dir
+
+        self._poolsock_name = os.path.join(self._runstate_dir, 'ipc')
+        assert len(self._poolsock_name) <= (
+            defines.MAX_RUNSTATE_DIR_PATH
+            + defines.MAX_UNIX_SOCKET_PATH_LENGTH
+            + 1
+        ), "pool IPC socket length exceeds maximum allowed"
+
+        assert pool_size >= 1
+        self._pool_size = pool_size
+        self._workers = {}
+
+        self._server = amsg.Server(self._poolsock_name, self._loop, self)
+        self._ready_evt = asyncio.Event()
+
+        self._running = None
+
+        self._stats_spawned = 0
+        self._stats_killed = 0
+
+    def is_running(self):
+        return bool(self._running)
+
+    async def _attach_worker(self, pid: int):
+        if not self._running:
+            return
+        logger.debug("Sending init args to worker with PID %s.", pid)
+        init_args, init_args_pickled = self._get_init_args()
+        worker = self._worker_class(  # type: ignore
+            self,
+            self._server,
+            pid,
+            *init_args,
+        )
+        await worker._attach(init_args_pickled)
+        self._report_worker(worker)
+
+        self._workers[pid] = worker
+        self._workers_queue.release(worker)
+        self._worker_attached()
+
+        logger.debug("started compiler worker process (PID %s)", pid)
+        if (
+            not self._ready_evt.is_set()
+            and len(self._workers) == self._pool_size
+        ):
+            logger.info(
+                f"started {self._pool_size} compiler worker "
+                f"process{'es' if self._pool_size > 1 else ''}",
+            )
+            self._ready_evt.set()
+
+        return worker
+
+    def _worker_attached(self):
+        pass
+
+    def worker_connected(self, pid, version):
+        logger.debug("Worker with PID %s connected.", pid)
+        self._loop.create_task(self._attach_worker(pid))
+        metrics.compiler_process_spawns.inc()
+        metrics.current_compiler_processes.inc()
+
+    def worker_disconnected(self, pid):
+        logger.debug("Worker with PID %s disconnected.", pid)
+        self._workers.pop(pid, None)
+        metrics.current_compiler_processes.dec()
+
+    async def start(self):
+        if self._running is not None:
+            raise RuntimeError(
+                'the compiler pool has already been started once')
+
+        self._workers_queue = queue.WorkerQueue(self._loop)
+
+        await self._server.start()
+        self._running = True
+
+        await self._start()
+
+        await self._wait_ready()
+
+    async def _wait_ready(self):
+        await asyncio.wait_for(
+            self._ready_evt.wait(),
+            PROCESS_INITIAL_RESPONSE_TIMEOUT
+        )
+
+    async def _create_compiler_process(self, numproc=None, version=0):
+        # Create a new compiler process. When numproc is None, a single
+        # standalone compiler worker process is started; if numproc is an int,
+        # a compiler template process will be created, which will then fork
+        # itself into `numproc` actual worker processes and run as a supervisor
+
+        env = _ENV
+        if debug.flags.server:
+            env = {'EDGEDB_DEBUG_SERVER': '1', **_ENV}
+
+        cmdline = [sys.executable]
+        if sys.flags.isolated:
+            cmdline.append('-I')
+
+        cmdline.extend([
+            '-m', WORKER_PKG + self._worker_mod,
+            '--sockname', self._poolsock_name,
+            '--version-serial', str(version),
+        ])
+        if numproc:
+            cmdline.extend([
+                '--numproc', str(numproc),
+            ])
+
+        transport, _ = await self._loop.subprocess_exec(
+            lambda: self,
+            *cmdline,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=None,
+            stderr=None,
+        )
+        return transport
+
+    async def _start(self):
+        raise NotImplementedError
+
+    async def stop(self):
+        if not self._running:
+            return
+        self._running = False
+
+        await self._server.stop()
+        self._server = None
+
+        self._workers_queue = queue.WorkerQueue(self._loop)
+        self._workers.clear()
+
+        await self._stop()
+
+    async def _stop(self):
+        raise NotImplementedError
+
+    def _report_worker(self, worker: Worker, *, action: str = "spawn"):
+        action = action.capitalize()
+        if not action.endswith("e"):
+            action += "e"
+        action += "d"
+        log_metrics.info(
+            "%s a compiler worker with PID %d; pool=%d;"
+            + " spawned=%d; killed=%d",
+            action,
+            worker.get_pid(),
+            len(self._workers),
+            self._stats_spawned,
+            self._stats_killed,
+        )
+
+    async def _acquire_worker(self, *, condition=None, weighter=None):
+        while (
+            worker := await self._workers_queue.acquire(
+                condition=condition, weighter=weighter
+            )
+        ).get_pid() not in self._workers:
+            # The worker was disconnected; skip to the next one.
+            pass
+        return worker
+
+    def _release_worker(self, worker, *, put_in_front: bool = True):
+        # Skip disconnected workers
+        if worker.get_pid() in self._workers:
+            self._workers_queue.release(worker, put_in_front=put_in_front)
+
+
 @srvargs.CompilerPoolMode.Fixed.assign_implementation
-class FixedPool(BasePool):
+class FixedPool(BaseLocalPool):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._template_transport = None
@@ -787,7 +821,7 @@ class FixedPool(BasePool):
 
 
 @srvargs.CompilerPoolMode.OnDemand.assign_implementation
-class SimpleAdaptivePool(BasePool):
+class SimpleAdaptivePool(BaseLocalPool):
     def __init__(self, *, pool_size, **kwargs):
         super().__init__(pool_size=1, **kwargs)
         self._worker_transports = {}
@@ -807,7 +841,7 @@ class SimpleAdaptivePool(BasePool):
         for transport in transports.values():
             await transport._wait()
 
-    async def _acquire_worker(self, *, condition=None):
+    async def _acquire_worker(self, *, condition=None, weighter=None):
         if (
             self._running and
             self._scale_up_handle is None
@@ -826,13 +860,15 @@ class SimpleAdaptivePool(BasePool):
         if self._scale_down_handle is not None:
             self._scale_down_handle.cancel()
             self._scale_down_handle = None
-        return await super()._acquire_worker(condition=condition)
+        return await super()._acquire_worker(
+            condition=condition, weighter=weighter
+        )
 
-    def _release_worker(self, worker):
+    def _release_worker(self, worker, *, put_in_front: bool = True):
         if self._scale_down_handle is not None:
             self._scale_down_handle.cancel()
             self._scale_down_handle = None
-        super()._release_worker(worker)
+        super()._release_worker(worker, put_in_front=put_in_front)
         if (
             self._running and
             self._workers_queue.count_waiters() == 0 and
@@ -907,6 +943,122 @@ class SimpleAdaptivePool(BasePool):
             worker.close()
 
 
+class RemoteWorker(BaseWorker):
+    def __init__(self, con, *args):
+        super().__init__(*args)
+        self._con = con
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        self._con.abort()
+
+
+@srvargs.CompilerPoolMode.Remote.assign_implementation
+class RemotePool(AbstractPool):
+    def __init__(self, *, address, pool_size, **kwargs):
+        super().__init__(**kwargs)
+        self._socket_path = address
+        self._worker = None
+        self._sync_lock = asyncio.Lock()
+        self._semaphore = asyncio.BoundedSemaphore(pool_size)
+
+    async def start(self, retry=False):
+        if self._worker is None:
+            self._worker = self._loop.create_future()
+        try:
+            await self._loop.create_unix_connection(
+                lambda: amsg.HubProtocol(
+                    loop=self._loop,
+                    on_pid=lambda *args: self._loop.create_task(
+                        self._connection_made(*args)
+                    ),
+                    on_connection_lost=self._connection_lost,
+                ),
+                self._socket_path,
+            )
+        except Exception:
+            if not retry:
+                raise
+            if self._worker is not None:
+                self._loop.call_later(1, lambda: self._loop.create_task(
+                    self.start(retry=True)
+                ))
+        else:
+            if not retry:
+                await self._worker
+
+    async def stop(self):
+        if self._worker is not None:
+            worker, self._worker = self._worker, None
+            if worker.done():
+                (await worker).close()
+
+    async def _connection_made(self, protocol, transport, _pid, version):
+        if self._worker is None:
+            return
+        try:
+            init_args, init_args_pickled = self._get_init_args()
+            worker = RemoteWorker(
+                amsg.HubConnection(transport, protocol, self._loop, version),
+                *init_args,
+            )
+            await worker.call(
+                '__init_server__',
+                init_args_pickled,
+            )
+        except BaseException:
+            transport.abort()
+            if self._worker is not None:
+                await self.start(retry=True)
+        else:
+            self._worker.set_result(worker)
+
+    def _connection_lost(self, _pid):
+        if self._worker is not None:
+            self._worker = self._loop.create_future()
+            self._loop.create_task(self.start(retry=True))
+
+    async def _acquire_worker(self, *, condition=None, cmp=None):
+        await self._semaphore.acquire()
+        return await self._worker
+
+    def _release_worker(self, worker, *, put_in_front: bool = True):
+        if self._sync_lock.locked():
+            self._sync_lock.release()
+        self._semaphore.release()
+
+    async def compile_in_tx(self, txid, pickled_state, *compile_args):
+        worker = await self._acquire_worker()
+        try:
+            return await worker.call(
+                'compile_in_tx',
+                hashlib.sha1(pickled_state).hexdigest(),
+                txid,
+                *compile_args
+            )
+        except state.StateNotFound:
+            return await worker.call(
+                'compile_in_tx',
+                pickled_state,
+                txid,
+                *compile_args
+            )
+        finally:
+            self._release_worker(worker)
+
+    async def _compute_compile_preargs(self, *args):
+        preargs, callback = await super()._compute_compile_preargs(*args)
+        if callback:
+            del preargs, callback
+            await self._sync_lock.acquire()
+            preargs, callback = await super()._compute_compile_preargs(*args)
+            if not callback:
+                self._sync_lock.release()
+        return preargs, callback
+
+
 async def create_compiler_pool(
     *,
     runstate_dir: str,
@@ -917,8 +1069,9 @@ async def create_compiler_pool(
     refl_schema,
     schema_class_layout,
     pool_class=FixedPool,
-) -> BasePool:
-    assert issubclass(pool_class, BasePool)
+    **kwargs,
+) -> AbstractPool:
+    assert issubclass(pool_class, AbstractPool)
     loop = asyncio.get_running_loop()
     pool = pool_class(
         loop=loop,
@@ -929,6 +1082,7 @@ async def create_compiler_pool(
         refl_schema=refl_schema,
         schema_class_layout=schema_class_layout,
         dbindex=dbindex,
+        **kwargs,
     )
 
     await pool.start()

--- a/edb/server/compiler_pool/remote_worker.py
+++ b/edb/server/compiler_pool/remote_worker.py
@@ -1,0 +1,481 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2022-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+from typing import *  # NoQA
+
+import argparse
+import gc
+import os
+import pickle
+import signal
+import time
+import traceback
+
+import immutables
+
+from edb import graphql
+
+from edb.common import debug
+from edb.common import devmode
+from edb.common import markup
+
+from edb.edgeql import parser as ql_parser
+
+from edb.pgsql import params as pgparams
+
+from edb.schema import schema as s_schema
+
+from edb.server import compiler
+from edb.server import config
+
+from . import amsg
+from . import state
+
+
+INITED: bool = False
+clients: immutables.Map[int, ClientSchema] = immutables.Map()
+BACKEND_RUNTIME_PARAMS: pgparams.BackendRuntimeParams = (
+    pgparams.get_default_runtime_params()
+)
+COMPILER: compiler.Compiler
+LAST_STATE: Optional[compiler.dbstate.CompilerConnectionState] = None
+STD_SCHEMA: s_schema.FlatSchema
+
+# "created continuously" means the interval between two consecutive spawns
+# is less than NUM_SPAWNS_RESET_INTERVAL seconds.
+NUM_SPAWNS_RESET_INTERVAL = 1
+
+
+class ClientSchema(NamedTuple):
+    dbs: state.DatabasesState
+    global_schema: s_schema.FlatSchema
+    instance_config: immutables.Map[str, config.SettingValue]
+
+
+def __init_worker__(
+    init_args_pickled: bytes,
+) -> None:
+    global INITED
+    global BACKEND_RUNTIME_PARAMS
+    global COMPILER
+    global STD_SCHEMA
+
+    (
+        backend_runtime_params,
+        std_schema,
+        refl_schema,
+        schema_class_layout,
+    ) = pickle.loads(init_args_pickled)
+
+    INITED = True
+    BACKEND_RUNTIME_PARAMS = backend_runtime_params
+    COMPILER = compiler.Compiler(
+        backend_runtime_params=BACKEND_RUNTIME_PARAMS,
+    )
+    STD_SCHEMA = std_schema
+
+    COMPILER.initialize(
+        std_schema,
+        refl_schema,
+        schema_class_layout,
+    )
+
+
+def __sync__(client_id, pickled_schema, invalidation):
+    global clients
+
+    for cid in invalidation:
+        try:
+            clients = clients.delete(cid)
+        except KeyError:
+            pass
+    try:
+        client_schema = clients.get(client_id)  # type: ClientSchema
+        if pickled_schema:
+            if client_schema is None:
+                dbs = {
+                    dbname: state.DatabaseState(
+                        dbname,
+                        pickle.loads(pickled_state.user_schema),
+                        pickle.loads(pickled_state.reflection_cache),
+                        pickle.loads(pickled_state.database_config),
+                    )
+                    for dbname, pickled_state in pickled_schema.dbs.items()
+                }
+                if debug.flags.server:
+                    print(client_id, "FULL SYNC: ", list(dbs))
+                client_schema = ClientSchema(
+                    immutables.Map(dbs),
+                    pickle.loads(pickled_schema.global_schema),
+                    pickle.loads(pickled_schema.instance_config),
+                )
+                clients = clients.set(client_id, client_schema)
+            else:
+                updates = {}
+                dbs = client_schema.dbs
+                if pickled_schema.dbs is not None:
+                    for dbname, pickled_state in pickled_schema.dbs.items():
+                        db_state = dbs.get(dbname)
+                        if db_state is None:
+                            assert pickled_state.user_schema is not None
+                            assert pickled_state.reflection_cache is not None
+                            assert pickled_state.database_config is not None
+                            db_state = state.DatabaseState(
+                                dbname,
+                                pickle.loads(pickled_state.user_schema),
+                                pickle.loads(pickled_state.reflection_cache),
+                                pickle.loads(pickled_state.database_config),
+                            )
+                            if debug.flags.server:
+                                print(client_id, "DIFF SYNC ADD: ", dbname)
+                            dbs = dbs.set(dbname, db_state)
+                        else:
+                            db_updates = {}
+                            if pickled_state.user_schema is not None:
+                                db_updates["user_schema"] = pickle.loads(
+                                    pickled_state.user_schema
+                                )
+                            if pickled_state.reflection_cache is not None:
+                                db_updates["reflection_cache"] = pickle.loads(
+                                    pickled_state.reflection_cache
+                                )
+                            if pickled_state.database_config is not None:
+                                db_updates["database_config"] = pickle.loads(
+                                    pickled_state.database_config
+                                )
+                            if db_updates:
+                                if debug.flags.server:
+                                    print(
+                                        client_id, "DIFF SYNC UPDATE: ", dbname
+                                    )
+                                dbs = dbs.set(
+                                    dbname,
+                                    dbs.get(dbname)._replace(**db_updates),
+                                )
+                if pickled_schema.dropped_dbs is not None:
+                    for dbname in pickled_schema.dropped_dbs:
+                        if debug.flags.server:
+                            print(client_id, "DIFF SYNC DROP: ", dbname)
+                        dbs = dbs.delete(dbname)
+                if dbs is not client_schema.dbs:
+                    updates["dbs"] = dbs
+                if pickled_schema.global_schema is not None:
+                    updates["global_schema"] = pickle.loads(
+                        pickled_schema.global_schema
+                    )
+                if pickled_schema.instance_config is not None:
+                    updates["instance_config"] = pickle.loads(
+                        pickled_schema.instance_config
+                    )
+                if updates:
+                    client_schema = client_schema._replace(**updates)
+                    clients = clients.set(client_id, client_schema)
+        else:
+            assert client_schema is not None
+
+    except Exception as ex:
+        raise state.FailedStateSync(
+            f"failed to sync worker state: {type(ex).__name__}({ex})"
+        ) from ex
+
+
+def compile(
+    client_id: int,
+    dbname: str,
+    *compile_args: Any,
+    **compile_kwargs: Any,
+):
+    client_schema = clients[client_id]
+    db = client_schema.dbs[dbname]
+    units, cstate = COMPILER.compile(
+        db.user_schema,
+        client_schema.global_schema,
+        db.reflection_cache,
+        db.database_config,
+        client_schema.instance_config,
+        *compile_args,
+        **compile_kwargs,
+    )
+
+    pickled_state = None
+    if cstate is not None:
+        global LAST_STATE
+        LAST_STATE = cstate
+        pickled_state = pickle.dumps(cstate, -1)
+
+    return units, pickled_state
+
+
+def compile_in_tx(cstate, *args, **kwargs):
+    global LAST_STATE
+    if cstate == state.REUSE_LAST_STATE_MARKER:
+        cstate = LAST_STATE
+    else:
+        cstate = pickle.loads(cstate)
+    units, cstate = COMPILER.compile_in_tx(cstate, *args, **kwargs)
+    LAST_STATE = cstate
+    return units, pickle.dumps(cstate, -1)
+
+
+def compile_notebook(
+    client_id: int,
+    dbname: str,
+    *compile_args: Any,
+    **compile_kwargs: Any,
+):
+    global clients
+    client_schema = clients[client_id]
+    db = client_schema.dbs[dbname]
+
+    return COMPILER.compile_notebook(
+        db.user_schema,
+        client_schema.global_schema,
+        db.reflection_cache,
+        db.database_config,
+        client_schema.instance_config,
+        *compile_args,
+        **compile_kwargs,
+    )
+
+
+def try_compile_rollback(
+    *compile_args: Any,
+    **compile_kwargs: Any,
+):
+    return COMPILER.try_compile_rollback(*compile_args, **compile_kwargs)
+
+
+def compile_graphql(
+    client_id: int,
+    dbname: str,
+    *compile_args: Any,
+    **compile_kwargs: Any,
+):
+    global clients
+    client_schema = clients[client_id]
+    db = client_schema.dbs[dbname]
+
+    return graphql.compile_graphql(
+        STD_SCHEMA,
+        db.user_schema,
+        client_schema.global_schema,
+        db.database_config,
+        client_schema.instance_config,
+        *compile_args,
+        **compile_kwargs,
+    )
+
+
+def call_for_client(client_id, pickled_schema, invalidation, msg, *args):
+    __sync__(client_id, pickled_schema, invalidation)
+    if msg is None:
+        methname = args[0]
+        dbname = args[1]
+        args = args[2:]
+    else:
+        assert args == ()
+        methname, args = pickle.loads(msg)
+        dbname = args[0]
+        args = args[6:]
+
+    if methname == "compile":
+        meth = compile
+    elif methname == "compile_notebook":
+        meth = compile_notebook
+    elif methname == "compile_graphql":
+        meth = compile_graphql
+    else:
+        meth = getattr(COMPILER, methname)
+    return meth(client_id, dbname, *args)
+
+
+def worker(sockname, version_serial):
+    con = amsg.WorkerConnection(sockname, version_serial)
+    try:
+        for req_id, req in con.iter_request():
+            try:
+                methname, args = pickle.loads(req)
+                if methname == "__init_worker__":
+                    meth = __init_worker__
+                else:
+                    if not INITED:
+                        raise RuntimeError(
+                            "call on uninitialized compiler worker"
+                        )
+                    if methname == "call_for_client":
+                        meth = call_for_client
+                    elif methname == "compile_in_tx":
+                        meth = compile_in_tx
+                    elif methname == "try_compile_rollback":
+                        meth = try_compile_rollback
+                    else:
+                        meth = getattr(COMPILER, methname)
+            except Exception as ex:
+                prepare_exception(ex)
+                if debug.flags.server:
+                    markup.dump(ex)
+                data = (1, ex, traceback.format_exc())
+            else:
+                try:
+                    res = meth(*args)
+                    data = (0, res)
+                except Exception as ex:
+                    prepare_exception(ex)
+                    if debug.flags.server:
+                        markup.dump(ex)
+                    data = (1, ex, traceback.format_exc())
+
+            try:
+                pickled = pickle.dumps(data, -1)
+            except Exception as ex:
+                ex_tb = traceback.format_exc()
+                ex_str = f"{ex}:\n\n{ex_tb}"
+                pickled = pickle.dumps((2, ex_str), -1)
+
+            con.reply(req_id, pickled)
+    finally:
+        con.abort()
+
+
+def run_worker(sockname, version_serial):
+    with devmode.CoverageConfig.enable_coverage_if_requested():
+        worker(sockname, version_serial)
+
+
+def prepare_exception(ex):
+    clear_exception_frames(ex)
+    if ex.__traceback__ is not None:
+        ex.__traceback__ = ex.__traceback__.tb_next
+
+
+def clear_exception_frames(er):
+    def _clear_exception_frames(er, visited):
+        if er in visited:
+            return er
+        visited.add(er)
+
+        traceback.clear_frames(er.__traceback__)
+
+        if er.__cause__ is not None:
+            er.__cause__ = _clear_exception_frames(er.__cause__, visited)
+        if er.__context__ is not None:
+            er.__context__ = _clear_exception_frames(er.__context__, visited)
+
+        return er
+
+    visited = set()
+    _clear_exception_frames(er, visited)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sockname")
+    parser.add_argument("--numproc")
+    parser.add_argument("--version-serial", type=int)
+    args = parser.parse_args()
+
+    ql_parser.preload(allow_rebuild=False)
+    gc.freeze()
+
+    if args.numproc is None:
+        # Run a single worker process
+        run_worker(args.sockname, args.version_serial)
+        return
+
+    numproc = int(args.numproc)
+    assert numproc >= 1
+
+    # Abort the template process if more than `max_worker_spawns`
+    # new workers are created continuously - it probably means the
+    # worker cannot start correctly.
+    max_worker_spawns = numproc * 2
+
+    children = set()
+    continuous_num_spawns = 0
+
+    for _ in range(int(args.numproc)):
+        # spawn initial workers
+        if pid := os.fork():
+            # main process
+            children.add(pid)
+            continuous_num_spawns += 1
+        else:
+            # child process
+            break
+    else:
+        # main process - redirect SIGTERM to SystemExit and wait for children
+        signal.signal(signal.SIGTERM, lambda *_: exit(os.EX_OK))
+        last_spawn_timestamp = time.monotonic()
+
+        try:
+            while children:
+                pid, status = os.wait()
+                children.remove(pid)
+                ec = os.waitstatus_to_exitcode(status)
+                if ec > 0 or -ec not in {0, signal.SIGINT}:
+                    # restart the child process if killed or ending abnormally,
+                    # unless we tried too many times continuously
+                    now = time.monotonic()
+                    if now - last_spawn_timestamp > NUM_SPAWNS_RESET_INTERVAL:
+                        continuous_num_spawns = 0
+                    last_spawn_timestamp = now
+                    continuous_num_spawns += 1
+                    if continuous_num_spawns > max_worker_spawns:
+                        # GOTCHA: we shouldn't return here because we need the
+                        # exception handler below to clean up the workers
+                        exit(os.EX_UNAVAILABLE)
+
+                    if pid := os.fork():
+                        # main process
+                        children.add(pid)
+                    else:
+                        # child process
+                        break
+            else:
+                # main process - all children ended normally
+                return
+        except BaseException as e:  # includes SystemExit and KeyboardInterrupt
+            # main process - kill and wait for the remaining workers to exit
+            try:
+                signal.signal(signal.SIGTERM, signal.SIG_DFL)
+                for pid in children:
+                    try:
+                        os.kill(pid, signal.SIGTERM)
+                    except OSError:
+                        pass
+                try:
+                    while children:
+                        pid, status = os.wait()
+                        children.discard(pid)
+                except OSError:
+                    pass
+            finally:
+                raise e
+
+    # child process - clear the SIGTERM handler for potential Rust impl
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    run_worker(args.sockname, args.version_serial)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass

--- a/edb/server/compiler_pool/remote_worker.py
+++ b/edb/server/compiler_pool/remote_worker.py
@@ -20,33 +20,20 @@
 from __future__ import annotations
 from typing import *  # NoQA
 
-import argparse
-import gc
-import os
 import pickle
-import signal
-import time
-import traceback
 
 import immutables
 
 from edb import graphql
 
 from edb.common import debug
-from edb.common import devmode
-from edb.common import markup
-
-from edb.edgeql import parser as ql_parser
-
 from edb.pgsql import params as pgparams
-
 from edb.schema import schema as s_schema
-
 from edb.server import compiler
 from edb.server import config
 
-from . import amsg
 from . import state
+from . import worker_proc
 
 
 INITED: bool = False
@@ -57,10 +44,6 @@ BACKEND_RUNTIME_PARAMS: pgparams.BackendRuntimeParams = (
 COMPILER: compiler.Compiler
 LAST_STATE: Optional[compiler.dbstate.CompilerConnectionState] = None
 STD_SCHEMA: s_schema.FlatSchema
-
-# "created continuously" means the interval between two consecutive spawns
-# is less than NUM_SPAWNS_RESET_INTERVAL seconds.
-NUM_SPAWNS_RESET_INTERVAL = 1
 
 
 class ClientSchema(NamedTuple):
@@ -306,176 +289,27 @@ def call_for_client(client_id, pickled_schema, invalidation, msg, *args):
     return meth(client_id, dbname, *args)
 
 
-def worker(sockname, version_serial):
-    con = amsg.WorkerConnection(sockname, version_serial)
-    try:
-        for req_id, req in con.iter_request():
-            try:
-                methname, args = pickle.loads(req)
-                if methname == "__init_worker__":
-                    meth = __init_worker__
-                else:
-                    if not INITED:
-                        raise RuntimeError(
-                            "call on uninitialized compiler worker"
-                        )
-                    if methname == "call_for_client":
-                        meth = call_for_client
-                    elif methname == "compile_in_tx":
-                        meth = compile_in_tx
-                    elif methname == "try_compile_rollback":
-                        meth = try_compile_rollback
-                    else:
-                        meth = getattr(COMPILER, methname)
-            except Exception as ex:
-                prepare_exception(ex)
-                if debug.flags.server:
-                    markup.dump(ex)
-                data = (1, ex, traceback.format_exc())
-            else:
-                try:
-                    res = meth(*args)
-                    data = (0, res)
-                except Exception as ex:
-                    prepare_exception(ex)
-                    if debug.flags.server:
-                        markup.dump(ex)
-                    data = (1, ex, traceback.format_exc())
-
-            try:
-                pickled = pickle.dumps(data, -1)
-            except Exception as ex:
-                ex_tb = traceback.format_exc()
-                ex_str = f"{ex}:\n\n{ex_tb}"
-                pickled = pickle.dumps((2, ex_str), -1)
-
-            con.reply(req_id, pickled)
-    finally:
-        con.abort()
-
-
-def run_worker(sockname, version_serial):
-    with devmode.CoverageConfig.enable_coverage_if_requested():
-        worker(sockname, version_serial)
-
-
-def prepare_exception(ex):
-    clear_exception_frames(ex)
-    if ex.__traceback__ is not None:
-        ex.__traceback__ = ex.__traceback__.tb_next
-
-
-def clear_exception_frames(er):
-    def _clear_exception_frames(er, visited):
-        if er in visited:
-            return er
-        visited.add(er)
-
-        traceback.clear_frames(er.__traceback__)
-
-        if er.__cause__ is not None:
-            er.__cause__ = _clear_exception_frames(er.__cause__, visited)
-        if er.__context__ is not None:
-            er.__context__ = _clear_exception_frames(er.__context__, visited)
-
-        return er
-
-    visited = set()
-    _clear_exception_frames(er, visited)
-
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--sockname")
-    parser.add_argument("--numproc")
-    parser.add_argument("--version-serial", type=int)
-    args = parser.parse_args()
-
-    ql_parser.preload(allow_rebuild=False)
-    gc.freeze()
-
-    if args.numproc is None:
-        # Run a single worker process
-        run_worker(args.sockname, args.version_serial)
-        return
-
-    numproc = int(args.numproc)
-    assert numproc >= 1
-
-    # Abort the template process if more than `max_worker_spawns`
-    # new workers are created continuously - it probably means the
-    # worker cannot start correctly.
-    max_worker_spawns = numproc * 2
-
-    children = set()
-    continuous_num_spawns = 0
-
-    for _ in range(int(args.numproc)):
-        # spawn initial workers
-        if pid := os.fork():
-            # main process
-            children.add(pid)
-            continuous_num_spawns += 1
-        else:
-            # child process
-            break
+def get_handler(methname):
+    if methname == "__init_worker__":
+        meth = __init_worker__
     else:
-        # main process - redirect SIGTERM to SystemExit and wait for children
-        signal.signal(signal.SIGTERM, lambda *_: exit(os.EX_OK))
-        last_spawn_timestamp = time.monotonic()
-
-        try:
-            while children:
-                pid, status = os.wait()
-                children.remove(pid)
-                ec = os.waitstatus_to_exitcode(status)
-                if ec > 0 or -ec not in {0, signal.SIGINT}:
-                    # restart the child process if killed or ending abnormally,
-                    # unless we tried too many times continuously
-                    now = time.monotonic()
-                    if now - last_spawn_timestamp > NUM_SPAWNS_RESET_INTERVAL:
-                        continuous_num_spawns = 0
-                    last_spawn_timestamp = now
-                    continuous_num_spawns += 1
-                    if continuous_num_spawns > max_worker_spawns:
-                        # GOTCHA: we shouldn't return here because we need the
-                        # exception handler below to clean up the workers
-                        exit(os.EX_UNAVAILABLE)
-
-                    if pid := os.fork():
-                        # main process
-                        children.add(pid)
-                    else:
-                        # child process
-                        break
-            else:
-                # main process - all children ended normally
-                return
-        except BaseException as e:  # includes SystemExit and KeyboardInterrupt
-            # main process - kill and wait for the remaining workers to exit
-            try:
-                signal.signal(signal.SIGTERM, signal.SIG_DFL)
-                for pid in children:
-                    try:
-                        os.kill(pid, signal.SIGTERM)
-                    except OSError:
-                        pass
-                try:
-                    while children:
-                        pid, status = os.wait()
-                        children.discard(pid)
-                except OSError:
-                    pass
-            finally:
-                raise e
-
-    # child process - clear the SIGTERM handler for potential Rust impl
-    signal.signal(signal.SIGTERM, signal.SIG_DFL)
-    run_worker(args.sockname, args.version_serial)
+        if not INITED:
+            raise RuntimeError(
+                "call on uninitialized compiler worker"
+            )
+        if methname == "call_for_client":
+            meth = call_for_client
+        elif methname == "compile_in_tx":
+            meth = compile_in_tx
+        elif methname == "try_compile_rollback":
+            meth = try_compile_rollback
+        else:
+            meth = getattr(COMPILER, methname)
+    return meth
 
 
 if __name__ == "__main__":
     try:
-        main()
+        worker_proc.main(get_handler)
     except KeyboardInterrupt:
         pass

--- a/edb/server/compiler_pool/remote_worker.py
+++ b/edb/server/compiler_pool/remote_worker.py
@@ -223,7 +223,7 @@ def compile(
     return units, pickled_state
 
 
-def compile_in_tx(cstate, *args, **kwargs):
+def compile_in_tx(cstate, _, *args, **kwargs):
     global LAST_STATE
     if cstate == state.REUSE_LAST_STATE_MARKER:
         cstate = LAST_STATE

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -1,0 +1,539 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2022-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import functools
+import hashlib
+import logging
+import os
+import pickle
+import time
+import traceback
+import typing
+
+import click
+import immutables
+
+from edb.common import debug
+from edb.common import markup
+
+from .. import args as srvargs
+from . import amsg
+from . import pool as pool_mod
+from . import worker as worker_mod
+from . import state as state_mod
+
+
+_client_id_seq = 0
+logger = logging.getLogger("edb.server")
+
+
+class PickledState(typing.NamedTuple):
+    user_schema: typing.Optional[bytes]
+    reflection_cache: typing.Optional[bytes]
+    database_config: typing.Optional[bytes]
+
+    def diff(self, other: PickledState):
+        return PickledState(
+            None
+            if self.user_schema is other.user_schema
+            else self.user_schema,
+            None
+            if self.reflection_cache is other.reflection_cache
+            else self.reflection_cache,
+            None
+            if self.database_config is other.database_config
+            else self.database_config,
+        )
+
+
+class ClientSchema(typing.NamedTuple):
+    dbs: immutables.Map[str, PickledState]
+    global_schema: typing.Optional[bytes]
+    instance_config: typing.Optional[bytes]
+    dropped_dbs: tuple
+
+    def diff(self, other: ClientSchema):
+        dropped_dbs = tuple(
+            dbname for dbname in other.dbs if dbname not in self.dbs
+        )
+        dbs: immutables.Map[str, PickledState] = immutables.Map()
+        for dbname, state in self.dbs.items():
+            other_state = other.dbs.get(dbname)
+            if other_state is None:
+                dbs = dbs.set(dbname, state)
+            elif state is not other_state:
+                dbs = dbs.set(dbname, state.diff(other_state))
+        return ClientSchema(
+            dbs,
+            None
+            if self.global_schema is other.global_schema
+            else self.global_schema,
+            None
+            if self.instance_config is other.instance_config
+            else self.instance_config,
+            dropped_dbs,
+        )
+
+
+class Worker(pool_mod.Worker):
+    def __init__(
+        self,
+        manager,
+        server,
+        pid,
+        backend_runtime_params,
+        std_schema,
+        refl_schema,
+        schema_class_layout,
+    ):
+        super().__init__(
+            manager,
+            server,
+            pid,
+            None,
+            backend_runtime_params,
+            std_schema,
+            refl_schema,
+            schema_class_layout,
+            None,
+            None,
+        )
+        self._cache = collections.OrderedDict()
+        self._invalidated_clients = []
+        self._last_used_by_client = {}
+
+    def get_client_schema(self, client_id):
+        return self._cache.get(client_id)
+
+    def set_client_schema(self, client_id, client_schema):
+        self._cache[client_id] = client_schema
+        self._cache.move_to_end(client_id, last=False)
+        self._last_used_by_client[client_id] = time.monotonic()
+
+    def cache_size(self):
+        return len(self._cache) - len(self._invalidated_clients)
+
+    def last_used(self, client_id):
+        return self._last_used_by_client.get(client_id, 0)
+
+    def invalidate(self, client_id):
+        if self._cache.pop(client_id, None):
+            self._invalidated_clients.append(client_id)
+        self._last_used_by_client.pop(client_id, None)
+
+    def invalidate_last(self, cache_size):
+        if len(self._cache) == cache_size:
+            client_id, _ = self._cache.popitem(last=True)
+            self._invalidated_clients.append(client_id)
+            self._last_used_by_client.pop(client_id, None)
+
+    def flush_invalidation(self):
+        rv, self._invalidated_clients = self._invalidated_clients, []
+        for client_id in rv:
+            self._cache.pop(client_id, None)
+        return rv
+
+    async def call(
+        self,
+        method_name,
+        *args,
+        sync_state=None,
+        msg=None,
+    ):
+        assert not self._closed
+
+        if self._con.is_closed():
+            raise RuntimeError(
+                "the connection to the compiler worker process is "
+                "unexpectedly closed"
+            )
+
+        if msg is None:
+            msg = pickle.dumps((method_name, args))
+        return await self._con.request(msg)
+
+
+class MultiSchemaPool(pool_mod.FixedPool):
+    _worker_class = Worker  # type: ignore
+    _worker_mod = "remote_worker"
+    _workers: typing.Dict[int, Worker]  # type: ignore
+    _clients: typing.Dict[int, ClientSchema]
+
+    def __init__(self, cache_size, **kwargs):
+        super().__init__(
+            dbindex=None,
+            backend_runtime_params=None,
+            std_schema=None,
+            refl_schema=None,
+            schema_class_layout=None,
+            **kwargs,
+        )
+        self._inited = asyncio.Event()
+        self._cache_size = cache_size
+        self._clients = {}
+
+    @functools.lru_cache(maxsize=None)
+    def _get_init_args(self):
+        init_args = (
+            self._backend_runtime_params,
+            self._std_schema,
+            self._refl_schema,
+            self._schema_class_layout,
+        )
+        pickled_args = pickle.dumps(init_args, -1)
+        return init_args, pickled_args
+
+    async def _attach_worker(self, pid: int):
+        if not self._running:
+            return
+        if not self._inited.is_set():
+            await self._inited.wait()
+        return await super()._attach_worker(pid)
+
+    async def _wait_ready(self):
+        pass
+
+    async def _init_server(self, client_id: int, init_args_pickled: bytes):
+        (
+            dbs,
+            backend_runtime_params,
+            std_schema,
+            refl_schema,
+            schema_class_layout,
+            global_schema,
+            system_config,
+        ) = pickle.loads(init_args_pickled)
+
+        if self._inited.is_set():
+            logger.debug("New client %d connected.", client_id)
+            if self._backend_runtime_params != backend_runtime_params:
+                raise RuntimeError(
+                    "Incompatible client: backend_runtime_params"
+                )
+            # if self._std_schema != std_schema:
+            #     raise RuntimeError("Incompatible client: std_schema")
+            # if self._refl_schema != refl_schema:
+            #     raise RuntimeError("Incompatible client: refl_schema")
+            if self._schema_class_layout != schema_class_layout:
+                raise RuntimeError("Incompatible client: schema_class_layout")
+        else:
+            self._backend_runtime_params = backend_runtime_params
+            self._std_schema = std_schema
+            self._refl_schema = refl_schema
+            self._schema_class_layout = schema_class_layout
+            self._inited.set()
+            logger.info(
+                "New client %d connected, compiler server initialized.",
+                client_id,
+            )
+        self._clients[client_id] = ClientSchema(
+            immutables.Map(
+                (
+                    dbname,
+                    PickledState(
+                        pickle.dumps(state.user_schema, -1),
+                        pickle.dumps(state.reflection_cache, -1),
+                        pickle.dumps(state.database_config, -1),
+                    ),
+                )
+                for dbname, state in dbs.items()
+            ),
+            pickle.dumps(global_schema, -1),
+            pickle.dumps(system_config, -1),
+            (),
+        )
+
+    def _sync(
+        self,
+        client_id: int,
+        dbname: str,
+        user_schema: typing.Optional[bytes],
+        reflection_cache: typing.Optional[bytes],
+        global_schema: typing.Optional[bytes],
+        database_config: typing.Optional[bytes],
+        system_config: typing.Optional[bytes],
+    ):
+        # EdgeDB instance syncs the schema with the compiler server
+        client = self._clients[client_id]
+        client_updates: typing.Dict[str, typing.Any] = {}
+        db = client.dbs.get(dbname)
+        if db is None:
+            assert user_schema is not None
+            assert reflection_cache is not None
+            assert database_config is not None
+            client_updates["dbs"] = client.dbs.set(
+                dbname,
+                PickledState(user_schema, reflection_cache, database_config),
+            )
+        else:
+            updates = {}
+
+            if user_schema is not None:
+                updates["user_schema"] = user_schema
+            if reflection_cache is not None:
+                updates["reflection_cache"] = reflection_cache
+            if database_config is not None:
+                updates["database_config"] = database_config
+
+            if updates:
+                db = db._replace(**updates)
+                client_updates["dbs"] = client.dbs.set(dbname, db)
+
+        if global_schema is not None:
+            client_updates["global_schema"] = global_schema
+
+        if system_config is not None:
+            client_updates["instance_config"] = system_config
+
+        if client_updates:
+            self._clients[client_id] = client._replace(**client_updates)
+            return True
+        else:
+            return False
+
+    def _weighter(self, client_id, worker: Worker):
+        client_schema = worker.get_client_schema(client_id)
+        return (
+            bool(client_schema),
+            worker.last_used(client_id)
+            if client_schema
+            else self._cache_size - worker.cache_size(),
+        )
+
+    async def _call_for_client(
+        self,
+        client_id,
+        method_name,
+        args,
+        msg,
+    ):
+        try:
+            updated = self._sync(client_id, *args[:6])
+        except Exception as ex:
+            raise state_mod.FailedStateSync(
+                f"failed to sync compiler server state: "
+                f"{type(ex).__name__}({ex})"
+            ) from ex
+        worker = await self._acquire_worker(
+            weighter=functools.partial(self._weighter, client_id)
+        )
+        try:
+            diff = client_schema = self._clients[client_id]
+            cache = worker.get_client_schema(client_id)
+            extra_args = ()
+            if cache is client_schema:
+                # client schema is already in sync, don't send again
+                diff = None
+            else:
+                if cache is None:
+                    # make room for the new client in this worker
+                    worker.invalidate_last(self._cache_size)
+                else:
+                    # only send the difference in user schema
+                    diff = client_schema.diff(cache)
+                if updated:
+                    # re-pickle the request if user schema changed
+                    msg = None
+                    extra_args = (method_name, args[0], *args[6:])
+            if msg:
+                msg = bytes(msg)
+            invalidation = worker.flush_invalidation()
+            resp = await worker.call(
+                "call_for_client",
+                client_id,
+                diff,
+                invalidation,
+                msg,
+                *extra_args,
+            )
+            status, *data = pickle.loads(resp)
+            if status == 0:
+                worker.set_client_schema(client_id, client_schema)
+                if method_name == "compile":
+                    if data[0][1]:
+                        worker._last_pickled_state = hashlib.sha1(
+                            data[0][1]
+                        ).hexdigest()
+            elif status == 1:
+                exc, tb = data
+                if not isinstance(exc, state_mod.FailedStateSync):
+                    worker.set_client_schema(client_id, client_schema)
+            else:
+                exc = RuntimeError(
+                    "could not serialize result in worker subprocess"
+                )
+                exc.__formatted_error__ = data[0]
+                raise exc
+
+            return resp
+        finally:
+            self._release_worker(worker)
+
+    async def compile_in_tx(
+        self, pickled_state, txid, *compile_args, msg=None
+    ):
+        if isinstance(pickled_state, str):
+            worker = await self._acquire_worker(
+                condition=lambda w: (w._last_pickled_state == pickled_state)
+            )
+            if worker._last_pickled_state == pickled_state:
+                pickled_state = state_mod.REUSE_LAST_STATE_MARKER
+                msg = None
+            else:
+                self._release_worker(worker)
+                raise state_mod.StateNotFound()
+        else:
+            worker = await self._acquire_worker()
+        try:
+            resp = await worker.call(
+                "compile_in_tx", pickled_state, txid, *compile_args, msg=msg
+            )
+            status, *data = pickle.loads(resp)
+            if status == 0:
+                worker._last_pickled_state = hashlib.sha1(
+                    data[0][1]
+                ).hexdigest()
+            return resp
+        finally:
+            self._release_worker(worker, put_in_front=False)
+
+    async def _request(self, method_name, msg):
+        worker = await self._acquire_worker()
+        try:
+            return await worker.call(method_name, msg=msg)
+        finally:
+            self._release_worker(worker)
+
+    async def call(self, protocol, req_id, msg):
+        client_id = protocol.client_id
+        method_name, args = pickle.loads(msg)
+        try:
+            if method_name != "__init_server__":
+                await self._ready_evt.wait()
+            if method_name == "__init_server__":
+                await self._init_server(client_id, *args)
+                pickled = pickle.dumps((0, None), -1)
+            elif method_name in {
+                "compile",
+                "compile_notebook",
+                "compile_graphql",
+            }:
+                pickled = await self._call_for_client(
+                    client_id, method_name, args, msg
+                )
+            elif method_name == "compile_in_tx":
+                pickled = await self.compile_in_tx(*args, msg=msg)
+            else:
+                pickled = await self._request(method_name, msg)
+        except Exception as ex:
+            worker_mod.prepare_exception(ex)
+            if debug.flags.server:
+                markup.dump(ex)
+            data = (1, ex, traceback.format_exc())
+            try:
+                pickled = pickle.dumps(data, -1)
+            except Exception as ex:
+                ex_tb = traceback.format_exc()
+                ex_str = f"{ex}:\n\n{ex_tb}"
+                pickled = pickle.dumps((2, ex_str), -1)
+        protocol.reply(req_id, pickled)
+
+    def client_disconnected(self, client_id):
+        logger.debug("Client %d disconnected, invalidating cache.", client_id)
+        self._clients.pop(client_id, None)
+        for worker in self._workers.values():
+            worker.invalidate(client_id)
+
+
+class CompilerServerProtocol(asyncio.Protocol):
+    def __init__(self, pool, loop):
+        global _client_id_seq
+        self._pool = pool
+        self._loop = loop
+        self._stream = amsg.MessageStream()
+        self._transport = None
+        self._client_id = _client_id_seq = _client_id_seq + 1
+
+    def connection_made(self, transport):
+        self._transport = transport
+        transport.write(
+            amsg._uint64_packer(os.getpid()) + amsg._uint64_packer(0)
+        )
+
+    def connection_lost(self, exc):
+        self._transport = None
+        self._pool.client_disconnected(self._client_id)
+
+    def data_received(self, data):
+        for msg in self._stream.feed_data(data):
+            msgview = memoryview(msg)
+            req_id = amsg._uint64_unpacker(msgview[:8])[0]
+            self._loop.create_task(self._pool.call(self, req_id, msgview[8:]))
+
+    @property
+    def client_id(self):
+        return self._client_id
+
+    def reply(self, req_id, resp):
+        self._transport.write(
+            b"".join(
+                (
+                    amsg._uint64_packer(len(resp) + 8),
+                    amsg._uint64_packer(req_id),
+                    resp,
+                )
+            )
+        )
+
+
+async def server_main(socket_path, pool_size, cache_size):
+    loop = asyncio.get_running_loop()
+    pool = MultiSchemaPool(
+        loop=loop,
+        runstate_dir=os.path.dirname(socket_path),
+        pool_size=pool_size,
+        cache_size=cache_size,
+    )
+    await pool.start()
+    try:
+        server = await loop.create_unix_server(
+            lambda: CompilerServerProtocol(pool, loop),
+            socket_path,
+            start_serving=False,
+        )
+        try:
+            await server.serve_forever()
+        finally:
+            server.close()
+            await server.wait_closed()
+    finally:
+        await pool.stop()
+
+
+@click.command()
+@srvargs.compiler_options
+def main(**kwargs):
+    asyncio.run(server_main(**kwargs))
+
+
+if __name__ == "__main__":
+    main()

--- a/edb/server/compiler_pool/state.py
+++ b/edb/server/compiler_pool/state.py
@@ -46,4 +46,8 @@ class StateNotFound(Exception):
     pass
 
 
+class IncompatibleClient(Exception):
+    pass
+
+
 REUSE_LAST_STATE_MARKER = b'REUSE_LAST_STATE_MARKER'

--- a/edb/server/compiler_pool/state.py
+++ b/edb/server/compiler_pool/state.py
@@ -42,4 +42,8 @@ class FailedStateSync(Exception):
     pass
 
 
+class StateNotFound(Exception):
+    pass
+
+
 REUSE_LAST_STATE_MARKER = b'REUSE_LAST_STATE_MARKER'

--- a/edb/server/compiler_pool/worker.py
+++ b/edb/server/compiler_pool/worker.py
@@ -20,33 +20,18 @@
 from __future__ import annotations
 from typing import *  # NoQA
 
-import argparse
-import gc
-import os
 import pickle
-import signal
-import time
-import traceback
 
 import immutables
 
 from edb import graphql
-
-from edb.common import debug
-from edb.common import devmode
-from edb.common import markup
-
-from edb.edgeql import parser as ql_parser
-
 from edb.pgsql import params as pgparams
-
 from edb.schema import schema as s_schema
-
 from edb.server import compiler
 from edb.server import config
 
-from . import amsg
 from . import state
+from . import worker_proc
 
 
 INITED: bool = False
@@ -58,10 +43,6 @@ LAST_STATE: Optional[compiler.dbstate.CompilerConnectionState] = None
 STD_SCHEMA: s_schema.FlatSchema
 GLOBAL_SCHEMA: s_schema.FlatSchema
 INSTANCE_CONFIG: immutables.Map[str, config.SettingValue]
-
-# "created continuously" means the interval between two consecutive spawns
-# is less than NUM_SPAWNS_RESET_INTERVAL seconds.
-NUM_SPAWNS_RESET_INTERVAL = 1
 
 
 def __init_worker__(
@@ -271,188 +252,31 @@ def compile_graphql(
     )
 
 
-def worker(sockname, version_serial):
-    con = amsg.WorkerConnection(sockname, version_serial)
-    try:
-        for req_id, req in con.iter_request():
-            try:
-                methname, args = pickle.loads(req)
-                if methname == '__init_worker__':
-                    meth = __init_worker__
-                else:
-                    if not INITED:
-                        raise RuntimeError(
-                            'call on uninitialized compiler worker')
-                    if methname == 'compile':
-                        meth = compile
-                    elif methname == 'compile_in_tx':
-                        meth = compile_in_tx
-                    elif methname == 'compile_notebook':
-                        meth = compile_notebook
-                    elif methname == 'compile_graphql':
-                        meth = compile_graphql
-                    elif methname == 'try_compile_rollback':
-                        meth = try_compile_rollback
-                    else:
-                        meth = getattr(COMPILER, methname)
-            except Exception as ex:
-                prepare_exception(ex)
-                if debug.flags.server:
-                    markup.dump(ex)
-                data = (
-                    1,
-                    ex,
-                    traceback.format_exc()
-                )
-            else:
-                try:
-                    res = meth(*args)
-                    data = (0, res)
-                except Exception as ex:
-                    prepare_exception(ex)
-                    if debug.flags.server:
-                        markup.dump(ex)
-                    data = (
-                        1,
-                        ex,
-                        traceback.format_exc()
-                    )
-
-            try:
-                pickled = pickle.dumps(data, -1)
-            except Exception as ex:
-                ex_tb = traceback.format_exc()
-                ex_str = f'{ex}:\n\n{ex_tb}'
-                pickled = pickle.dumps((2, ex_str), -1)
-
-            con.reply(req_id, pickled)
-    finally:
-        con.abort()
-
-
-def run_worker(sockname, version_serial):
-    with devmode.CoverageConfig.enable_coverage_if_requested():
-        worker(sockname, version_serial)
-
-
-def prepare_exception(ex):
-    clear_exception_frames(ex)
-    if ex.__traceback__ is not None:
-        ex.__traceback__ = ex.__traceback__.tb_next
-
-
-def clear_exception_frames(er):
-
-    def _clear_exception_frames(er, visited):
-        if er in visited:
-            return er
-        visited.add(er)
-
-        traceback.clear_frames(er.__traceback__)
-
-        if er.__cause__ is not None:
-            er.__cause__ = _clear_exception_frames(er.__cause__, visited)
-        if er.__context__ is not None:
-            er.__context__ = _clear_exception_frames(er.__context__, visited)
-
-        return er
-
-    visited = set()
-    _clear_exception_frames(er, visited)
-
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--sockname')
-    parser.add_argument('--numproc')
-    parser.add_argument('--version-serial', type=int)
-    args = parser.parse_args()
-
-    ql_parser.preload(allow_rebuild=False)
-    gc.freeze()
-
-    if args.numproc is None:
-        # Run a single worker process
-        run_worker(args.sockname, args.version_serial)
-        return
-
-    numproc = int(args.numproc)
-    assert numproc >= 1
-
-    # Abort the template process if more than `max_worker_spawns`
-    # new workers are created continuously - it probably means the
-    # worker cannot start correctly.
-    max_worker_spawns = numproc * 2
-
-    children = set()
-    continuous_num_spawns = 0
-
-    for _ in range(int(args.numproc)):
-        # spawn initial workers
-        if pid := os.fork():
-            # main process
-            children.add(pid)
-            continuous_num_spawns += 1
-        else:
-            # child process
-            break
+def get_handler(methname):
+    if methname == "__init_worker__":
+        meth = __init_worker__
     else:
-        # main process - redirect SIGTERM to SystemExit and wait for children
-        signal.signal(signal.SIGTERM, lambda *_: exit(os.EX_OK))
-        last_spawn_timestamp = time.monotonic()
-
-        try:
-            while children:
-                pid, status = os.wait()
-                children.remove(pid)
-                ec = os.waitstatus_to_exitcode(status)
-                if ec > 0 or -ec not in {0, signal.SIGINT}:
-                    # restart the child process if killed or ending abnormally,
-                    # unless we tried too many times continuously
-                    now = time.monotonic()
-                    if now - last_spawn_timestamp > NUM_SPAWNS_RESET_INTERVAL:
-                        continuous_num_spawns = 0
-                    last_spawn_timestamp = now
-                    continuous_num_spawns += 1
-                    if continuous_num_spawns > max_worker_spawns:
-                        # GOTCHA: we shouldn't return here because we need the
-                        # exception handler below to clean up the workers
-                        exit(os.EX_UNAVAILABLE)
-
-                    if pid := os.fork():
-                        # main process
-                        children.add(pid)
-                    else:
-                        # child process
-                        break
-            else:
-                # main process - all children ended normally
-                return
-        except BaseException as e:  # includes SystemExit and KeyboardInterrupt
-            # main process - kill and wait for the remaining workers to exit
-            try:
-                signal.signal(signal.SIGTERM, signal.SIG_DFL)
-                for pid in children:
-                    try:
-                        os.kill(pid, signal.SIGTERM)
-                    except OSError:
-                        pass
-                try:
-                    while children:
-                        pid, status = os.wait()
-                        children.discard(pid)
-                except OSError:
-                    pass
-            finally:
-                raise e
-
-    # child process - clear the SIGTERM handler for potential Rust impl
-    signal.signal(signal.SIGTERM, signal.SIG_DFL)
-    run_worker(args.sockname, args.version_serial)
+        if not INITED:
+            raise RuntimeError(
+                "call on uninitialized compiler worker"
+            )
+        if methname == "compile":
+            meth = compile
+        elif methname == "compile_in_tx":
+            meth = compile_in_tx
+        elif methname == "compile_notebook":
+            meth = compile_notebook
+        elif methname == "compile_graphql":
+            meth = compile_graphql
+        elif methname == "try_compile_rollback":
+            meth = try_compile_rollback
+        else:
+            meth = getattr(COMPILER, methname)
+    return meth
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
-        main()
+        worker_proc.main(get_handler)
     except KeyboardInterrupt:
         pass

--- a/edb/server/compiler_pool/worker_proc.py
+++ b/edb/server/compiler_pool/worker_proc.py
@@ -1,0 +1,192 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2022-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import argparse
+import gc
+import os
+import pickle
+import signal
+import time
+import traceback
+
+from edb.common import debug
+from edb.common import devmode
+from edb.common import markup
+from edb.edgeql import parser as ql_parser
+
+from . import amsg
+
+
+# "created continuously" means the interval between two consecutive spawns
+# is less than NUM_SPAWNS_RESET_INTERVAL seconds.
+NUM_SPAWNS_RESET_INTERVAL = 1
+
+
+def worker(sockname, version_serial, get_handler):
+    con = amsg.WorkerConnection(sockname, version_serial)
+    try:
+        for req_id, req in con.iter_request():
+            try:
+                methname, args = pickle.loads(req)
+                meth = get_handler(methname)
+            except Exception as ex:
+                prepare_exception(ex)
+                if debug.flags.server:
+                    markup.dump(ex)
+                data = (1, ex, traceback.format_exc())
+            else:
+                try:
+                    res = meth(*args)
+                    data = (0, res)
+                except Exception as ex:
+                    prepare_exception(ex)
+                    if debug.flags.server:
+                        markup.dump(ex)
+                    data = (1, ex, traceback.format_exc())
+
+            try:
+                pickled = pickle.dumps(data, -1)
+            except Exception as ex:
+                ex_tb = traceback.format_exc()
+                ex_str = f"{ex}:\n\n{ex_tb}"
+                pickled = pickle.dumps((2, ex_str), -1)
+
+            con.reply(req_id, pickled)
+    finally:
+        con.abort()
+
+
+def run_worker(sockname, version_serial, get_handler):
+    with devmode.CoverageConfig.enable_coverage_if_requested():
+        worker(sockname, version_serial, get_handler)
+
+
+def prepare_exception(ex):
+    clear_exception_frames(ex)
+    if ex.__traceback__ is not None:
+        ex.__traceback__ = ex.__traceback__.tb_next
+
+
+def clear_exception_frames(er):
+    def _clear_exception_frames(er, visited):
+        if er in visited:
+            return er
+        visited.add(er)
+
+        traceback.clear_frames(er.__traceback__)
+
+        if er.__cause__ is not None:
+            er.__cause__ = _clear_exception_frames(er.__cause__, visited)
+        if er.__context__ is not None:
+            er.__context__ = _clear_exception_frames(er.__context__, visited)
+
+        return er
+
+    visited = set()
+    _clear_exception_frames(er, visited)
+
+
+def main(get_handler):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sockname")
+    parser.add_argument("--numproc")
+    parser.add_argument("--version-serial", type=int)
+    args = parser.parse_args()
+
+    ql_parser.preload(allow_rebuild=False)
+    gc.freeze()
+
+    if args.numproc is None:
+        # Run a single worker process
+        run_worker(args.sockname, args.version_serial, get_handler)
+        return
+
+    numproc = int(args.numproc)
+    assert numproc >= 1
+
+    # Abort the template process if more than `max_worker_spawns`
+    # new workers are created continuously - it probably means the
+    # worker cannot start correctly.
+    max_worker_spawns = numproc * 2
+
+    children = set()
+    continuous_num_spawns = 0
+
+    for _ in range(int(args.numproc)):
+        # spawn initial workers
+        if pid := os.fork():
+            # main process
+            children.add(pid)
+            continuous_num_spawns += 1
+        else:
+            # child process
+            break
+    else:
+        # main process - redirect SIGTERM to SystemExit and wait for children
+        signal.signal(signal.SIGTERM, lambda *_: exit(os.EX_OK))
+        last_spawn_timestamp = time.monotonic()
+
+        try:
+            while children:
+                pid, status = os.wait()
+                children.remove(pid)
+                ec = os.waitstatus_to_exitcode(status)
+                if ec > 0 or -ec not in {0, signal.SIGINT}:
+                    # restart the child process if killed or ending abnormally,
+                    # unless we tried too many times continuously
+                    now = time.monotonic()
+                    if now - last_spawn_timestamp > NUM_SPAWNS_RESET_INTERVAL:
+                        continuous_num_spawns = 0
+                    last_spawn_timestamp = now
+                    continuous_num_spawns += 1
+                    if continuous_num_spawns > max_worker_spawns:
+                        # GOTCHA: we shouldn't return here because we need the
+                        # exception handler below to clean up the workers
+                        exit(os.EX_UNAVAILABLE)
+
+                    if pid := os.fork():
+                        # main process
+                        children.add(pid)
+                    else:
+                        # child process
+                        break
+            else:
+                # main process - all children ended normally
+                return
+        except BaseException as e:  # includes SystemExit and KeyboardInterrupt
+            # main process - kill and wait for the remaining workers to exit
+            try:
+                signal.signal(signal.SIGTERM, signal.SIG_DFL)
+                for pid in children:
+                    try:
+                        os.kill(pid, signal.SIGTERM)
+                    except OSError:
+                        pass
+                try:
+                    while children:
+                        pid, status = os.wait()
+                        children.discard(pid)
+                except OSError:
+                    pass
+            finally:
+                raise e
+
+    # child process - clear the SIGTERM handler for potential Rust impl
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    run_worker(args.sockname, args.version_serial, get_handler)

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -23,6 +23,7 @@ from edb import buildmeta
 
 
 EDGEDB_PORT = 5656
+EDGEDB_REMOTE_COMPILER_PORT = 5660
 EDGEDB_SUPERGROUP = 'edgedb_supergroup'
 EDGEDB_SUPERUSER = 'edgedb'
 EDGEDB_TEMPLATE_DB = '__edgedbtpl__'

--- a/edb/server/protocol/binary.pxd
+++ b/edb/server/protocol/binary.pxd
@@ -108,6 +108,7 @@ cdef class EdgeConnection:
         tuple max_protocol
 
         object last_state
+        int last_state_id
 
         pgcon.PGConnection _pinned_pgcon
         bint _pinned_pgcon_in_tx

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -923,9 +923,10 @@ cdef class EdgeConnection:
         started_at = time.monotonic()
         try:
             if _dbview.in_tx():
-                units, self.last_state = await compiler_pool.compile_in_tx(
+                result = await compiler_pool.compile_in_tx(
                     _dbview.txid,
                     self.last_state,
+                    self.last_state_id,
                     query_req.source,
                     query_req.io_format,
                     query_req.expect_one,
@@ -937,7 +938,7 @@ cdef class EdgeConnection:
                     query_req.inline_objectids,
                 )
             else:
-                units, self.last_state = await compiler_pool.compile(
+                result = await compiler_pool.compile(
                     _dbview.dbname,
                     _dbview.get_user_schema(),
                     _dbview.get_global_schema(),
@@ -956,6 +957,7 @@ cdef class EdgeConnection:
                     self.protocol_version,
                     query_req.inline_objectids,
                 )
+            units, self.last_state, self.last_state_id = result
         finally:
             metrics.edgeql_query_compilation_duration.observe(
                 time.monotonic() - started_at)
@@ -978,9 +980,10 @@ cdef class EdgeConnection:
         started_at = time.monotonic()
         try:
             if _dbview.in_tx():
-                units, self.last_state = await compiler_pool.compile_in_tx(
+                result = await compiler_pool.compile_in_tx(
                     _dbview.txid,
                     self.last_state,
+                    self.last_state_id,
                     source,
                     FMT_SCRIPT,
                     False,
@@ -991,7 +994,7 @@ cdef class EdgeConnection:
                     self.protocol_version,
                 )
             else:
-                units, self.last_state = await compiler_pool.compile(
+                result = await compiler_pool.compile(
                     _dbview.dbname,
                     _dbview.get_user_schema(),
                     _dbview.get_global_schema(),
@@ -1009,6 +1012,7 @@ cdef class EdgeConnection:
                     stmt_mode,
                     self.protocol_version,
                 )
+            units, self.last_state, self.last_state_id = result
         finally:
             metrics.edgeql_query_compilation_duration.observe(
                 time.monotonic() - started_at)

--- a/edb/server/protocol/edgeql_ext.pyx
+++ b/edb/server/protocol/edgeql_ext.pyx
@@ -132,7 +132,7 @@ async def handle_request(
 async def compile(db, server, bytes query):
     compiler_pool = server.get_compiler_pool()
 
-    units, _ = await compiler_pool.compile(
+    units, _, _ = await compiler_pool.compile(
         db.name,
         db.user_schema,
         server.get_global_schema(),

--- a/edb/server/protocol/system_api.py
+++ b/edb/server/protocol/system_api.py
@@ -105,7 +105,7 @@ async def handle_status_request(
 async def compile(server, query):
     compiler_pool = server.get_compiler_pool()
 
-    units, _ = await compiler_pool.compile(
+    units, _, _ = await compiler_pool.compile(
         edbdef.EDGEDB_SYSTEM_DB,
         s_schema.FlatSchema(),  # user schema
         server.get_global_schema(),

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -28,6 +28,7 @@ from edb import buildmeta
 from edb.common import debug
 from edb.common import devmode as dm
 from edb.server import args as srv_args
+from edb.server import logsetup
 from edb.server import main as srv_main
 
 
@@ -52,6 +53,7 @@ def server(version=False, **kwargs):
     os.environ['EDGEDB_DEBUG_SERVER'] = '1'
     debug.init_debug_flags()
     kwargs['security'] = srv_args.ServerSecurityMode.InsecureDevMode
+    logsetup.setup_logging(kwargs['log_level'], kwargs['log_to'])
     srv_main.server_main(**kwargs)
 
 

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -412,6 +412,7 @@ class TestCompilerPool(tbs.TestCase):
                 await asyncio.gather(*(pool_.compile_in_tx(
                     context.state.current_tx().id,
                     pickle.dumps(context.state),
+                    0,
                     edgeql.Source.from_string('SELECT 123'),
                     edbcompiler.IoFormat.BINARY,
                     False, 101, False, True, 'single', (0, 12), True

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -93,7 +93,8 @@ class TestAmsg(tbs.TestCase):
             await server.start()
             try:
                 proc = await asyncio.create_subprocess_exec(
-                    sys.executable, "-m", pool.WORKER_MOD,
+                    sys.executable,
+                    "-m", pool.WORKER_PKG + pool.BaseLocalPool._worker_mod,
                     "--sockname", sock_name,
                     "--numproc", str(num_proc),
                     "--version-serial", "1",


### PR DESCRIPTION
Depends on #3550.

## Overall architecture

![cloud demo drawio](https://user-images.githubusercontent.com/1751601/156193655-44a7de77-0e5c-4da5-86aa-47b8e83bfd70.png)

## Usage

### EdgeDB Server:

```
edgedb-server --compiler-pool-mode remote --compiler-pool-addr /path/to/socket --compiler-pool-size 4
```

When the mode is set to `remote`, the pool size means how many concurrent compile requests can the EdgeDB server issue at most, default is `2`.

### Compiler Server:

```
edgedb-server compiler /path/to/socket --pool-size 4
```

The compiler server will also create another socket file under the same dir for internal communication. Pool size means the number of worker processes the compiler server will maintain, default to the number of CPUs.


## Schema

Information needed to compile:

* "**std schema**" (system schema): Immutable constructs, identical among all EdgeDB instances (clients):
  * `backend_runtime_params` - for now just assume it's identical among clients;
  * Shared among the same catalog_version, so identical among clients:
    * `std_schema`
    * `refl_schema`
    * `schema_class_layout`
* "**schema n**" (client schema): Different across clients, and changes on the fly:
  * `global_schema`
  * `system_config`
  * DatabaseStates
    * `dbname` (key)
    * `user_schema`
    * `reflection_cache`
    * `database_config`

![cloud demo-第 2 页 drawio](https://user-images.githubusercontent.com/1751601/156246808-783d6a62-116b-487f-9c64-6a1c0a65cb07.png)

* All EdgeDB instances (clients) share the same system schema;
* Compiler server always keep in sync with all connected clients;
* Compiler server keeps only one copy of the std schema to bootstrap new worker subprocesses;
* Compiler server only keeps pickled copies of the client schemas;
* Each compiler worker has an LRU cache for client schemas;
* If a client disconnects from the compiler server, its cache in the worker is invalidated;
* The compiler server manages the cache in all workers by sending additional RPC parameters as instructions which are followed by the workers.

## Distribution Algorithm

### Client-based Requests

This includes `compile()`, `compile_notebook()` and `compile_graphql()`.

* If some workers have the schema for the client, choose the most-recently-used worker among them;
* Or else, choose a worker with the least client schemas.

### Transaction-based Requests

This is only `compile_in_tx()`, but `compile()` may also affect the compiler state.

Each worker keeps only one most-recent compiler state, the compiler server keeps the SHA1 of the pickled states in sync with the workers. Between the EdgeDB instance and the compiler worker, EdgeDB firstly calls `compile_in_tx()` with the SHA1 of the previous pickled state, and retry with the full pickled state if the compiler server replies the SHA1 missed the cache. Like a regular EdgeDB/compiler, the worker is put to the end of the queue for higher probability of cache hit.

Benchmarks: 4 CPUs, 4 worker process, 4 test processes running the server test suite, semaphore=4

* Cache hit: 97%
* Transaction pickled state average size: 165KB (23KB ~ 1.26MB)

UPDATE: the compiler server should generate a sequential number to reflect the different unique pickled states, instead of calculating the SHA1 of hundreds of KBs of data.

### Other Requests

Other requests like `try_compile_rollback()` or anything on the COMPILER is simply using the workers at the beginning of the queue.

## TODOs

- [x] Fix mypy & pyflakes
- [x] Extract duplicate code
- [x] Manually test most branches
- [x] Add automated tests (https://github.com/edgedb/edgedb/runs/5487539100?check_suite_focus=true)
- [ ] Maybe use `dbview.dbver`?
- [ ] CLI interface - do we want DSN?
