### PR TITLE
Interfaces and types should work in GraphQL fragments.

### DIFF
--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -1344,36 +1344,46 @@ class GQLCoreSchema:
         kwargs: Dict[str, Any] = {'dummy': dummy}
 
         if not name.startswith('__graphql__::'):
-            if edb_base is None:
-                if '::' in name:
-                    edb_base = self.edb_schema.get(
-                        name,
-                        type=s_types.Type,
-                    )
-                else:
-                    for module in self.modules:
+            # The name may potentially contain the suffix "_Type",
+            # which in 99% cases indicates that it's a GraphQL
+            # internal type generated from the EdgeDB base type, but
+            # we technically need to check both.
+            if name.endswith('_Type'):
+                names = [name[:-len('_Type')], name]
+            else:
+                names = [name]
+
+            for tname in names:
+                if edb_base is None:
+                    if '::' in tname:
                         edb_base = self.edb_schema.get(
-                            f'{module}::{name}',
+                            tname,
                             type=s_types.Type,
-                            default=None,
                         )
-                        if edb_base:
-                            break
+                    else:
+                        for module in self.modules:
+                            edb_base = self.edb_schema.get(
+                                f'{module}::{tname}',
+                                type=s_types.Type,
+                                default=None,
+                            )
+                            if edb_base:
+                                break
 
-                    # XXX: find a better way to do this
-                    if edb_base is None:
-                        edb_base = self.edb_schema.get_global(
-                            s_types.Array, name, default=None
-                        )
+                        # XXX: find a better way to do this
+                        if edb_base is None:
+                            edb_base = self.edb_schema.get_global(
+                                s_types.Array, tname, default=None
+                            )
 
-                    if edb_base is None:
-                        edb_base = self.edb_schema.get_global(
-                            s_types.Tuple, name, default=None
-                        )
+                        if edb_base is None:
+                            edb_base = self.edb_schema.get_global(
+                                s_types.Tuple, tname, default=None
+                            )
 
-                    if edb_base is None:
-                        raise AssertionError(
-                            f'unresolved type: {module}::{name}')
+                if edb_base is None:
+                    raise AssertionError(
+                        f'unresolved type: {module}::{name}')
 
             kwargs['edb_base'] = edb_base
 

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -1648,6 +1648,34 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             }],
         })
 
+    def test_graphql_functional_fragment_05(self):
+        # ISSUE #3514
+        #
+        # Fragment on the actual type should also work.
+        self.assert_graphql_query_result(r"""
+            fragment userFrag on User_Type {
+                active
+                profile {
+                    value
+                }
+            }
+
+            query {
+                User(filter: {name: {eq: "Alice"}}) {
+                    name
+                    ... userFrag
+                }
+            }
+        """, {
+            'User': [{
+                'name': 'Alice',
+                'active': True,
+                'profile': {
+                    'value': 'special',
+                }
+            }],
+        })
+
     def test_graphql_functional_fragment_type_01(self):
         self.assert_graphql_query_result(r"""
             fragment userFrag on User {
@@ -2137,6 +2165,32 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             }
         """, {
             'NamedObject': [{
+                'name': 'Alice',
+                'active': True,
+                'profile': {
+                    'value': 'special',
+                }
+            }],
+        })
+
+    def test_graphql_functional_fragment_type_18(self):
+        # ISSUE #3514
+        #
+        # Fragment on the actual type should also work.
+        self.assert_graphql_query_result(r"""
+            query {
+                User(filter: {name: {eq: "Alice"}}) {
+                    ... on User_Type {
+                        active
+                        profile {
+                            value
+                        }
+                    }
+                    name
+                }
+            }
+        """, {
+            'User': [{
                 'name': 'Alice',
                 'active': True,
                 'profile': {


### PR DESCRIPTION
We primarily reflect EdgeDB types into GraphQL interfaces to account for
inheritance, but using the types should work no worse than interfaces in
GraphQL.

Fixes #3514.