### PR TITLE
Fix spelling mistake

### DIFF
--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -469,7 +469,7 @@ EdgeDB stores and outputs timezone-aware values in UTC.
                           duration + duration -> duration
                           datetime + cal::relative_duration \
                               -> cal::relative_duration
-                          cal::local_dateiime + cal::relative_duration \
+                          cal::local_datetime + cal::relative_duration \
                               -> cal::relative_duration
                           cal::local_date + cal::relative_duration \
                               -> cal::relative_duration


### PR DESCRIPTION
Simple fix on the docs for https://www.edgedb.com/docs/stdlib/datetime#operator::dtplus

![image](https://user-images.githubusercontent.com/49576606/155904371-82395746-3a94-4330-9adb-d930cbad1abc.png)
