### PR TITLE
Make sure that nested mutations work in GraphQL.

### DIFF
--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -1036,7 +1036,8 @@ class GraphQLTranslator:
 
             # NOTE: there will be more operations in the future
             if fname == 'set':
-                return self._get_input_expr_for_pointer_mutaiton(field)
+                return qlast.DetachedExpr(
+                    expr=self._get_input_expr_for_pointer_mutaiton(field))
             elif fname == 'clear':
                 cond = field.value
                 if isinstance(cond, gql_ast.VariableNode):
@@ -1109,7 +1110,7 @@ class GraphQLTranslator:
                 newset.elements.append(eqlpath)
                 return qlast.UnaryOp(
                     op='DISTINCT',
-                    operand=newset,
+                    operand=qlast.DetachedExpr(expr=newset),
                 )
             elif fname == 'remove':
                 alias = f'x{self._context.counter}'
@@ -1119,7 +1120,9 @@ class GraphQLTranslator:
                     where=qlast.BinOp(
                         left=qlast.Path(steps=[qlast.ObjectRef(name=alias)]),
                         op='NOT IN',
-                        right=self._visit_insert_value(field.value)
+                        right=qlast.DetachedExpr(
+                            expr=self._visit_insert_value(field.value)
+                        )
                     )
                 )
 
@@ -1163,6 +1166,12 @@ class GraphQLTranslator:
 
         # get the type of the value being inserted
         _, target = self._get_parent_and_current_type()
+
+        if target.is_object_type:
+            # Object types need to be wrapped in a DETACHED in
+            # mutations to avoid referencing the root object.
+            compexpr = qlast.DetachedExpr(expr=compexpr)
+
         if (isinstance(field.value, gql_ast.ListValueNode) and
                 target.is_object_type):
             # Need to wrap the set into an "assert_distinct()" if the

--- a/tests/schemas/graphql_other.esdl
+++ b/tests/schemas/graphql_other.esdl
@@ -27,4 +27,9 @@ type Foo {
     property `select` -> str;
     property after -> str;
     required property color -> ColorEnum;
+
+    # Testing linking to the same type
+    multi link foos -> Foo {
+        on target delete deferred restrict;
+    }
 }

--- a/tests/test_http_graphql_mutation.py
+++ b/tests/test_http_graphql_mutation.py
@@ -1286,6 +1286,193 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
             "Game": []
         })
 
+    def test_graphql_mutation_insert_nested_09(self):
+        # Issue #3470
+        # Test nested insert of the same type.
+        data = {
+            'after': 'BaseFoo09',
+            'color': 'GREEN',
+            'foos': [{
+                'after': 'NestedFoo090',
+                'color': 'RED',
+            }, {
+                'after': 'NestedFoo091',
+                'color': 'BLUE',
+            }],
+        }
+
+        validation_query = r"""
+            query {
+                other__Foo(filter: {after: {eq: "BaseFoo09"}}) {
+                    after
+                    color
+                    foos(order: {color: {dir: ASC}}) {
+                        after
+                        color
+                    }
+                }
+            }
+        """
+
+        self.assert_graphql_query_result(r"""
+            mutation insert_other__Foo {
+                insert_other__Foo(
+                    data: [{
+                        after: "BaseFoo09",
+                        color: GREEN,
+                        foos: [{
+                            data: {
+                                after: "NestedFoo090",
+                                color: RED,
+                            }
+                        }, {
+                            data: {
+                                after: "NestedFoo091",
+                                color: BLUE,
+                            }
+                        }]
+                    }]
+                ) {
+                    after
+                    color
+                    foos(order: {color: {dir: ASC}}) {
+                        after
+                        color
+                    }
+                }
+            }
+        """, {
+            "insert_other__Foo": [data]
+        })
+
+        self.assert_graphql_query_result(validation_query, {
+            "other__Foo": [data]
+        })
+
+        self.assert_graphql_query_result(r"""
+            mutation delete_other__Foo {
+                delete_other__Foo(
+                    filter: {after: {like: "%Foo09%"}},
+                    order: {color: {dir: ASC}}
+                ) {
+                    after
+                    color
+                }
+            }
+        """, {
+            "delete_other__Foo": [{
+                'after': 'NestedFoo090',
+                'color': 'RED',
+            }, {
+                'after': 'BaseFoo09',
+                'color': 'GREEN',
+            }, {
+                'after': 'NestedFoo091',
+                'color': 'BLUE',
+            }]
+        })
+
+    def test_graphql_mutation_insert_nested_10(self):
+        # Issue #3470
+        # Test nested insert of the same type.
+        data = {
+            'after': 'BaseFoo10',
+            'color': 'GREEN',
+            'foos': [{
+                'after': 'NestedFoo100',
+                'color': 'RED',
+            }, {
+                'after': 'NestedFoo101',
+                'color': 'BLUE',
+            }],
+        }
+
+        validation_query = r"""
+            query {
+                other__Foo(filter: {after: {eq: "BaseFoo10"}}) {
+                    after
+                    color
+                    foos(order: {color: {dir: ASC}}) {
+                        after
+                        color
+                    }
+                }
+            }
+        """
+
+        self.assert_graphql_query_result(r"""
+            mutation insert_other__Foo {
+                insert_other__Foo(
+                    data: [{
+                        after: "NestedFoo100",
+                        color: RED,
+                    }]
+                ) {
+                    after
+                    color
+                }
+            }
+        """, {
+            "insert_other__Foo": [data['foos'][0]]
+        })
+
+        self.assert_graphql_query_result(r"""
+            mutation insert_other__Foo {
+                insert_other__Foo(
+                    data: [{
+                        after: "BaseFoo10",
+                        color: GREEN,
+                        foos: [{
+                            filter: {
+                                after: {eq: "NestedFoo100"},
+                            }
+                        }, {
+                            data: {
+                                after: "NestedFoo101",
+                                color: BLUE,
+                            }
+                        }]
+                    }]
+                ) {
+                    after
+                    color
+                    foos(order: {color: {dir: ASC}}) {
+                        after
+                        color
+                    }
+                }
+            }
+        """, {
+            "insert_other__Foo": [data]
+        })
+
+        self.assert_graphql_query_result(validation_query, {
+            "other__Foo": [data]
+        })
+
+        self.assert_graphql_query_result(r"""
+            mutation delete_other__Foo {
+                delete_other__Foo(
+                    filter: {after: {like: "%Foo10%"}},
+                    order: {color: {dir: ASC}}
+                ) {
+                    after
+                    color
+                }
+            }
+        """, {
+            "delete_other__Foo": [{
+                'after': 'NestedFoo100',
+                'color': 'RED',
+            }, {
+                'after': 'BaseFoo10',
+                'color': 'GREEN',
+            }, {
+                'after': 'NestedFoo101',
+                'color': 'BLUE',
+            }]
+        })
+
     def test_graphql_mutation_insert_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
@@ -2821,6 +3008,220 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
             "update_Profile": [{
                 'name': 'Alice profile',
                 'value': 'special',
+            }]
+        })
+
+    def test_graphql_mutation_update_multiple_02(self):
+        # Issue #3470
+        # Test nested update of the same type.
+        data = {
+            'after': 'BaseFoo02',
+            'color': 'GREEN',
+            'foos': [{
+                'after': 'NestedFoo020',
+                'color': 'RED',
+            }, {
+                'after': 'NestedFoo021',
+                'color': 'BLUE',
+            }],
+        }
+
+        validation_query = r"""
+            query {
+                other__Foo(filter: {after: {eq: "BaseFoo02"}}) {
+                    after
+                    color
+                    foos(order: {color: {dir: ASC}}) {
+                        after
+                        color
+                    }
+                }
+            }
+        """
+
+        self.graphql_query(r"""
+            mutation insert_other__Foo {
+                insert_other__Foo(
+                    data: [{
+                        after: "NestedFoo020",
+                        color: RED
+                    }, {
+                        after: "BaseFoo02",
+                        color: GREEN
+                    }, {
+                        after: "NestedFoo021",
+                        color: BLUE
+                    }]
+                ) {
+                    color
+                }
+            }
+        """)
+
+        self.assert_graphql_query_result(r"""
+            mutation update_other__Foo {
+                update_other__Foo(
+                    filter: {after: {eq: "BaseFoo02"}},
+                    data: {
+                        foos: {
+                            set: [{
+                                filter: {
+                                    after: {like: "NestedFoo02%"},
+                                }
+                            }]
+                        }
+                    }
+                ) {
+                    after
+                    color
+                    foos(order: {color: {dir: ASC}}) {
+                        after
+                        color
+                    }
+                }
+            }
+        """, {
+            "update_other__Foo": [data]
+        })
+
+        self.assert_graphql_query_result(validation_query, {
+            "other__Foo": [data]
+        })
+
+        self.assert_graphql_query_result(r"""
+            mutation delete_other__Foo {
+                delete_other__Foo(
+                    filter: {after: {like: "%Foo02%"}},
+                    order: {color: {dir: ASC}}
+                ) {
+                    after
+                    color
+                }
+            }
+        """, {
+            "delete_other__Foo": [{
+                'after': 'NestedFoo020',
+                'color': 'RED',
+            }, {
+                'after': 'BaseFoo02',
+                'color': 'GREEN',
+            }, {
+                'after': 'NestedFoo021',
+                'color': 'BLUE',
+            }]
+        })
+
+    def test_graphql_mutation_update_multiple_03(self):
+        # Issue #3470
+        # Test nested update of the same type.
+        self.graphql_query(r"""
+            mutation insert_other__Foo {
+                insert_other__Foo(
+                    data: [{
+                        after: "NestedFoo030",
+                        color: RED
+                    }, {
+                        after: "BaseFoo03",
+                        color: GREEN
+                    }, {
+                        after: "NestedFoo031",
+                        color: BLUE
+                    }]
+                ) {
+                    color
+                }
+            }
+        """)
+
+        self.assert_graphql_query_result(r"""
+            mutation update_other__Foo {
+                update_other__Foo(
+                    filter: {after: {eq: "BaseFoo03"}},
+                    data: {
+                        foos: {
+                            add: [{
+                                filter: {
+                                    after: {like: "NestedFoo03%"},
+                                }
+                            }]
+                        }
+                    }
+                ) {
+                    after
+                    color
+                    foos(order: {color: {dir: ASC}}) {
+                        after
+                        color
+                    }
+                }
+            }
+        """, {
+            "update_other__Foo": [{
+                'after': 'BaseFoo03',
+                'color': 'GREEN',
+                'foos': [{
+                    'after': 'NestedFoo030',
+                    'color': 'RED',
+                }, {
+                    'after': 'NestedFoo031',
+                    'color': 'BLUE',
+                }],
+            }]
+        })
+
+        self.assert_graphql_query_result(r"""
+            mutation update_other__Foo {
+                update_other__Foo(
+                    filter: {after: {eq: "BaseFoo03"}},
+                    data: {
+                        foos: {
+                            remove: [{
+                                filter: {
+                                    after: {eq: "NestedFoo031"},
+                                }
+                            }]
+                        }
+                    }
+                ) {
+                    after
+                    color
+                    foos(order: {color: {dir: ASC}}) {
+                        after
+                        color
+                    }
+                }
+            }
+        """, {
+            "update_other__Foo": [{
+                'after': 'BaseFoo03',
+                'color': 'GREEN',
+                'foos': [{
+                    'after': 'NestedFoo030',
+                    'color': 'RED',
+                }],
+            }]
+        })
+
+        self.assert_graphql_query_result(r"""
+            mutation delete_other__Foo {
+                delete_other__Foo(
+                    filter: {after: {like: "%Foo03%"}},
+                    order: {color: {dir: ASC}}
+                ) {
+                    after
+                    color
+                }
+            }
+        """, {
+            "delete_other__Foo": [{
+                'after': 'NestedFoo030',
+                'color': 'RED',
+            }, {
+                'after': 'BaseFoo03',
+                'color': 'GREEN',
+            }, {
+                'after': 'NestedFoo031',
+                'color': 'BLUE',
             }]
         })
 


### PR DESCRIPTION
Nested mutations of objects of the same type need a DETACHED separating
one layer from another in order to work properly, otherwise either error
or silent empty sets result.

Fixes #3470