### PR TITLE
Determine func/oper argument type modifiers in advance of compiling args

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_01_07_00_00
+EDGEDB_CATALOG_VERSION = 2022_03_01_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -531,9 +531,6 @@ class ContextLevel(compiler.ContextLevel):
     """A set of schema objects for which the shadowing rewrite should be
        disabled."""
 
-    path_log: Optional[List[irast.PathId]]
-    """An optional list of path ids added to the scope tree in this context."""
-
     def __init__(
         self,
         prevlevel: Optional[ContextLevel],
@@ -592,7 +589,6 @@ class ContextLevel(compiler.ContextLevel):
             self.compiling_update_shape = False
             self.in_conditional = None
             self.disable_shadowing = set()
-            self.path_log = None
             self.recompiling_schema_alias = False
 
         else:
@@ -637,7 +633,6 @@ class ContextLevel(compiler.ContextLevel):
             self.compiling_update_shape = prevlevel.compiling_update_shape
             self.in_conditional = prevlevel.in_conditional
             self.disable_shadowing = prevlevel.disable_shadowing
-            self.path_log = prevlevel.path_log
             self.recompiling_schema_alias = prevlevel.recompiling_schema_alias
 
             if mode == ContextSwitchMode.SUBQUERY:

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -26,7 +26,6 @@ from typing import *
 from edb import errors
 
 from edb.ir import ast as irast
-from edb.ir import utils as irutils
 
 from edb.schema import constraints as s_constr
 from edb.schema import functions as s_func
@@ -95,7 +94,11 @@ def compile_FunctionCall(
         ctx.env.options.schema_object_context is s_constr.Constraint
     )
 
-    args, kwargs, arg_ctxs = compile_call_args(expr, funcname, ctx=ctx)
+    typemods = polyres.find_callable_typemods(
+        funcs, num_args=len(expr.args), kwargs_names=expr.kwargs.keys(),
+        ctx=ctx)
+    args, kwargs = compile_func_call_args(
+        expr, funcname, typemods, ctx=ctx)
     matched = polyres.find_callable(funcs, args=args, kwargs=kwargs, ctx=ctx)
     if not matched:
         alts = [f.get_signature_as_str(env.schema) for f in funcs]
@@ -198,7 +201,6 @@ def compile_FunctionCall(
     final_args, params_typemods = finalize_args(
         matched_call,
         is_polymorphic=is_polymorphic,
-        arg_ctxs=arg_ctxs,
         ctx=ctx,
     )
 
@@ -285,7 +287,7 @@ CONDITIONAL_OPS = {
 
 
 def compile_operator(
-        qlexpr: qlast.Base, op_name: str, qlargs: List[qlast.Base], *,
+        qlexpr: qlast.Base, op_name: str, qlargs: List[qlast.Expr], *,
         ctx: context.ContextLevel) -> irast.Set:
 
     env = ctx.env
@@ -300,26 +302,18 @@ def compile_operator(
     fq_op_name = next(iter(opers)).get_shortname(ctx.env.schema)
     conditional_args = CONDITIONAL_OPS.get(fq_op_name)
 
-    arg_ctxs = {}
+    typemods, _ = polyres.find_callable_typemods(
+        opers, num_args=len(qlargs), kwargs_names=set(), ctx=ctx)
+
     args = []
+
     for ai, qlarg in enumerate(qlargs):
-        with ctx.newscope(fenced=True) as fencectx:
-            fencectx.path_log = []
-            # We put on a SET OF fence preemptively in case this is
-            # a SET OF arg, which we don't know yet due to polymorphic
-            # matching.  We will remove it if necessary in `finalize_args()`.
-            if conditional_args and ai in conditional_args:
-                fencectx.in_conditional = qlexpr.context
-
-            arg_ir = dispatch.compile(qlarg, ctx=fencectx)
-
-            arg_ir = setgen.scoped_set(
-                setgen.ensure_stmt(arg_ir, ctx=fencectx),
-                ctx=fencectx)
-
-            arg_ir = setgen.ensure_set(arg_ir, srcctx=qlarg.context, ctx=ctx)
-
-            arg_ctxs[arg_ir] = fencectx
+        arg_ir = compile_arg(
+            qlarg,
+            typemods[ai],
+            in_conditional=bool(conditional_args and ai in conditional_args),
+            ctx=ctx,
+        )
 
         arg_type = inference.infer_type(arg_ir, ctx.env)
         if arg_type is None:
@@ -533,7 +527,6 @@ def compile_operator(
 
     final_args, params_typemods = finalize_args(
         matched_call,
-        arg_ctxs=arg_ctxs,
         actual_typemods=actual_typemods,
         is_polymorphic=is_polymorphic,
         ctx=ctx,
@@ -663,39 +656,59 @@ def validate_recursive_operator(
     return matched
 
 
-def compile_call_arg(
-        arg_ql: qlast.Expr, *,
-        ctx: context.ContextLevel) -> Tuple[irast.Set, context.ContextLevel]:
-    with ctx.new() as argctx:
-        argctx.path_log = []
-        # We put on a SET OF fence preemptively in case this is
-        # a SET OF arg, which we don't know yet due to polymorphic
-        # matching.  We will remove it if necessary in `finalize_args()`.
-        # Similarly, delay the decision to inject the implicit limit to
-        # `finalize_args()`.
-        arg_ql = qlast.SelectQuery(
-            result=arg_ql, context=arg_ql.context,
-            implicit=True, rptr_passthrough=True)
+def compile_arg(
+        arg_ql: qlast.Expr, typemod: ft.TypeModifier, *,
+        in_conditional: bool=False,
+        ctx: context.ContextLevel) -> irast.Set:
+    fenced = typemod is ft.TypeModifier.SetOfType
+    optional = typemod is ft.TypeModifier.OptionalType
+
+    # Create a a branch for OPTIONAL ones. The OPTIONAL branch is to
+    # have a place to mark as optional in the scope tree.
+    # For fenced arguments we instead wrap it in a SELECT below.
+    new = ctx.newscope(fenced=False) if optional else ctx.new()
+    with new as argctx:
+        if in_conditional:
+            argctx.in_conditional = arg_ql.context
+
+        if optional:
+            argctx.path_scope.mark_as_optional()
+
+        if fenced:
+            arg_ql = qlast.SelectQuery(
+                result=arg_ql, context=arg_ql.context,
+                implicit=True, rptr_passthrough=True)
+
         argctx.inhibit_implicit_limit = True
-        return dispatch.compile(arg_ql, ctx=argctx), argctx
+
+        arg_ir = dispatch.compile(arg_ql, ctx=argctx)
+
+        if optional:
+            pathctx.register_set_in_scope(arg_ir, optional=True, ctx=ctx)
+
+            if arg_ir.path_scope_id is None:
+                pathctx.assign_set_scope(arg_ir, argctx.path_scope, ctx=argctx)
+
+        return arg_ir
 
 
-def compile_call_args(
+def compile_func_call_args(
     expr: qlast.FunctionCall,
     funcname: sn.Name,
+    typemods: Tuple[
+        Sequence[ft.TypeModifier], Dict[str, ft.TypeModifier]],
     *,
     ctx: context.ContextLevel
 ) -> Tuple[
     List[Tuple[s_types.Type, irast.Set]],
     Dict[str, Tuple[s_types.Type, irast.Set]],
-    Dict[irast.Set, context.ContextLevel],
 ]:
+    arg_typemods, kwarg_typemods = typemods
     args = []
     kwargs = {}
-    arg_ctxs = {}
 
     for ai, arg in enumerate(expr.args):
-        arg_ir, arg_ctx = compile_call_arg(arg, ctx=ctx)
+        arg_ir = compile_arg(arg, arg_typemods[ai], ctx=ctx)
         arg_type = inference.infer_type(arg_ir, ctx.env)
         if arg_type is None:
             raise errors.QueryError(
@@ -703,11 +716,10 @@ def compile_call_args(
                 f'#{ai} of function {funcname}',
                 context=arg.context)
 
-        arg_ctxs[arg_ir] = arg_ctx
         args.append((arg_type, arg_ir))
 
     for aname, arg in expr.kwargs.items():
-        arg_ir, arg_ctx = compile_call_arg(arg, ctx=ctx)
+        arg_ir = compile_arg(arg, kwarg_typemods[aname], ctx=ctx)
 
         arg_type = inference.infer_type(arg_ir, ctx.env)
         if arg_type is None:
@@ -716,40 +728,13 @@ def compile_call_args(
                 f'${aname} of function {funcname}',
                 context=arg.context)
 
-        arg_ctxs[arg_ir] = arg_ctx
         kwargs[aname] = (arg_type, arg_ir)
 
-    return args, kwargs, arg_ctxs
-
-
-def process_path_log(arg_ctx: Optional[context.ContextLevel],
-                     arg_scope: Optional[irast.ScopeTreeNode]) -> None:
-    if arg_ctx and arg_ctx.path_log is not None:
-        # Since we don't know whether arguments are OPTIONAL or SET OF
-        # until after doing polymorphic matching, paths in an OPTIONAL
-        # or SET OF argument could get factored into an existing
-        # optional node, destroying its optionality.
-        #
-        # To fix this, we track all of the paths attached to the tree
-        # while compiling an argument and find and adjust the
-        # optionality of any factored out nodes after the fact.
-        for path_id in arg_ctx.path_log:
-            for prefix in path_id.iter_prefixes(include_ptr=True):
-                assert arg_scope is not None
-                # If the node is still here, nothing to do
-                desc = arg_scope.find_descendant(prefix)
-                if desc:
-                    continue
-                visible = arg_scope.find_visible(prefix)
-                if visible:
-                    if visible.optional_count:
-                        visible.optional_count -= 1
-        arg_ctx.path_log = []
+    return args, kwargs
 
 
 def finalize_args(
     bound_call: polyres.BoundCall, *,
-    arg_ctxs: Dict[irast.Set, context.ContextLevel],
     actual_typemods: Sequence[ft.TypeModifier] = (),
     is_polymorphic: bool = False,
     ctx: context.ContextLevel,
@@ -775,34 +760,11 @@ def finalize_args(
 
         typemods.append(param_mod)
 
-        arg_ctx = arg_ctxs.get(arg)
-        arg_scope = pathctx.get_set_scope(arg, ctx=ctx)
         if param_mod is not ft.TypeModifier.SetOfType:
             param_shortname = param.get_parameter_name(ctx.env.schema)
 
-            # Arg was wrapped for scope fencing purposes,
-            # but that fence has been removed above, so unwrap it.
-            arg = irutils.unwrap_set(arg)
-
-            if (param_mod is ft.TypeModifier.OptionalType or
-                    param_shortname in bound_call.null_args):
-
-                process_path_log(arg_ctx, arg_scope)
-
-                if arg_scope is not None:
-                    # Due to the construction of relgen, the (unfenced)
-                    # subscope is necessary to shield LHS paths from the outer
-                    # query to prevent path binding which may break OPTIONAL.
-                    arg_scope.mark_as_optional()
-                    branch = arg_scope.unfence()
-
+            if param_shortname in bound_call.null_args:
                 pathctx.register_set_in_scope(arg, optional=True, ctx=ctx)
-
-                if arg_scope is not None and arg.path_scope_id is None:
-                    pathctx.assign_set_scope(arg, branch, ctx=ctx)
-
-            elif arg_scope is not None:
-                arg_scope.collapse()
 
             # Object type arguments to functions may be overloaded, so
             # we populate a path id field so that we can also pass the
@@ -823,7 +785,6 @@ def finalize_args(
                     ctx=ctx,
                 )
         else:
-            process_path_log(arg_ctx, arg_scope)
             is_array_agg = (
                 isinstance(bound_call.func, s_func.Function)
                 and (
@@ -874,10 +835,5 @@ def finalize_args(
         args.append(
             irast.CallArg(expr=arg, expr_type_path_id=arg_type_path_id,
                           is_default=barg.is_default))
-
-        # If we have any logged paths left over and our enclosing
-        # context is logging paths, propagate them up.
-        if arg_ctx and arg_ctx.path_log and ctx.path_log is not None:
-            ctx.path_log.extend(arg_ctx.path_log)
 
     return args, typemods

--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -88,9 +88,6 @@ def register_set_in_scope(
     if path_scope is None:
         path_scope = ctx.path_scope
 
-    if ctx.path_log is not None:
-        ctx.path_log.append(ir_set.path_id)
-
     return path_scope.attach_path(
         ir_set.path_id,
         optional=optional,

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -32,6 +32,7 @@ from edb.ir import utils as irutils
 from edb.schema import functions as s_func
 from edb.schema import name as sn
 from edb.schema import types as s_types
+from edb.schema import pseudo as s_pseudo
 
 from edb.edgeql import qltypes as ft
 
@@ -48,6 +49,7 @@ class BoundArg(NamedTuple):
     val: irast.Set
     valtype: s_types.Type
     cast_distance: int
+    arg_id: Optional[Union[int, str]]
     is_default: bool = False
 
 
@@ -75,17 +77,75 @@ _OPTIONAL = ft.TypeModifier.OptionalType
 _SINGLETON = ft.TypeModifier.SingletonType
 
 
+def find_callable_typemods(
+        candidates: Sequence[s_func.CallableLike], *,
+        num_args: int,
+        kwargs_names: AbstractSet[str],
+        ctx: context.ContextLevel) -> Tuple[
+            Sequence[ft.TypeModifier], Dict[str, ft.TypeModifier]]:
+    """Find the type modifiers for a callable.
+
+    We do this early, before we've compiled/checked the arguments,
+    so that we can compile the arguments with the proper fences.
+    """
+
+    typ = s_pseudo.PseudoType.get(ctx.env.schema, 'anytype')
+    dummy = irast.EmptySet()  # type: ignore
+    args = [(typ, dummy)] * num_args
+    kwargs = {k: (typ, dummy) for k in kwargs_names}
+    options = find_callable(
+        candidates, basic_matching_only=True, args=args, kwargs=kwargs, ctx=ctx
+    )
+
+    # No options means an error is going to happen later, but for now,
+    # just return some placeholders so that we can make it to the
+    # error later.
+    if not options:
+        return (
+            [_SINGLETON] * num_args,
+            {k: _SINGLETON for k in kwargs_names},
+        )
+
+    fts: Dict[Union[int, str], ft.TypeModifier] = {}
+    for choice in options:
+        for barg in choice.args:
+            if not barg.param or barg.arg_id is None:
+                continue
+            ft = barg.param.get_typemod(ctx.env.schema)
+            if barg.arg_id in fts and fts[barg.arg_id] != ft:
+                if ft == _SET_OF or fts[barg.arg_id] == _SET_OF:
+                    raise errors.QueryError(
+                        f'argument could be SET OF or not in call to '
+                        f'{candidates[0].get_verbosename(ctx.env.schema)}: '
+                        f'seems like a stdlib bug!')
+                else:
+                    # If there is a mix between OPTIONAL and SINGLETON
+                    # arguments in possible call sites, we just call it
+                    # optional. Generated code quality will be a little
+                    # worse but still correct.
+                    fts[barg.arg_id] = _OPTIONAL
+            else:
+                fts[barg.arg_id] = ft
+
+    return (
+        [fts[i] for i in range(num_args)],
+        {s: fts[s] for s in kwargs_names},
+    )
+
+
 def find_callable(
         candidates: Iterable[s_func.CallableLike], *,
         args: Sequence[Tuple[s_types.Type, irast.Set]],
         kwargs: Mapping[str, Tuple[s_types.Type, irast.Set]],
+        basic_matching_only: bool=False,
         ctx: context.ContextLevel) -> List[BoundCall]:
 
     implicit_cast_distance = None
     matched = []
 
     for candidate in candidates:
-        call = try_bind_call_args(args, kwargs, candidate, ctx=ctx)
+        call = try_bind_call_args(
+            args, kwargs, candidate, basic_matching_only, ctx=ctx)
         if call is None:
             continue
 
@@ -138,7 +198,9 @@ def find_callable(
 def try_bind_call_args(
         args: Sequence[Tuple[s_types.Type, irast.Set]],
         kwargs: Mapping[str, Tuple[s_types.Type, irast.Set]],
-        func: s_func.CallableLike, *,
+        func: s_func.CallableLike,
+        basic_matching_only: bool,
+        *,
         ctx: context.ContextLevel) -> Optional[BoundCall]:
 
     return_type = func.get_return_type(ctx.env.schema)
@@ -151,6 +213,8 @@ def try_bind_call_args(
         param_type: s_types.Type,
     ) -> int:
         nonlocal resolved_poly_base_type
+        if basic_matching_only:
+            return 0
 
         if in_polymorphic_func:
             # Compiling a body of a polymorphic function.
@@ -228,7 +292,7 @@ def try_bind_call_args(
                     irast.BytesConstant(value=b'\x00', typeref=typeref),
                     typehint=bytes_t,
                     ctx=ctx)
-                bargs = [BoundArg(None, bytes_t, argval, bytes_t, 0)]
+                bargs = [BoundArg(None, bytes_t, argval, bytes_t, 0, -1)]
             return BoundCall(
                 func, bargs, set(),
                 return_type, False)
@@ -277,7 +341,8 @@ def try_bind_call_args(
                 return None
 
             bound_args_prep.append(
-                BoundArg(param, param_type, arg_val, arg_type, cd))
+                BoundArg(param, param_type, arg_val, arg_type, cd,
+                         param_shortname))
 
         else:
             if param.get_default(schema) is None:
@@ -318,15 +383,16 @@ def try_bind_call_args(
                     return None
 
                 bound_args_prep.append(
-                    BoundArg(param, param_type, arg_val, arg_type, cd))
+                    BoundArg(param, param_type, arg_val, arg_type, cd, ai - 1))
 
-                for arg_type, arg_val in args[ai:]:
+                for di, (arg_type, arg_val) in enumerate(args[ai:]):
                     cd = _get_cast_distance(arg_val, arg_type, var_type)
                     if cd < 0:
                         return None
 
                     bound_args_prep.append(
-                        BoundArg(param, param_type, arg_val, arg_type, cd))
+                        BoundArg(param, param_type, arg_val, arg_type, cd,
+                                 ai + di))
 
                 break
 
@@ -335,7 +401,7 @@ def try_bind_call_args(
                 return None
 
             bound_args_prep.append(
-                BoundArg(param, param_type, arg_val, arg_type, cd))
+                BoundArg(param, param_type, arg_val, arg_type, cd, ai - 1))
 
         else:
             break
@@ -395,7 +461,7 @@ def try_bind_call_args(
 
                 param_type = param.get_type(schema)
 
-                if empty_default:
+                if empty_default and not basic_matching_only:
                     default_type = None
 
                     if param_type.is_any(schema):
@@ -429,6 +495,7 @@ def try_bind_call_args(
                         default,
                         param_type,
                         0,
+                        None,
                         True,
                     )
                 )
@@ -450,13 +517,14 @@ def try_bind_call_args(
         bm_set = setgen.ensure_set(
             irast.BytesConstant(value=bm, typeref=typeref),
             typehint=bytes_t, ctx=ctx)
-        bound_param_args.insert(0, BoundArg(None, bytes_t, bm_set, bytes_t, 0))
+        bound_param_args.insert(
+            0, BoundArg(None, bytes_t, bm_set, bytes_t, 0, None))
 
     if return_type.is_polymorphic(schema):
         if resolved_poly_base_type is not None:
             ctx.env.schema, return_type = return_type.to_nonpolymorphic(
                 ctx.env.schema, resolved_poly_base_type)
-        elif not in_polymorphic_func:
+        elif not in_polymorphic_func and not basic_matching_only:
             return None
 
     # resolved_poly_base_type may be legitimately None within
@@ -472,6 +540,7 @@ def try_bind_call_args(
                     barg.val,
                     barg.valtype,
                     barg.cast_distance,
+                    barg.arg_id,
                 )
 
     return BoundCall(

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -81,8 +81,7 @@ def find_callable_typemods(
         candidates: Sequence[s_func.CallableLike], *,
         num_args: int,
         kwargs_names: AbstractSet[str],
-        ctx: context.ContextLevel) -> Tuple[
-            Sequence[ft.TypeModifier], Dict[str, ft.TypeModifier]]:
+        ctx: context.ContextLevel) -> Dict[Union[int, str], ft.TypeModifier]:
     """Find the type modifiers for a callable.
 
     We do this early, before we've compiled/checked the arguments,
@@ -101,10 +100,7 @@ def find_callable_typemods(
     # just return some placeholders so that we can make it to the
     # error later.
     if not options:
-        return (
-            [_SINGLETON] * num_args,
-            {k: _SINGLETON for k in kwargs_names},
-        )
+        return {k: _SINGLETON for k in set(range(num_args)) | kwargs_names}
 
     fts: Dict[Union[int, str], ft.TypeModifier] = {}
     for choice in options:
@@ -127,10 +123,7 @@ def find_callable_typemods(
             else:
                 fts[barg.arg_id] = ft
 
-    return (
-        [fts[i] for i in range(num_args)],
-        {s: fts[s] for s in kwargs_names},
-    )
+    return fts
 
 
 def find_callable(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -83,7 +83,8 @@ def process_view(
     # factoring fence to be respected.
     hackscope = ctx.path_scope.attach_branch()
     pathctx.register_set_in_scope(ir_set, path_scope=hackscope, ctx=ctx)
-    hackscope.collapse()
+    hackscope.remove()
+    ctx.path_scope.attach_subtree(hackscope)
 
     view_scls, ir = _process_view(
         ir_set,

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -563,11 +563,14 @@ class ScopeTreeNode:
                         unnest_fence, existing_finfo, context,
                     )
 
-                    existing_fenced = existing.parent_fence is not self
+                    existing_fenced = existing.parent_fence is not factor_point
                     if existing.is_optional_upto(factor_point):
                         existing.mark_as_optional()
 
-                    desc_fenced = current.fence is not node or existing_fenced
+                    desc_fenced = (
+                        current.fence is not node
+                        or self.fence is not factor_point
+                    )
 
                     existing.remove()
                     current.remove()

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -254,7 +254,7 @@ class ScopeTreeNode:
                 An optional child to skip during the traversal. This
                 is useful for avoiding performance pathologies when
                 repeatedly searching descendants while climbing the
-                tree (see find_factoring_point).
+                tree (see find_factorable_nodes).
 
         Top-first.
         """
@@ -556,6 +556,7 @@ class ScopeTreeNode:
                         existing_ns,
                         existing_finfo,
                         unnest_fence,
+                        node_fenced,
                     ) = factorable
 
                     self._check_factoring_errors(
@@ -566,11 +567,6 @@ class ScopeTreeNode:
                     existing_fenced = existing.parent_fence is not factor_point
                     if existing.is_optional_upto(factor_point):
                         existing.mark_as_optional()
-
-                    desc_fenced = (
-                        current.fence is not node
-                        or self.fence is not factor_point
-                    )
 
                     existing.remove()
                     current.remove()
@@ -587,7 +583,7 @@ class ScopeTreeNode:
                     existing.fuse_subtree(
                         current,
                         self_fenced=existing_fenced,
-                        node_fenced=desc_fenced)
+                        node_fenced=node_fenced)
 
                     current = existing
 
@@ -908,6 +904,7 @@ class ScopeTreeNode:
             AbstractSet[pathid.Namespace],
             FenceInfo,
             bool,
+            bool,
         ]
     ]:
         """Find nodes factorable with path_id (if attaching path_id to self)
@@ -951,7 +948,8 @@ class ScopeTreeNode:
                 if (has_path_id(descendant)
                         and _paths_equal(descendant.path_id, path_id, cns)):
                     points.append((
-                        descendant, node, cns, finfo, unnest_fence_seen
+                        descendant, node, cns, finfo,
+                        unnest_fence_seen, fence_seen,
                     ))
 
             namespaces |= ans

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -71,13 +71,8 @@ class ScopeTreeNode:
     factoring_allowlist: Set[pathid.PathId]
     """A list of prefixes that are always allowed to be factored."""
 
-    optional_count: Optional[int]
-    """Whether this node represents an optional path.
-
-    If None, the node is not an optional path. If 0, it is.
-    If positive, the node *was* an optional path but has had non-optional
-    nodes merged into it, but could become optional again.
-    """
+    optional: bool
+    """Whether this node represents an optional path."""
 
     children: List[ScopeTreeNode]
     """A set of child nodes."""
@@ -110,7 +105,7 @@ class ScopeTreeNode:
         self.unnest_fence = False
         self.factoring_fence = False
         self.factoring_allowlist = set()
-        self.optional_count = 0 if optional else None
+        self.optional = optional
         self.children = []
         self.namespaces = set()
         self._parent: Optional[weakref.ReferenceType[ScopeTreeNode]] = None
@@ -153,11 +148,7 @@ class ScopeTreeNode:
             )
         else:
             name = self.path_id.pformat_internal(debug=debug)
-        ocount = self.optional_count
-        return (
-            f'{name}{" [OPT]" if self.optional else ""}'
-            f'{" ["+str(ocount)+"]" if ocount else ""}'
-        )
+        return f'{name}{" [OPT]" if self.optional else ""}'
 
     def debugname(self, fuller: bool=False) -> str:
         parts = [f'{self._name(debug=fuller)}']
@@ -171,10 +162,6 @@ class ScopeTreeNode:
             parts.append('no-factor')
         parts.append(f'0x{id(self):0x}')
         return ' '.join(parts)
-
-    @property
-    def optional(self) -> bool:
-        return self.optional_count == 0
 
     @property
     def fence_info(self) -> FenceInfo:
@@ -499,7 +486,8 @@ class ScopeTreeNode:
 
             path_id = descendant.path_id.strip_namespace(dns)
             visible, visible_finfo, vns = self.find_visible_ex(path_id)
-            desc_optional = descendant.is_optional_upto(node.parent)
+            desc_optional = (
+                descendant.is_optional_upto(node.parent) or self.optional)
 
             # If descendant is covered up by one CBRANCH, it is because it
             # was put there by a fence_pointer in attach_path. If the path
@@ -531,6 +519,7 @@ class ScopeTreeNode:
 
                 # This path is already present in the tree, discard,
                 # but merge its OPTIONAL status, if any.
+
                 desc_fenced = (
                     descendant.fence is not node.fence
                     or was_fenced
@@ -538,14 +527,14 @@ class ScopeTreeNode:
                 )
                 descendant.remove()
                 descendant._gravestone = visible
-                keep_optional = desc_optional or desc_fenced
-                if keep_optional:
-                    descendant.mark_as_optional()
+                descendant.optional = desc_optional
                 descendant.strip_path_namespace(dns | vns)
-                visible.fuse_subtree(descendant, self_fenced=False)
+                visible.fuse_subtree(
+                    descendant, self_fenced=False, node_fenced=desc_fenced)
 
             elif descendant.parent_fence is node:
                 # Unfenced path.
+
                 # Search for occurences elsewhere in the tree that
                 # can be factored with this one.
                 # If found, attach that node directly to the factoring point
@@ -578,6 +567,8 @@ class ScopeTreeNode:
                     if existing.is_optional_upto(factor_point):
                         existing.mark_as_optional()
 
+                    desc_fenced = current.fence is not node or existing_fenced
+
                     existing.remove()
                     current.remove()
 
@@ -591,7 +582,9 @@ class ScopeTreeNode:
                     # Discard the node from the subtree being attached.
                     current._gravestone = existing
                     existing.fuse_subtree(
-                        current, self_fenced=existing_fenced)
+                        current,
+                        self_fenced=existing_fenced,
+                        node_fenced=desc_fenced)
 
                     current = existing
 
@@ -664,20 +657,18 @@ class ScopeTreeNode:
         self,
         node: ScopeTreeNode,
         self_fenced: bool=False,
+        node_fenced: bool=False,
     ) -> None:
         node.remove()
 
-        if (
-            self.optional_count is not None
-            and not node.optional
-        ):
-            self.optional_count += 1
+        if not node.optional and not node_fenced:
+            self.optional = False
         if node.optional and self_fenced:
-            self.mark_as_optional()
+            self.optional = True
 
         if node.path_id is not None:
             subtree = ScopeTreeNode(fenced=True)
-            subtree.optional_count = node.optional_count
+            subtree.optional = node.optional
             for child in tuple(node.children):
                 subtree.attach_child(child)
         else:
@@ -709,7 +700,7 @@ class ScopeTreeNode:
 
     def mark_as_optional(self) -> None:
         """Indicate that this scope is used as an OPTIONAL argument."""
-        self.optional_count = 0
+        self.optional = True
 
     def is_optional(self, path_id: pathid.PathId) -> bool:
         node = self.find_visible(path_id)
@@ -740,43 +731,6 @@ class ScopeTreeNode:
         parent = self.parent
         if parent is not None:
             parent.remove_subtree(self)
-
-    def collapse(self) -> None:
-        """Remove the node, reattaching the children to the parent."""
-        parent = self.parent
-        if parent is None:
-            raise ValueError('cannot collapse the root node')
-
-        if self.path_id is not None:
-            subtree = ScopeTreeNode()
-
-            for child in self.children:
-                subtree.attach_child(child)
-        else:
-            subtree = self
-
-        self.remove()
-        parent.attach_subtree(subtree)
-
-    def unfence(self) -> ScopeTreeNode:
-        """Remove the node, reattaching the children as an unfenced branch."""
-        parent = self.parent
-        if parent is None:
-            raise ValueError('cannot unfence the root node')
-
-        subtree = ScopeTreeNode(optional=self.optional)
-
-        for child in list(self.children):
-            subtree.attach_child(child)
-
-        self.remove()
-
-        parent_subtree = ScopeTreeNode(fenced=True)
-        parent_subtree.attach_child(subtree)
-
-        parent.attach_subtree(parent_subtree)
-
-        return subtree
 
     def is_empty(self) -> bool:
         if self.path_id is not None:
@@ -936,7 +890,7 @@ class ScopeTreeNode:
     def is_optional_upto(self, ancestor: Optional[ScopeTreeNode]) -> bool:
         node: Optional[ScopeTreeNode] = self
         while node and node is not ancestor:
-            if node.optional_count is not None:
+            if node.optional:
                 return True
             node = node.parent
         return False

--- a/edb/lib/std/12-abstractops.edgeql
+++ b/edb/lib/std/12-abstractops.edgeql
@@ -37,10 +37,10 @@ CREATE ABSTRACT INFIX OPERATOR
 std::`=` (l: anytype, r: anytype) -> std::bool;
 
 CREATE ABSTRACT INFIX OPERATOR
-std::`?=` (l: anytype, r: anytype) -> std::bool;
+std::`?=` (l: OPTIONAL anytype, r: OPTIONAL anytype) -> std::bool;
 
 CREATE ABSTRACT INFIX OPERATOR
 std::`!=` (l: anytype, r: anytype) -> std::bool;
 
 CREATE ABSTRACT INFIX OPERATOR
-std::`?!=` (l: anytype, r: anytype) -> std::bool;
+std::`?!=` (l: OPTIONAL anytype, r: OPTIONAL anytype) -> std::bool;

--- a/tests/schemas/issues.esdl
+++ b/tests/schemas/issues.esdl
@@ -147,3 +147,12 @@ scalar type EmulatedEnum extending str {
 function ident(a: str) -> str {
     USING (SELECT a)
 }
+
+
+function opt_test(tag: int64, x: str) -> str using (x ?? '');
+function opt_test(tag: bool, x: optional str) -> str using (x ?? '');
+function opt_test(tag: int64, x: int64) -> int64 using (x ?? -1);
+function opt_test(tag: bool, x: optional int64) -> int64 using (x ?? -1);
+
+function opt_test(tag: int64, x: int64, y: optional int64) -> int64 using (y ?? -1);
+function opt_test(tag: bool, x: optional int64, y: optional int64) -> int64 using (y ?? -1);

--- a/tests/schemas/issues_coalesce_setup.edgeql
+++ b/tests/schemas/issues_coalesce_setup.edgeql
@@ -16,15 +16,6 @@
 # limitations under the License.
 #
 
-create function opt_test(tag: int64, x: str) -> str using (x ?? '');
-create function opt_test(tag: bool, x: optional str) -> str using (x ?? '');
-create function opt_test(tag: int64, x: int64) -> int64 using (x ?? -1);
-create function opt_test(tag: bool, x: optional int64) -> int64 using (x ?? -1);
-
-create function opt_test(tag: int64, x: int64, y: optional int64) -> int64 using (y ?? -1);
-create function opt_test(tag: bool, x: optional int64, y: optional int64) -> int64 using (y ?? -1);
-
-
 INSERT Priority {
     name := 'High'
 };

--- a/tests/schemas/issues_coalesce_setup.edgeql
+++ b/tests/schemas/issues_coalesce_setup.edgeql
@@ -16,6 +16,14 @@
 # limitations under the License.
 #
 
+create function opt_test(tag: int64, x: str) -> str using (x ?? '');
+create function opt_test(tag: bool, x: optional str) -> str using (x ?? '');
+create function opt_test(tag: int64, x: int64) -> int64 using (x ?? -1);
+create function opt_test(tag: bool, x: optional int64) -> int64 using (x ?? -1);
+
+create function opt_test(tag: int64, x: int64, y: optional int64) -> int64 using (y ?? -1);
+create function opt_test(tag: bool, x: optional int64, y: optional int64) -> int64 using (y ?? -1);
+
 
 INSERT Priority {
     name := 'High'


### PR DESCRIPTION
This is based on a previous attempt, #2132.

This allows us to compile arguments with the correct fences in the
first place, instead of trying to fix them up after the fact.

The key insight here is that if a function argument could be either
OPTIONAL or SINGLETON, it is safe to treat it as optional. The
generated code will be a bit worse, since it will include an optional
wrapper.

This change allowed me to rip out a bunch nasty mechanisms for dealing
with OPTIONAL that I introduced during the first few months of my
employment and that I have been trying to kill ever since
(optional_count, path_log).

This is about code-size-neutral but the added code is boring plumbing
(to find typemods before fully typechecking) and the removed code is
fiddly hacks.

This also proves that it should be possible to precompute a scope tree
without needing to do move typechecking before scope tree inference.