### PR TITLE
Make the codegen tests always use issues

### DIFF
--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -36,10 +36,7 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
     """
 
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
-                          'cards.esdl')
-
-    SCHEMA_ISSUES = os.path.join(os.path.dirname(__file__), 'schemas',
-                                 'issues.esdl')
+                          'issues.esdl')
 
     def _compile_to_tree(self, source):
         qltree = qlparser.parse(source)
@@ -74,10 +71,10 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
                 f"{table} referenced more than once: {sql}")
 
     def test_codegen_no_self_join_single(self):
-        self.no_self_join_test("SELECT User.avatar", ["User", "Card"])
+        self.no_self_join_test("SELECT Issue.status", ["Issue", "Status"])
 
     def test_codegen_no_self_join_multi(self):
-        self.no_self_join_test("SELECT User.deck.name", ["User"])
+        self.no_self_join_test("SELECT Issue.watchers.name", ["User"])
 
     def no_optional_test(self, query):
         sql = self._compile(query)
@@ -91,25 +88,21 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
 
     def test_codegen_elide_optional_wrapper_01(self):
         self.no_optional_test('''
-            with module issues
             select Issue { te := .time_estimate ?? -1 }
         ''')
 
     def test_codegen_elide_optional_wrapper_02(self):
         self.no_optional_test('''
-            with module issues
             SELECT (Issue.name, Issue.time_estimate ?= 60)
         ''')
 
     def test_codegen_elide_optional_wrapper_03(self):
         self.no_optional_test('''
-            with module issues
             SELECT opt_test(0, <str>Issue.time_estimate)
         ''')
 
     def test_codegen_elide_optional_wrapper_04(self):
         self.no_optional_test('''
-            with module issues
             SELECT (Issue, opt_test(0, <str>Issue.time_estimate))
         ''')
 


### PR DESCRIPTION
None of the things we are testing need anything in cards really, so
might as well simplify matters.