### PR TITLE
Fix issues involving scalar set identity/bond of a union

### DIFF
--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -580,9 +580,6 @@ def new_rel_rvar(
         ir_set: irast.Set, stmt: pgast.Query, *,
         lateral: bool=True,
         ctx: context.CompilerContextLevel) -> pgast.PathRangeVar:
-    if irutils.is_scalar_view_set(ir_set):
-        ensure_bond_for_expr(ir_set, stmt, ctx=ctx)
-
     return rvar_for_rel(stmt, typeref=ir_set.typeref, lateral=lateral, ctx=ctx)
 
 


### PR DESCRIPTION
1. When _get_path_var_in_setop fails, clear the NULL entries
   so that a future call doesn't succeed based on the presence
   of those.
2. Skip ensure_bond_for_expr on scalar view sets. I don't think
   it is needed anymore, and causes performance issues on the
   #3525 test case. (Fixing this also would fix the bug in the
   absence of fix 1).
3. Don't let values relations produce identity aspects. This
   fixes a bug that currently only shows up without normalization
   on so the test for it doesn't *really* actually test it...

Fixes #3525