### PR TITLE
Fix card inference bug and support chained cardinality restriction

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -839,6 +839,7 @@ def _is_ptr_or_self_ref(
                 env.set_types[ir_set] == srccls
                 or (
                     (rptr := ir_set.rptr) is not None
+                    and env.set_types[rptr.source] == srccls
                     and srccls.maybe_get_ptr(
                         env.schema,
                         rptr.ptrref.shortname.get_local_name()

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -834,16 +834,13 @@ def _is_ptr_or_self_ref(
 
         return (
             isinstance(srccls, s_objtypes.ObjectType)
-            and ir_set.expr is None
             and (
                 env.set_types[ir_set] == srccls
                 or (
                     (rptr := ir_set.rptr) is not None
-                    and env.set_types[rptr.source] == srccls
-                    and srccls.maybe_get_ptr(
-                        env.schema,
-                        rptr.ptrref.shortname.get_local_name()
-                    ) is not None
+                    and isinstance(rptr.ptrref, irast.PointerRef)
+                    and not rptr.ptrref.is_computable
+                    and _is_ptr_or_self_ref(rptr.source, result_expr, env)
                 )
             )
         )
@@ -854,13 +851,11 @@ def extract_filters(
     filter_set: irast.Set,
     scope_tree: irast.ScopeTreeNode,
     ctx: inference_context.InfCtx,
-) -> Sequence[Tuple[s_pointers.Pointer, irast.Set]]:
+) -> Sequence[Tuple[Sequence[s_pointers.Pointer], irast.Set]]:
 
     env = ctx.env
     schema = env.schema
     scope_tree = inf_utils.get_set_scope(filter_set, scope_tree, ctx=ctx)
-
-    ptr: s_pointers.Pointer
 
     expr = filter_set.expr
     if isinstance(expr, irast.OperatorCall):
@@ -886,19 +881,22 @@ def extract_filters(
                 if infer_cardinality(
                     right, scope_tree=scope_tree, ctx=ctx,
                 ).is_single():
+                    ptrs = []
                     left_stype = env.set_types[left]
                     if left_stype == result_stype:
                         assert isinstance(left_stype, s_objtypes.ObjectType)
                         _ptr = left_stype.getptr(schema, sn.UnqualName('id'))
+                        ptrs.append(_ptr)
                     else:
-                        assert left.rptr is not None
-                        _ptr = env.schema.get(left.rptr.ptrref.name,
-                                              type=s_pointers.Pointer)
+                        while env.set_types[left] != result_stype:
+                            assert left.rptr is not None
+                            _ptr = env.schema.get(left.rptr.ptrref.name,
+                                                  type=s_pointers.Pointer)
+                            ptrs.append(_ptr)
+                            left = left.rptr.source
+                        ptrs.reverse()
 
-                    assert _ptr is not None
-                    ptr = _ptr
-
-                    return [(ptr, right)]
+                    return [(ptrs, right)]
 
         elif str(expr.func_shortname) == 'std::AND':
             left, right = (a.expr for a in expr.args)
@@ -915,6 +913,28 @@ def extract_filters(
     return []
 
 
+def _all_have_exclusive(
+    ptrs: Sequence[s_pointers.Pointer],
+    ctx: inference_context.InfCtx,
+) -> bool:
+    return all(
+        bool(ptr.get_exclusive_constraints(ctx.env.schema))
+        for ptr in ptrs
+    )
+
+
+def _track_all_constraint_refs(
+    ptrs: Sequence[s_pointers.Pointer],
+    ctx: inference_context.InfCtx,
+) -> None:
+    for ptr in ptrs:
+        for constr in ptr.get_exclusive_constraints(ctx.env.schema):
+            # We need to track all schema refs, since an expression
+            # in the schema needs to depend on any constraint
+            # that affects its cardinality.
+            ctx.env.add_schema_ref(constr, None)
+
+
 def extract_exclusive_filters(
     result_set: irast.Set,
     filter_set: irast.Set,
@@ -927,22 +947,24 @@ def extract_exclusive_filters(
     results: List[Tuple[Tuple[s_pointers.Pointer, irast.Set], ...]] = []
     if filtered_ptrs:
         schema = ctx.env.schema
+        # Only look at paths where all trailing pointers are exclusive;
+        # that is, if we see `.foo.bar`, `bar` must be exclusive.
+        # If that's the case, then we can look at whether `.foo` is
+        # exclusive or used in an exclusive object constraint.
         filtered_ptrs_map = {
-            ptr.get_nearest_non_derived_parent(schema): expr
-            for ptr, expr in filtered_ptrs
+            ptrs[0].get_nearest_non_derived_parent(schema): (ptrs, expr)
+            for ptrs, expr in filtered_ptrs
+            if _all_have_exclusive(ptrs[1:], ctx)
         }
         ptr_set = set(filtered_ptrs_map)
         # First look at each referenced pointer and see if it has
         # an exclusive constraint.
-        for ptr, expr in filtered_ptrs_map.items():
-            for constr in ptr.get_exclusive_constraints(schema):
+        for ptr, (ptrs, expr) in filtered_ptrs_map.items():
+            if _all_have_exclusive([ptr], ctx):
                 # Bingo, got an equality filter on a pointer with a
                 # unique constraint
                 results.append(((ptr, expr),))
-                # We need to track all schema refs, since an expression
-                # in the schema needs to depend on any constraint
-                # that affects its cardinality.
-                ctx.env.add_schema_ref(constr, None)
+                _track_all_constraint_refs(ptrs, ctx)
 
         # Then look at all the object exclusive constraints
         result_stype = ctx.env.set_types[result_set]
@@ -950,8 +972,11 @@ def extract_exclusive_filters(
             result_stype, ptr_set, ctx.env)
         for constr, obj_exc_ptrs in obj_exclusives.items():
             results.append(
-                tuple((ptr, filtered_ptrs_map[ptr]) for ptr in obj_exc_ptrs))
+                tuple((ptr, filtered_ptrs_map[ptr][1]) for ptr in obj_exc_ptrs)
+            )
             ctx.env.add_schema_ref(constr, None)
+            for ptr in obj_exc_ptrs:
+                _track_all_constraint_refs(filtered_ptrs_map[ptr][0], ctx)
 
     return results
 

--- a/tests/schemas/cards_ir_inference.esdl
+++ b/tests/schemas/cards_ir_inference.esdl
@@ -43,6 +43,10 @@ type User extending Named {
     link avatar -> Card {
         property text -> str;
     }
+
+    link unique_avatar -> Card {
+        constraint exclusive;
+    }
 }
 
 type Card extending Named {

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -907,3 +907,11 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         AT_MOST_ONE
         """
+
+    def test_edgeql_ir_card_inference_105(self):
+        """
+        select User
+        filter .avatar.name = 'Dragon'
+% OK %
+        MANY
+        """

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -570,6 +570,14 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         AT_MOST_ONE
         """
 
+    def test_edgeql_ir_card_inference_60b(self):
+        """
+        SELECT Person
+        FILTER .p = 12 AND .card.name = 'Imp'
+% OK %
+        AT_MOST_ONE
+        """
+
     def test_edgeql_ir_card_inference_61(self):
         """
         SELECT Person FILTER .first = "Phil" OR .last = "Emarg"
@@ -914,4 +922,12 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
         filter .avatar.name = 'Dragon'
 % OK %
         MANY
+        """
+
+    def test_edgeql_ir_card_inference_106(self):
+        """
+        select User
+        filter .unique_avatar.name = 'Dragon'
+% OK %
+        AT_MOST_ONE
         """


### PR DESCRIPTION
There is a soundness bug in card inference where we only look at the
rightmost element in the path. So if a filter is on `.foo.name`, we
check if `name` has an exclusive constraint *on the subject object*,
which is wrong.

To avoid this breaking code that relied on this in an unsound way
but could be sound, this is paired with implementation of chained
cardinality restriction on filters.

That is, make `select Foo filter .bar.baz = 'key'` infer cardinality
`AtMostOne` if `bar` and `baz` both have exclusive constraints.

Previously, it would have been necessary to write
`select Foo filter .bar = (select Bar filter .baz = 'key')` if you wanted
cardinality One.

Closes #3566.