### PR TITLE
Fix recursive computed ordering issue.

### DIFF
--- a/edb/common/topological.py
+++ b/edb/common/topological.py
@@ -142,10 +142,14 @@ def sort_ex(
         weak_link: bool = False,
     ) -> None:
         if item in visiting:
+            # Separate the matching item from the rest of the visiting
+            # set for error reporting.
+            vis_list = list(visiting - {item})
+            cycle_item = item if len(vis_list) == 0 else vis_list[-1]
             raise CycleError(
-                f"dependency cycle between {list(visiting)[-1]!r} "
+                f"dependency cycle between {cycle_item!r} "
                 f"and {item!r}",
-                path=list(visiting)[1:],
+                path=vis_list,
                 item=item,
             )
         if item not in visited:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1863,6 +1863,69 @@ class TestSchema(tb.BaseSchemaLoadTest):
             }
         ''', modname='default')
 
+    def test_schema_computed_01(self):
+        # Issue #3499
+        """
+            type Version {
+                multi link fields -> Field {
+                    property position -> int32 {
+                        default := 0;
+                    }
+                }
+                multi link sections :=
+                    (select .ordered_fields filter .type = 'section');
+                multi link ordered_fields :=
+                    (select .fields order by @position);
+            }
+
+            type Field {
+                required property type -> str;
+                multi link versions := .<fields[is Version];
+            }
+        """
+
+    def test_schema_computed_02(self):
+        # Issue #3499
+        """
+            type Version {
+                multi link fields -> Field {
+                    property position -> int32 {
+                        default := 0;
+                    }
+                }
+                multi link ordered_fields :=
+                    (select .fields order by @position);
+                multi link sections :=
+                    (select .ordered_fields filter .type = 'section');
+            }
+
+            type Field {
+                required property type -> str;
+                multi link versions := .<fields[is Version];
+            }
+        """
+
+    def test_schema_computed_03(self):
+        # Issue #3499
+        """
+            type Version {
+                multi link ordered_fields :=
+                    (select .fields order by @position);
+                multi link sections :=
+                    (select .ordered_fields filter .type = 'section');
+                multi link fields -> Field {
+                    property position -> int32 {
+                        default := 0;
+                    }
+                }
+            }
+
+            type Field {
+                required property type -> str;
+                multi link versions := .<fields[is Version];
+            }
+        """
+
 
 class TestGetMigration(tb.BaseSchemaLoadTest):
     """Test migration deparse consistency.


### PR DESCRIPTION
Recursively infer the targets of computed links and properties when
ordering SDL.

Fix #3499