### PR TITLE
Use path_id instead of type at the root of filter inference

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -835,7 +835,7 @@ def _is_ptr_or_self_ref(
         return (
             isinstance(srccls, s_objtypes.ObjectType)
             and (
-                env.set_types[ir_set] == srccls
+                ir_expr.path_id == result_expr.path_id
                 or (
                     (rptr := ir_set.rptr) is not None
                     and isinstance(rptr.ptrref, irast.PointerRef)
@@ -888,7 +888,7 @@ def extract_filters(
                         _ptr = left_stype.getptr(schema, sn.UnqualName('id'))
                         ptrs.append(_ptr)
                     else:
-                        while env.set_types[left] != result_stype:
+                        while left.path_id != result_set.path_id:
                             assert left.rptr is not None
                             _ptr = env.schema.get(left.rptr.ptrref.name,
                                                   type=s_pointers.Pointer)

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -931,3 +931,34 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         AT_MOST_ONE
         """
+
+    def test_edgeql_ir_card_inference_107(self):
+        """
+        WITH
+          __scope_0_Hero := DETACHED default::User
+        UPDATE __scope_0_Hero
+        FILTER (__scope_0_Hero.name = "Spider-Man")
+        SET {
+          name := ("The Amazing " ++ __scope_0_Hero.name)
+        }
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_108(self):
+        """
+        WITH
+          __scope_0_Hero := DETACHED default::User
+        SELECT __scope_0_Hero
+        FILTER (__scope_0_Hero.name = "Spider-Man")
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_109(self):
+        """
+        select User
+        filter (detached (select User limit 1)).name = 'Alice'
+% OK %
+        MANY
+        """


### PR DESCRIPTION
This fixes some false positives and false negatives.
Fixes #3590.