### PR TITLE
Don't enforce exclusivity of non-exclusive obj constraints in UPDATE

### DIFF
--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -508,8 +508,12 @@ def compile_inheritance_conflict_selects(
     beginning at the start of the statement.
     """
     pointers = _get_exclusive_ptr_constraints(typ, ctx=ctx)
-    obj_constrs = typ.get_constraints(ctx.env.schema).objects(
-        ctx.env.schema)
+    exclusive = ctx.env.schema.get('std::exclusive', type=s_constr.Constraint)
+    obj_constrs = [
+        constr for constr in
+        typ.get_constraints(ctx.env.schema).objects(ctx.env.schema)
+        if constr.issubclass(ctx.env.schema, exclusive)
+    ]
 
     # This is a little silly, but for *this* we need to do one per
     # constraint (so that we can properly identify which constraint

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -572,6 +572,8 @@ def compile_inheritance_conflict_checks(
     base_object = ctx.env.schema.get(
         'std::BaseObject', type=s_objtypes.ObjectType)
 
+    subject_stype = subject_stype.get_nearest_non_derived_parent(
+        ctx.env.schema)
     subject_stypes = [subject_stype]
     # For updates, we need to also consider all descendants, because
     # those could also have interesting constraints of their own.

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -4457,7 +4457,7 @@ class TestInsert(tb.QueryTestCase):
         # This should be fine.
         await self.con.execute(query)
 
-    async def test_edgeql_insert_update_cross_type_conflict_05(self):
+    async def test_edgeql_insert_update_cross_type_conflict_05a(self):
         # this isn't really an insert test
         await self.con.execute('''
             INSERT Person { name := 'Foo' };
@@ -4466,6 +4466,22 @@ class TestInsert(tb.QueryTestCase):
 
         query = r'''
             UPDATE Person FILTER true SET { name := "!" };
+        '''
+
+        with self.assertRaisesRegex(edgedb.ConstraintViolationError,
+                                    "name violates exclusivity constraint"):
+            await self.con.execute(query)
+
+    async def test_edgeql_insert_update_cross_type_conflict_05b(self):
+        # this isn't really an insert test
+        await self.con.execute('''
+            INSERT Person { name := 'Foo' };
+            INSERT DerivedPerson { name := 'Bar' };
+        ''')
+
+        query = r'''
+            WITH P := Person
+            UPDATE P FILTER true SET { name := "!" };
         '''
 
         with self.assertRaisesRegex(edgedb.ConstraintViolationError,


### PR DESCRIPTION
In the case that was reported, also, this bug only triggered
because of two suboptimal codegen issues:
  * We generate the conflict checks even when there
    is a single update of a type without children
  * We generate conflict checks for a single UPDATE on a
    type without subtypes.

Those are worth following up on. (The first one is marked with a TODO
already, but I think the second one is just an oversight.)