### PR TITLE
Enforce newly created exclusive constraints across tables

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -219,6 +219,31 @@ class MetaCommand(sd.Command, metaclass=CommandMeta):
             raise AssertionError(f"there is no {ctxcls} in context stack")
         ctx.op.inhview_updates.add(source)
 
+    def schedule_post_inhview_update_command(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        cmd: sd.Command,
+        ctxcls: Type[sd.CommandContextToken[sd.Command]],
+    ) -> None:
+        ctx = context.get_topmost_ancestor(ctxcls)
+        if ctx is None:
+            raise AssertionError(f"there is no {ctxcls} in context stack")
+        ctx.op.post_inhview_update_commands.append(cmd)
+
+        # HACK: Abstract pointers pre-1.2 didn't have source in their
+        # views, and so the constraint enforcement we generate for
+        # them (added in 1.2) won't work. So whenever we might be
+        # generating that code, regenerate the view, so it will work
+        # on a 1.2 instance that was upgraded from 1.1.
+        # This can be cherry-picked into 1.x, then immediately
+        # removed in the main branch.
+        if (
+            isinstance(ctx.op, AlterLink)
+            and ctx.op.scls.generic(schema)
+        ):
+            ctx.op.inhview_updates.add(ctx.op.scls)
+
 
 class CommandGroupAdapted(MetaCommand, adapts=sd.CommandGroup):
     pass
@@ -1754,6 +1779,25 @@ class ConstraintCommand(MetaCommand):
 
         return op
 
+    @classmethod
+    def enforce_constraint(
+            cls, constraint, schema, context, source_context=None):
+
+        if cls.constraint_is_effective(schema, constraint):
+            subject = constraint.get_subject(schema)
+
+            if subject is not None:
+                schemac_to_backendc = \
+                    schemamech.ConstraintMech.\
+                    schema_constraint_to_backend_constraint
+                bconstr = schemac_to_backendc(
+                    subject, constraint, schema, context,
+                    source_context)
+
+                return bconstr.enforce_ops()
+        else:
+            return dbops.CommandGroup()
+
 
 class CreateConstraint(ConstraintCommand, adapts=s_constr.CreateConstraint):
     def apply(
@@ -1767,6 +1811,20 @@ class CreateConstraint(ConstraintCommand, adapts=s_constr.CreateConstraint):
         op = self.create_constraint(
             constraint, schema, context, self.source_context)
         self.pgops.add(op)
+
+        # If the constraint is being added to existing data,
+        # we need to enforce it on the existing data. (This only
+        # matters for
+        if (
+            (subject := constraint.get_subject(schema))
+            and isinstance(
+                subject, (s_objtypes.ObjectType, s_pointers.Pointer))
+            and not context.is_creating(subject)
+        ):
+            op = self.enforce_constraint(
+                constraint, schema, context, self.source_context)
+            self.schedule_post_inhview_update_command(
+                schema, context, op, s_sources.SourceCommandContext)
 
         return schema
 
@@ -1865,6 +1923,18 @@ class AlterConstraint(
             else:
                 op.add_command(bconstr.alter_ops(orig_bconstr))
             self.pgops.add(op)
+
+            if (
+                (subject := constraint.get_subject(schema))
+                and isinstance(
+                    subject, (s_objtypes.ObjectType, s_pointers.Pointer))
+                and not context.is_creating(subject)
+            ):
+                op = self.enforce_constraint(
+                    constraint, schema, context, self.source_context)
+                self.schedule_post_inhview_update_command(
+                    schema, context, op,
+                    s_objtypes.ObjectTypeCommandContext,)
 
         return schema
 
@@ -2399,6 +2469,7 @@ class CompositeMetaCommand(MetaCommand):
         self._multicommands = {}
         self.update_search_indexes = None
         self.inhview_updates = set()
+        self.post_inhview_update_commands = []
 
     def _get_multicommand(
             self, context, cmdtype, object_name, *,
@@ -2503,12 +2574,14 @@ class CompositeMetaCommand(MetaCommand):
                     )
                     if ptr_stor_info.column_type != pgtype:
                         return None
-                    cols.append((ptr_stor_info.column_name, alias))
+                    cols.append((ptr_stor_info.column_name, alias, True))
+                elif ptrname == sn.UnqualName('source'):
+                    cols.append(('NULL::uuid', alias, False))
                 else:
                     return None
         else:
             cols = [
-                (ptrname, alias)
+                (ptrname, alias, True)
                 for ptrname, (alias, _) in ptrnames.items()
             ]
 
@@ -2525,7 +2598,9 @@ class CompositeMetaCommand(MetaCommand):
         talias = qi(tabname[1])
 
         coltext = ',\n'.join(
-            f'{f"{talias}.{qi(col)}"} AS {qi(alias)}' for col, alias in cols
+            f'{f"{talias}.{qi(col)}"} AS {qi(alias)}' if is_col else
+            f'{col} AS {qi(alias)}'
+            for col, alias, is_col in cols
         )
 
         return textwrap.dedent(f'''\
@@ -2588,6 +2663,22 @@ class CompositeMetaCommand(MetaCommand):
             )
             ptrs['target'] = ('target', lp_info.column_type)
 
+        descendants = [
+            child for child in obj.descendants(schema)
+            if has_table(child, schema) and child not in exclude_children
+        ]
+
+        # Hackily force 'source' to appear in abstract links. We need
+        # source present in the code we generate to enforce newly
+        # created exclusive constraints across types.
+        if (
+            ptrs
+            and isinstance(obj, s_links.Link)
+            and sn.UnqualName('source') not in ptrs
+            and obj.generic(schema)
+        ):
+            ptrs[sn.UnqualName('source')] = ('source', ('uuid',))
+
         components = []
         if not exclude_self:
             components.append(
@@ -2595,8 +2686,7 @@ class CompositeMetaCommand(MetaCommand):
 
         components.extend(
             cls._get_select_from(schema, child, ptrs, pg_schema)
-            for child in obj.descendants(schema)
-            if has_table(child, schema) and child not in exclude_children
+            for child in descendants
         )
 
         query = '\nUNION ALL\n'.join(filter(None, components))
@@ -2751,6 +2841,8 @@ class CompositeMetaCommand(MetaCommand):
                 if has_table(s, schema):
                     self.alter_inhview(
                         schema, context, s, alter_ancestors=False)
+
+        self.pgops.update(self.post_inhview_update_commands)
 
 
 class IndexCommand(MetaCommand):

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1814,7 +1814,8 @@ class CreateConstraint(ConstraintCommand, adapts=s_constr.CreateConstraint):
 
         # If the constraint is being added to existing data,
         # we need to enforce it on the existing data. (This only
-        # matters for
+        # matters when inheritance is in play and we use triggers
+        # to enforce exclusivity across tables.)
         if (
             (subject := constraint.get_subject(schema))
             and isinstance(

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -33,6 +33,7 @@ from edb.edgeql import parser as ql_parser
 from edb.edgeql.compiler import astutils as ql_astutils
 
 from edb.schema import name as s_name
+from edb.schema import pointers as s_pointers
 from edb.schema import scalars as s_scalars
 from edb.schema import utils as s_utils
 from edb.schema import types as s_types
@@ -194,10 +195,12 @@ class ConstraintMech:
                 context=source_context,
             )
         elif ref_tables:
-            subject_db_name, _ = next(iter(ref_tables.items()))
+            subject_db_name, info = next(iter(ref_tables.items()))
+            table_type = info[0][3].table_type
         else:
             subject_db_name = common.get_backend_name(
                 schema, subject, catenate=False)
+            table_type = 'ObjectType'
 
         exclusive_expr_refs = cls._get_exclusive_refs(ir)
 
@@ -205,6 +208,7 @@ class ConstraintMech:
             'subject_db_name': subject_db_name,
             'expressions': [],
             'origin_expressions': [],
+            'table_type': table_type,
         }
 
         if constraint_origin != constraint:
@@ -326,6 +330,10 @@ class SchemaDomainConstraint:
 
         return ops
 
+    def enforce_ops(self):
+        ops = dbops.CommandGroup()
+        return ops
+
 
 class SchemaTableConstraint:
     def __init__(self, subject, constraint, pg_constr_data, schema):
@@ -388,6 +396,60 @@ class SchemaTableConstraint:
             name=tabconstr.get_subject_name(quote=False), constraint=tabconstr)
 
         ops.add_command(add_constr)
+
+        return ops
+
+    def enforce_ops(self):
+        ops = dbops.CommandGroup()
+
+        tabconstr = self._table_constraint(self)
+
+        constr_name = tabconstr.constraint_name()
+        raw_constr_name = tabconstr.constraint_name(quote=False)
+
+        for expr, origin_expr in zip(
+                tabconstr._exprdata, tabconstr._origin_exprdata):
+            exprdata = expr['exprdata']
+            origin_exprdata = origin_expr['exprdata']
+            old_expr = origin_exprdata['old']
+            new_expr = exprdata['new']
+
+            schemaname, tablename = tabconstr.get_origin_table_name()
+            real_tablename = tabconstr.get_subject_name(quote=False)
+
+            errmsg = 'duplicate key value violates unique ' \
+                     'constraint {constr}'.format(constr=constr_name)
+            detail = common.quote_literal(
+                f"Key ({origin_exprdata['plain']}) already exists."
+            )
+
+            if (
+                isinstance(self._subject, s_pointers.Pointer)
+                and self._pg_constr_data['table_type'] == 'link'
+            ):
+                key = "source"
+            else:
+                key = "id"
+
+            check = dbops.Query(
+                f'''
+                SELECT
+                    edgedb.raise(
+                        NULL::text,
+                        'unique_violation',
+                        msg => '{errmsg}',
+                        "constraint" => '{raw_constr_name}',
+                        "table" => '{tablename}',
+                        "schema" => '{schemaname}',
+                        detail => {detail}
+                    )
+                FROM {common.qname(schemaname, tablename+"_t")} AS OLD
+                CROSS JOIN {common.qname(*real_tablename)} AS NEW
+                WHERE {old_expr} = {new_expr} and OLD.{key} != NEW.{key}
+                INTO _dummy_text;
+                '''
+            )
+            ops.add_command(check)
 
         return ops
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1330,6 +1330,19 @@ class CommandContext:
         return any(isinstance(ctx.op, DeleteObject)
                    and ctx.op.scls == obj for ctx in self.stack)
 
+    def is_creating(self, obj: so.Object) -> bool:
+        """Return True if *obj* is being created in this context.
+
+        :param obj:
+            The object in question.
+
+        :returns:
+            True if *obj* is being created in this context.
+        """
+        return any(isinstance(ctx.op, CreateObject)
+                   and getattr(ctx.op, 'scls', None) == obj
+                   for ctx in self.stack)
+
     def push(self, token: CommandContextToken[Command]) -> None:
         self.stack.append(token)
 


### PR DESCRIPTION
And on rebases also.

In order to make it work for constraints on abstract links, abstract link views need
to be fixed to include `source`, which is a bit hacky.

That is a change to the pgsql schema, but we can avoid any trouble from that by
forcing a view update whenever we are generating code that might reference
the `source` of an abstract link view. I tested that bit manually.