### PR TITLE
Properly track modaliases inside transactions

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1877,8 +1877,7 @@ class Compiler:
                 if comp.requires_restart:
                     unit.config_requires_restart = True
 
-                if ctx.state.current_tx().is_implicit():
-                    unit.modaliases = ctx.state.current_tx().get_modaliases()
+                unit.modaliases = ctx.state.current_tx().get_modaliases()
 
                 if comp.config_op is not None:
                     unit.config_ops.append(comp.config_op)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -407,7 +407,7 @@ cdef class DatabaseConnectionView:
 
         key = (key, self.get_modaliases(), self.get_session_config())
 
-        if self._in_tx_with_ddl or self._in_tx_with_set:
+        if self._in_tx_with_ddl:
             query_unit = self._eql_to_compiled.get(key)
         else:
             query_unit, qu_dbver = self._db._eql_to_compiled.get(

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -464,6 +464,35 @@ class TestServerProto(tb.QueryTestCase):
                 SELECT foo::len('aaa')
             ''')
 
+    async def test_server_proto_set_reset_alias_06(self):
+        await self.con.query('START TRANSACTION')
+
+        await self.con.execute('''
+            SET MODULE test;
+        ''')
+        await self.con.query('select Tmp2')
+        await self.con.query('ROLLBACK')
+
+        with self.assertRaises(edgedb.InvalidReferenceError):
+            await self.con.query('select Tmp2')
+
+    async def test_server_proto_set_reset_alias_07(self):
+        await self.con.query('START TRANSACTION')
+
+        await self.con.execute('''
+            SET MODULE test;
+        ''')
+        await self.con.query('select Tmp2')
+
+        await self.con.execute('''
+            SET MODULE default;
+        ''')
+
+        with self.assertRaises(edgedb.InvalidReferenceError):
+            await self.con.query('select Tmp2')
+
+        await self.con.query('ROLLBACK')
+
     async def test_server_proto_basic_datatypes_01(self):
         for _ in range(10):
             self.assertEqual(


### PR DESCRIPTION
This was causing us to use invalid cache keys.

Also, read from and write to the same cache when in txes with SETs.

Fixes #3604.