### PR TITLE
Initial draft of wasm server integration

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_03_01_00_00
+EDGEDB_CATALOG_VERSION = 2022_03_14_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/lib/ext/webassembly.edgeql
+++ b/edb/lib/ext/webassembly.edgeql
@@ -1,0 +1,20 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2018-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+CREATE EXTENSION PACKAGE webassembly VERSION '0.1';

--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -24,6 +24,7 @@ cdef class HttpRequest:
 
     cdef:
         public object url
+        public bytes uri
         public bytes version
         public bint should_keep_alive
         public bytes content_type
@@ -31,6 +32,7 @@ cdef class HttpRequest:
         public bytes accept
         public bytes body
         public bytes host
+        public list headers
 
 
 cdef class HttpResponse:

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -33,6 +33,7 @@ from edb.common import debug
 from edb.common import markup
 
 from edb.graphql import extension as graphql_ext
+from edb.wasm import wasm_ext
 
 from edb.server import args as srvargs
 from edb.server.protocol cimport binary
@@ -51,14 +52,18 @@ HTTPStatus = http.HTTPStatus
 
 
 cdef class HttpRequest:
-    pass
+    def __cinit__(self):
+        self.headers = []
 
 
 cdef class HttpResponse:
 
     def __cinit__(self):
         self.status = HTTPStatus.OK
+
+        # TODO(tailhook) maybe None is better? This is kept for backcompat
         self.content_type = b'text/plain'
+
         self.custom_headers = {}
         self.body = b''
         self.close_connection = False
@@ -168,9 +173,11 @@ cdef class HttpProtocol:
             self.unhandled_exception(ex)
 
     def on_url(self, url: bytes):
+        self.current_request.uri = url
         self.current_request.url = httptools.parse_url(url)
 
     def on_header(self, name: bytes, value: bytes):
+        self.current_request.headers.append((name, value))
         name = name.lower()
         if name == b'content-type':
             self.current_request.content_type = value
@@ -246,9 +253,12 @@ cdef class HttpProtocol:
             return
         data = [
             b'HTTP/', req_version, b' ', resp_status, b'\r\n',
-            b'Content-Type: ', content_type, b'\r\n',
             b'Content-Length: ', f'{len(body)}'.encode(), b'\r\n',
         ]
+
+        # no content-type might be useful for 201 replies
+        if content_type is not None:
+            data.extend([b'Content-Type: ', content_type, b'\r\n'])
 
         for key, value in custom_headers.items():
             data.append(f'{key}: {value}\r\n'.encode())
@@ -401,8 +411,11 @@ cdef class HttpProtocol:
         if len(path_parts) >= 3 and path_parts[0] == 'db':
             root, dbname, extname, *args = path_parts
             db = self.server.maybe_get_db(dbname=dbname)
+
             if extname == 'edgeql':
                 extname = 'edgeql_http'
+            elif extname == 'wasm':
+                extname = 'webassembly'
 
             if db is not None and extname in db.extensions:
                 if extname == 'graphql':
@@ -417,6 +430,11 @@ cdef class HttpProtocol:
                     return
                 elif extname == 'edgeql_http':
                     await edgeql_ext.handle_request(
+                        request, response, db, args, self.server
+                    )
+                    return
+                elif extname == 'webassembly':
+                    await wasm_ext.handle_request(
                         request, response, db, args, self.server
                     )
                     return

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -1724,6 +1724,9 @@ class Server(ha_base.ClusterProtocol):
 
         return obj
 
+    def wasm_socket_path(self) -> str:
+        return os.path.join(self._runstate_dir, '.s.wasm_ext')
+
 
 def _cleanup_wildcard_addrs(
     hosts: Sequence[str]

--- a/edb/wasm/wasm_ext.py
+++ b/edb/wasm/wasm_ext.py
@@ -1,0 +1,80 @@
+import logging
+import asyncio
+import http
+import json
+import pickle
+
+from functools import partial
+
+from edb import errors
+from edb.server.protocol import protocol
+from edb.server.dbview import dbview
+#from edb.server import server
+
+log = logging.getLogger(__name__)
+
+
+def handle_error(
+    request: protocol.HttpRequest,
+    response: protocol.HttpResponse,
+    error: Exception,
+):
+    er_type = type(error)
+    if not issubclass(er_type, errors.EdgeDBError):
+        er_type = errors.InternalServerError
+
+    # TODO(tailhook) figure out whether we want to expose error message here
+    # for arbitrary errors
+    response.body = json.dumps({
+        'kind': 'error',
+        'error': {
+            'message': str(error),
+            'type': er_type.__name__,
+        }
+    }).encode()
+    response.content_type = b'application/json'
+    response.status = http.HTTPStatus.INTERNAL_SERVER_ERROR
+    response.close_connection = True
+
+
+async def proxy_request(
+    request: protocol.HttpRequest,
+    response: protocol.HttpResponse,
+    server  # : server.Server,  # circular import
+) -> None:
+    req_data = pickle.dumps(dict(
+        method=bytes(request.method),
+        url=request.uri,
+        headers=request.headers,
+        body=request.body,
+    ), protocol=5)
+
+    loop = asyncio.get_running_loop()
+    reader = asyncio.StreamReader()
+    transport, protocol = await loop.create_unix_connection(
+        partial(asyncio.StreamReaderProtocol, reader),
+        server.wasm_socket_path(),
+    )
+    writer = asyncio.StreamWriter(transport, protocol, reader, loop)
+    writer.write(req_data)
+    writer.write_eof()
+    resp_data = pickle.loads(await reader.read())
+    response.status = http.HTTPStatus(resp_data['status'])
+    headers = resp_data['headers']
+    response.content_type = headers.pop('content-type', None)
+    response.custom_headers = headers
+    response.body = resp_data['body']
+
+async def handle_request(
+    request: protocol.HttpRequest,
+    response: protocol.HttpResponse,
+    db: dbview.Database,
+    args: list[str],
+    server  # : server.Server,  # circular import
+) -> None:
+    try:
+        await proxy_request(request, response, server)
+    except Exception as e:
+        log.exception("Exception during wasm request: %s", e)
+        # TODO(tailhook) figure out what we want to expose to users
+        handle_error(request, response, e)


### PR DESCRIPTION
This is as simple as it can get:
1. Has single version of extension without any configuration
2. Relies on wasm server listening on `$runstate_dir/.s.wasm_ext`
3. Uses unix socket with one connection per request (similarly to SCGI)
4. Uses Pythonic Pickle to serialize request/response

Technically it works, but doesn't make too much sense to integrate right now. Anyone having access to [edgedb/edgedb-wasm](https://github.com/edgedb/edgedb-wasm) repo (still private) can play with it though.