### PR TITLE
Remove the whole "computable branch" mechanism

### DIFF
--- a/edb/edgeql/compiler/pathctx.py
+++ b/edb/edgeql/compiler/pathctx.py
@@ -84,11 +84,11 @@ def register_set_in_scope(
         ir_set: irast.Set, *,
         path_scope: Optional[irast.ScopeTreeNode]=None,
         optional: bool=False,
-        ctx: context.ContextLevel) -> List[irast.ScopeTreeNode]:
+        ctx: context.ContextLevel) -> None:
     if path_scope is None:
         path_scope = ctx.path_scope
 
-    return path_scope.attach_path(
+    path_scope.attach_path(
         ir_set.path_id,
         optional=optional,
         context=ir_set.context,


### PR DESCRIPTION
Our scopetree representation of computables currently puts the head of
any computable under a CBRANCH in the scope tree. This is done to hide
the actual head of a computable path from the scope of the computation
itself.

In order to accomplish that hiding, the CBRANCHs are turned into
FENCEs while compiling the computables; this produces a scopetree
that doesn't follow the visibility invariants. A bunch of other
machinery needs to be able to reason about CBRANCHs in order to
properly do path factoring on computed paths.

But it seems that protecting the head of the path from the computation
scope isn't needed after all! I can't really think of why it would be
needed, so my guess is that in practice it was working around now-fixed
bugs in the scopetree and namespace implementations? Am I missing something?

(This change as I originally tested it broke
test_edgeql_volatility_select_nested_03b, which turns out to be because
this exposed a cardinality inference bug, which is fixed by #3628.
This was fortuitous, since it was while debugging that issue that
I noticed some unusual behavior with CBRANCHs and decided to just
try removing them.)