### PR TITLE
Generate fresh ids for free shapes when possible

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -207,9 +207,7 @@ def _common_cardinality(
 
 
 def _is_singleton_type(typeref: irast.TypeRef) -> bool:
-    if typeref.material_type:
-        typeref = typeref.material_type
-    return typeref.name_hint == sn.QualName('std', 'FreeObject')
+    return typeutils.is_free_object(typeref)
 
 
 @functools.singledispatch

--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -206,10 +206,6 @@ def _common_cardinality(
     return cartesian_cardinality(cards)
 
 
-def _is_singleton_type(typeref: irast.TypeRef) -> bool:
-    return typeutils.is_free_object(typeref)
-
-
 @functools.singledispatch
 def _infer_cardinality(
     ir: irast.Base,
@@ -616,7 +612,7 @@ def _infer_set_inner(
         card = AT_MOST_ONE
     elif ir.expr is not None:
         card = expr_card
-    elif _is_singleton_type(ir.typeref):
+    elif typeutils.is_free_object(ir.typeref):
         card = ONE
     else:
         card = MANY

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -26,6 +26,7 @@ import uuid
 from edb.edgeql import qltypes
 
 from edb.schema import links as s_links
+from edb.schema import name as s_name
 from edb.schema import properties as s_props
 from edb.schema import pointers as s_pointers
 from edb.schema import pseudo as s_pseudo
@@ -39,7 +40,6 @@ from . import ast as irast
 
 if TYPE_CHECKING:
 
-    from edb.schema import name as s_name
     from edb.schema import schema as s_schema
 
 
@@ -113,6 +113,12 @@ def is_json(typeref: irast.TypeRef) -> bool:
 def is_bytes(typeref: irast.TypeRef) -> bool:
     """Return True if *typeref* describes the bytes type."""
     return typeref.real_base_type.id == s_obj.get_known_type_id('std::bytes')
+
+
+def is_free_object(typeref: irast.TypeRef) -> bool:
+    if typeref.material_type:
+        typeref = typeref.material_type
+    return typeref.name_hint == s_name.QualName('std', 'FreeObject')
 
 
 def is_persistent_tuple(typeref: irast.TypeRef) -> bool:

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -480,3 +480,17 @@ def collapse_query(query: pgast.Query) -> pgast.BaseExpr:
         return val
     else:
         return query
+
+
+def compile_typeref(expr: irast.TypeRef) -> pgast.BaseExpr:
+    if expr.collection:
+        raise NotImplementedError()
+    else:
+        result = pgast.TypeCast(
+            arg=pgast.StringConstant(val=str(expr.id)),
+            type_name=pgast.TypeName(
+                name=('uuid',)
+            )
+        )
+
+    return result

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -583,17 +583,7 @@ def compile_Tuple(
 def compile_TypeRef(
         expr: irast.TypeRef, *,
         ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
-    if expr.collection:
-        raise NotImplementedError()
-    else:
-        result = pgast.TypeCast(
-            arg=pgast.StringConstant(val=str(expr.id)),
-            type_name=pgast.TypeName(
-                name=('uuid',)
-            )
-        )
-
-    return result
+    return astutils.compile_typeref(expr)
 
 
 @dispatch.compile.register(irast.FunctionCall)

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -234,6 +234,15 @@ def get_path_var(
     if found_path_var:
         return found_path_var
 
+    # Slight hack: Inject the __type__ field of a FreeObject when necessary
+    if (
+        rel_rvar is None
+        and ptrref
+        and ptrref.shortname.name == '__type__'
+        and irtyputils.is_free_object(src_path_id.target)
+    ):
+        return astutils.compile_typeref(src_path_id.target.real_material_type)
+
     if rel_rvar is None:
         raise LookupError(
             f'there is no range var for '

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -444,9 +444,17 @@ def ensure_source_rvar(
         rvar = relctx.maybe_get_path_rvar(
             scope_stmt, ir_set.path_id, aspect='source', ctx=ctx)
         if rvar is None:
-            rvar = relctx.new_root_rvar(ir_set, lateral=True, ctx=ctx)
-            relctx.include_rvar(
-                scope_stmt, rvar, path_id=ir_set.path_id, ctx=ctx)
+            if irtyputils.is_free_object(ir_set.path_id.target):
+                # Free objects don't have a real source, and
+                # generating a new fake source doesn't work because
+                # the ids don't match, so instead we call the existing
+                # value rvar a source.
+                rvar = relctx.get_path_rvar(
+                    scope_stmt, ir_set.path_id, aspect='value', ctx=ctx)
+            else:
+                rvar = relctx.new_root_rvar(ir_set, lateral=True, ctx=ctx)
+                relctx.include_rvar(
+                    scope_stmt, rvar, path_id=ir_set.path_id, ctx=ctx)
             pathctx.put_path_rvar(
                 stmt, ir_set.path_id, rvar, aspect='source', env=ctx.env)
 

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -7145,3 +7145,15 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ''',
             {1, 2}
         )
+
+    async def test_edgeql_select_free_object_distinct_01(self):
+        foo, bar = await self.con.query_single('''
+            select ({foo := "test"}, {bar := 1000})
+        ''')
+        self.assertNotEqual(foo.id, bar.id)
+
+    async def test_edgeql_select_free_object_distinct_02(self):
+        vals = await self.con.query('''
+            for x in {1,2,3} union { asdf := 10*x };
+        ''')
+        self.assertEqual(len(vals), len({v.id for v in vals}))


### PR DESCRIPTION
Free shapes generated from cross products are not guarenteed to have
unique ids, however. So while
  `for x in User union { asdf := x.name ++ "!", x := .id}`
generates unique ids,
  `select (User, { asdf := User.name ++ "!", x := .id})`
does not.

I'm not sure if there is a good way to avoid this. We ban cross products
of volatile computations for this reason, but doing that to free objects
seems aggressive?