### PR TITLE
Fix a multiplicity computation bug for tuples

### DIFF
--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -344,7 +344,7 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         """
         SELECT (1, Card.name).0
 % OK %
-        ONE
+        MANY
         """
 
     def test_edgeql_ir_mult_inference_40(self):
@@ -726,4 +726,11 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         SELECT <str>{}
 % OK %
         ZERO
+        """
+
+    def test_edgeql_ir_mult_inference_76(self):
+        """
+        SELECT (Card, User).1
+% OK %
+        MANY
         """

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2948,7 +2948,8 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(
             """
             WITH X1 := (Card { z := (.<deck[IS User], .<deck[IS User]@count)}),
-                 X2 := X1 { owners2 := .z.0 { count := X1.z.1 } },
+                 X2 := X1 { owners2 := assert_distinct(
+                     .z.0 { count := X1.z.1 }) },
             SELECT X2 { name, owners2: {name, count} ORDER BY .name }
             FILTER .name = 'Dwarf';
             """,


### PR DESCRIPTION
Currently we track the multiplicity of each element of a tuple
and preserve it, but this doesn't work in general: Consider
`(User, Card)`, where both elements (and the result) have multiplicty
ONE but `(User, Card).1` ought to have multiplicity MANY.

Fix this by taking cardinality and cross products into account
and only preserving element multiplicity for elements that can't
get duplicated.

It might be possible to do better by taking into account correlation
more, though: this will report that (Card.name, Card.cost).name
is MANY.