### PR TITLE
Remove the physical FreeObject from the database

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_03_01_00_00
+EDGEDB_CATALOG_VERSION = 2022_03_18_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -268,18 +268,15 @@ def compile_InsertQuery(
         assert isinstance(subject, irast.Set)
 
         subject_stype = setgen.get_set_type(subject, ctx=ictx)
+        if subject_stype.is_free_object_type(ctx.env.schema):
+            raise errors.QueryError(
+                f'free objects cannot be inserted',
+                context=expr.subject.context)
+
         if subject_stype.get_abstract(ctx.env.schema):
             raise errors.QueryError(
                 f'cannot insert into abstract '
                 f'{subject_stype.get_verbosename(ctx.env.schema)}',
-                context=expr.subject.context)
-
-        if (
-            subject_stype.is_free_object_type(ctx.env.schema)
-            and not ctx.env.options.bootstrap_mode
-        ):
-            raise errors.QueryError(
-                f'free objects cannot be inserted',
                 context=expr.subject.context)
 
         if subject_stype.is_view(ctx.env.schema):

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -268,15 +268,15 @@ def compile_InsertQuery(
         assert isinstance(subject, irast.Set)
 
         subject_stype = setgen.get_set_type(subject, ctx=ictx)
-        if subject_stype.is_free_object_type(ctx.env.schema):
-            raise errors.QueryError(
-                f'free objects cannot be inserted',
-                context=expr.subject.context)
-
         if subject_stype.get_abstract(ctx.env.schema):
             raise errors.QueryError(
                 f'cannot insert into abstract '
                 f'{subject_stype.get_verbosename(ctx.env.schema)}',
+                context=expr.subject.context)
+
+        if subject_stype.is_free_object_type(ctx.env.schema):
+            raise errors.QueryError(
+                f'free objects cannot be inserted',
                 context=expr.subject.context)
 
         if subject_stype.is_view(ctx.env.schema):

--- a/edb/lib/std/60-baseobject.edgeql
+++ b/edb/lib/std/60-baseobject.edgeql
@@ -44,7 +44,7 @@ CREATE ABSTRACT TYPE std::Object EXTENDING std::BaseObject {
         'Root object type for user-defined types';
 };
 
-CREATE ABSTRACT TYPE std::FreeObject EXTENDING std::BaseObject {
+CREATE TYPE std::FreeObject EXTENDING std::BaseObject {
     CREATE ANNOTATION std::description :=
         'Object type for free shapes';
 };

--- a/edb/lib/std/60-baseobject.edgeql
+++ b/edb/lib/std/60-baseobject.edgeql
@@ -44,7 +44,7 @@ CREATE ABSTRACT TYPE std::Object EXTENDING std::BaseObject {
         'Root object type for user-defined types';
 };
 
-CREATE TYPE std::FreeObject EXTENDING std::BaseObject {
+CREATE ABSTRACT TYPE std::FreeObject EXTENDING std::BaseObject {
     CREATE ANNOTATION std::description :=
         'Object type for free shapes';
 };

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1011,16 +1011,6 @@ async def _init_defaults(schema, compiler, conn):
     return schema
 
 
-async def _populate_data(schema, compiler, conn):
-    script = '''
-        INSERT std::FreeObject;
-    '''
-
-    schema, sql = compile_bootstrap_script(compiler, schema, script)
-    await _execute_ddl(conn, sql)
-    return schema
-
-
 async def _configure(
     ctx: BootstrapContext,
     config_spec: config.Spec,
@@ -1578,7 +1568,6 @@ async def _bootstrap(ctx: BootstrapContext) -> None:
 
         schema = s_schema.FlatSchema()
         schema = await _init_defaults(schema, compiler, tpl_ctx.conn)
-        schema = await _populate_data(schema, compiler, tpl_ctx.conn)
     finally:
         if in_dev_mode:
             await ctx.conn.execute(


### PR DESCRIPTION
In #3631, the compiler was made to bypass the actual table. Now, skip
populating it at all.