### PR TITLE
Clear out some Set.expr fields that pgsql shouldn't ever need

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -140,6 +140,8 @@ def new_set_from_set(
         expr: Optional[irast.Expr]=None,
         context: Optional[parsing.ParserContext]=None,
         is_binding: Optional[irast.BindingKind]=None,
+        is_materialized_ref: Optional[bool]=None,
+        is_visible_binding_ref: Optional[bool]=None,
         ctx: context.ContextLevel) -> irast.Set:
     """Create a new ir.Set from another ir.Set.
 
@@ -162,6 +164,10 @@ def new_set_from_set(
         context = ir_set.context
     if is_binding is None:
         is_binding = ir_set.is_binding
+    if is_materialized_ref is None:
+        is_materialized_ref = ir_set.is_materialized_ref
+    if is_visible_binding_ref is None:
+        is_visible_binding_ref = ir_set.is_visible_binding_ref
     return new_set(
         path_id=path_id,
         path_scope_id=ir_set.path_scope_id,
@@ -170,6 +176,8 @@ def new_set_from_set(
         rptr=rptr,
         context=context,
         is_binding=is_binding,
+        is_materialized_ref=is_materialized_ref,
+        is_visible_binding_ref=is_visible_binding_ref,
         ircls=type(ir_set),
         ctx=ctx,
     )

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -167,6 +167,7 @@ def compile_ForQuery(
 
         iterator_stmt = setgen.new_set_from_set(
             iterator_view, preserve_scope_ns=True, ctx=sctx)
+        iterator_view.is_visible_binding_ref = True
         stmt.iterator_stmt = iterator_stmt
 
         iterator_type = setgen.get_set_type(iterator_stmt, ctx=ctx)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -120,7 +120,13 @@ def fini_expression(
     ):
         ir = setgen.scoped_set(ir, ctx=ctx)
 
-    _fixup_materialized_sets(ir, ctx=ctx)
+    # exprs_to_clear collects sets where we should never need to use
+    # their expr in pgsql compilation, so we strip it out to make this
+    # more evident in debug output. We have to do the clearing at the
+    # end, because multiplicity/cardinality inference needs to be able
+    # to look through those pointers.
+    exprs_to_clear = _fixup_materialized_sets(ir, ctx=ctx)
+    exprs_to_clear.extend(_find_visible_binding_refs(ir, ctx=ctx))
 
     # The inference context object will be shared between
     # cardinality and multiplicity inferrers.
@@ -224,6 +230,9 @@ def fini_expression(
             context=srcctx,
         )
 
+    for ir_set in exprs_to_clear:
+        ir_set.expr = None
+
     assert isinstance(ir, irast.Set)
     source_map = {k: v for k, v in ctx.source_map.items()
                   if isinstance(k, s_pointers.Pointer)}
@@ -260,13 +269,15 @@ def fini_expression(
 
 def _fixup_materialized_sets(
     ir: irast.Base, *, ctx: context.ContextLevel
-) -> None:
+) -> List[irast.Set]:
     # Make sure that all materialized sets have their views compiled
     flt = lambda n: isinstance(n, irast.Stmt)
     children: List[irast.Stmt] = ast_visitor.find_children(ir, flt)
     for nobe in ctx.source_map.values():
         if nobe.irexpr:
             children += ast_visitor.find_children(nobe.irexpr, flt)
+
+    to_clear = []
     for stmt in ordered.OrderedSet(children):
         if not stmt.materialized_sets:
             continue
@@ -326,12 +337,26 @@ def _fixup_materialized_sets(
             for use_set in mat_set.use_sets:
                 if use_set != mat_set.materialized:
                     use_set.is_materialized_ref = True
+                    # XXX: Deleting it on linkprops breaks a bunch of
+                    # linkprop related DML...
+                    if not use_set.path_id.is_linkprop_path():
+                        to_clear.append(use_set)
 
             assert (
                 not any(use.src_path() for use in mat_set.uses)
                 or mat_set.materialized.rptr
             ), f"materialized ptr {mat_set.uses} missing rptr"
             mat_set.finalized = True
+
+    return to_clear
+
+
+def _find_visible_binding_refs(
+    ir: irast.Base, *, ctx: context.ContextLevel
+) -> List[irast.Set]:
+    flt = lambda n: isinstance(n, irast.Set) and n.is_visible_binding_ref
+    children: List[irast.Set] = ast_visitor.find_children(ir, flt)
+    return children
 
 
 def _try_namespace_fix(

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -477,6 +477,11 @@ class Set(Base):
     is_binding: typing.Optional[BindingKind] = None
 
     is_materialized_ref: bool = False
+    # A ref to a visible binding (like a for iterator variable) should
+    # never need to be compiled--it should always be found. We set a
+    # flag instead of clearing expr because clearing expr can mess up
+    # card/multi inference.
+    is_visible_binding_ref: bool = False
 
     def __repr__(self) -> str:
         return f'<ir.Set \'{self.path_id}\' at 0x{id(self):x}>'

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1129,6 +1129,8 @@ class PointerCommandOrFragment(
             if (
                 expr_rptr.direction is PointerDirection.Outbound
                 and expr_rptr.source.rptr is None
+                and isinstance(expr_rptr.ptrref, irast.PointerRef)
+                and schema.has_object(expr_rptr.ptrref.id)
             ):
                 new_schema, aliased_ptr = irtyputils.ptrcls_from_ptrref(
                     expr_rptr.ptrref, schema=schema


### PR DESCRIPTION
This includes most sets with is_materialized_ref as well as
variables bound with `FOR` (and, soon, `USING` in `GROUP`).

Doing this tracking for `FOR` helps catch some bugs better.
The main goal with actually clearing the `expr` fields is to
clarify the IR in debug output.