### PR TITLE
minor documentation fixes

### DIFF
--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -41,10 +41,10 @@ the length of a string.
   type User {
     required property username -> str {
       # as custom constraint
-      constraint expression on (len(__subject__) < 25);
+      constraint expression on (len(__subject__) <= 25);
 
       # with built-in
-      constraint max_len_value(24);
+      constraint max_len_value(25);
     };
   }
 

--- a/docs/datamodel/constraints.rst
+++ b/docs/datamodel/constraints.rst
@@ -44,7 +44,7 @@ the length of a string.
       constraint expression on (len(__subject__) < 25);
 
       # with built-in
-      constraint min_len_value(25);
+      constraint max_len_value(24);
     };
   }
 

--- a/docs/datamodel/inheritance.rst
+++ b/docs/datamodel/inheritance.rst
@@ -56,7 +56,7 @@ types out of combinations of more basic types.
     property last_name -> str;
   }
 
-  abstract type Email {
+  abstract type HasEmail {
     property email -> str;
   }
 

--- a/docs/guides/relations.rst
+++ b/docs/guides/relations.rst
@@ -17,11 +17,11 @@ many-to-many.
     - ``single``
     - Yes
   * - One-to-many
-    - ``single``
-    - No
-  * - Many-to-one
     - ``multi``
     - Yes
+  * - Many-to-one
+    - ``single``
+    - No
   * - Many-to-many
     - ``multi``
     - No


### PR DESCRIPTION
Three small fixes. Two to make code examples more consistent and one to correct a confusing mistake on the page about modelling relations. 