### PR TITLE
Correct typo s/measurment/measurement

### DIFF
--- a/docs/stdlib/datetime.rst
+++ b/docs/stdlib/datetime.rst
@@ -300,7 +300,7 @@ EdgeDB stores and outputs timezone-aware values in UTC.
     A type representing a span of time.
 
     Unlike :eql:type:`std::duration` a ``relative_duration`` is not a precise
-    measurment because it uses 3 different units under the hood: months, days
+    measurement because it uses 3 different units under the hood: months, days
     and seconds. However not all months have the same number of days and not
     all days have the same number of seconds. For example 2019 was a leap year
     and had 366 days. Notice how the number of hours in each year below is


### PR DESCRIPTION
Correct typo s/measurment/measurement

Great documentation and really enjoying working with EdgeDB. Thanks for the hard work!