### PR TITLE
Fix a bug involving computable shadowing

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -396,7 +396,7 @@ class ContextLevel(compiler.ContextLevel):
     type_rewrites: Dict[s_types.Type, irast.Set]
     """Access policy rewrites for schema-level types."""
 
-    aliased_views: ChainMap[s_name.Name, Optional[s_types.Type]]
+    aliased_views: ChainMap[s_name.Name, s_types.Type]
     """A dictionary of views aliased in a statement body."""
 
     must_use_views: Dict[

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1438,11 +1438,7 @@ def _get_computable_ctx(
 
             subctx.modaliases = qlctx.modaliases.copy()
             subctx.aliased_views = qlctx.aliased_views.new_child()
-            source_stype = get_set_type(source, ctx=ctx)
 
-            if source_scls.is_view(ctx.env.schema):
-                scls_name = source_stype.get_name(ctx.env.schema)
-                subctx.aliased_views[scls_name] = None
             subctx.view_nodes = qlctx.view_nodes.copy()
             subctx.view_map = ctx.view_map.new_child()
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -22,6 +22,7 @@
 
 from __future__ import annotations
 
+import collections
 import functools
 from typing import *
 
@@ -85,6 +86,10 @@ def process_view(
     pathctx.register_set_in_scope(ir_set, path_scope=hackscope, ctx=ctx)
     hackscope.remove()
     ctx.path_scope.attach_subtree(hackscope)
+
+    # Make a snapshot of aliased_views that can't be mutated
+    # in any parent scopes.
+    ctx.aliased_views = collections.ChainMap(dict(ctx.aliased_views))
 
     view_scls, ir = _process_view(
         ir_set,

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -7157,3 +7157,16 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             for x in {1,2,3} union { asdf := 10*x };
         ''')
         self.assertEqual(len(vals), len({v.id for v in vals}))
+
+    async def test_edgeql_select_shadow_computable_01(self):
+        # The thing this is testing for
+        await self.assert_query_result(
+            '''
+            SELECT User := User { name, is_elvis := User.name = 'Elvis' }
+            ORDER BY User.is_elvis
+            ''',
+            [
+                {"is_elvis": False, "name": "Yury"},
+                {"is_elvis": True, "name": "Elvis"}
+            ]
+        )


### PR DESCRIPTION
Because aliased_views is mutable, we have a bug where a
computable property that references the type it is on
can have that name point to a different alias for it when
it gets recompiled.

Since the aliased_views mutability is depended on currently,
fix this by taking a snapshot of aliased_views when doing
process_view.

Also delete some unneeded code that I thought ought to have been
handling this case :P.