### PR TITLE
Make has_external_rvar mirror has_rvar more closely

### DIFF
--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -257,7 +257,7 @@ def include_specific_rvar(
     if not has_rvar(stmt, rvar, ctx=ctx):
         if not (
             ctx.env.external_rvars
-            and has_external_rvar(path_id, aspects, ctx=ctx)
+            and has_external_rvar(rvar, ctx=ctx)
         ):
             rel_join(stmt, rvar, ctx=ctx)
         # Make sure that the path namespace of *rvar* is mapped
@@ -301,18 +301,11 @@ def has_rvar(
 
 
 def has_external_rvar(
-    path_id: irast.PathId,
-    aspects: Iterable[str],
+    rvar: pgast.PathRangeVar,
     *,
     ctx: context.CompilerContextLevel,
 ) -> bool:
-    return (
-        bool(ctx.env.external_rvars)
-        and all(
-            (path_id, aspect) in ctx.env.external_rvars
-            for aspect in aspects
-        )
-    )
+    return rvar in ctx.env.external_rvars.values()
 
 
 def _maybe_get_path_rvar(


### PR DESCRIPTION
Just check the existence of the rvar; we don't need to check the path
and aspect for the one thing it is being used for.

This is needed for a tweak in my group-by branch that makes more rvars
show up as `new`.