### PR TITLE
Add an `FOR GROUP` construct and desugaring code from GROUP

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -482,6 +482,7 @@ class SubjectMixin(Base):
 
 class ReturningMixin(Base):
     __abstract_node__ = True
+    result_alias: typing.Optional[str] = None
     result: Expr
 
 
@@ -527,7 +528,7 @@ class Query(Statement):
 
 
 class SelectQuery(Query, ReturningMixin, SelectClauseMixin):
-    result_alias: typing.Optional[str] = None
+    pass
 
 
 class GroupingIdentList(Base):
@@ -541,15 +542,15 @@ class GroupingElement(Base):
     __abstract_node__ = True
 
 
-class GroupingSimple(Base):
+class GroupingSimple(GroupingElement):
     element: GroupingAtom
 
 
-class GroupingSets(Base):
+class GroupingSets(GroupingElement):
     sets: typing.List[GroupingElement]
 
 
-class GroupingOperation(Base):
+class GroupingOperation(GroupingElement):
     oper: str
     elements: typing.List[GroupingAtom]
 
@@ -558,6 +559,13 @@ class GroupQuery(Query, SubjectMixin):
     subject_alias: typing.Optional[str] = None
     using: typing.Optional[typing.List[AliasedExpr]]
     by: typing.List[GroupingElement]
+
+
+class InternalGroupQuery(
+        GroupQuery, ReturningMixin, FilterMixin, OrderByMixin):
+    group_alias: str
+    grouping_alias: typing.Optional[str]
+    from_desugaring: bool = False
 
 
 class InsertQuery(Query, SubjectMixin):

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -78,6 +78,12 @@ class GlobalCompilerOptions:
     #: to contain DML in the top-level shape computables.
     allow_top_level_shape_dml: bool = False
 
+    #: Is this a dev instance of the compiler
+    dev_instance: bool = False
+
+    #: Is the compiler running in testmode
+    testmode: bool = False
+
 
 @dataclass
 class CompilerOptions(GlobalCompilerOptions):

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -79,7 +79,7 @@ class GlobalCompilerOptions:
     allow_top_level_shape_dml: bool = False
 
     #: Is this a dev instance of the compiler
-    dev_instance: bool = False
+    devmode: bool = False
 
     #: Is the compiler running in testmode
     testmode: bool = False

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -242,11 +242,9 @@ def compile_InternalGroupQuery(
     # We want to disallow use of FOR GROUP except for when running
     # a dev build. Check for the presence of a test schema element
     # to detect whether we're on a dev build.
-    if not expr.from_desugaring and not ctx.env.schema.get(
-        'cfg::TestSessionConfig', None
-    ):
+    if not expr.from_desugaring and not ctx.env.options.dev_instance:
         raise errors.UnsupportedFeatureError(
-            'FOR GROUP is an internal testing feature',
+            "'FOR GROUP' is an internal testing feature",
             context=expr.context,
         )
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -235,6 +235,26 @@ def compile_ForQuery(
     return result
 
 
+@dispatch.compile.register(qlast.InternalGroupQuery)
+def compile_InternalGroupQuery(
+    expr: qlast.InternalGroupQuery, *, ctx: context.ContextLevel
+) -> irast.Set:
+    # We want to disallow use of FOR GROUP except for when running
+    # a dev build. Check for the presence of a test schema element
+    # to detect whether we're on a dev build.
+    if not expr.from_desugaring and not ctx.env.schema.get(
+        'cfg::TestSessionConfig', None
+    ):
+        raise errors.UnsupportedFeatureError(
+            'FOR GROUP is an internal testing feature',
+            context=expr.context,
+        )
+
+    raise errors.UnsupportedFeatureError(
+        "'FOR GROUP' statement is not currently implemented",
+        context=expr.context)
+
+
 @dispatch.compile.register(qlast.GroupQuery)
 def compile_GroupQuery(
         expr: qlast.Base, *, ctx: context.ContextLevel) -> irast.Set:

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -240,7 +240,7 @@ def compile_InternalGroupQuery(
     expr: qlast.InternalGroupQuery, *, ctx: context.ContextLevel
 ) -> irast.Set:
     # We disallow use of FOR GROUP except for when running on a dev build.
-    if not expr.from_desugaring and not ctx.env.options.dev_instance:
+    if not expr.from_desugaring and not ctx.env.options.devmode:
         raise errors.UnsupportedFeatureError(
             "'FOR GROUP' is an internal testing feature",
             context=expr.context,

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -239,9 +239,7 @@ def compile_ForQuery(
 def compile_InternalGroupQuery(
     expr: qlast.InternalGroupQuery, *, ctx: context.ContextLevel
 ) -> irast.Set:
-    # We want to disallow use of FOR GROUP except for when running
-    # a dev build. Check for the presence of a test schema element
-    # to detect whether we're on a dev build.
+    # We disallow use of FOR GROUP except for when running on a dev build.
     if not expr.from_desugaring and not ctx.env.options.dev_instance:
         raise errors.UnsupportedFeatureError(
             "'FOR GROUP' is an internal testing feature",

--- a/edb/edgeql/desugar_group.py
+++ b/edb/edgeql/desugar_group.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-"""Desugar GROUP queries into internal IGROUP queries.
+"""Desugar GROUP queries into internal FOR GROUP queries.
 
 This code is called by both the model and the real implementation,
 though if that starts becoming a problem it should just be abandoned.

--- a/edb/edgeql/desugar_group.py
+++ b/edb/edgeql/desugar_group.py
@@ -1,0 +1,236 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Desugar GROUP queries into internal IGROUP queries.
+
+This code is called by both the model and the real implementation,
+though if that starts becoming a problem it should just be abandoned.
+"""
+
+from __future__ import annotations
+
+
+from typing import *
+
+from edb.common import ordered
+from edb.common.compiler import AliasGenerator
+
+from edb.edgeql import ast as qlast
+
+
+def name_path(name: str) -> qlast.Path:
+    return qlast.Path(steps=[qlast.ObjectRef(name=name)])
+
+
+def make_free_object(els: Dict[str, qlast.Expr]) -> qlast.Shape:
+    return qlast.Shape(
+        expr=None,
+        elements=[
+            qlast.ShapeElement(
+                expr=qlast.Path(
+                    steps=[qlast.Ptr(ptr=qlast.ObjectRef(name=name))]),
+                compexpr=expr
+            )
+            for name, expr in els.items()
+        ],
+    )
+
+
+def collect_grouping_atoms(
+        els: List[qlast.GroupingElement]) -> AbstractSet[str]:
+    atoms: ordered.OrderedSet[str] = ordered.OrderedSet()
+
+    def _collect_atom(el: qlast.GroupingAtom) -> None:
+        if isinstance(el, qlast.GroupingIdentList):
+            for at in el.elements:
+                _collect_atom(at)
+
+        else:
+            assert isinstance(el, qlast.ObjectRef)
+            atoms.add(el.name)
+
+    def _collect_el(el: qlast.GroupingElement) -> None:
+        if isinstance(el, qlast.GroupingSets):
+            for sub in el.sets:
+                _collect_el(sub)
+        elif isinstance(el, qlast.GroupingOperation):
+            for at in el.elements:
+                _collect_atom(at)
+        elif isinstance(el, qlast.GroupingSimple):
+            _collect_atom(el.element)
+        else:
+            raise AssertionError('Unknown GroupingElement')
+
+    for el in els:
+        _collect_el(el)
+
+    return atoms
+
+
+def desugar_group(
+    node: qlast.GroupQuery,
+    aliases: AliasGenerator,
+) -> qlast.InternalGroupQuery:
+    assert not isinstance(node, qlast.InternalGroupQuery)
+    alias_map: Dict[str, Tuple[str, qlast.Expr]] = {}
+
+    def rewrite_atom(el: qlast.GroupingAtom) -> qlast.GroupingAtom:
+        if isinstance(el, qlast.ObjectRef):
+            return el
+        elif isinstance(el, qlast.Path):
+            assert isinstance(el.steps[0], qlast.Ptr)
+            ptrname = el.steps[0].ptr.name
+            if ptrname not in alias_map:
+                alias = aliases.get(ptrname)
+                alias_map[ptrname] = (alias, el)
+            alias = alias_map[ptrname][0]
+            return qlast.ObjectRef(name=alias)
+        else:
+            return qlast.GroupingIdentList(
+                context=el.context,
+                elements=tuple(rewrite_atom(at) for at in el.elements),
+            )
+
+    def rewrite(el: qlast.GroupingElement) -> qlast.GroupingElement:
+        if isinstance(el, qlast.GroupingSimple):
+            return qlast.GroupingSimple(
+                context=el.context, element=rewrite_atom(el.element))
+        elif isinstance(el, qlast.GroupingSets):
+            return qlast.GroupingSets(
+                context=el.context, sets=[rewrite(s) for s in el.sets])
+        elif isinstance(el, qlast.GroupingOperation):
+            return qlast.GroupingOperation(
+                context=el.context,
+                oper=el.oper,
+                elements=[rewrite_atom(a) for a in el.elements])
+        raise AssertionError
+
+    for using_clause in (node.using or ()):
+        alias_map[using_clause.alias] = (using_clause.alias, using_clause.expr)
+
+    using = node.using[:] if node.using else []
+    by = [rewrite(by_el) for by_el in node.by]
+    for alias, path in alias_map.values():
+        using.append(qlast.AliasedExpr(alias=alias, expr=path))
+
+    actual_keys = collect_grouping_atoms(by)
+
+    g_alias = aliases.get('g')
+    grouping_alias = aliases.get('grouping')
+    output_dict = {
+        'key': make_free_object({
+            name: name_path(alias)
+            for name, (alias, _) in alias_map.items()
+            if alias in actual_keys
+        }),
+        'grouping': qlast.FunctionCall(
+            func='array_unpack',
+            args=[name_path(grouping_alias)],
+        ),
+        'elements': name_path(g_alias),
+    }
+    output_shape = make_free_object(output_dict)
+
+    return qlast.InternalGroupQuery(
+        context=node.context,
+        aliases=node.aliases,
+        subject_alias=node.subject_alias,
+        subject=node.subject,
+        # rewritten parts!
+        using=using,
+        by=by,
+        group_alias=g_alias,
+        grouping_alias=grouping_alias,
+        result=output_shape,
+        from_desugaring=True,
+    )
+
+
+def try_group_rewrite(
+    node: qlast.Query,
+    aliases: AliasGenerator,
+) -> Optional[qlast.Query]:
+    """
+    Try to apply some syntactic rewrites of GROUP expressions so we
+    can generate better code.
+
+    The two key desugarings are:
+
+    * Sink a shape into the internal group result
+
+        SELECT (GROUP ...) <shape>
+        [filter-clause] [order-clause] [other clauses]
+        =>
+        SELECT (
+          FOR GROUP ...
+          UNION <igroup-body> <shape>
+          [filter-clause]
+          [order-clause]
+        ) [other clauses]
+
+    * Convert a FOR over a group into just an internal group (and
+      a trivial FOR)
+
+        FOR g in (GROUP ...) UNION <body>
+        =>
+        FOR GROUP ...
+        UNION (
+            FOR g IN (<group-body>)
+            UNION <body>
+        )
+    """
+
+    # TODO: would Python's new pattern matching fit well here???
+
+    # Sink shapes into the GROUP
+    if (
+        isinstance(node, qlast.SelectQuery)
+        and isinstance(node.result, qlast.Shape)
+        and isinstance(node.result.expr, qlast.GroupQuery)
+    ):
+        igroup = desugar_group(node.result.expr, aliases)
+        igroup = igroup.replace(result=qlast.Shape(
+            expr=igroup.result, elements=node.result.elements))
+
+        # FILTER gets sunk into the body of the FOR GROUP
+        if node.where or node.orderby:
+            igroup = igroup.replace(
+                # We need to move the result_alias in case
+                # the FILTER depends on it.
+                result_alias=node.result_alias,
+                where=node.where,
+                orderby=node.orderby,
+            )
+
+        return node.replace(
+            result=igroup, result_alias=None, where=None, orderby=None)
+
+    # Eliminate FORs over GROUPs
+    if (
+        isinstance(node, qlast.ForQuery)
+        and isinstance(node.iterator, qlast.GroupQuery)
+    ):
+        igroup = desugar_group(node.iterator, aliases)
+        new_result = qlast.ForQuery(
+            iterator_alias=node.iterator_alias,
+            iterator=igroup.result,
+            result=node.result,
+        )
+        return igroup.replace(result=new_result, aliases=node.aliases)
+
+    return None

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -64,6 +64,9 @@ class ExprStmtCore(Nonterm):
     def reduce_SimpleGroup(self, *kids):
         self.val = kids[0].val
 
+    def reduce_InternalGroup(self, *kids):
+        self.val = kids[0].val
+
     def reduce_SimpleInsert(self, *kids):
         self.val = kids[0].val
 
@@ -193,12 +196,17 @@ class ByClause(Nonterm):
         self.val = kids[1].val
 
 
-class OptUsingClause(Nonterm):
+class UsingClause(Nonterm):
     def reduce_USING_AliasedExprList(self, *kids):
         self.val = kids[1].val
 
     def reduce_USING_AliasedExprList_COMMA(self, *kids):
         self.val = kids[1].val
+
+
+class OptUsingClause(Nonterm):
+    def reduce_UsingClause(self, *kids):
+        self.val = kids[0].val
 
     def reduce_empty(self, *kids):
         self.val = None
@@ -214,6 +222,37 @@ class SimpleGroup(Nonterm):
             subject_alias=kids[1].val.alias,
             using=kids[2].val,
             by=kids[3].val,
+        )
+
+
+class OptGroupingAlias(Nonterm):
+    def reduce_COMMA_Identifier(self, *kids):
+        self.val = kids[1].val
+
+    def reduce_empty(self, *kids):
+        self.val = None
+
+
+class InternalGroup(Nonterm):
+    def reduce_InternalGroup(self, *kids):
+        r"%reduce FOR GROUP OptionallyAliasedExpr \
+                  UsingClause \
+                  ByClause \
+                  INTO Identifier OptGroupingAlias \
+                  UNION OptionallyAliasedExpr \
+                  OptFilterClause OptSortClause \
+        "
+        self.val = qlast.InternalGroupQuery(
+            subject=kids[2].val.expr,
+            subject_alias=kids[2].val.alias,
+            using=kids[3].val,
+            by=kids[4].val,
+            group_alias=kids[6].val,
+            grouping_alias=kids[7].val,
+            result_alias=kids[9].val.alias,
+            result=kids[9].val.expr,
+            where=kids[10].val,
+            orderby=kids[11].val,
         )
 
 

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -947,6 +947,16 @@ def trace_Group(
                 for by_el in node.by:
                     trace(by_el, ctx=byctx)
 
+        if isinstance(node, qlast.InternalGroupQuery):
+            with alias_context(nctx, node.using) as byctx:
+                ctx.objects[sn.QualName('__alias__', node.group_alias)] = (
+                    SentinelObject)
+                if node.grouping_alias:
+                    ctx.objects[
+                        sn.QualName('__alias__', node.grouping_alias)] = (
+                            SentinelObject)
+                trace(node.result, ctx=byctx)
+
         return tip
 
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -589,7 +589,7 @@ class Compiler:
                     and not ctx.schema_reflection_mode
                 ),
                 testmode=self.get_config_val(ctx, '__internal_testmode'),
-                dev_instance=self._is_dev_instance(),
+                devmode=self._is_dev_instance(),
             ),
         )
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -588,6 +588,8 @@ class Compiler:
                     not ctx.bootstrap_mode
                     and not ctx.schema_reflection_mode
                 ),
+                testmode=self.get_config_val(ctx, '__internal_testmode'),
+                dev_instance=self._is_dev_instance(),
             ),
         )
 
@@ -2638,6 +2640,11 @@ class Compiler:
                     and any(elements)
                 )
             )
+
+    def _is_dev_instance(self) -> bool:
+        # Determine whether we are on a dev instance by the presence
+        # of a test schema element.
+        return bool(self._std_schema.get('cfg::TestSessionConfig', None))
 
     def get_config_val(
         self,


### PR DESCRIPTION
The implementation strategy for our nice shape-based `GROUP` is
essentially to implement the original `GROUP ... INTO` proposal
and desugar the real `GROUP` into it.

For development and testing purposes, I want it to be possible to
write tests and dev instance queries using the internal `GROUP`,
so this adds syntax for it under the name `FOR GROUP`.

This allows us to reuse with slight modification most of the tests
that are lying around for the old GROUP, so this includes major
updates to that test suite.

This also implement the desugaring (including some optimizations) from
real GROUP into `FOR GROUP`, and updates the toy model to use the
desugaring.