### PR TITLE
Search the source_rvar for materialized refs

### DIFF
--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -118,9 +118,12 @@ def compile_materialized_exprs(
             card = mat_set.cardinality
             is_singleton = card.is_single() and not card.can_be_zero()
 
-            matctx.path_scope = matctx.path_scope.new_child()
+            old_scope = matctx.path_scope
+            matctx.path_scope = old_scope.new_child()
             for mat_id in mat_ids:
-                matctx.path_scope[mat_id] = None
+                for k in old_scope:
+                    if k.startswith(mat_id):
+                        matctx.path_scope[k] = None
             mat_qry = relgen.set_as_subquery(
                 mat_set.materialized, as_value=True, ctx=matctx
             )

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1020,7 +1020,8 @@ def _get_rel_path_output(
             raise ValueError(
                 f'could not resolve trailing pointer class for {path_id}')
 
-        assert not ptrref.is_computable
+        if ptrref.is_computable:
+            raise LookupError("can't lookup computable ptrref")
 
         if ptr_info is None:
             ptr_info = pg_types.get_ptrref_storage_info(

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -926,9 +926,6 @@ class TestEdgeQLFor(tb.QueryTestCase):
             ],
         )
 
-    @test.xfail("""
-        This is an issue with materialization and arrays
-    """)
     async def test_edgeql_for_in_function_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -1155,12 +1155,6 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
 
             self.assertEqual(len(res), 4)
 
-    @test.xfail('''
-        Fails the `not ir_set.is_materialized_ref` assertion
-
-        Before that assertion the test was passing, though it was
-        also calling next() too many times.
-    ''')
     async def test_edgeql_volatility_select_nested_06e(self):
         # here we want some deduplicating to happen
         # same as above but with an extra select


### PR DESCRIPTION
This is able to find materialized rvars that didn't need to be
unpacked to resolve the source.