### PR TITLE
Delete some code marked "remove after postgres 11"

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3038,21 +3038,6 @@ def process_set_as_agg_expr_inner(
 
                         query.sort_clause = []
 
-                if (irtyputils.is_scalar(ir_arg.typeref)
-                        and ir_arg.typeref.base_type is not None):
-                    # Cast scalar refs to the base type in aggregate
-                    # expressions, since PostgreSQL does not create array
-                    # types for custom domains and will fail to process a
-                    # query with custom domains appearing as array
-                    # elements.
-                    #
-                    # XXX: Remove this once we switch to PostgreSQL 11,
-                    #      which supports domain type arrays.
-                    pgtype_name = pg_types.pg_type_from_ir_typeref(
-                        ir_arg.typeref.base_type)
-                    pgtype = pgast.TypeName(name=pgtype_name)
-                    arg_ref = pgast.TypeCast(arg=arg_ref, type_name=pgtype)
-
                 args.append(arg_ref)
 
         name = get_func_call_backend_name(expr, ctx=newctx)

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -29,7 +29,6 @@ from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import qltypes as ft
 from edb.edgeql import parser as qlparser
 from edb.edgeql import utils as qlutils
-from edb.schema import scalars as s_scalars
 
 from . import abc as s_abc
 from . import annos as s_anno
@@ -671,6 +670,7 @@ class ConstraintCommand(
         from edb.ir import utils as ir_utils
         from . import pointers as s_pointers
         from . import links as s_links
+        from . import scalars as s_scalars
 
         bases = self.get_resolved_attribute_value(
             'bases', schema=schema, context=context,

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -28,7 +28,6 @@ from edb.edgeql import qltypes
 from . import delta as sd
 from . import name as sn
 from . import objects as so
-from . import scalars as s_scalars
 from . import types as s_types
 
 if TYPE_CHECKING:
@@ -135,8 +134,6 @@ class PseudoType(
         concrete_type: s_types.Type
     ) -> Optional[s_types.Type]:
         if self.is_any(schema):
-            if isinstance(concrete_type, s_scalars.ScalarType):
-                return concrete_type.get_topmost_concrete_base(schema)
             return concrete_type
         elif self.is_anytuple(schema):
             if (not concrete_type.is_tuple(schema) or

--- a/tests/schemas/casts.esdl
+++ b/tests/schemas/casts.esdl
@@ -21,6 +21,9 @@ scalar type custom_str_t extending str {
     constraint regexp('[A-Z]+');
 }
 
+scalar type foo extending str;
+scalar type bar extending str;
+
 type Test {
     property p_bool -> bool;
     property p_str -> str;

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -2474,3 +2474,17 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             ''',
             [],
         )
+
+    async def test_edgeql_casts_custom_scalars_01(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError, r'cannot cast'):
+            await self.con.execute("""
+                SELECT <foo><bar>'test'
+            """)
+
+    async def test_edgeql_casts_custom_scalars_02(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.QueryError, r'cannot cast'):
+            await self.con.execute("""
+                SELECT <array<foo>><array<bar>>['test']
+            """)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -11113,7 +11113,8 @@ type default::Foo {
         await self.con.execute(r"""
             ALTER TYPE TestArrays {
                 ALTER PROPERTY y {
-                    SET TYPE array<c>;
+                    SET TYPE array<c> USING (
+                        <array<c>><array<str>>.y);
                 }
             };
         """)
@@ -11165,7 +11166,8 @@ type default::Foo {
         await self.con.execute(r"""
             ALTER TYPE TestArrays {
                 ALTER PROPERTY y {
-                    SET TYPE array<c>;
+                    SET TYPE array<c> USING (
+                        <array<c>><array<str>>.y);
                 }
             };
         """)

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -777,6 +777,14 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [2],
         )
 
+    async def test_edgeql_functions_array_get_07(self):
+        await self.assert_query_result(
+            r'''
+                SELECT array_get([Issue.number], 0)
+            ''',
+            {'1', '2', '3', '4'},
+        )
+
     @test.xfail(
         "Known collation issue on Heroku Postgres",
         unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"


### PR DESCRIPTION
The code forced custom scalar array_agg elements to their base
type. Dropping this code broke an array_get test, which revealed a
more general bug issue where forcing polymorphic scalars to their base
type caused trouble with array_get defaults.

This also fixed a bug where arrays of custom scalars could be casted
between even though the actual scalar type could not.

Additionally, removing a now-unused import perturbed the import order
in such a way as to break things, so I sunk an import down into a function