### PR TITLE
Don't emit the contents of array_agg and the like *twice*

### DIFF
--- a/edb/edgeql/compiler/eta_expand.py
+++ b/edb/edgeql/compiler/eta_expand.py
@@ -118,7 +118,7 @@ def needs_eta_expansion_expr(
     """
     if isinstance(ir, irast.SelectStmt):
         return needs_eta_expansion(
-            ir.result, is_processed=bool(ir.where or ir.orderby), ctx=ctx)
+            ir.result, has_clauses=bool(ir.where or ir.orderby), ctx=ctx)
 
     if isinstance(stype, s_types.Array):
         if isinstance(ir, irast.Array):
@@ -149,7 +149,7 @@ def needs_eta_expansion_expr(
 def needs_eta_expansion(
     ir: irast.Set,
     *,
-    is_processed: bool = False,
+    has_clauses: bool = False,
     ctx: context.ContextLevel,
 ) -> bool:
     """Determine if a set is in need of η-expansion"""
@@ -168,7 +168,7 @@ def needs_eta_expansion(
     # might be processed by a clause. This is because the pgsql side
     # will produce *either* a value or serialized for array_agg/array
     # literals.
-    if is_processed and (
+    if has_clauses and (
         (subarray := stype.find_array(ctx.env.schema))
         and subarray.contains_object(ctx.env.schema)
     ):

--- a/edb/edgeql/compiler/eta_expand.py
+++ b/edb/edgeql/compiler/eta_expand.py
@@ -117,7 +117,8 @@ def needs_eta_expansion_expr(
     in which none of the arguments are sets that need expansion.
     """
     if isinstance(ir, irast.SelectStmt):
-        return needs_eta_expansion(ir.result, ctx=ctx)
+        return needs_eta_expansion(
+            ir.result, is_processed=bool(ir.where or ir.orderby), ctx=ctx)
 
     if isinstance(stype, s_types.Array):
         if isinstance(ir, irast.Array):
@@ -148,6 +149,7 @@ def needs_eta_expansion_expr(
 def needs_eta_expansion(
     ir: irast.Set,
     *,
+    is_processed: bool = False,
     ctx: context.ContextLevel,
 ) -> bool:
     """Determine if a set is in need of η-expansion"""
@@ -160,6 +162,16 @@ def needs_eta_expansion(
         return False
 
     if ALWAYS_EXPAND:
+        return True
+
+    # Object containing arrays always need to be eta expanded if they
+    # might be processed by a clause. This is because the pgsql side
+    # will produce *either* a value or serialized for array_agg/array
+    # literals.
+    if is_processed and (
+        (subarray := stype.find_array(ctx.env.schema))
+        and subarray.contains_object(ctx.env.schema)
+    ):
         return True
 
     # If we are directly projecting an element out of a tuple, we can just

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -133,6 +133,30 @@ def is_persistent_tuple(typeref: irast.TypeRef) -> bool:
         return False
 
 
+def contains_predicate(
+    typeref: irast.TypeRef,
+    pred: Callable[[irast.TypeRef], bool],
+) -> bool:
+    if pred(typeref):
+        return True
+
+    if typeref.intersection:
+        return any(
+            contains_predicate(sub, pred) for sub in typeref.intersection
+        )
+    if typeref.union:
+        return any(
+            contains_predicate(sub, pred) for sub in typeref.union
+        )
+    return any(
+        contains_predicate(sub, pred) for sub in typeref.subtypes
+    )
+
+
+def contains_object(typeref: irast.TypeRef) -> bool:
+    return contains_predicate(typeref, is_object)
+
+
 def type_to_typeref(
     schema: s_schema.Schema,
     t: s_types.Type,

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -140,11 +140,11 @@ def contains_predicate(
     if pred(typeref):
         return True
 
-    if typeref.intersection:
+    elif typeref.intersection:
         return any(
             contains_predicate(sub, pred) for sub in typeref.intersection
         )
-    if typeref.union:
+    elif typeref.union:
         return any(
             contains_predicate(sub, pred) for sub in typeref.union
         )

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -162,6 +162,7 @@ def compile_iterator_expr(
     assert isinstance(iterator_expr.expr, irast.SelectStmt)
 
     with ctx.new() as subctx:
+        subctx.expr_exposed = False
         subctx.rel = query
 
         already_existed = bool(relctx.maybe_get_path_rvar(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2950,7 +2950,8 @@ def process_set_as_agg_expr_inner(
             # the (unacceptable) hardcoding of function names,
             # check if the aggregate accepts a single argument
             # of "any" to determine serialized input safety.
-            serialization_safe = expr.func_polymorphic
+            serialization_safe = (
+                expr.func_polymorphic and aspect == 'serialized')
 
             if not serialization_safe:
                 argctx.expr_exposed = False
@@ -3108,6 +3109,12 @@ def process_set_as_agg_expr_inner(
 
     pathctx.put_path_var_if_not_exists(
         stmt, ir_set.path_id, set_expr, aspect=aspect, env=ctx.env)
+    # Cheat a little bit: as discussed above, pretend the serialized
+    # value is also really a value. Eta-expansion should ensure this
+    # only happens when we don't really need the value again.
+    if aspect == 'serialized':
+        pathctx.put_path_var_if_not_exists(
+            stmt, ir_set.path_id, set_expr, aspect='value', env=ctx.env)
 
     return new_stmt_set_rvar(ir_set, stmt, ctx=ctx)
 
@@ -3124,30 +3131,28 @@ def process_set_as_agg_expr(
     if expr.func_initial_value is not None:
         wrapper = stmt
 
-    # When in a serialization context, we need to compute both a value
-    # version and a serialized version of the aggregate function call,
-    # since we may need both (Consider `WITH X := array_agg(User), ...`).
+    # In a serialization context that produces something containing an object,
+    # we produce *only* a serialized value, and we claim it is the value too.
+    # For this to be correct, we need to only have serialized agg expr results
+    # in cases where value can't be used anymore. Our eta-expansion pass
+    # make sure this happens.
+    # (... the only such *function* currently is array_agg.)
+
+    # Though if the result type contains no objects, the value should be good
+    # enough, so don't generate a bunch of unnecessary code to produce
+    # a serialized value when we can use value.
+    serialized = (
+        output.in_serialization_ctx(ctx=ctx)
+        and irtyputils.contains_object(ir_set.typeref)
+    )
 
     cctx = ctx.subrel() if wrapper else ctx.new()
     with cctx as xctx:
-        xctx.expr_exposed = False
+        xctx.expr_exposed = serialized
+        aspect = 'serialized' if serialized else 'value'
         process_set_as_agg_expr_inner(
-            ir_set, xctx.rel, aspect='value', wrapper=wrapper,
+            ir_set, xctx.rel, aspect=aspect, wrapper=wrapper,
             ctx=xctx)
-
-    # Though if the result type is a scalar, the value should be good
-    # enough, so don't generate a bunch of unnessecary code to produce
-    # a serialized value when we can use value.
-    if (
-        output.in_serialization_ctx(ctx=ctx)
-        and not irtyputils.is_scalar(ir_set.typeref)
-    ):
-        cctx = ctx.subrel() if wrapper else ctx.new()
-        with cctx as xctx:
-            xctx.expr_exposed = True
-            process_set_as_agg_expr_inner(
-                ir_set, xctx.rel, aspect='serialized', wrapper=wrapper,
-                ctx=xctx)
 
     return new_stmt_set_rvar(ir_set, stmt, ctx=ctx)
 
@@ -3222,7 +3227,10 @@ def process_set_as_array_expr(
 
     elements = []
     s_elements = []
-    serializing = output.in_serialization_ctx(ctx=ctx)
+    serializing = (
+        output.in_serialization_ctx(ctx=ctx)
+        and irtyputils.contains_object(ir_set.typeref)
+    )
 
     for ir_element in expr.elements:
         element = dispatch.compile(ir_element, ctx=ctx)
@@ -3245,24 +3253,24 @@ def process_set_as_array_expr(
 
             s_elements.append(s_var)
 
-    set_expr = build_array_expr(expr, elements, ctx=ctx)
-
-    pathctx.put_path_value_var_if_not_exists(
-        stmt, ir_set.path_id, set_expr, env=ctx.env)
-
     if serializing:
-        s_set_expr = astutils.safe_array_expr(
+        set_expr = astutils.safe_array_expr(
             s_elements, ser_safe=all(x.ser_safe for x in s_elements))
 
         if irutils.is_empty_array_expr(expr):
-            s_set_expr = pgast.TypeCast(
-                arg=s_set_expr,
+            set_expr = pgast.TypeCast(
+                arg=set_expr,
                 type_name=pgast.TypeName(
                     name=pg_types.pg_type_from_ir_typeref(expr.typeref)
                 )
             )
 
         pathctx.put_path_serialized_var(
-            stmt, ir_set.path_id, s_set_expr, env=ctx.env)
+            stmt, ir_set.path_id, set_expr, env=ctx.env)
+    else:
+        set_expr = build_array_expr(expr, elements, ctx=ctx)
+
+    pathctx.put_path_value_var_if_not_exists(
+        stmt, ir_set.path_id, set_expr, env=ctx.env)
 
     return new_stmt_set_rvar(ir_set, stmt, ctx=ctx)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -273,6 +273,9 @@ class Type(
     def contains_json(self, schema: s_schema.Schema) -> bool:
         return self.contains_predicate(lambda x: x.is_json(schema), schema)
 
+    def find_array(self, schema: s_schema.Schema) -> Optional[Type]:
+        return self.find_predicate(lambda x: x.is_array(), schema)
+
     def contains_array_of_tuples(self, schema: s_schema.Schema) -> bool:
         return self.contains_predicate(
             lambda x: x.is_array_of_tuples(schema), schema)

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -3106,6 +3106,32 @@ class TestExpressions(tb.QueryTestCase):
             ],
         )
 
+    async def test_edgeql_expr_array_23(self):
+        await self.assert_query_result(
+            r'''
+            WITH X := [(1, 2)],
+            SELECT X FILTER X[0].0 = 1;
+            ''',
+            [[[1, 2]]],
+        )
+
+    async def test_edgeql_expr_array_24(self):
+        await self.assert_query_result(
+            r'''
+            WITH X := [(foo := 1, bar := 2)],
+            SELECT X FILTER X[0].foo = 1;
+            ''',
+            [[{"bar": 2, "foo": 1}]],
+        )
+
+    async def test_edgeql_expr_array_25(self):
+        await self.assert_query_result(
+            r'''
+            SELECT X := [(foo := 1, bar := 2)] FILTER X[0].foo = 1;
+            ''',
+            [[{"bar": 2, "foo": 1}]],
+        )
+
     async def test_edgeql_expr_coalesce_01(self):
         await self.assert_query_result(
             r'''SELECT <int64>{} ?? 4 ?? 5;''',

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -397,6 +397,32 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             )
         )
 
+    async def test_edgeql_functions_array_agg_21(self):
+        await self.assert_query_result(
+            r'''
+            WITH X := array_agg((1, 2)),
+            SELECT X FILTER X[0].0 = 1;
+            ''',
+            [[[1, 2]]],
+        )
+
+    async def test_edgeql_functions_array_agg_22(self):
+        await self.assert_query_result(
+            r'''
+            WITH X := array_agg((foo := 1, bar := 2)),
+            SELECT X FILTER X[0].foo = 1;
+            ''',
+            [[{"bar": 2, "foo": 1}]],
+        )
+
+    async def test_edgeql_functions_array_agg_23(self):
+        await self.assert_query_result(
+            r'''
+            SELECT X := array_agg((foo := 1, bar := 2)) FILTER X[0].foo = 1;
+            ''',
+            [[{"bar": 2, "foo": 1}]],
+        )
+
     async def test_edgeql_functions_array_unpack_01(self):
         await self.assert_query_result(
             r'''SELECT [1, 2];''',

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -6875,6 +6875,21 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             [[{"id": str}], [{"id": str}]]
         )
 
+    async def test_edgeql_collection_shape_08(self):
+        await self.assert_query_result(
+            r'''
+                SELECT X := array_agg(User) FILTER X[0].name != 'Sully';
+            ''',
+            [[{"id": str}, {"id": str}]]
+        )
+
+        await self.assert_query_result(
+            r'''
+            SELECT X := [User] FILTER X[0].name = 'Elvis';
+            ''',
+            [[{"id": str}]]
+        )
+
     async def test_edgeql_assert_fail_object_computed_01(self):
         # check that accessing a trivial computable on an object
         # that will fail to evaluate still fails
@@ -7144,6 +7159,17 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             for x in 2 union (select {1,x} filter random() > 0)
             ''',
             {1, 2}
+        )
+
+    async def test_edgeql_with_rebind_01(self):
+        await self.assert_query_result(
+            r'''
+            WITH Z := (SELECT User { name })
+            SELECT Z
+            ''',
+            [
+                {'id': str}, {'id': str}
+            ],
         )
 
     async def test_edgeql_select_free_object_distinct_01(self):


### PR DESCRIPTION
Currently we will duplicate an array_agg/array literal in most cases
other than appearing at the very toplevel, once for value and once for
serialized. Avoid this by pretending the serialized output is the value
if we know it is only being used for "not NULL" style things; use eta
expansion to ensure this.