### PR TITLE
Implement GROUP

### DIFF
--- a/edb/edgeql/compiler/group.py
+++ b/edb/edgeql/compiler/group.py
@@ -1,0 +1,238 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+
+from typing import *
+
+from edb.common import ast as ast_visitor
+
+from edb.edgeql import qltypes
+from edb.ir import ast as irast
+
+from . import context
+from . import inference
+from . import setgen
+
+
+class FindAggregatingUses(ast_visitor.NodeVisitor):
+    """
+    Find aggregated uses of a target node that can be hoisted.
+    """
+    skip_hidden = True
+    extra_skips = frozenset(['materialized_sets'])
+
+    def __init__(
+        self,
+        target: irast.PathId,
+        *,
+        ctx: context.ContextLevel,
+    ) -> None:
+        super().__init__()
+        self.target = target
+        self.aggregate: Optional[irast.Set] = None
+        self.sightings: Set[Optional[irast.Set]] = set()
+        self.ctx = ctx
+        # Track pathids that we've seen. pathids that we are interested
+        # in but haven't seen get marked as False.
+        self.seen: Dict[irast.PathId, bool] = {}
+        self.skippable: Dict[
+            Optional[irast.Set], FrozenSet[irast.PathId]] = {}
+        self.scope_tree = ctx.path_scope
+        # We don't bother trying to reuse the existing inference
+        # context because we make singleton assumptions that it
+        # wouldn't and because ignore_computed_cards could invalidate
+        # it.
+        self.infctx = inference.make_ctx(ctx.env)._replace(
+            singletons=frozenset({target}),
+            ignore_computed_cards=True,
+        )
+
+    def visit_Stmt(self, stmt: irast.Stmt) -> Any:
+        # Sometimes there is sharing, so we want the official scope
+        # for a node to be based on its appearance in the result,
+        # not in a subquery.
+        # I think it might not actually matter, though.
+
+        old = self.aggregate
+
+        # Can't handle ORDER/LIMIT/OFFSET which operate on the whole set
+        # TODO: but often we probably could with arguments to the
+        # aggregates, as long as the argument to the aggregate is just
+        # a reference
+        if isinstance(stmt, irast.SelectStmt) and (
+            stmt.orderby or stmt.limit or stmt.offset or stmt.materialized_sets
+        ):
+            self.aggregate = None
+
+        self.visit(stmt.bindings)
+        if stmt.iterator_stmt:
+            self.visit(stmt.iterator_stmt)
+        if isinstance(stmt, (irast.MutatingStmt, irast.GroupStmt)):
+            self.visit(stmt.subject)
+        if isinstance(stmt, irast.GroupStmt):
+            for v in stmt.using.values():
+                self.visit(v)
+        self.visit(stmt.result)
+
+        res = self.generic_visit(stmt)
+
+        self.aggregate = old
+
+        return res
+
+    def repeated_node_visit(self, node: irast.Base) -> None:
+        if isinstance(node, irast.Set):
+            self.seen[node.path_id] = True
+
+    def visit_Set(self, node: irast.Set, skip_rptr: bool=False) -> None:
+        self.seen[node.path_id] = True
+
+        if node.path_id == self.target:
+            self.sightings.add(self.aggregate)
+            return
+
+        old_scope = self.scope_tree
+        if node.path_scope_id is not None:
+            self.scope_tree = self.ctx.env.scope_tree_nodes[node.path_scope_id]
+
+        # We also can't handle references inside of a semi-join,
+        # because the bodies are executed one at a time, and so the
+        # semi-join deduplication doesn't work.
+        is_semijoin = (
+            node.rptr
+            and node.path_id.is_objtype_path()
+            and not self.scope_tree.is_visible(node.rptr.source.path_id)
+        )
+
+        old = self.aggregate
+        if is_semijoin:
+            self.aggregate = None
+
+        self.visit(node.shape)
+
+        if not node.expr and node.rptr:
+            self.visit(node.rptr.source)
+        elif node.rptr:
+            if node.rptr.source.path_id not in self.seen:
+                self.seen[node.rptr.source.path_id] = False
+
+        if isinstance(node.expr, irast.Call):
+            self.process_call(node.expr, node)
+        else:
+            self.visit(node.expr)
+
+        self.aggregate = old
+        self.scope_tree = old_scope
+
+    def process_call(self, node: irast.Call, ir_set: irast.Set) -> None:
+        # It needs to be backed by an actual SQL function and must
+        # not return SET OF
+        returns_set = node.typemod == qltypes.TypeModifier.SetOfType
+        calls_sql_func = (
+            isinstance(node, irast.FunctionCall)
+            and node.func_sql_function
+        )
+        for arg, typemod in zip(node.args, node.params_typemods):
+            old = self.aggregate
+            # If this *returns* a set, it is going to mess things up since
+            # the operation can't actually run on multiple things...
+
+            old_seen = None
+
+            # TODO: we would like to do better in some cases with
+            # DISTINCT and the like where there are built in features
+            # to do it in a GROUP
+            if returns_set:
+                self.aggregate = None
+            elif (
+                calls_sql_func
+                and typemod == qltypes.TypeModifier.SetOfType
+                # Don't hoist aggregates whose outputs contain objects
+                # (I think this can only be array_agg).
+                #
+                # We have to eta-expand to put a shape on them anyway,
+                # so there's no real point, and we mishandled that
+                # case in a few places.  Eventually we'll want to properly
+                # be able to serialize in the first place, though.
+                and not setgen.get_set_type(
+                    ir_set, ctx=self.ctx).contains_object(self.ctx.env.schema)
+            ):
+                old_seen = self.seen
+                self.seen = {}
+                self.aggregate = ir_set
+            self.visit(arg)
+            self.aggregate = old
+
+            force_fail = False
+            if old_seen is not None:
+                self.skippable[ir_set] = frozenset({
+                    k for k, v in self.seen.items() if not v
+                    and self.scope_tree.is_visible(k)
+                })
+                for k, was_seen in self.seen.items():
+                    # If we referred to some visible set and also
+                    # spotted the target, we can't actually compile
+                    # the target separately, so ditch it.
+                    if (
+                        was_seen
+                        and self.scope_tree.is_visible(k)
+                        and ir_set in self.sightings
+                    ):
+                        force_fail = True
+                        self.sightings.discard(ir_set)
+                        self.sightings.add(None)
+                    old_seen[k] = self.seen.get(k, False) | was_seen
+
+                # If, assuming the target is single, the aggregate is
+                # still multi, then we can't extract it, since that
+                # would lead to actually return multiple elements in a
+                # SQL subquery.
+                if (
+                    ir_set in self.sightings
+                    and inference.infer_cardinality(
+                        arg.expr, scope_tree=self.scope_tree,
+                        ctx=self.infctx).is_multi()
+                ):
+                    force_fail = True
+
+                self.seen = old_seen
+
+            if force_fail:
+                self.sightings.discard(ir_set)
+                self.sightings.add(None)
+
+
+def infer_group_aggregates(
+    ir: irast.Base,
+    *,
+    ctx: context.ContextLevel,
+) -> None:
+    flt = lambda n: isinstance(n, irast.GroupStmt)
+    groups: List[irast.GroupStmt] = ast_visitor.find_children(ir, flt)
+    for stmt in groups:
+        visitor = FindAggregatingUses(
+            stmt.group_binding.path_id,
+            ctx=ctx,
+        )
+        visitor.visit(stmt.result)
+        stmt.group_aggregate_sets = {
+            k: visitor.skippable.get(k, frozenset())
+            for k in visitor.sightings
+        }

--- a/edb/edgeql/compiler/inference/context.py
+++ b/edb/edgeql/compiler/inference/context.py
@@ -63,6 +63,7 @@ class InfCtx(NamedTuple):
     ]
     singletons: FrozenSet[irast.PathId]
     distinct_iterator: Optional[irast.PathId]
+    ignore_computed_cards: bool
 
 
 def make_ctx(env: context.Environment) -> InfCtx:
@@ -72,4 +73,5 @@ def make_ctx(env: context.Environment) -> InfCtx:
         inferred_multiplicity={},
         singletons=frozenset(env.singletons),
         distinct_iterator=None,
+        ignore_computed_cards=False,
     )

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -672,7 +672,19 @@ def __infer_group_stmt(
     scope_tree: irast.ScopeTreeNode,
     ctx: inf_ctx.InfCtx,
 ) -> inf_ctx.MultiplicityInfo:
-    raise NotImplementedError
+    infer_multiplicity(ir.subject, scope_tree=scope_tree, ctx=ctx)
+    for binding, _ in ir.using.values():
+        infer_multiplicity(binding, scope_tree=scope_tree, ctx=ctx)
+    result_mult = _infer_stmt_multiplicity(ir, scope_tree=scope_tree, ctx=ctx)
+
+    for clause in (ir.orderby or ()):
+        new_scope = inf_utils.get_set_scope(clause.expr, scope_tree, ctx=ctx)
+        infer_multiplicity(clause.expr, scope_tree=new_scope, ctx=ctx)
+
+    if result_mult.fresh_free_object:
+        return result_mult
+    else:
+        return MANY
 
 
 @_infer_multiplicity.register

--- a/edb/edgeql/compiler/inference/volatility.py
+++ b/edb/edgeql/compiler/inference/volatility.py
@@ -278,7 +278,8 @@ def __infer_group_stmt(
     ir: irast.GroupStmt,
     env: context.Environment,
 ) -> InferredVolatility:
-    raise NotImplementedError
+    components = [ir.subject, ir.result] + [v for v, _ in ir.using.values()]
+    return _common_volatility(components, env)
 
 
 @_infer_volatility_inner.register

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -172,6 +172,10 @@ def preserve_view_shape(
             derived_name_base=derived_name_base)
         new.append((nptr, op))
     ctx.env.view_shapes[derived] = new
+    if isinstance(base, s_types.Type) and isinstance(derived, s_types.Type):
+        ctx.env.view_shapes_metadata[derived] = (
+            ctx.env.view_shapes_metadata[base]).replace()
+
     # All of the pointers should already exist, so nothing should have
     # been created.
     assert schema is ctx.env.schema

--- a/edb/edgeql/desugar_group.py
+++ b/edb/edgeql/desugar_group.py
@@ -33,6 +33,10 @@ from edb.common.compiler import AliasGenerator
 from edb.edgeql import ast as qlast
 
 
+def key_name(s: str) -> str:
+    return s.split('~')[0]
+
+
 def name_path(name: str) -> qlast.Path:
     return qlast.Path(steps=[qlast.ObjectRef(name=name)])
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -254,6 +254,10 @@ class BasePointerRef(ImmutableBase):
             res.update(child.descendants())
         return res
 
+    @property
+    def real_material_ptr(self) -> BasePointerRef:
+        return self.material_ptr or self
+
     def __repr__(self) -> str:
         return f'<ir.{type(self).__name__} \'{self.name}\' at 0x{id(self):x}>'
 
@@ -876,11 +880,19 @@ class SelectStmt(FilteredStmt):
     implicit_wrapper: bool = False
 
 
-class GroupStmt(Stmt):
-    subject: Set
-    groupby: typing.List[Set]
-    result: Set
-    group_path_id: PathId
+class GroupStmt(FilteredStmt):
+    subject: Set = EmptySet()  # type: ignore
+    using: typing.Dict[str, typing.Tuple[Set, qltypes.Cardinality]] = (
+        ast.field(factory=dict))
+    by: typing.List[qlast.GroupingElement]
+    result: Set = EmptySet()  # type: ignore
+    group_binding: Set = EmptySet()  # type: ignore
+    grouping_binding: typing.Optional[Set] = None
+    orderby: typing.Optional[typing.List[SortExpr]] = None
+    # Optimization information
+    group_aggregate_sets: typing.Dict[
+        typing.Optional[Set], typing.FrozenSet[PathId]
+    ] = ast.field(factory=dict)
 
 
 class MutatingStmt(Stmt):

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -354,8 +354,11 @@ class FindPathScopes(ast.NodeVisitor):
         self.visit(stmt.bindings)
         if stmt.iterator_stmt:
             self.visit(stmt.iterator_stmt)
-        if isinstance(stmt, irast.MutatingStmt):
+        if isinstance(stmt, (irast.MutatingStmt, irast.GroupStmt)):
             self.visit(stmt.subject)
+        if isinstance(stmt, irast.GroupStmt):
+            for v in stmt.using.values():
+                self.visit(v)
         self.visit(stmt.result)
 
         return self.generic_visit(stmt)

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -733,6 +733,9 @@ class SQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_CaseExpr(self, node):
         self.write('(CASE ')
+        if node.arg:
+            self.visit(node.arg)
+            self.write(' ')
         for arg in node.args:
             self.visit(arg)
             self.new_lines = 1

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -116,6 +116,7 @@ def compile_materialized_exprs(
             # We pack optional things into arrays also, since it works.
             # TODO: use NULL?
             card = mat_set.cardinality
+            assert card != qltypes.Cardinality.UNKNOWN
             is_singleton = card.is_single() and not card.can_be_zero()
 
             old_scope = matctx.path_scope
@@ -132,7 +133,6 @@ def compile_materialized_exprs(
                 mat_qry = relctx.set_to_array(
                     path_id=mat_set.materialized.path_id,
                     query=mat_qry,
-                    materializing=True,
                     ctx=matctx)
 
             if not mat_qry.target_list[0].name:
@@ -159,7 +159,7 @@ def compile_iterator_expr(
         ctx: context.CompilerContextLevel) \
         -> pgast.PathRangeVar:
 
-    assert isinstance(iterator_expr.expr, irast.SelectStmt)
+    assert isinstance(iterator_expr.expr, (irast.GroupStmt, irast.SelectStmt))
 
     with ctx.new() as subctx:
         subctx.expr_exposed = False

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -391,6 +391,10 @@ def _rewrite_config_insert(
         overwrite_query, ir_set.path_id, id_expr, force=True, env=ctx.env)
     pathctx.put_path_value_var(
         overwrite_query, ir_set.path_id, id_expr, force=True, env=ctx.env)
+    pathctx.put_path_source_rvar(
+        overwrite_query, ir_set.path_id,
+        relctx.rvar_for_rel(pgast.NullRelation(), ctx=ctx),
+        env=ctx.env)
 
     relctx.add_type_rel_overlay(
         ir_set.typeref,

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -141,6 +141,11 @@ class CompilerContextLevel(compiler.ContextLevel):
     #: optionality scaffolding.
     force_optional: FrozenSet[irast.PathId]
 
+    #: Paths that can be ignored when they appear as the source of a
+    # computable. This is key to optimizing away free object sources in
+    # group by aggregates.
+    skippable_sources: FrozenSet[irast.PathId]
+
     #: Specifies that references to a specific Set must be narrowed
     #: by only selecting instances of type specified by the mapping value.
     intersection_narrowing: Dict[irast.Set, irast.Set]
@@ -231,6 +236,7 @@ class CompilerContextLevel(compiler.ContextLevel):
 
             self.disable_semi_join = frozenset()
             self.force_optional = frozenset()
+            self.skippable_sources = frozenset()
             self.intersection_narrowing = {}
 
             self.path_scope = collections.ChainMap()
@@ -267,6 +273,7 @@ class CompilerContextLevel(compiler.ContextLevel):
 
             self.disable_semi_join = prevlevel.disable_semi_join
             self.force_optional = prevlevel.force_optional
+            self.skippable_sources = prevlevel.skippable_sources
             self.intersection_narrowing = prevlevel.intersection_narrowing
 
             self.path_scope = prevlevel.path_scope

--- a/edb/pgsql/compiler/group.py
+++ b/edb/pgsql/compiler/group.py
@@ -1,0 +1,386 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2008-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+
+from typing import *
+
+from edb.edgeql import ast as qlast
+from edb.edgeql import desugar_group
+from edb.ir import ast as irast
+from edb.pgsql import ast as pgast
+
+from . import astutils
+from . import clauses
+from . import context
+from . import dispatch
+from . import output
+from . import pathctx
+from . import relctx
+from . import relgen
+
+
+def compile_grouping_atom(
+    el: qlast.GroupingAtom,
+    stmt: irast.GroupStmt, *, ctx: context.CompilerContextLevel
+) -> pgast.Base:
+    '''Compile a GroupingAtom into sql grouping sets'''
+    if isinstance(el, qlast.GroupingIdentList):
+        return pgast.GroupingOperation(
+            args=[
+                compile_grouping_atom(at, stmt, ctx=ctx) for at in el.elements
+            ],
+        )
+
+    assert isinstance(el, qlast.ObjectRef)
+    alias_set, _ = stmt.using[el.name]
+    return pathctx.get_path_value_var(
+        ctx.rel, alias_set.path_id, env=ctx.env)
+
+
+def compile_grouping_el(
+    el: qlast.GroupingElement,
+    stmt: irast.GroupStmt, *, ctx: context.CompilerContextLevel
+) -> pgast.Base:
+    '''Compile a GroupingElement into sql grouping sets'''
+    if isinstance(el, qlast.GroupingSets):
+        return pgast.GroupingOperation(
+            operation='GROUPING SETS',
+            args=[compile_grouping_el(sub, stmt, ctx=ctx) for sub in el.sets],
+        )
+    elif isinstance(el, qlast.GroupingOperation):
+        return pgast.GroupingOperation(
+            operation=el.oper,
+            args=[
+                compile_grouping_atom(at, stmt, ctx=ctx) for at in el.elements
+            ],
+        )
+    elif isinstance(el, qlast.GroupingSimple):
+        return compile_grouping_atom(el.element, stmt, ctx=ctx)
+    raise AssertionError('Unknown GroupingElement')
+
+
+def _compile_grouping_value(
+        stmt: irast.GroupStmt, used_args: AbstractSet[str], *,
+        ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
+    '''Produce the value for the grouping binding saying what is grouped on'''
+    assert stmt.grouping_binding
+    grouprel = ctx.rel
+
+    # If there is only one thing grouped on, just output the hardcoded
+    if len(used_args) == 1:
+        return pgast.ArrayExpr(
+            elements=[
+                pgast.StringConstant(
+                    val=desugar_group.key_name(list(used_args)[0]))]
+        )
+
+    using = {k: stmt.using[k] for k in used_args}
+
+    args = [
+        pathctx.get_path_var(
+            grouprel, alias_set.path_id, aspect='value', env=ctx.env)
+        for alias_set, _ in using.values()
+    ]
+
+    # Call grouping on each element we group on to produce a bitmask
+    grouping_alias = ctx.env.aliases.get('g')
+    grouping_call = pgast.FuncCall(name=('grouping',), args=args)
+    subq = pgast.SelectStmt(
+        target_list=[
+            pgast.ResTarget(name=grouping_alias, val=grouping_call),
+        ]
+    )
+    q = pgast.SelectStmt(
+        from_clause=[pgast.RangeSubselect(
+            subquery=subq,
+            alias=pgast.Alias(aliasname=ctx.env.aliases.get())
+        )]
+    )
+
+    grouping_ref = pgast.ColumnRef(name=(grouping_alias,))
+
+    # Generate a call to ARRAY[...] with a case for each grouping
+    # element, then array_remove out the NULLs.
+    els: List[pgast.BaseExpr] = []
+    for i, name in enumerate(using):
+        name = desugar_group.key_name(name)
+        mask = 1 << (len(using) - i - 1)
+        # (CASE (e & <mask>) WHEN 0 THEN '<name>' ELSE NULL END)
+
+        els.append(pgast.CaseExpr(
+            arg=pgast.Expr(
+                kind=pgast.ExprKind.OP,
+                name='&',
+                lexpr=grouping_ref,
+                rexpr=pgast.LiteralExpr(expr=str(mask))
+            ),
+            args=[
+                pgast.CaseWhen(
+                    expr=pgast.LiteralExpr(expr='0'),
+                    result=pgast.StringConstant(val=name)
+                )
+            ],
+            defresult=pgast.NullConstant()
+        ))
+
+    val = pgast.FuncCall(
+        name=('array_remove',),
+        args=[pgast.ArrayExpr(elements=els), pgast.NullConstant()]
+    )
+
+    q.target_list.append(pgast.ResTarget(val=val))
+
+    return q
+
+
+def _compile_grouping_binding(
+        stmt: irast.GroupStmt, *, used_args: AbstractSet[str],
+        ctx: context.CompilerContextLevel) -> None:
+    assert stmt.grouping_binding
+    pathctx.put_path_var(
+        ctx.rel, stmt.grouping_binding.path_id,
+        _compile_grouping_value(stmt, used_args=used_args, ctx=ctx),
+        aspect='value', env=ctx.env)
+
+
+def _compile_group(
+        stmt: irast.GroupStmt, *,
+        ctx: context.CompilerContextLevel,
+        parent_ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
+
+    query = ctx.stmt
+
+    # Compile a GROUP BY into a subquery, along with all the aggregations
+    with ctx.subrel() as groupctx:
+        grouprel = groupctx.rel
+
+        # First compile the actual subject
+        # subrel *solely* for path id map reasons
+        with groupctx.subrel() as subjctx:
+            subjctx.expr_exposed = False
+
+            dispatch.visit(stmt.subject, ctx=subjctx)
+            if stmt.subject.path_id.is_objtype_path():
+                # This shouldn't technically be needed but we generate
+                # better code with it.
+                relgen.ensure_source_rvar(
+                    stmt.subject, subjctx.rel, ctx=subjctx)
+
+        subj_rvar = relctx.rvar_for_rel(
+            subjctx.rel, ctx=groupctx, lateral=True)
+        aspects = pathctx.list_path_aspects(
+            subjctx.rel, stmt.subject.path_id, env=ctx.env)
+
+        pathctx.put_path_id_map(
+            subjctx.rel,
+            stmt.group_binding.path_id, stmt.subject.path_id)
+
+        # update_mask=False because we are doing this solely to remap
+        # elements individually and don't want to affect the mask.
+        relctx.include_rvar(
+            grouprel, subj_rvar, stmt.group_binding.path_id,
+            aspects=aspects,
+            update_mask=False, ctx=groupctx)
+        relctx.include_rvar(
+            grouprel, subj_rvar, stmt.subject.path_id,
+            aspects=aspects,
+            update_mask=False, ctx=groupctx)
+
+        # Now we compile the bindings
+        groupctx.path_scope = subjctx.path_scope.new_child()
+        groupctx.path_scope[stmt.group_binding.path_id] = None
+
+        # Compile all the 'using' items
+        for _alias, (value, using_card) in stmt.using.items():
+            # If the using bit is nullable, we need to compile it
+            # as optional, or we'll get in trouble.
+            # TODO: Can we do better here and not do this
+            # in obvious cases like directly referencing an optional
+            # property.
+            if using_card.can_be_zero():
+                groupctx.force_optional = ctx.force_optional | {value.path_id}
+            groupctx.path_scope[value.path_id] = None
+
+            dispatch.visit(value, ctx=groupctx)
+            groupctx.force_optional = ctx.force_optional
+
+        # Compile all of the aggregate calls that we found. This lets us
+        # compute things like sum and count without needing to materialize
+        # the result.
+        for group_use, skippable in stmt.group_aggregate_sets.items():
+            if not group_use:
+                continue
+            with groupctx.subrel() as hoistctx:
+                hoistctx.skippable_sources |= skippable
+
+                relgen.process_set_as_agg_expr_inner(
+                    group_use, hoistctx.rel,
+                    aspect='value', wrapper=None, for_group_by=True,
+                    ctx=hoistctx)
+                pathctx.get_path_value_output(
+                    rel=hoistctx.rel, path_id=group_use.path_id, env=ctx.env)
+                pathctx.put_path_value_var(
+                    grouprel, group_use.path_id, hoistctx.rel, env=ctx.env
+                )
+
+        packed = False
+        # Materializing the actual grouping sets
+        if None in stmt.group_aggregate_sets:
+            packed = True
+            # TODO: Be able to directly output the final serialized version
+            # if it is consumed directly.
+            with context.output_format(ctx, context.OutputFormat.NATIVE), (
+                    ctx.new()) as matctx:
+                matctx.materializing |= {stmt}
+                matctx.expr_exposed = True
+
+                mat_qry = relgen.set_as_subquery(
+                    stmt.group_binding, as_value=True, ctx=matctx)
+                mat_qry = relctx.set_to_array(
+                    path_id=stmt.group_binding.path_id,
+                    for_group_by=True,
+                    query=mat_qry,
+                    ctx=matctx)
+                if not mat_qry.target_list[0].name:
+                    mat_qry.target_list[0].name = ctx.env.aliases.get('v')
+
+                ref = pgast.ColumnRef(
+                    name=[mat_qry.target_list[0].name],
+                    is_packed_multi=True,
+                )
+                pathctx.put_path_packed_output(
+                    mat_qry, stmt.group_binding.path_id, ref)
+
+                pathctx.put_path_var(
+                    grouprel, stmt.group_binding.path_id, mat_qry,
+                    aspect='value',
+                    flavor='packed', env=ctx.env
+                )
+
+        used_args = desugar_group.collect_grouping_atoms(stmt.by)
+
+        if stmt.grouping_binding:
+            _compile_grouping_binding(stmt, used_args=used_args, ctx=groupctx)
+
+        # We want to make sure that every grouping key is associated
+        # with exactly one output from the query. The means that
+        # tuples must be packed up and keys must not have an extra
+        # serialized output.
+        #
+        # We do this by manually packing up any TupleVarBases and
+        # copying value aspects to serialized.
+        # of the grouping keys get an extra serialized output from
+        # grouprel, so we just copy all their value aspects to their
+        # serialized aspects.
+        using = {k: stmt.using[k] for k in used_args}
+        for using_val, _ in using.values():
+            uvar = pathctx.get_path_var(
+                grouprel, using_val.path_id, aspect='value', env=ctx.env)
+            if isinstance(uvar, pgast.TupleVarBase):
+                uvar = output.output_as_value(uvar, env=ctx.env)
+                pathctx.put_path_var(
+                    grouprel, using_val.path_id, uvar,
+                    aspect='value', force=True, env=ctx.env)
+
+            uout = pathctx.get_path_output(
+                grouprel, using_val.path_id, aspect='value', env=ctx.env)
+            pathctx._put_path_output_var(
+                grouprel, using_val.path_id, 'serialized', uout, env=ctx.env)
+
+        grouprel.group_clause = [
+            compile_grouping_el(el, stmt, ctx=groupctx) for el in stmt.by
+        ]
+
+    group_rvar = relctx.rvar_for_rel(grouprel, ctx=ctx, lateral=True)
+    if packed:
+        relctx.include_rvar(
+            query, group_rvar, path_id=stmt.group_binding.path_id,
+            flavor='packed', update_mask=False, pull_namespace=False,
+            aspects=('value',),
+            ctx=ctx)
+    else:
+        # Not include_rvar because we don't actually provide the path id!
+        relctx.rel_join(query, group_rvar, ctx=ctx)
+
+    # Set up the hoisted aggregates and bindings to be found
+    # in the group subquery.
+    for group_use in [
+        *stmt.group_aggregate_sets,
+        *[x for x, _ in stmt.using.values()],
+        stmt.grouping_binding,
+    ]:
+        if group_use:
+            pathctx.put_path_rvar(
+                query, group_use.path_id,
+                group_rvar, aspect='value', env=ctx.env)
+
+    vol_ref = None
+
+    def _get_volatility_ref() -> Optional[pgast.BaseExpr]:
+        nonlocal vol_ref
+        if vol_ref:
+            return vol_ref
+
+        name = ctx.env.aliases.get('key')
+        grouprel.target_list.append(
+            pgast.ResTarget(
+                name=name,
+                val=pgast.FuncCall(name=('row_number',), args=[],
+                                   over=pgast.WindowDef())
+            )
+        )
+        vol_ref = pgast.ColumnRef(name=[group_rvar.alias.aliasname, name])
+        return vol_ref
+
+    with ctx.new() as outctx:
+
+        outctx.volatility_ref += (lambda stmt, xctx: _get_volatility_ref(),)
+
+        # Process materialized sets
+        clauses.compile_materialized_exprs(query, stmt, ctx=outctx)
+
+        clauses.compile_output(stmt.result, ctx=outctx)
+
+    with ctx.new() as ictx:
+        # FILTER and ORDER BY need to have the base result as a
+        # volatility ref.
+        clauses.setup_iterator_volatility(stmt.result, ctx=ictx)
+
+        # The FILTER clause.
+        if stmt.where is not None:
+            query.where_clause = astutils.extend_binop(
+                query.where_clause,
+                clauses.compile_filter_clause(
+                    stmt.where, stmt.where_card, ctx=ctx))
+
+        # The ORDER BY clause
+        if stmt.orderby is not None:
+            with ctx.new() as ictx:
+                query.sort_clause = clauses.compile_orderby_clause(
+                    stmt.orderby, ctx=ictx)
+
+    return query
+
+
+def compile_group(
+        stmt: irast.GroupStmt, *,
+        ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
+    with ctx.substmt() as sctx:
+        return _compile_group(stmt, ctx=sctx, parent_ctx=ctx)

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -352,7 +352,8 @@ def _find_rel_rvar(
         assert flavor == 'normal'
         var = rel.path_namespace.get((path_id, alt_aspect))
         if var is not None:
-            put_path_var(rel, path_id, var, aspect=aspect, env=env)
+            put_path_var(
+                rel, path_id, var, aspect=aspect, flavor=flavor, env=env)
             return src_aspect, None, var
 
     return src_aspect, rel_rvar, None
@@ -1086,14 +1087,15 @@ def _get_path_output(
         (src_path_id := path_id.src_path())
         and (src_rptr := src_path_id.rptr())
         and (
-            src_rptr.is_computable
-            or src_rptr.out_cardinality.is_multi()
+            src_rptr.real_material_ptr.out_cardinality.is_multi()
+            and not irtyputils.is_free_object(src_path_id.target)
         )
     ):
         # A value reference to Object.id is the same as a value
         # reference to the Object itself. (Though we want to only
         # apply this in the cases that process_set_as_path does this
-        # optimization, which means not for multi props.)
+        # optimization, which means not for multi props. We also always
+        # allow it for free objects.)
         src_path_id = path_id.src_path()
         assert src_path_id is not None
         id_output = maybe_get_path_output(rel, src_path_id,
@@ -1179,6 +1181,18 @@ def _get_path_output(
             if isinstance(ref, pgast.ColumnRef):
                 optional = ref.optional
                 is_packed_multi = ref.is_packed_multi
+
+            # group by will register a *subquery* as a path var
+            # for a packed group, and if we want to avoid losing
+            # track of whether is is multi, we need to figure that out.
+            if (
+                isinstance(ref, pgast.SelectStmt)
+                and flavor == 'packed'
+                and ref.packed_path_outputs
+                and (path_id, aspect) in ref.packed_path_outputs
+            ):
+                is_packed_multi = ref.packed_path_outputs[
+                    path_id, aspect].is_packed_multi
 
             if nullable and not allow_nullable:
                 assert isinstance(rel, pgast.SelectStmt), \

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -762,7 +762,7 @@ def maybe_get_scope_stmt(
 
 def set_to_array(
         path_id: irast.PathId, query: pgast.Query, *,
-        materializing: bool=False,
+        for_group_by: bool=False,
         ctx: context.CompilerContextLevel) -> pgast.Query:
     """Collapse a set into an array."""
     subrvar = pgast.RangeSubselect(
@@ -794,6 +794,22 @@ def set_to_array(
             val, path_id=path_id, env=ctx.env)
 
     pg_type = output.get_pg_type(path_id.target, ctx=ctx)
+
+    agg_filter_safe = True
+
+    if for_group_by:
+        # When doing this as part of a GROUP, the stuff being aggregated
+        # needs to actually appear *inside* of the aggregate call...
+        result.target_list = [pgast.ResTarget(val=val, ser_safe=val.ser_safe)]
+        val = result
+        try_collapse = astutils.collapse_query(val)
+        if isinstance(try_collapse, pgast.ColumnRef):
+            val = try_collapse
+        else:
+            agg_filter_safe = False
+
+        result = pgast.SelectStmt()
+
     orig_val = val
 
     if (path_id.is_array_path()
@@ -810,10 +826,18 @@ def set_to_array(
         agg_filter=(
             astutils.new_binop(orig_val, pgast.NullConstant(),
                                'IS DISTINCT FROM')
-            if orig_val.nullable else None
+            if orig_val.nullable and agg_filter_safe else None
         ),
         ser_safe=val.ser_safe,
     )
+
+    # If this is for a group by, and the body isn't just a column ref,
+    # then we need to remove NULLs after the fact.
+    if orig_val.nullable and not agg_filter_safe:
+        array_agg = pgast.FuncCall(
+            name=('array_remove',),
+            args=[array_agg, pgast.NullConstant()]
+        )
 
     agg_expr = pgast.CoalesceExpr(
         args=[

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1473,9 +1473,7 @@ def process_set_as_distinct(
         subrvar = relctx.rvar_for_rel(
             subqry, typeref=arg.typeref, lateral=True, ctx=subctx)
 
-    aspects = pathctx.list_path_aspects(subqry, arg.path_id, env=ctx.env)
-    relctx.include_rvar(
-        stmt, subrvar, ir_set.path_id, aspects=aspects, ctx=ctx)
+    relctx.include_rvar(stmt, subrvar, ir_set.path_id, ctx=ctx)
 
     value_var = pathctx.get_rvar_path_var(
         subrvar, ir_set.path_id, aspect='value', env=ctx.env)
@@ -2509,14 +2507,11 @@ def process_set_as_std_min_max(
 
         pathctx.put_path_id_map(newctx.rel, ir_set.path_id, ir_arg.path_id)
 
-    aspects = pathctx.list_path_aspects(
-        newctx.rel, ir_set.path_id, env=ctx.env)
-
     func_rvar = relctx.new_rel_rvar(ir_set, newctx.rel, ctx=ctx)
     relctx.include_rvar(stmt, func_rvar, ir_set.path_id,
-                        pull_namespace=False, aspects=aspects, ctx=ctx)
+                        pull_namespace=False, ctx=ctx)
 
-    return new_stmt_set_rvar(ir_set, stmt, aspects=aspects, ctx=ctx)
+    return new_stmt_set_rvar(ir_set, stmt, ctx=ctx)
 
 
 def _process_set_func_with_ordinality(

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -62,6 +62,7 @@ class ExprType(enum.IntEnum):
     Insert = enum.auto()
     Update = enum.auto()
     Delete = enum.auto()
+    Group = enum.auto()
 
     def is_update(self) -> bool:
         return self == ExprType.Update
@@ -70,7 +71,7 @@ class ExprType(enum.IntEnum):
         return self == ExprType.Insert
 
     def is_mutation(self) -> bool:
-        return self != ExprType.Select
+        return self != ExprType.Select and self != ExprType.Group
 
 
 TypeT = typing.TypeVar('TypeT', bound='Type')

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -1,0 +1,968 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2012-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os.path
+
+import edgedb
+
+from edb.testbase import server as tb
+
+
+class TestEdgeQLGroup(tb.QueryTestCase):
+    '''These tests are focused on using the internal GROUP statement.'''
+
+    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
+                          'issues.esdl')
+
+    SCHEMA_CARDS = os.path.join(os.path.dirname(__file__), 'schemas',
+                                'cards.esdl')
+
+    SETUP = [
+        os.path.join(os.path.dirname(__file__), 'schemas',
+                     'issues_setup.edgeql'),
+        'SET MODULE cards;',
+        os.path.join(os.path.dirname(__file__), 'schemas',
+                     'cards_setup.edgeql'),
+    ]
+
+    async def test_edgeql_group_simple_01(self):
+        await self.assert_query_result(
+            r'''
+            GROUP cards::Card {name} BY .element
+            ''',
+            tb.bag([
+                {
+                    "elements": tb.bag(
+                        [{"name": "Bog monster"}, {"name": "Giant turtle"}]),
+                    "key": {"element": "Water"}
+                },
+                {
+                    "elements": tb.bag([{"name": "Imp"}, {"name": "Dragon"}]),
+                    "key": {"element": "Fire"}
+                },
+                {
+                    "elements": tb.bag([{"name": "Dwarf"}, {"name": "Golem"}]),
+                    "key": {"element": "Earth"}
+                },
+                {
+                    "elements": tb.bag([
+                        {"name": "Sprite"},
+                        {"name": "Giant eagle"},
+                        {"name": "Djinn"}
+                    ]),
+                    "key": {"element": "Air"}
+                }
+            ])
+        )
+
+    async def test_edgeql_group_simple_02(self):
+        await self.assert_query_result(
+            r'''
+            SELECT (GROUP cards::Card {name} BY .element)
+            ''',
+            tb.bag([
+                {
+                    "elements": tb.bag(
+                        [{"name": "Bog monster"}, {"name": "Giant turtle"}]),
+                    "key": {"element": "Water"}
+                },
+                {
+                    "elements": tb.bag([{"name": "Imp"}, {"name": "Dragon"}]),
+                    "key": {"element": "Fire"}
+                },
+                {
+                    "elements": tb.bag([{"name": "Dwarf"}, {"name": "Golem"}]),
+                    "key": {"element": "Earth"}
+                },
+                {
+                    "elements": tb.bag([
+                        {"name": "Sprite"},
+                        {"name": "Giant eagle"},
+                        {"name": "Djinn"}
+                    ]),
+                    "key": {"element": "Air"}
+                }
+            ])
+        )
+
+    async def test_edgeql_group_simple_03(self):
+        # the compilation here is kind of a bummer; could we avoid an
+        # unnest?
+        await self.assert_query_result(
+            r'''
+            SELECT (GROUP cards::Card {name} BY .element)
+            FILTER .key.element != 'Air';
+            ''',
+            tb.bag([
+                {
+                    "elements": tb.bag(
+                        [{"name": "Bog monster"}, {"name": "Giant turtle"}]),
+                    "key": {"element": "Water"}
+                },
+                {
+                    "elements": tb.bag([{"name": "Imp"}, {"name": "Dragon"}]),
+                    "key": {"element": "Fire"}
+                },
+                {
+                    "elements": tb.bag([{"name": "Dwarf"}, {"name": "Golem"}]),
+                    "key": {"element": "Earth"}
+                },
+            ])
+        )
+
+    async def test_edgeql_group_simple_no_id_output_01(self):
+        # the implicitly injected id was making it into the output
+        # in native mode at one point
+        res = await self.con.query('GROUP cards::Card {name} BY .element')
+        el = tuple(tuple(res)[0].elements)[0]
+        self.assertNotIn("id := ", str(el))
+
+    async def test_edgeql_group_simple_unused_alias_01(self):
+        await self.con.query('''
+            WITH MODULE cards
+            SELECT (
+              GROUP Card
+              USING x := count(.owners), nowners := x,
+              BY CUBE (.element, nowners)
+            )
+        ''')
+
+    async def test_edgeql_group_process_select_01(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            SELECT (GROUP Card BY .element) {
+                element := .key.element,
+                cnt := count(.elements),
+            };
+            ''',
+            tb.bag([
+                {"cnt": 2, "element": "Water"},
+                {"cnt": 2, "element": "Fire"},
+                {"cnt": 2, "element": "Earth"},
+                {"cnt": 3, "element": "Air"}
+            ])
+        )
+
+    async def test_edgeql_group_process_select_02(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            SELECT (GROUP Card BY .element) {
+                element := .key.element,
+                cnt := count(.elements),
+            } FILTER .element != 'Water';
+            ''',
+            tb.bag([
+                {"cnt": 2, "element": "Fire"},
+                {"cnt": 2, "element": "Earth"},
+                {"cnt": 3, "element": "Air"},
+            ])
+        )
+
+    async def test_edgeql_group_process_select_03(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            SELECT (GROUP Card BY .element) {
+                element := .key.element,
+                cnt := count(.elements),
+            } ORDER BY .element;
+            ''',
+            [
+                {"cnt": 3, "element": "Air"},
+                {"cnt": 2, "element": "Earth"},
+                {"cnt": 2, "element": "Fire"},
+                {"cnt": 2, "element": "Water"},
+            ]
+        )
+
+    async def test_edgeql_group_process_for_01a(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            FOR g IN (GROUP Card BY .element) UNION (
+                element := g.key.element,
+                cnt := count(g.elements),
+            );
+            ''',
+            tb.bag([
+                {"cnt": 2, "element": "Water"},
+                {"cnt": 2, "element": "Fire"},
+                {"cnt": 2, "element": "Earth"},
+                {"cnt": 3, "element": "Air"},
+            ])
+        )
+
+    async def test_edgeql_group_process_select_04(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            SELECT (GROUP Card BY .element) {
+                cnt := count(.elements),
+            };
+            ''',
+            tb.bag([
+                {"cnt": 2}, {"cnt": 2}, {"cnt": 2}, {"cnt": 3}
+            ])
+        )
+
+    async def test_edgeql_group_process_for_01b(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            FOR g IN (SELECT (GROUP Card BY .element)) UNION (
+                element := g.key.element,
+                cnt := count(g.elements),
+            );
+            ''',
+            tb.bag([
+                {"cnt": 2, "element": "Water"},
+                {"cnt": 2, "element": "Fire"},
+                {"cnt": 2, "element": "Earth"},
+                {"cnt": 3, "element": "Air"}
+            ])
+        )
+
+    async def test_edgeql_group_process_for_01c(self):
+        await self.assert_query_result(
+            r'''
+            with module cards
+            for h in (group Card by .element) union (for g in h union (
+                element := g.key.element,
+                cnt := count(g.elements),
+            ));
+            ''',
+            tb.bag([
+                {"cnt": 2, "element": "Water"},
+                {"cnt": 2, "element": "Fire"},
+                {"cnt": 2, "element": "Earth"},
+                {"cnt": 3, "element": "Air"},
+            ])
+        )
+
+    async def test_edgeql_group_process_for_01d(self):
+        await self.assert_query_result(
+            r'''
+            with module cards
+            for g in (group Card by .element) union (for gi in 0 union (
+                element := g.key.element,
+                cst := sum(g.elements.cost + gi),
+            ));
+            ''',
+            tb.bag([
+                {"cst": 5, "element": "Water"},
+                {"cst": 6, "element": "Fire"},
+                {"cst": 4, "element": "Earth"},
+                {"cst": 7, "element": "Air"},
+            ])
+        )
+
+    async def test_edgeql_group_sets_01(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            GROUP Card {name}
+            USING nowners := count(.owners)
+            BY {.element, nowners};
+            ''',
+            tb.bag([
+                {
+                    "elements": [
+                        {"name": "Bog monster"}, {"name": "Giant turtle"}],
+                    "grouping": ["element"],
+                    "key": {"element": "Water", "nowners": None}
+                },
+                {
+                    "elements": [{"name": "Dragon"}, {"name": "Imp"}],
+                    "grouping": ["element"],
+                    "key": {"element": "Fire", "nowners": None}
+                },
+                {
+                    "elements": [{"name": "Dwarf"}, {"name": "Golem"}],
+                    "grouping": ["element"],
+                    "key": {"element": "Earth", "nowners": None}
+                },
+                {
+                    "elements": [
+                        {"name": "Djinn"},
+                        {"name": "Giant eagle"},
+                        {"name": "Sprite"},
+                    ],
+                    "grouping": ["element"],
+                    "key": {"element": "Air", "nowners": None}
+                },
+                {
+                    "elements": [{"name": "Golem"}],
+                    "grouping": ["nowners"],
+                    "key": {"element": None, "nowners": 3}
+                },
+                {
+                    "elements": [
+                        {"name": "Bog monster"}, {"name": "Giant turtle"}],
+                    "grouping": ["nowners"],
+                    "key": {"element": None, "nowners": 4}
+                },
+                {
+                    "elements": [
+                        {"name": "Djinn"},
+                        {"name": "Dragon"},
+                        {"name": "Dwarf"},
+                        {"name": "Giant eagle"},
+                        {"name": "Sprite"},
+                    ],
+                    "grouping": ["nowners"],
+                    "key": {"element": None, "nowners": 2}
+                },
+                {
+                    "elements": [{"name": "Imp"}],
+                    "grouping": ["nowners"],
+                    "key": {"element": None, "nowners": 1}
+                }
+            ]),
+            sort={'elements': lambda x: x['name']},
+        )
+
+    async def test_edgeql_group_sets_02(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            GROUP Card
+            USING nowners := count(.owners)
+            BY {.element, nowners};
+            ''',
+            tb.bag([
+                {
+                    "elements": [{"id": str}] * 2,
+                    "grouping": ["element"],
+                    "key": {"element": "Water", "nowners": None}
+                },
+                {
+                    "elements": [{"id": str}] * 2,
+                    "grouping": ["element"],
+                    "key": {"element": "Fire", "nowners": None}
+                },
+                {
+                    "elements": [{"id": str}] * 2,
+                    "grouping": ["element"],
+                    "key": {"element": "Earth", "nowners": None}
+                },
+                {
+                    "elements": [{"id": str}] * 3,
+                    "grouping": ["element"],
+                    "key": {"element": "Air", "nowners": None}
+                },
+                {
+                    "elements": [{"id": str}] * 1,
+                    "grouping": ["nowners"],
+                    "key": {"element": None, "nowners": 3}
+                },
+                {
+                    "elements": [{"id": str}] * 2,
+                    "grouping": ["nowners"],
+                    "key": {"element": None, "nowners": 4}
+                },
+                {
+                    "elements": [{"id": str}] * 5,
+                    "grouping": ["nowners"],
+                    "key": {"element": None, "nowners": 2}
+                },
+                {
+                    "elements": [{"id": str}] * 1,
+                    "grouping": ["nowners"],
+                    "key": {"element": None, "nowners": 1}
+                }
+            ]),
+        )
+
+    async def test_edgeql_group_grouping_sets_01(self):
+        res = [
+            {"grouping": [], "num": 9},
+            {"grouping": ["element"], "num": int},
+            {"grouping": ["element"], "num": int},
+            {"grouping": ["element"], "num": int},
+            {"grouping": ["element"], "num": int},
+            {"grouping": ["element", "nowners"], "num": int},
+            {"grouping": ["element", "nowners"], "num": int},
+            {"grouping": ["element", "nowners"], "num": int},
+            {"grouping": ["element", "nowners"], "num": int},
+            {"grouping": ["element", "nowners"], "num": int},
+            {"grouping": ["element", "nowners"], "num": int},
+            {"grouping": ["nowners"], "num": int},
+            {"grouping": ["nowners"], "num": int},
+            {"grouping": ["nowners"], "num": int},
+            {"grouping": ["nowners"], "num": int},
+        ]
+
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            SELECT (
+              GROUP Card
+              USING nowners := count(.owners)
+              BY CUBE (.element, nowners)
+            ) {
+                num := count(.elements),
+                grouping
+            } ORDER BY array_agg((SELECT _ := .grouping ORDER BY _))
+            ''',
+            res
+        )
+
+        # With an extra SELECT
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            SELECT (SELECT (
+              GROUP Card
+              USING nowners := count(.owners)
+              BY CUBE (.element, nowners)
+            ) {
+                num := count(.elements),
+                grouping
+            }) ORDER BY array_agg((SELECT _ := .grouping ORDER BY _))
+            ''',
+            res
+        )
+
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            SELECT (
+              GROUP Card
+              USING x := count(.owners), nowners := x,
+              BY CUBE (.element, nowners)
+            ) {
+                num := count(.elements),
+                grouping
+            } ORDER BY array_agg((SELECT _ := .grouping ORDER BY _))
+            ''',
+            res
+        )
+
+    async def test_edgeql_group_grouping_sets_02(self):
+        # we just care about the grouping names we generate
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            SELECT (
+              WITH W := (SELECT Card { name } LIMIT 1)
+              GROUP W
+              USING nowners := count(.owners)
+              BY CUBE (.element, .cost, nowners)
+            ) { grouping }
+            ORDER BY (
+                count(.grouping),
+                array_agg((SELECT _ := .grouping ORDER BY _))
+            )
+            ''',
+            [
+                {"grouping": set()},
+                {"grouping": {"cost"}},
+                {"grouping": {"element"}},
+                {"grouping": {"nowners"}},
+                {"grouping": {"cost", "element"}},
+                {"grouping": {"cost", "nowners"}},
+                {"grouping": {"element", "nowners"}},
+                {"grouping": {"element", "cost", "nowners"}}
+            ]
+        )
+
+    async def test_edgeql_group_for_01(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            FOR g in (GROUP Card BY .element) UNION (
+                WITH U := g.elements,
+                SELECT U {
+                    name,
+                    cost_ratio := .cost / math::mean(g.elements.cost)
+            });
+            ''',
+            tb.bag([
+                {"cost_ratio": 0.42857142857142855, "name": "Sprite"},
+                {"cost_ratio": 0.8571428571428571, "name": "Giant eagle"},
+                {"cost_ratio": 1.7142857142857142, "name": "Djinn"},
+                {"cost_ratio": 0.5, "name": "Dwarf"},
+                {"cost_ratio": 1.5, "name": "Golem"},
+                {"cost_ratio": 0.3333333333333333, "name": "Imp"},
+                {"cost_ratio": 1.6666666666666667, "name": "Dragon"},
+                {"cost_ratio": 0.8, "name": "Bog monster"},
+                {"cost_ratio": 1.2, "name": "Giant turtle"}
+            ])
+        )
+
+    async def test_edgeql_group_simple_old_01(self):
+        await self.assert_query_result(
+            r'''
+                for g in (group User by .name)
+                union count(g.elements.<owner);
+            ''',
+            {4, 2},
+        )
+
+    async def test_edgeql_group_semi_join_01(self):
+        # this is useless, but shouldn't crash
+        await self.assert_query_result(
+            r'''
+                select (group User by .name).elements
+            ''',
+            [{}, {}],
+        )
+
+    async def test_edgeql_group_by_tuple_01(self):
+        await self.assert_query_result(
+            r"""
+                GROUP Issue
+                USING B := (Issue.status.name, Issue.time_estimate)
+                # This tuple will be {} for Issues lacking
+                # time_estimate. So effectively we're expecting only 2
+                # subsets, grouped by:
+                # - {}
+                # - ('Open', 3000)
+                BY B
+            """,
+            tb.bag([
+                {
+                    'key': {'B': ["Open", 3000]},
+                    'elements': [{}] * 1,
+                },
+                {
+                    'key': {'B': None},
+                    'elements': [{}] * 3,
+                },
+            ]),
+        )
+
+    async def test_edgeql_group_by_group_by_01(self):
+        res = tb.bag([
+            {
+                "elements": tb.bag([
+                    {
+                        "agrouping": ["element"],
+                        "key": {"element": "Water", "nowners": None},
+                        "num": 2
+                    },
+                    {
+                        "agrouping": ["element"],
+                        "key": {"element": "Fire", "nowners": None},
+                        "num": 2
+                    },
+                    {
+                        "agrouping": ["element"],
+                        "key": {"element": "Earth", "nowners": None},
+                        "num": 2
+                    },
+                    {
+                        "agrouping": ["element"],
+                        "key": {"element": "Air", "nowners": None},
+                        "num": 3
+                    }
+                ]),
+                "grouping": ["agrouping"],
+                "key": {"agrouping": ["element"]}
+            },
+            {
+                "elements": tb.bag([
+                    {
+                        "agrouping": ["nowners"],
+                        "key": {"element": None, "nowners": 3},
+                        "num": 1
+                    },
+                    {
+                        "agrouping": ["nowners"],
+                        "key": {"element": None, "nowners": 4},
+                        "num": 2
+                    },
+                    {
+                        "agrouping": ["nowners"],
+                        "key": {"element": None, "nowners": 2},
+                        "num": 5
+                    },
+                    {
+                        "agrouping": ["nowners"],
+                        "key": {"element": None, "nowners": 1},
+                        "num": 1
+                    }
+                ]),
+                "grouping": ["agrouping"],
+                "key": {"agrouping": ["nowners"]}
+            }
+        ])
+
+        qry = r'''
+            WITH MODULE cards
+            GROUP (
+              SELECT (
+                GROUP Card
+                USING nowners := count(.owners)
+                BY {.element, nowners}
+              ) {
+                  num := count(.elements),
+                  key: {element, nowners},
+                  agrouping := array_agg((SELECT _ := .grouping ORDER BY _))
+              }
+            ) BY .agrouping
+        '''
+
+        await self.assert_query_result(qry, res)
+
+        # Wrapping in a select caused trouble
+        await self.assert_query_result(f'SELECT ({qry})', res)
+
+    async def test_edgeql_group_by_group_by_02(self):
+        res = tb.bag([
+            {
+                "elements": tb.bag([
+                    {"key": {"cost": 1, "element": None}, "n": 3},
+                    {"key": {"cost": 2, "element": None}, "n": 2},
+                    {"key": {"cost": 3, "element": None}, "n": 2},
+                    {"key": {"cost": 4, "element": None}, "n": 1},
+                    {"key": {"cost": 5, "element": None}, "n": 1},
+                ]),
+                "key": {"grouping": ["cost"]}
+            },
+            {
+                "elements": tb.bag([
+                    {"key": {"cost": None, "element": "Water"}, "n": 2},
+                    {"key": {"cost": None, "element": "Earth"}, "n": 2},
+                    {"key": {"cost": None, "element": "Fire"}, "n": 2},
+                    {"key": {"cost": None, "element": "Air"}, "n": 3},
+                ]),
+                "key": {"grouping": ["element"]}
+            }
+        ])
+
+        await self.assert_query_result(
+            '''
+            WITH MODULE cards, G := (
+            GROUP (
+              GROUP Card
+              BY {.element, .cost}
+            )
+            USING grouping := array_agg(.grouping)
+            BY grouping),
+            SELECT G {
+                key: {grouping},
+                elements: { n := count(.elements), key: {element, cost}}
+            }
+            ''',
+            res,
+        )
+
+        await self.assert_query_result(
+            '''
+            WITH MODULE cards,
+            SELECT (
+            GROUP (
+              GROUP Card
+              BY {.element, .cost}
+            )
+            USING grouping := array_agg(.grouping)
+            BY grouping) {
+                key: {grouping},
+                elements: { n := count(.elements), key: {element, cost}}
+            }
+            ''',
+            res,
+        )
+
+    async def _test_edgeql_group_by_group_by_03(self, qry):
+        res = tb.bag([
+            {
+                "el": "Water",
+                "groups": tb.bag([
+                    {"elements": [{"cost": 2, "name": "Bog monster"}],
+                     "even": 0},
+                    {"elements": [{"cost": 3, "name": "Giant turtle"}],
+                     "even": 1}
+                ])
+            },
+            {
+                "el": "Fire",
+                "groups": [
+                    {
+                        "elements": tb.bag([
+                            {"cost": 1, "name": "Imp"},
+                            {"cost": 5, "name": "Dragon"}
+                        ]),
+                        "even": 1
+                    }
+                ]
+            },
+            {
+                "el": "Earth",
+                "groups": [
+                    {
+                        "elements": tb.bag([
+                            {"cost": 1, "name": "Dwarf"},
+                            {"cost": 3, "name": "Golem"}
+                        ]),
+                        "even": 1
+                    }
+                ]
+            },
+            {
+                "el": "Air",
+                "groups": tb.bag([
+                    {
+                        "elements": tb.bag([
+                            {"cost": 2, "name": "Giant eagle"},
+                            {"cost": 4, "name": "Djinn"}
+                        ]),
+                        "even": 0
+                    },
+                    {"elements": [{"cost": 1, "name": "Sprite"}], "even": 1}
+                ])
+            }
+        ])
+
+        await self.assert_query_result(qry, res)
+
+    async def test_edgeql_group_by_group_by_03a(self):
+        await self._test_edgeql_group_by_group_by_03(
+            '''
+            with module cards
+            select (group Card by .element) {
+                el := .key.element,
+                groups := (
+                  with z := (group .elements using x := .cost%2 by x)
+                  for z in z union (
+                    even := z.key.x,
+                    elements := array_agg(z.elements{name, cost}),
+                  )
+                )
+            };
+            '''
+        )
+
+    async def test_edgeql_group_by_group_by_03b(self):
+        await self._test_edgeql_group_by_group_by_03(
+            '''
+            with module cards
+            select (group Card by .element) {
+                el := .key.element,
+                groups := (
+                  with z := (group .elements using x := .cost%2 by x)
+                  select (
+                    even := z.key.x,
+                    elements := array_agg(z.elements{name, cost}),
+                  )
+                )
+            };
+            '''
+        )
+
+    async def test_edgeql_group_by_group_by_03c(self):
+        await self._test_edgeql_group_by_group_by_03(
+            '''
+            with module cards
+            select (group Card by .element) {
+                el := .key.element,
+                groups := (
+                  for z in (group .elements using x := .cost%2 by x) union (
+                    even := z.key.x,
+                    elements := array_agg(z.elements{name, cost}),
+                  )
+                )
+            };
+            '''
+        )
+
+    async def test_edgeql_group_id_errors(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError,
+            r"may not name a grouping alias 'id'"
+        ):
+            await self.con.execute('''
+                group cards::Card{name} using id := .id by id
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError,
+            r"may not group by a field named id",
+            _position=44,
+        ):
+            await self.con.execute('''
+                group cards::Card{name} by .id
+            ''')
+
+    async def test_edgeql_group_tuple_01(self):
+        await self.con.execute('''
+            create type tup {
+                create multi property tup -> tuple<int64, int64> ;
+            };
+            insert tup { tup := {(1, 1), (1, 2), (1, 1), (2, 1)} };
+        ''')
+
+        await self.assert_query_result(
+            '''
+                with X := tup.tup,
+                group X using z := X by z;
+            ''',
+            tb.bag([
+                {"elements": [[1, 2]], "key": {"z": [1, 2]}},
+                {"elements": [[2, 1]], "key": {"z": [2, 1]}},
+                {"elements": tb.bag([[1, 1], [1, 1]]), "key": {"z": [1, 1]}}
+            ])
+        )
+
+    async def test_edgeql_group_tuple_02(self):
+        await self.assert_query_result(
+            '''
+                with X := {(1, 1), (1, 2), (1, 1), (2, 1)},
+                group X using z := X by z;
+            ''',
+            tb.bag([
+                {"elements": [[1, 2]], "key": {"z": [1, 2]}},
+                {"elements": [[2, 1]], "key": {"z": [2, 1]}},
+                {"elements": tb.bag([[1, 1], [1, 1]]), "key": {"z": [1, 1]}}
+            ])
+        )
+
+    async def test_edgeql_group_semijoin_group_01(self):
+        await self.assert_query_result(
+            '''
+                with module cards
+                group (
+                    select (group Card{name, cost} by .element)
+                    order by .key.element limit 1
+                ).elements by .cost;
+            ''',
+            tb.bag([
+                {
+                    "elements": [{"cost": 1, "name": "Sprite"}],
+                    "grouping": ["cost"],
+                    "key": {"cost": 1}
+                },
+                {
+                    "elements": [{"cost": 2, "name": "Giant eagle"}],
+                    "grouping": ["cost"],
+                    "key": {"cost": 2}
+                },
+                {
+                    "elements": [{"cost": 4, "name": "Djinn"}],
+                    "grouping": ["cost"],
+                    "key": {"cost": 4}
+                }
+            ])
+        )
+
+    async def test_edgeql_group_simple_agg_01(self):
+        await self.assert_query_result(
+            r'''
+                with module cards
+                select (group Card by .element) {
+                    el := .key.element, cs := array_agg(.elements)
+                };
+            ''',
+            tb.bag([
+                {'el': "Water", 'cs': [{'id': str}] * 2},
+                {'el': "Fire", 'cs': [{'id': str}] * 2},
+                {'el': "Earth", 'cs': [{'id': str}] * 2},
+                {'el': "Air", 'cs': [{'id': str}] * 3},
+            ]),
+        )
+
+    async def test_edgeql_group_simple_agg_02(self):
+        await self.assert_query_result(
+            r'''
+                with module cards
+                select (group Card by .element) {
+                    el := .key.element, cs := array_agg(.elements { name })
+                };
+            ''',
+            tb.bag([
+                {
+                    "cs": tb.bag(
+                        [{"name": "Bog monster"}, {"name": "Giant turtle"}]),
+                    "el": "Water"
+                },
+                {
+                    "cs": tb.bag([{"name": "Imp"}, {"name": "Dragon"}]),
+                    "el": "Fire",
+                },
+                {
+                    "cs": tb.bag([{"name": "Dwarf"}, {"name": "Golem"}]),
+                    "el": "Earth",
+                },
+                {
+                    "cs": tb.bag([
+                        {"name": "Sprite"},
+                        {"name": "Giant eagle"},
+                        {"name": "Djinn"}
+                    ]),
+                    "el": "Air",
+                }
+            ])
+        )
+
+    async def test_edgeql_group_agg_with_free_ref_01(self):
+        out = await self.con.query(r'''
+            with module cards
+            select (group Card by .element) {
+                id, els := array_agg((.id, .elements.name))
+            };
+        ''')
+
+        for obj in out:
+            for el in obj.els:
+                self.assertEqual(obj.id, el[0])
+
+    async def test_edgeql_group_agg_multi_01(self):
+        await self.assert_query_result(
+            '''
+                with module cards
+                for g in (group Card BY .element) union (
+                    array_agg(g.elements.name ++ {"!", "?"})
+                );
+            ''',
+            tb.bag([
+                {"Bog monster!", "Bog monster?",
+                 "Giant turtle!", "Giant turtle?"},
+                {"Imp!", "Imp?", "Dragon!", "Dragon?"},
+                {"Dwarf!", "Dwarf?", "Golem!", "Golem?"},
+                {"Sprite!", "Sprite?", "Giant eagle!",
+                 "Giant eagle?", "Djinn!", "Djinn?"}
+            ])
+        )
+
+    async def test_edgeql_group_agg_multi_02(self):
+        await self.assert_query_result(
+            '''
+                with module cards
+                for g in (group Card BY .element) union (
+                    count((Award { multi z := g.elements.name }.z))
+                );          ''',
+            tb.bag([6, 6, 6, 9]),
+        )
+
+    async def test_edgeql_group_agg_multi_03(self):
+        await self.assert_query_result(
+            '''
+                for g in (group BooleanTest by .val) union (
+                    array_agg(g.elements.tags)
+                );
+            ''',
+            tb.bag([
+                ["red"],
+                [],
+                tb.bag(["red", "green"]),
+                tb.bag(["red", "black"]),
+            ]),
+        )

--- a/tests/test_edgeql_internal_group.py
+++ b/tests/test_edgeql_internal_group.py
@@ -22,7 +22,6 @@ from edb.testbase import server as tb
 from edb.tools import test
 
 
-@test.not_implemented('GROUP statement is not yet implemented')
 class TestEdgeQLGroupInternal(tb.QueryTestCase):
     '''These tests are focused on using the internal GROUP statement.'''
 
@@ -148,10 +147,6 @@ class TestEdgeQLGroupInternal(tb.QueryTestCase):
             [1, 1, 1],
         )
 
-    @test.xfail('''
-        doing this array_agg misses shapes
-        ... but the real equivalent works
-    ''')
     async def test_edgeql_igroup_simple_09(self):
         await self.assert_query_result(
             r'''
@@ -194,10 +189,6 @@ class TestEdgeQLGroupInternal(tb.QueryTestCase):
             ]),
         )
 
-    @test.xfail('''
-        doing this array_agg misses shapes
-        ... but the real equivalent works
-    ''')
     async def test_edgeql_igroup_simple_bare_02(self):
         await self.assert_query_result(
             r'''
@@ -617,7 +608,6 @@ class TestEdgeQLGroupInternal(tb.QueryTestCase):
                     ],
                 }
             ],
-            # XXX: Prevent spurious successes
             always_typenames=True,
         )
 
@@ -1083,7 +1073,7 @@ class TestEdgeQLGroupInternal(tb.QueryTestCase):
 
     async def test_edgeql_igroup_by_multiple_07b(self):
         # The tricky part here is the reference to Card in both parts,
-        # which are separate. XXX: Wait, is that what we want?
+        # which are separate.
         await self.assert_query_result(
             r"""
                 WITH MODULE cards


### PR DESCRIPTION
This is mostly an implementation of `FOR GROUP`, since we already have
code for compiling real `GROUP` to `FOR GROUP`.

The general case materializes the group. As an optimization for common
aggregation cases, we find calls to aggregate functions that reference
the group and compile them separately and included them in the
grouping output.