### PR TITLE
Fix a collection of json casting bugs

### DIFF
--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -124,6 +124,11 @@ class CompilerContextLevel(compiler.ContextLevel):
     #: directly exposed to the output of the statement.
     expr_exposed: Optional[bool]
 
+    #: A hack that indicates a tuple element that should be treated as
+    #: exposed. This enables us to treat 'bar' in (foo, bar).1 as exposed,
+    #: which eta-expansion and some casts rely on.
+    expr_exposed_tuple_cheat: Optional[irast.TupleElement]
+
     #: Expression to use to force SQL expression volatility in this context
     #: (Delayed with a lambda to avoid inserting it when not used.)
     volatility_ref: Tuple[
@@ -231,6 +236,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.materializing = frozenset()
 
             self.expr_exposed = None
+            self.expr_exposed_tuple_cheat = None
             self.volatility_ref = ()
             self.current_insert_path_id = None
 
@@ -268,6 +274,7 @@ class CompilerContextLevel(compiler.ContextLevel):
             self.materializing = prevlevel.materializing
 
             self.expr_exposed = prevlevel.expr_exposed
+            self.expr_exposed_tuple_cheat = prevlevel.expr_exposed_tuple_cheat
             self.volatility_ref = prevlevel.volatility_ref
             self.current_insert_path_id = prevlevel.current_insert_path_id
 

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -2335,6 +2335,42 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 r"""SELECT <tuple<json, json>> to_json('[3000]')"""
             )
 
+    async def test_edgeql_casts_json_13(self):
+        await self.assert_query_result(
+            r'''
+                select <array<json>>to_json('null')
+            ''',
+            [],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select <array<str>>to_json('null')
+            ''',
+            [],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select <array<int64>>json_get(to_json('{}'), 'foo')
+            ''',
+            [],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select <tuple<str>>to_json('null')
+            ''',
+            [],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select <tuple<json>>to_json('null')
+            ''',
+            [],
+        )
+
     async def test_edgeql_casts_assignment_01(self):
         async with self._run_and_rollback():
             await self.con.execute(r"""


### PR DESCRIPTION
* Produce empty sets when a toplevel null is cast to an array or tuple
 * Force a NULL check on casts to array<json>, where previously we
   could spuriously produce an empty array instead of an empty set.

Fixing the latter without causing further trouble involved fixing the
exposedness handling of indirections on tuple literals.

Fixes #3671.