### PR TITLE
Don't reverse the order of large set literals/union chains

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -200,7 +200,7 @@ def compile_Set(
             bigunion = _balance(
                 elements,
                 lambda l, r, c: qlast.SetConstructorOp(
-                    left=l, right=r, context=c),
+                    left=l, right=r, rebalanced=True, context=c),
                 expr.context
             )
             return dispatch.compile(bigunion, ctx=ctx)
@@ -697,11 +697,11 @@ def flatten_set(expr: qlast.Set) -> List[qlast.Expr]:
 def collect_binop(expr: qlast.BinOp) -> List[qlast.Expr]:
     elements = []
 
-    stack = [expr.left, expr.right]
+    stack = [expr.right, expr.left]
     while stack:
         el = stack.pop()
         if isinstance(el, qlast.BinOp) and el.op == expr.op:
-            stack.extend([el.left, el.right])
+            stack.extend([el.right, el.left])
         else:
             elements.append(el)
 

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -6316,6 +6316,25 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
         assert len(res) == 100
 
+    async def test_edgeql_select_set_literal_in_order(self):
+        # *Technically speaking*, we don't necessarily promise
+        # semantically that a set literal's elements be returned in
+        # order. In practice, we want to, though.
+
+        # Test for a range of lengths
+        for n in (2, 4, 10, 25):
+            s = list(range(n))
+            await self.assert_query_result(
+                f"SELECT {set(s)}",
+                s
+            )
+
+            us = ' union '.join(str(i) for i in s)
+            await self.assert_query_result(
+                f"SELECT {us}",
+                s
+            )
+
     async def test_edgeql_select_shape_on_scalar(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,


### PR DESCRIPTION
The issue here is that the explicit iterative traversal accidentally
went right-to-left instead of left-to-right and that because
SetConstructorOp has an op field that is set to `UNION`, it got
rebalanced a *second* time.