### PR TITLE
Produce an error instead of malformed SQL on `insert foo { name }`

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -536,12 +536,11 @@ def _normalize_view_ptr_expr(
     ptrname = lexpr.ptr.name
 
     compexpr: Optional[qlast.Expr] = shape_el.compexpr
-    if compexpr is None and is_mutation and shape_el.elements:
-        # Short shape form in INSERT or UPDATE, e.g
-        #     INSERT Foo { bar: Spam { name := 'name' }}
-        # is prohibited.
-        raise errors.EdgeQLSyntaxError(
-            "unexpected ':'", context=steps[-1].context)
+    if compexpr is None and is_mutation:
+        raise errors.QueryError(
+            "mutation queries must specify values with ':='",
+            context=steps[-1].context,
+        )
 
     ptrcls: Optional[s_pointers.Pointer]
 

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -68,6 +68,15 @@ class TestInsert(tb.QueryTestCase):
                 };
             ''')
 
+    async def test_edgeql_insert_fail_4(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            r"mutation queries must specify values with ':='",
+        ):
+            await self.con.execute('''
+                INSERT Person { name };
+            ''')
+
     async def test_edgeql_insert_simple_01(self):
         await self.con.execute(r"""
             INSERT InsertTest {

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -3396,8 +3396,9 @@ class TestUpdate(tb.QueryTestCase):
 
     async def test_edgeql_update_subnavigate_01(self):
         with self.assertRaisesRegex(
-                edgedb.EdgeQLSyntaxError,
-                "unexpected ':'"):
+            edgedb.QueryError,
+            r"mutation queries must specify values with ':='",
+        ):
             await self.con.execute('''
                 UPDATE UpdateTest
                 SET {


### PR DESCRIPTION
We produced an error for the `insert foo { bar: { name } }` case,
but not `insert foo { name }`. I changed the error from the former
to match the error message I wrote for the latter, since I thought
that syntax error wasn't particularly helpful.

Fixes #3647.