### PR TITLE
Fix json -> array<json> cast in stdlib

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_03_18_00_00
+EDGEDB_CATALOG_VERSION = 2022_03_28_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/lib/std/30-jsonfuncs.edgeql
+++ b/edb/lib/std/30-jsonfuncs.edgeql
@@ -241,12 +241,8 @@ CREATE CAST FROM std::json TO anytuple {
 CREATE CAST FROM std::json TO array<json> {
     SET volatility := 'Immutable';
     USING SQL $$
-    SELECT CASE jsonb_typeof(val)
-    WHEN 'null' THEN NULL
-    ELSE
-        (SELECT array_agg(j)
-         FROM jsonb_array_elements(val) AS j)
-    END
+    SELECT array_agg(j)
+    FROM jsonb_array_elements(nullif(val, 'null'::jsonb)) as j;
     $$;
 };
 

--- a/edb/lib/std/30-jsonfuncs.edgeql
+++ b/edb/lib/std/30-jsonfuncs.edgeql
@@ -241,8 +241,12 @@ CREATE CAST FROM std::json TO anytuple {
 CREATE CAST FROM std::json TO array<json> {
     SET volatility := 'Immutable';
     USING SQL $$
-        SELECT array_agg(j)
-        FROM jsonb_array_elements(val) AS j
+    SELECT CASE jsonb_typeof(val)
+    WHEN 'null' THEN NULL
+    ELSE
+        (SELECT array_agg(j)
+         FROM jsonb_array_elements(val) AS j)
+    END
     $$;
 };
 

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -204,21 +204,6 @@ def compile_BooleanConstant(
     )
 
 
-def _json_to_json_array_cast(
-        arg: pgast.BaseExpr, res: pgast.BaseExpr) -> pgast.BaseExpr:
-
-    return pgast.CaseExpr(
-        arg=pgast.FuncCall(name=('jsonb_typeof',), args=[arg]),
-        args=[
-            pgast.CaseWhen(
-                expr=pgast.StringConstant(val='null'),
-                result=pgast.NullConstant()
-            )
-        ],
-        defresult=res,
-    )
-
-
 @dispatch.compile.register(irast.TypeCast)
 def compile_TypeCast(
         expr: irast.TypeCast, *,
@@ -254,13 +239,6 @@ def compile_TypeCast(
 
     else:
         raise errors.UnsupportedFeatureError('cast not supported')
-
-    # HACK: the cast from json to array<json> in the stdlib produces
-    # an error on the 'null' case when it ought to return an empty
-    # set. Since we can't make stdlib changes in point releases,
-    # fix up the code on the compiler side.
-    if str(expr.cast_name) == 'std::std|cast@std|json@array<std||json>':
-        res = _json_to_json_array_cast(pg_expr, res)
 
     if expr.cardinality_mod is qlast.CardinalityModifier.Required:
         res = pgast.FuncCall(


### PR DESCRIPTION
This bug was fixed in #3676, but via a compiler hack that was easily
cherry-pickable to 1.x. Now we can just fix it in the library.