### PR TITLE
Check that index expressions are immutable

### DIFF
--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -312,6 +312,12 @@ class IndexCommand(
                     f'the index expression where only singletons '
                     f'are allowed')
 
+            if expr.irast.volatility != qltypes.Volatility.Immutable:
+                raise errors.SchemaDefinitionError(
+                    f'index expressions must be immutable',
+                    context=value.qlast.context,
+                )
+
             return expr
         else:
             return super().compile_expr_field(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -10392,6 +10392,23 @@ type default::Foo {
                 }
             """)
 
+    async def test_edgeql_ddl_index_04(self):
+        with self.assertRaisesRegex(
+            edgedb.SchemaDefinitionError,
+            r"index expressions must be immutable"
+        ):
+            await self.con.execute(r"""
+                create function f(s: str) -> str {
+                    set volatility := "stable";
+                    using (s)
+                };
+
+                create type Bar {
+                    create property x -> str;
+                    create index on (f(.x));
+                };
+            """)
+
     async def test_edgeql_ddl_errors_01(self):
         await self.con.execute('''
             CREATE TYPE Err1 {


### PR DESCRIPTION
This requires also having volatility inference consider properties of
objects marked as singletons to be immutable; indexes can't call
STABLE functions but can of course access the table.

Fixes the ISE bug in #3679.