### PR TITLE
Fix some inheritance issues with renames and expr refs

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2021,7 +2021,11 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                         assert isinstance(value, s_expr.Expression)
                         # Strip the "compiled" out of the expression
                         value = s_expr.Expression.not_compiled(value)
-                        if fixer:
+                        # We don't run the fixer on inherited fields because
+                        # they can't have changed (and because running it
+                        # on inherited constraint finalexprs breaks
+                        # the extra parens in it...)
+                        if fixer and not ref.field_is_inherited(schema, fn):
                             with obj_cmd.new_context(schema, context, obj):
                                 value = fixer(
                                     schema, cmd_create, fn, context, value)

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1912,7 +1912,12 @@ class AlterPointer(
 
         assert isinstance(expression.irast, irast.Statement)
         target = expression.irast.stype
-        self.set_attribute_value('target', target)
+        self.set_attribute_value(
+            'target',
+            target,
+            inherited=pointer.field_is_inherited(schema, 'target'),
+            computed=pointer.field_is_computed(schema, 'target'),
+        )
 
 
 class DeletePointer(

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -10891,3 +10891,30 @@ class TestEdgeQLDataMigrationNonisolated(EdgeQLDataMigrationTestCase):
             with module test
             delete Tgt;
         """)
+
+    async def test_edgeql_migration_rename_with_stuff_01(self):
+        await self.migrate(
+            r"""
+                type Base {
+                        property x -> str;
+                        property xbang := .x ++ "!";
+                }
+
+                type NamedObject extending Base {
+                        required property foo -> str;
+                }
+            """
+        )
+
+        await self.migrate(
+            r"""
+                type Base {
+                        property x -> str;
+                        property xbang := .x ++ "!";
+                }
+
+                type ReNamedObject extending Base {
+                        required property foo -> str;
+                }
+            """
+        )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -6914,6 +6914,106 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             """
         ])
 
+    def test_schema_migrations_rename_with_stuff_01(self):
+        self._assert_migration_equivalence([
+            r"""
+                type Base {
+                        property x -> str;
+                        property xbang := .x ++ "!";
+                }
+
+                type NamedObject extending Base {
+                        required property foo -> str;
+                }
+            """,
+            r"""
+                type Base {
+                        property x -> str;
+                        property xbang := .x ++ "!";
+                }
+
+                type ReNamedObject extending Base {
+                        required property foo -> str;
+                }
+            """
+        ])
+
+    def test_schema_migrations_rename_with_stuff_02(self):
+        self._assert_migration_equivalence([
+            r"""
+                type Base {
+                        property x -> str;
+                        index on (.x);
+                }
+
+                type NamedObject extending Base {
+                        required property foo -> str;
+                }
+            """,
+            r"""
+                type Base {
+                        property x -> str;
+                        index on (.x);
+                }
+
+                type ReNamedObject extending Base {
+                        required property foo -> str;
+                }
+            """
+        ])
+
+    def test_schema_migrations_rename_with_stuff_03(self):
+        self._assert_migration_equivalence([
+            r"""
+                type Base {
+                        property x -> str;
+                        property z -> str {
+                            constraint expression on (__subject__ != "lol");
+                        };
+                }
+
+                type NamedObject extending Base {
+                        required property foo -> str;
+                }
+            """,
+            r"""
+                type Base {
+                        property x -> str;
+                        property z -> str {
+                            constraint expression on (__subject__ != "lol");
+                        };
+                }
+
+                type ReNamedObject extending Base {
+                        required property foo -> str;
+                }
+            """
+        ])
+
+    def test_schema_migrations_rename_with_stuff_04(self):
+        self._assert_migration_equivalence([
+            r"""
+                type Base {
+                        property x -> str;
+                        constraint expression on ((.x != "lol"));
+                }
+
+                type NamedObject extending Base {
+                        required property foo -> str;
+                }
+            """,
+            r"""
+                type Base {
+                        property x -> str;
+                        constraint expression on ((.x != "lol"));
+                }
+
+                type ReNamedObject extending Base {
+                        required property foo -> str;
+                }
+            """
+        ])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
* Preserve computed/inherited types for computed pointers
 * Avoid mangling inherited attributes with the expression fixer

Fixes #3620