### PR TITLE
Fix type filters in GraphQL.

### DIFF
--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -662,7 +662,14 @@ class GQLCoreSchema:
                 # Aliased types ignore their ancestors in order to
                 # allow all their fields appear properly in the
                 # filters.
-                if not tgt.is_view(self.edb_schema):
+                #
+                # If the target is not a view, but this is computed,
+                # so we cannot later override it, thus we can use the
+                # type as is.
+                if (
+                    not tgt.is_view(self.edb_schema) and
+                    not ptr.is_pure_computable(self.edb_schema)
+                ):
                     # We want to look at the pointer lineage because that
                     # will be reflected into GraphQL interface that is
                     # being extended and the type cannot be changed.

--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -55,6 +55,7 @@ type User extending NamedObject {
     link profile -> Profile;
     # a link pointing to an abstract type
     multi link favorites -> NamedObject;
+    multi link fav_users := .favorites[is User];
 }
 
 alias SettingAlias := Setting {

--- a/tests/schemas/graphql_setup.edgeql
+++ b/tests/schemas/graphql_setup.edgeql
@@ -84,6 +84,7 @@ INSERT Person {
         name := 'Bob profile',
         value := 'special',
     }),
+    favorites := {UserGroup, User}
 };
 
 WITH MODULE other

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -579,6 +579,43 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         self.assertTrue(len(res) > 0,
                         'querying "BaseObject" returned no results')
 
+    def test_graphql_functional_query_21(self):
+        # test filtering by nested object
+        self.assert_graphql_query_result(r"""
+            query {
+                User(filter: {name: {eq: "Bob"}}) {
+                    name
+                    fav_users(order: {name: {dir: ASC}}) {
+                        name
+                        # only present in User
+                        active
+                        score
+                    }
+                }
+            }
+        """, {
+            'User': [{
+                'name': 'Bob',
+                'fav_users': [
+                    {
+                        'name': 'Alice',
+                        'active': True,
+                        'score': 5,
+                    },
+                    {
+                        'name': 'Jane',
+                        'active': True,
+                        'score': 1.23,
+                    },
+                    {
+                        'name': 'John',
+                        'active': True,
+                        'score': 3.14,
+                    },
+                ]
+            }],
+        })
+
     def test_graphql_functional_alias_01(self):
         self.assert_graphql_query_result(
             r"""


### PR DESCRIPTION
When a computed link uses a type filter the more specific type should be
reflected as the target.

Fixes #3683