### PR TITLE
Fix a collection of nested shape path reference issues

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -512,6 +512,10 @@ def _infer_set_inner(
     if rptr is not None:
         rptrref = rptr.ptrref
 
+        source_card = infer_cardinality(
+            rptr.source, scope_tree=scope_tree, ctx=ctx,
+        )
+
         ctx.env.schema, ptrcls = typeutils.ptrcls_from_ptrref(
             rptrref, schema=ctx.env.schema)
         if ir.expr:
@@ -524,10 +528,6 @@ def _infer_set_inner(
                 scope_tree=scope_tree,
                 ctx=ctx,
             )
-
-        source_card = infer_cardinality(
-            rptr.source, scope_tree=scope_tree, ctx=ctx,
-        )
 
     # We have now inferred all of the subtrees we need to, so it is
     # safe to return.


### PR DESCRIPTION
* When computing potentially visible sets from a computable, don't
   skip the source if the reference to the source occurs outside the
   scope of the computable. This fixes cases where the source is used
   in a WITH binding outside the shape, and allows those to be
   properly materialized. Fixes #3678.
 * When remapping paths to computed sources in compile_path,
   don't copy the remapped set's expr/rptr. They shouldn't be
   needed and this could result in a TypeIntersection rptr
   on a set with an expr, which broke card inference when
   the source path had a type intersection.
 * Suppress recompiling a computable when the path has been
   remapped. The computable must already be visible, and it
   was breaking things on the pgsql side.

This cleans up most of the leftover problems from #3261, I think.