### PR TITLE
Pin the version of edgedb-cli that we use

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -546,7 +546,7 @@ class ci_helper(setuptools.Command):
             print(binascii.hexlify(ext_hash).decode())
 
         elif self.type == 'cli':
-            print(_get_edgedbcli_rev())
+            print(EDGEDBCLI_COMMIT)
 
         elif self.type == 'build_temp':
             print(pathlib.Path(build.build_temp).resolve())

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ BUILD_DEPS = [
 RUST_VERSION = '1.53.0'  # Also update docs/internal/dev.rst
 
 EDGEDBCLI_REPO = 'https://github.com/edgedb/edgedb-cli'
+EDGEDBCLI_COMMIT = '87cb7e08452f37b97e95475df43006fa6131c0bf'
 
 EXTRA_DEPS = {
     'test': TEST_DEPS,
@@ -394,6 +395,8 @@ def _compile_cli(build_base, build_temp):
     env['PSQL_DEFAULT_PATH'] = build_base / 'postgres' / 'install' / 'bin'
     git_rev = env.get("EDGEDBCLI_GIT_REV")
     if not git_rev:
+        git_rev = EDGEDBCLI_COMMIT
+    elif git_rev == 'master':
         git_rev = _get_edgedbcli_rev()
 
     subprocess.run(

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ BUILD_DEPS = [
 RUST_VERSION = '1.53.0'  # Also update docs/internal/dev.rst
 
 EDGEDBCLI_REPO = 'https://github.com/edgedb/edgedb-cli'
+# This can be either a tag or a commit
 EDGEDBCLI_COMMIT = '87cb7e08452f37b97e95475df43006fa6131c0bf'
 
 EXTRA_DEPS = {
@@ -367,11 +368,13 @@ def _check_rust():
             f'edgedb from source (see https://rustup.rs/)')
 
 
-def _get_edgedbcli_rev():
+def _get_edgedbcli_rev(name):
     output = subprocess.check_output(
-        ['git', 'ls-remote', EDGEDBCLI_REPO, 'master'],
+        ['git', 'ls-remote', EDGEDBCLI_REPO, name],
         universal_newlines=True,
-    )
+    ).strip()
+    if not output:
+        return None
     rev, _ = output.split()
     return rev
 
@@ -393,11 +396,15 @@ def _compile_cli(build_base, build_temp):
     env = dict(os.environ)
     env['CARGO_TARGET_DIR'] = str(build_temp / 'rust' / 'cli')
     env['PSQL_DEFAULT_PATH'] = build_base / 'postgres' / 'install' / 'bin'
-    git_rev = env.get("EDGEDBCLI_GIT_REV")
+    git_name = env.get("EDGEDBCLI_GIT_REV")
+    if not git_name:
+        git_name = EDGEDBCLI_COMMIT
+    # The name can be a branch or tag, so we attempt to look it up
+    # with ls-remote. If we don't find anything, we assume it's a
+    # commit hash.
+    git_rev = _get_edgedbcli_rev(git_name)
     if not git_rev:
-        git_rev = EDGEDBCLI_COMMIT
-    elif git_rev == 'master':
-        git_rev = _get_edgedbcli_rev()
+        git_rev = git_name
 
     subprocess.run(
         [


### PR DESCRIPTION
This will ensure that edgedb and the cli stay in sync, require a test
suite run for cli updates, and make it possible to bisect beyond
cli/server interface breakages.