### PR TITLE
Change --compiler-pool-size to control max size for on_demand

### DIFF
--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -788,13 +788,13 @@ class FixedPool(BasePool):
 
 @srvargs.CompilerPoolMode.OnDemand.assign_implementation
 class SimpleAdaptivePool(BasePool):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, *, pool_size, **kwargs):
+        super().__init__(pool_size=1, **kwargs)
         self._worker_transports = {}
         self._expected_num_workers = 0
         self._scale_up_handle = None
         self._scale_down_handle = None
-        self._max_num_workers = srvargs.compute_default_compiler_pool_size()
+        self._max_num_workers = pool_size
 
     async def _start(self):
         async with taskgroup.TaskGroup() as g:


### PR DESCRIPTION
The initial pool size is hard-coded to `1` for on_demand pool.

This partially reverts commit f4c7772e0dedcd6d198ff15a1bb9c6c3eb500eae, refs #3550.