### PR TITLE
preparser: Fix detection of characters after `r`

### DIFF
--- a/edb/edgeql-parser/src/preparser.rs
+++ b/edb/edgeql-parser/src/preparser.rs
@@ -53,14 +53,16 @@ pub fn full_statement(data: &[u8], continuation: Option<Continuation>)
                     // rb'something' -- skip `b` but match on quote
                     iter.next();
                 };
-                match iter.next() {
+                match iter.peek() {
                     None => {
                         return Err(Continuation {
                             position: idx,
                             braces: braces_buf,
                         });
                     }
-                    Some((_, end @ (b'\'' | b'"'))) => {
+                    Some((_, start @ (b'\'' | b'"'))) => {
+                        let end = *start;
+                        iter.next();
                         while let Some((_, b)) = iter.next() {
                             if b == end {
                                 continue 'outer;

--- a/edb/edgeql-parser/tests/preparser.rs
+++ b/edb/edgeql-parser/tests/preparser.rs
@@ -134,6 +134,11 @@ fn test_schema() {
 }
 
 #[test]
+fn test_function() {
+    test_statement(b"drop function foo(s: str); ", 26);
+}
+
+#[test]
 fn empty() {
     assert!(is_empty(""));
     assert!(is_empty(" "));


### PR DESCRIPTION
Bug was introduced by fixing edgedb/edgedb-cli#676

Fixes edgedb/edgedb-cli#694