### PR TITLE
Compute the argument map in advance during pg compilation

### DIFF
--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -429,13 +429,15 @@ class NullRelation(ReturningQuery):
     where_clause: typing.Optional[BaseExpr] = None
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class Param:
     #: postgres' variable index
     index: int
 
     #: whether parameter is required
     required: bool
+
+    used: bool = False
 
 
 class Query(ReturningQuery):

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -111,6 +111,8 @@ def compile_ir_to_sql_tree(
         ctx.expr_exposed = True
         for sing in singletons:
             ctx.path_scope[sing] = ctx.rel
+        clauses.populate_argmap(query_params, ctx=ctx)
+
         qtree = dispatch.compile(ir_expr, ctx=ctx)
         if isinstance(ir_expr, irast.Set) and not singleton_mode:
             assert isinstance(qtree, pgast.Query)

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -24,7 +24,6 @@ from typing import *
 
 import collections
 import contextlib
-import itertools
 import enum
 import uuid
 
@@ -78,9 +77,6 @@ class CompilerContextLevel(compiler.ContextLevel):
 
     #: mapping of named args to position
     argmap: Dict[str, pgast.Param]
-
-    #: next argument number for named arguments
-    next_argument: Iterator[int]
 
     #: whether compiling in singleton expression mode
     singleton_mode: bool
@@ -220,7 +216,6 @@ class CompilerContextLevel(compiler.ContextLevel):
 
             self.env = env
             self.argmap = collections.OrderedDict()
-            self.next_argument = itertools.count(1)
 
             self.singleton_mode = False
 
@@ -258,7 +253,6 @@ class CompilerContextLevel(compiler.ContextLevel):
         else:
             self.env = prevlevel.env
             self.argmap = prevlevel.argmap
-            self.next_argument = prevlevel.next_argument
 
             self.singleton_mode = prevlevel.singleton_mode
 

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -128,22 +128,9 @@ def compile_Parameter(
             nullable=not expr.required,
         )
     else:
-        try:
-            index = ctx.argmap[expr.name].index
-        except KeyError:
-            if expr.name in ctx.argmap:
-                index = ctx.argmap[expr.name].index
-            else:
-                if expr.name.startswith('__edb_arg_'):
-                    index = int(expr.name[10:]) + 1
-                elif is_decimal:
-                    index = int(expr.name) + 1
-                else:
-                    index = next(ctx.next_argument)
-                ctx.argmap[expr.name] = pgast.Param(
-                    index=index,
-                    required=expr.required,
-                )
+        index = ctx.argmap[expr.name].index
+        ctx.argmap[expr.name].used = True
+
         result = pgast.ParamRef(number=index, nullable=not expr.required)
 
     return pgast.TypeCast(

--- a/edb/pgsql/dbops/functions.py
+++ b/edb/pgsql/dbops/functions.py
@@ -169,8 +169,9 @@ class CreateOrReplaceFunction(ddl.DDLOperation, FunctionOperation):
 class DropFunction(ddl.DDLOperation, FunctionOperation):
     def __init__(
             self, name, args, *,
+            if_exists=False,
             has_variadic=False, conditions=None, neg_conditions=None):
-        self.conditional = False
+        self.conditional = if_exists
         if conditions:
             c = []
             for cond in conditions:

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -421,7 +421,14 @@ class Compiler:
                         text=sql,
                     )
 
-                    cf = pg_dbops.CreateFunction(func, or_replace=True)
+                    # We drop first instead of using or_replace, in case
+                    # something about the arguments changed.
+                    df = pg_dbops.DropFunction(
+                        name=func.name, args=func.args, if_exists=True
+                    )
+                    df.generate(block)
+
+                    cf = pg_dbops.CreateFunction(func)
                     cf.generate(block)
 
                     cache_mm[eql_hash] = argnames

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -4949,6 +4949,13 @@ aa \
             {True}
         )
 
+    async def test_edgeql_typeop_09(self):
+        await self.assert_query_result(
+            r'''SELECT (INTROSPECT TYPEOF 1e100n).name ++ "!" ++ <str>$test''',
+            ['std::bigint!?'],
+            variables={'test': '?'},
+        )
+
     async def test_edgeql_assert_single_01(self):
         await self.con.execute("""
             INSERT User {


### PR DESCRIPTION
This fixes an obscure bug involving named parameters, constant
extraction, and INTROSPECT, but the main goal here is to set things up
for assigning param indexes for globals.