### PR TITLE
Mild rework of new_set_from_set

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from typing import *
 
 import contextlib
+import enum
 
 from edb import errors
 
@@ -131,14 +132,21 @@ def get_set_type(
     return ctx.env.set_types[ir_set]
 
 
+class KeepCurrentT(enum.Enum):
+    KeepCurrent = 0
+
+
+KeepCurrent: Final = KeepCurrentT.KeepCurrent
+
+
 def new_set_from_set(
         ir_set: irast.Set, *,
         merge_current_ns: bool=False,
-        path_scope_id: Optional[int | Literal['']]='',
+        path_scope_id: Optional[int | KeepCurrentT]=KeepCurrent,
         path_id: Optional[irast.PathId]=None,
         stype: Optional[s_types.Type]=None,
-        rptr: Optional[irast.Pointer | Literal['']]='',
-        expr: Optional[irast.Expr | Literal['']]='',
+        rptr: Optional[irast.Pointer | KeepCurrentT]=KeepCurrent,
+        expr: Optional[irast.Expr | KeepCurrentT]=KeepCurrent,
         context: Optional[parsing.ParserContext]=None,
         is_binding: Optional[irast.BindingKind]=None,
         is_materialized_ref: Optional[bool]=None,
@@ -158,11 +166,11 @@ def new_set_from_set(
         path_id = path_id.merge_namespace(ctx.path_id_namespace)
     if stype is None:
         stype = get_set_type(ir_set, ctx=ctx)
-    if path_scope_id == '':
+    if path_scope_id == KeepCurrent:
         path_scope_id = ir_set.path_scope_id
-    if rptr == '':
+    if rptr == KeepCurrent:
         rptr = ir_set.rptr
-    if expr == '':
+    if expr == KeepCurrent:
         expr = ir_set.expr
     if context is None:
         context = ir_set.context

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -133,11 +133,12 @@ def get_set_type(
 
 def new_set_from_set(
         ir_set: irast.Set, *,
-        preserve_scope_ns: bool=False,
+        merge_current_ns: bool=False,
+        path_scope_id: Optional[int | Literal['']]='',
         path_id: Optional[irast.PathId]=None,
         stype: Optional[s_types.Type]=None,
-        rptr: Optional[irast.Pointer]=None,
-        expr: Optional[irast.Expr]=None,
+        rptr: Optional[irast.Pointer | Literal['']]='',
+        expr: Optional[irast.Expr | Literal['']]='',
         context: Optional[parsing.ParserContext]=None,
         is_binding: Optional[irast.BindingKind]=None,
         is_materialized_ref: Optional[bool]=None,
@@ -145,20 +146,23 @@ def new_set_from_set(
         ctx: context.ContextLevel) -> irast.Set:
     """Create a new ir.Set from another ir.Set.
 
-    The new Set inherits source Set's scope, schema item, expression,
-    and, if *preserve_scope_ns* is set, path_id.  If *preserve_scope_ns*
-    is False, the new Set's path_id will be namespaced with the currently
-    active scope namespace.
+    The new Set inherits source everything from the old set that
+    is not overriden.
+
+    If *merge_current_ns* is set, the new Set's path_id will be
+    namespaced with the currently active scope namespace.
     """
     if path_id is None:
         path_id = ir_set.path_id
-    if not preserve_scope_ns:
+    if merge_current_ns:
         path_id = path_id.merge_namespace(ctx.path_id_namespace)
     if stype is None:
         stype = get_set_type(ir_set, ctx=ctx)
-    if rptr is None:
+    if path_scope_id == '':
+        path_scope_id = ir_set.path_scope_id
+    if rptr == '':
         rptr = ir_set.rptr
-    if expr is None:
+    if expr == '':
         expr = ir_set.expr
     if context is None:
         context = ir_set.context
@@ -170,7 +174,7 @@ def new_set_from_set(
         is_visible_binding_ref = ir_set.is_visible_binding_ref
     return new_set(
         path_id=path_id,
-        path_scope_id=ir_set.path_scope_id,
+        path_scope_id=path_scope_id,
         stype=stype,
         expr=expr,
         rptr=rptr,
@@ -267,8 +271,7 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
                 refnode = anchors.get(step.name)
 
             if refnode is not None:
-                path_tip = new_set_from_set(
-                    refnode, preserve_scope_ns=True, ctx=ctx)
+                path_tip = new_set_from_set(refnode, ctx=ctx)
             else:
                 stype = schemactx.get_schema_type(
                     step,
@@ -301,8 +304,8 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
                     view_scope_info = ctx.path_scope_map[view_set]
                     path_tip = new_set_from_set(
                         view_set,
-                        preserve_scope_ns=(
-                            view_scope_info.pinned_path_id_ns is not None
+                        merge_current_ns=(
+                            view_scope_info.pinned_path_id_ns is None
                         ),
                         is_binding=view_scope_info.binding_kind,
                         ctx=ctx,
@@ -490,10 +493,7 @@ def compile_path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
         # so we need to do some remapping.
         if mapped := get_view_map_remapping(path_tip.path_id, ctx):
             path_tip = new_set_from_set(
-                path_tip,
-                path_id=mapped.path_id,
-                preserve_scope_ns=True,
-                ctx=ctx)
+                path_tip, path_id=mapped.path_id, ctx=ctx)
             # If we are remapping a source path, then we know that
             # the path is visible, so we shouldn't recompile it
             # if it is a computable path.
@@ -1112,14 +1112,12 @@ def ensure_set(
     stype = get_set_type(ir_set, ctx=ctx)
 
     if type_override is not None and stype != type_override:
-        ir_set = new_set_from_set(
-            ir_set, stype=type_override, preserve_scope_ns=True, ctx=ctx)
+        ir_set = new_set_from_set(ir_set, stype=type_override, ctx=ctx)
 
         stype = type_override
 
     if srcctx is not None:
-        ir_set = new_set_from_set(
-            ir_set, preserve_scope_ns=True, context=srcctx, ctx=ctx)
+        ir_set = new_set_from_set(ir_set, context=srcctx, ctx=ctx)
 
     if (isinstance(ir_set, irast.EmptySet)
             and (stype is None or stype.is_any(ctx.env.schema))
@@ -1165,8 +1163,7 @@ def fixup_computable_source_set(
     if source_scls.is_view(ctx.env.schema):
         source_set_stype = source_scls.peel_view(ctx.env.schema)
         source_set = new_set_from_set(
-            source_set, stype=source_set_stype,
-            preserve_scope_ns=True, ctx=ctx)
+            source_set, stype=source_set_stype, ctx=ctx)
         source_set.shape = ()
         if source_set.rptr is not None:
             source_rptrref = source_set.rptr.ptrref
@@ -1322,6 +1319,7 @@ def computable_ptr_set(
 
     comp_ir_set = new_set_from_set(
         comp_ir_set, path_id=result_path_id, rptr=rptr, context=srcctx,
+        merge_current_ns=True,
         ctx=ctx)
 
     rptr.target = comp_ir_set
@@ -1352,7 +1350,6 @@ def _get_schema_computed_ctx(
             remapped_source = new_set_from_set(
                 rptr.source,
                 rptr=rptr.source.rptr,
-                preserve_scope_ns=True,
                 ctx=ctx,
             )
             key = inner_path_id.strip_namespace(inner_path_id.namespace)
@@ -1485,8 +1482,7 @@ def _get_computable_ctx(
                 inner_path_id = remap_path_id(inner_path_id, remapctx)
 
             remapped_source = new_set_from_set(
-                rptr.source, rptr=rptr.source.rptr,
-                preserve_scope_ns=True, ctx=ctx)
+                rptr.source, rptr=rptr.source.rptr, ctx=ctx)
             update_view_map(inner_path_id, remapped_source, ctx=subctx)
 
             yield subctx

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -183,8 +183,7 @@ def compile_ForQuery(
                 ctx=ectx,
             )
 
-        iterator_stmt = setgen.new_set_from_set(
-            iterator_view, preserve_scope_ns=True, ctx=sctx)
+        iterator_stmt = setgen.new_set_from_set(iterator_view, ctx=sctx)
         iterator_view.is_visible_binding_ref = True
         stmt.iterator_stmt = iterator_stmt
 
@@ -341,8 +340,7 @@ def compile_InternalGroupQuery(
                     )
                     binding.context = using_entry.expr.context
                     stmt.using[using_entry.alias] = (
-                        setgen.new_set_from_set(
-                            binding, preserve_scope_ns=True, ctx=sctx),
+                        setgen.new_set_from_set(binding, ctx=sctx),
                         qltypes.Cardinality.UNKNOWN)
                     binding.is_visible_binding_ref = True
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -405,9 +405,7 @@ def _setup_shape_source(cur_set: irast.Set, ctx: context.ContextLevel) -> None:
                 ptrref=not_none(sub_set.path_id.rptr()),
                 is_definition=True,
             )
-            sub_set = setgen.new_set_from_set(
-                sub_set, preserve_scope_ns=True,
-                rptr=sub_rptr, ctx=ctx)
+            sub_set = setgen.new_set_from_set(sub_set, rptr=sub_rptr, ctx=ctx)
             sub_rptr.target = sub_set
             ptr_shape.append((sub_set, sub_op))
         cur_set.shape = tuple(ptr_shape)

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -467,6 +467,8 @@ class Set(Base):
 
     __ast_frozen_fields__ = frozenset({'typeref'})
 
+    # N.B: Make sure to add new fields to setgen.new_set_from_set!
+
     path_id: PathId
     path_scope_id: typing.Optional[int] = None
     typeref: TypeRef


### PR DESCRIPTION
* Distinguish between None and "keep the old value", for
   fields where None is valid. One of the issues in #3700
   was partially caused by a passed in None causing a value
   to be kept (though it that case the best fix was to *always*
   keep the old value).
 * Make `preserve_scope_ns` the default behavior by replacing it
   with a new argument, `merge_current_ns`, that has inverted
   behavior and is also False by default.
   `preserve_scope_ns=True` was passed by every call site but two,
   and only one call site used its default value.