### PR TITLE
Fix `array<uuid>` not showing up in introspection queries

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_03_31_00_00
+EDGEDB_CATALOG_VERSION = 2022_04_05_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2353,7 +2353,16 @@ class CreateCollectionType(
     CollectionTypeCommand[CollectionTypeT],
     sd.CreateObject[CollectionTypeT],
 ):
-    pass
+    def canonicalize_attributes(
+        self,
+        schema: s_schema.Schema,
+        context: CommandContext,
+    ) -> s_schema.Schema:
+        # Even if we create a collection while setting up internal
+        # things, we don't mark it internal, since something visible
+        # might use it later.
+        self.set_attribute_value('internal', False)
+        return super().canonicalize_attributes(schema, context)
 
 
 class AlterCollectionType(

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2356,7 +2356,7 @@ class CreateCollectionType(
     def canonicalize_attributes(
         self,
         schema: s_schema.Schema,
-        context: CommandContext,
+        context: sd.CommandContext,
     ) -> s_schema.Schema:
         # Even if we create a collection while setting up internal
         # things, we don't mark it internal, since something visible

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -13111,6 +13111,21 @@ type default::Foo {
                 };
             """)
 
+    async def test_edgeql_ddl_uuid_array_01(self):
+        await self.con.execute(r"""
+            create type Foo {
+                create property uuid_array_prop -> array<uuid>
+            }
+        """)
+
+        await self.assert_query_result(
+            r"""
+                select schema::Property {target: {name}}
+                filter .name = 'uuid_array_prop';
+            """,
+            [{'target': {'name': 'array<std::uuid>'}}]
+        )
+
 
 class TestConsecutiveMigrations(tb.DDLTestCase):
     TRANSACTION_ISOLATION = False


### PR DESCRIPTION
It gets used in some internal stuff, and so is being created
marked internal.