### PR TITLE
Avoid 'Text file busy' errors during build when CLI is running

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -422,9 +422,17 @@ def _compile_cli(build_base, build_temp):
         check=True,
     )
 
+    cli_dest = ROOT_PATH / 'edb' / 'cli' / 'edgedb'
+    # Delete the target first, to avoid "Text file busy" errors during
+    # the copy if the CLI is currently running.
+    try:
+        cli_dest.unlink()
+    except FileNotFoundError:
+        pass
+
     shutil.copy(
         rust_root / 'bin' / 'edgedb',
-        ROOT_PATH / 'edb' / 'cli' / 'edgedb',
+        cli_dest,
     )
 
 


### PR DESCRIPTION
You aren't allowed to *modify* a running executable (demand paging
means that .text might not be fully resident in memory, so the kernel
needs to be able to load the correct contents of the executable from
disk), but you can delete it (it will get unlinked from the directory
structure, but a live reference to the file will keep it alive until
the program exits).

So unlink the `edgedb` executable file before doing the copy.