### PR TITLE
Make schema::Type.from_alias include generated target types

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_04_05_00_00
+EDGEDB_CATALOG_VERSION = 2022_04_06_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -76,7 +76,8 @@ CREATE TYPE schema::PseudoType EXTENDING schema::Type;
 
 ALTER TYPE schema::Type {
     CREATE PROPERTY expr -> std::str;
-    CREATE PROPERTY from_alias := EXISTS(.expr);
+    CREATE PROPERTY expr_type -> int64;
+    CREATE PROPERTY from_alias := EXISTS(.expr_type);
     # Backwards compatibility.
     CREATE PROPERTY is_from_alias := .from_alias;
 };

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -76,8 +76,7 @@ CREATE TYPE schema::PseudoType EXTENDING schema::Type;
 
 ALTER TYPE schema::Type {
     CREATE PROPERTY expr -> std::str;
-    CREATE PROPERTY expr_type -> int64;
-    CREATE PROPERTY from_alias := EXISTS(.expr_type);
+    CREATE PROPERTY from_alias -> bool;
     # Backwards compatibility.
     CREATE PROPERTY is_from_alias := .from_alias;
 };

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -479,6 +479,7 @@ def define_alias(
                 'expr': expr,
                 'alias_is_persistent': True,
                 'expr_type': s_types.ExprType.Select,
+                'from_alias': True,
             },
         )
         derived_delta.add(ct)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -104,6 +104,13 @@ class Type(
         ExprType,
         default=None, compcoef=0.909)
 
+    # True for views.  This should always match the value of
+    # `bool(expr_type)`, but can be exported in the introspection
+    # schema without revealing weird internals.
+    from_alias = so.SchemaField(
+        bool,
+        default=False, compcoef=0.909)
+
     # True for aliases defined by CREATE ALIAS, false for local
     # aliases in queries.
     alias_is_persistent = so.SchemaField(
@@ -153,6 +160,7 @@ class Type(
 
         derived_attrs['name'] = name
         derived_attrs['bases'] = so.ObjectList.create(schema, [self])
+        derived_attrs['from_alias'] = bool(derived_attrs.get('expr_type'))
 
         cmd = sd.get_object_delta_command(
             objtype=type(self),
@@ -350,7 +358,7 @@ class Type(
             f'{type(self)} does not support to_nonpolymorphic()')
 
     def is_view(self, schema: s_schema.Schema) -> bool:
-        return self.get_expr_type(schema) is not None
+        return self.get_from_alias(schema)
 
     def castable_to(
         self,

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -109,7 +109,7 @@ class Type(
     # schema without revealing weird internals.
     from_alias = so.SchemaField(
         bool,
-        default=False, compcoef=0.909)
+        default=False, compcoef=1.0)
 
     # True for aliases defined by CREATE ALIAS, false for local
     # aliases in queries.

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -1070,6 +1070,15 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             }]
         )
 
+        await self.assert_query_result(
+            r"""
+                select schema::Pointer {name, target: {from_alias}}
+                filter .name = 'winner'
+                and .source.name = 'default::AwardAlias'
+            """,
+            [{"name": "winner", "target": {"from_alias": True}}]
+        )
+
     async def test_edgeql_aliases_backlinks_01(self):
         async with self.assertRaisesRegexTx(
             edgedb.InvalidReferenceError,


### PR DESCRIPTION
Aliases with nested shapes need to create schema types for
those views, and it gives the names like `__UserAlias__deck`.

These are types that have `is_view` as True inside the compiler
but don't have an `expr` field, so this fact isn't exposed
to introspection at all.

An alternative would be to add a new field (`is_view`, perhaps)
instead of changing `from_alias`, but I think that having
`from_alias` be true on the target types generated from alias
definitions makes sense.

Needed to fix edgedb/edgedb-studio#13.