### PR TITLE
Fix some issues with defaults

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -4636,7 +4636,8 @@ class PropertyMetaCommand(CompositeMetaCommand, PointerMetaCommand):
                         raise errors.UnsupportedFeatureError(
                             f'default value for '
                             f'{prop.get_verbosename(schema, with_parent=True)}'
-                            f' is too complicated for a link property default',
+                            f' is too complicated; link property defaults '
+                            f'must not depend on database contents',
                             context=self.source_context)
 
                     cols = self.get_columns(

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3251,12 +3251,8 @@ class PointerMetaCommand(MetaCommand):
         default_value = None
 
         if default is not None:
-            if isinstance(default, s_expr.Expression):
-                default_value = schemamech.ptr_default_to_col_default(
-                    schema, ptr, default)
-            else:
-                default_value = common.quote_literal(
-                    str(default))
+            default_value = schemamech.ptr_default_to_col_default(
+                schema, ptr, default)
         elif (tgt := ptr.get_target(schema)) and tgt.issubclass(
                 schema, schema.get('std::sequence')):
             # TODO: replace this with a generic scalar type default
@@ -3288,6 +3284,7 @@ class PointerMetaCommand(MetaCommand):
                         pointer.get_required(schema)
                         and not pointer.is_pure_computable(schema)
                         and not sets_required
+                        and not (pointer.get_default(schema) and not default)
                     ) or (
                         ptr_stor_info.table_type == 'link'
                         and not pointer.is_link_property(schema)
@@ -3482,9 +3479,25 @@ class PointerMetaCommand(MetaCommand):
         source_ctx = self.get_referrer_context_or_die(context)
         source_op = source_ctx.op
 
+        alter_table = None
+        if not ptr_table or is_lprop:
+            alter_table = source_op.get_alter_table(
+                schema,
+                context,
+                manual=True,
+            )
+            alter_table.add_operation(
+                dbops.AlterTableAlterColumnNull(
+                    column_name=ptr_stor_info.column_name,
+                    null=not new_required,
+                )
+            )
+
         # Ignore optionality changes resulting from the creation of
         # an overloaded pointer as there is no data yet.
         if isinstance(source_op, sd.CreateObject):
+            if alter_table:
+                self.pgops.add(alter_table)
             return
 
         ops = dbops.CommandGroup()
@@ -3601,18 +3614,7 @@ class PointerMetaCommand(MetaCommand):
                 if is_required:
                     ops.add_command(dbops.Query(check_qry))
 
-        if not ptr_table or is_lprop:
-            alter_table = source_op.get_alter_table(
-                schema,
-                context,
-                manual=True,
-            )
-            alter_table.add_operation(
-                dbops.AlterTableAlterColumnNull(
-                    column_name=ptr_stor_info.column_name,
-                    null=not new_required,
-                )
-            )
+        if alter_table:
             ops.add_command(alter_table)
 
         self.pgops.add(ops)
@@ -4166,6 +4168,10 @@ class LinkMetaCommand(CompositeMetaCommand, PointerMetaCommand):
             ptr_stor_info = types.get_pointer_storage_info(
                 link, resolve_type=False, schema=schema)
 
+            fills_required = any(
+                x.fill_expr for x in
+                self.get_subcommands(
+                    type=s_pointers.AlterPointerLowerCardinality))
             sets_required = bool(
                 self.get_subcommands(
                     type=s_pointers.AlterPointerLowerCardinality))
@@ -4224,10 +4230,17 @@ class LinkMetaCommand(CompositeMetaCommand, PointerMetaCommand):
                     s_objtypes.ObjectTypeCommandContext,
                 )
 
+            if (
+                (default := link.get_default(schema))
+                and not link.is_pure_computable(schema)
+                and not fills_required
+            ):
+                self._alter_pointer_optionality(
+                    schema, schema, context, fill_expr=default)
             # If we're creating a required multi pointer without a SET
             # REQUIRED USING inside, run the alter_pointer_optionality
             # path to produce an error if there is existing data.
-            if (
+            elif (
                 link.get_cardinality(schema).is_multi()
                 and link.get_required(schema)
                 and not link.is_pure_computable(schema)
@@ -4589,9 +4602,14 @@ class PropertyMetaCommand(CompositeMetaCommand, PointerMetaCommand):
             ptr_stor_info = types.get_pointer_storage_info(
                 prop, resolve_type=False, schema=schema)
 
+            fills_required = any(
+                x.fill_expr for x in
+                self.get_subcommands(
+                    type=s_pointers.AlterPointerLowerCardinality))
             sets_required = bool(
                 self.get_subcommands(
                     type=s_pointers.AlterPointerLowerCardinality))
+
             if (
                 not isinstance(src.scls, s_objtypes.ObjectType)
                 or ptr_stor_info.table_type == 'ObjectType'
@@ -4609,6 +4627,17 @@ class PropertyMetaCommand(CompositeMetaCommand, PointerMetaCommand):
 
                     default_value = self.get_pointer_default(
                         prop, schema, context)
+
+                    if (
+                        isinstance(src.scls, s_links.Link)
+                        and not default_value
+                        and prop.get_default(schema)
+                    ):
+                        raise errors.UnsupportedFeatureError(
+                            f'default value for '
+                            f'{prop.get_verbosename(schema, with_parent=True)}'
+                            f' is too complicated for a link property default',
+                            context=self.source_context)
 
                     cols = self.get_columns(
                         prop, schema, default_value, sets_required)
@@ -4635,10 +4664,17 @@ class PropertyMetaCommand(CompositeMetaCommand, PointerMetaCommand):
                     s_sources.SourceCommandContext,
                 )
 
+            if (
+                (default := prop.get_default(schema))
+                and not prop.is_pure_computable(schema)
+                and not fills_required
+            ):
+                self._alter_pointer_optionality(
+                    schema, schema, context, fill_expr=default)
             # If we're creating a required multi pointer without a SET
             # REQUIRED USING inside, run the alter_pointer_optionality
             # path to produce an error if there is existing data.
-            if (
+            elif (
                 prop.get_cardinality(schema).is_multi()
                 and prop.get_required(schema)
                 and not prop.is_pure_computable(schema)

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -467,7 +467,10 @@ def ptr_default_to_col_default(schema, ptr, expr):
     if not ir_utils.is_const(ir):
         return None
 
-    sql_expr = compiler.compile_ir_to_sql_tree(ir, singleton_mode=True)
+    try:
+        sql_expr = compiler.compile_ir_to_sql_tree(ir, singleton_mode=True)
+    except errors.UnsupportedFeatureError:
+        return None
     sql_text = codegen.SQLSourceGenerator.to_source(sql_expr)
 
     return sql_text

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1868,9 +1868,15 @@ class AlterPointer(
                 # and this is no longer a computable.
                 self.set_attribute_value('computable', False)
                 computed_fields = pointer.get_computed_fields(schema)
-                if 'required' in computed_fields:
+                if (
+                    'required' in computed_fields
+                    and not self.has_attribute_value('required')
+                ):
                     self.set_attribute_value('required', None)
-                if 'cardinality' in computed_fields:
+                if (
+                    'cardinality' in computed_fields
+                    and not self.has_attribute_value('cardinality')
+                ):
                     self.set_attribute_value('cardinality', None)
 
             # Clear the placeholder value for 'expr'.

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -4084,7 +4084,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }],
         )
 
-    async def test_edgeql_migration_eq_18(self):
+    async def test_edgeql_migration_eq_18a(self):
         await self.migrate(r"""
             type Base {
                 property name := 'computable'
@@ -4120,6 +4120,84 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 'name': 'something',
             }, {
                 'name': 'something',
+            }],
+        )
+
+    async def test_edgeql_migration_eq_18b(self):
+        await self.migrate(r"""
+            type Base {
+                property name := 'computable'
+            }
+        """)
+        await self.con.execute(r"""
+            SET MODULE test;
+
+            INSERT Base;
+        """)
+
+        await self.migrate(r"""
+            type Base {
+                # change a property from a computable to regular with a default
+                property name -> str {
+                    default := <str>count(Object)
+                }
+            }
+        """)
+
+        # Insert a new object, this one should have a new default name.
+        await self.con.execute(r"""
+            INSERT Base;
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT Base {
+                    name,
+                } ORDER BY .name EMPTY LAST;
+            """,
+            [{
+                'name': str,
+            }, {
+                'name': str,
+            }],
+        )
+
+    async def test_edgeql_migration_eq_18c(self):
+        await self.migrate(r"""
+            type Base {
+                property name := 'computable'
+            }
+        """)
+        await self.con.execute(r"""
+            SET MODULE test;
+
+            INSERT Base;
+        """)
+
+        await self.migrate(r"""
+            type Base {
+                # change a property from a computable to regular with a default
+                required property name -> str {
+                    default := <str>count(Object)
+                }
+            }
+        """)
+
+        # Insert a new object, this one should have a new default name.
+        await self.con.execute(r"""
+            INSERT Base;
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT Base {
+                    name,
+                } ORDER BY .name EMPTY LAST;
+            """,
+            [{
+                'name': str,
+            }, {
+                'name': str,
             }],
         )
 

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1922,7 +1922,8 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         with self.assertRaisesRegex(
             edgedb.UnsupportedFeatureError,
             "default value for property 'x' of link 'asdf' of object type "
-            "'default::Bar' is too complicated for a link property default"
+            "'default::Bar' is too complicated; "
+            "link property defaults must not depend on database contents"
         ):
             await self.con.execute('''
                 create type Bar {

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1876,6 +1876,64 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 INSERT TestDefault06;
             """)
 
+    async def test_edgeql_ddl_default_07(self):
+        await self.con.execute(r"""
+            CREATE TYPE Foo;
+            INSERT Foo;
+
+            alter type Foo {
+                create required property name -> str {
+                    set default := 'something'
+                }
+            };
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT Foo.name;
+            """,
+            {'something'},
+        )
+
+    async def test_edgeql_ddl_default_08(self):
+        await self.con.execute(r"""
+            CREATE TYPE Foo;
+            INSERT Foo;
+
+            alter type Foo {
+                create required multi property name -> str {
+                    set default := 'something'
+                }
+            };
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT Foo.name;
+            """,
+            {'something'},
+        )
+
+    async def test_edgeql_ddl_default_09(self):
+        await self.con.execute(r"""
+            CREATE TYPE Foo;
+        """)
+
+        with self.assertRaisesRegex(
+            edgedb.UnsupportedFeatureError,
+            "default value for property 'x' of link 'asdf' of object type "
+            "'default::Bar' is too complicated for a link property default"
+        ):
+            await self.con.execute('''
+                create type Bar {
+                    create link asdf -> Foo {
+                        create property x -> int64 {
+                            set default := count(Object)
+                        }
+                    }
+                };
+            ''')
+
     async def test_edgeql_ddl_default_circular(self):
         await self.con.execute(r"""
             CREATE TYPE TestDefaultCircular {
@@ -13224,18 +13282,20 @@ type default::Foo {
                 alter type Foo set abstract;
             """)
 
-    async def test_edgeql_ddl_no_type_intro_in_default(self):
-        with self.assertRaisesRegex(
-                edgedb.UnsupportedFeatureError,
-                r"type introspection not supported in simple expressions"):
-            await self.con.execute(r"""
-                create scalar type Foo extending sequence;
-                create type Project {
-                    create required property number -> Foo {
-                        set default := sequence_next(introspect Foo);
-                    }
-                };
-            """)
+    async def test_edgeql_no_type_intro_in_default(self):
+        await self.con.execute(r"""
+            create scalar type Foo extending sequence;
+            create type Project {
+                create required property number -> Foo {
+                    set default := sequence_next(introspect Foo);
+                }
+            };
+        """)
+
+        await self.con.execute(r"""
+            insert Project;
+            insert Project;
+        """)
 
     async def test_edgeql_ddl_uuid_array_01(self):
         await self.con.execute(r"""


### PR DESCRIPTION
My initial goal here was to delete `ptr_default_to_col_default` and
not set column defaults at all, since we inject the defaults ourselves
anyway. I then realized that the default does serve the actual purpose
of populating data when a new column is created--and that there was a
bug, since multi pointers and things with complex defaults would not
get this treatment, so I used the _alter_pointer_optionality path
to populate that data instead of defaults.

But it also turns out that link properties do actually require having
the defualt column set, since we don't inject the values there. I
didn't want to try to make that change now, so instead I just added an
error for the cases where we can't set a column default on a link
property.

This means I didn't actually accomplish the initial goal, but did fix
a bunch of bugs, so still a win.