### PR TITLE
Fix a collection of issues with aliases

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_04_06_00_00
+EDGEDB_CATALOG_VERSION = 2022_04_13_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -232,6 +232,9 @@ class Environment:
     compiled_stmts: Dict[qlast.Statement, irast.Stmt]
     """A mapping of from input edgeql to compiled IR"""
 
+    actually_toplevel_result_view_name: Optional[s_name.QualName]
+    """The name of a view being defined as an alias."""
+
     def __init__(
         self,
         *,
@@ -271,6 +274,7 @@ class Environment:
         self.scope_tree_nodes = weakref.WeakValueDictionary()
         self.materialized_sets = {}
         self.compiled_stmts = {}
+        self.actually_toplevel_result_view_name = None
 
     def add_schema_ref(
             self, sobj: s_obj.Object, expr: Optional[qlast.Base]) -> None:

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -232,7 +232,7 @@ class Environment:
     compiled_stmts: Dict[qlast.Statement, irast.Stmt]
     """A mapping of from input edgeql to compiled IR"""
 
-    actually_toplevel_result_view_name: Optional[s_name.QualName]
+    alias_result_view_name: Optional[s_name.QualName]
     """The name of a view being defined as an alias."""
 
     def __init__(
@@ -240,6 +240,7 @@ class Environment:
         *,
         schema: s_schema.Schema,
         path_scope: Optional[irast.ScopeTreeNode] = None,
+        alias_result_view_name: Optional[s_name.QualName] = None,
         options: Optional[GlobalCompilerOptions] = None,
     ) -> None:
         if options is None:
@@ -274,7 +275,7 @@ class Environment:
         self.scope_tree_nodes = weakref.WeakValueDictionary()
         self.materialized_sets = {}
         self.compiled_stmts = {}
-        self.actually_toplevel_result_view_name = None
+        self.alias_result_view_name = alias_result_view_name
 
     def add_schema_ref(
             self, sobj: s_obj.Object, expr: Optional[qlast.Base]) -> None:

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -69,7 +69,11 @@ def init_context(
             name=s_name.UnqualName('__derived__'),
         )
 
-    env = context.Environment(schema=schema, options=options)
+    env = context.Environment(
+        schema=schema,
+        options=options,
+        alias_result_view_name=options.result_view_name,
+    )
     ctx = context.ContextLevel(None, context.ContextSwitchMode.NEW, env=env)
     _ = context.CompilerContext(initial=ctx)
 
@@ -98,7 +102,6 @@ def init_context(
 
     ctx.derived_target_module = options.derived_target_module
     ctx.toplevel_result_view_name = options.result_view_name
-    ctx.env.actually_toplevel_result_view_name = options.result_view_name
     ctx.implicit_id_in_shapes = options.implicit_id_in_shapes
     ctx.implicit_tid_in_shapes = options.implicit_tid_in_shapes
     ctx.implicit_tname_in_shapes = options.implicit_tname_in_shapes

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -98,6 +98,7 @@ def init_context(
 
     ctx.derived_target_module = options.derived_target_module
     ctx.toplevel_result_view_name = options.result_view_name
+    ctx.env.actually_toplevel_result_view_name = options.result_view_name
     ctx.implicit_id_in_shapes = options.implicit_id_in_shapes
     ctx.implicit_tid_in_shapes = options.implicit_tid_in_shapes
     ctx.implicit_tname_in_shapes = options.implicit_tname_in_shapes

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -122,8 +122,9 @@ def _process_view(
 ) -> Tuple[s_objtypes.ObjectType, irast.Set]:
     path_id = ir_set.path_id
 
-    if (view_name is None and ctx.env.options.schema_view_mode
-            and view_rptr is not None):
+    needs_real_name = view_name is None and ctx.env.options.schema_view_mode
+    generated_name = None
+    if needs_real_name and view_rptr is not None:
         # Make sure persistent schema expression aliases have properly formed
         # names as opposed to the usual mangled form of the ephemeral
         # aliases.  This is needed for introspection readability, as well
@@ -148,7 +149,20 @@ def _process_view(
                 'neither ptrcls_name, not ptrcls'
             )
 
-        name = f'{source_name}__{ptr_name}'
+        generated_name = f'{source_name}__{ptr_name}'
+    elif needs_real_name and ctx.env.actually_toplevel_result_view_name:
+        # If this is a persistent schema expression but we aren't just
+        # obviously sitting on an rptr (e.g CREATE ALIAS V := (Foo { x }, 10)),
+        # we create a name like __V__Foo__2.
+        source_name = ctx.env.actually_toplevel_result_view_name.name
+        type_name = stype.get_name(ctx.env.schema).name
+        generated_name = f'__{source_name}__{type_name}'
+
+    if generated_name:
+        # If there are multiple, we want to stick a number on, but we'd
+        # like to skip the number if there aren't.
+        name = ctx.aliases.get(
+            generated_name).replace('~1', '').replace('~', '__')
         view_name = sn.QualName(
             module=ctx.derived_target_module or '__derived__',
             name=name,

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -150,11 +150,11 @@ def _process_view(
             )
 
         generated_name = f'{source_name}__{ptr_name}'
-    elif needs_real_name and ctx.env.actually_toplevel_result_view_name:
+    elif needs_real_name and ctx.env.alias_result_view_name:
         # If this is a persistent schema expression but we aren't just
         # obviously sitting on an rptr (e.g CREATE ALIAS V := (Foo { x }, 10)),
         # we create a name like __V__Foo__2.
-        source_name = ctx.env.actually_toplevel_result_view_name.name
+        source_name = ctx.env.alias_result_view_name.name
         type_name = stype.get_name(ctx.env.schema).name
         generated_name = f'__{source_name}__{type_name}'
 

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -516,24 +516,6 @@ def define_alias(
 
     type_cmd.set_attribute_value('expr', expr)
 
-    # The deltas created for the expr_aliases via
-    # as_create_delta/delta_objects are already complete. What's more,
-    # canonicalizing them again can introduce incorrect changes: since
-    # the alias types are created by the compiler with
-    # inheritance_refdicts={'pointers'}, they are missing all
-    # inherited refs except for pointers (notably, constraints).
-    #
-    # If the delta includes a rebase, canonicalizing that will add
-    # back in those things---so mark everything as canonical to
-    # avoid that.
-    #
-    # Except that the collection operations we generated above came
-    # from shells, and are missing things that they need to be
-    # complete.
-    for op in derived_delta.get_subcommands(type=sd.ObjectCommand):
-        if not issubclass(op.get_schema_metaclass(), s_types.Collection):
-            op.canonical = True
-
     result = sd.CommandGroup()
     result.update(derived_delta.get_subcommands())
     type_shell = s_types.TypeShell(

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -312,6 +312,7 @@ class ObjectType(
                 schema,
                 sd.DeleteObject,
                 if_unused=True,
+                if_exists=True,
             )
         else:
             return None

--- a/edb/schema/ordering.py
+++ b/edb/schema/ordering.py
@@ -941,6 +941,7 @@ def _extract_op(stack: Sequence[sd.Command]) -> List[sd.Command]:
             ddl_identity=stack_op.ddl_identity,
             aux_object_data=stack_op.aux_object_data,
             annotations=stack_op.annotations,
+            canonical=stack_op.canonical,
             orig_cmd_type=type(stack_op),
         )
         parent_op.add(alter_delta)

--- a/edb/schema/reflection/structure.py
+++ b/edb/schema/reflection/structure.py
@@ -423,12 +423,14 @@ def generate_structure(schema: s_schema.Schema) -> SchemaReflectionParts:
 
             if fn in ownfields:
                 qual = "REQUIRED" if field.required else "OPTIONAL"
+                otd = " { ON TARGET DELETE ALLOW }" if field.weak_ref else ""
                 if ptr is None:
                     schema = _run_ddl(
                         f'''
                             ALTER TYPE {rschema_name} {{
                                 CREATE {qual}
-                                {storage.ptrkind} {fn} -> {storage.ptrtype};
+                                {storage.ptrkind} {fn} -> {storage.ptrtype}
+                                {otd};
                             }}
                         ''',
                         schema=schema,

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -130,6 +130,26 @@ class Type(
         int,
         default=None, inheritable=False)
 
+    def compare(
+        self,
+        other: so.Object,
+        *,
+        our_schema: s_schema.Schema,
+        their_schema: s_schema.Schema,
+        context: so.ComparisonContext,
+    ) -> float:
+        # We need to be able to compare objects and scalars, in some places
+        if (
+            isinstance(other, Type)
+            and not isinstance(other, self.__class__)
+            and not isinstance(self, other.__class__)
+        ):
+            return 0.0
+
+        return super().compare(
+            other,
+            our_schema=our_schema, their_schema=their_schema, context=context)
+
     def is_blocking_ref(
         self, schema: s_schema.Schema, reference: so.Object
     ) -> bool:
@@ -1450,8 +1470,7 @@ class ArrayTypeShell(CollectionTypeShell[Array_T_co]):
             )
 
         el = self.subtype
-        if (isinstance(el, CollectionTypeShell)
-                and schema.get_by_id(el.get_id(schema), None) is None):
+        if isinstance(el, CollectionTypeShell):
             cmd.add(el.as_create_delta(schema))
 
         ca.set_attribute_value('name', ca.classname)

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -10030,8 +10030,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             ''')
 
     @test.xfail('''
-        edgedb.errors.InvalidReferenceError: scalar type 'test::Alias'
-        does not exist
+        Referring to alias unsupported from computable
     ''')
     async def test_edgeql_migration_alias_01(self):
         await self.migrate(r'''
@@ -10126,9 +10125,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
         )
 
     @test.xfail('''
-        The second migration check produces the following issue:
-
-        No more "proposed", but not "completed" either.
+        Referring to alias unsupported from computable
     ''')
     async def test_edgeql_migration_alias_03(self):
         await self.migrate(r'''
@@ -10187,11 +10184,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
         )
 
     @test.xfail('''
-        The migration works, but then the query produces this error
-        (implying that the migration didn't update the type of the computable).
-
-        edgedb.errors.InvalidValueError: invalid input syntax for type
-        std::int64: "alias"
+        Referring to alias unsupported from computable
     ''')
     async def test_edgeql_migration_alias_04(self):
         # Same as the previous test, but using a single DDL command to
@@ -10248,8 +10241,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
         )
 
     @test.xfail('''
-        edgedb.errors.InvalidReferenceError: object type 'test::Alias'
-        does not exist
+        Referring to alias unsupported from computable
     ''')
     async def test_edgeql_migration_alias_05(self):
         await self.migrate(r'''
@@ -10291,9 +10283,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
         )
 
     @test.xfail('''
-        The second migration check produces the following issue:
-
-        No more "proposed", but not "completed" either.
+        Referring to alias unsupported from computable
     ''')
     async def test_edgeql_migration_alias_06(self):
         await self.migrate(r'''
@@ -10357,8 +10347,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
         )
 
     @test.xfail('''
-        edgedb.errors.InvalidReferenceError: object type 'test::Fuz'
-        does not exist
+        Referring to alias unsupported from computable
     ''')
     async def test_edgeql_migration_alias_07(self):
         await self.migrate(r'''
@@ -10450,6 +10439,50 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
                 },
             ],
         )
+
+    async def test_edgeql_migration_alias_08(self):
+        await self.migrate(r'''
+            type Foo;
+            type Bar;
+            alias X := Foo;
+        ''')
+
+        await self.migrate(r'''
+            type Foo;
+            type Bar;
+            alias X := Bar;
+        ''')
+
+        await self.migrate(r'''
+            type Foo;
+            type Bar;
+            alias X := 30;
+        ''')
+
+        await self.migrate(r'''
+            type Foo;
+            type Bar;
+            alias X := (Bar { z := 10 }, 30);
+        ''')
+
+        # delete it
+        await self.migrate(r'''
+            type Foo;
+            type Bar;
+        ''')
+
+    async def test_edgeql_migration_alias_09(self):
+        await self.migrate(r'''
+            type Foo;
+            type Bar;
+            alias X := Foo { bar := Bar { z := 1 } };
+        ''')
+
+        await self.migrate(r'''
+            type Foo;
+            type Bar;
+            alias X := Bar;
+        ''')
 
     async def test_edgeql_migration_tuple_01(self):
         await self.migrate(r'''

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -8060,6 +8060,14 @@ type default::Foo {
                 }
             """)
 
+    async def test_edgeql_ddl_alias_10(self):
+        await self.con.execute(r"""
+            create type Foo;
+            create type Bar;
+            create alias X := Foo { bar := Bar { z := 1 } };
+            alter alias X using (Bar);
+        """)
+
     async def test_edgeql_ddl_inheritance_alter_01(self):
         await self.con.execute(r"""
             CREATE TYPE InhTest01 {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -6343,7 +6343,11 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             };
         """])
 
-    @test.xfail('''Trips a SchemaError''')
+    @test.xfail('''
+        Trips a SchemaError in the initial migration accessing a missing type
+
+        The type produces from the default is a view type not in the schema
+    ''')
     def test_schema_migrations_equivalence_rename_alias_02(self):
         self._assert_migration_equivalence([r"""
             type Note {


### PR DESCRIPTION
* Fix migrating an alias between different types. Previously,
   when doing this, constraints would be added to the view object
   even though they are normally left off; the fix was to make the
   object commands in define_alias canonical.
 * Make the rptr weak_ref field be stored with ON TARGET DELETE ALLOW,
   which fixes some issues when migrating away from a complex alias.
 * Support comparision between ObjectType and ScalarType so that
   you can migrate between them.
 * Fix a number of issues with aliases that have a view inside of a
   tuple. The main piece here is generating proper names for all views
   that appear in aliases, not just ones that appear with an rptr.