### PR TITLE
Expose Function.backend_name to introspection

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_04_21_00_01
+EDGEDB_CATALOG_VERSION = 2022_04_25_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -432,6 +432,7 @@ CREATE TYPE schema::Function
     };
 
     CREATE MULTI LINK used_globals EXTENDING schema::ordered -> schema::Global;
+    CREATE PROPERTY backend_name -> std::uuid;
 };
 
 


### PR DESCRIPTION
This is pretty marginal, but I want it to support some bad scripts I
use to rewrite queries between different instances of a database.

In general, while we don't *support* directly writing SQL queries
against our database, I think that the introspection schema ought
to still contain the information necessary for it to be possible.