### PR TITLE
Set 'transient_derivation' when producing union/intersection types

### DIFF
--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -385,7 +385,7 @@ def get_union_type(
 
     ctx.env.schema, union, created = s_utils.ensure_union_type(
         ctx.env.schema, types,
-        opaque=opaque, preserve_derived=preserve_derived)
+        opaque=opaque, preserve_derived=preserve_derived, transient=True)
 
     if created:
         ctx.env.created_schema_objects.add(union)
@@ -408,7 +408,7 @@ def get_intersection_type(
 ) -> s_types.Type:
 
     ctx.env.schema, intersection, created = s_utils.ensure_intersection_type(
-        ctx.env.schema, types)
+        ctx.env.schema, types, transient=True)
 
     if created:
         ctx.env.created_schema_objects.add(intersection)
@@ -546,6 +546,8 @@ def get_union_pointer(
     source: s_sources.Source,
     direction: s_pointers.PointerDirection,
     components: Iterable[s_pointers.Pointer],
+    opaque: bool = False,
+    modname: Optional[str] = None,
     ctx: context.ContextLevel,
 ) -> s_pointers.Pointer:
 
@@ -555,6 +557,9 @@ def get_union_pointer(
         source,
         direction=direction,
         components=components,
+        opaque=opaque,
+        modname=modname,
+        transient=True,
     )
 
     ctx.env.created_schema_objects.add(ptr)

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -691,14 +691,14 @@ def resolve_ptr(
                     )
 
             opaque = not far_endpoints
-            ctx.env.schema, ptr = s_pointers.get_or_create_union_pointer(
-                ctx.env.schema,
+            ptr = schemactx.get_union_pointer(
                 ptrname=s_name.UnqualName(pointer_name),
                 source=near_endpoint,
                 direction=direction,
                 components=concrete_ptrs,
                 opaque=opaque,
                 modname=ctx.derived_target_module,
+                ctx=ctx,
             )
 
     if ptr is not None:

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -342,6 +342,7 @@ def get_or_create_union_type(
     schema: s_schema.Schema,
     components: Iterable[ObjectType],
     *,
+    transient: bool = False,
     opaque: bool = False,
     module: Optional[str] = None,
 ) -> Tuple[s_schema.Schema, ObjectType, bool]:
@@ -367,6 +368,7 @@ def get_or_create_union_type(
                 is_opaque_union=opaque,
                 abstract=True,
             ),
+            transient=transient,
         )
 
         if not opaque:
@@ -386,6 +388,7 @@ def get_or_create_intersection_type(
     components: Iterable[ObjectType],
     *,
     module: Optional[str] = None,
+    transient: bool = False,
 ) -> Tuple[s_schema.Schema, ObjectType, bool]:
 
     name = s_types.get_intersection_type_name(
@@ -407,6 +410,7 @@ def get_or_create_intersection_type(
                 intersection_of=so.ObjectSet.create(schema, components),
                 abstract=True,
             ),
+            transient=transient,
         )
 
         ptrs_dict = collections.defaultdict(list)
@@ -425,6 +429,7 @@ def get_or_create_intersection_type(
                     ptrname=pn,
                     source=objtype,
                     components=set(ptrs),
+                    transient=transient,
                 )
             else:
                 ptr = ptrs[0]

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -2677,6 +2677,7 @@ def get_or_create_union_pointer(
     direction: PointerDirection,
     components: Iterable[Pointer],
     *,
+    transient: bool = False,
     opaque: bool = False,
     modname: Optional[str] = None,
 ) -> Tuple[s_schema.Schema, Pointer]:
@@ -2721,8 +2722,8 @@ def get_or_create_union_pointer(
 
     target: s_types.Type
 
-    schema, target = utils.get_union_type(
-        schema, targets, opaque=opaque, module=modname)
+    schema, target, _ = utils.ensure_union_type(
+        schema, targets, opaque=opaque, module=modname, transient=transient)
 
     cardinality = qltypes.SchemaCardinality.One
     for component in components:
@@ -2752,6 +2753,7 @@ def get_or_create_union_pointer(
             'cardinality': cardinality,
             'required': required,
         },
+        transient=transient,
     )
 
     if isinstance(result, s_sources.Source):
@@ -2787,6 +2789,7 @@ def get_or_create_intersection_pointer(
     source: s_objtypes.ObjectType,
     components: Iterable[Pointer], *,
     modname: Optional[str] = None,
+    transient: bool = False,
 ) -> Tuple[s_schema.Schema, Pointer]:
 
     components = list(components)
@@ -2818,6 +2821,7 @@ def get_or_create_intersection_pointer(
             'intersection_of': so.ObjectSet.create(schema, components),
             'cardinality': cardinality,
         },
+        transient=transient,
     )
 
     return schema, result

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -865,6 +865,7 @@ def ensure_union_type(
     opaque: bool = False,
     module: Optional[str] = None,
     preserve_derived: bool = False,
+    transient: bool = False,
 ) -> Tuple[s_schema.Schema, s_types.Type, bool]:
 
     from edb.schema import objtypes as s_objtypes
@@ -942,6 +943,7 @@ def ensure_union_type(
             components=objtypes,
             opaque=opaque,
             module=module,
+            transient=transient,
         )
 
     return schema, uniontype, created
@@ -990,6 +992,7 @@ def ensure_intersection_type(
     schema: s_schema.Schema,
     types: Iterable[s_types.Type],
     *,
+    transient: bool = False,
     module: Optional[str] = None,
 ) -> Tuple[s_schema.Schema, s_types.Type, bool]:
 
@@ -1038,6 +1041,7 @@ def ensure_intersection_type(
             schema,
             components=cast(Iterable[s_objtypes.ObjectType], components_list),
             module=module,
+            transient=transient,
         )
 
 


### PR DESCRIPTION
This avoids needing to recompile constraints and defaults whenever
unions and intersections are done. In *particular*, this avoids the
need to recompile calls for `id`'s constraint and default every single
time.