### PR TITLE
Drop broken special case for nested insert FOR

### DIFF
--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1959,35 +1959,6 @@ def process_link_values(
 
             dispatch.visit(ir_expr, ctx=input_rel_ctx)
 
-            if (
-                isinstance(ir_expr.expr, irast.Stmt)
-                and ir_expr.expr.iterator_stmt is not None
-            ):
-                # The link value is computaed by a FOR expression,
-                # check if the statement is a DML statement, and if so,
-                # pull the iterator scope so that link property expressions
-                # have the correct context.
-                inner_iterator_cte = None
-                inner_iterator_path_id = ir_expr.expr.iterator_stmt.path_id
-                for cte in (input_rel_ctx.toplevel_stmt.ctes or ()):
-                    if cte.query.path_id == inner_iterator_path_id:
-                        inner_iterator_cte = cte
-                        break
-                if inner_iterator_cte is not None:
-                    inner_iterator_rvar = relctx.rvar_for_rel(
-                        inner_iterator_cte, lateral=True, ctx=subrelctx)
-
-                    relctx.include_rvar(
-                        input_rel,
-                        inner_iterator_rvar,
-                        path_id=inner_iterator_path_id,
-                        ctx=subrelctx,
-                    )
-
-                    input_rel_ctx.path_scope[inner_iterator_path_id] = (
-                        input_rel
-                    )
-
     input_stmt: pgast.Query = input_rel
 
     input_rvar = pgast.RangeSubselect(

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -2807,6 +2807,38 @@ class TestUpdate(tb.QueryTestCase):
                 ) FILTER false;
             """)
 
+    async def test_edgeql_insert_multi_required_01(self):
+        await self.con.execute("""
+            insert MultiRequiredTest {
+              name := "___",
+              prop := "!",
+              tags := (
+                for i in {(x := "90"), (x := "240")}
+                union (
+                  insert Tag {
+                    name := i.x,
+                  }
+                )
+              ),
+            };
+        """)
+
+    async def test_edgeql_insert_multi_required_02(self):
+        await self.con.execute("""
+            insert MultiRequiredTest {
+              name := "___",
+              prop := "!",
+              tags := (
+                for i in {"90", "240"}
+                union (
+                  insert Tag {
+                    name := i,
+                  }
+                )
+              ),
+            };
+        """)
+
     async def test_edgeql_subtract_badness_01(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,


### PR DESCRIPTION
There is some code that detects when a nested insert contains a DML
inside an iterator, and explicitly reincludes it. I think that this
was a workaround for when the general DML/iterator mechanisms were
much more broken than they are now.

It causes an extra join, and in the case of multi required things, the
join is broken. Just drop that code.

Fixes #3789.