### PR TITLE
Change __type__ to point to an ObjectType

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_04_21_00_01
+EDGEDB_CATALOG_VERSION = 2022_04_27_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -88,13 +88,6 @@ ALTER TYPE schema::Type {
 };
 
 
-ALTER TYPE std::BaseObject {
-    CREATE REQUIRED LINK __type__ -> schema::Type {
-        SET readonly := True;
-    };
-};
-
-
 CREATE ABSTRACT LINK schema::reference {
     CREATE PROPERTY owned -> std::bool;
     # Backwards compatibility.
@@ -357,6 +350,13 @@ CREATE TYPE schema::ObjectType
     EXTENDING
         schema::InheritingObject, schema::ConsistencySubject,
         schema::AnnotationSubject, schema::Type, schema::Source;
+
+
+ALTER TYPE std::BaseObject {
+    CREATE REQUIRED LINK __type__ -> schema::ObjectType {
+        SET readonly := True;
+    };
+};
 
 
 ALTER TYPE schema::ObjectType {

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -222,7 +222,7 @@ class TestIntrospection(tb.QueryTestCase):
                 'links': [{
                     'name': '__type__',
                     'target': {
-                        'name': 'schema::Type',
+                        'name': 'schema::ObjectType',
                         'compound_type': False,
                     },
                     'cardinality': 'One',

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7216,7 +7216,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             type test::Child extending test::Parent, test::Parent2 {
                 annotation test::anno := 'annotated';
                 index on (.foo);
-                required single link __type__ -> schema::Type {
+                required single link __type__ -> schema::ObjectType {
                     readonly := true;
                 };
                 overloaded single link foo extending test::f -> test::Foo {
@@ -7240,7 +7240,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Child extending test::Parent, test::Parent2 {
-                required single link __type__ -> schema::Type {
+                required single link __type__ -> schema::ObjectType {
                     readonly := true;
                 };
                 overloaded single link foo extending test::f -> test::Foo {
@@ -7381,7 +7381,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Foo {
-                required single link __type__ -> schema::Type {
+                required single link __type__ -> schema::ObjectType {
                     readonly := true;
                 };
                 required single property id -> std::uuid {
@@ -7398,7 +7398,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Foo {
-                required single link __type__ -> schema::Type {
+                required single link __type__ -> schema::ObjectType {
                     readonly := true;
                 };
                 required single property id -> std::uuid {
@@ -7416,7 +7416,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Bar extending test::Foo {
-                required single link __type__ -> schema::Type {
+                required single link __type__ -> schema::ObjectType {
                     readonly := true;
                 };
                 required single property id -> std::uuid {
@@ -7466,7 +7466,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             """
             type test::User extending test::HasImage {
                 index on (__subject__.image);
-                required single link __type__ -> schema::Type {
+                required single link __type__ -> schema::ObjectType {
                     readonly := true;
                 };
                 required single property id -> std::uuid {
@@ -7482,7 +7482,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::User extending test::HasImage {
-                required single link __type__ -> schema::Type {
+                required single link __type__ -> schema::ObjectType {
                     readonly := true;
                 };
                 required single property id -> std::uuid {
@@ -7506,7 +7506,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             '''
             abstract type test::HasImage {
                 index on (__subject__.image);
-                required single link __type__ -> schema::Type {
+                required single link __type__ -> schema::ObjectType {
                     readonly := true;
                 };
                 required single property id -> std::uuid {
@@ -7521,7 +7521,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             abstract type test::HasImage {
-                required single link __type__ -> schema::Type {
+                required single link __type__ -> schema::ObjectType {
                     readonly := true;
                 };
                 required single property id -> std::uuid {
@@ -7620,7 +7620,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::UniqueName {
-                required single link __type__ -> schema::Type {
+                required single link __type__ -> schema::ObjectType {
                     readonly := true;
                 };
                 optional single link translated_label
@@ -7640,7 +7640,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             '''
             type test::UniqueName {
-                required single link __type__ -> schema::Type {
+                required single link __type__ -> schema::ObjectType {
                     readonly := true;
                 };
                 optional single link translated_label
@@ -8260,7 +8260,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Foo {
-                required single link __type__ -> schema::Type {
+                required single link __type__ -> schema::ObjectType {
                     readonly := true;
                 };
                 optional single link bar -> std::Object {
@@ -8319,7 +8319,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
 
             """
             type test::Object {
-                required single link __type__ -> schema::Type {
+                required single link __type__ -> schema::ObjectType {
                     readonly := true;
                 };
                 required single property id -> std::uuid {
@@ -8331,7 +8331,7 @@ class TestDescribe(tb.BaseSchemaLoadTest):
             # The following builtins are masked by the above:
 
             # abstract type std::Object extending std::BaseObject {
-            #     required single link __type__ -> schema::Type {
+            #     required single link __type__ -> schema::ObjectType {
             #         readonly := true;
             #     };
             #     required single property id -> std::uuid {


### PR DESCRIPTION
This type is more precise and should be more efficient to access
(skips checking 12 tables that we know can't contain it...).