### PR TITLE
Switch to the new system for ACL access kinds

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_04_28_00_00
+EDGEDB_CATALOG_VERSION = 2022_04_29_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1170,7 +1170,7 @@ class AccessPolicyCommand(ObjectDDL):
 class CreateAccessPolicy(CreateObject, AccessPolicyCommand):
     condition: typing.Optional[Expr]
     action: qltypes.AccessPolicyAction
-    access_kind: typing.List[qltypes.AccessKind]
+    access_kinds: typing.List[qltypes.AccessKind]
     expr: Expr
 
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1405,6 +1405,14 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
         self._visit_DropObject(node, 'CONSTRAINT', after_name=after_name)
 
+    def _format_access_kinds(self, kinds: List[qltypes.AccessKind]) -> str:
+        if kinds == list(qltypes.AccessKind):
+            return 'all'
+        skinds = ', '.join(str(kind).lower() for kind in kinds)
+        skinds = skinds.replace("update", "update ")
+        skinds = skinds.replace("update read, update write", "update")
+        return skinds
+
     def visit_CreateAccessPolicy(
         self,
         node: qlast.CreateAccessPolicy
@@ -1419,8 +1427,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
                 self._block_ws(-1)
             self._block_ws(1)
             self._write_keywords(str(node.action) + ' ')
-            for kind in node.access_kind:
-                self._write_keywords(str(kind) + ' ')
+            if node.access_kinds:
+                self._write_keywords(
+                    self._format_access_kinds(node.access_kinds) + ' ')
             self._write_keywords('USING ')
             self.write('(')
             self.visit(node.expr)

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -452,19 +452,30 @@ class OptWhenBlock(Nonterm):
 class AccessKind(Nonterm):
 
     def reduce_ALL(self, *kids):
-        self.val = qltypes.AccessKind.All
+        self.val = list(qltypes.AccessKind)
 
-    def reduce_READ(self, *kids):
-        self.val = qltypes.AccessKind.Read
+    def reduce_SELECT(self, *kids):
+        self.val = [qltypes.AccessKind.Select]
 
-    def reduce_WRITE(self, *kids):
-        self.val = qltypes.AccessKind.Write
+    def reduce_UPDATE(self, *kids):
+        self.val = [
+            qltypes.AccessKind.UpdateRead, qltypes.AccessKind.UpdateWrite]
+
+    def reduce_UPDATE_READ(self, *kids):
+        self.val = [qltypes.AccessKind.UpdateRead]
+
+    def reduce_UPDATE_WRITE(self, *kids):
+        self.val = [qltypes.AccessKind.UpdateWrite]
+
+    def reduce_INSERT(self, *kids):
+        self.val = [qltypes.AccessKind.Insert]
 
     def reduce_DELETE(self, *kids):
-        self.val = qltypes.AccessKind.Delete
+        self.val = [qltypes.AccessKind.Delete]
 
 
-class AccessKindList(parsing.ListNonterm, element=AccessKind):
+class AccessKindList(parsing.ListNonterm, element=AccessKind,
+                     separator=tokens.T_COMMA):
     pass
 
 

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -1764,7 +1764,7 @@ class CreateAccessPolicyStmt(Nonterm):
             name=kids[3].val,
             condition=kids[4].val,
             action=kids[5].val,
-            access_kind=kids[6].val,
+            access_kinds=[y for x in kids[6].val for y in x],
             expr=kids[9].val,
             commands=kids[11].val,
         )

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -938,7 +938,7 @@ class AccessPolicyDeclarationBlock(Nonterm):
             name=kids[2].val,
             condition=kids[3].val,
             action=kids[4].val,
-            access_kind=kids[5].val,
+            access_kinds=[y for x in kids[5].val for y in x],
             expr=kids[8].val,
             commands=kids[10].val,
         )
@@ -955,7 +955,7 @@ class AccessPolicyDeclarationShort(Nonterm):
             name=kids[2].val,
             condition=kids[3].val,
             action=kids[4].val,
-            access_kind=kids[5].val,
+            access_kinds=[y for x in kids[5].val for y in x],
             expr=kids[8].val,
         )
 

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -194,10 +194,11 @@ class AccessPolicyAction(s_enum.StrEnum):
 
 
 class AccessKind(s_enum.StrEnum):
-    All = 'All'
-    Read = 'Read'
-    Write = 'Write'
+    Select = 'Select'
+    UpdateRead = 'UpdateRead'
+    UpdateWrite = 'UpdateWrite'
     Delete = 'Delete'
+    Insert = 'Insert'
 
 
 class DescribeLanguage(s_enum.StrEnum):

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -44,7 +44,7 @@ CREATE SCALAR TYPE schema::AccessPolicyAction
     EXTENDING enum<Allow, Deny>;
 
 CREATE SCALAR TYPE schema::AccessKind
-    EXTENDING enum<All, Read, Write, `Delete`>;
+    EXTENDING enum<`Select`, UpdateRead, UpdateWrite, `Delete`, `Insert`>;
 
 
 # Base type for all schema entities.
@@ -377,7 +377,8 @@ ALTER TYPE schema::ObjectType {
 
 ALTER TYPE schema::AccessPolicy {
   CREATE REQUIRED LINK subject -> schema::ObjectType;
-  CREATE REQUIRED PROPERTY access_kind -> array<schema::AccessKind>;
+  CREATE REQUIRED PROPERTY _access_kinds -> array<schema::AccessKind>;
+  CREATE PROPERTY access_kinds := array_unpack(._access_kinds);
   CREATE PROPERTY condition -> std::str;
   CREATE REQUIRED PROPERTY action -> schema::AccessPolicyAction;
   CREATE REQUIRED PROPERTY expr -> std::str;

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5455,7 +5455,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 create access policy all_on allow all using (true);
                 create access policy filtering
                     when (global filtering)
-                    deny read write using (.name ?!= global cur);
+                    deny select, delete using (.name ?!= global cur);
             };
             create type Bot extending User;
         """)
@@ -5463,13 +5463,16 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         await self.assert_query_result(
             '''
                 select schema::AccessPolicy {
-                    name, condition, expr, action, access_kind,
+                    name, condition, expr, action, access_kinds,
                     sname := .subject.name, root := not exists .bases };
 
             ''',
             tb.bag([
                 {
-                    "access_kind": ["All"],
+                    "access_kinds": [
+                        "Select", "UpdateRead", "UpdateWrite", "Delete",
+                        "Insert"
+                    ],
                     "action": "Allow",
                     "condition": None,
                     "expr": "true",
@@ -5478,7 +5481,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     "root": True,
                 },
                 {
-                    "access_kind": ["Read", "Write"],
+                    "access_kinds": ["Select", "Delete"],
                     "action": "Deny",
                     "condition": "global default::filtering",
                     "expr": "(.name ?!= global default::cur)",
@@ -5487,7 +5490,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     "root": True,
                 },
                 {
-                    "access_kind": ["All"],
+                    "access_kinds": [
+                        "Select", "UpdateRead", "UpdateWrite", "Delete",
+                        "Insert"
+                    ],
                     "action": "Allow",
                     "condition": None,
                     "expr": "true",
@@ -5496,7 +5502,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     "root": False,
                 },
                 {
-                    "access_kind": ["Read", "Write"],
+                    "access_kinds": ["Select", "Delete"],
                     "action": "Deny",
                     "condition": "global default::filtering",
                     "expr": "(.name ?!= global default::cur)",

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -5494,7 +5494,7 @@ aa';
         """
         create type Foo {
             create access policy test
-            allow read write
+            allow select, update write
             using (true);
         };
         """

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -1729,7 +1729,7 @@ annotation test::foo;
         module test {
             type Foo {
                 access policy test
-                allow read write
+                allow select, update, insert
                 using (1 + 2 = 3);
             };
         };


### PR DESCRIPTION
While we're at it, make 'access_kinds' a computed multi
property. We'll make it an actual multi property later (hopefully
before 2.0).