### PR TITLE
Fix IN array_unpack for bigints

### DIFF
--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1369,16 +1369,19 @@ def process_set_as_membership_expr(
         newctx.expr_exposed = False
         left_out = dispatch.compile(left_arg, ctx=newctx)
 
-        right_arg = irutils.unwrap_set(right_arg)
+        orig_right_arg = right_arg
+        unwrapped_right_arg = irutils.unwrap_set(right_arg)
         # If the right operand of [NOT] IN is an array_unpack call,
         # then use the ANY/ALL array comparison operator directly,
         # since that has a higher chance of using the indexes.
-        right_expr = right_arg.expr
+        right_expr = unwrapped_right_arg.expr
         needs_coalesce = False
+
         if (
             isinstance(right_expr, irast.FunctionCall)
             and str(right_expr.func_shortname) == 'std::array_unpack'
             and not right_expr.args[0].cardinality.is_multi()
+            and (not expr.sql_operator or len(expr.sql_operator) <= 1)
         ):
             is_array_unpack = True
             right_arg = right_expr.args[0].expr
@@ -1389,6 +1392,11 @@ def process_set_as_membership_expr(
         left_is_row_expr = astutils.is_row_expr(left_out)
 
         with newctx.subrel() as _, _.newscope() as subctx:
+            if is_array_unpack:
+                relctx.update_scope(orig_right_arg, subctx.rel, ctx=subctx)
+                relctx.update_scope(
+                    unwrapped_right_arg, subctx.rel, ctx=subctx)
+
             dispatch.compile(right_arg, ctx=subctx)
             right_rel = subctx.rel
             right_out = pathctx.get_path_value_var(

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -537,6 +537,19 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
             [True],
         )
 
+        await self.assert_query_result(
+            r'''SELECT 1n IN array_unpack([1n]);''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select 1n in array_unpack(
+                    <array<bigint>><array<str>>to_json('["1"]'))
+            ''',
+            [True],
+        )
+
     async def test_edgeql_functions_enumerate_01(self):
         await self.assert_query_result(
             r'''SELECT [10, 20];''',

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -205,3 +205,15 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             "uuid_generate", group_sql,
             "group has unnecessary uuid_generate",
         )
+
+    def test_codegen_in_array_unpack_no_dupe(self):
+        sql = self._compile('''
+            select 1 in array_unpack(
+                <array<int64>><array<str>>to_json('["1"]'))
+        ''')
+
+        count = sql.count('["1"]')
+        self.assertEqual(
+            count,
+            1,
+            f"argument needlessly duplicated")


### PR DESCRIPTION
The way we insert casts for the comparison operator breaks on
array_unpacks.

Also, we failed to take into account the scopes that we skipped over,
which caused trouble in the double cast cases.

Fixes #3817.