### PR TITLE
Put more parens around index expressions in generated DDL

### DIFF
--- a/edb/pgsql/dbops/indexes.py
+++ b/edb/pgsql/dbops/indexes.py
@@ -93,7 +93,7 @@ class Index(tables.InheritableTableObject):
             exprs = [qi(c) for c in self.columns]
 
         # TODO: Make NULLs behavior configurable
-        expr = ', '.join(f'{e} NULLS FIRST' for e in exprs)
+        expr = ', '.join(f'({e}) NULLS FIRST' for e in exprs)
 
         code = '''
             CREATE {unique} INDEX {name}

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -11014,6 +11014,14 @@ type default::Foo {
                 };
             """)
 
+    async def test_edgeql_ddl_index_05(self):
+        await self.con.execute(r"""
+            create type Artist {
+                create property oid -> bigint;
+                create index on (<str>.oid)
+            };
+        """)
+
     async def test_edgeql_ddl_errors_01(self):
         await self.con.execute('''
             CREATE TYPE Err1 {


### PR DESCRIPTION
Fixes #3819.