### PR TITLE
Remove an xfail from a test that works now

### DIFF
--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -1401,10 +1401,6 @@ class TestIntrospection(tb.QueryTestCase):
 
         self.assertGreater(res, 0)
 
-    @test.xfail("""
-       We don't always properly filter things when
-       intersections/unions/backlinks are involved.
-    """)
     async def test_edgeql_introspection_reverse_leaks_01(self):
         res1 = await self.con.query(r"""
             WITH MODULE schema


### PR DESCRIPTION
This was an issue where we weren't properly applying the access rules
for schema objects on unfiltered backlinks. This was fixed when we
switched to the new access policy mechanism, which handles that case,
in #3823.