### PR TITLE
Drop the never-read-from optional field of qlast.Parameter

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -365,7 +365,6 @@ class BytesConstant(BaseConstant):
 
 class Parameter(Expr):
     name: str
-    optional: bool
 
 
 class UnaryOp(Expr):

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -1253,7 +1253,7 @@ class Constant(Nonterm):
     # | BaseBytesConstant
 
     def reduce_ARGUMENT(self, *kids):
-        self.val = qlast.Parameter(name=kids[0].val[1:], optional=False)
+        self.val = qlast.Parameter(name=kids[0].val[1:])
 
     def reduce_BaseNumberConstant(self, *kids):
         self.val = kids[0].val

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -1599,7 +1599,10 @@ class GraphQLTranslator:
 
         return qlast.TypeCast(
             type=casttype,
-            expr=qlast.Parameter(name=varname, optional=optional),
+            expr=qlast.Parameter(name=varname),
+            cardinality_mod=(
+                qlast.CardinalityModifier.Optional if optional else None
+            ),
         )
 
     def visit_StringValueNode(self, node):

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1349,7 +1349,7 @@ class DeleteFunction(FunctionCommand, adapts=s_funcs.DeleteFunction):
             # (not just an alias to a SQL function).
 
             overload = False
-            if nativecode:
+            if nativecode and func.find_object_param_overloads(schema):
                 dbf, overload_replace = self.compile_edgeql_function(
                     func, schema, context)
                 if overload_replace:

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -4561,7 +4561,7 @@ def _make_json_caster(
 ) -> Callable[[str], str]:
     cast_expr = qlast.TypeCast(
         expr=qlast.TypeCast(
-            expr=qlast.Parameter(name="__replaceme__", optional=False),
+            expr=qlast.Parameter(name="__replaceme__"),
             type=s_utils.typeref_to_ast(schema, schema.get('std::json')),
         ),
         type=s_utils.typeref_to_ast(schema, stype),

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -2211,7 +2211,7 @@ def get_params_symtable(
     anchors: Dict[str, qlast.Expr] = {}
 
     defaults_mask = qlast.TypeCast(
-        expr=qlast.Parameter(name='__defaults_mask__', optional=False),
+        expr=qlast.Parameter(name='__defaults_mask__'),
         type=qlast.TypeName(
             maintype=qlast.ObjectRef(
                 module='std',
@@ -2226,9 +2226,9 @@ def get_params_symtable(
             p.get_typemod(schema) is not ft.TypeModifier.SingletonType
         )
         anchors[p_shortname] = qlast.TypeCast(
-            expr=qlast.Parameter(
-                name=p_shortname,
-                optional=p_is_optional,
+            expr=qlast.Parameter(name=p_shortname),
+            cardinality_mod=(
+                qlast.CardinalityModifier.Optional if p_is_optional else None
             ),
             type=utils.typeref_to_ast(schema, p.get_type(schema)),
         )

--- a/tests/schemas/cards_ir_inference.esdl
+++ b/tests/schemas/cards_ir_inference.esdl
@@ -131,7 +131,7 @@ type Person extending BadlyNamed {
 
 function taking_opt_returning_non_opt(a: optional str) -> str {
     using (
-        a
+        a ?? ""
     );
 };
 

--- a/tests/test_edgeql_coalesce.py
+++ b/tests/test_edgeql_coalesce.py
@@ -1188,7 +1188,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
         await self.con.execute(
             r'''
                 CREATE FUNCTION optfunc(
-                        a: std::str, b: OPTIONAL std::str) -> std::str
+                        a: std::str, b: OPTIONAL std::str) -> OPTIONAL std::str
                     USING EdgeQL $$
                         SELECT b IF a = 'foo' ELSE a
                     $$;
@@ -1397,7 +1397,8 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     async def test_edgeql_coalesce_correlation_03(self):
         # TODO: add this to the schema if we want more like it
         await self.con.execute('''
-            CREATE FUNCTION opts(x: OPTIONAL str) -> str { USING (x) };
+            CREATE FUNCTION opts(x: OPTIONAL str) -> OPTIONAL str {
+                USING (x) };
         ''')
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -6075,7 +6075,7 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
         await self.migrate(r"""
             function hello02(a: int64, b: OPTIONAL int64=42) -> str
                 using edgeql $$
-                    SELECT 'hello' ++ <str>(a + b)
+                    SELECT 'hello' ++ <str>(a + (b ?? -1))
                 $$
         """)
 
@@ -6087,6 +6087,11 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
         await self.assert_query_result(
             r"""SELECT hello02(1, 2);""",
             ['hello3'],
+        )
+
+        await self.assert_query_result(
+            r"""SELECT hello02(1, <int64>{});""",
+            ['hello0'],
         )
 
     async def test_edgeql_migration_eq_function_03(self):

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -4396,6 +4396,19 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 $$;
             """)
 
+    async def test_edgeql_ddl_function_35(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidFunctionDefinitionError,
+            r"return cardinality mismatch"
+        ):
+            await self.con.execute(r"""
+                CREATE FUNCTION broken_edgeql_func35(
+                    a: optional std::int64) -> std::int64
+                USING EdgeQL $$
+                    SELECT a
+                $$;
+            """)
+
     async def test_edgeql_ddl_function_rename_01(self):
         await self.con.execute("""
             CREATE FUNCTION foo(s: str) -> str {


### PR DESCRIPTION
Properly set cardinality_mod in the enclosing cast, in the locations
it is set. The fixes a bug with OPTIONAL function arguments not having
the correct cardinality. (This was an accident. I was just trying to
delete dead code.)

Also, skip recompiling functions during delete unless it is *actually*
overloaded. This is a minor performance win and also mostly fixes an
issue where it is not possible to delete an existing function that
now fails to compile due to a bug fix.