### PR TITLE
Explain that regex flags must be embedded options

### DIFF
--- a/docs/stdlib/string.rst
+++ b/docs/stdlib/string.rst
@@ -697,8 +697,8 @@ BRE, ERE, and ARE support can be found in `PostgreSQL documentation`_.
                 functions-matching.html#POSIX-SYNTAX-DETAILS
 
 For convenience, here's a table outlining the different options
-accepted as the ``flag`` argument to various regular expression
-functions:
+accepted as the ``flags`` argument to various regular expression
+functions, or as [embedded options](https://www.postgresql.org/docs/10/functions-matching.html#POSIX-METASYNTAX) in the pattern itself, e.g. `'(?i)fooBAR'`:
 
 .. _string_regexp_flags:
 

--- a/docs/stdlib/string.rst
+++ b/docs/stdlib/string.rst
@@ -698,8 +698,11 @@ BRE, ERE, and ARE support can be found in `PostgreSQL documentation`_.
 
 For convenience, here's a table outlining the different options
 accepted as the ``flags`` argument to various regular expression
-functions, or as [embedded options](https://www.postgresql.org/docs/10/functions-matching.html#POSIX-METASYNTAX) in the pattern itself, e.g. `'(?i)fooBAR'`:
+functions, or as `embedded options`_ in the pattern itself, e.g. ``'(?i)fooBAR'``:
 
+.. _`embedded options`:
+                https://www.postgresql.org/docs/10/functions-matching.html#POSIX-METASYNTAX  
+                
 .. _string_regexp_flags:
 
 Option Flags


### PR DESCRIPTION
Because I had some difficulty after reading that the flags are for a `flags` argument, I was stuck for a while not knowing how to pass flags to `re_test` and `re_match` since I only see a `flags` argument for `re_replace`.