### PR TITLE
Support global variables on HTTP/graphql protocols

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -484,7 +484,10 @@ def compile_GlobalExpr(
 
     param_set: qlast.Expr | irast.Set
     present_set: qlast.Expr | irast.Set | None
-    if ctx.env.options.func_params is None:
+    if (
+        ctx.env.options.func_params is None
+        and not ctx.env.options.json_parameters
+    ):
         param_set, present_set = setgen.get_global_param_sets(glob, ctx=ctx)
     else:
         param_set, present_set = setgen.get_func_global_param_sets(

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -760,13 +760,17 @@ def get_globals(
     else:
         globs.update(bound_call.func.get_used_globals(schema).objects(schema))
 
-    if ctx.env.options.func_params is None:
+    if (
+        ctx.env.options.func_params is None
+        and not ctx.env.options.json_parameters
+    ):
         glob_set = setgen.get_globals_as_json(
             tuple(globs), ctx=ctx, srcctx=expr.context)
     else:
-        # Make sure that we properly track the globals we use
-        for glob in globs:
-            setgen.get_global_param(glob, ctx=ctx)
+        if ctx.env.options.func_params is not None:
+            # Make sure that we properly track the globals we use in functions
+            for glob in globs:
+                setgen.get_global_param(glob, ctx=ctx)
         glob_set = setgen.get_func_global_json_arg(ctx=ctx)
 
     return [glob_set]

--- a/edb/graphql/compiler.py
+++ b/edb/graphql/compiler.py
@@ -42,6 +42,7 @@ class CompiledOperation:
     sql: bytes
     sql_hash: bytes
     sql_args: List[str]
+    has_globals: bool
     cacheable: bool
     cache_deps_vars: Optional[FrozenSet[str]]
     variables: Dict
@@ -114,6 +115,8 @@ def compile_graphql(
         expected_cardinality_one=True,
         output_format=pg_compiler.OutputFormat.JSON)
 
+    has_globals = bool(argmap.pop('__edb_json_globals__', None))
+
     args: List[Optional[str]] = [None] * len(argmap)
     for argname, param in argmap.items():
         args[param.index - 1] = argname
@@ -125,6 +128,7 @@ def compile_graphql(
         sql=sql_bytes,
         sql_hash=sql_hash,
         sql_args=args,  # type: ignore[arg-type]  # XXX: optional bug?
+        has_globals=has_globals,
         cacheable=op.cacheable,
         cache_deps_vars=op.cache_deps_vars,
         variables=op.variables_desc,

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -142,7 +142,8 @@ class EdgeQLTestCase(BaseHttpExtensionTest, server.QueryTestCase):
     def get_extension_path(cls):
         return 'edgeql'
 
-    def edgeql_query(self, query, *, use_http_post=True, variables=None):
+    def edgeql_query(
+            self, query, *, use_http_post=True, variables=None, globals=None):
         req_data = {
             'query': query
         }
@@ -150,6 +151,8 @@ class EdgeQLTestCase(BaseHttpExtensionTest, server.QueryTestCase):
         if use_http_post:
             if variables is not None:
                 req_data['variables'] = variables
+            if globals is not None:
+                req_data['globals'] = globals
             req = urllib.request.Request(self.http_addr, method='POST')
             req.add_header('Content-Type', 'application/json')
             response = urllib.request.urlopen(
@@ -159,6 +162,8 @@ class EdgeQLTestCase(BaseHttpExtensionTest, server.QueryTestCase):
         else:
             if variables is not None:
                 req_data['variables'] = json.dumps(variables)
+            if globals is not None:
+                req_data['globals'] = json.dumps(globals)
             response = urllib.request.urlopen(
                 f'{self.http_addr}/?{urllib.parse.urlencode(req_data)}',
                 context=self.tls_context,
@@ -178,11 +183,13 @@ class EdgeQLTestCase(BaseHttpExtensionTest, server.QueryTestCase):
     def assert_edgeql_query_result(self, query, result, *,
                                    msg=None, sort=None,
                                    use_http_post=True,
-                                   variables=None):
+                                   variables=None,
+                                   globals=None):
         res = self.edgeql_query(
             query,
             use_http_post=use_http_post,
-            variables=variables)
+            variables=variables,
+            globals=globals)
 
         if sort is not None:
             # GQL will always have a single object returned. The data is
@@ -203,7 +210,8 @@ class GraphQLTestCase(BaseHttpExtensionTest, server.QueryTestCase):
 
     def graphql_query(self, query, *, operation_name=None,
                       use_http_post=True,
-                      variables=None):
+                      variables=None,
+                      globals=None):
         req_data = {
             'query': query
         }
@@ -214,6 +222,8 @@ class GraphQLTestCase(BaseHttpExtensionTest, server.QueryTestCase):
         if use_http_post:
             if variables is not None:
                 req_data['variables'] = variables
+            if globals is not None:
+                req_data['globals'] = globals
             req = urllib.request.Request(self.http_addr, method='POST')
             req.add_header('Content-Type', 'application/json')
             response = urllib.request.urlopen(
@@ -223,6 +233,8 @@ class GraphQLTestCase(BaseHttpExtensionTest, server.QueryTestCase):
         else:
             if variables is not None:
                 req_data['variables'] = json.dumps(variables)
+            if globals is not None:
+                req_data['globals'] = json.dumps(globals)
             response = urllib.request.urlopen(
                 f'{self.http_addr}/?{urllib.parse.urlencode(req_data)}',
                 context=self.tls_context,
@@ -259,12 +271,14 @@ class GraphQLTestCase(BaseHttpExtensionTest, server.QueryTestCase):
                                     msg=None, sort=None,
                                     operation_name=None,
                                     use_http_post=True,
-                                    variables=None):
+                                    variables=None,
+                                    globals=None):
         res = self.graphql_query(
             query,
             operation_name=operation_name,
             use_http_post=use_http_post,
-            variables=variables)
+            variables=variables,
+            globals=globals)
 
         if sort is not None:
             # GQL will always have a single object returned. The data is

--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -142,3 +142,22 @@ type Game extending NamedObject {
 type LinkedList extending NamedObject {
     link next -> LinkedList
 }
+
+global test_global_str -> str;
+global test_global_array -> array<str>;
+global test_global_id -> uuid;
+required global test_global_def -> str {
+    default := ""
+};
+optional global test_global_def2 -> str {
+    default := ""
+};
+function get_glob() -> optional str using (global test_global_str);
+
+alias GlobalTest := {
+    gstr := global test_global_str,
+	garray := global test_global_array,
+	gid := global test_global_id,
+	gdef := global test_global_def,
+	gdef2 := global test_global_def2,
+};

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -257,3 +257,63 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
                 r'''SELECT <str>$x ?? '-default' ''',
                 variables={'x': None},
             )
+
+    def test_http_edgeql_query_globals_01(self):
+        Q = r'''select GlobalTest { gstr, garray, gid, gdef, gdef2 }'''
+
+        for use_http_post in [True, False]:
+            self.assert_edgeql_query_result(
+                Q,
+                [{'gstr': 'WOO',
+                  'gid': '84ed3d8b-5eb2-4d31-9e1e-efb66180445c', 'gdef': '',
+                  'gdef2': None, 'garray': ['x', 'y', 'z']}],
+                use_http_post=use_http_post,
+                globals={
+                    'default::test_global_str': "WOO",
+                    'default::test_global_id': (
+                        '84ed3d8b-5eb2-4d31-9e1e-efb66180445c'),
+                    'default::test_global_def': None,
+                    'default::test_global_def2': None,
+                    'default::test_global_array': ['x', 'y', 'z'],
+                },
+            )
+
+            self.assert_edgeql_query_result(
+                Q,
+                [{'gdef': 'x', 'gdef2': 'x'}],
+                use_http_post=use_http_post,
+                globals={
+                    'default::test_global_def': 'x',
+                    'default::test_global_def2': 'x',
+                },
+            )
+
+            self.assert_edgeql_query_result(
+                Q,
+                [{'gstr': None, 'garray': None, 'gid': None,
+                  'gdef': '', 'gdef2': ''}],
+                use_http_post=use_http_post,
+            )
+
+    def test_http_edgeql_query_globals_02(self):
+        Q = r'''select (global test_global_str) ++ <str>$test'''
+
+        for use_http_post in [True, False]:
+            self.assert_edgeql_query_result(
+                Q,
+                ['foo!'],
+                variables={'test': '!'},
+                globals={'default::test_global_str': 'foo'},
+                use_http_post=use_http_post,
+            )
+
+    def test_http_edgeql_query_globals_03(self):
+        Q = r'''select get_glob()'''
+
+        for use_http_post in [True, False]:
+            self.assert_edgeql_query_result(
+                Q,
+                ['foo'],
+                globals={'default::test_global_str': 'foo'},
+                use_http_post=use_http_post,
+            )

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -4046,6 +4046,50 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             ]
         })
 
+    def test_graphql_globals_01(self):
+        Q = r'''query { GlobalTest { gstr, garray, gid, gdef, gdef2 } }'''
+
+        for use_http_post in [True, False]:
+            self.assert_graphql_query_result(
+                Q,
+                {
+                    "GlobalTest": [{
+                        'gstr': 'WOO',
+                        'gid': '84ed3d8b-5eb2-4d31-9e1e-efb66180445c',
+                        'gdef': '',
+                        'gdef2': None, 'garray': ['x', 'y', 'z']
+                    }],
+                },
+                use_http_post=use_http_post,
+                globals={
+                    'default::test_global_str': "WOO",
+                    'default::test_global_id': (
+                        '84ed3d8b-5eb2-4d31-9e1e-efb66180445c'),
+                    'default::test_global_def': None,
+                    'default::test_global_def2': None,
+                    'default::test_global_array': ['x', 'y', 'z'],
+                },
+            )
+
+            self.assert_graphql_query_result(
+                Q,
+                {'GlobalTest': [{'gdef': 'x', 'gdef2': 'x'}]},
+                use_http_post=use_http_post,
+                globals={
+                    'default::test_global_def': 'x',
+                    'default::test_global_def2': 'x',
+                },
+            )
+
+            self.assert_graphql_query_result(
+                Q,
+                {'GlobalTest': [
+                    {'gstr': None, 'garray': None, 'gid': None,
+                     'gdef': '', 'gdef2': ''}
+                ]},
+                use_http_post=use_http_post,
+            )
+
 
 class TestGraphQLInit(tb.GraphQLTestCase):
     """Test GraphQL initialization on an empty database."""


### PR DESCRIPTION
Adds a `globals` argument to the queries that works just like the
`variables` argument.

We pass it in JSON-encoded as one query argument, and fully reuse the
mechanisms for functions that use global variables.

Fixes #3829.