### PR TITLE
Fix generation of dummy_pathid in nonconflict ctes

### DIFF
--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -956,9 +956,10 @@ def compile_insert_else_body(
                     name_hint=sn.QualName(
                         module='__derived__',
                         name=ctx.env.aliases.get('dummy'))))
-            dummy_q = pgast.SelectStmt()
-            relctx.ensure_transient_identity_for_path(
-                dummy_pathid, dummy_q, ctx=ictx)
+            with ctx.subrel() as dctx:
+                dummy_q = dctx.rel
+                relctx.ensure_transient_identity_for_path(
+                    dummy_pathid, dummy_q, ctx=dctx)
             dummy_rvar = relctx.rvar_for_rel(
                 dummy_q, lateral=True, ctx=ictx)
             relctx.include_rvar(ictx.rel, dummy_rvar,

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -3103,6 +3103,19 @@ class TestInsert(tb.QueryTestCase):
         self.assertEqual(len(obj3), 1)
         self.assertEqual(obj1.id, tuple(obj3)[0].id)
 
+    async def test_edgeql_insert_unless_conflict_24(self):
+        await self.con.execute('''
+            WITH
+                raw_data := to_json('[1,2]')
+            for data in {<int64>json_array_unpack(raw_data)} union(
+                INSERT Person {
+                    note := (INSERT Note { name := 'x' }),
+                    name := <str>data,
+                }
+                UNLESS conflict on .name
+            );
+        ''')
+
     async def test_edgeql_insert_dependent_01(self):
         query = r'''
             SELECT (


### PR DESCRIPTION
Since the relevant rel wasn't in the hierarchy, the search for the
enclosing volatility ref wasn't succeeding, and when nonconflict CTEs
were used in a for loop, sometimes things could get
duplicated. (Depending on the vagaries of how pg orders the loops, I
think).

Fixes #3847.