### PR TITLE
Recompile functions on access policy changes

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1935,13 +1935,21 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                       CommandContext, s_expr.Expression],
                      s_expr.Expression]
         ]=None,
+        include_ancestors: bool=False,
         extra_refs: Optional[Dict[so.Object, List[str]]]=None,
+        filter: Type[so.Object] | Tuple[Type[so.Object], ...] | None = None,
         metadata_only: bool=True,
     ) -> s_schema.Schema:
         scls = self.scls
         expr_refs = s_expr.get_expr_referrers(schema, scls)
+        if include_ancestors and isinstance(scls, so.InheritingObject):
+            for anc in scls.get_ancestors(schema).objects(schema):
+                expr_refs.update(s_expr.get_expr_referrers(schema, anc))
         if extra_refs:
             expr_refs.update(extra_refs)
+        if filter is not None:
+            expr_refs = {
+                k: v for k, v in expr_refs.items() if isinstance(k, filter)}
 
         if expr_refs:
             try:

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -180,9 +180,12 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
 
         assert isinstance(ir, irast_.Statement)
 
+        # XXX: ref stuff - why doesn't it go into the delta tree? - temporary??
+        srefs = {ref for ref in ir.schema_refs if schema.has_object(ref.id)}
+
         return cls(
             text=expr.text,
-            refs=so.ObjectSet.create(schema, ir.schema_refs),
+            refs=so.ObjectSet.create(schema, srefs),
             _qlast=expr.qlast,
             _irast=ir,
         )


### PR DESCRIPTION
When an access policy on a type used by a function changes, we need to
recompile the function.

To make this work, we need to also track link targets in schema_refs,
so that we always depend on the targets directly and not just the link.

Fixes #3843.