### PR TITLE
Always correctly handle variadic arguments when producing AST from migrations

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4753,6 +4753,13 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             }
         """])
 
+    def test_schema_migrations_equivalence_function_21(self):
+        self._assert_migration_equivalence([r"""
+            function foo(variadic s: str) -> str using ("!");
+        """, r"""
+            function foo(variadic s: str) -> str using ("?");
+        """])
+
     def test_schema_migrations_equivalence_recursive_01(self):
         with self.assertRaisesRegex(
             errors.InvalidDefinitionError,


### PR DESCRIPTION
In our schema, we store variadic types with an array argument, and we need
be consistent about stripping it away when producing ASTs.

Fixes #3807.