### PR TITLE
Fix wrong type name in str->bigint cast error message

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_05_06_00_00
+EDGEDB_CATALOG_VERSION = 2022_05_12_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -522,7 +522,7 @@ class StrToBigint(dbops.Function):
                     NULL::numeric,
                     'invalid_text_representation',
                     msg => (
-                        'invalid syntax for type edgedb.bigint_t: '
+                        'invalid input syntax for type edgedb.bigint_t: '
                         || quote_literal(val)
                     )
                 );
@@ -553,7 +553,7 @@ class StrToDecimal(dbops.Function):
                     NULL::numeric,
                     'invalid_text_representation',
                     msg => (
-                        'invalid syntax for type numeric: '
+                        'invalid input syntax for type numeric: '
                         || quote_literal(val)
                     )
                 )
@@ -2522,7 +2522,7 @@ class StrToBool(dbops.Function):
                 edgedb.raise(
                     NULL::text[],
                     'invalid_text_representation',
-                    msg => 'invalid syntax for type bool: '
+                    msg => 'invalid input syntax for type bool: '
                            || quote_literal(val)
                 )
             )

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -498,25 +498,36 @@ class AlterCurrentDatabaseSetArray(dbops.Function):
 
 class StrToBigint(dbops.Function):
     """Parse bigint from text."""
+
+    # The plpgsql execption handling nonsense is actually just so that
+    # we can produce an exception that mentions edgedb.bigint_t
+    # instead of numeric, and thus produce the right user-facing
+    # exception. As a nice side effect it is like twice as fast
+    # as the previous code too.
     text = r'''
-        SELECT
-            (CASE WHEN scale(v.column1) = 0 THEN
-                v.column1
+        DECLARE
+            v numeric;
+        BEGIN
+            BEGIN
+              v := val::numeric;
+            EXCEPTION
+              WHEN OTHERS THEN
+                 v := NULL;
+            END;
+
+            IF scale(v) = 0 THEN
+                RETURN v::edgedb.bigint_t;
             ELSE
-                edgedb.raise(
+                EXECUTE edgedb.raise(
                     NULL::numeric,
                     'invalid_text_representation',
                     msg => (
                         'invalid syntax for edgedb.bigint_t: '
                         || quote_literal(val)
                     )
-                )
-            END)::edgedb.bigint_t
-        FROM
-            (VALUES (
-                val::numeric
-            )) AS v
-        ;
+                );
+            END IF;
+        END;
     '''
 
     def __init__(self) -> None:
@@ -524,6 +535,7 @@ class StrToBigint(dbops.Function):
             name=('edgedb', 'str_to_bigint'),
             args=[('val', ('text',))],
             returns=('edgedb', 'bigint_t'),
+            language='plpgsql',
             # Stable because it's raising exceptions.
             volatility='stable',
             strict=True,

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -522,7 +522,7 @@ class StrToBigint(dbops.Function):
                     NULL::numeric,
                     'invalid_text_representation',
                     msg => (
-                        'invalid syntax for edgedb.bigint_t: '
+                        'invalid syntax for type edgedb.bigint_t: '
                         || quote_literal(val)
                     )
                 );
@@ -553,7 +553,7 @@ class StrToDecimal(dbops.Function):
                     NULL::numeric,
                     'invalid_text_representation',
                     msg => (
-                        'invalid syntax for numeric: '
+                        'invalid syntax for type numeric: '
                         || quote_literal(val)
                     )
                 )
@@ -2522,7 +2522,8 @@ class StrToBool(dbops.Function):
                 edgedb.raise(
                     NULL::text[],
                     'invalid_text_representation',
-                    msg => 'invalid syntax for bool: ' || quote_literal(val)
+                    msg => 'invalid syntax for type bool: '
+                           || quote_literal(val)
                 )
             )
         )[2] IS NULL;

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -1367,13 +1367,13 @@ class TestEdgeQLCasts(tb.QueryTestCase):
     async def test_edgeql_casts_numeric_08(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'invalid input syntax for std::bigint'):
+                r'invalid input syntax for type std::bigint'):
             await self.con.query_single(
                 'SELECT <bigint>"100000n"')
 
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
-                r'invalid input syntax for std::decimal'):
+                r'invalid input syntax for type std::decimal'):
             await self.con.query_single(
                 'SELECT <decimal>"12313.132n')
 

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -1353,6 +1353,13 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         )
 
     async def test_edgeql_casts_numeric_07(self):
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError,
+                r'invalid input syntax for std::bigint'):
+            await self.con.query_single(
+                'SELECT <bigint>"100000n"')
+
+    async def test_edgeql_casts_numeric_07(self):
         numerics = ['int16', 'int32', 'int64', 'float32', 'float64', 'bigint',
                     'decimal']
 

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -566,7 +566,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                         't', 'f', 'tr', 'fa'}:
             async with self.assertRaisesRegexTx(
                     edgedb.InvalidValueError,
-                    fr"invalid syntax for std::bool: '{variant}'"):
+                    fr"invalid syntax for type std::bool: '{variant}'"):
                 await self.con.query_single(f'SELECT <bool>"{variant}"')
 
         self.assertTrue(

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -1359,6 +1359,12 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             await self.con.query_single(
                 'SELECT <bigint>"100000n"')
 
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError,
+                r'invalid input syntax for std::decimal'):
+            await self.con.query_single(
+                'SELECT <decimal>"12313.132n')
+
     async def test_edgeql_casts_numeric_07(self):
         numerics = ['int16', 'int32', 'int64', 'float32', 'float64', 'bigint',
                     'decimal']

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -1353,6 +1353,18 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         )
 
     async def test_edgeql_casts_numeric_07(self):
+        numerics = ['int16', 'int32', 'int64', 'float32', 'float64', 'bigint',
+                    'decimal']
+
+        for t1, t2 in itertools.product(numerics, numerics):
+            await self.assert_query_result(
+                f'''
+                    SELECT <{t1}><{t2}>1;
+                ''',
+                [1],
+            )
+
+    async def test_edgeql_casts_numeric_08(self):
         async with self.assertRaisesRegexTx(
                 edgedb.InvalidValueError,
                 r'invalid input syntax for std::bigint'):
@@ -1364,18 +1376,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 r'invalid input syntax for std::decimal'):
             await self.con.query_single(
                 'SELECT <decimal>"12313.132n')
-
-    async def test_edgeql_casts_numeric_07(self):
-        numerics = ['int16', 'int32', 'int64', 'float32', 'float64', 'bigint',
-                    'decimal']
-
-        for t1, t2 in itertools.product(numerics, numerics):
-            await self.assert_query_result(
-                f'''
-                    SELECT <{t1}><{t2}>1;
-                ''',
-                [1],
-            )
 
     async def test_edgeql_casts_collections_01(self):
         await self.assert_query_result(

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -566,7 +566,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                         't', 'f', 'tr', 'fa'}:
             async with self.assertRaisesRegexTx(
                     edgedb.InvalidValueError,
-                    fr"invalid syntax for type std::bool: '{variant}'"):
+                    fr"invalid input syntax for type std::bool: '{variant}'"):
                 await self.con.query_single(f'SELECT <bool>"{variant}"')
 
         self.assertTrue(
@@ -1375,7 +1375,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 edgedb.InvalidValueError,
                 r'invalid input syntax for type std::decimal'):
             await self.con.query_single(
-                'SELECT <decimal>"12313.132n')
+                'SELECT <decimal>"12313.132n"')
 
     async def test_edgeql_casts_collections_01(self):
         await self.assert_query_result(

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -894,7 +894,7 @@ class TestEdgeQLDT(tb.QueryTestCase):
     async def test_edgeql_dt_bigint_01(self):
         with self.assertRaisesRegex(
             edgedb.InvalidValueError,
-            'invalid syntax for type std::bigint'
+            'invalid input syntax for type std::bigint'
         ):
             await self.con.execute(
                 r'''

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -894,7 +894,7 @@ class TestEdgeQLDT(tb.QueryTestCase):
     async def test_edgeql_dt_bigint_01(self):
         with self.assertRaisesRegex(
             edgedb.InvalidValueError,
-            'invalid syntax for std::bigint'
+            'invalid syntax for type std::bigint'
         ):
             await self.con.execute(
                 r'''

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -2869,7 +2869,7 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
 
     async def test_edgeql_functions_to_bigint_02(self):
         with self.assertRaisesRegex(edgedb.InvalidValueError,
-                                    'invalid syntax'):
+                                    'invalid input syntax'):
             async with self.con.transaction():
                 await self.con.query('''SELECT to_bigint('1.02')''')
 


### PR DESCRIPTION
This turned out to be much more interesting than a simple typo: since
our bigint type is really just a numeric (big *decimal*) with a
constraint on it, if a cast to bigint failed, the postgres error
message would mention numeric, which we would map to std::decimal.

Fix this by catching the error on the cast to numeric and reraising
our own error in that case. Some sources on the internet suggested
this might be slow, so I measured the different versions I tried:
having a separate cast_to_decimal_or_null function that did the error
handling was a slowdown, but inlining that and making the whole thing
plpgsql was actually a 2x speedup.

Fixes #3737.