### PR TITLE
Expose Tuple.named to introspection.

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_05_06_00_00
+EDGEDB_CATALOG_VERSION = 2022_05_13_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -129,6 +129,7 @@ CREATE TYPE schema::TupleElement EXTENDING std::BaseObject {
 
 
 CREATE TYPE schema::Tuple EXTENDING schema::CollectionType {
+    CREATE REQUIRED PROPERTY named -> bool;
     CREATE MULTI LINK element_types EXTENDING schema::ordered
     -> schema::TupleElement {
         CREATE CONSTRAINT std::exclusive;


### PR DESCRIPTION
Context: 

> It appears there's not really a good way to tell if a tuple is a named tuple or not from introspection, but there are separate type descriptors for them, and they get decoded into different types (array vs. object/map) in clients. Currently the query builder assumes that if a introspected tuple type has keys that look like indexes that it's an unnamed tuple, so there's an edge case if the user creates a tuple type like tuple<`0`: str, `1`: str>, then query builder will infer the result type of that to be an array but the actual result will be an object. We can fix this in a slightly hacky way by parsing the name of the tuple, but would it be possible to change edgedb so the introspected keys are null for unnamed tuples?