### PR TITLE
Enable reflecting scalar sets as multi property in the schema

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_05_13_00_00
+EDGEDB_CATALOG_VERSION = 2022_05_13_00_01
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -1406,6 +1406,8 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         self._visit_DropObject(node, 'CONSTRAINT', after_name=after_name)
 
     def _format_access_kinds(self, kinds: List[qltypes.AccessKind]) -> str:
+        # Canonicalize the order, since the schema loses track
+        kinds = [k for k in list(qltypes.AccessKind) if k in kinds]
         if kinds == list(qltypes.AccessKind):
             return 'all'
         skinds = ', '.join(str(kind).lower() for kind in kinds)

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -381,8 +381,7 @@ ALTER TYPE schema::ObjectType {
 
 ALTER TYPE schema::AccessPolicy {
   CREATE REQUIRED LINK subject -> schema::ObjectType;
-  CREATE REQUIRED PROPERTY _access_kinds -> array<schema::AccessKind>;
-  CREATE PROPERTY access_kinds := array_unpack(._access_kinds);
+  CREATE MULTI PROPERTY access_kinds -> schema::AccessKind;
   CREATE PROPERTY condition -> std::str;
   CREATE REQUIRED PROPERTY action -> schema::AccessPolicyAction;
   CREATE REQUIRED PROPERTY expr -> std::str;

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -2150,6 +2150,14 @@ class ObjectCollectionDuplicateNameError(Exception):
     pass
 
 
+# A set of scalars that should be reflected as a multi prop, not as an
+# array.
+class MultiPropSet(
+    checked.FrozenCheckedSet[T],
+):
+    pass
+
+
 class ObjectCollection(
     ObjectContainer,
     parametric.SingleParametricType[Object_T],

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -396,11 +396,15 @@ def _build_object_mutation_shape(
 
         else:
             target_expr = f'${var_n}'
+            if cardinality and cardinality.is_multi():
+                target_expr = f'json_array_unpack(<json>{target_expr})'
             if target.is_enum(schema):
                 target_expr = f'<str>{target_expr}'
             target_expr = f'<{target.get_name(schema)}>{target_expr}'
 
-            if v is None or isinstance(v, numbers.Number):
+            if v is not None and cardinality.is_multi():
+                target_value = list(v)
+            elif v is None or isinstance(v, numbers.Number):
                 target_value = v
             else:
                 target_value = str(v)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5482,10 +5482,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ''',
             tb.bag([
                 {
-                    "access_kinds": [
+                    "access_kinds": {
                         "Select", "UpdateRead", "UpdateWrite", "Delete",
                         "Insert"
-                    ],
+                    },
                     "action": "Allow",
                     "condition": None,
                     "expr": "true",
@@ -5494,7 +5494,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     "root": True,
                 },
                 {
-                    "access_kinds": ["Select", "Delete"],
+                    "access_kinds": {"Select", "Delete"},
                     "action": "Deny",
                     "condition": "global default::filtering",
                     "expr": "(.name ?!= global default::cur)",
@@ -5503,10 +5503,10 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     "root": True,
                 },
                 {
-                    "access_kinds": [
+                    "access_kinds": {
                         "Select", "UpdateRead", "UpdateWrite", "Delete",
                         "Insert"
-                    ],
+                    },
                     "action": "Allow",
                     "condition": None,
                     "expr": "true",
@@ -5515,7 +5515,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                     "root": False,
                 },
                 {
-                    "access_kinds": ["Select", "Delete"],
+                    "access_kinds": {"Select", "Delete"},
                     "action": "Deny",
                     "condition": "global default::filtering",
                     "expr": "(.name ?!= global default::cur)",


### PR DESCRIPTION
And make `access_kinds` a proper multi property, instead of reflecting
it as an array as `_access_kinds` and unpacking it.