### PR TITLE
Remove references of unix-domain sockets as valid connection parameters

### DIFF
--- a/docs/cli/edgedb.rst
+++ b/docs/cli/edgedb.rst
@@ -63,15 +63,12 @@ Options
 
 :cli:synopsis:`-H <hostname>, --host=<hostname>`
     Specifies the host name of the machine on which the server is running.
-    If :cli:synopsis:`<hostname>` begins with a slash (``/``), it is used
-    as the directory where the command looks for the server Unix-domain
-    socket.  Defaults to the value of the ``EDGEDB_HOST`` environment
-    variable.
+    Defaults to the value of the ``EDGEDB_HOST`` environment variable.
 
 :cli:synopsis:`-P <port>, --port=<port>`
-    Specifies the TCP port or the local Unix-domain socket file extension
-    on which the server is listening for connections.  Defaults to the value
-    of the ``EDGEDB_PORT`` environment variable or, if not set, to ``5656``.
+    Specifies the TCP port on which the server is listening for connections.
+    Defaults to the value of the ``EDGEDB_PORT`` environment variable or, 
+    if not set, to ``5656``.
 
 :cli:synopsis:`-u <username>, --user=<username>`
     Connect to the database as the user :cli:synopsis:`<username>`.

--- a/docs/cli/edgedb_connopts.rst
+++ b/docs/cli/edgedb_connopts.rst
@@ -40,15 +40,12 @@ Connection flags
 
 :cli:synopsis:`-H <hostname>, --host=<hostname>`
     Specifies the host name of the machine on which the server is running.
-    If :cli:synopsis:`<hostname>` begins with a slash (``/``), it is used
-    as the directory where the command looks for the server Unix-domain
-    socket.  Defaults to the value of the ``EDGEDB_HOST`` environment
-    variable.
+    Defaults to the value of the ``EDGEDB_HOST`` environment variable.
 
 :cli:synopsis:`-P <port>, --port=<port>`
-    Specifies the TCP port or the local Unix-domain socket file extension
-    on which the server is listening for connections.  Defaults to the value
-    of the ``EDGEDB_PORT`` environment variable or, if not set, to ``5656``.
+    Specifies the TCP port on which the server is listening for connections.
+    Defaults to the value of the ``EDGEDB_PORT`` environment variable or, 
+    if not set, to ``5656``.
 
 :cli:synopsis:`-u <username>, --user=<username>`
     Connect to the database as the user :cli:synopsis:`<username>`.

--- a/docs/reference/protocol/index.rst
+++ b/docs/reference/protocol/index.rst
@@ -5,8 +5,7 @@ Binary protocol
 ===============
 
 EdgeDB uses a message-based binary protocol for communication between
-clients and servers.  The protocol is supported over TCP/IP and also over
-Unix-domain sockets.
+clients and servers.  The protocol is supported over TCP/IP.
 
 
 .. toctree::

--- a/docs/stdlib/cfg.rst
+++ b/docs/stdlib/cfg.rst
@@ -43,8 +43,7 @@ Connection settings
 :eql:synopsis:`listen_addresses -> multi str`
   Specifies the TCP/IP address(es) on which the server is to listen for
   connections from client applications.  If the list is empty, the server
-  does not listen on any IP interface at all, in which case only Unix-domain
-  sockets can be used to connect to it.
+  does not listen on any IP interface at all.
 
 :eql:synopsis:`listen_port -> int16`
   The TCP port the server listens on; ``5656`` by default.  Note that the


### PR DESCRIPTION
## Summary
As discussed with @elprans, unix-domain sockets were deprecated as a connection method to EdgeDB. This PR removes references of unix-domain sockets as valid connection parameters.