### PR TITLE
Makefile: Use `--no-build-isolation` when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ casts:
 
 build:
 	find edb -name '*.pyx' | xargs touch
-	pip install -Ue .[docs,test]
+	pip install --no-build-isolation -Ue .[docs,test]
 
 
 clean:


### PR DESCRIPTION
Otherwise modern `pip` will attempt to build dependencies in a clean
environment, which makes it hard to test against development versions of
dependencies.