### PR TITLE
Use correct enum reference in `Exposure.__bool__`

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -58,7 +58,7 @@ class Exposure(enum.IntEnum):
     EXPOSED = 2
 
     def __bool__(self) -> bool:
-        return self == self.EXPOSED
+        return self == Exposure.EXPOSED
 
 
 class ContextSwitchMode(enum.Enum):


### PR DESCRIPTION
Enums expose members as class vars, not instance vars, and the latter
would trigger an `AttributeError` under Python 3.11.