### PR TITLE
Fix definition of the `BaseDeltaItem_T` type alias

### DIFF
--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -526,7 +526,7 @@ class InheritingObjectCommand(sd.ObjectCommand[so.InheritingObjectT]):
 
 BaseDeltaItem_T = Tuple[
     List[so.ObjectShell[so.InheritingObjectT]],
-    Union[str, Tuple[str, so.ObjectShell]],
+    Union[str, Tuple[str, so.ObjectShell[so.InheritingObjectT]]],
 ]
 
 


### PR DESCRIPTION
The second `ObjectShell` reference is missing a type argument, which
triggers a `TypeError` under Python 3.11.