### PR TITLE
Cache sets in card inference independent of their call sites

### DIFF
--- a/edb/edgeql/compiler/inference/context.py
+++ b/edb/edgeql/compiler/inference/context.py
@@ -54,7 +54,10 @@ class MultiplicityInfo:
 class InfCtx(NamedTuple):
     env: context.Environment
     inferred_cardinality: Dict[
-        Tuple[irast.Base, irast.ScopeTreeNode, FrozenSet[irast.PathId]],
+        Union[
+            Tuple[irast.Base, irast.ScopeTreeNode, FrozenSet[irast.PathId]],
+            irast.Base,
+        ],
         qltypes.Cardinality,
     ]
     inferred_multiplicity: Dict[

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -7284,3 +7284,20 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             for x in {1,2,3} union w
         ''')
         self.assertEqual(1, len({v.id for v in vals}))
+
+    async def test_edgeql_select_card_blowup_01(self):
+        # This used to really blow up cardinality inference
+        await self.con.query('''
+        SELECT Comment {
+          issue := assert_exists(( .issue {
+            status1 := ( .status { a := .__type__.name, b := .__type__.id } ),
+            status2 := ( .status { a := .__type__.name, b := .__type__.id } ),
+            status3 := ( .status { a := .__type__.name, b := .__type__.id } ),
+            status4 := ( .status { a := .__type__.name, b := .__type__.id } ),
+            status5 := ( .status { a := .__type__.name, b := .__type__.id } ),
+            status6 := ( .status { a := .__type__.name, b := .__type__.id } ),
+            status7 := ( .status { a := .__type__.name, b := .__type__.id } ),
+            status8 := ( .status { a := .__type__.name, b := .__type__.id } ),
+          })),
+        };
+        ''')


### PR DESCRIPTION
Sets have a semi-intrinsic cardinality (though for aliases it can
still depend on positions in the tree), and we want to cache that
independently from the cardinality of a *reference to a set*.

Importantly, we don't want to recheck everything whenever `singletons`
changes.

Fixes #3859.