### PR TITLE
Fix a cross-type constraint violation bug

### DIFF
--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -238,11 +238,6 @@ def _constr_matters(
     return (
         not constr.generic(schema)
         and not constr.get_delegated(schema)
-        and (
-            constr.get_owned(schema)
-            or all(anc.get_delegated(schema) or anc.generic(schema) for anc
-                   in constr.get_ancestors(schema).objects(schema))
-        )
     )
 
 

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -232,12 +232,24 @@ def _compile_conflict_select(
 
 
 def _constr_matters(
-    constr: s_constr.Constraint, ctx: context.ContextLevel,
+    constr: s_constr.Constraint, *,
+    only_local: bool=False,
+    ctx: context.ContextLevel,
 ) -> bool:
     schema = ctx.env.schema
     return (
         not constr.generic(schema)
         and not constr.get_delegated(schema)
+        and (
+            # In some use sites we always process ancestor constraints
+            # too, so in those cases a constraint only matters if it
+            # is the "top" constraint where it actually starts
+            # applying.
+            not only_local
+            or constr.get_owned(schema)
+            or all(anc.get_delegated(schema) or anc.generic(schema) for anc
+                   in constr.get_ancestors(schema).objects(schema))
+        )
     )
 
 
@@ -263,7 +275,7 @@ def _split_constraints(
         for p_constr in p_constrs:
             ancs = (p_constr,) + p_constr.get_ancestors(schema).objects(schema)
             for anc in ancs:
-                if not _constr_matters(anc, ctx):
+                if not _constr_matters(anc, only_local=True, ctx=ctx):
                     continue
                 p_ptr = anc.get_subject(schema)
                 assert isinstance(p_ptr, s_pointers.Pointer)
@@ -277,7 +289,7 @@ def _split_constraints(
     for obj_constr in obj_constrs:
         ancs = (obj_constr,) + obj_constr.get_ancestors(schema).objects(schema)
         for anc in ancs:
-            if not _constr_matters(anc, ctx):
+            if not _constr_matters(anc, only_local=True, ctx=ctx):
                 continue
             obj = anc.get_subject(schema)
             assert isinstance(obj, s_objtypes.ObjectType)
@@ -545,7 +557,7 @@ def compile_inheritance_conflict_selects(
             # everything must be in play, since constraints can depend on
             # nonexistence also.
             if (
-                _constr_matters(ptr_constr, ctx)
+                _constr_matters(ptr_constr, ctx=ctx)
                 and (
                     isinstance(stmt, irast.InsertStmt)
                     or (_get_needed_ptrs(typ, (), [name], ctx)[0] & shape_ptrs)
@@ -555,7 +567,7 @@ def compile_inheritance_conflict_selects(
     for obj_constr in obj_constrs:
         # See note above about needed ptrs check
         if (
-            _constr_matters(obj_constr, ctx)
+            _constr_matters(obj_constr, ctx=ctx)
             and (
                 isinstance(stmt, irast.InsertStmt)
                 or (_get_needed_ptrs(


### PR DESCRIPTION
An incorrect optimization would incorrectly decide that an inherited
constraint didn't matter. So in a hierarchy {X, Y} < B < A,
with a constraint on a field in A,
if we try to insert to both X and Y, we will find a constraint
on the nearest common ancestor B and would then decide that the
constraint didn't matter because it was declared not-delegated on
an ancestor, A.

Honestly I can't remember what I was thinking with that logic, which
seems clearly wrong.