### PR TITLE
Fix a collection of access policy bugs

### DIFF
--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -292,6 +292,14 @@ def get_nearest_dml_stmt(ir_set: irast.Set) -> Optional[irast.MutatingStmt]:
             return cur_set.expr
         elif isinstance(cur_set.expr, irast.SelectStmt):
             cur_set = cur_set.expr.result
+        # FIXME: This is a very narrow hack around issue #3030 designed
+        # to make the most common case work: assert_exists inserted by
+        # access policies.
+        elif (
+            isinstance(cur_set.expr, irast.FunctionCall)
+            and str(cur_set.expr.func_shortname) == 'std::assert_exists'
+        ):
+            cur_set = cur_set.expr.args[0].expr
         elif cur_set.rptr is not None:
             cur_set = cur_set.rptr.source
         else:

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1026,6 +1026,14 @@ def _get_rel_path_output(
             ptr_info = pg_types.get_ptrref_storage_info(
                 ptrref, resolve_type=False, link_bias=False)
 
+        # Refuse to try to access a link table when we are actually
+        # looking at an object rel. This check is needed because
+        # relgen._lookup_set_rvar_in_source sometimes does some pretty
+        # wild maybe_get_path_value_var calls.
+        if ptr_info.table_type == 'link' and (
+                rel.path_id and not rel.path_id.rptr()):
+            raise LookupError("can't access link table on object rel")
+
         result = pgast.ColumnRef(
             name=[ptr_info.column_name],
             nullable=not ptrref.required)

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 from typing import *
 
+import collections
 import uuid
 
 from edb import errors
@@ -1373,6 +1374,10 @@ def range_for_material_objtype(
                 sctx.pending_type_ctes.add(key)
                 sctx.pending_query = sctx.rel
                 sctx.volatility_ref = ()
+                sctx.type_rel_overlays = collections.defaultdict(
+                    lambda: collections.defaultdict(list))
+                sctx.ptr_rel_overlays = collections.defaultdict(
+                    lambda: collections.defaultdict(list))
                 dispatch.visit(rewrite, ctx=sctx)
                 type_cte = pgast.CommonTableExpr(
                     name=ctx.env.aliases.get('t'),

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -513,7 +513,7 @@ class ConstraintCommand(
                         path_prefix_anchor=qlast.Subject().name,
                         allow_generic_type_output=True,
                         schema_object_context=self.get_schema_metaclass(),
-                        apply_query_rewrites=not context.stdmode,
+                        apply_query_rewrites=False,
                         track_schema_ref_exprs=track_schema_ref_exprs,
                     ),
                 )

--- a/tests/test_edgeql_filter.py
+++ b/tests/test_edgeql_filter.py
@@ -153,8 +153,7 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                     SELECT Issue
                     FILTER
                         NOT EXISTS Issue.time_estimate
-                    ORDER BY Issue.owner.name
-                ).owner{name};
+                ).owner{name} ORDER BY .name;
             ''',
             # Elvis and Yury have Issues without time_estimate.
             [{'name': 'Elvis'}, {'name': 'Yury'}],

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -3017,7 +3017,33 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ["Alice"],
         )
 
-    async def test_edgeql_scope_source_rebind_03(self):
+    async def test_edgeql_scope_source_rebind_03a(self):
+        await self.assert_query_result(
+            """
+                WITH
+                U := (SELECT User {
+                    cards := (SELECT .deck FILTER random() > 0) }),
+                A := (SELECT U FILTER .name = 'Alice')
+                SELECT A {cards: {name}};
+            """,
+            [
+                {
+                    "cards": tb.bag([
+                        {"name": "Imp"},
+                        {"name": "Dragon"},
+                        {"name": "Bog monster"},
+                        {"name": "Giant turtle"}
+                    ]),
+                }
+            ]
+        )
+
+    async def test_edgeql_scope_source_rebind_03b(self):
+        await self.con.execute('''
+            alter type User create access policy test
+            allow all using (true)
+        ''')
+
         await self.assert_query_result(
             """
                 WITH

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1896,7 +1896,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 }
             };
             """,
-            [
+            tb.bag([
                 {
                     'name': 'Elvis',
                     'foo': [
@@ -1911,7 +1911,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                         {'bar': 'Yury', 'number': '3'}
                     ],
                 },
-            ],
+            ]),
         )
 
     async def test_edgeql_select_tvariant_06(self):


### PR DESCRIPTION
Many of these were found by putting a trivial access policy on
std::Object and running the test suite.

 * Disable overlays when compiling type rewrites: they aren't
   really in scope.
 * Work around issue #3030 by looking through assert_exists
   when looking for DML.
 * Fix a bad interaction with materialization that can generate
   invalid queries
 * Fix an issue with UNLESS CONFLICT by compiling constraints
   without query rewrites enabled to avoid introducing extra
   dependencies that broke our constraint key detection
 * Fix ordering in some tests that broke when the
   std::Object policy perturbed their ordreing