### PR TITLE
Make INSERT UNLESS CONFLICT/access policy behavior consistent

### DIFF
--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -389,8 +389,10 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
             [{"name": "Release EdgeDB"}],
         )
 
-        await self.assert_query_result(
-            '''
+        async with self.assertRaisesRegexTx(
+                edgedb.ConstraintViolationError,
+                "violates exclusivity constraint"):
+            await self.con.query('''
                 INSERT Issue {
                     number := '4',
                     name := 'Regression.',
@@ -398,9 +400,7 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
                     owner := (SELECT User FILTER User.name = 'Elvis'),
                     status := (SELECT Status FILTER Status.name = 'Closed'),
                 } UNLESS CONFLICT ON (.number) ELSE Issue;
-            ''',
-            []
-        )
+            ''')
 
     async def test_edgeql_policies_08(self):
         async with self.assertRaisesRegexTx(


### PR DESCRIPTION
When doing an INSERT UNLESS CONFLICT that conflicts with objects that
are not visible, consistently raise a constraint error.

Currently we raise a constraint error in cases where we can't use
postgres ON CONFLICT, such as if the body contains an insert to a
single link, but succeed with an empty set in ELSE otherwise.

I went with failing in both cases instead of succeding in both cases
for a couple reasons:
 1. The implementation of always failing is much more straightforward.
    Always succeeding is I think doable, by doing a conflict select
    that ignores access policies. The ELSE branch, then, would need
    to make sure to reapply the access policies.
 2. I don't like having the ELSE branch trigger but having no
    objects appear in it.