### PR TITLE
Support externally specified object ids

### DIFF
--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -187,8 +187,18 @@ def _compile_conflict_select(
                 left=lhs, right=rhs,
             ))
 
-    insert_subject = qlast.Path(steps=[
-        s_utils.name_to_ast_ref(subject_typ.get_name(ctx.env.schema))])
+    # If the type we are looking at is BaseObject, then this must a
+    # conflict check we are synthesizing for an explicit .id. We need
+    # to ignore access policies in that case, since there is no
+    # trigger to back us up.
+    ignore_rewrites = (
+        str(subject_typ.get_name(ctx.env.schema)) == 'std::BaseObject')
+    if ignore_rewrites:
+        assert not obj_constrs
+        assert len(constrs) == 1 and len(constrs['id'][1]) == 1
+    insert_subject = ctx.create_anchor(setgen.class_set(
+        subject_typ, ignore_rewrites=ignore_rewrites, ctx=ctx
+    ))
 
     for constr in obj_constrs:
         subjectexpr = constr.get_subjectexpr(ctx.env.schema)
@@ -358,6 +368,7 @@ def compile_conflict_select(
 
 def _get_exclusive_ptr_constraints(
     typ: s_objtypes.ObjectType,
+    include_id: bool,
     *, ctx: context.ContextLevel,
 ) -> Dict[str, Tuple[s_pointers.Pointer, List[s_constr.Constraint]]]:
     schema = ctx.env.schema
@@ -370,7 +381,7 @@ def _get_exclusive_ptr_constraints(
                      if c.issubclass(schema, exclusive_constr)]
         if ex_cnstrs:
             name = ptr.get_shortname(schema).name
-            if name != 'id':
+            if name != 'id' or include_id:
                 pointers[name] = ptr, ex_cnstrs
 
     return pointers
@@ -386,7 +397,7 @@ def compile_insert_unless_conflict(
     This requires synthesizing a conditional based on all the exclusive
     constraints on the object.
     """
-    pointers = _get_exclusive_ptr_constraints(typ, ctx=ctx)
+    pointers = _get_exclusive_ptr_constraints(typ, include_id=False, ctx=ctx)
     obj_constrs = typ.get_constraints(ctx.env.schema).objects(ctx.env.schema)
 
     select_ir, always_check, _ = compile_conflict_select(
@@ -394,6 +405,7 @@ def compile_insert_unless_conflict(
         constrs=pointers,
         obj_constrs=obj_constrs,
         parser_context=stmt.context, ctx=ctx)
+    assert not _has_explicit_id_write(stmt)
 
     return irast.OnConflictClause(
         constraint=None, select_ir=select_ir, always_check=always_check,
@@ -515,6 +527,14 @@ def compile_insert_unless_conflict_on(
     )
 
 
+def _has_explicit_id_write(stmt: irast.MutatingStmt) -> bool:
+    for elem, _ in stmt.subject.shape:
+        assert elem.rptr is not None
+        if elem.rptr.ptrref.shortname.name == 'id':
+            return elem.context is not None
+    return False
+
+
 def compile_inheritance_conflict_selects(
     stmt: irast.MutatingStmt,
     conflict: irast.MutatingStmt,
@@ -532,7 +552,9 @@ def compile_inheritance_conflict_selects(
     cross-type exclusive constraints, and they use a snapshot
     beginning at the start of the statement.
     """
-    pointers = _get_exclusive_ptr_constraints(typ, ctx=ctx)
+    has_id_write = _has_explicit_id_write(stmt)
+    pointers = _get_exclusive_ptr_constraints(
+        typ, include_id=has_id_write, ctx=ctx)
     exclusive = ctx.env.schema.get('std::exclusive', type=s_constr.Constraint)
     obj_constrs = [
         constr for constr in
@@ -611,7 +633,10 @@ def compile_inheritance_conflict_checks(
     subject_stype: s_objtypes.ObjectType,
     *, ctx: context.ContextLevel,
 ) -> Optional[List[irast.OnConflictClause]]:
-    if not ctx.env.dml_stmts:
+
+    has_id_write = _has_explicit_id_write(stmt)
+
+    if not ctx.env.dml_stmts and not has_id_write:
         return None
 
     assert isinstance(subject_stype, s_objtypes.ObjectType)
@@ -665,6 +690,13 @@ def compile_inheritance_conflict_checks(
                 for anc in ancs:
                     if anc != base_object:
                         modified_ancestors.add((subject_stype, anc, ir))
+
+    # If `id` is explicitly written to, synthesize a check against
+    # BaseObject to ensure that it doesn't conflict with anything,
+    # since we disable the trigger for id's exclusive constraint for
+    # performance reasons.
+    if has_id_write:
+        modified_ancestors.add((subject_stype, base_object, stmt))
 
     conflicters = []
     for subject_stype, anc_type, ir in modified_ancestors:

--- a/edb/edgeql/compiler/conflicts.py
+++ b/edb/edgeql/compiler/conflicts.py
@@ -191,6 +191,8 @@ def _compile_conflict_select(
     # conflict check we are synthesizing for an explicit .id. We need
     # to ignore access policies in that case, since there is no
     # trigger to back us up.
+    # (We can't insert directly into the abstract BaseObject, so this
+    # is a safe assumption.)
     ignore_rewrites = (
         str(subject_typ.get_name(ctx.env.schema)) == 'std::BaseObject')
     if ignore_rewrites:

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -85,10 +85,12 @@ def new_set(
     """
 
     skip_subtypes: bool = kwargs.get('skip_subtypes', False)
+    ignore_rewrites: bool = kwargs.get('ignore_rewrites', False)
     rw_key = (stype, skip_subtypes)
 
     if (
-        rw_key not in ctx.type_rewrites
+        not ignore_rewrites
+        and rw_key not in ctx.type_rewrites
         and isinstance(stype, s_objtypes.ObjectType)
         and ctx.env.options.apply_query_rewrites
     ):
@@ -143,6 +145,7 @@ def new_set_from_set(
         is_materialized_ref: Optional[bool]=None,
         is_visible_binding_ref: Optional[bool]=None,
         skip_subtypes: Optional[bool]=None,
+        ignore_rewrites: Optional[bool]=None,
         ctx: context.ContextLevel) -> irast.Set:
     """Create a new ir.Set from another ir.Set.
 
@@ -174,6 +177,8 @@ def new_set_from_set(
         is_visible_binding_ref = ir_set.is_visible_binding_ref
     if skip_subtypes is None:
         skip_subtypes = ir_set.skip_subtypes
+    if ignore_rewrites is None:
+        ignore_rewrites = ir_set.ignore_rewrites
     return new_set(
         path_id=path_id,
         path_scope_id=path_scope_id,
@@ -185,6 +190,7 @@ def new_set_from_set(
         is_materialized_ref=is_materialized_ref,
         is_visible_binding_ref=is_visible_binding_ref,
         skip_subtypes=skip_subtypes,
+        ignore_rewrites=ignore_rewrites,
         ircls=type(ir_set),
         ctx=ctx,
     )
@@ -1081,12 +1087,14 @@ def class_set(
         stype: s_types.Type, *,
         path_id: Optional[irast.PathId]=None,
         skip_subtypes: bool=False,
+        ignore_rewrites: bool=False,
         ctx: context.ContextLevel) -> irast.Set:
 
     if path_id is None:
         path_id = pathctx.get_path_id(stype, ctx=ctx)
     return new_set(
-        path_id=path_id, stype=stype, skip_subtypes=skip_subtypes, ctx=ctx)
+        path_id=path_id, stype=stype,
+        skip_subtypes=skip_subtypes, ignore_rewrites=ignore_rewrites, ctx=ctx)
 
 
 def expression_set(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1073,7 +1073,7 @@ def _normalize_view_ptr_expr(
             ctx.env.schema, 'cardinality', qltypes.SchemaCardinality.Unknown)
 
     if (
-        ptrcls.is_protected_pointer(ctx.env.schema)
+        ptrcls.is_protected_pointer(exprtype, ctx.env.schema)
         and (compexpr is not None or is_polymorphic)
         and not from_default
         and not ctx.env.options.allow_writing_protected_pointers

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -499,6 +499,10 @@ class Set(Base):
 
     # Whether to force this to not select subtypes
     skip_subtypes: bool = False
+    # Whether to force this to ignore rewrites. Very dangerous!
+    # Currently only used for preventing duplicate explicit .id
+    # insertions to BaseObject.
+    ignore_rewrites: bool = False
 
     def __repr__(self) -> str:
         return f'<ir.Set \'{self.path_id}\' at 0x{id(self):x}>'

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -486,7 +486,8 @@ def new_primitive_rvar(
     dml_source = irutils.get_nearest_dml_stmt(ir_set)
     set_rvar = range_for_typeref(
         typeref, path_id, lateral=lateral, dml_source=dml_source,
-        include_descendants=not ir_set.skip_subtypes, ctx=ctx)
+        include_descendants=not ir_set.skip_subtypes,
+        ignore_rewrites=ir_set.ignore_rewrites, ctx=ctx)
     pathctx.put_rvar_path_bond(set_rvar, path_id)
 
     rptr = ir_set.rptr
@@ -1351,6 +1352,7 @@ def range_for_material_objtype(
     lateral: bool=False,
     include_overlays: bool=True,
     include_descendants: bool=True,
+    ignore_rewrites: bool=False,
     dml_source: Optional[irast.MutatingStmt]=None,
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
@@ -1364,7 +1366,8 @@ def range_for_material_objtype(
 
     key = (typeref.id, include_descendants)
     if (
-        (rewrite := ctx.env.type_rewrites.get(key)) is not None
+        not ignore_rewrites
+        and (rewrite := ctx.env.type_rewrites.get(key)) is not None
         and key not in ctx.pending_type_ctes
         and not for_mutation
     ):
@@ -1501,6 +1504,7 @@ def range_for_typeref(
     lateral: bool=False,
     for_mutation: bool=False,
     include_descendants: bool=True,
+    ignore_rewrites: bool=False,
     dml_source: Optional[irast.MutatingStmt]=None,
     ctx: context.CompilerContextLevel,
 ) -> pgast.PathRangeVar:
@@ -1581,6 +1585,7 @@ def range_for_typeref(
             path_id,
             lateral=lateral,
             include_descendants=include_descendants,
+            ignore_rewrites=ignore_rewrites,
             for_mutation=for_mutation,
             dml_source=dml_source,
             ctx=ctx,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -664,8 +664,14 @@ class Pointer(referencing.ReferencedInheritingObject,
     def is_link_property(self, schema: s_schema.Schema) -> bool:
         raise NotImplementedError
 
-    def is_protected_pointer(self, schema: s_schema.Schema) -> bool:
-        return self.get_shortname(schema).name in {'id', '__type__'}
+    def is_protected_pointer(
+        self, exprtype: s_types.ExprType, schema: s_schema.Schema
+    ) -> bool:
+        sn = self.get_shortname(schema).name
+        return (
+            sn == '__type__'
+            or (sn == 'id' and not exprtype.is_mutation())
+        )
 
     def is_dumpable(self, schema: s_schema.Schema) -> bool:
         return (

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -2200,8 +2200,21 @@ class TestUpdate(tb.QueryTestCase):
                 };
             ''')
 
-    @test.xfail("nested UPDATE not supported")
     async def test_edgeql_update_protect_readonly_03(self):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "cannot update property 'id': "
+            "it is declared as read-only",
+        ):
+            await self.con.execute(r'''
+                UPDATE UpdateTest
+                SET {
+                    id := <uuid>'77841036-8e35-49ce-b509-2cafa0c25c4f'
+                };
+            ''')
+
+    @test.xfail("nested UPDATE not supported")
+    async def test_edgeql_update_protect_readonly_04(self):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             "cannot update property 'readonly_note': "


### PR DESCRIPTION
Most of the work here is in inserting checks to prevent duplicate
`id`s, since we don't have a trigger on `id` for performance
reasons. We use the conflict mechanism for this. The dodgy bit is that
we have to do it with access policies disabled, to make sure they don't
hide something.

Fixes #3510.