### PR TITLE
Fix backend connection pool over-acquire

### DIFF
--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -539,7 +539,7 @@ class Server(ha_base.ClusterProtocol):
                 'Postgres is not available: ' + self._pg_unavailable_msg
             )
 
-        for _ in range(self._pg_pool.max_capacity + 1):
+        for _ in range(self._pg_pool.max_capacity):
             conn = await self._pg_pool.acquire(dbname)
             if conn.is_healthy():
                 return conn


### PR DESCRIPTION
There is an off-by-one error in `acquire_pgcon` that allows server to
attempt to acquire a connection over the allowed
`max-backend-connections` limit.

Fixes: #3877