### PR TITLE
Fix floordiv and modulus operators.

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_05_13_00_03
+EDGEDB_CATALOG_VERSION = 2022_05_26_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 


### PR DESCRIPTION
The floordiv (`//`) and modulus (`%`) operators had some corner cases
where they would produce the wrong result or an error due to the
implementation calculations.

Add some fuzztests for these operators.