### PR TITLE
Fix a scope leak that caused miscompiles

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1460,9 +1460,11 @@ def get_view_map_remapping(
     """
     key = path_id.strip_namespace(path_id.namespace)
     entries = ctx.view_map.get(key, ())
-    fixed_path_id = path_id.merge_namespace(ctx.path_id_namespace)
+    fixed_path_id = path_id.merge_namespace(ctx.path_id_namespace, deep=True)
     for inner_path_id, mapped in entries:
-        fixed_inner = inner_path_id.merge_namespace(ctx.path_id_namespace)
+        fixed_inner = inner_path_id.merge_namespace(
+            ctx.path_id_namespace, deep=True)
+
         if fixed_inner == fixed_path_id:
             return mapped
     return None

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -28,6 +28,7 @@ from edb import errors
 
 from edb.ir import ast as irast
 from edb.ir import utils as irutils
+from edb.ir import typeutils as irtyputils
 
 from edb.schema import modules as s_mod
 from edb.schema import name as s_name
@@ -383,10 +384,10 @@ def _try_namespace_fix(
         replacement = scope.find_visible(prefix, allow_group=True)
         if (
             replacement and replacement.path_id
-            and replacement.path_id.namespace != obj.path_id.namespace
+            and prefix != replacement.path_id
         ):
-            new = obj.path_id.strip_namespace(
-                obj.path_id.namespace - replacement.path_id.namespace)
+            new = irtyputils.replace_pathid_prefix(
+                obj.path_id, prefix, replacement.path_id)
 
             obj.path_id = new
             break

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -362,24 +362,31 @@ class PathId:
 
         if result._prefix is not None:
             result._prefix = result._get_minimal_prefix(
-                result._prefix)
+                result._prefix.replace_namespace(namespace))
 
         return result
 
     def merge_namespace(
         self,
         namespace: AbstractSet[Namespace],
+        *,
+        deep: bool=False,
     ) -> PathId:
         """Return a copy of this ``PathId`` that has *namespace* added to its
            namespace.
         """
-        if not self._namespace:
-            new_namespace = namespace
-        else:
-            new_namespace = self._namespace | frozenset(namespace)
+        new_namespace = self._namespace | frozenset(namespace)
 
-        if new_namespace != self._namespace:
-            return self.replace_namespace(new_namespace)
+        if new_namespace != self._namespace or deep:
+            result = self.__class__(self)
+            result._namespace = new_namespace
+            if deep and result._prefix is not None:
+                result._prefix = result._prefix.merge_namespace(new_namespace)
+            if result._prefix is not None:
+                result._prefix = result._get_minimal_prefix(result._prefix)
+
+            return result
+
         else:
             return self
 

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -59,6 +59,7 @@ type Card extending Named {
     property elemental_cost := <str>.cost ++ ' ' ++ .element;
     multi link awards -> Award;
     multi link good_awards := (SELECT .awards FILTER .name != '3rd');
+    single link best_award := (select .awards order by .name limit 1);
 }
 
 type SpecialCard extending Card;

--- a/tests/schemas/cards_setup.edgeql
+++ b/tests/schemas/cards_setup.edgeql
@@ -31,7 +31,7 @@ INSERT Card {
     name := 'Dragon',
     element := 'Fire',
     cost := 5,
-    awards := (SELECT Award FILTER .name = '1st'),
+    awards := (SELECT Award FILTER .name IN {'1st', '3rd'}),
 };
 
 INSERT Card {

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -976,5 +976,5 @@ class TestEdgeQLGroup(tb.QueryTestCase):
                    using awd_size := count(.awards)
                 by awd_size, .element) { grouping };
             ''',
-            [{"grouping": ["awd_size", "element"]}] * 5,
+            [{"grouping": ["awd_size", "element"]}] * 6,
         )

--- a/tests/test_edgeql_ir_pathid.py
+++ b/tests/test_edgeql_ir_pathid.py
@@ -25,6 +25,8 @@ from edb.ir import typeutils as irtyputils
 from edb.schema import name as s_name
 from edb.schema import pointers as s_pointers
 
+from edb.tools import test
+
 
 class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
     """Unit tests for path id logic."""
@@ -194,3 +196,56 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
                 '.>deck[IS default::Card]',
             ]
         )
+
+    def test_edgeql_ir_pathid_replace_01(self):
+        base_1 = self.mk_path('Card')
+        base_2 = self.mk_path('SpecialCard')
+
+        ns = {'ns'}
+        ptr_1 = self.extend(base_1, 'name', ns=ns)
+        ptr_2 = self.extend(base_2, 'name', ns=ns)
+
+        ptr_1b = irtyputils.replace_pathid_prefix(ptr_1, base_1, base_2)
+
+        self.assertEqual(ptr_2, ptr_1b)
+
+    def test_edgeql_ir_pathid_replace_02(self):
+        base_1 = self.mk_path('Card', ns={'ns1'})
+        base_2 = self.mk_path('SpecialCard', ns={'ns2'})
+
+        ptr_1 = self.extend(base_1, 'name')
+        ptr_2 = self.extend(base_2, 'name')
+
+        ptr_1b = irtyputils.replace_pathid_prefix(ptr_1, base_1, base_2)
+
+        self.assertEqual(ptr_2, ptr_1b)
+
+    def test_edgeql_ir_pathid_replace_03a(self):
+        base_1 = self.mk_path('User', 'deck')
+        base_2 = self.mk_path('Bot', 'deck')
+
+        ptr_1 = self.extend(base_1, '@count')
+        ptr_2 = self.extend(base_2, '@count')
+
+        ptr_1b = irtyputils.replace_pathid_prefix(
+            ptr_1, base_1, base_2, permissive_ptr_path=True)
+
+        self.assertEqual(repr(ptr_2), repr(ptr_1b))
+
+        ptr_1b = irtyputils.replace_pathid_prefix(
+            ptr_1, base_1.ptr_path(), base_2.ptr_path())
+
+        self.assertEqual(repr(ptr_2), repr(ptr_1b))
+
+    @test.xfail("We don't handle linkprops when doing type remapping")
+    def test_edgeql_ir_pathid_replace_03b(self):
+        base_1 = self.mk_path('User', 'deck')
+        base_2 = self.mk_path('Bot', 'deck')
+
+        ptr_1 = self.extend(base_1, '@count')
+        ptr_2 = self.extend(base_2, '@count')
+
+        ptr_1b = irtyputils.replace_pathid_prefix(
+            ptr_1, base_1, base_2, permissive_ptr_path=True)
+
+        self.assertEqual(ptr_2, ptr_1b)

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -2963,7 +2963,10 @@ class TestEdgeQLScope(tb.QueryTestCase):
             """,
             [
                 {
-                    "avatar": {"awards": [{"name": "1st"}], "name": "Dragon"},
+                    "avatar": {
+                        "awards": tb.bag([{"name": "1st"}, {"name": "3rd"}]),
+                        "name": "Dragon",
+                    },
                     "name": "Alice"
                 }
             ]
@@ -3064,6 +3067,10 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
+    @test.xfail('''
+        Fails assert not ir_set.is_materialized_ref
+        Broken in fix for #3898
+    ''')
     async def test_edgeql_scope_source_rebind_04(self):
         await self.assert_query_result(
             """
@@ -3762,4 +3769,18 @@ class TestEdgeQLScope(tb.QueryTestCase):
             [
                 {"name": "Dave"}
             ]
+        )
+
+    async def test_edgeql_computable_join_01(self):
+        await self.assert_query_result(
+            r'''
+            select Card {
+                multi w := (
+                    select .awards { name }
+                    filter .name = Card.best_award.name
+                )
+            }
+            filter .name = 'Dragon';
+            ''',
+            [{"w": [{"name": "1st"}]}]
         )


### PR DESCRIPTION
_try_namespace_fix is too aggressive in obliterating namespaces, and
will do it in cases that causes a reference to a pointer in a
computable to lose its namespacing and improperly correlate with
something outside.

Switch it to using replace_pathid_prefix; this requires fixing
replace_pathid_prefix to not also obliterate namespaces in dodgy ways.

Unfortunately this also breaks a fairly subtle materialization test;
I'm pretty sure that was working by accident, though, and the failure
mode is an ISE, not a miscompilation.

Fixes #3898.