### PR TITLE
Manage task refs in taskgroup

### DIFF
--- a/edb/common/taskgroup.py
+++ b/edb/common/taskgroup.py
@@ -25,7 +25,6 @@ import sys
 import textwrap
 import traceback
 import types
-import weakref
 
 
 class TaskGroup:
@@ -42,7 +41,7 @@ class TaskGroup:
         self._loop = None
         self._parent_task = None
         self._parent_cancel_requested = False
-        self._tasks = weakref.WeakSet()
+        self._tasks = set()
         self._unfinished_tasks = 0
         self._errors = []
         self._base_error = None
@@ -233,6 +232,7 @@ class TaskGroup:
                 t.cancel()
 
     def _on_task_done(self, task):
+        self._tasks.discard(task)
         self._unfinished_tasks -= 1
         assert self._unfinished_tasks >= 0
 


### PR DESCRIPTION
https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
We usually use `TaskGroup.create_task()` with the assumption that the
enclosing `async with` block will wait untill all inner tasks complete,
without storing the references of the inner tasks, which can be GC-ed.

Partially reverted #2068