### PR TITLE
Fix typo in Next.js tutorial

### DIFF
--- a/docs/guides/tutorials/nextjs.rst
+++ b/docs/guides/tutorials/nextjs.rst
@@ -110,7 +110,7 @@ static data. Replace the contents of ``pages/index.tsx`` with the following.
     );
   };
 
-  export default Home;
+  export default HomePage;
 
 After saving, Next.js should hot-reload, and the homepage should look
 something like this.


### PR DESCRIPTION
The tutorial references `Home` but should reference `HomePage`