### PR TITLE
Fix assert_single (et al) induced miscompilation of nested shape w/ WITH

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1519,6 +1519,7 @@ def _get_computable_ctx(
 
             subctx.view_nodes = qlctx.view_nodes.copy()
             subctx.view_map = ctx.view_map.new_child()
+            subctx.view_sets = ctx.view_sets.copy()
 
             source_scope = pathctx.get_set_scope(rptr.source, ctx=ctx)
             if source_scope and source_scope.namespaces:

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -346,10 +346,9 @@ def _find_rel_rvar(
             rel_rvar = maybe_get_path_rvar(
                 rel, src_path_id, aspect='source', env=env)
 
-    if rel_rvar is None and alt_aspect is not None:
+    if rel_rvar is None and alt_aspect is not None and flavor == 'normal':
         # There is no source range var for the requested aspect,
         # check if there is a cached var with less specificity.
-        assert flavor == 'normal'
         var = rel.path_namespace.get((path_id, alt_aspect))
         if var is not None:
             put_path_var(

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -3719,6 +3719,62 @@ class TestEdgeQLScope(tb.QueryTestCase):
             [{"name": "Dragon", "nameLen": 6, "nameLen2": 6}]
         )
 
+    async def test_edgeql_select_outer_rebind_07a(self):
+        await self.assert_query_result(
+            r'''
+                SELECT assert_single((
+                  SELECT User {
+                  deck := (
+                    WITH
+                      User_deck := User.deck
+                    SELECT User_deck {
+                      awards := (
+                        User_deck.awards { name }
+                      )
+                    }
+                  )
+                }) filter .name ILIKE 'Alice%');
+            ''',
+            tb.bag([
+                {
+                    "deck": tb.bag([
+                        {"awards": [{"name": "2nd"}]},
+                        {"awards": tb.bag([{"name": "1st"}, {"name": "3rd"}])},
+                        {"awards": []},
+                        {"awards": []}
+                    ])
+                }
+            ])
+        )
+
+    async def test_edgeql_select_outer_rebind_07b(self):
+        await self.assert_query_result(
+            r'''
+                SELECT assert_exists((
+                  SELECT User {
+                  deck := (
+                    WITH
+                      User_deck := User.deck
+                    SELECT User_deck {
+                      awards := (
+                        User_deck.awards { name }
+                      )
+                    }
+                  )
+                }) filter .name ILIKE 'Alice%');
+            ''',
+            tb.bag([
+                {
+                    "deck": tb.bag([
+                        {"awards": [{"name": "2nd"}]},
+                        {"awards": tb.bag([{"name": "1st"}, {"name": "3rd"}])},
+                        {"awards": []},
+                        {"awards": []}
+                    ])
+                }
+            ])
+        )
+
     async def test_edgeql_scope_for_with_computable_01(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
We need to copy view_sets when doing a computable context, so that a
potential recompilation of the view set doesn't effect it's definition
in other contexts.

Fixes #3794.