### PR TITLE
Make Annotation a valid annotation subject

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_05_27_00_00
+EDGEDB_CATALOG_VERSION = 2022_05_31_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -145,12 +145,13 @@ CREATE TYPE schema::Delta EXTENDING schema::Object {
 };
 
 
-CREATE TYPE schema::Annotation EXTENDING schema::Object {
+CREATE ABSTRACT TYPE schema::AnnotationSubject EXTENDING schema::Object;
+
+CREATE TYPE schema::Annotation EXTENDING schema::AnnotationSubject {
     CREATE PROPERTY inheritable -> std::bool;
 };
 
-
-CREATE ABSTRACT TYPE schema::AnnotationSubject EXTENDING schema::Object {
+ALTER TYPE schema::AnnotationSubject {
     CREATE MULTI LINK annotations EXTENDING schema::reference
     -> schema::Annotation {
         CREATE PROPERTY value -> std::str;

--- a/edb/lib/std/15-attrs.edgeql
+++ b/edb/lib/std/15-attrs.edgeql
@@ -18,7 +18,15 @@
 
 ## Generic annotations.
 
-CREATE ABSTRACT ANNOTATION std::title;
 CREATE ABSTRACT ANNOTATION std::description;
-CREATE ABSTRACT ANNOTATION std::deprecated;
+ALTER ABSTRACT ANNOTATION std::description {
+    CREATE ANNOTATION std::description := 'A short documentation string.';
+};
+CREATE ABSTRACT ANNOTATION std::title {
+    CREATE ANNOTATION std::description := 'A human-readable name.';
+};
+CREATE ABSTRACT ANNOTATION std::deprecated {
+    CREATE ANNOTATION std::description :=
+        'A marker that an item is deprecated.';
+};
 CREATE ABSTRACT ANNOTATION std::identifier;

--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -604,7 +604,7 @@ def write_meta_create_object(
                 target = cmd.get_attribute_value(target_link)
 
                 append_query = f'''
-                    SELECT schema::{target_field.type.__name__} {{
+                    SELECT DETACHED schema::{target_field.type.__name__} {{
                         {shape}
                     }} FILTER
                         .name__internal = <str>$__{target_link}
@@ -859,7 +859,7 @@ def _update_lprops(
         assignments.append(textwrap.dedent(
             f'''\
             {refdict.attr} += (
-                SELECT schema::{target_clsname} {{{shape}
+                SELECT DETACHED schema::{target_clsname} {{{shape}
                 }} FILTER .id = <uuid>$__{target_link}
             )'''
         ))
@@ -884,7 +884,7 @@ def _update_lprops(
             assignments.append(textwrap.dedent(
                 f'''\
                 {refdict.attr}__internal += (
-                    SELECT schema::{mcls.__name__} {{{shadow_shape}
+                    SELECT DETACHED schema::{mcls.__name__} {{{shadow_shape}
                     }} FILTER .name__internal = <str>$__{target_link}_shadow
                 )'''
             ))


### PR DESCRIPTION
Currently it is accepted in the syntax but then rejected with an ISE.
Fixing this requires a little hackery on the schema side, since it
doesn't support forward references.

Also requires fixing a bug in the schema writer code for AS_LINK,
where the Annotation being updated would be improperly correlated
with the Annotation we are creating a link to.

Also, put std::description annotations on some of the standard
annotations, because now we can.