### PR TITLE
Expose 'body' and 'language' fields on schema::Function

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_05_31_00_00
+EDGEDB_CATALOG_VERSION = 2022_05_31_00_01
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1191,14 +1191,16 @@ class DropAccessPolicy(DropObject, AccessPolicyCommand):
 
 
 class Language(s_enum.StrEnum):
-    SQL = 'SQL'
-    EdgeQL = 'EDGEQL'
+    # We want to expose this in the schema as 'Builtin', hence the
+    # name mismatch.
+    SQL = 'Builtin'
+    EdgeQL = 'EdgeQL'
 
 
 class FunctionCode(Clause):
     language: Language = Language.EdgeQL
     code: typing.Optional[str] = None
-    nativecode: typing.Optional[Expr] = None
+    body: typing.Optional[Expr] = None
     from_function: typing.Optional[str] = None
     from_expr: bool = False
 
@@ -1214,7 +1216,7 @@ class CreateFunction(CreateObject, FunctionCommand):
 
     returning: TypeExpr
     code: FunctionCode
-    nativecode: typing.Optional[Expr]
+    body: typing.Optional[Expr]
     returning_typemod: qltypes.TypeModifier = \
         qltypes.TypeModifier.SingletonType
 
@@ -1222,7 +1224,7 @@ class CreateFunction(CreateObject, FunctionCommand):
 class AlterFunction(AlterObject, FunctionCommand):
 
     code: FunctionCode = FunctionCode  # type: ignore
-    nativecode: typing.Optional[Expr]
+    body: typing.Optional[Expr]
 
 
 class DropFunction(DropObject, FunctionCommand):

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -854,8 +854,8 @@ def trace_Function(
         else:
             params[param.name] = s_name.QualName('std', 'BaseObject')
 
-    if node.nativecode is not None:
-        deps.append(FunctionDependency(expr=node.nativecode, params=params))
+    if node.body is not None:
+        deps.append(FunctionDependency(expr=node.body, params=params))
     elif (
         node.code is not None
         and node.code.language is qlast.Language.EdgeQL

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -49,6 +49,9 @@ CREATE SCALAR TYPE schema::AccessPolicyAction
 CREATE SCALAR TYPE schema::AccessKind
     EXTENDING enum<`Select`, UpdateRead, UpdateWrite, `Delete`, `Insert`>;
 
+CREATE SCALAR TYPE schema::FuncLanguage
+    EXTENDING enum<EdgeQL, Builtin>;
+
 
 # Base type for all schema entities.
 CREATE ABSTRACT TYPE schema::Object EXTENDING std::BaseObject {
@@ -439,6 +442,9 @@ CREATE TYPE schema::Function
     CREATE PROPERTY preserves_optionality -> std::bool {
         SET default := false;
     };
+
+    CREATE REQUIRED PROPERTY language -> schema::FuncLanguage;
+    CREATE PROPERTY body -> str;
 
     CREATE MULTI LINK used_globals EXTENDING schema::ordered -> schema::Global;
 };

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -741,6 +741,8 @@ class TestIntrospection(tb.QueryTestCase):
                             type: { name },
                         } ORDER BY @index
                     },
+                    language,
+                    body,
                 }
                 FILTER
                     .name IN {'std::count', 'sys::get_version'}
@@ -770,7 +772,9 @@ class TestIntrospection(tb.QueryTestCase):
                     "return_type": {
                         "name": "std::int64",
                         "element_types": [],
-                    }
+                    },
+                    "language": "Builtin",
+                    "body": None,
                 },
                 {
                     "name": "sys::get_version",
@@ -795,8 +799,10 @@ class TestIntrospection(tb.QueryTestCase):
                             {"name": "local",
                              "type": {"name": "array<std::str>"}}
                         ]
-                    }
-                }
+                    },
+                    "language": "EdgeQL",
+                    "body": str,
+                },
             ]
         )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1772,7 +1772,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
         with self.assertRaisesRegex(
             errors.SchemaDefinitionError,
             r"cannot alter property 'val' of object type 'default::Foo' "
-            r"because this affects nativecode expression of "
+            r"because this affects body expression of "
             r"function 'default::foo\(v:.+int64\)'"
         ):
             self.run_ddl(schema, r'''


### PR DESCRIPTION
'nativecode' becomes 'body', and gets exposed, while 'language' is
exposed and modified so that SQL is exported as 'Builtin'.