### PR TITLE
Fix arithemtic fuzz tests.

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_05_31_00_00
+EDGEDB_CATALOG_VERSION = 2022_06_02_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 


### PR DESCRIPTION
The `%` operator should never produce the result equal to the divisor
for negative divisors, it should be 0 instead.