### PR TITLE
Improve invalid unit hint for std::duration

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -2222,7 +2222,7 @@ class DurationInFunction(dbops.Function):
                         || quote_literal(val)
                     ),
                     detail => (
-                        '{"hint":"Units bigger than days cannot be used '
+                        '{"hint":"Units bigger than hours cannot be used '
                         || 'for std::duration."}'
                     )
                 )


### PR DESCRIPTION
The current hint implies that `days` is a valid unit for `std::duration` which is not the case. `hours` is the largest valid unit.
 
```
$ edgedb -I sample
EdgeDB 2.0-dev.6602+f921621 (repl 1.2.0)
Type \help for help, \quit to quit.
edgedb> select <duration>'1 day';
edgedb error: InvalidValueError: invalid input syntax for type std::duration: '1 day'
  Hint: Units bigger than days cannot be used for std::duration.
```