### PR TITLE
Expose 'body' and 'language' fields on schema::Function

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_06_02_00_00
+EDGEDB_CATALOG_VERSION = 2022_06_06_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -440,6 +440,9 @@ CREATE TYPE schema::Function
         SET default := false;
     };
 
+    CREATE PROPERTY body -> str;
+    CREATE REQUIRED PROPERTY language -> str;
+
     CREATE MULTI LINK used_globals EXTENDING schema::ordered -> schema::Global;
 };
 

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1985,7 +1985,8 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                     if fn == 'expr':
                         fdesc = 'expression'
                     else:
-                        fdesc = f"{fn.replace('_', ' ')} expression"
+                        sfn = type(ref).get_field(fn).sname
+                        fdesc = f"{sfn.replace('_', ' ')} expression"
 
                     vn = ref.get_verbosename(schema, with_parent=True)
 

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1203,10 +1203,15 @@ class Function(
         str, default=None, compcoef=0.4)
 
     nativecode = so.SchemaField(
-        s_expr.Expression, default=None, compcoef=0.9)
+        s_expr.Expression, default=None, compcoef=0.9,
+        reflection_name='body')
 
     language = so.SchemaField(
-        qlast.Language, default=None, compcoef=0.4, coerce=True)
+        qlast.Language, default=None, compcoef=0.4, coerce=True,
+        reflection_name='language_real')
+
+    reflected_language = so.SchemaField(
+        str, reflection_name='language')
 
     from_function = so.SchemaField(
         str, default=None, compcoef=0.4)
@@ -1898,6 +1903,8 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
         assert isinstance(cmd, CreateFunction)
 
+        reflected_language = 'builtin'
+
         assert isinstance(astnode, qlast.CreateFunction)
         if astnode.code is not None:
             cmd.set_attribute_value(
@@ -1905,6 +1912,8 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                 astnode.code.language,
             )
             if astnode.code.language is qlast.Language.EdgeQL:
+                reflected_language = 'EdgeQL'
+
                 nativecode_expr: qlast.Base
 
                 if astnode.nativecode is not None:
@@ -1942,6 +1951,8 @@ class CreateFunction(CreateCallableObject[Function], FunctionCommand):
                     'code',
                     astnode.code.code,
                 )
+
+        cmd.set_attribute_value('reflected_language', reflected_language)
 
         return cmd
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -247,7 +247,7 @@ class ComparisonContext:
 # derived from ProtoField for validation
 class Field(struct.ProtoField, Generic[T]):
 
-    __slots__ = ('name', 'type', 'coerce',
+    __slots__ = ('name', 'sname', 'type', 'coerce',
                  'compcoef', 'inheritable', 'simpledelta',
                  'merge_fn', 'ephemeral',
                  'allow_ddl_set', 'ddl_identity', 'special_ddl_syntax',
@@ -257,6 +257,9 @@ class Field(struct.ProtoField, Generic[T]):
 
     #: Name of the field on the target class; assigned by ObjectMeta
     name: str
+    #: The name to use when reflecting the field into the schema.
+    #: The same as name by default, but can be overridden.
+    sname: str
     #: The type of the value stored in the field
     type: Type[T]
     #: Specifies if *type* is a generic type of the host object
@@ -329,6 +332,7 @@ class Field(struct.ProtoField, Generic[T]):
         reflection_method: ReflectionMethod = ReflectionMethod.REGULAR,
         reflection_proxy: Optional[Tuple[str, str]] = None,
         name: Optional[str] = None,
+        reflection_name: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Schema item core attribute definition.
@@ -356,6 +360,8 @@ class Field(struct.ProtoField, Generic[T]):
 
         if name is not None:
             self.name = name
+        if reflection_name is not None:
+            self.sname = reflection_name
 
         if (
             merge_fn is default_field_merge
@@ -620,6 +626,8 @@ class ObjectMeta(type):
                     f'expected, got {type(field)}')
 
             field.name = k
+            if not hasattr(field, 'sname'):
+                field.sname = k
             myfields[k] = field
             del clsdict[k]
 

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -741,6 +741,8 @@ class TestIntrospection(tb.QueryTestCase):
                             type: { name },
                         } ORDER BY @index
                     },
+                    language,
+                    body,
                 }
                 FILTER
                     .name IN {'std::count', 'sys::get_version'}
@@ -770,7 +772,9 @@ class TestIntrospection(tb.QueryTestCase):
                     "return_type": {
                         "name": "std::int64",
                         "element_types": [],
-                    }
+                    },
+                    "language": "builtin",
+                    "body": None,
                 },
                 {
                     "name": "sys::get_version",
@@ -795,8 +799,10 @@ class TestIntrospection(tb.QueryTestCase):
                             {"name": "local",
                              "type": {"name": "array<std::str>"}}
                         ]
-                    }
-                }
+                    },
+                    "language": "EdgeQL",
+                    "body": str,
+                },
             ]
         )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1772,7 +1772,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
         with self.assertRaisesRegex(
             errors.SchemaDefinitionError,
             r"cannot alter property 'val' of object type 'default::Foo' "
-            r"because this affects nativecode expression of "
+            r"because this affects body expression of "
             r"function 'default::foo\(v:.+int64\)'"
         ):
             self.run_ddl(schema, r'''


### PR DESCRIPTION
Implemented by supporting exposing schema fields to introspection
with a different name than is used internally.