### PR TITLE
Fix `describe`/`populate`/`describe` sequence

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1035,7 +1035,10 @@ class Compiler:
                 ),
             )
             all_ddl = mstate.accepted_cmds + new_ddl
-            mstate = mstate._replace(accepted_cmds=all_ddl)
+            mstate = mstate._replace(
+                accepted_cmds=all_ddl,
+                last_proposed=None,
+            )
             if debug.flags.delta_plan:
                 debug.header('Populate Migration DDL AST')
                 text = []

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -2399,6 +2399,31 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
 
         await self.fast_forward_describe_migration()
 
+    async def test_edgeql_migration_describe_populate_describe(self):
+        await self.start_migration('''
+            type Foo;
+        ''')
+
+        await self.assert_describe_migration({
+            'confirmed': [],
+            'complete': False,
+            'proposed': {
+                'statements': [{
+                    'text': (
+                        'CREATE TYPE test::Foo;'
+                    )
+                }],
+            },
+        })
+
+        await self.con.execute('POPULATE MIGRATION;')
+
+        await self.assert_describe_migration({
+            'confirmed': ['CREATE TYPE test::Foo;'],
+            'complete': True,
+            'proposed': None,
+        })
+
     async def test_edgeql_migration_computed_01(self):
         await self.migrate(r'''
             type Foo {


### PR DESCRIPTION
Currently, if one runs `describe current migration` _before_ `populate
migration`, then subsequent `describe current migration` will
incorrectly return a `complete: false` response.  Fix this.

Fixes: #3958