### PR TITLE
Remove activation socket name customization

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -127,7 +127,6 @@ class ServerConfig(NamedTuple):
     testmode: bool
     bind_addresses: list[str]
     port: int
-    activation_socket_names: list[str]
     background: bool
     pidfile_dir: pathlib.Path
     daemon_user: str
@@ -441,17 +440,6 @@ _server_options = [
         '-P', '--port', type=PortType(), default=None,
         help='port to listen on'),
     click.option(
-        '--activation-socket-name', type=str, multiple=True,
-        help='The names of the activation sockets to listen on, specify '
-             'multiple times for several sockets.  Should match a Sockets '
-             'entry in service plist on macOS, or FileDescriptorName= in '
-             'systemd .socket unit.  If not specified, defaults to '
-             '"edgedb-server" on macOS and all sockets passed by systemd '
-             'on Linux.  When the server is started via socket activation '
-             '--bind-address, --port, and the corresponding config settings '
-             'are ignored, and the server only listens on the socket passed '
-             'by the system service manager.'),
-    click.option(
         '-b', '--background', is_flag=True, help='daemonize'),
     click.option(
         '--pidfile-dir', type=PathPath(), default='/run/edgedb/',
@@ -698,7 +686,6 @@ def compiler_options(func):
 
 def parse_args(**kwargs: Any):
     kwargs['bind_addresses'] = kwargs.pop('bind_address')
-    kwargs['activation_socket_names'] = kwargs.pop('activation_socket_name')
 
     if kwargs['echo_runtime_info']:
         warnings.warn(

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -166,8 +166,7 @@ async def _run_server(
     new_instance: bool,
 ):
 
-    sockets = service_manager.get_activation_listen_sockets(
-        args.activation_socket_names)
+    sockets = service_manager.get_activation_listen_sockets()
 
     if sockets:
         logger.info("detected service manager socket activation")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ ignore_missing_imports = true
 warn_redundant_casts = true
 warn_unused_configs = true
 show_column_numbers = true
+show_error_codes = true
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
The recently-added `--activation-socket-name` option is deemed
unnecessary.  Remove it and always use the default behavior of
activating on all passed sockets on Linux and on the hardcoded
"edgedb-server" socket on macOS.

Also, don't emit a warning about `launch_activate_socket` if
the server isn't actually running under launchd.