### PR TITLE
Remove the need for an extra Execute roundtrip on output tid mismatch

### DIFF
--- a/edb/protocol/messages.py
+++ b/edb/protocol/messages.py
@@ -517,6 +517,7 @@ class CompilationFlag(enum.IntFlag):
 
     INJECT_OUTPUT_TYPE_IDS   = 1 << 0    # noqa
     INJECT_OUTPUT_TYPE_NAMES = 1 << 1    # noqa
+    INJECT_OUTPUT_OBJECT_IDS = 1 << 2    # noqa
 
 
 class ErrorSeverity(enum.Enum):

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -25,6 +25,7 @@ import logging
 import time
 import statistics
 import traceback
+import sys
 
 cimport cython
 cimport cpython
@@ -356,6 +357,7 @@ cdef class EdgeConnection:
                 f'in_tx:{0}',
                 f'tx_error:{0}',
                 *args,
+                file=sys.stderr,
             )
         else:
             print(
@@ -364,6 +366,7 @@ cdef class EdgeConnection:
                 f'in_tx:{int(self._dbview.in_tx())}',
                 f'tx_error:{int(self._dbview.in_tx_error())}',
                 *args,
+                file=sys.stderr,
             )
 
     cdef write(self, WriteBuffer buf):
@@ -1534,6 +1537,10 @@ cdef class EdgeConnection:
             compilation_flags
             & messages.CompilationFlag.INJECT_OUTPUT_TYPE_IDS
         )
+        inline_objectids = (
+            compilation_flags
+            & messages.CompilationFlag.INJECT_OUTPUT_OBJECT_IDS
+        )
 
         output_format = self.parse_output_format(self.buffer.read_byte())
         expect_one = (
@@ -1552,7 +1559,7 @@ cdef class EdgeConnection:
             implicit_limit=implicit_limit,
             inline_typeids=inline_typeids,
             inline_typenames=inline_typenames,
-            inline_objectids=True,
+            inline_objectids=inline_objectids,
             allow_capabilities=allow_capabilities,
         )
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
 
 # Dependencies needed both at build- and run-time
 COMMON_DEPS = [
-    'edgedb @ git+https://github.com/edgedb/edgedb-python@9bfae8723952e79079f9647144d3dd1c6e2604eb',
+    'edgedb @ git+https://github.com/edgedb/edgedb-python@681477217fad176012a9d37598e0f4fd56598f55',
     'parsing~=2.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
 
 # Dependencies needed both at build- and run-time
 COMMON_DEPS = [
-    'edgedb==0.24.0a3',
+    'edgedb @ git+https://github.com/edgedb/edgedb-python@9bfae8723952e79079f9647144d3dd1c6e2604eb',
     'parsing~=2.0',
 ]
 


### PR DESCRIPTION
When only the output type descriptor passed by the client in `Execute`
does not match the server's, the server is still able to execute the
statement right away and provide the correct data descriptor alongside
data.  This saves an extra roundtrip in cases where the client knows the
input shape (e.g. there are no arguments, or the client is able to infer
the type descriptor from the types of values passed as arguments).