### PR TITLE
Some tweaks to dump output:

### DIFF
--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -179,12 +179,14 @@ def dump_code(*args, **kwargs):
 
 def dump_sql(sql, *args, **kwargs):
     import edb.pgsql.codegen
-    dump_code(edb.pgsql.codegen.generate_source(sql), *args, **kwargs)
+    dump_code(
+        edb.pgsql.codegen.generate_source(sql, *args, **kwargs), lexer='SQL'
+    )
 
 
 def dump_edgeql(eql, *args, **kwargs):
     import edb.edgeql.codegen
-    dump_code(edb.edgeql.codegen.generate_source(eql), *args, **kwargs)
+    dump_code(edb.edgeql.codegen.generate_source(eql, *args, **kwargs))
 
 
 def set_trace(**kwargs):

--- a/edb/common/markup/renderers/styles.py
+++ b/edb/common/markup/renderers/styles.py
@@ -106,7 +106,7 @@ class Dark256(StylesTable):
 
     ref = Style(color='#586c9e')
 
-    unknown_object = Style(color='#454545')
+    unknown_object = Style(color='#707070')
     unknown_markup = overflow = Style(color='white', bgcolor='#84345a')
     serialization_error = Style(color='white', bgcolor='#900')
 

--- a/edb/pgsql/ast.py
+++ b/edb/pgsql/ast.py
@@ -44,7 +44,7 @@ class Base(ast.AST):
 
     def dump_sql(self) -> None:
         from edb.common.debug import dump_sql
-        dump_sql(self)
+        dump_sql(self, reordered=True, pretty=True)
 
 
 class ImmutableBase(ast.ImmutableASTMixin, Base):

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -70,10 +70,12 @@ class SQLSourceGenerator(codegen.SourceGenerator):
     @classmethod
     def to_source(
             cls, node, indent_with=' ' * 4, add_line_information=False,
+            reordered=False,
             pretty=True):
         try:
             return super().to_source(
                 node, indent_with=indent_with,
+                reordered=reordered,
                 add_line_information=add_line_information, pretty=pretty)
         except SQLSourceGeneratorError as e:
             ctx = SQLSourceGeneratorContext(node)


### PR DESCRIPTION
* Make .dump_sql method on SQL asts use reordered mode by default
 * Make dump_sql use SQL keyword highlighting instead of python
   (The dump done when EDGEDB_DEBUG_EDGEQL_COMPILE_SQL_TEXT=1
   is set already does this. This is just for when calls to
   dump_sql are added in debug code.)
 * Lighten the font color for "unknown" types (which includes names
   and pathids)