### PR TITLE
Fix a collection of group/materialization issues

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -44,7 +44,7 @@ from edb.common import verutils
 
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2022_06_10_00_00
+EDGEDB_CATALOG_VERSION = 2022_06_21_00_00
 EDGEDB_MAJOR_VERSION = 2
 
 

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -187,7 +187,6 @@ def derive_view(
     derived_name: Optional[sn.QualName] = None,
     derived_name_quals: Optional[Sequence[str]] = (),
     preserve_shape: bool = False,
-    preserve_path_id: bool = False,
     exprtype: s_types.ExprType = s_types.ExprType.Select,
     inheritance_merge: bool = True,
     attrs: Optional[Dict[str, Any]] = None,
@@ -237,7 +236,6 @@ def derive_view(
                 inheritance_refdicts={'pointers'},
                 mark_derived=True,
                 transient=True,
-                preserve_path_id=preserve_path_id,
                 attrs=attrs,
             )
 
@@ -300,7 +298,6 @@ def derive_ptr(
     derived_name: Optional[sn.QualName] = None,
     derived_name_quals: Optional[Sequence[str]] = (),
     preserve_shape: bool = False,
-    preserve_path_id: bool = False,
     derive_backlink: bool = False,
     inheritance_merge: bool = True,
     attrs: Optional[Dict[str, Any]] = None,
@@ -329,7 +326,6 @@ def derive_ptr(
         inheritance_refdicts={'pointers'},
         mark_derived=True,
         transient=True,
-        preserve_path_id=preserve_path_id,
         attrs=attrs)
 
     # Delete the bogus parents from a derived computed backlink.

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -787,20 +787,10 @@ def extend_path(
 
     orig_ptrcls = ptrcls
 
-    # For view ptrclses, find the place where the pointer is "really"
-    # defined that is, either its schema definition site or where it
-    # last had a expression defining it.
-    #
+    # Find the pointer definition site.
     # This makes it so that views don't change path ids unless they are
     # introducing some computation.
-    while (
-        ptrcls.get_is_derived(ctx.env.schema)
-        and not ptrcls.get_defined_here(ctx.env.schema)
-        and (bases := ptrcls.get_bases(ctx.env.schema).objects(ctx.env.schema))
-        and len(bases) == 1
-        and bases[0].get_source(ctx.env.schema)
-    ):
-        ptrcls = bases[0]
+    ptrcls = ptrcls.get_nearest_defined(ctx.env.schema)
 
     path_id = pathctx.extend_path_id(
         src_path_id,

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -266,6 +266,7 @@ def _make_group_binding(
         preserve_shape=True, ctx=ctx)
 
     binding_set = setgen.class_set(binding_type, ctx=ctx)
+    binding_set.is_visible_binding_ref = True
 
     name = s_name.UnqualName(alias)
     ctx.aliased_views[name] = binding_type

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -352,6 +352,7 @@ def _fixup_materialized_sets(
                 subctx.implicit_tid_in_shapes = False
                 subctx.implicit_tname_in_shapes = False
                 subctx.path_scope = new_scope
+                subctx.path_scope = parent.attach_fence()
                 viewgen.late_compile_view_shapes(ir_set, ctx=subctx)
 
             for use_set in mat_set.use_sets:

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -205,7 +205,6 @@ class BasePointerRef(ImmutableBase):
     # The defaults set here are mostly to try to reduce debug spew output.
     name: sn.QualName
     shortname: sn.QualName
-    path_id_name: typing.Optional[sn.QualName]
     std_parent_name: typing.Optional[sn.QualName] = None
     out_source: TypeRef
     out_target: TypeRef
@@ -223,6 +222,7 @@ class BasePointerRef(ImmutableBase):
     out_cardinality: qltypes.Cardinality
     # Inbound cardinality of the pointer.
     in_cardinality: qltypes.Cardinality = qltypes.Cardinality.MANY
+    defined_here: bool = False
 
     def dir_target(self, direction: s_pointers.PointerDirection) -> TypeRef:
         if direction is s_pointers.PointerDirection.Outbound:

--- a/edb/ir/pathid.py
+++ b/edb/ir/pathid.py
@@ -325,7 +325,7 @@ class PathId:
 
         result = self.__class__()
         result._path = self._path + ((ptrref, direction), target_ref)
-        link_name = ptrref.path_id_name or ptrref.name
+        link_name = ptrref.name
         lnk = (link_name, direction, is_linkprop)
         result._is_linkprop = is_linkprop
 
@@ -431,7 +431,7 @@ class PathId:
             )
 
             if debug:
-                link_name = str(ptrspec[0].path_id_name or ptrspec[0].name)
+                link_name = str(ptrspec[0].name)
                 ptr = f'({link_name})'
             else:
                 ptr = ptrspec[0].shortname.name

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -513,6 +513,8 @@ def ptrref_from_ptrcls(  # NoQA: F811
     elif isinstance(ptrcls, s_pointers.Pointer):
         ircls = irast.PointerRef
         kwargs['id'] = ptrcls.id
+        kwargs['defined_here'] = ptrcls.get_defined_here(schema)
+
     else:
         raise AssertionError(f'unexpected pointer class: {ptrcls}')
 
@@ -654,7 +656,6 @@ def ptrref_from_ptrcls(  # NoQA: F811
         out_target=out_target,
         name=ptrcls.get_name(schema),
         shortname=ptrcls.get_shortname(schema),
-        path_id_name=ptrcls.get_path_id_name(schema),
         std_parent_name=std_parent_name,
         source_ptr=source_ptr,
         base_ptr=base_ptr,
@@ -989,22 +990,6 @@ def replace_pathid_prefix(
             continue
         dir = part.rptr_dir()
         assert dir
-
-        # If the ptrref doesn't match the new result type, try to find
-        # the correct ptrref, up or down the hierarchy.
-        # TODO: Do we need to handle the link property case?
-        if (
-            ptrref.out_source
-            and result.target != ptrref.out_source
-        ):
-            ancptr: Optional[irast.BasePointerRef] = ptrref
-            while ancptr:
-                if new_ptrref := maybe_find_actual_ptrref(
-                    result.target, ancptr, dir=dir, material=False,
-                ):
-                    ptrref = new_ptrref
-                    break
-                ancptr = ancptr.base_ptr
 
         if ptrref.source_ptr:
             result = result.ptr_path()

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -102,7 +102,14 @@ def compile_materialized_exprs(
         matctx.materializing |= {stmt}
         matctx.expr_exposed = True
 
-        for mat_set in stmt.materialized_sets.values():
+        # HACK: Sort longer paths before shorter ones
+        # We want foo->bar to appear before foo
+        mat_sets = sorted(
+            (stmt.materialized_sets.values()),
+            key=lambda m: -len(m.materialized.path_id),
+        )
+
+        for mat_set in mat_sets:
             if len(mat_set.uses) <= 1:
                 continue
             assert mat_set.finalized

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -111,7 +111,7 @@ def _pull_path_namespace(
 
             rvar = pathctx.maybe_get_path_rvar(
                 target, path_id, aspect=aspect, flavor=flavor, env=ctx.env)
-            if rvar is None:
+            if rvar is None or flavor == 'packed':
                 pathctx.put_path_rvar(
                     target, path_id, source, aspect=aspect, flavor=flavor,
                     env=ctx.env)
@@ -952,7 +952,7 @@ def unpack_var(
                 # Construct a path_id for the element
                 el_name = sn.QualName('__tuple__', st.element_name or str(i))
                 el_ref = irast.TupleIndirectionPointerRef(
-                    name=el_name, shortname=el_name, path_id_name=el_name,
+                    name=el_name, shortname=el_name,
                     out_source=path_id.target,
                     out_target=st,
                     out_cardinality=qltypes.Cardinality.ONE,
@@ -1020,17 +1020,7 @@ def unpack_var(
                 src_path, el_ptrref = el.path_id.src_path(), el.path_id.rptr()
                 assert src_path and el_ptrref
 
-                # We want to graft the ptrref for this element onto
-                # the main path_id. To get the right one (that will
-                # match code that wants to consume this), we need to
-                # find the ptrref that matches the path_id view type.
-                ptrref = irtyputils.maybe_find_actual_ptrref(
-                    path_id.target, el_ptrref, material=False)
-                if not ptrref:
-                    # A missing ptrref should mean that this computable isn't
-                    # actually used, so we don't need to worry too hard.
-                    ptrref = el_ptrref
-                el_id = path_id.ptr_path().extend(ptrref=ptrref)
+                el_id = path_id.ptr_path().extend(ptrref=el_ptrref)
 
                 assert el.rptr
                 card = el.rptr.ptrref.dir_cardinality(el.rptr.direction)

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1313,7 +1313,9 @@ def process_set_as_subquery(
             return _new_subquery_stmt_set_rvar(ir_set, stmt, ctx=ctx)
 
         # materialized refs should always get picked up by now
-        assert not ir_set.is_materialized_ref
+        assert not ir_set.is_materialized_ref, (
+            f"Can't find materialized set {ir_set.path_id}"
+        )
         assert isinstance(expr, irast.Stmt)
 
         inner_set = expr.result

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1149,7 +1149,6 @@ class CommandContextToken(Generic[Command_T]):
     inheritance_merge: Optional[bool]
     inheritance_refdicts: Optional[AbstractSet[str]]
     mark_derived: Optional[bool]
-    preserve_path_id: Optional[bool]
     enable_recursion: Optional[bool]
     transient_derivation: Optional[bool]
 
@@ -1170,7 +1169,6 @@ class CommandContextToken(Generic[Command_T]):
         self.inheritance_merge = None
         self.inheritance_refdicts = None
         self.mark_derived = None
-        self.preserve_path_id = None
         self.enable_recursion = None
         self.transient_derivation = None
 
@@ -1269,13 +1267,6 @@ class CommandContext:
         for ctx in reversed(self.stack):
             if ctx.mark_derived is not None:
                 return ctx.mark_derived
-        return None
-
-    @property
-    def preserve_path_id(self) -> Optional[bool]:
-        for ctx in reversed(self.stack):
-            if ctx.preserve_path_id is not None:
-                return ctx.preserve_path_id
         return None
 
     @property

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -674,10 +674,6 @@ class CreateInheritingObject(
             schema, ancestors)
         self.set_attribute_value('ancestors', ancestors_coll.as_shell(schema))
 
-        if context.preserve_path_id and len(bases) == 1:
-            base_name = bases[0].get_name(schema)
-            self.set_attribute_value('path_id_name', base_name)
-
         if context.mark_derived:
             self.set_attribute_value('is_derived', True)
 

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -975,15 +975,6 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         inheritable=False,
     )
 
-    # The path_id_name field is solely for the purposes of the compiler
-    # so that this item can act as a transparent proxy for the item
-    # it has been derived from, specifically in path ids.
-    path_id_name = SchemaField(
-        sn.QualName,
-        inheritable=False,
-        ephemeral=True,
-        default=None)
-
     # Fields that have been computed by the system as opposed to
     # set explicitly or inherited.
     computed_fields = SchemaField(

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -440,6 +440,15 @@ class Pointer(referencing.ReferencedInheritingObject,
         aux_cmd_data=True,
     )
 
+    # Is this pointer a "definition site" of some kind or just a
+    # trivial inheritor. Used to determine whether to use this pointer
+    # or a parent when computing path ids.
+    defined_here = so.SchemaField(
+        bool,
+        inheritable=False,
+        ephemeral=True,
+        default=False)
+
     # Computable pointers have this set to an expression
     # defining them.
     expr = so.SchemaField(

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -554,6 +554,26 @@ class Pointer(referencing.ReferencedInheritingObject,
         else:
             return schema, non_derived_parent
 
+    def get_nearest_defined(self, schema: s_schema.Schema) -> Pointer:
+        """
+        Find the pointer definition site.
+
+        For view pointers, find the place where the pointer is "really"
+        defined that is, either its schema definition site or where it
+        last had a expression defining it.
+        """
+        ptrcls = self
+        while (
+            ptrcls.get_is_derived(schema)
+            and not ptrcls.get_defined_here(schema)
+            and (bases := ptrcls.get_bases(schema).objects(schema))
+            and len(bases) == 1
+            and bases[0].get_source(schema)
+        ):
+            ptrcls = bases[0]
+
+        return ptrcls
+
     def get_near_endpoint(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/referencing.py
+++ b/edb/schema/referencing.py
@@ -272,7 +272,6 @@ class ReferencedInheritingObject(
         dctx: Optional[sd.CommandContext] = None,
         derived_name_base: Optional[sn.Name] = None,
         inheritance_merge: bool = True,
-        preserve_path_id: Optional[bool] = None,
         inheritance_refdicts: Optional[AbstractSet[str]] = None,
         transient: bool = False,
         name: Optional[sn.QualName] = None,
@@ -365,9 +364,6 @@ class ReferencedInheritingObject(
 
             if transient:
                 context.current().transient_derivation = True
-
-            if preserve_path_id:
-                context.current().preserve_path_id = True
 
             parent_cmd.add(cmd)
             schema = delta.apply(schema, context)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -170,7 +170,6 @@ class Type(
         mark_derived: bool = False,
         attrs: Optional[Mapping[str, Any]] = None,
         inheritance_merge: bool = True,
-        preserve_path_id: bool = False,
         transient: bool = False,
         inheritance_refdicts: Optional[AbstractSet[str]] = None,
         **kwargs: Any,
@@ -218,9 +217,6 @@ class Type(
 
             if transient:
                 context.current().transient_derivation = True
-
-            if preserve_path_id:
-                context.current().preserve_path_id = True
 
             delta.add(cmd)
             schema = delta.apply(schema, context)

--- a/tests/test_edgeql_internal_group.py
+++ b/tests/test_edgeql_internal_group.py
@@ -611,7 +611,6 @@ class TestEdgeQLGroupInternal(tb.QueryTestCase):
             always_typenames=True,
         )
 
-    @test.xerror('Broken when injecting types - is not a computed pointer')
     async def test_edgeql_igroup_returning_08(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_ir_pathid.py
+++ b/tests/test_edgeql_ir_pathid.py
@@ -25,8 +25,6 @@ from edb.ir import typeutils as irtyputils
 from edb.schema import name as s_name
 from edb.schema import pointers as s_pointers
 
-from edb.tools import test
-
 
 class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
     """Unit tests for path id logic."""
@@ -207,7 +205,7 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
 
         ptr_1b = irtyputils.replace_pathid_prefix(ptr_1, base_1, base_2)
 
-        self.assertEqual(ptr_2, ptr_1b)
+        self.assertEqual(repr(ptr_2), repr(ptr_1b))
 
     def test_edgeql_ir_pathid_replace_02(self):
         base_1 = self.mk_path('Card', ns={'ns1'})
@@ -218,7 +216,7 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
 
         ptr_1b = irtyputils.replace_pathid_prefix(ptr_1, base_1, base_2)
 
-        self.assertEqual(ptr_2, ptr_1b)
+        self.assertEqual(repr(ptr_2), repr(ptr_1b))
 
     def test_edgeql_ir_pathid_replace_03a(self):
         base_1 = self.mk_path('User', 'deck')
@@ -237,7 +235,6 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
 
         self.assertEqual(repr(ptr_2), repr(ptr_1b))
 
-    @test.xfail("We don't handle linkprops when doing type remapping")
     def test_edgeql_ir_pathid_replace_03b(self):
         base_1 = self.mk_path('User', 'deck')
         base_2 = self.mk_path('Bot', 'deck')
@@ -248,4 +245,4 @@ class TestEdgeQLIRPathID(tb.BaseEdgeQLCompilerTest):
         ptr_1b = irtyputils.replace_pathid_prefix(
             ptr_1, base_1, base_2, permissive_ptr_path=True)
 
-        self.assertEqual(ptr_2, ptr_1b)
+        self.assertEqual(repr(ptr_2), repr(ptr_1b))

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -431,7 +431,6 @@ class TestEdgeQLScope(tb.QueryTestCase):
         await self.assert_query_result(query, res)
         await self.assert_query_result(query, res, implicit_limit=100)
 
-    @test.xerror("Eta-expansion breaks somehow with link properties")
     async def test_edgeql_scope_tuple_04f(self):
         # Similar to above tests, but forcing use of eta-expansion
         query = r'''


### PR DESCRIPTION
The core change here is to make setgen.extend_path use a parent ptrcls
when the passed ptrcls is just a trivial derivation.

This is essentially a generalization of the existing 'path_id_name'
mechanism that covers more cases and behaves in a more principled way.
Because we do a better job now of using the right pointer, this allows
eliminating the mechanism where replace_prefix would search for new
pointer refs that directly match the type.

(Eliminating that mechanism was one of the drivers of how this was
done. Despite that all being my code and having *just* gone and
written tests for that behavior, I realized that the whole scheme was
pretty half-baked: calling replace_prefix with prefix==replacement
could cause the path to change!)

Unfortunately the path_id changes regressed
test_edgeql_group_by_group_by_03a, a fairly hairy test that we now
fail to compile.

Closes #3967.
Closes #3955.