### PR TITLE
Bring back Parse message

### DIFF
--- a/docs/reference/protocol/messages.rst
+++ b/docs/reference/protocol/messages.rst
@@ -75,6 +75,9 @@ Messages
     * - :ref:`ref_protocol_msg_flush`
       - Force the server to flush its output buffers.
 
+    * - :ref:`ref_protocol_msg_parse`
+      - Parse EdgeQL command(s).
+
     * - :ref:`ref_protocol_msg_execute`
       - Parse and/or execute a query.
 
@@ -335,26 +338,55 @@ The data in *arguments* must be encoded as a
 :ref:`tuple value <ref_protocol_fmt_tuple>` described by
 a type descriptor identified by *input_typedesc_id*.
 
-Known headers:
 
-* 0xFF01 ``IMPLICIT_LIMIT`` -- implicit limit for objects returned.
-  Valid format: decimal number encoded as UTF-8 text. Not set by default.
+.. eql:struct:: edb.protocol.enums.Cardinality
 
-* 0xFF02 ``IMPLICIT_TYPENAMES`` -- if set to "true" all returned objects have
-  a ``__tname__`` property set to their type name (equivalent to having
-  an implicit "__tname__ := .__type__.name" computed property.)
-  Note that specifying this header might slow down queries.
 
-* 0xFF03 ``IMPLICIT_TYPEIDS`` -- if set to "true" all returned objects have
-  a ``__tid__`` property set to their type ID (equivalent to having
-  an implicit "__tid__ := .__type__.id" computed property.)
+.. _ref_protocol_msg_parse:
 
-* 0xFF04 ``ALLOW_CAPABILITIES``: ``uint64`` -- optional bitmask of
-  capabilities allowed for this query.  See RFC1004_ for more information.
+Parse
+=====
 
-* 0xFF05 ``EXPLICIT_OBJECTIDS`` -- If set to "true" returned objects will
-  not have an implicit ``id`` property i.e. query shapes will have to
-  explicitly list id properties.
+Sent by: client.
+
+.. eql:struct:: edb.protocol.Parse
+
+.. eql:struct:: edb.protocol.Capability
+
+See RFC1004_ for more information on capability flags.
+
+.. eql:struct:: edb.protocol.CompilationFlag
+
+Use:
+
+* ``0x0000_0000_0000_0001`` (``INJECT_OUTPUT_TYPE_IDS``) -- if set, all
+  returned objects have a ``__tid__`` property set to their type ID
+  (equivalent to having an implicit ``__tid__ := .__type__.id`` computed
+  property.)
+
+* ``0x0000_0000_0000_0002`` (``INJECT_OUTPUT_TYPE_NAMES``) -- if set all
+  returned objects have a ``__tname__`` property set to their type name
+  (equivalent to having an implicit ``__tname__ := .__type__.name`` computed
+  property.)  Note that specifying this flag might slow down queries.
+
+* ``0x0000_0000_0000_0004`` (``INJECT_OUTPUT_OBJECT_IDS``) -- if set all
+  returned objects have an ``id`` property set to their identifier, even if
+  not specified explicitly in the output shape.
+
+.. eql:struct:: edb.protocol.OutputFormat
+
+Use:
+
+* ``BINARY`` to return data encoded in binary.
+
+* ``JSON`` to return data as single row and single field that contains
+  the resultset as a single JSON array".
+
+* ``JSON_ELEMENTS`` to return a single JSON string per top-level set element.
+  This can be used to iterate over a large result set efficiently.
+
+* ``NONE`` to prevent the server from returning data, even if the EdgeQL
+  statement does.
 
 .. eql:struct:: edb.protocol.enums.Cardinality
 

--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -36,6 +36,7 @@
 0x_03_01_00_03   UnexpectedMessageError
 
 0x_03_02_00_00   InputDataError
+0x_03_02_01_00   ParameterTypeMismatchError
 
 0x_03_03_00_00   ResultCardinalityMismatchError
 

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -17,6 +17,7 @@ __all__ = base.__all__ + (  # type: ignore
     'TypeSpecNotFoundError',
     'UnexpectedMessageError',
     'InputDataError',
+    'ParameterTypeMismatchError',
     'ResultCardinalityMismatchError',
     'CapabilityError',
     'UnsupportedCapabilityError',
@@ -121,6 +122,10 @@ class UnexpectedMessageError(BinaryProtocolError):
 
 class InputDataError(ProtocolError):
     _code = 0x_03_02_00_00
+
+
+class ParameterTypeMismatchError(InputDataError):
+    _code = 0x_03_02_01_00
 
 
 class ResultCardinalityMismatchError(ProtocolError):

--- a/edb/protocol/messages.py
+++ b/edb/protocol/messages.py
@@ -775,6 +775,22 @@ class RestoreEof(ClientMessage):
     message_length = MessageLength
 
 
+class Parse(ClientMessage):
+
+    mtype = MessageType('P')
+    message_length = MessageLength
+    headers = Headers
+    allowed_capabilities = EnumOf(UInt64, Capability,
+                                  'A bit mask of allowed capabilities.')
+    compilation_flags = EnumOf(UInt64, CompilationFlag,
+                               'A bit mask of query options.')
+    implicit_limit = UInt64('Implicit LIMIT clause on returned sets.')
+    output_format = EnumOf(UInt8, OutputFormat, 'Data output format.')
+    expected_cardinality = EnumOf(UInt8, Cardinality,
+                                  'Expected result cardinality.')
+    command_text = String('Command text.')
+
+
 class Execute(ClientMessage):
 
     mtype = MessageType('O')

--- a/edb/server/protocol/binary.pxd
+++ b/edb/server/protocol/binary.pxd
@@ -134,6 +134,7 @@ cdef class EdgeConnection:
 
     cdef interpret_backend_error(self, exc)
 
+    cdef QueryRequestInfo parse_execute_request(self)
     cdef parse_output_format(self, bytes mode)
     cdef parse_cardinality(self, bytes card)
     cdef char render_cardinality(self, query_unit) except -1

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1266,17 +1266,15 @@ cdef class EdgeConnection:
 
     async def _parse(
         self,
-        bytes eql,
         QueryRequestInfo query_req,
     ) -> CompiledQuery:
         cdef dbview.DatabaseConnectionView _dbview
         source = query_req.source
+        text = source.text()
 
         if self.debug:
-            self.debug_print('PARSE', eql)
-
-        if self.debug:
-            self.debug_print('Cache key', source.text())
+            self.debug_print('PARSE', text)
+            self.debug_print('Cache key', source.cache_key())
             self.debug_print('Extra variables', source.variables(),
                              'after', source.first_extra())
 
@@ -1292,7 +1290,7 @@ cdef class EdgeConnection:
                 # ROLLBACK or ROLLBACK TO TRANSACTION could be parsed;
                 # try doing just that.
                 query_unit_group, num_remain = await self._compile_rollback(
-                    eql
+                    text.encode("utf-8")
                 )
                 if num_remain:
                     # Raise an error if there were more than just a
@@ -1520,6 +1518,7 @@ cdef class EdgeConnection:
             bytes state = None, orig_state = None
             dbview.DatabaseConnectionView _dbview
             pgcon.PGConnection conn
+            WriteBuffer bound_args_buf
 
         query_unit = compiled.query_unit_group[0]
         _dbview = self.get_dbview()
@@ -1613,21 +1612,17 @@ cdef class EdgeConnection:
         finally:
             self.maybe_release_pgcon(conn)
 
-    async def execute(self):
+    cdef QueryRequestInfo parse_execute_request(self):
         cdef:
-            WriteBuffer bound_args_buf
-
+            uint64_t allow_capabilities = 0
+            uint64_t compilation_flags = 0
+            int64_t implicit_limit = 0
+            bint inline_typenames = False
+            bint inline_typeids = False
+            bint inline_objectids = False
+            object output_format
+            bint expect_one = False
             bytes query
-            QueryRequestInfo query_req
-
-            bytes in_tid
-            bytes out_tid
-            bytes bound_args
-            uint64_t allow_capabilities
-            uint64_t compilation_flags
-            int64_t implicit_limit
-
-        self.ignore_headers()
 
         allow_capabilities = <uint64_t>self.buffer.read_int64()
         compilation_flags = <uint64_t>self.buffer.read_int64()
@@ -1660,7 +1655,7 @@ cdef class EdgeConnection:
         if not query:
             raise errors.BinaryProtocolError('empty query')
 
-        query_req = QueryRequestInfo(
+        return QueryRequestInfo(
             self._tokenize(query),
             self.protocol_version,
             output_format=output_format,
@@ -1672,9 +1667,41 @@ cdef class EdgeConnection:
             allow_capabilities=allow_capabilities,
         )
 
+    async def parse(self):
+        cdef:
+            bytes eql
+            QueryRequestInfo query_req
+            WriteBuffer parse_complete
+            WriteBuffer buf
+
+        self._last_anon_compiled = None
+
+        self.ignore_headers()
+
+        query_req = self.parse_execute_request()
+        compiled = await self._parse(query_req)
+
+        buf = self.make_command_data_description_msg(compiled)
+
+        self._last_anon_compiled = compiled
+        self._last_anon_compiled_hash = hash(query_req)
+
+        self.write(buf)
+        self.flush()
+
+    async def execute(self):
+        cdef:
+            QueryRequestInfo query_req
+            bytes in_tid
+            bytes out_tid
+            bytes args
+
+        self.ignore_headers()
+
+        query_req = self.parse_execute_request()
         in_tid = self.buffer.read_bytes(16)
         out_tid = self.buffer.read_bytes(16)
-        bind_args = self.buffer.read_len_prefixed_bytes()
+        args = self.buffer.read_len_prefixed_bytes()
         self.buffer.finish_message()
 
         if (
@@ -1692,9 +1719,9 @@ cdef class EdgeConnection:
             )
             if query_unit_group is None:
                 if self.debug:
-                    self.debug_print('EXECUTE /REPARSE', query)
+                    self.debug_print('EXECUTE /CACHE MISS', query_req.text())
 
-                compiled = await self._parse(query, query_req)
+                compiled = await self._parse(query_req)
                 self._last_anon_compiled = compiled
                 self._last_anon_compiled_hash = hash(query_req)
                 query_unit_group = compiled.query_unit_group
@@ -1716,27 +1743,24 @@ cdef class EdgeConnection:
                 errors.DisabledCapabilityError,
             )
 
-        if (
-            query_unit_group.in_type_id != in_tid or
-            query_unit_group.out_type_id != out_tid
-        ):
-            # The client has outdated information about type specs.
-            if self.debug:
-                self.debug_print('EXECUTE /MISMATCH', query)
+        if query_unit_group.in_type_id != in_tid:
+            raise errors.ParameterTypeMismatchError(
+                "specified parameter type(s) do not match the parameter "
+                "types inferred from specified command(s)"
+            )
 
+        if query_unit_group.out_type_id != out_tid:
+            # The client has no up-to-date information about the output,
+            # so provide one.
             self.write(self.make_command_data_description_msg(compiled))
 
-            if self._cancelled:
-                raise ConnectionAbortedError
-            return
-
         if self.debug:
-            self.debug_print('EXECUTE', query)
+            self.debug_print('EXECUTE', query_req.text())
 
         # Clear the _last_anon_compiled so that the next Execute - if
-        # identical - will always lookup in the cache and honor the `cacheable`
-        # flag to compile the query again. Put it another way, this is the
-        # legacy Execute of the "anonymous" prepared statement.
+        # identical - will always lookup in the cache and honor the
+        # `cacheable` flag to compile the query again. Put it another way,
+        # this is the legacy Execute of the "anonymous" prepared statement.
         self._last_anon_compiled = None
 
         metrics.edgeql_query_compilations.inc(1.0, 'cache')
@@ -1747,22 +1771,28 @@ cdef class EdgeConnection:
             assert len(query_unit_group) == 1
             await self._execute_rollback(compiled)
         elif len(query_unit_group) > 1:
-            await self._execute_script(compiled, bind_args)
+            await self._execute_script(compiled, args)
             self.write(
                 self.make_command_complete_msg_by_group(
                     compiled.query_unit_group
                 )
             )
-            self.flush()
         else:
             use_prep = (
                 len(query_unit_group) == 1
                 and bool(query_unit_group[0].sql_hash)
             )
-            await self._execute(compiled, bind_args, use_prep)
+            await self._execute(compiled, args, use_prep)
             self.write(
-                self.make_command_complete_msg(compiled.query_unit_group[0])
+                self.make_command_complete_msg(
+                    compiled.query_unit_group[0],
+                ),
             )
+
+        if self._cancelled:
+            raise ConnectionAbortedError
+
+        self.flush()
 
     async def sync(self):
         self.buffer.consume_message()
@@ -1842,28 +1872,11 @@ cdef class EdgeConnection:
                 mtype = self.buffer.get_message_type()
 
                 try:
-                    if mtype == b'P':
-                        raise errors.BinaryProtocolError(
-                            "Prepare message (P) is not supported in "
-                            "protocols greater 1.0")
-
-                    elif mtype == b'D':
-                        raise errors.BinaryProtocolError(
-                            "Describe message (D) is not supported in "
-                            "protocols greater 0.13")
-
-                    elif mtype == b'E':
-                        raise errors.BinaryProtocolError(
-                            "Legacy Execute message (E) is not supported in "
-                            "protocols greater 1.0")
-
-                    elif mtype == b'O':
+                    if mtype == b'O':
                         await self.execute()
 
-                    elif mtype == b'Q':
-                        raise errors.BinaryProtocolError(
-                            "ExecuteScript message (Q) is not supported in "
-                            "protocols greater 1.0")
+                    elif mtype == b'P':
+                        await self.parse()
 
                     elif mtype == b'S':
                         await self.sync()
@@ -1880,6 +1893,21 @@ cdef class EdgeConnection:
                         # so if an error occurs the server should send an
                         # ERROR message immediately.
                         await self.restore()
+
+                    elif mtype == b'D':
+                        raise errors.BinaryProtocolError(
+                            "Describe message (D) is not supported in "
+                            "protocols greater 0.13")
+
+                    elif mtype == b'E':
+                        raise errors.BinaryProtocolError(
+                            "Legacy Execute message (E) is not supported in "
+                            "protocols greater 1.0")
+
+                    elif mtype == b'Q':
+                        raise errors.BinaryProtocolError(
+                            "ExecuteScript message (Q) is not supported in "
+                            "protocols greater 1.0")
 
                     else:
                         self.fallthrough()

--- a/edb/server/protocol/binary_v0.pyx
+++ b/edb/server/protocol/binary_v0.pyx
@@ -101,7 +101,7 @@ cdef class EdgeConnectionBackwardsCompatible(EdgeConnection):
         self._last_anon_compiled = None
 
         eql, query_req, stmt_name = self.legacy_parse_prepare_query_part(True)
-        compiled_query = await self._parse(eql, query_req)
+        compiled_query = await self._parse(query_req)
 
         buf = WriteBuffer.new_message(b'1')  # ParseComplete
 
@@ -374,7 +374,7 @@ cdef class EdgeConnectionBackwardsCompatible(EdgeConnection):
             if self.debug:
                 self.debug_print('OPTIMISTIC EXECUTE /REPARSE', query)
 
-            compiled = await self._parse(query, query_req)
+            compiled = await self._parse(query_req)
             self._last_anon_compiled = compiled
             query_unit_group = compiled.query_unit_group
             if self._cancelled:

--- a/edb/server/protocol/binary_v0.pyx
+++ b/edb/server/protocol/binary_v0.pyx
@@ -233,7 +233,7 @@ cdef class EdgeConnectionBackwardsCompatible(EdgeConnection):
                         if self.protocol_version >= (0, 14):
                             raise errors.BinaryProtocolError(
                                 "Describe message (D) is not supported in "
-                                "protocols greater 0.13")
+                                "protocol versions greater than 0.13")
                         await self.legacy_describe()
 
                     elif mtype == b'E':

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -52,6 +52,7 @@ from edb.server import defines as edgedb_defines
 
 from edb.common import assert_data_shape
 from edb.common import devmode
+from edb.common import debug
 from edb.common import taskgroup
 
 from edb.protocol import protocol as test_protocol
@@ -402,11 +403,13 @@ async def init_cluster(
     if init_settings is None:
         init_settings = {}
 
+    log_level = 's' if not debug.flags.server else 'd'
+
     if backend_dsn:
         cluster = edgedb_cluster.TempClusterWithRemotePg(
             backend_dsn,
             testmode=True,
-            log_level='s',
+            log_level=log_level,
             data_dir_prefix='edb-test-',
             security=security,
             http_endpoint_security=http_endpoint_security,
@@ -416,7 +419,7 @@ async def init_cluster(
     elif data_dir is None:
         cluster = edgedb_cluster.TempCluster(
             testmode=True,
-            log_level='s',
+            log_level=log_level,
             data_dir_prefix='edb-test-',
             security=security,
             http_endpoint_security=http_endpoint_security,
@@ -426,7 +429,7 @@ async def init_cluster(
     else:
         cluster = edgedb_cluster.Cluster(
             data_dir=data_dir,
-            log_level='s',
+            log_level=log_level,
             security=security,
             http_endpoint_security=http_endpoint_security,
             compiler_pool_mode=compiler_pool_mode,

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
 
 # Dependencies needed both at build- and run-time
 COMMON_DEPS = [
-    'edgedb @ git+https://github.com/edgedb/edgedb-python@9bfae8723952e79079f9647144d3dd1c6e2604eb',
+    'edgedb @ git+https://github.com/edgedb/edgedb-python@b7a604bee7f5e85616935479bd662d2f2467c05a',
     'parsing~=2.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
 
 # Dependencies needed both at build- and run-time
 COMMON_DEPS = [
-    'edgedb @ git+https://github.com/edgedb/edgedb-python@b7a604bee7f5e85616935479bd662d2f2467c05a',
+    'edgedb @ git+https://github.com/edgedb/edgedb-python@09bfcc85856fd8ecb727b9179695f7a9045ce088',
     'parsing~=2.0',
 ]
 


### PR DESCRIPTION
Upon further consideration it was decided that an explicit "parse only"
mode deserves a dedicated message rather than a magical type descriptor
id or a boolean flag in `Execute`.

Another aspect of this change is that a mismatching _input_ type
descriptor in `Execute` now causes a `ParameterTypeMismatchError`
instead of treating the condition as a non-error.