### PR TITLE
Fix linkprops in pre-filtered shape links

### DIFF
--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -284,8 +284,9 @@ def include_specific_rvar(
         if parent_scope is not None:
             scopes.append(parent_scope)
 
-        if not any(scope.path_id == path_id or
-                   scope.find_child(path_id) for scope in scopes):
+        tpath_id = path_id.tgt_path()
+        if not any(scope.path_id == tpath_id or
+                   scope.find_child(tpath_id) for scope in scopes):
             pathctx.put_path_id_mask(stmt, path_id)
 
     return rvar

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -1283,3 +1283,22 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
                     filter .name = 'Dragon'
                 '''
             )
+
+    async def test_edgeql_props_intersect_01(self):
+        await self.assert_query_result(
+            r'''
+            select Named {
+               [IS User].deck:{name, @count}
+            } filter .name = 'Alice';
+            ''',
+            [
+                {
+                    "deck": tb.bag([
+                        {"@count": 2, "name": "Imp"},
+                        {"@count": 2, "name": "Dragon"},
+                        {"@count": 3, "name": "Bog monster"},
+                        {"@count": 3, "name": "Giant turtle"},
+                    ])
+                }
+            ]
+        )

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -3839,3 +3839,11 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ''',
             [{"w": [{"name": "1st"}]}]
         )
+
+    async def test_edgeql_scope_intersection_semijoin_01(self):
+        await self.assert_query_result(
+            r'''
+                select count(Named[IS User].deck);
+            ''',
+            [9],
+        )

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -217,3 +217,15 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             count,
             1,
             f"argument needlessly duplicated")
+
+    def test_codegen_filtered_link_no_semijoin(self):
+        sql = self._compile('''
+            select Named {
+               [IS User].todo:{name}
+            }
+       ''')
+
+        self.assertNotIn(
+            " IN ", sql,
+            "unexpected semi-join",
+        )


### PR DESCRIPTION
This makes shape elements like `[IS User].deck:{name, @count}` work,
and avoids doing a semijoin on them.

Fixes the bug in the test case in #3782.