### PR TITLE
Require specifying RESET TO DEFAULT when changing global type

### DIFF
--- a/edb/edgeql-parser/src/keywords.rs
+++ b/edb/edgeql-parser/src/keywords.rs
@@ -22,6 +22,7 @@ pub const UNRESERVED_KEYWORDS: &[&str] = &[
     "database",
     "ddl",
     "declare",
+    "default",
     "deferrable",
     "deferred",
     "delegated",

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -1047,6 +1047,14 @@ class DropGlobal(DropObject, GlobalCommand):
     pass
 
 
+class SetGlobalType(SetField):
+    name: str = 'target'
+    special_syntax: bool = True
+    value: typing.Optional[TypeExpr]
+    cast_expr: typing.Optional[Expr] = None
+    reset_value: bool = False
+
+
 class LinkCommand(ObjectDDL):
 
     __abstract_node__ = True

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -2038,6 +2038,19 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             after_name=after_name,
         )
 
+    def visit_SetGlobalType(self, node: qlast.SetGlobalType) -> None:
+        if node.value is None:
+            self._write_keywords('RESET TYPE')
+        else:
+            self._write_keywords('SET TYPE ')
+            self.visit(node.value)
+            if node.cast_expr is not None:
+                self._write_keywords(' USING (')
+                self.visit(node.cast_expr)
+                self.write(')')
+            elif node.reset_value:
+                self._write_keywords(' RESET TO DEFAULT')
+
     def visit_CreateGlobal(
         self,
         node: qlast.CreateGlobal

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -429,6 +429,12 @@ class ResetFieldStmt(Nonterm):
             value=None,
         )
 
+    def reduce_RESET_DEFAULT(self, *kids):
+        self.val = qlast.SetField(
+            name='default',
+            value=None,
+        )
+
 
 class CreateAnnotationValueStmt(Nonterm):
     def reduce_CREATE_ANNOTATION_NodeName_ASSIGN_Expr(self, *kids):
@@ -2708,6 +2714,26 @@ class CreateGlobalStmt(Nonterm):
         )
 
 
+class SetGlobalTypeStmt(Nonterm):
+
+    def reduce_SETTYPE_FullTypeExpr_OptAlterUsingClause(self, *kids):
+        self.val = qlast.SetGlobalType(
+            value=kids[1].val,
+            cast_expr=kids[2].val,
+        )
+
+    def reduce_SETTYPE_FullTypeExpr_RESET_TO_DEFAULT(self, *kids):
+        self.val = qlast.SetGlobalType(
+            value=kids[1].val,
+            reset_value=True,
+        )
+
+    def reduce_RESET_TYPE(self, *kids):
+        self.val = qlast.SetGlobalType(
+            value=None,
+        )
+
+
 commands_block(
     'AlterGlobal',
     UsingStmt,
@@ -2717,7 +2743,7 @@ commands_block(
     CreateAnnotationValueStmt,
     AlterAnnotationValueStmt,
     DropAnnotationValueStmt,
-    SetPointerTypeStmt,
+    SetGlobalTypeStmt,
     SetCardinalityStmt,
     SetRequiredStmt,
     opt=False

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -74,6 +74,7 @@ from edb.pgsql import dbops
 from edb.pgsql import params
 
 from edb.server import defines as edbdef
+from edb.server.config import ops as config_ops
 
 from . import ast as pg_ast
 from .common import qname as q
@@ -675,6 +676,33 @@ class AlterGlobal(
     adapts=s_globals.AlterGlobal,
 ):
     pass
+
+
+class SetGlobalType(
+    GlobalCommand,  # ???
+    adapts=s_globals.SetGlobalType,
+):
+    def register_config_op(self, op, context):
+        ops = context.get(sd.DeltaRootContext).op.config_ops
+        ops.append(op)
+
+    def apply(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+
+        schema = super().apply(schema, context)
+        if self.reset_value:
+            op = config_ops.Operation(
+                opcode=config_ops.OpCode.CONFIG_RESET,
+                scope=ql_ft.ConfigScope.GLOBAL,
+                setting_name=str(self.scls.get_name(schema)),
+                value=None,
+            )
+            self.register_config_op(op, context)
+
+        return schema
 
 
 class DeleteGlobal(
@@ -6228,6 +6256,7 @@ class DeltaRoot(MetaCommand, adapts=sd.DeltaRoot):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._renames = {}
+        self.config_ops = []
 
     def apply(
         self,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -365,7 +365,7 @@ class Compiler:
         self._compile_schema_storage_in_delta(
             ctx, pgdelta, subblock, context=context)
 
-        return block, new_types
+        return block, new_types, pgdelta.config_ops
 
     def _compile_schema_storage_in_delta(
         self,
@@ -904,7 +904,7 @@ class Compiler:
 
         # Apply and adapt delta, build native delta plan, which
         # will also update the schema.
-        block, new_types = self._process_delta(ctx, delta)
+        block, new_types, config_ops = self._process_delta(ctx, delta)
 
         ddl_stmt_id: Optional[str] = None
 
@@ -974,6 +974,7 @@ class Compiler:
             user_schema=current_tx.get_user_schema_if_updated(),
             cached_reflection=current_tx.get_cached_reflection_if_updated(),
             global_schema=current_tx.get_global_schema_if_updated(),
+            config_ops=config_ops,
         )
 
     def _compile_ql_migration(
@@ -1830,6 +1831,8 @@ class Compiler:
                         pickle.dumps(comp.cached_reflection, -1)
                 if comp.global_schema is not None:
                     unit.global_schema = pickle.dumps(comp.global_schema, -1)
+
+                unit.config_ops.extend(comp.config_ops)
 
             elif isinstance(comp, dbstate.TxControlQuery):
                 unit.sql = comp.sql

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -135,6 +135,8 @@ class DDLQuery(BaseQuery):
     create_db_template: Optional[str] = None
     has_role_ddl: bool = False
     ddl_stmt_id: Optional[str] = None
+    config_ops: List[config.Operation] = (
+        dataclasses.field(default_factory=list))
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
This is more explicit and leaves us with space to to properly add
USING in 3.0.

Also actually do the reseting to the default.