### PR TITLE
Allow multi-statement requests to return data

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -419,14 +419,12 @@ def compile_bootstrap_script(
     schema: s_schema.Schema,
     eql: str,
     *,
-    single_statement: bool = False,
     expected_cardinality_one: bool = False,
     output_format: edbcompiler.OutputFormat = edbcompiler.OutputFormat.JSON,
 ) -> Tuple[s_schema.Schema, str]:
 
     ctx = edbcompiler.new_compiler_context(
         user_schema=schema,
-        single_statement=single_statement,
         expected_cardinality_one=expected_cardinality_one,
         json_parameters=True,
         output_format=output_format,
@@ -828,7 +826,6 @@ async def _init_stdlib(
         } FILTER .builtin AND NOT (.abstract ?? False);
         ''',
         expected_cardinality_one=False,
-        single_statement=True,
     )
     schema = stdlib.stdschema
     typemap = await conn.fetchval(sql)
@@ -922,7 +919,6 @@ async def _init_stdlib(
             }
             ''',
             expected_cardinality_one=False,
-            single_statement=True,
         )
         await conn.execute(sql)
 
@@ -942,7 +938,6 @@ async def _init_stdlib(
             }
             ''',
             expected_cardinality_one=False,
-            single_statement=True,
         )
         await conn.execute(sql)
 
@@ -1074,7 +1069,6 @@ async def _compile_sys_queries(
         schema,
         'SELECT cfg::get_config_json()',
         expected_cardinality_one=True,
-        single_statement=True,
     )
 
     queries['config'] = sql
@@ -1084,7 +1078,6 @@ async def _compile_sys_queries(
         schema,
         "SELECT cfg::get_config_json(sources := ['database'])",
         expected_cardinality_one=True,
-        single_statement=True,
     )
 
     queries['dbconfig'] = sql
@@ -1094,7 +1087,6 @@ async def _compile_sys_queries(
         schema,
         "SELECT cfg::get_config_json(max_source := 'system override')",
         expected_cardinality_one=True,
-        single_statement=True,
     )
 
     queries['sysconfig'] = sql
@@ -1104,7 +1096,6 @@ async def _compile_sys_queries(
         schema,
         'SELECT (SELECT sys::Database FILTER NOT .builtin).name',
         expected_cardinality_one=False,
-        single_statement=True,
     )
 
     queries['listdbs'] = sql
@@ -1121,7 +1112,6 @@ async def _compile_sys_queries(
         schema,
         role_query,
         expected_cardinality_one=False,
-        single_statement=True,
     )
     queries['roles'] = sql
 
@@ -1136,7 +1126,6 @@ async def _compile_sys_queries(
         schema,
         tids_query,
         expected_cardinality_one=False,
-        single_statement=True,
     )
 
     queries['backend_tids'] = sql
@@ -1156,7 +1145,6 @@ async def _compile_sys_queries(
     units = compiler._compile(
         ctx=edbcompiler.new_compiler_context(
             user_schema=schema,
-            single_statement=True,
             expected_cardinality_one=True,
             json_parameters=False,
             output_format=edbcompiler.OutputFormat.BINARY,

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -25,7 +25,7 @@ from .compiler import compile_edgeql_script
 from .compiler import load_std_schema
 from .compiler import new_compiler, new_compiler_context
 from .dbstate import QueryUnit
-from .enums import Capability, CompileStatementMode, Cardinality
+from .enums import Capability, Cardinality
 from .enums import OutputFormat
 
 
@@ -35,7 +35,8 @@ __all__ = (
     'CompileContext',
     'CompilerDatabaseState',
     'QueryUnit',
-    'Capability', 'CompileStatementMode', 'OutputFormat',
+    'Capability',
+    'OutputFormat',
     'compile_edgeql_script',
     'load_std_schema',
     'new_compiler',

--- a/edb/server/compiler/enums.py
+++ b/edb/server/compiler/enums.py
@@ -26,13 +26,6 @@ from edb.common import enum as strenum
 from edb.protocol.enums import * # NoQA
 
 
-class CompileStatementMode(enum.Enum):
-
-    SKIP_FIRST = 'skip_first'
-    ALL = 'all'
-    SINGLE = 'single'
-
-
 if TYPE_CHECKING:
     Error_T = TypeVar('Error_T')
 

--- a/edb/server/protocol/edgeql_ext.pyx
+++ b/edb/server/protocol/edgeql_ext.pyx
@@ -160,7 +160,7 @@ async def compile(db, server, bytes query):
         0,              # no implicit limit
         False,          # no inlining of type IDs
         False,          # no inlining of type names
-        compiler.CompileStatementMode.SINGLE,
+        False,          # skip_first
         edbdef.CURRENT_PROTOCOL,  # protocol_version
         True,           # inline_objectids
         True,           # json parameters

--- a/edb/server/protocol/system_api.py
+++ b/edb/server/protocol/system_api.py
@@ -30,7 +30,6 @@ from edb.common import markup
 
 from edb.schema import schema as s_schema
 
-from edb.server import compiler
 from edb.server.compiler import OutputFormat
 from edb.server.compiler import enums
 from edb.server import defines as edbdef
@@ -120,7 +119,7 @@ async def compile(server, query):
         0,              # no implicit limit
         False,          # no inlining of type IDs
         False,          # no inlining of type names
-        compiler.CompileStatementMode.SINGLE,
+        False,          # skip_first
         edbdef.CURRENT_PROTOCOL,  # protocol_version
         True,           # inline_objectids
         True,           # json parameters

--- a/edb/tools/wipe.py
+++ b/edb/tools/wipe.py
@@ -293,7 +293,6 @@ async def _get_dbs_and_roles(
         user_schema=s_schema.FlatSchema(),
         global_schema=s_schema.FlatSchema(),
         expected_cardinality_one=False,
-        single_statement=True,
         output_format=edbcompiler.OutputFormat.JSON,
         bootstrap_mode=True,
     )

--- a/tests/test_edgeql_globals.py
+++ b/tests/test_edgeql_globals.py
@@ -98,7 +98,6 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
         await self.con.execute('''
             set global cur_user := "Bob";
             set global def_cur_user := "Dave";
-            select 1;
         ''')
 
         await self.assert_query_result(

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -22,6 +22,7 @@ import os
 import edgedb
 
 from edb.testbase import http as tb
+from edb.tools import test
 
 
 class TestHttpEdgeQL(tb.EdgeQLTestCase):
@@ -191,14 +192,15 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
             [],
         )
 
+    @test.xerror("this is not supported yet")
     def test_http_edgeql_query_08(self):
-        with self.assertRaisesRegex(edgedb.ProtocolError,
-                                    r'expected one statement, got 2'):
-            self.edgeql_query(
-                r"""
-                    SELECT 1;
-                    SELECT 2;
-                """)
+        self.assert_edgeql_query_result(
+            r"""
+                SELECT 1;
+                SELECT 2;
+            """,
+            [2],
+        )
 
     def test_http_edgeql_query_09(self):
         self.assert_edgeql_query_result(

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -416,7 +416,7 @@ class TestCompilerPool(tbs.TestCase):
                     0,
                     edgeql.Source.from_string('SELECT 123'),
                     edbcompiler.OutputFormat.BINARY,
-                    False, 101, False, True, 'single', (0, 12), True
+                    False, 101, False, True, False, (0, 12), True
                 ) for _ in range(4)))
             finally:
                 await pool_.stop()

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -290,26 +290,37 @@ class TestServerProto(tb.QueryTestCase):
                 r'it does not return any data'):
             await self.con.query_required_single_json('START TRANSACTION')
 
-    async def test_server_proto_fetch_single_command_04(self):
-        with self.assertRaisesRegex(edgedb.ProtocolError,
-                                    'expected one statement'):
+    async def test_server_proto_query_script_01(self):
+        self.assertEqual(
             await self.con.query('''
+                SET MODULE test;
                 SELECT 1;
-                SET MODULE blah;
-            ''')
+            '''),
+            [1],
+        )
 
-        with self.assertRaisesRegex(edgedb.ProtocolError,
-                                    'expected one statement'):
-            await self.con.query_single('''
-                SELECT 1;
-                SET MODULE blah;
-            ''')
-
-        with self.assertRaisesRegex(edgedb.ProtocolError,
-                                    'expected one statement'):
+        self.assertEqual(
             await self.con.query_json('''
+                SET MODULE test;
                 SELECT 1;
-                SET MODULE blah;
+            '''),
+            '[1]',
+        )
+
+        with self.assertRaisesRegex(
+                edgedb.InterfaceError,
+                r'it does not return any data'):
+            await self.con.query_required_single('''
+                SELECT 1;
+                SET MODULE test;
+            ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InterfaceError,
+                r'it does not return any data'):
+            await self.con.query_required_single_json('''
+                SELECT 1;
+                SET MODULE test;
             ''')
 
     async def test_server_proto_set_reset_alias_01(self):


### PR DESCRIPTION
Currently, if a request contains multiple statements it is considered to
be a "script", i.e. it will not return any data messages back to the
caller.  This is a rather arbitrary limitation at this point, and lifting
it not only simplifies the internal logic, but also enables useful
client patterns, such as DML followed by a `select` without the need to
resort to complex `with` ladders.  Thus, make it so that `output_format`
always controls the output of the trailing statement regardless of how
many preceding statements were in the request (preceding statements
still have their output suppressed).

EdgeQL+HTTP is not supported yet, will be tackled in a followup PR.