### PR TITLE
Allow DML in free shapes

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -538,7 +538,7 @@ class ContextLevel(compiler.ContextLevel):
     empty_result_type_hint: Optional[s_types.Type]
     """Type to use if the statement result expression is an empty set ctor."""
 
-    defining_view: Optional[s_types.Type]
+    defining_view: Optional[s_objtypes.ObjectType]
     """Whether a view is currently being defined (as opposed to be compiled)"""
 
     recompiling_schema_alias: bool

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -24,8 +24,10 @@ from __future__ import annotations
 from typing import *
 
 from edb import errors
+from edb.common.typeutils import not_none
 
 from edb.ir import ast as irast
+from edb.ir import utils as irutils
 
 from edb.schema import constraints as s_constr
 from edb.schema import functions as s_func
@@ -162,9 +164,12 @@ def compile_FunctionCall(
                 f'{ctx.env.options.in_ddl_context_name}',
                 context=expr.context,
             )
-        elif ((dv := ctx.defining_view) is not None and
-                dv.get_expr_type(ctx.env.schema) is s_types.ExprType.Select and
-                not ctx.env.options.allow_top_level_shape_dml):
+        elif (
+            (dv := ctx.defining_view) is not None
+            and dv.get_expr_type(ctx.env.schema) is s_types.ExprType.Select
+            and not irutils.is_trivial_free_object(
+                not_none(ctx.partial_path_prefix))
+        ):
             # This is some shape in a regular query. Although
             # DML is not allowed in the computable, but it may
             # be possible to refactor it.

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -77,10 +77,6 @@ class GlobalCompilerOptions:
     #: error. When this is not None, any DML should cause an error.
     in_ddl_context_name: Optional[str] = None
 
-    #: Sometimes (like in queries compiled form GraphQL) it may be OK
-    #: to contain DML in the top-level shape computables.
-    allow_top_level_shape_dml: bool = False
-
     #: Is this a dev instance of the compiler
     devmode: bool = False
 

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -32,6 +32,7 @@ from edb.common.typeutils import not_none
 
 from edb.ir import ast as irast
 from edb.ir import typeutils
+from edb.ir import utils as irutils
 
 from edb.schema import ddl as s_ddl
 from edb.schema import functions as s_func
@@ -1052,9 +1053,12 @@ def init_stmt(
                 f'{ctx.env.options.in_ddl_context_name}',
                 context=qlstmt.context,
             )
-        elif ((dv := ctx.defining_view) is not None and
-                dv.get_expr_type(ctx.env.schema) is s_types.ExprType.Select and
-                not ctx.env.options.allow_top_level_shape_dml):
+        elif (
+            (dv := ctx.defining_view) is not None
+            and dv.get_expr_type(ctx.env.schema) is s_types.ExprType.Select
+            and not irutils.is_trivial_free_object(
+                not_none(ctx.partial_path_prefix))
+        ):
             # This is some shape in a regular query. Although
             # DML is not allowed in the computable, but it may
             # be possible to refactor it.

--- a/edb/graphql/compiler.py
+++ b/edb/graphql/compiler.py
@@ -99,7 +99,6 @@ def compile_graphql(
         ),
         options=qlcompiler.CompilerOptions(
             json_parameters=True,
-            allow_top_level_shape_dml=True,
         ),
     )
 

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -120,10 +120,14 @@ def is_bytes(typeref: irast.TypeRef) -> bool:
     return typeref.real_base_type.id == s_obj.get_known_type_id('std::bytes')
 
 
+def is_exactly_free_object(typeref: irast.TypeRef) -> bool:
+    return typeref.name_hint == s_name.QualName('std', 'FreeObject')
+
+
 def is_free_object(typeref: irast.TypeRef) -> bool:
     if typeref.material_type:
         typeref = typeref.material_type
-    return typeref.name_hint == s_name.QualName('std', 'FreeObject')
+    return is_exactly_free_object(typeref)
 
 
 def is_persistent_tuple(typeref: irast.TypeRef) -> bool:

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -265,6 +265,11 @@ def is_type_intersection_reference(ir_expr: irast.Base) -> bool:
     return source_is_type_intersection
 
 
+def is_trivial_free_object(ir: irast.Set) -> bool:
+    ir = unwrap_set(ir)
+    return not ir.expr and typeutils.is_exactly_free_object(ir.typeref)
+
+
 def collapse_type_intersection(
     ir_set: irast.Set,
 ) -> Tuple[irast.Set, List[irast.TypeIntersectionPointer]]:


### PR DESCRIPTION
We only allow it in "bare" free shapes, not a view on another free
shape, which could have acquired real cardinality.

This lets us eliminate the `allow_top_level_shape_dml` hack by which
we permitted such code in the edgeql generated by graphql.

Fixes #3889.