### PR TITLE
Avoid references to `expr~4` and the like in scopetree messages

### DIFF
--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -605,11 +605,19 @@ class ScopeTreeNode:
 
             assert offending_node.path_id is not None
 
+            imp = ''
+            offending_id = f'{offending_node.path_id.pformat()!r}'
+            existing_id = f'{existing.path_id.pformat()!r}'
+            # If the id is generated, don't leak meaningless info
+            # and try to explain that the reference is implicit.
+            if '~' in offending_id:
+                imp = 'implicit '
+                offending_id = 'an object'
+                existing_id = 'it'
+
             raise errors.InvalidReferenceError(
-                f'reference to '
-                f'{offending_node.path_id.pformat()!r} '
-                f'changes the interpretation of '
-                f'{existing.path_id.pformat()!r} '
+                f'{imp}reference to {offending_id} '
+                f'changes the interpretation of {existing_id} '
                 f'elsewhere in the query',
                 context=context,
             )

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -1302,3 +1302,19 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
                 }
             ]
         )
+
+    async def test_edgeql_props_bogus_01(self):
+        with self.assertRaisesRegex(
+                edgedb.QueryError,
+                r"implicit reference to an object changes the "
+                r"interpretation of it elsewhere in the query"):
+
+            await self.con.query(
+                r'''
+                    select (
+                      select User
+                    ).deck {
+                      linkprop := @count
+                    };
+                '''
+            )


### PR DESCRIPTION
The message still isn't good, though.

Fixes #3707.