### PR TITLE
Fix renaming and changing value of annotation in populate migration flow

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2177,7 +2177,8 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         astnode = self._get_ast_node(schema, context)
 
         if astnode.get_field('name'):
-            name = context.early_renames.get(self.classname, self.classname)
+            name = sn.shortname_from_fullname(self.classname)
+            name = context.early_renames.get(name, name)
             op = astnode(  # type: ignore
                 name=self._deparse_name(schema, context, name),
             )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5460,6 +5460,19 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
         """, r"""
         """])
 
+    def test_schema_migrations_equivalence_annotation_08(self):
+        self._assert_migration_equivalence([r"""
+            abstract annotation ann1;
+            type T {
+                annotation ann1 := 'test!';
+            };
+        """, r"""
+            abstract annotation ann2;
+            type T {
+                annotation ann2 := 'test?';
+            };
+        """])
+
     def test_schema_migrations_equivalence_index_01(self):
         self._assert_migration_equivalence([r"""
             type Base {


### PR DESCRIPTION
This fixes a bug found in connection with #3741.