### PR TITLE
Add JSON casts to range types.

### DIFF
--- a/edb/lib/cal.edgeql
+++ b/edb/lib/cal.edgeql
@@ -2125,3 +2125,55 @@ CREATE FUNCTION std::contains(
        SELECT "haystack" @> ("needle"::date)
     $$;
 };
+
+
+CREATE CAST FROM std::json TO range<cal::local_datetime> {
+    SET volatility := 'Stable';
+    USING SQL $$
+        SELECT CASE
+            WHEN "inc_lower" AND "inc_upper"
+            THEN edgedb.local_datetime_range_t("lower", "upper", '[]')
+            WHEN NOT "inc_lower" AND "inc_upper"
+            THEN edgedb.local_datetime_range_t("lower", "upper", '(]')
+            WHEN NOT "inc_lower" AND NOT "inc_upper"
+            THEN edgedb.local_datetime_range_t("lower", "upper", '()')
+            WHEN "inc_lower" AND NOT "inc_upper"
+            THEN edgedb.local_datetime_range_t("lower", "upper", '[)')
+        END
+        FROM (
+            SELECT
+                edgedb.local_datetime_in(edgedb.jsonb_extract_scalar(
+                    val->'lower', 'string')) AS lower,
+                edgedb.local_datetime_in(edgedb.jsonb_extract_scalar(
+                    val->'upper', 'string')) AS upper,
+                edgedb.range_inc_from_jsonb(val, 'inc_lower') AS inc_lower,
+                edgedb.range_inc_from_jsonb(val, 'inc_upper') AS inc_upper
+        ) AS a;
+    $$;
+};
+
+
+CREATE CAST FROM std::json TO range<cal::local_date> {
+    SET volatility := 'Stable';
+    USING SQL $$
+        SELECT CASE
+            WHEN "inc_lower" AND "inc_upper"
+            THEN daterange("lower", "upper", '[]')
+            WHEN NOT "inc_lower" AND "inc_upper"
+            THEN daterange("lower", "upper", '(]')
+            WHEN NOT "inc_lower" AND NOT "inc_upper"
+            THEN daterange("lower", "upper", '()')
+            WHEN "inc_lower" AND NOT "inc_upper"
+            THEN daterange("lower", "upper", '[)')
+        END
+        FROM (
+            SELECT
+                edgedb.local_date_in(edgedb.jsonb_extract_scalar(
+                    val->'lower', 'string')) AS lower,
+                edgedb.local_date_in(edgedb.jsonb_extract_scalar(
+                    val->'upper', 'string')) AS upper,
+                edgedb.range_inc_from_jsonb(val, 'inc_lower') AS inc_lower,
+                edgedb.range_inc_from_jsonb(val, 'inc_upper') AS inc_upper
+        ) AS a;
+    $$;
+};

--- a/edb/lib/std/30-jsonfuncs.edgeql
+++ b/edb/lib/std/30-jsonfuncs.edgeql
@@ -438,3 +438,166 @@ CREATE CAST FROM std::json TO std::bigint {
     );
     $$;
 };
+
+
+# Range casts
+CREATE CAST FROM range<std::anypoint> TO std::json {
+    SET volatility := 'Stable';
+    USING SQL FUNCTION 'edgedb.range_to_jsonb';
+};
+
+
+CREATE CAST FROM std::json TO range<std::int32> {
+    SET volatility := 'Stable';
+    USING SQL $$
+        SELECT CASE
+            WHEN "inc_lower" AND "inc_upper"
+            THEN int4range("lower", "upper", '[]')
+            WHEN NOT "inc_lower" AND "inc_upper"
+            THEN int4range("lower", "upper", '(]')
+            WHEN NOT "inc_lower" AND NOT "inc_upper"
+            THEN int4range("lower", "upper", '()')
+            WHEN "inc_lower" AND NOT "inc_upper"
+            THEN int4range("lower", "upper", '[)')
+        END
+        FROM (
+            SELECT
+                edgedb.jsonb_extract_scalar(
+                    val->'lower', 'number')::int4 AS lower,
+                edgedb.jsonb_extract_scalar(
+                    val->'upper', 'number')::int4 AS upper,
+                edgedb.range_inc_from_jsonb(val, 'inc_lower') AS inc_lower,
+                edgedb.range_inc_from_jsonb(val, 'inc_upper') AS inc_upper
+        ) AS a;
+    $$;
+};
+
+
+CREATE CAST FROM std::json TO range<std::int64> {
+    SET volatility := 'Stable';
+    USING SQL $$
+        SELECT CASE
+            WHEN "inc_lower" AND "inc_upper"
+            THEN int8range("lower", "upper", '[]')
+            WHEN NOT "inc_lower" AND "inc_upper"
+            THEN int8range("lower", "upper", '(]')
+            WHEN NOT "inc_lower" AND NOT "inc_upper"
+            THEN int8range("lower", "upper", '()')
+            WHEN "inc_lower" AND NOT "inc_upper"
+            THEN int8range("lower", "upper", '[)')
+        END
+        FROM (
+            SELECT
+                edgedb.jsonb_extract_scalar(
+                    val->'lower', 'number')::int8 AS lower,
+                edgedb.jsonb_extract_scalar(
+                    val->'upper', 'number')::int8 AS upper,
+                edgedb.range_inc_from_jsonb(val, 'inc_lower') AS inc_lower,
+                edgedb.range_inc_from_jsonb(val, 'inc_upper') AS inc_upper
+        ) AS a;
+    $$;
+};
+
+
+CREATE CAST FROM std::json TO range<std::float32> {
+    SET volatility := 'Stable';
+    USING SQL $$
+        SELECT CASE
+            WHEN "inc_lower" AND "inc_upper"
+            THEN edgedb.float32_range_t("lower", "upper", '[]')
+            WHEN NOT "inc_lower" AND "inc_upper"
+            THEN edgedb.float32_range_t("lower", "upper", '(]')
+            WHEN NOT "inc_lower" AND NOT "inc_upper"
+            THEN edgedb.float32_range_t("lower", "upper", '()')
+            WHEN "inc_lower" AND NOT "inc_upper"
+            THEN edgedb.float32_range_t("lower", "upper", '[)')
+        END
+        FROM (
+            SELECT
+                edgedb.jsonb_extract_scalar(
+                    val->'lower', 'number')::float4 AS lower,
+                edgedb.jsonb_extract_scalar(
+                    val->'upper', 'number')::float4 AS upper,
+                edgedb.range_inc_from_jsonb(val, 'inc_lower') AS inc_lower,
+                edgedb.range_inc_from_jsonb(val, 'inc_upper') AS inc_upper
+        ) AS a;
+    $$;
+};
+
+
+CREATE CAST FROM std::json TO range<std::float64> {
+    SET volatility := 'Stable';
+    USING SQL $$
+        SELECT CASE
+            WHEN "inc_lower" AND "inc_upper"
+            THEN edgedb.float64_range_t("lower", "upper", '[]')
+            WHEN NOT "inc_lower" AND "inc_upper"
+            THEN edgedb.float64_range_t("lower", "upper", '(]')
+            WHEN NOT "inc_lower" AND NOT "inc_upper"
+            THEN edgedb.float64_range_t("lower", "upper", '()')
+            WHEN "inc_lower" AND NOT "inc_upper"
+            THEN edgedb.float64_range_t("lower", "upper", '[)')
+        END
+        FROM (
+            SELECT
+                edgedb.jsonb_extract_scalar(
+                    val->'lower', 'number')::float8 AS lower,
+                edgedb.jsonb_extract_scalar(
+                    val->'upper', 'number')::float8 AS upper,
+                edgedb.range_inc_from_jsonb(val, 'inc_lower') AS inc_lower,
+                edgedb.range_inc_from_jsonb(val, 'inc_upper') AS inc_upper
+        ) AS a;
+    $$;
+};
+
+
+CREATE CAST FROM std::json TO range<std::decimal> {
+    SET volatility := 'Stable';
+    USING SQL $$
+        SELECT CASE
+            WHEN "inc_lower" AND "inc_upper"
+            THEN numrange("lower", "upper", '[]')
+            WHEN NOT "inc_lower" AND "inc_upper"
+            THEN numrange("lower", "upper", '(]')
+            WHEN NOT "inc_lower" AND NOT "inc_upper"
+            THEN numrange("lower", "upper", '()')
+            WHEN "inc_lower" AND NOT "inc_upper"
+            THEN numrange("lower", "upper", '[)')
+        END
+        FROM (
+            SELECT
+                edgedb.jsonb_extract_scalar(
+                    val->'lower', 'number')::numeric AS lower,
+                edgedb.jsonb_extract_scalar(
+                    val->'upper', 'number')::numeric AS upper,
+                edgedb.range_inc_from_jsonb(val, 'inc_lower') AS inc_lower,
+                edgedb.range_inc_from_jsonb(val, 'inc_upper') AS inc_upper
+        ) AS a;
+    $$;
+};
+
+
+CREATE CAST FROM std::json TO range<std::datetime> {
+    SET volatility := 'Stable';
+    USING SQL $$
+        SELECT CASE
+            WHEN "inc_lower" AND "inc_upper"
+            THEN edgedb.datetime_range_t("lower", "upper", '[]')
+            WHEN NOT "inc_lower" AND "inc_upper"
+            THEN edgedb.datetime_range_t("lower", "upper", '(]')
+            WHEN NOT "inc_lower" AND NOT "inc_upper"
+            THEN edgedb.datetime_range_t("lower", "upper", '()')
+            WHEN "inc_lower" AND NOT "inc_upper"
+            THEN edgedb.datetime_range_t("lower", "upper", '[)')
+        END
+        FROM (
+            SELECT
+                edgedb.datetime_in(edgedb.jsonb_extract_scalar(
+                    val->'lower', 'string')) AS lower,
+                edgedb.datetime_in(edgedb.jsonb_extract_scalar(
+                    val->'upper', 'string')) AS upper,
+                edgedb.range_inc_from_jsonb(val, 'inc_lower') AS inc_lower,
+                edgedb.range_inc_from_jsonb(val, 'inc_upper') AS inc_upper
+        ) AS a;
+    $$;
+};

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -557,6 +557,12 @@ def serialize_expr_to_json(
             env=env,
         )
 
+    elif irtyputils.is_range(styperef) and not expr.ser_safe:
+        val = pgast.FuncCall(
+            # Use the actual generic helper for converting anyrange to jsonb
+            name=('edgedb', 'range_to_jsonb'),
+            args=[expr], null_safe=True, ser_safe=True)
+
     elif irtyputils.is_collection(styperef) and not expr.ser_safe:
         val = coll_as_json_object(expr, styperef=styperef, env=env)
 

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2006,6 +2006,7 @@ def process_set_as_type_cast(
         pathctx.put_path_id_map(ctx.rel, ir_set.path_id, inner_set.path_id)
 
         if (is_json_cast
+                and not irtyputils.is_range(inner_set.typeref)
                 and (irtyputils.is_collection(inner_set.typeref)
                      or irtyputils.is_object(inner_set.typeref))):
             subctx.expr_exposed = True

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -769,7 +769,7 @@ class ConnectedTestCaseMixin:
                                   *,
                                   always_typenames=False,
                                   msg=None, sort=None, implicit_limit=0,
-                                  variables=None):
+                                  variables=None, json_only=False):
         fetch_args = variables if isinstance(variables, tuple) else ()
         fetch_kw = variables if isinstance(variables, dict) else {}
         try:
@@ -792,6 +792,9 @@ class ConnectedTestCaseMixin:
         except Exception:
             self.add_fail_notes(serialization='json')
             raise
+
+        if json_only:
+            return
 
         if exp_result_binary is ...:
             # The expected result is the same

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -5941,6 +5941,501 @@ aa \
                     )
                 ''')
 
+    async def test_edgeql_expr_range_32(self):
+        # Test casting ranges to JSON.
+
+        await self.assert_query_result(
+            f'''
+                select <json>range(<int32>2, <int32>10);
+            ''',
+            [{
+                "lower": 2,
+                "inc_lower": True,
+                "upper": 10,
+                "inc_upper": False,
+            }],
+            json_only=True,
+        )
+
+        await self.assert_query_result(
+            f'''
+                select <json>range(<int64>2, <int64>10);
+            ''',
+            [{
+                "lower": 2,
+                "inc_lower": True,
+                "upper": 10,
+                "inc_upper": False,
+            }],
+            json_only=True,
+        )
+
+        await self.assert_query_result(
+            f'''
+                select <json>range(<float32>2.5, <float32>10.5);
+            ''',
+            [{
+                "lower": 2.5,
+                "inc_lower": True,
+                "upper": 10.5,
+                "inc_upper": False,
+            }],
+            json_only=True,
+        )
+
+        await self.assert_query_result(
+            f'''
+                select <json>range(<float64>2.5, <float64>10.5);
+            ''',
+            [{
+                "lower": 2.5,
+                "inc_lower": True,
+                "upper": 10.5,
+                "inc_upper": False,
+            }],
+            json_only=True,
+        )
+
+        await self.assert_query_result(
+            f'''
+                select <json>range(2.5n, 10.5n);
+            ''',
+            [{
+                "lower": 2.5,
+                "inc_lower": True,
+                "upper": 10.5,
+                "inc_upper": False,
+            }],
+            json_only=True,
+        )
+
+        await self.assert_query_result(
+            f'''
+                select <json>range(
+                    <datetime>'2022-06-10T13:00:00Z',
+                    <datetime>'2022-06-17T12:00:00Z'
+                );
+            ''',
+            [{
+                "lower": "2022-06-10T13:00:00+00:00",
+                "inc_lower": True,
+                "upper": "2022-06-17T12:00:00+00:00",
+                "inc_upper": False,
+            }],
+            json_only=True,
+        )
+
+        await self.assert_query_result(
+            f'''
+                select <json>range(
+                    <cal::local_datetime>'2022-06-10T13:00:00',
+                    <cal::local_datetime>'2022-06-17T12:00:00'
+                );
+            ''',
+            [{
+                "lower": "2022-06-10T13:00:00",
+                "inc_lower": True,
+                "upper": "2022-06-17T12:00:00",
+                "inc_upper": False,
+            }],
+            json_only=True,
+        )
+
+        await self.assert_query_result(
+            f'''
+                select <json>range(
+                    <cal::local_date>'2022-06-10',
+                    <cal::local_date>'2022-06-17'
+                );
+            ''',
+            [{
+                "lower": "2022-06-10",
+                "inc_lower": True,
+                "upper": "2022-06-17",
+                "inc_upper": False,
+            }],
+            json_only=True,
+        )
+
+    async def test_edgeql_expr_range_33(self):
+        # Test casting ranges from JSON.
+
+        await self.assert_query_result(
+            r'''
+                select <range<int32>>to_json('{
+                    "lower": 2,
+                    "inc_lower": true,
+                    "upper": 10,
+                    "inc_upper": false
+                }') = range(<int32>2, <int32>10);
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select <range<int64>>to_json('{
+                    "lower": 2,
+                    "inc_lower": true,
+                    "upper": 10,
+                    "inc_upper": false
+                }') = range(<int64>2, <int64>10);
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select <range<float32>>to_json('{
+                    "lower": 2.5,
+                    "inc_lower": true,
+                    "upper": 10.5,
+                    "inc_upper": false
+                }') = range(<float32>2.5, <float32>10.5);
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select <range<float64>>to_json('{
+                    "lower": 2.5,
+                    "inc_lower": true,
+                    "upper": 10.5,
+                    "inc_upper": false
+                }') = range(<float64>2.5, <float64>10.5);
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select <range<decimal>>to_json('{
+                    "lower": 2.5,
+                    "inc_lower": true,
+                    "upper": 10.5,
+                    "inc_upper": false
+                }') = range(2.5n, 10.5n);
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select <range<datetime>>to_json('{
+                    "lower": "2022-06-10T13:00:00+00:00",
+                    "inc_lower": true,
+                    "upper": "2022-06-17T12:00:00+00:00",
+                    "inc_upper": false
+                }') = range(
+                    <datetime>'2022-06-10T13:00:00Z',
+                    <datetime>'2022-06-17T12:00:00Z'
+                );
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select <range<cal::local_datetime>>to_json('{
+                    "lower": "2022-06-10T13:00:00",
+                    "inc_lower": true,
+                    "upper": "2022-06-17T12:00:00",
+                    "inc_upper": false
+                }') = range(
+                    <cal::local_datetime>'2022-06-10T13:00:00',
+                    <cal::local_datetime>'2022-06-17T12:00:00'
+                );
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select <range<cal::local_date>>to_json('{
+                    "lower": "2022-06-10",
+                    "inc_lower": true,
+                    "upper": "2022-06-17",
+                    "inc_upper": false
+                }') = range(
+                    <cal::local_date>'2022-06-10',
+                    <cal::local_date>'2022-06-17'
+                );
+            ''',
+            [True],
+        )
+
+    async def test_edgeql_expr_range_34(self):
+        # Test casting ranges from JSON.
+
+        await self.assert_query_result(
+            r'''
+                select <range<int64>>to_json('{
+                    "lower": 2,
+                    "inc_lower": true,
+                    "upper": 10,
+                    "inc_upper": true
+                }') = range(2, 11);
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select <range<int64>>to_json('{
+                    "lower": null,
+                    "inc_lower": true,
+                    "upper": 10,
+                    "inc_upper": false
+                }') = range(<int64>{}, 10);
+            ''',
+            [True],
+        )
+
+        await self.assert_query_result(
+            r'''
+                select <range<int64>>to_json('{
+                    "lower": 2,
+                    "inc_lower": true,
+                    "inc_upper": false
+                }') = range(2);
+            ''',
+            [True],
+        )
+
+        with self.assertRaisesRegex(
+                edgedb.NumericOutOfRangeError,
+                r'"2147483648" is out of range for type std::int32'):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<int32>>to_json('{
+                        "lower": 2,
+                        "inc_lower": true,
+                        "upper": 2147483648,
+                        "inc_upper": false
+                    }') = range(2, 10);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.NumericOutOfRangeError,
+                r'"9223372036854775808" is out of range for '
+                r'type std::int64'):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<int64>>to_json('{
+                        "lower": 2,
+                        "inc_lower": true,
+                        "upper": 9223372036854775808,
+                        "inc_upper": false
+                    }') = range(2, 10);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.NumericOutOfRangeError,
+                r'.+ is out of range for type std::float32'):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<float32>>to_json('{
+                        "lower": 2,
+                        "inc_lower": true,
+                        "upper": 1e100,
+                        "inc_upper": false
+                    }') = range(2.0, 10.0);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.NumericOutOfRangeError,
+                r'.+ is out of range for type std::float64'):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<float64>>to_json('{
+                        "lower": 2,
+                        "inc_lower": true,
+                        "upper": 1e500,
+                        "inc_upper": false
+                    }') = range(2.0, 10.0);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r'expected JSON number or null; got JSON string'):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<int64>>to_json('{
+                        "lower": "2",
+                        "inc_lower": true,
+                        "upper": 10,
+                        "inc_upper": false
+                    }') = range(2, 10);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r'invalid input syntax for type std::int64: "2.5"'):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<int64>>to_json('{
+                        "lower": 2.5,
+                        "inc_lower": true,
+                        "upper": 10,
+                        "inc_upper": false
+                    }') = range(2, 10);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r"JSON object must have key 'inc_upper' "
+                r"with value true or false"):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<int64>>to_json('{
+                        "lower": 2,
+                        "inc_lower": true,
+                        "upper": 10,
+                        "inc_upper": null
+                    }') = range(2, 10);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r"JSON object must have key 'inc_lower' "
+                r"with value true or false"):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<int64>>to_json('{
+                        "lower": 2,
+                        "upper": 10,
+                        "inc_upper": false
+                    }') = range(2, 10);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r"JSON object must have key 'inc_lower' "
+                r"with value true or false"):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<int64>>to_json('["bad", null]') =
+                        range(2, 10);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r"JSON object must have key 'inc_lower' "
+                r"with value true or false"):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<int64>>to_json('{"bad": null}') =
+                        range(2, 10);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r"JSON object must have key 'inc_lower' "
+                r"with value true or false"):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<int64>>to_json('"bad"') =
+                        range(2, 10);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r"JSON object must have key 'inc_lower' "
+                r"with value true or false"):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<int64>>to_json('null') =
+                        range(2, 10);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r"JSON object must have key 'inc_lower' "
+                r"with value true or false"):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<int64>>to_json('1312') =
+                        range(2, 10);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r"JSON object must have key 'inc_lower' "
+                r"with value true or false"):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<int64>>to_json('true') =
+                        range(2, 10);
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r"invalid input syntax for type cal::local_date: "
+                r"'2022.06.10'"):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<cal::local_date>>to_json('{
+                        "lower": "2022.06.10",
+                        "inc_lower": true,
+                        "upper": "2022-06-17",
+                        "inc_upper": false
+                    }') = range(
+                        <cal::local_date>'2022-06-10',
+                        <cal::local_date>'2022-06-17'
+                    );
+                ''')
+
+        with self.assertRaisesRegex(
+                edgedb.InvalidValueError,
+                r"invalid input syntax for type cal::local_date: "
+                r"'12022-06-17'"):
+            async with self.con.transaction():
+                await self.con.query_single(r'''
+                    select <range<cal::local_date>>to_json('{
+                        "lower": "2022-06-10",
+                        "inc_lower": true,
+                        "upper": "12022-06-17",
+                        "inc_upper": false
+                    }') = range(
+                        <cal::local_date>'2022-06-10',
+                        <cal::local_date>'2022-06-17'
+                    );
+                ''')
+
+    async def test_edgeql_expr_range_35(self):
+        # Test casting shapes containing ranges to JSON.
+
+        await self.assert_query_result(
+            r'''
+                select <json>{
+                    int := 42,
+                    range0 := range(2, 10),
+                    nested := {
+                        range1 := range(5)
+                    }
+                };
+            ''',
+            [{
+                "int": 42,
+                "range0": {
+                    "lower": 2,
+                    "inc_lower": True,
+                    "upper": 10,
+                    "inc_upper": False,
+                },
+                "nested": {
+                    "range1": {
+                        "lower": 5,
+                        "inc_lower": True,
+                        "upper": None,
+                        "inc_upper": False,
+                    },
+                },
+            }],
+            json_only=True,
+        )
+
     async def test_edgeql_expr_cannot_assign_dunder_type_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError, r'cannot assign to __type__'):


### PR DESCRIPTION
Add casts to and from JSON to all our range types. The JSON generated is
structured as an object with the following fields: "lower", "inc_lower",
"upper", "inc_upper".