### PR TITLE
Disallow shapes on computed links

### DIFF
--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1217,7 +1217,7 @@ class PointerCommandOrFragment(
             and target.is_view(expression.irast.schema)
         ):
             raise errors.UnsupportedFeatureError(
-                f'including a shape on schema-defined computed pointers '
+                f'including a shape on schema-defined computed links '
                 f'is not yet supported',
                 context=self.source_context,
             )

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1211,6 +1211,17 @@ class PointerCommandOrFragment(
                     context=srcctx,
                 )
 
+        if (
+            not isinstance(source, Pointer)
+            and not source.is_view(schema)  # type: ignore
+            and target.is_view(expression.irast.schema)
+        ):
+            raise errors.UnsupportedFeatureError(
+                f'including a shape on schema-defined computed pointers '
+                f'is not yet supported',
+                context=self.source_context,
+            )
+
         spec_target: Optional[
             Union[
                 s_types.TypeShell[s_types.Type],

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6526,7 +6526,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # have a decent error.
         async with self.assertRaisesRegexTx(
             edgedb.UnsupportedFeatureError,
-            r"including a shape on schema-defined computed pointers "
+            r"including a shape on schema-defined computed links "
             r"is not yet supported"
         ):
             await self.con.execute("""

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -6517,6 +6517,22 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             }],
         )
 
+    async def test_edgeql_ddl_link_computable_02(self):
+        await self.con.execute('''
+            CREATE TYPE LinkTarget;
+        ''')
+
+        # TODO We want to actually support this, but until then we should
+        # have a decent error.
+        async with self.assertRaisesRegexTx(
+            edgedb.UnsupportedFeatureError,
+            r"including a shape on schema-defined computed pointers "
+            r"is not yet supported"
+        ):
+            await self.con.execute("""
+                CREATE TYPE X { CREATE LINK x := LinkTarget { z := 1 } };
+            """)
+
     async def test_edgeql_ddl_link_computable_circular_01(self):
         await self.con.execute('''\
             CREATE TYPE CompLinkCircular {


### PR DESCRIPTION
We currently produce nonsensical error messages saying a type does not
exist that clearly does.

Fixes #3369.